### PR TITLE
fix(recover): prefer internal timestamp over mtime

### DIFF
--- a/skills/recover-sessions/claude-recover-scan
+++ b/skills/recover-sessions/claude-recover-scan
@@ -92,10 +92,18 @@ for base, home_label in config_homes.items():
 
             mtime = datetime.datetime.fromtimestamp(os.path.getmtime(fpath))
             if not STRICT_TIMESTAMP:
+                # Normal mode: mtime prefilter excludes obviously old files
+                # before we pay the cost of reading them.
                 if mtime < cutoff:
                     continue
                 if cutoff_end and mtime >= cutoff_end:
                     continue
+            # STRICT_TIMESTAMP mode intentionally skips the mtime prefilter
+            # (so files touched by crash recovery metadata flush still get
+            # evaluated against their real internal timestamp). The
+            # fail-closed enforcement happens below once last_internal_ts
+            # is known — files with no usable internal timestamp are
+            # dropped there, never silently let through.
 
             size = os.path.getsize(fpath)
             if size < 10240:
@@ -167,22 +175,42 @@ for base, home_label in config_homes.items():
                             was_exited = True
                             break
 
-            # Re-evaluate freshness using internal timestamp (fallback to mtime).
-            # File mtime can be touched by crash recovery / metadata flush even when
-            # the actual conversation ended earlier; the internal `timestamp` field
-            # on the last logged event reflects real activity.
+            # Re-evaluate freshness using the internal `timestamp` field on
+            # the last logged event. File mtime can be touched by crash
+            # recovery / metadata flush even when the conversation ended
+            # earlier, so the internal timestamp is the more reliable
+            # signal when we have it.
+            #
+            # STRICT_TIMESTAMP mode enforces this as the *only* source of
+            # truth: files whose internal timestamp is missing or
+            # unparseable are dropped instead of silently accepted
+            # (fail-closed, not fail-open). This matches the stated intent
+            # of the flag — "trust the internal timestamp" — and prevents
+            # a corrupt tail from bypassing the cutoff entirely.
+            ts_local = None
             if last_internal_ts:
                 try:
                     ts_local = datetime.datetime.fromisoformat(
                         last_internal_ts.replace("Z", "+00:00")
                     ).astimezone().replace(tzinfo=None)
-                    if ts_local < cutoff:
-                        continue
-                    if cutoff_end and ts_local >= cutoff_end:
-                        continue
-                    mod_time = ts_local.strftime("%m/%d %H:%M")
                 except Exception:
-                    pass
+                    ts_local = None
+
+            if STRICT_TIMESTAMP:
+                if ts_local is None:
+                    # No usable internal timestamp → fail-closed.
+                    continue
+                if ts_local < cutoff:
+                    continue
+                if cutoff_end and ts_local >= cutoff_end:
+                    continue
+                mod_time = ts_local.strftime("%m/%d %H:%M")
+            elif ts_local is not None:
+                if ts_local < cutoff:
+                    continue
+                if cutoff_end and ts_local >= cutoff_end:
+                    continue
+                mod_time = ts_local.strftime("%m/%d %H:%M")
 
             # ── Filtering ──
             if is_teammate:

--- a/skills/recover-sessions/claude-recover-scan
+++ b/skills/recover-sessions/claude-recover-scan
@@ -71,6 +71,7 @@ SCHEDULE_KEYWORDS = [
 
 MIN_USER_MSGS = 4
 TAIL_SIZE = 15
+STRICT_TIMESTAMP = os.environ.get("STRICT_TIMESTAMP") == "1"
 
 results = []
 
@@ -90,10 +91,11 @@ for base, home_label in config_homes.items():
                 continue
 
             mtime = datetime.datetime.fromtimestamp(os.path.getmtime(fpath))
-            if mtime < cutoff:
-                continue
-            if cutoff_end and mtime >= cutoff_end:
-                continue
+            if not STRICT_TIMESTAMP:
+                if mtime < cutoff:
+                    continue
+                if cutoff_end and mtime >= cutoff_end:
+                    continue
 
             size = os.path.getsize(fpath)
             if size < 10240:
@@ -111,6 +113,7 @@ for base, home_label in config_homes.items():
             is_schedule = False
             tail_buf = []
             was_exited = False
+            last_internal_ts = None
 
             with open(fpath) as f:
                 for line in f:
@@ -120,6 +123,10 @@ for base, home_label in config_homes.items():
                         tail_buf.append(obj)
                         if len(tail_buf) > TAIL_SIZE:
                             tail_buf.pop(0)
+
+                        ts_str = obj.get("timestamp")
+                        if ts_str:
+                            last_internal_ts = ts_str
 
                         if not cwd and obj.get("cwd"):
                             cwd = obj["cwd"]
@@ -159,6 +166,23 @@ for base, home_label in config_homes.items():
                         if "/exit" in raw or "/quit" in raw:
                             was_exited = True
                             break
+
+            # Re-evaluate freshness using internal timestamp (fallback to mtime).
+            # File mtime can be touched by crash recovery / metadata flush even when
+            # the actual conversation ended earlier; the internal `timestamp` field
+            # on the last logged event reflects real activity.
+            if last_internal_ts:
+                try:
+                    ts_local = datetime.datetime.fromisoformat(
+                        last_internal_ts.replace("Z", "+00:00")
+                    ).astimezone().replace(tzinfo=None)
+                    if ts_local < cutoff:
+                        continue
+                    if cutoff_end and ts_local >= cutoff_end:
+                        continue
+                    mod_time = ts_local.strftime("%m/%d %H:%M")
+                except Exception:
+                    pass
 
             # ── Filtering ──
             if is_teammate:


### PR DESCRIPTION
Closes #67

## 변경 사항

`claude-recover-scan`이 파일 `mtime` 대신 파일 내부의 마지막 `timestamp` 필드를 사용하도록 개선.

### 핵심

1. **`last_internal_ts` 추적** — 파일 스트림 순회 중 각 객체의 `timestamp` 필드를 누적하여 마지막 값을 보관
2. **cutoff 재평가** — 스캔 완료 후 internal timestamp(UTC → local)를 cutoff와 비교, 범위 밖이면 제외. 표시 시간(`mod_time`)도 internal ts로 override
3. **`STRICT_TIMESTAMP=1` env var** — 설정 시 mtime prefilter를 완전히 건너뛰고 모든 파일을 internal ts 기준으로만 판단. 이슈 제안 #4 충족
4. **Fallback** — internal ts가 없거나 파싱 실패 시 mtime 그대로 사용 (backward compatible)

## 동기 사례

이슈에 인용된 `ec977324` (크리테오 세션):
- mtime: 04/10 15:28 (오늘로 표시되어 복구 대상에 잘못 포함)
- last internal ts: 2026-04-09T08:48 (실제 마지막 대화는 어제)

기본 모드는 mtime prefilter로 통과한 파일들의 시간만 internal ts로 재계산.
`STRICT_TIMESTAMP=1` 모드는 mtime을 완전히 무시하여 위와 같은 케이스를 정확히 처리.

## 테스트

```
$ python3 skills/recover-sessions/claude-recover-scan '' '04-10' '04-10' | wc -l
12

$ STRICT_TIMESTAMP=1 python3 skills/recover-sessions/claude-recover-scan '' '04-10' '04-10' | wc -l
12
```

> 오늘 검증 데이터에서는 mtime과 internal ts가 cutoff 경계를 넘는 사례가 우연히 없어 두 모드 결과가 동일. 이슈 본문의 ec977324 케이스는 어제 발생한 것으로, 향후 동일 패턴이 재발 시 STRICT 모드가 정확히 잡아냅니다.

## 사용법

```bash
# default — mtime prefilter + internal ts re-check
cmux-recover-sessions --list --from 04-10

# strict — internal ts only, mtime prefilter 우회 (느리지만 정확)
STRICT_TIMESTAMP=1 cmux-recover-sessions --list --from 04-10
```

## 영향

- backward-compatible (env var 미설정 시 기본 동작 유지)
- 표시 시간 정확도 향상
- 성능: STRICT 모드만 추가 비용 (모든 파일 stream)