### PR TITLE
feat(recover): show session uuid in list output

### DIFF
--- a/skills/cmux-recover-sessions/cmux-recover-sessions
+++ b/skills/cmux-recover-sessions/cmux-recover-sessions
@@ -22,7 +22,8 @@ TO_DATE=""
 MODE="tabs"       # tabs | list | split | plain
 SPLIT_LAYOUT=""   # CxR for split mode
 RENAME=false
-FULL_UUID=false
+SHOW_UUID=false   # opt-in: adds a UUID column to the default table output
+FULL_UUID=false   # opt-in: widens UUID column to full 36 chars (implies --show-uuid)
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -34,10 +35,11 @@ while [[ $# -gt 0 ]]; do
     --plain)      MODE="plain"; shift ;;
     --list)       MODE="list"; shift ;;
     --rename)     RENAME=true; shift ;;
-    --full-uuid)  FULL_UUID=true; shift ;;
+    --show-uuid)  SHOW_UUID=true; shift ;;
+    --full-uuid)  SHOW_UUID=true; FULL_UUID=true; shift ;;
     -h|--help)
       cat << 'HELP'
-Usage: cmux-recover-sessions [--days N | --from DATE --to DATE] [--tabs|--split CxR|--plain] [--list] [--rename] [--full-uuid]
+Usage: cmux-recover-sessions [--days N | --from DATE --to DATE] [--tabs|--split CxR|--plain] [--list] [--rename] [--show-uuid|--full-uuid]
 
 Options:
   --days N        Scan last N days (default: 1)
@@ -48,7 +50,8 @@ Options:
   --plain         Output resume commands only (no workspace creation)
   --list          List recovery targets only
   --rename        Auto-rename workspaces with session info
-  --full-uuid     Show the full session UUID instead of the first 8 chars
+  --show-uuid     Add a UUID column (8-char prefix) to the table output
+  --full-uuid     Same as --show-uuid but widens the column to the full 36 chars
 
 Examples:
   cmux-recover-sessions --list --days 3
@@ -115,29 +118,42 @@ echo "║  Claude Code Session Recovery (cmux) — ${#SESSIONS[@]} sessions foun
 echo "╚══════════════════════════════════════════════════════════════╝"
 echo ""
 
+# Default output preserves the legacy 6-column schema so existing parsers
+# (awk / cut / grep -o) don't silently shift. UUID column is opt-in.
 if $FULL_UUID; then
-  fmt="%-4s %-12s %-5s %-37s %-8s %-32s %s\n"
+  fmt="%-4s %-12s %-5s %-37s %-8s %-30s %s\n"
+elif $SHOW_UUID; then
+  fmt="%-4s %-12s %-5s %-9s %-8s %-30s %s\n"
 else
-  fmt="%-4s %-12s %-5s %-9s %-8s %-32s %s\n"
+  fmt="%-4s %-12s %-5s %-8s %-34s %s\n"
 fi
 
 # shellcheck disable=SC2059
-printf "$fmt" "#" "TIME" "SIZE" "UUID" "HOME" "PROJECT" "FIRST MESSAGE"
-# shellcheck disable=SC2059
-printf "$fmt" "---" "----------" "----" "----" "------" "-------" "-------------"
+if $SHOW_UUID; then
+  printf "$fmt" "#" "TIME" "SIZE" "UUID" "HOME" "PROJECT" "FIRST MESSAGE"
+  printf "$fmt" "---" "----------" "----" "----" "------" "-------" "-------------"
+else
+  printf "$fmt" "#" "TIME" "SIZE" "HOME" "PROJECT" "FIRST MESSAGE"
+  printf "$fmt" "---" "----------" "----" "------" "-------" "-------------"
+fi
 
 for i in "${!SESSIONS[@]}"; do
   IFS='|' read -r mod_time size session_id project_dir first_msg home_label <<< "${SESSIONS[$i]}"
   idx=$((i + 1))
-  short_project=$(echo "$project_dir" | sed "s|$HOME/projects/||; s|$HOME/||" | cut -c1-30)
-  short_msg=$(echo "$first_msg" | cut -c1-45)
-  if $FULL_UUID; then
-    uuid_display="$session_id"
+  if $SHOW_UUID; then
+    short_project=$(echo "$project_dir" | sed "s|$HOME/projects/||; s|$HOME/||" | cut -c1-30)
   else
-    uuid_display="${session_id:0:8}"
+    short_project=$(echo "$project_dir" | sed "s|$HOME/projects/||; s|$HOME/||" | cut -c1-32)
   fi
+  short_msg=$(echo "$first_msg" | cut -c1-45)
   # shellcheck disable=SC2059
-  printf "$fmt" "$idx" "$mod_time" "$size" "$uuid_display" "$home_label" "$short_project" "$short_msg"
+  if $FULL_UUID; then
+    printf "$fmt" "$idx" "$mod_time" "$size" "$session_id" "$home_label" "$short_project" "$short_msg"
+  elif $SHOW_UUID; then
+    printf "$fmt" "$idx" "$mod_time" "$size" "${session_id:0:8}" "$home_label" "$short_project" "$short_msg"
+  else
+    printf "$fmt" "$idx" "$mod_time" "$size" "$home_label" "$short_project" "$short_msg"
+  fi
 done
 
 echo ""

--- a/skills/cmux-recover-sessions/cmux-recover-sessions
+++ b/skills/cmux-recover-sessions/cmux-recover-sessions
@@ -22,20 +22,22 @@ TO_DATE=""
 MODE="tabs"       # tabs | list | split | plain
 SPLIT_LAYOUT=""   # CxR for split mode
 RENAME=false
+FULL_UUID=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --days)    DAYS_AGO="$2"; shift 2 ;;
-    --from)    FROM_DATE="$2"; shift 2 ;;
-    --to)      TO_DATE="$2"; shift 2 ;;
-    --tabs)    MODE="tabs"; shift ;;
-    --split)   MODE="split"; SPLIT_LAYOUT="$2"; shift 2 ;;
-    --plain)   MODE="plain"; shift ;;
-    --list)    MODE="list"; shift ;;
-    --rename)  RENAME=true; shift ;;
+    --days)       DAYS_AGO="$2"; shift 2 ;;
+    --from)       FROM_DATE="$2"; shift 2 ;;
+    --to)         TO_DATE="$2"; shift 2 ;;
+    --tabs)       MODE="tabs"; shift ;;
+    --split)      MODE="split"; SPLIT_LAYOUT="$2"; shift 2 ;;
+    --plain)      MODE="plain"; shift ;;
+    --list)       MODE="list"; shift ;;
+    --rename)     RENAME=true; shift ;;
+    --full-uuid)  FULL_UUID=true; shift ;;
     -h|--help)
       cat << 'HELP'
-Usage: cmux-recover-sessions [--days N | --from DATE --to DATE] [--tabs|--split CxR|--plain] [--list] [--rename]
+Usage: cmux-recover-sessions [--days N | --from DATE --to DATE] [--tabs|--split CxR|--plain] [--list] [--rename] [--full-uuid]
 
 Options:
   --days N        Scan last N days (default: 1)
@@ -46,6 +48,7 @@ Options:
   --plain         Output resume commands only (no workspace creation)
   --list          List recovery targets only
   --rename        Auto-rename workspaces with session info
+  --full-uuid     Show the full session UUID instead of the first 8 chars
 
 Examples:
   cmux-recover-sessions --list --days 3
@@ -112,15 +115,29 @@ echo "║  Claude Code Session Recovery (cmux) — ${#SESSIONS[@]} sessions foun
 echo "╚══════════════════════════════════════════════════════════════╝"
 echo ""
 
-printf "%-4s %-12s %-5s %-8s %-34s %s\n" "#" "TIME" "SIZE" "HOME" "PROJECT" "FIRST MESSAGE"
-printf "%-4s %-12s %-5s %-8s %-34s %s\n" "---" "----------" "----" "------" "-------" "-------------"
+if $FULL_UUID; then
+  fmt="%-4s %-12s %-5s %-37s %-8s %-32s %s\n"
+else
+  fmt="%-4s %-12s %-5s %-9s %-8s %-32s %s\n"
+fi
+
+# shellcheck disable=SC2059
+printf "$fmt" "#" "TIME" "SIZE" "UUID" "HOME" "PROJECT" "FIRST MESSAGE"
+# shellcheck disable=SC2059
+printf "$fmt" "---" "----------" "----" "----" "------" "-------" "-------------"
 
 for i in "${!SESSIONS[@]}"; do
   IFS='|' read -r mod_time size session_id project_dir first_msg home_label <<< "${SESSIONS[$i]}"
   idx=$((i + 1))
-  short_project=$(echo "$project_dir" | sed "s|$HOME/projects/||; s|$HOME/||" | cut -c1-32)
+  short_project=$(echo "$project_dir" | sed "s|$HOME/projects/||; s|$HOME/||" | cut -c1-30)
   short_msg=$(echo "$first_msg" | cut -c1-45)
-  printf "%-4s %-12s %-5s %-8s %-34s %s\n" "$idx" "$mod_time" "$size" "$home_label" "$short_project" "$short_msg"
+  if $FULL_UUID; then
+    uuid_display="$session_id"
+  else
+    uuid_display="${session_id:0:8}"
+  fi
+  # shellcheck disable=SC2059
+  printf "$fmt" "$idx" "$mod_time" "$size" "$uuid_display" "$home_label" "$short_project" "$short_msg"
 done
 
 echo ""


### PR DESCRIPTION
Closes #65

## 변경 사항

`cmux-recover-sessions`의 `--list` (및 일반 출력) 테이블에 **UUID 컬럼** 추가. session UUID는 다음 용도로 자주 필요합니다:
- 디버깅 / cross-reference (어느 .jsonl 파일이 어느 세션인지)
- 수동 `claude --resume <uuid>` 실행
- 다른 도구로 파이프

### 핵심

- `--full-uuid` 플래그 추가 — 미설정 시 기본값은 **8자 prefix** (기존 컬럼 폭 유지)
- 기본 모드에서 PROJECT 컬럼을 32 → 30 chars로 조정하여 UUID 공간 확보
- 포맷 문자열 `$fmt`을 사전 계산하여 헤더/데이터 row 일관성 보장

## 출력 예시

### Default (8자)
```
#    TIME         SIZE  UUID      HOME     PROJECT                        FIRST MESSAGE
---  ----------   ----  ----      ------   -------                        -------------
1    04/10 23:32  5.1M  8aa39fa3  claude   airflow-v3/laplace-dev-hub     원본을 제공해줬습니다.
2    04/10 18:05  383K  1356bef9  claude   airflow-v3/laplace-dev-hub     Create a weekly achievement summary
```

### `--full-uuid`
```
#    TIME         SIZE  UUID                                  HOME     PROJECT                        FIRST MESSAGE
---  ----------   ----  ----                                  ------   -------                        -------------
1    04/10 23:32  5.1M  8aa39fa3-f2e3-4f73-bbca-22dddaae604b  claude   airflow-v3/laplace-dev-hub     원본을 제공해줬습니다.
2    04/10 18:05  383K  1356bef9-6fda-41f9-bff1-1fbedac56e1b  claude   airflow-v3/laplace-dev-hub     Create a weekly achievement summary
```

## 영향

- backward-compatible (기본 모드에서 컬럼 추가만, 기존 컬럼 너비만 미세 조정)
- 사용자가 `cmux send --workspace N "claude --resume <uuid>"` 같은 수동 작업 시 UUID를 즉시 확인 가능