### PR TITLE
fix(retrospect): add duplicate memory check before creating entries

### DIFF
--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -207,6 +207,15 @@ For each approved action:
    - Include: rule, why, how to apply
    - Update `MEMORY.md` index
 
+   **⚠️ MANDATORY: Duplicate check before creating any memory file:**
+   a. Reuse Stage 2 Step 7's repeat scan results — if a finding was matched to an existing memory file, that file is the merge target
+   b. If no Stage 2 match: scan MEMORY.md index for entries with overlapping root cause or topic (concept-level, not keyword)
+   c. For each candidate, read the existing memory file and compare:
+      - Same root cause / principle → **merge**: append new context (사례, How to apply 항목) to the existing file
+      - Related but distinct principle → **create new file** (genuinely different insight)
+   d. **Never create a new file when the insight is a specific instance of an existing general rule** — add it as a numbered sub-item instead
+   e. After merge or create, update MEMORY.md index (update description if merged, add new line if created)
+
 2. **GitHub issue** → Use project's issue creation skill or `gh issue create`
    - Title: Conventional Commits format (per project convention)
    - Body: per project convention, with background + task list
@@ -232,7 +241,8 @@ For each approved action:
 
    | Artifact | Verification |
    |----------|-------------|
-   | MEMORY.md feedback | File exists + MEMORY.md index updated |
+   | MEMORY.md feedback (new) | File exists + MEMORY.md index updated |
+   | MEMORY.md feedback (merged) | Existing file updated (diff shown) + MEMORY.md index description updated if needed |
    | GitHub issue | `gh issue view {url}` returns valid data |
    | Hook code | Script file exists + settings.json 등록 확인 (dry-run은 hook 유형별로 달라 generic 불가) |
    | CLAUDE.md draft | Diff shown to user + explicit approval received |
@@ -278,6 +288,7 @@ If you catch yourself:
 - Proposing `memory` for a pattern that already exists in MEMORY.md (MUST escalate instead)
 - Skipping tracer/analyst agent calls ("I can analyze this myself")
 - Generating artifacts without verification ("issue created" without showing URL)
+- Creating a new memory file without checking existing entries for overlap (MUST merge into existing when root cause matches)
 
 **ALL of these mean: STOP. Return to Stage 2.**
 

--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -208,10 +208,13 @@ For each approved action:
    - Update `MEMORY.md` index
 
    **⚠️ MANDATORY: Duplicate check before creating any memory file:**
-   a. Reuse Stage 2 Step 7's repeat scan results — if a finding was matched to an existing memory file, that file is the merge target
+
+   **Precondition:** This check applies ONLY when the finding's action type is `memory` (new pattern). If Stage 2 already marked `repeat=true` and escalated to issue/hook/CLAUDE.md, skip this check — the escalation ladder takes precedence over merge.
+
+   a. Reuse Stage 2 Step 7's repeat scan results — if a finding matched an existing memory but was NOT escalated (i.e., it's a genuinely new sub-pattern), that file is the merge target
    b. If no Stage 2 match: scan MEMORY.md index for entries with overlapping root cause or topic (concept-level, not keyword)
    c. For each candidate, read the existing memory file and compare:
-      - Same root cause / principle → **merge**: append new context (사례, How to apply 항목) to the existing file
+      - Same root cause / principle → **merge**: append new context (사례, How to apply 항목) to the existing file. If merge makes this the 2nd+ occurrence, re-evaluate whether action type should escalate per Stage 2 Step 8
       - Related but distinct principle → **create new file** (genuinely different insight)
    d. **Never create a new file when the insight is a specific instance of an existing general rule** — add it as a numbered sub-item instead
    e. After merge or create, update MEMORY.md index (update description if merged, add new line if created)


### PR DESCRIPTION
## Summary
- Stage 4 Step 1에 기존 메모리 중복 확인 + merge 로직 추가 (a~e sub-steps)
- Verification 테이블에 new/merged 케이스 분리
- Red Flags에 중복 파일 생성 방지 규칙 추가

## Background
2026-04-13 laplace-dev-hub 세션에서 retrospect 실행 시 신규 메모리 2개를 생성했으나, 기존 메모리와 중복되어 유저가 지적. 삭제 후 기존 파일에 통합함. Stage 4에 중복 확인 단계가 없어서 발생한 문제.

## Test plan
- [ ] retrospect 스킬 실행 시 기존 메모리와 중복되는 finding이 있을 때 새 파일 대신 기존 파일에 merge되는지 확인
- [ ] 기존 메모리와 관련 없는 genuinely new finding은 새 파일로 생성되는지 확인

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)