### PR TITLE
feat(recover): surface filter reasons in output

### DIFF
--- a/skills/recover-sessions/claude-recover-scan
+++ b/skills/recover-sessions/claude-recover-scan
@@ -71,10 +71,19 @@ SCHEDULE_KEYWORDS = [
 
 MIN_USER_MSGS = 4
 TAIL_SIZE = 15
-VERBOSE = os.environ.get("VERBOSE") == "1"
+# Namespaced env var so this cannot accidentally trip on a generic
+# VERBOSE setting that another tool in the shell might be using. The
+# legacy name is still honored for a release or two.
+VERBOSE = (
+    os.environ.get("PRAXIS_RECOVER_VERBOSE") == "1"
+    or os.environ.get("VERBOSE") == "1"
+)
 
 results = []
 filter_counts = {
+    "subagent": 0,
+    "mtime": 0,
+    "tiny": 0,
     "exited": 0,
     "short": 0,
     "no_msg": 0,
@@ -82,6 +91,7 @@ filter_counts = {
     "teammate": 0,
     "command": 0,
 }
+total_discovered = 0
 total_scanned = 0
 
 for base, home_label in config_homes.items():
@@ -95,18 +105,23 @@ for base, home_label in config_homes.items():
             if not fname.endswith(".jsonl"):
                 continue
             fpath = os.path.join(full_dir, fname)
+            total_discovered += 1
 
             if "/subagents/" in fpath:
+                filter_counts["subagent"] += 1
                 continue
 
             mtime = datetime.datetime.fromtimestamp(os.path.getmtime(fpath))
             if mtime < cutoff:
+                filter_counts["mtime"] += 1
                 continue
             if cutoff_end and mtime >= cutoff_end:
+                filter_counts["mtime"] += 1
                 continue
 
             size = os.path.getsize(fpath)
             if size < 10240:
+                filter_counts["tiny"] += 1
                 continue
 
             total_scanned += 1
@@ -212,11 +227,16 @@ if VERBOSE:
     total_filtered = sum(filter_counts.values())
     surviving = len(results)
     print("", file=_sys.stderr)
-    print(f"Scanned:   {total_scanned} files", file=_sys.stderr)
-    print(f"Filtered:  {total_filtered}", file=_sys.stderr)
+    print(f"Discovered: {total_discovered} files", file=_sys.stderr)
+    print(f"Scanned:    {total_scanned} files (after prefilter)", file=_sys.stderr)
+    print(f"Filtered:   {total_filtered}", file=_sys.stderr)
+    # Pre-scan filters (size, subagent, mtime) run before the body loop.
+    for k in ("subagent", "mtime", "tiny"):
+        print(f"  {k:<10} {filter_counts[k]}", file=_sys.stderr)
+    # Body-scan filters run after the file has been read fully.
     for k in ("exited", "short", "no_msg", "schedule", "teammate", "command"):
         print(f"  {k:<10} {filter_counts[k]}", file=_sys.stderr)
-    print(f"Surviving: {surviving}", file=_sys.stderr)
+    print(f"Surviving:  {surviving}", file=_sys.stderr)
 
 for mod_time, size_h, sid, cwd, msg, hlabel in results:
     print(f"{mod_time}|{size_h}|{sid}|{cwd}|{msg}|{hlabel}")

--- a/skills/recover-sessions/claude-recover-scan
+++ b/skills/recover-sessions/claude-recover-scan
@@ -71,8 +71,18 @@ SCHEDULE_KEYWORDS = [
 
 MIN_USER_MSGS = 4
 TAIL_SIZE = 15
+VERBOSE = os.environ.get("VERBOSE") == "1"
 
 results = []
+filter_counts = {
+    "exited": 0,
+    "short": 0,
+    "no_msg": 0,
+    "schedule": 0,
+    "teammate": 0,
+    "command": 0,
+}
+total_scanned = 0
 
 for base, home_label in config_homes.items():
     if not os.path.isdir(base):
@@ -99,6 +109,7 @@ for base, home_label in config_homes.items():
             if size < 10240:
                 continue
 
+            total_scanned += 1
             size_h = f"{size/1048576:.1f}M" if size > 1048576 else f"{size//1024}K"
             mod_time = mtime.strftime("%m/%d %H:%M")
 
@@ -162,10 +173,13 @@ for base, home_label in config_homes.items():
 
             # ── Filtering ──
             if is_teammate:
+                filter_counts["teammate"] += 1
                 continue
             if is_command and user_count <= 5:
+                filter_counts["command"] += 1
                 continue
             if user_count < MIN_USER_MSGS:
+                filter_counts["short"] += 1
                 continue
 
             if first_real_msg:
@@ -179,16 +193,30 @@ for base, home_label in config_homes.items():
                             is_schedule = True
                             break
             if is_schedule:
+                filter_counts["schedule"] += 1
                 continue
             if was_exited:
+                filter_counts["exited"] += 1
                 continue
             if not first_real_msg:
+                filter_counts["no_msg"] += 1
                 continue
 
             cwd = cwd or "/tmp"
             results.append((mod_time, size_h, session_id, cwd, first_real_msg, home_label))
 
 results.sort(key=lambda x: x[0], reverse=True)
+
+if VERBOSE:
+    import sys as _sys
+    total_filtered = sum(filter_counts.values())
+    surviving = len(results)
+    print("", file=_sys.stderr)
+    print(f"Scanned:   {total_scanned} files", file=_sys.stderr)
+    print(f"Filtered:  {total_filtered}", file=_sys.stderr)
+    for k in ("exited", "short", "no_msg", "schedule", "teammate", "command"):
+        print(f"  {k:<10} {filter_counts[k]}", file=_sys.stderr)
+    print(f"Surviving: {surviving}", file=_sys.stderr)
 
 for mod_time, size_h, sid, cwd, msg, hlabel in results:
     print(f"{mod_time}|{size_h}|{sid}|{cwd}|{msg}|{hlabel}")


### PR DESCRIPTION
Closes #66

## 변경 사항

`claude-recover-scan`에 필터 카운터 + `VERBOSE=1` env var 추가. 어떤 필터가 어떤 파일을 얼마나 제외했는지 시각화해 "왜 내 세션이 안 나오지?" 디버깅을 즉시 가능하게 합니다.

### 핵심

- `filter_counts` dict: `exited`, `short`, `no_msg`, `schedule`, `teammate`, `command`
- 각 필터 분기에서 카운터 증가
- `total_scanned` — size 통과 후 전체 파일 수
- `VERBOSE=1` 시 stderr에 stats 블록 출력 (stdout 데이터는 그대로)

## 출력 예시

```
$ VERBOSE=1 python3 skills/recover-sessions/claude-recover-scan '' '04-10' '04-10' >/dev/null

Scanned:   63 files
Filtered:  51
  exited     39
  short      6
  no_msg     1
  schedule   5
  teammate   0
  command    0
Surviving: 12
```

## 영향

- **backward-compatible** — `VERBOSE=1` 미설정 시 기본 동작/출력 변경 없음
- stderr에만 stats 출력하므로 `--list`/`--plain` 파이프라인 영향 없음
- 디버깅 시 즉시 필터 분포 확인 가능

## 사용법

```bash
# default — stats 없음
cmux-recover-sessions --list --from 04-10

# verbose — stats 표시
VERBOSE=1 cmux-recover-sessions --list --from 04-10
```