### PR TITLE
feat: add turbo-implement skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,14 @@ Development workflow skills for Claude Code — disciplined, fast, resilient.
 
 Each skill is an orchestrator with pluggable steps. External integrations (issue tracker, PR tool, code review) are routed via the project's CLAUDE.md — no hardcoded dependencies.
 
-## Skills (12)
+## Skills (13)
 
 ### Workflow Lifecycle
 
 | Skill | Purpose | Pluggable Steps |
 |-------|---------|-----------------|
 | `turbo-setup` | Compound setup — issue + plan + branch + worktree + deps in one pass | issue creation, planning |
+| `turbo-implement` | Implementation orchestrator — selects execution mode and chains to delivery | ralph, autopilot (pluggable) |
 | `turbo-deliver` | Compound delivery — auto-detects PR state for full or merge-only mode | code review, PR creation |
 | `verify-completion` | Enforce verification evidence before any completion claim | — (built-in) |
 
@@ -43,7 +44,13 @@ Project CLAUDE.md (routing config)
 │  issue(pluggable) → plan(pluggable) → branch     │
 │  → worktree → deps                               │
 └──────────────────────────────────────────────────┘
-        │  implement...
+        │
+        ▼
+┌─ turbo-implement ────────────────────────────────┐
+│  context → mode select → execute → chain         │
+│  modes: manual | ralph | autopilot | guided      │
+└──────────────────────────────────────────────────┘
+        │
         ▼
 ┌─ turbo-deliver ──────────────────────────────────┐
 │  Step 0: mode detect (PR exists?)                │

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Development workflow skills for Claude Code — disciplined, fast, resilient.
 | Skill | Description |
 |-------|-------------|
 | `turbo-setup` | Compound setup — issue + plan + branch + worktree + deps in one step |
+| `turbo-implement` | Implementation orchestrator — mode selection (manual/ralph/autopilot/guided) and chaining |
 | `turbo-deliver` | Compound delivery — auto-detects PR state for full pipeline or merge-only mode |
 | `verify-completion` | Enforce verification evidence before any completion claim |
 

--- a/skills/turbo-implement/SKILL.md
+++ b/skills/turbo-implement/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: turbo-implement
+description: >
+  Implementation orchestrator between turbo-setup and turbo-deliver.
+  Auto-detects git state from turbo-setup, selects execution mode, and chains to turbo-deliver on completion.
+  Triggers on "implement", "turbo-implement", "start coding", "build it".
+---
+
+# Turbo Implement
+
+## Overview
+
+Bridges the gap between setup and delivery. After turbo-setup creates the workspace, turbo-implement orchestrates the actual implementation work and chains to turbo-deliver when done.
+
+**Core principle:** The implementation phase needs structure, not just "go code." Mode selection matches task complexity to execution strategy.
+
+**Chains from:** `turbo-setup` (auto-detects issue/branch from git state)
+**Chains to:** `turbo-deliver` (invoked on completion)
+
+## The Iron Law
+
+```
+IMPLEMENTATION MODE MUST MATCH TASK COMPLEXITY.
+NO DELIVERY WITHOUT VERIFICATION.
+```
+
+## When to Use
+
+- After `turbo-setup` completes (or after manually creating a branch/worktree)
+- Triggers: "implement", "turbo-implement", "start coding", "build it"
+- No input required — auto-detects from git state
+
+## Inputs (Auto-Detected)
+
+All inputs are derived from the current working directory (same as turbo-deliver):
+
+```bash
+BRANCH=$(git branch --show-current)
+ISSUE_NUMBER=$(echo "$BRANCH" | grep -oP '(?<=hub-)\d+|(?<=issue-)\d+')
+WORKTREE_PATH=$(pwd)
+TARGET_REPO=$(basename $(git remote get-url origin) .git)
+```
+
+**Validation (STOP if any fails):**
+- [ ] Branch name contains issue number
+- [ ] Working directory is clean (or has only untracked files)
+
+## Process
+
+### Step 1: Gather Context
+
+```bash
+# Read issue details
+ISSUE=$(gh issue view "$ISSUE_NUMBER" --json title,body,labels)
+
+# Check for existing spec files
+SPEC=$(ls .omc/specs/deep-interview-*.md 2>/dev/null | head -1)
+PLAN=$(ls .omc/plans/*.md 2>/dev/null | head -1)
+```
+
+Present context summary:
+
+```
+═══════════════════════════════════════════════
+ Turbo Implement
+═══════════════════════════════════════════════
+
+ Issue:   #<N> — <title>
+ Branch:  <branch>
+ Spec:    <path or "none">
+ Plan:    <path or "none">
+═══════════════════════════════════════════════
+```
+
+### Step 2: Select Execution Mode
+
+Present mode options based on detected context:
+
+```
+How should this be implemented?
+1. Manual — I'll implement, call /turbo-deliver when done
+2. Ralph — persistence loop until all acceptance criteria pass
+3. Autopilot — full autonomous: plan → implement → QA → validate
+4. Guided — implement step-by-step with verification after each change
+```
+
+**Mode routing heuristics (suggest but don't force):**
+
+| Signal | Suggested Mode |
+|--------|---------------|
+| Spec file exists with acceptance criteria | Ralph (criteria-driven loop) |
+| Plan file exists with implementation steps | Autopilot (plan-driven execution) |
+| Simple task (1-2 files, clear scope) | Guided |
+| No spec, no plan, complex task | Manual (needs more planning first) |
+
+### Step 3: Execute
+
+#### Mode: Manual
+
+Report context and exit. User implements manually.
+
+```
+Ready to implement. When done, run /turbo-deliver to complete the lifecycle.
+
+Useful commands:
+  /verify-completion  — check tests/lint before delivery
+  /turbo-deliver      — full delivery pipeline
+  /debug              — if you hit a bug
+```
+
+#### Mode: Ralph (pluggable)
+
+Delegate to the project's persistence loop skill (defined in CLAUDE.md routing).
+Default: `oh-my-claudecode:ralph`.
+
+Pass the spec or issue body as the task definition:
+
+```
+Task: Implement issue #<N> — <title>
+Acceptance criteria: <from spec or issue body>
+Verify: run tests + lint after each change
+```
+
+#### Mode: Autopilot (pluggable)
+
+Delegate to the project's autonomous execution skill (defined in CLAUDE.md routing).
+Default: `oh-my-claudecode:autopilot`.
+
+If a spec file exists, pass it as Phase 0 output (autopilot skips expansion).
+If a plan file exists, pass it as Phase 1 output (autopilot skips planning).
+
+#### Mode: Guided
+
+Interactive step-by-step implementation:
+
+1. Break the task into small steps (from spec, plan, or issue body)
+2. For each step:
+   - Show what needs to change
+   - Implement the change
+   - Run relevant tests
+   - Show results, ask to proceed
+3. After all steps: run full verification
+
+### Step 4: Chain to Delivery
+
+After implementation completes (any mode except Manual):
+
+```
+Implementation complete. Chain to turbo-deliver?
+1. Yes — run /turbo-deliver now (Recommended)
+2. Not yet — I want to review changes first
+3. Skip — I'll deliver manually later
+```
+
+If "Yes": invoke `turbo-deliver` skill.
+If "Not yet": show `git diff --stat` and wait.
+
+## Error Handling
+
+| Situation | Action |
+|-----------|--------|
+| No issue number in branch | Ask user for issue reference |
+| Spec/plan file not found | Proceed without — suggest Manual or Guided mode |
+| Ralph/autopilot not available | Fall back to Guided mode |
+| Implementation fails mid-way | Save progress, report status, suggest `/debug` |
+| Tests fail after implementation | Invoke `debug` skill for root cause analysis |
+
+## Pipeline Visualization
+
+```
+┌─────────────┐    ┌──────────────────┐    ┌──────────────┐
+│ TURBO-SETUP │───▶│ TURBO-IMPLEMENT  │───▶│TURBO-DELIVER │
+│             │    │                  │    │              │
+│ issue       │    │ Step 1: context  │    │ verify       │
+│ branch      │    │ Step 2: mode     │    │ review       │
+│ worktree    │    │ Step 3: execute  │    │ PR           │
+│ deps        │    │ Step 4: chain    │    │ merge        │
+└─────────────┘    └──────────────────┘    └──────────────┘
+                    modes:
+                    · manual (exit)
+                    · ralph (loop)
+                    · autopilot (autonomous)
+                    · guided (interactive)
+```
+
+## Chaining Interface
+
+**From turbo-setup:**
+```
+turbo-setup outputs → git state (branch, worktree, issue#)
+turbo-implement reads → git state (auto-detect, no explicit handoff)
+```
+
+**To turbo-deliver:**
+```
+turbo-implement completion → invokes turbo-deliver skill
+turbo-deliver reads → git state (auto-detect, no explicit handoff)
+```
+
+All three skills share the same auto-detection mechanism: read git branch, extract issue number, detect worktree. No explicit state passing needed.
+
+## Integration
+
+**Workflow position:**
+```
+[turbo-setup] → [turbo-implement] → [turbo-deliver] → [done]
+```
+
+**Previous step:** `turbo-setup` (workspace ready)
+**Next step:** `turbo-deliver` (delivery pipeline)


### PR DESCRIPTION
## Summary
- turbo-setup과 turbo-deliver 사이의 구현 단계를 오케스트레이션하는 `turbo-implement` 스킬 추가
- 4가지 실행 모드: manual / ralph / autopilot / guided
- git 상태와 spec/plan 파일을 자동 감지하여 모드 추천
- README, AGENTS.md 반영

Closes #43

## Test plan
- [ ] SKILL.md 구조 검증
- [ ] README 스킬 테이블에 turbo-implement 존재 확인
- [ ] AGENTS.md 아키텍처 다이어그램에 turbo-implement 존재 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)