### PR TITLE
feat(recover): dedupe conversation chains

### DIFF
--- a/skills/recover-sessions/claude-recover-scan
+++ b/skills/recover-sessions/claude-recover-scan
@@ -190,5 +190,25 @@ for base, home_label in config_homes.items():
 
 results.sort(key=lambda x: x[0], reverse=True)
 
+# Dedupe conversation chains: same (cwd, normalized first message) → keep newest only.
+# Claude Code creates a new .jsonl with a fresh UUID on every --resume/--continue,
+# so a single logical conversation appears as multiple files. Without dedupe the
+# user gets several workspaces all pointing at the same chain (older snapshots
+# render the conversation from an earlier point and look "reverted").
+# Set NO_DEDUPE=1 to preserve every snapshot (e.g. when the same prompt was used
+# to start independent conversations and you want to inspect both).
+NO_DEDUPE = os.environ.get("NO_DEDUPE") == "1"
+if not NO_DEDUPE:
+    seen_chain_keys = set()
+    deduped = []
+    for entry in results:
+        _, _, _, cwd, msg, _ = entry
+        chain_key = (cwd, msg[:60].strip().lower())
+        if chain_key in seen_chain_keys:
+            continue
+        seen_chain_keys.add(chain_key)
+        deduped.append(entry)
+    results = deduped
+
 for mod_time, size_h, sid, cwd, msg, hlabel in results:
     print(f"{mod_time}|{size_h}|{sid}|{cwd}|{msg}|{hlabel}")

--- a/skills/recover-sessions/claude-recover-scan
+++ b/skills/recover-sessions/claude-recover-scan
@@ -190,20 +190,27 @@ for base, home_label in config_homes.items():
 
 results.sort(key=lambda x: x[0], reverse=True)
 
-# Dedupe conversation chains: same (cwd, normalized first message) → keep newest only.
-# Claude Code creates a new .jsonl with a fresh UUID on every --resume/--continue,
-# so a single logical conversation appears as multiple files. Without dedupe the
-# user gets several workspaces all pointing at the same chain (older snapshots
-# render the conversation from an earlier point and look "reverted").
-# Set NO_DEDUPE=1 to preserve every snapshot (e.g. when the same prompt was used
-# to start independent conversations and you want to inspect both).
+# Dedupe conversation chains: same (home, cwd, normalized first message) →
+# keep newest only. Claude Code creates a new .jsonl with a fresh UUID on
+# every --resume/--continue, so one logical conversation surfaces as many
+# files. Without dedupe the user gets several workspaces all pointing at
+# the same chain (older snapshots render from an earlier point and look
+# "reverted").
+#
+# The chain key is deliberately scoped to `home_label` so that two
+# different Claude config homes (e.g. ~/.claude and ~/.claude-2) cannot
+# be folded into each other even if they share a cwd and prompt — they
+# are separate trust boundaries with separate credentials.
+#
+# Set NO_DEDUPE=1 to preserve every snapshot (useful when the same prompt
+# was used to start independent conversations).
 NO_DEDUPE = os.environ.get("NO_DEDUPE") == "1"
 if not NO_DEDUPE:
     seen_chain_keys = set()
     deduped = []
     for entry in results:
-        _, _, _, cwd, msg, _ = entry
-        chain_key = (cwd, msg[:60].strip().lower())
+        _, _, _, cwd, msg, home_label = entry
+        chain_key = (home_label, cwd, msg[:60].strip().lower())
         if chain_key in seen_chain_keys:
             continue
         seen_chain_keys.add(chain_key)


### PR DESCRIPTION
Closes #63

## 변경 사항

`claude-recover-scan`에 chain dedupe 레이어 추가. 같은 cwd 내에서 첫 user 메시지 prefix(60자, lower+strip 정규화)가 동일한 파일들을 한 chain으로 묶고, **가장 최신 entry 하나만** 결과에 남깁니다.

### 핵심

1. **정렬 후 fold** — `results`는 이미 mod_time 내림차순으로 정렬되므로 같은 chain key의 첫 등장이 곧 최신
2. **chain key**: `(cwd, first_real_msg[:60].strip().lower())`
3. **`NO_DEDUPE=1` env var** — 동일 prompt로 독립 대화를 재시작한 경우 등 양쪽 모두 보존하고 싶을 때
4. **순서 보존** — dedupe 후에도 newest-first 정렬 유지

## 동기 사례

이슈에 인용된 `laplace-web-v2#2076 cogs deploy` 대화:
```
2710bf60: 29 msgs, 0.3M, last 15:39 ★ 최신 → 유지
b8d425d2: 54 msgs, 0.6M, last 14:14         → dedupe로 제외
```

이전에는 두 UUID가 별도 #13/#20으로 등장 → b8d425d2를 열면 "첫 대화 상태"로 보이는 혼란.

## 테스트

```
$ python3 skills/recover-sessions/claude-recover-scan 10 '' '' | wc -l       # default (dedupe ON)
33

$ NO_DEDUPE=1 python3 skills/recover-sessions/claude-recover-scan 10 '' '' | wc -l
38
```

10일 범위에서 **5개 chain 중복**이 자동 제거됨. 단일 일자(04-10)에서는 chain이 없어 차이 없음.

## 영향

- **backward-compatible** — `NO_DEDUPE=1` 미설정 시 기본 dedupe 적용
- 메모리 부담 미미 (set + 작은 list)
- 정확도 향상: 사용자가 같은 chain의 이전 스냅샷을 잘못 열어 "복구 실패"로 오해하는 케이스 제거

## 향후

이슈 #67 PR 머지 후 dedupe 정렬 기준이 mtime → internal timestamp로 자동 전환되어 더 정확해짐. 별도 코드 변경 불필요 (`results`가 이미 그 기준으로 정렬되기 때문).