### PR TITLE
docs(recover): clarify resume vs recover skills

### DIFF
--- a/skills/cmux-recover-sessions/SKILL.md
+++ b/skills/cmux-recover-sessions/SKILL.md
@@ -5,7 +5,11 @@ description: >
   by scanning the .jsonl files Claude Code persists automatically. Interactive
   interview chooses recovery scope and layout. Use this when sessions died and
   you need them back, NOT for restoring an intentionally saved layout.
-  If the request mentions "snapshot" or "json" as the source, prefer cmux-resume-sessions instead.
+  Priority: crash context wins. If the request mentions a crash/power loss/OOM,
+  prefer this skill even when the user also mentions a snapshot — the snapshot
+  may be stale, and .jsonl scan reflects the real final state.
+  Only defer to cmux-resume-sessions when there is NO crash context and the user
+  explicitly wants to rehydrate a saved snapshot.
   Triggers on "터졌다", "크래시 복구", "크래시 복원", "전원 꺼짐 복구", "OOM 복구", "세션 살려야", "recover cmux", "crash recovery", "power loss recovery", "cmux session recovery".
 ---
 

--- a/skills/cmux-recover-sessions/SKILL.md
+++ b/skills/cmux-recover-sessions/SKILL.md
@@ -5,7 +5,8 @@ description: >
   by scanning the .jsonl files Claude Code persists automatically. Interactive
   interview chooses recovery scope and layout. Use this when sessions died and
   you need them back, NOT for restoring an intentionally saved layout.
-  Triggers on "터졌다", "크래시", "복구", "살려야", "recover cmux", "crash recovery", "cmux session recovery".
+  If the request mentions "snapshot" or "json" as the source, prefer cmux-resume-sessions instead.
+  Triggers on "터졌다", "크래시 복구", "크래시 복원", "전원 꺼짐 복구", "OOM 복구", "세션 살려야", "recover cmux", "crash recovery", "power loss recovery", "cmux session recovery".
 ---
 
 # Recover Sessions (cmux)

--- a/skills/cmux-recover-sessions/SKILL.md
+++ b/skills/cmux-recover-sessions/SKILL.md
@@ -1,9 +1,20 @@
 ---
 name: cmux-recover-sessions
-description: Bulk recover Claude Code sessions after crash or power loss into cmux workspaces. Interactive interview to determine recovery scope and layout. Triggers on "recover cmux", "cmux session recovery", "cmux restore sessions".
+description: >
+  Bulk recover Claude Code sessions after a crash, power loss, OOM kill, or reboot
+  by scanning the .jsonl files Claude Code persists automatically. Interactive
+  interview chooses recovery scope and layout. Use this when sessions died and
+  you need them back, NOT for restoring an intentionally saved layout.
+  Triggers on "터졌다", "크래시", "복구", "살려야", "recover cmux", "crash recovery", "cmux session recovery".
 ---
 
 # Recover Sessions (cmux)
+
+> ⚠️ **Wrong skill?** If you have a JSON snapshot you previously saved with
+> `cmux-save-sessions` and just want to rehydrate that exact layout, use
+> **`cmux-resume-sessions`** instead. Recover scans the on-disk `.jsonl` files
+> Claude Code persists automatically — useful precisely *because* you never
+> got a chance to save anything before the crash.
 
 ## Overview
 

--- a/skills/cmux-resume-sessions/SKILL.md
+++ b/skills/cmux-resume-sessions/SKILL.md
@@ -3,7 +3,8 @@ name: cmux-resume-sessions
 description: >
   Restore cmux workspaces from a JSON snapshot saved by cmux-save-sessions.
   Use this when you want to rehydrate an intentionally saved layout, NOT after a crash.
-  Triggers on "resume sessions", "session resume", "cmux resume", "restore from snapshot", "rehydrate sessions".
+  If the request mentions "snapshot" or "json" alongside a crash word, still prefer this skill.
+  Triggers on "resume sessions", "session resume", "session restore", "restore sessions", "cmux resume", "restore from snapshot", "rehydrate sessions", "세션 복원", "스냅샷 복구", "스냅샷 복원".
 ---
 
 # cmux Resume Sessions

--- a/skills/cmux-resume-sessions/SKILL.md
+++ b/skills/cmux-resume-sessions/SKILL.md
@@ -2,8 +2,10 @@
 name: cmux-resume-sessions
 description: >
   Restore cmux workspaces from a JSON snapshot saved by cmux-save-sessions.
-  Use this when you want to rehydrate an intentionally saved layout, NOT after a crash.
-  If the request mentions "snapshot" or "json" alongside a crash word, still prefer this skill.
+  Use this when you want to rehydrate an intentionally saved layout with NO crash context.
+  Crash routing override: if the request mentions a crash, power loss, OOM, or "살려야",
+  route to cmux-recover-sessions instead — even when the user also mentions a snapshot,
+  because the snapshot may be stale and .jsonl scanning reflects the real latest state.
   Triggers on "resume sessions", "session resume", "session restore", "restore sessions", "cmux resume", "restore from snapshot", "rehydrate sessions", "세션 복원", "스냅샷 복구", "스냅샷 복원".
 ---
 

--- a/skills/cmux-resume-sessions/SKILL.md
+++ b/skills/cmux-resume-sessions/SKILL.md
@@ -1,12 +1,17 @@
 ---
 name: cmux-resume-sessions
 description: >
-  Restore cmux workspaces from a JSON snapshot.
-  Uses snapshots saved by cmux-save-sessions as input.
-  Triggers on "resume sessions", "session restore", "session resume", "cmux resume", "restore sessions".
+  Restore cmux workspaces from a JSON snapshot saved by cmux-save-sessions.
+  Use this when you want to rehydrate an intentionally saved layout, NOT after a crash.
+  Triggers on "resume sessions", "session resume", "cmux resume", "restore from snapshot", "rehydrate sessions".
 ---
 
 # cmux Resume Sessions
+
+> ⚠️ **Wrong skill?** If your sessions died from a crash / power loss / OOM kill,
+> use **`cmux-recover-sessions`** instead. That skill scans `.jsonl` files on
+> disk and finds sessions you never explicitly saved. Resume only works on a
+> JSON snapshot you produced earlier with `cmux-save-sessions`.
 
 ## Overview
 
@@ -14,8 +19,8 @@ Restores cmux workspaces from a JSON snapshot saved by `cmux-save-sessions`.
 Restores workspace structure (name, cwd) and continues Claude Code conversations automatically.
 
 > **Role separation**:
-> - `cmux-resume-sessions`: Intentional restore from JSON snapshot (file-based)
-> - `cmux-recover-sessions`: Post-crash/power-loss recovery from tmux sessions (process-based)
+> - `cmux-resume-sessions` (this skill): Intentional restore from a JSON snapshot you saved on purpose (file-based)
+> - `cmux-recover-sessions`: Post-crash/power-loss recovery from `.jsonl` files Claude Code persists automatically (process-based)
 
 ## The Iron Law
 


### PR DESCRIPTION
Closes #68

## 변경 사항

`cmux-resume-sessions`와 `cmux-recover-sessions`를 명확히 구분하기 위한 문서 개선. 실제 크래시 복구 상황에서 잘못된 스킬을 호출하는 사례가 발생했습니다.

### 핵심

1. **두 SKILL.md 상단에 "Wrong skill?" 경고 박스 추가** — 사용자가 SKILL.md를 열자마자 본인이 다른 스킬을 찾아야 하는지 즉시 판단 가능
2. **frontmatter description 재작성**:
   - `recover`: "터졌다", "크래시", "복구", "살려야", "crash recovery", "OOM kill", "reboot" 강조
   - `resume`: "snapshot", "rehydrate", "intentionally saved layout" 강조
3. **트리거 키워드 disambiguation** — 기존 양쪽에 모두 매치되던 "restore"가 더 이상 양쪽에 등장하지 않음:
   - resume: `restore from snapshot` (한정적)
   - recover: `crash recovery` (한정적)
4. **resume의 Role separation 박스 강화** — "intentional snapshot you saved on purpose" vs "automatic .jsonl files Claude Code persists"로 메커니즘 차이 명시

## 동기 사례

오늘 (2026-04-10) 실제 발생: 사용자가 "터진지 30분 안 됐다, 금일까지 동작한 세션 살려야 한다" 요청 시 AI 어시스턴트가 처음에 `cmux-resume-sessions`(스냅샷 기반)를 호출. 실제로는 크래시 복구 시나리오라 `cmux-recover-sessions`가 정답. 두 스킬의 트리거/설명이 매우 비슷해 헷갈리기 쉬운 상태였음.

## 영향

- 문서 변경만, 실행 동작에 영향 없음
- 새로운 트리거 키워드(특히 한국어 "터졌다", "크래시", "복구", "살려야")로 한국어 사용자가 위급 상황에서 정확한 스킬을 찾을 확률 증가