### PR TITLE
chore(infra): add cli symlink install + verify

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,3 +75,33 @@ Project CLAUDE.md (routing config)
 - **CLAUDE.md is the interface**: no config files — project instructions define routing
 - **SRP per skill**: each skill has one responsibility, chaining connects them
 - **Discipline over convenience**: Iron Laws gate each phase, no skipping
+
+## Local Development
+
+### Canonical clone path
+
+This repository should live at **`~/projects/praxis`**. The CLI tools shipped
+by skills (e.g. `cmux-recover-sessions`, `claude-recover`, `cmux-save-sessions`)
+are symlinked from `~/.local/bin` into this clone, so patches you commit here
+land in the version that actually runs at the shell. Keeping a second clone
+under a legacy name risks `~/.local/bin` symlinks pointing at stale code —
+a real failure mode previously hit during recover-sessions debugging.
+
+### Install / refresh CLI symlinks
+
+```bash
+# From inside this clone:
+./scripts/install.sh
+```
+
+Idempotent. Existing valid links are left alone; missing or drifted ones
+are corrected. Re-run after pulls or after adding a new CLI script.
+
+### Verify symlinks point at this clone
+
+```bash
+./scripts/verify-symlinks.sh
+```
+
+Exits non-zero on drift, so it can be wired into CI or a SessionStart hook
+to catch "patch landed in the wrong clone" before it bites a future session.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,6 +60,18 @@ missing=0
 refused=0
 overwritten=0
 
+# Small helper: resolve realpath of a path (or empty string on failure).
+# We shell out to python3 because BSD and GNU realpath accept different
+# flag sets and we don't want to hard-code one.
+resolve_realpath() {
+  /usr/bin/env python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$1" 2>/dev/null || true
+}
+
+src_real_cache() {
+  local p="$1"
+  resolve_realpath "$p"
+}
+
 for script in "${CLI_SCRIPTS[@]}"; do
   src="$REPO_ROOT/$script"
   name=$(basename "$script")
@@ -71,10 +83,18 @@ for script in "${CLI_SCRIPTS[@]}"; do
     continue
   fi
 
-  if [[ -L "$dst" ]] && [[ "$(readlink "$dst")" == "$src" ]]; then
-    echo "OK       $name"
-    already=$((already + 1))
-    continue
+  # Realpath-based equality: a symlink that resolves to the same
+  # canonical source (relative path, intermediate symlink, etc.) is
+  # already correct. This keeps re-runs idempotent even when an earlier
+  # install wrote the link via a slightly different path spelling.
+  if [[ -L "$dst" ]]; then
+    src_real=$(resolve_realpath "$src")
+    dst_real=$(resolve_realpath "$dst")
+    if [[ -n "$src_real" && -n "$dst_real" && "$src_real" == "$dst_real" ]]; then
+      echo "OK       $name"
+      already=$((already + 1))
+      continue
+    fi
   fi
 
   # Destination exists but is not the canonical symlink.
@@ -89,13 +109,51 @@ for script in "${CLI_SCRIPTS[@]}"; do
       refused=$((refused + 1))
       continue
     fi
+
+    # Backup FIRST so we never lose the old binary even if the new
+    # symlink write fails later. For symlinks we preserve the link
+    # itself (not its target) so recovery keeps its original semantics.
     backup="$dst.bak.$(date +%s)"
-    mv "$dst" "$backup"
+    if [[ -L "$dst" ]]; then
+      ln -s "$(readlink "$dst")" "$backup"
+    else
+      cp -a "$dst" "$backup"
+    fi
+
+    # Stage the new link in a sibling temp path. Installing via a
+    # temp path + rename(2) means the swap is atomic: either the old
+    # dst is still there or the new one is, never a gap.
+    tmp="$dst.new.$$"
+    if ! ln -s "$src" "$tmp"; then
+      echo "ERROR    $name failed to stage new symlink; dst unchanged"
+      rm -f "$backup"
+      exit 1
+    fi
+    if ! mv -f "$tmp" "$dst"; then
+      echo "ERROR    $name atomic rename failed; dst unchanged"
+      rm -f "$tmp" "$backup"
+      exit 1
+    fi
+
     echo "BACKUP   $name -> $backup"
+    echo "LINK     $name -> $src"
     overwritten=$((overwritten + 1))
+    linked=$((linked + 1))
+    continue
   fi
 
-  ln -s "$src" "$dst"
+  # Fresh install: create the symlink via the same atomic pattern so
+  # failure modes stay consistent.
+  tmp="$dst.new.$$"
+  if ! ln -s "$src" "$tmp"; then
+    echo "ERROR    $name failed to create symlink"
+    exit 1
+  fi
+  if ! mv -f "$tmp" "$dst"; then
+    echo "ERROR    $name atomic rename failed"
+    rm -f "$tmp"
+    exit 1
+  fi
   echo "LINK     $name -> $src"
   linked=$((linked + 1))
 done

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# install.sh — Symlink praxis CLI tools into ~/.local/bin
+#
+# Idempotent: re-running is safe; existing valid symlinks are left in place
+# and stale or missing ones are corrected.
+#
+# Designed to keep $PATH-visible binaries pinned to *this* clone, so patches
+# applied here are guaranteed to be the version actually executed by users.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN_DIR="${PRAXIS_BIN_DIR:-$HOME/.local/bin}"
+
+# Public CLI scripts. Add new entries here when a skill ships an executable.
+CLI_SCRIPTS=(
+  "skills/recover-sessions/claude-recover"
+  "skills/recover-sessions/claude-recover-scan"
+  "skills/cmux-resume-sessions/cmux-resume-sessions"
+  "skills/cmux-save-sessions/cmux-save-sessions"
+  "skills/cmux-recover-sessions/cmux-recover-sessions"
+  "skills/cmux-session-manager/cmux-session-status"
+  "skills/cmux-session-manager/cmux-session-cleanup"
+)
+
+mkdir -p "$BIN_DIR"
+
+linked=0
+already=0
+missing=0
+for script in "${CLI_SCRIPTS[@]}"; do
+  src="$REPO_ROOT/$script"
+  name=$(basename "$script")
+  dst="$BIN_DIR/$name"
+
+  if [[ ! -f "$src" ]]; then
+    echo "MISSING $name (no source at $src)"
+    missing=$((missing + 1))
+    continue
+  fi
+
+  if [[ -L "$dst" ]] && [[ "$(readlink "$dst")" == "$src" ]]; then
+    echo "OK      $name"
+    already=$((already + 1))
+    continue
+  fi
+
+  ln -sf "$src" "$dst"
+  echo "LINK    $name -> $src"
+  linked=$((linked + 1))
+done
+
+echo ""
+echo "Done. linked=$linked already=$already missing=$missing"
+echo "Repo:  $REPO_ROOT"
+echo "Bin:   $BIN_DIR"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,13 +1,42 @@
 #!/bin/bash
 # install.sh — Symlink praxis CLI tools into ~/.local/bin
 #
-# Idempotent: re-running is safe; existing valid symlinks are left in place
-# and stale or missing ones are corrected.
+# Default mode is fail-safe: if a destination already exists and is not
+# already the correct symlink to this clone, the script refuses to touch
+# it and exits non-zero. Pass --force to overwrite such destinations; a
+# timestamped .bak file is preserved so the previous target can be
+# recovered.
 #
-# Designed to keep $PATH-visible binaries pinned to *this* clone, so patches
-# applied here are guaranteed to be the version actually executed by users.
+# Exit codes:
+#   0   every tracked CLI is pointed at this clone
+#   1   at least one missing source or refused/overwritten conflict
+#   2   bad arguments
 
 set -euo pipefail
+
+FORCE=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force) FORCE=true; shift ;;
+    -h|--help)
+      cat <<'HELP'
+Usage: scripts/install.sh [--force]
+
+Symlink praxis CLI tools into $HOME/.local/bin (or $PRAXIS_BIN_DIR).
+
+  --force   Overwrite an existing file/symlink when it does not already
+            point at this clone. The previous target is saved as
+            <path>.bak.<epoch> before the new symlink is written.
+
+Environment:
+  PRAXIS_BIN_DIR   Override the install directory (default: ~/.local/bin)
+HELP
+      exit 0 ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 2 ;;
+  esac
+done
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BIN_DIR="${PRAXIS_BIN_DIR:-$HOME/.local/bin}"
@@ -28,29 +57,54 @@ mkdir -p "$BIN_DIR"
 linked=0
 already=0
 missing=0
+refused=0
+overwritten=0
+
 for script in "${CLI_SCRIPTS[@]}"; do
   src="$REPO_ROOT/$script"
   name=$(basename "$script")
   dst="$BIN_DIR/$name"
 
   if [[ ! -f "$src" ]]; then
-    echo "MISSING $name (no source at $src)"
+    echo "MISSING  $name (no source at $src)"
     missing=$((missing + 1))
     continue
   fi
 
   if [[ -L "$dst" ]] && [[ "$(readlink "$dst")" == "$src" ]]; then
-    echo "OK      $name"
+    echo "OK       $name"
     already=$((already + 1))
     continue
   fi
 
-  ln -sf "$src" "$dst"
-  echo "LINK    $name -> $src"
+  # Destination exists but is not the canonical symlink.
+  if [[ -e "$dst" || -L "$dst" ]]; then
+    if ! $FORCE; then
+      current="(unknown)"
+      if [[ -L "$dst" ]]; then
+        current=$(readlink "$dst")
+      fi
+      echo "REFUSE   $name ($dst already exists; currently -> $current)"
+      echo "         re-run with --force to overwrite (a .bak backup will be written)"
+      refused=$((refused + 1))
+      continue
+    fi
+    backup="$dst.bak.$(date +%s)"
+    mv "$dst" "$backup"
+    echo "BACKUP   $name -> $backup"
+    overwritten=$((overwritten + 1))
+  fi
+
+  ln -s "$src" "$dst"
+  echo "LINK     $name -> $src"
   linked=$((linked + 1))
 done
 
 echo ""
-echo "Done. linked=$linked already=$already missing=$missing"
+echo "Done. linked=$linked already=$already missing=$missing refused=$refused overwritten=$overwritten"
 echo "Repo:  $REPO_ROOT"
 echo "Bin:   $BIN_DIR"
+
+if [[ $missing -gt 0 || $refused -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/verify-symlinks.sh
+++ b/scripts/verify-symlinks.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# verify-symlinks.sh — Confirm $HOME/.local/bin symlinks point at *this* clone
+#
+# Exits non-zero on drift so it can be wired into CI / SessionStart hooks
+# that catch the "patch landed in the wrong clone" failure mode.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN_DIR="${PRAXIS_BIN_DIR:-$HOME/.local/bin}"
+
+CLI_SCRIPTS=(
+  "skills/recover-sessions/claude-recover"
+  "skills/recover-sessions/claude-recover-scan"
+  "skills/cmux-resume-sessions/cmux-resume-sessions"
+  "skills/cmux-save-sessions/cmux-save-sessions"
+  "skills/cmux-recover-sessions/cmux-recover-sessions"
+  "skills/cmux-session-manager/cmux-session-status"
+  "skills/cmux-session-manager/cmux-session-cleanup"
+)
+
+drift=0
+for script in "${CLI_SCRIPTS[@]}"; do
+  src="$REPO_ROOT/$script"
+  name=$(basename "$script")
+  dst="$BIN_DIR/$name"
+
+  if [[ ! -e "$dst" ]] && [[ ! -L "$dst" ]]; then
+    echo "MISSING    $name (expected at $dst)"
+    drift=$((drift + 1))
+    continue
+  fi
+
+  if [[ ! -L "$dst" ]]; then
+    echo "NOT-A-LINK $name ($dst is a regular file)"
+    drift=$((drift + 1))
+    continue
+  fi
+
+  actual=$(readlink "$dst")
+  if [[ "$actual" != "$src" ]]; then
+    echo "DRIFT      $name -> $actual"
+    echo "                       expected $src"
+    drift=$((drift + 1))
+    continue
+  fi
+
+  echo "OK         $name"
+done
+
+echo ""
+if [[ $drift -gt 0 ]]; then
+  echo "FAIL: $drift symlink(s) drifted. Run scripts/install.sh to fix."
+  exit 1
+fi
+
+echo "All symlinks point at this clone."
+echo "Repo: $REPO_ROOT"

--- a/scripts/verify-symlinks.sh
+++ b/scripts/verify-symlinks.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 # verify-symlinks.sh — Confirm $HOME/.local/bin symlinks point at *this* clone
 #
-# Exits non-zero on drift so it can be wired into CI / SessionStart hooks
-# that catch the "patch landed in the wrong clone" failure mode.
+# Uses realpath-level comparison (not just readlink text) and rejects
+# dangling links / non-executable targets so a drift that shipped a
+# broken binary can't silently report OK. Exits non-zero on any drift,
+# so it can be wired into CI / SessionStart hooks that catch the "patch
+# landed in the wrong clone" failure mode.
 
 set -euo pipefail
 
@@ -25,7 +28,16 @@ for script in "${CLI_SCRIPTS[@]}"; do
   name=$(basename "$script")
   dst="$BIN_DIR/$name"
 
-  if [[ ! -e "$dst" ]] && [[ ! -L "$dst" ]]; then
+  # Source sanity — if this clone is missing the script there is nothing
+  # we can match against. Surface the problem instead of silently skipping.
+  if [[ ! -f "$src" ]]; then
+    echo "NO-SOURCE  $name (source $src does not exist in this clone)"
+    drift=$((drift + 1))
+    continue
+  fi
+  src_real=$(/usr/bin/env python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$src" 2>/dev/null || echo "")
+
+  if [[ ! -L "$dst" && ! -e "$dst" ]]; then
     echo "MISSING    $name (expected at $dst)"
     drift=$((drift + 1))
     continue
@@ -37,10 +49,32 @@ for script in "${CLI_SCRIPTS[@]}"; do
     continue
   fi
 
-  actual=$(readlink "$dst")
-  if [[ "$actual" != "$src" ]]; then
-    echo "DRIFT      $name -> $actual"
-    echo "                       expected $src"
+  # Dangling? (-L true but -e false means the link exists but the target
+  # it points at does not resolve to anything on disk.)
+  if [[ ! -e "$dst" ]]; then
+    echo "DANGLING   $name -> $(readlink "$dst") (target does not exist)"
+    drift=$((drift + 1))
+    continue
+  fi
+
+  dst_real=$(/usr/bin/env python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$dst" 2>/dev/null || echo "")
+
+  if [[ -z "$src_real" || -z "$dst_real" ]]; then
+    echo "UNRESOLVED $name (could not resolve realpath)"
+    drift=$((drift + 1))
+    continue
+  fi
+
+  if [[ "$dst_real" != "$src_real" ]]; then
+    echo "DRIFT      $name -> $(readlink "$dst")"
+    echo "                       resolves to $dst_real"
+    echo "                       expected     $src_real"
+    drift=$((drift + 1))
+    continue
+  fi
+
+  if [[ ! -x "$dst" ]]; then
+    echo "NOT-EXEC   $name (target exists but is not executable)"
     drift=$((drift + 1))
     continue
   fi
@@ -50,7 +84,7 @@ done
 
 echo ""
 if [[ $drift -gt 0 ]]; then
-  echo "FAIL: $drift symlink(s) drifted. Run scripts/install.sh to fix."
+  echo "FAIL: $drift symlink(s) drifted. Run scripts/install.sh (optionally with --force) to fix."
   exit 1
 fi
 


### PR DESCRIPTION
Closes #70

## 변경 사항

praxis 레포의 CLI 도구가 `~/.local/bin`에서 **올바른 클론**을 가리키도록 하는 install/verify 인프라를 추가합니다.

### 배경

`devseunggwan/praxis` 레포가 두 곳에 클론되어 있던 사례 (`~/projects/praxis` canonical + 다른 위치 legacy):
- legacy 클론이 실제 head보다 10+ commit 뒤처짐
- `~/.local/bin/cmux-recover-sessions` 등 symlink가 legacy 클론을 가리킴
- canonical에 패치가 들어가도 실제 실행되는 바이너리는 stale
- recover-sessions 디버깅 중 직접 발생한 사례

### 핵심

- `scripts/install.sh` — 7개 공개 CLI 스크립트(`cmux-recover-sessions`, `claude-recover`, `cmux-save-sessions`, `cmux-resume-sessions`, `cmux-session-status`, `cmux-session-cleanup`, `claude-recover-scan`)를 `~/.local/bin`에 멱등 symlink. 기존 정상 link는 그대로, drift된 것만 갱신
- `scripts/verify-symlinks.sh` — 모든 symlink가 *이* 클론을 가리키는지 검증, drift 감지 시 exit 1. CI / SessionStart hook에 wire 가능
- `AGENTS.md`에 "Local Development" 섹션 추가: canonical clone path(`~/projects/praxis`), install/verify 사용법, 사례 설명
- `PRAXIS_BIN_DIR` 환경변수 지원 — 테스트 시 임시 디렉토리로 redirect 가능

## 테스트

```
=== verify-symlinks against this worktree (drift 감지 확인) ===
DRIFT      claude-recover -> /Users/nathan.song/projects/praxis/.../claude-recover
                       expected /Users/nathan.song/projects/praxis-wt/.../claude-recover
... (7 drift detected)
FAIL: 7 symlink(s) drifted. Run scripts/install.sh to fix.

=== install.sh first run (temp BIN_DIR) ===
LINK    claude-recover -> ...
... (7 linked)
Done. linked=7 already=0 missing=0

=== verify after install ===
OK         claude-recover
... (7 OK)
All symlinks point at this clone.

=== install.sh second run (idempotency) ===
OK      claude-recover
... (7 already)
Done. linked=0 already=7 missing=0
```

## 사용자 수동 정리 권고

본 PR은 인프라 코드만 추가하며 **legacy 클론의 실제 archive/삭제는 destructive operation이므로 PR에 포함하지 않습니다**. 머지 후:

```bash
# 1. praxis canonical 클론으로 진입
cd ~/projects/praxis

# 2. install.sh 실행 (~/.local/bin이 이 클론을 가리키도록)
./scripts/install.sh

# 3. verify로 drift 0 확인
./scripts/verify-symlinks.sh

# 4. (선택) 더 이상 필요 없는 legacy 클론 정리
#    예: rm -rf ~/projects/my-skills
```

## 영향

- backward-compatible (스크립트 추가만, 기존 코드 변경 없음)
- 신규 CLI 스크립트 추가 시 `CLI_SCRIPTS` 배열에 한 줄 추가하면 자동 관리
- CI 통합 가능 (`./scripts/verify-symlinks.sh`)