### PR TITLE
feat(skills): add --permission-mode to cmux-delegate

### DIFF
--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -43,6 +43,7 @@ description: Delegate a task to an independent Claude Code session in a new cmux
 | `--account` | (기본 계정) | Claude 계정 프로필 (예: `claude-2` → `CLAUDE_CONFIG_DIR=~/.claude-2`) |
 | `--session` | (신규 생성) | 기존 워크스페이스에 전달 (이름 또는 workspace ref) |
 | `--distribute` | false | 독립 항목별 병렬 분산 실행 |
+| `--permission-mode` | `auto` | Claude 권한 모드 (acceptEdits/auto/bypassPermissions/default/dontAsk/plan) |
 
 ## Process
 
@@ -58,6 +59,7 @@ budget = args["max-budget-usd"] || ""
 account = args.account || ""
 session = args.session || ""
 distribute = args.distribute || false
+permission_mode = args["permission-mode"] || "auto"
 task = args.task (remaining text after flags)
 short_task = task[:30], sanitized to [a-zA-Z0-9가-힣 -] only (for cmux workspace name)
 timestamp = epoch seconds + PID (e.g., 1744163800-12345) to avoid collision
@@ -188,7 +190,7 @@ trap 'rm -f "$SCRIPT_FILE"' EXIT
 
 cat "$PROMPT_FILE" | {claude_env} claude \
   --model {model} \
-  --permission-mode auto \
+  --permission-mode {permission_mode} \
   {budget_flag}
 
 # Notify on completion


### PR DESCRIPTION
## Summary
- `--permission-mode` 인자 추가 (기본값: `auto`)
- 하드코딩된 `--permission-mode auto`를 `{permission_mode}` 템플릿으로 교체
- Arguments 테이블, Step 1 파싱, Step 4 래퍼 스크립트 3곳 변경

## Permission Mode 설명

| 모드 | 동작 | 사용 시나리오 |
|------|------|-------------|
| `default` | 모든 도구 호출 전 유저에게 승인 요청 | 민감한 작업, 프로덕션 환경에서 수동 통제 |
| `acceptEdits` | 파일 편집 자동 승인, 나머지 승인 요청 | 코드 수정 허용, shell 명령은 통제 |
| `auto` | 대부분 자동 승인 (유저 설정 기반) | **위임 세션 기본값** — 자율 실행 목적 |
| `dontAsk` | 모든 도구 자동 승인, 프롬프트 없음 | 완전 자동화 파이프라인, CI 환경 |
| `bypassPermissions` | 모든 권한 체크 건너뜀 | 인터넷 없는 샌드박스 전용 ⚠️ |
| `plan` | 코드 편집/실행 불가, 계획만 수립 | 설계 리뷰, 아키텍처 검토 |

## 기본값 비교

| 레이어 | 기본값 | 비고 |
|--------|--------|------|
| Claude Code CLI (플래그 없음) | `default` | 모든 변경 전 인터랙티브 승인 요청 |
| `~/.claude/settings.json` | `permissions.defaultMode` 미설정 시 `default` | `{"permissions": {"defaultMode": "..."}}`로 변경 가능 |
| **cmux-delegate v2** | **`auto`** | 위임 세션은 자율 실행이 목적이므로 override |

> 출처: [code.claude.com/docs/en/permission-modes](https://code.claude.com/docs/en/permission-modes)
> "In the default permission mode, Claude proposes modifications and requires your explicit approval before any files are altered."

**cmux-delegate 권장 조합:**
- 조사/분석 위임 → `auto` (기본값)
- 코드 리뷰 위임 → `plan` (읽기만)
- 구현 위임 → `acceptEdits` (코드 수정 허용, 위험한 shell 차단)
- 사람 개입 필요 → `default` (각 변경마다 승인)

## Test plan
- [ ] `--permission-mode` 미지정 시 기본값 `auto` 적용 확인
- [ ] `--permission-mode default`로 지정 시 래퍼 스크립트에 반영 확인

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)