### PR TITLE
fix(recover): robust /exit detection via user-only tail

### DIFF
--- a/skills/recover-sessions/claude-recover-scan
+++ b/skills/recover-sessions/claude-recover-scan
@@ -154,18 +154,29 @@ for base, home_label in config_homes.items():
                     except Exception:
                         pass
 
-            # Detect intentional exit by scanning the last N user messages.
-            # /exit/quit appear as <command-name>/exit</command-name> in a user message.
-            # Tracking user messages separately keeps detection reliable regardless of
-            # how many tool_result / attachment / file-history-snapshot events were
-            # appended after /exit.
-            for obj in user_tail_buf:
+            # Detect intentional exit by inspecting ONLY the most recent real
+            # user turn. Earlier /exit hits in the tail (e.g. a session that
+            # was resumed after an explicit exit) must not bubble up, or we
+            # risk dropping live sessions whose tail still carries the stale
+            # /exit command. Wrappers like <local-command-stdout> and
+            # <local-command-caveat> are skipped because Claude Code emits
+            # those as additional user-type events after executing /exit.
+            for obj in reversed(user_tail_buf):
                 msg = obj.get("message", {})
                 raw = msg.get("content", "") if isinstance(msg, dict) else str(msg)
-                if isinstance(raw, str):
-                    if "/exit" in raw or "/quit" in raw:
-                        was_exited = True
-                        break
+                if not isinstance(raw, str):
+                    continue
+                c = raw.strip()
+                if c.startswith("<local-command-stdout>") or c.startswith("<local-command-caveat>"):
+                    continue
+                # First real user turn we hit (scanning from newest back).
+                # Require the explicit <command-name>/exit</command-name>
+                # token so that a literal "/exit" in chat prose does not
+                # trigger the filter.
+                if ("<command-name>/exit</command-name>" in c
+                        or "<command-name>/quit</command-name>" in c):
+                    was_exited = True
+                break
 
             # ── Filtering ──
             if is_teammate:

--- a/skills/recover-sessions/claude-recover-scan
+++ b/skills/recover-sessions/claude-recover-scan
@@ -71,6 +71,7 @@ SCHEDULE_KEYWORDS = [
 
 MIN_USER_MSGS = 4
 TAIL_SIZE = 15
+USER_TAIL_SIZE = 20
 
 results = []
 
@@ -110,6 +111,7 @@ for base, home_label in config_homes.items():
             is_command = False
             is_schedule = False
             tail_buf = []
+            user_tail_buf = []
             was_exited = False
 
             with open(fpath) as f:
@@ -126,6 +128,9 @@ for base, home_label in config_homes.items():
 
                         if obj.get("type") == "user" and not obj.get("isSidechain"):
                             user_count += 1
+                            user_tail_buf.append(obj)
+                            if len(user_tail_buf) > USER_TAIL_SIZE:
+                                user_tail_buf.pop(0)
                             msg = obj.get("message", {})
                             raw = msg.get("content", "") if isinstance(msg, dict) else str(msg)
                             if not isinstance(raw, str):
@@ -149,16 +154,18 @@ for base, home_label in config_homes.items():
                     except Exception:
                         pass
 
-            # Detect intentional exit in tail
-            # Check for /exit command or known goodbye messages
-            for obj in tail_buf:
-                if obj.get("type") == "user":
-                    msg = obj.get("message", {})
-                    raw = msg.get("content", "") if isinstance(msg, dict) else str(msg)
-                    if isinstance(raw, str):
-                        if "/exit" in raw or "/quit" in raw:
-                            was_exited = True
-                            break
+            # Detect intentional exit by scanning the last N user messages.
+            # /exit/quit appear as <command-name>/exit</command-name> in a user message.
+            # Tracking user messages separately keeps detection reliable regardless of
+            # how many tool_result / attachment / file-history-snapshot events were
+            # appended after /exit.
+            for obj in user_tail_buf:
+                msg = obj.get("message", {})
+                raw = msg.get("content", "") if isinstance(msg, dict) else str(msg)
+                if isinstance(raw, str):
+                    if "/exit" in raw or "/quit" in raw:
+                        was_exited = True
+                        break
 
             # ── Filtering ──
             if is_teammate:


### PR DESCRIPTION
Closes #62

## 변경 사항

`/exit` 감지를 일반 `tail_buf`(15 객체)가 아닌 **user 메시지 전용 tail buffer**(`user_tail_buf`, 20 메시지)에서 수행하도록 변경. 이로써 `/exit` 이후 `tool_result` / `attachment` / `file-history-snapshot` 등 비-user 이벤트가 많이 append되어도 `/exit`가 감지 윈도우 밖으로 밀려나지 않습니다.

### 핵심

- `USER_TAIL_SIZE = 20` 상수 추가
- `user_tail_buf` — `type=='user' and not isSidechain`인 메시지만 누적, 마지막 20개 유지
- exit 감지 루프를 `user_tail_buf` 기반으로 변경
- `tail_buf`(일반)는 그대로 유지 (다른 용도가 있을 경우 호환 보장)

## 테스트

같은 데이터 기준 비교 (오늘 04-10 laplace-dev-hub):

| 버전 | survivors |
|------|-----------|
| 기존 (TAIL_SIZE=15) | 12 |
| 임시 (TAIL_SIZE=50) | 10 |
| **본 PR (USER_TAIL_SIZE=20)** | **11** |

본 PR은 단순 TAIL_SIZE 확장이 아닌 **윈도우 의존성을 user 메시지 단위로 축소**한 근본적 fix입니다.

```
$ python3 skills/recover-sessions/claude-recover-scan '' '04-10' '04-10' | wc -l
11
```

## 영향

- 기본값 변경 없이 user-only tail로 정확도 향상
- 메모리 부담 미미 (object 20개 추가 추적)
- 기존 `tail_buf` 의존 코드 없으므로 backward-compatible