### PR TITLE
docs: add prerequisites and compatibility tiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,14 @@ Development workflow skills for Claude Code — disciplined, fast, resilient.
 
 Each skill is an orchestrator with pluggable steps. External integrations (issue tracker, PR tool, code review) are routed via the project's CLAUDE.md — no hardcoded dependencies.
 
+## Prerequisites
+
+| Tier | What works | Dependencies |
+|------|-----------|--------------|
+| **Standalone** | turbo-setup, recover-sessions | `gh` CLI |
+| **Enhanced** | + turbo-implement, turbo-completion, debug, retrospect | + oh-my-claudecode |
+| **Full** | + all cmux-* skills | + cmux |
+
 ## Skills (12)
 
 ### Workflow Lifecycle

--- a/README.md
+++ b/README.md
@@ -32,6 +32,26 @@ Development workflow skills for Claude Code — disciplined, fast, resilient.
 | `cmux-session-manager` | cmux session lifecycle automation — status, cleanup, init, report |
 | `cmux-orchestrator` | Dispatch and supervise multiple Claude Code workers in cmux workspaces |
 
+## Prerequisites
+
+Most skills delegate to external agents or session managers. Install the dependencies that match your usage tier.
+
+| Dependency | Required for | Install |
+|------------|-------------|---------|
+| **oh-my-claudecode** | Agent delegation (tracer, analyst, ultraqa, code-reviewer) | `omc install` |
+| **cmux** | Session management skills (cmux-*) | `npm i -g @anthropic/cmux` |
+| **gh CLI** | Issue/PR operations (turbo-*) | `brew install gh` |
+
+### Compatibility Tiers
+
+| Tier | What works | What you need |
+|------|-----------|---------------|
+| **Standalone** | turbo-setup, recover-sessions | `gh` CLI only |
+| **Enhanced** | + turbo-implement, turbo-completion, debug, retrospect | + oh-my-claudecode |
+| **Full** | + all cmux-* skills | + cmux |
+
+> Skills in higher tiers fall back to manual/built-in alternatives when their dependencies are missing, but with reduced functionality.
+
 ## Installation
 
 ### Plugin (recommended)


### PR DESCRIPTION
## Summary

- README.md에 Prerequisites 섹션 추가 (OMC, cmux, gh CLI 의존성 테이블)
- Compatibility Tiers (Standalone / Enhanced / Full) 매트릭스 추가
- AGENTS.md에도 동일한 tier 테이블 반영

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)