### PR TITLE
chore: remove unused .gitmodules file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "planning-with-files"]
-	path = planning-with-files
-	url = https://github.com/devseunggwan/planning-with-files.git

--- a/README.md
+++ b/README.md
@@ -10,24 +10,10 @@ Personal collection of Claude Code skills.
 | context-recovery | Return to main task after completing a side-task |
 | pr-dev-to-prod | Create release PR from dev to prod branch with impact analysis |
 
-## Submodules
-
-| Skill | Description |
-|-------|-------------|
-| planning-with-files | Task planning and progress tracking |
-
 ## Usage
 
-Clone with submodules:
-
 ```bash
-git clone --recursive https://github.com/devseunggwan/skills.git ~/.claude/skills
-```
-
-Update submodules:
-
-```bash
-git submodule update --init --remote
+git clone https://github.com/devseunggwan/skills.git ~/.claude/skills
 ```
 
 ## License


### PR DESCRIPTION
## Summary

- Remove unused `.gitmodules` file
- Remove `planning-with-files` submodule reference (not initialized, not used)
- Update README to remove Submodules section and simplify clone command

## Changes

| File | Change |
|------|--------|
| `.gitmodules` | Deleted |
| `README.md` | Remove Submodules section, simplify Usage |

## Background

The `planning-with-files` submodule was defined but never initialized. Similar functionality is provided by `superpowers:writing-plans` and `superpowers:executing-plans` plugins.

Closes #8

🤖 Generated with [Claude Code](https://claude.ai/claude-code)