### PR TITLE
feat(routing): add multi-provider routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 | **Standalone** | turbo-setup, recover-sessions | `gh` CLI |
 | **Enhanced** | + turbo-implement, turbo-completion, debug, retrospect | + oh-my-claudecode |
 | **Full** | + all cmux-* skills | + cmux |
+| **Multi-provider** | + codex/gemini routing in cmux-*, turbo-implement | + codex-cli, gemini-cli |
 
 ## Skills (12)
 
@@ -55,7 +56,7 @@ Project CLAUDE.md (routing config)
         ▼
 ┌─ turbo-implement ────────────────────────────────┐
 │  context → mode select → execute → chain         │
-│  modes: manual | ralph | autopilot | guided      │
+│  modes: manual | ralph | autopilot | guided | codex│
 └──────────────────────────────────────────────────┘
         │
         ▼
@@ -75,6 +76,83 @@ Project CLAUDE.md (routing config)
 - **CLAUDE.md is the interface**: no config files — project instructions define routing
 - **SRP per skill**: each skill has one responsibility, chaining connects them
 - **Discipline over convenience**: Iron Laws gate each phase, no skipping
+
+## Provider Routing
+
+Skills that dispatch external CLI workers (`cmux-orchestrator`, `cmux-delegate`, `turbo-implement`) can route tasks to multiple AI providers. When only `claude` is installed, the system behaves exactly as before — no errors, no degradation.
+
+### Provider CLI Spec
+
+| Provider | Non-interactive command | Output format | Stdin prompt |
+|----------|----------------------|---------------|-------------|
+| `claude` | `cat $F \| claude --model {m} --output-format stream-json --permission-mode auto` | stream-json (JSONL) | `cat file \| claude` |
+| `codex` | `cat $F \| codex exec {m:+-m m}` | stdout text / `--json` JSONL | `cat file \| codex exec` |
+| `gemini` | `gemini -p "$(cat $F)" --approval-mode yolo {m:+-m m}` | stream-json (`-o stream-json`) | via `-p` flag |
+
+All providers share the same completion sentinel: `; echo '===WORKER_DONE===' >> $LOG` appended after the CLI exits.
+
+### Model Notation
+
+Unified `--model` flag across all skills: `<provider>:<model>` or bare model name.
+
+| Notation | Resolves to | CLI command |
+|----------|-------------|-------------|
+| `opus`, `sonnet`, `haiku` | `claude:{name}` | `claude --model {name}` |
+| `claude:opus` | Claude Opus | `claude --model opus` |
+| `codex` | Codex default model | `codex exec` |
+| `codex:o3` | Codex with o3 | `codex exec -m o3` |
+| `gemini` | Gemini default model | `gemini` |
+| `gemini:flash` | Gemini Flash | `gemini -m flash` |
+
+Bare names (`opus`, `sonnet`, `haiku`) always resolve to Claude — full backward compatibility.
+
+### Task-Type Routing
+
+Two-phase routing: task keywords select the provider, then complexity selects the model.
+
+**Phase 1 — Task type to provider:**
+
+| Task pattern | Provider | Rationale |
+|-------------|----------|-----------|
+| implement, fix, refactor, code generation | `codex` | Code-centric, fast execution |
+| search, analyze, summarize, large context | `gemini` | Large context window, search integration |
+| review, design, architecture, security, debug | `claude` | Reasoning depth, nuanced judgment |
+| Default (unmatched) | `claude` | Safe default |
+
+**Phase 2 — Complexity to model (claude only; codex/gemini use provider defaults):**
+
+| Provider | Low | Medium | High |
+|----------|-----|--------|------|
+| `claude` | haiku | sonnet | opus |
+| `codex` | (default) | (default) | (default or explicit) |
+| `gemini` | (default) | (default) | (default or explicit) |
+
+### Fallback Policy
+
+1. **Pre-flight**: `command -v <cli>` before dispatch. If missing → fall back to `claude:sonnet` with warning.
+2. **Runtime**: Worker failure → re-dispatch with `claude` as fallback provider.
+3. **Graceful**: If only `claude` is installed, all routing resolves to claude. Original behavior preserved.
+
+### Provider Resolution Logic
+
+Skills parse `--model` using this algorithm:
+
+```
+input = "--model" value
+
+if input matches /^(codex|gemini)(:.+)?$/:
+  provider = match[1]           # "codex" or "gemini"
+  sub_model = match[2] || ""    # "" or "o3" or "flash"
+elif input in ["opus", "sonnet", "haiku"]:
+  provider = "claude"
+  sub_model = input
+elif input matches /^claude:.+$/:
+  provider = "claude"
+  sub_model = split(":")[1]
+else:
+  provider = "claude"
+  sub_model = input
+```
 
 ## Local Development
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,9 +140,9 @@ Skills parse `--model` using this algorithm:
 ```
 input = "--model" value
 
-if input matches /^(codex|gemini)(:.+)?$/:
+if input matches /^(codex|gemini)(?::(.+))?$/:
   provider = match[1]           # "codex" or "gemini"
-  sub_model = match[2] || ""    # "" or "o3" or "flash"
+  sub_model = match[2] || ""    # "" or "o3" or "flash" (colon stripped)
 elif input in ["opus", "sonnet", "haiku"]:
   provider = "claude"
   sub_model = input

--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -37,7 +37,7 @@ description: Delegate a task to an independent Claude Code session in a new cmux
 | Argument | Default | Description |
 |----------|---------|-------------|
 | `<task>` | (required) | 위임할 작업 설명 |
-| `--model` | `sonnet` | Claude 모델 (opus/sonnet/haiku) |
+| `--model` | `sonnet` | Provider:model notation. `opus`/`sonnet`/`haiku` = claude. `codex`, `codex:o3`, `gemini`, `gemini:flash` 지원. See CLAUDE.md Provider Routing. |
 | `--cwd` | current dir | 새 세션의 작업 디렉토리 |
 | `--max-budget-usd` | (none) | 최대 예산 한도 |
 | `--account` | (기본 계정) | Claude 계정 프로필 (예: `claude-2` → `CLAUDE_CONFIG_DIR=~/.claude-2`) |
@@ -63,6 +63,26 @@ permission_mode = args["permission-mode"] || "auto"
 task = args.task (remaining text after flags)
 short_task = task[:30], sanitized to [a-zA-Z0-9가-힣 -] only (for cmux workspace name)
 timestamp = epoch seconds + PID (e.g., 1744163800-12345) to avoid collision
+
+# Provider resolution (from CLAUDE.md Provider Resolution Logic)
+if model matches /^(codex|gemini)(:.+)?$/:
+  provider = match[1]           # "codex" or "gemini"
+  sub_model = match[2] || ""    # "" or "o3" or "flash"
+elif model in ["opus", "sonnet", "haiku"]:
+  provider = "claude"
+  sub_model = model
+elif model matches /^claude:.+$/:
+  provider = "claude"
+  sub_model = split(":")[1]
+else:
+  provider = "claude"
+  sub_model = model
+
+# Pre-flight: verify provider CLI is available
+if ! command -v "$provider" &>/dev/null:
+  warn "⚠ ${provider} CLI not found, falling back to claude:sonnet"
+  provider = "claude"
+  sub_model = "sonnet"
 ```
 
 ### Step 1.5: Session Resolution
@@ -171,10 +191,11 @@ Report results in Korean.
 1. 프롬프트를 섹션별로 분리 → 각각 개별 .md 파일 생성
 2. Context 섹션은 모든 분할 파일에 공통 포함
 3. 각 파일에 대해 개별 래퍼 .sh 생성
-4. 모델 라우팅: `--model`이 명시적이면 전체 동일, 없으면 복잡도 기반 자동 배정
-   - 데이터 조회/상태 확인 → haiku
-   - 분석/구현 → sonnet
-   - 설계/보안 → opus
+4. 라우팅: `--model`이 명시적이면 전체 동일, 없으면 작업 유형 기반 자동 배정 (CLAUDE.md Task-Type Routing 참조)
+   - 코드 구현/수정 → `codex` (CLI 존재 시) 또는 `claude:sonnet`
+   - 검색/분석/대용량 컨텍스트 → `gemini` (CLI 존재 시) 또는 `claude:sonnet`
+   - 설계/보안/리뷰 → `claude:opus`
+   - 데이터 조회/상태 확인 → `claude:haiku`
 
 ### Step 4: Generate Wrapper Script
 
@@ -188,17 +209,32 @@ SCRIPT_FILE="/tmp/cmux-delegate-{timestamp}.sh"
 # Cleanup: .sh만 삭제. .md는 보존 (다른 워크스페이스가 참조할 수 있음)
 trap 'rm -f "$SCRIPT_FILE"' EXIT
 
-cat "$PROMPT_FILE" | {claude_env} claude \
-  --model {model} \
-  --permission-mode {permission_mode} \
-  {budget_flag}
+# Provider-specific invocation (from CLAUDE.md Provider CLI Spec)
+case "{provider}" in
+  claude)
+    cat "$PROMPT_FILE" | {claude_env} claude \
+      --model {sub_model} \
+      --permission-mode {permission_mode} \
+      {budget_flag}
+    ;;
+  codex)
+    cat "$PROMPT_FILE" | codex exec \
+      {sub_model:+-m {sub_model}}
+    ;;
+  gemini)
+    gemini -p "$(cat "$PROMPT_FILE")" \
+      --approval-mode yolo \
+      {sub_model:+-m {sub_model}}
+    ;;
+esac
 
 # Notify on completion
 cmux notify --title "cmux-delegate" --body "Task completed: {short_task}" 2>/dev/null || true
 ```
 
-`{claude_env}`는 account가 지정된 경우 `CLAUDE_CONFIG_DIR=~/.{account}`로 치환합니다.
-`{budget_flag}`는 budget이 지정된 경우에만 `--max-budget-usd {budget}`로 치환합니다.
+`{provider}`와 `{sub_model}`은 Step 1의 provider resolution 결과에서 치환합니다.
+`{claude_env}`는 account가 지정된 경우 `CLAUDE_CONFIG_DIR=~/.{account}`로 치환합니다 (claude provider만 해당).
+`{budget_flag}`는 budget이 지정된 경우에만 `--max-budget-usd {budget}`로 치환합니다 (claude provider만 해당, codex/gemini는 budget 미지원).
 
 **이 파일도 `Write` 도구로 생성합니다.** 단, 파일 내용 자체에 shell 변수(`$PROMPT_FILE` 등)가 포함되므로 이는 의도된 것입니다 — 중요한 것은 사용자 프롬프트가 이 스크립트를 거치지 않는다는 점입니다.
 
@@ -254,7 +290,8 @@ cmux send-key --workspace "$TARGET" Enter
 ```
 Delegated to {WS_REF}
   Task: {short_task}
-  Model: {model}
+  Provider: {provider}
+  Model: {sub_model || "default"}
   Account: {account || "default"}
   Prompt: /tmp/cmux-delegate-{timestamp}.md
   CWD: {cwd}
@@ -266,9 +303,9 @@ cmux에서 {WS_REF} 탭을 확인하세요.
 **distribute 모드:**
 ```
 Distributed to {N} workspaces:
-  | Workspace | Task | Model | Account |
-  |-----------|------|-------|---------|
-  | {ws_ref}  | {item_title} | {model} | {account} |
+  | Workspace | Task | Provider | Model | Account |
+  |-----------|------|----------|-------|---------|
+  | {ws_ref}  | {item_title} | {provider} | {sub_model} | {account} |
   ...
 
 각 cmux 탭에서 진행 상황을 확인하세요.
@@ -301,7 +338,7 @@ cmux에서 {session_name} 탭을 확인하세요.
 ### 단일 세션 (기본)
 
 ```
-사용자: /cmux-delegate "전체 검수" --model opus --account claude-2
+사용자: /cmux-delegate "전체 검수" --model claude:opus --account claude-2
   │
   ├── Step 1.6: Account Resolution
   │     └── CLAUDE_CONFIG_DIR=~/.claude-2

--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -65,9 +65,9 @@ short_task = task[:30], sanitized to [a-zA-Z0-9가-힣 -] only (for cmux workspa
 timestamp = epoch seconds + PID (e.g., 1744163800-12345) to avoid collision
 
 # Provider resolution (from CLAUDE.md Provider Resolution Logic)
-if model matches /^(codex|gemini)(:.+)?$/:
+if model matches /^(codex|gemini)(?::(.+))?$/:
   provider = match[1]           # "codex" or "gemini"
-  sub_model = match[2] || ""    # "" or "o3" or "flash"
+  sub_model = match[2] || ""    # "" or "o3" or "flash" (colon stripped)
 elif model in ["opus", "sonnet", "haiku"]:
   provider = "claude"
   sub_model = model

--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -37,7 +37,7 @@ description: Delegate a task to an independent Claude Code session in a new cmux
 | Argument | Default | Description |
 |----------|---------|-------------|
 | `<task>` | (required) | 위임할 작업 설명 |
-| `--model` | `sonnet` | Provider:model notation. `opus`/`sonnet`/`haiku` = claude. `codex`, `codex:o3`, `gemini`, `gemini:flash` 지원. See CLAUDE.md Provider Routing. |
+| `--model` | `sonnet` | Provider:model notation. `opus`/`sonnet`/`haiku` = claude. Also supports `codex`, `codex:o3`, `gemini`, `gemini:flash`. See CLAUDE.md Provider Routing. |
 | `--cwd` | current dir | 새 세션의 작업 디렉토리 |
 | `--max-budget-usd` | (none) | 최대 예산 한도 |
 | `--account` | (기본 계정) | Claude 계정 프로필 (예: `claude-2` → `CLAUDE_CONFIG_DIR=~/.claude-2`) |
@@ -191,11 +191,11 @@ Report results in Korean.
 1. 프롬프트를 섹션별로 분리 → 각각 개별 .md 파일 생성
 2. Context 섹션은 모든 분할 파일에 공통 포함
 3. 각 파일에 대해 개별 래퍼 .sh 생성
-4. 라우팅: `--model`이 명시적이면 전체 동일, 없으면 작업 유형 기반 자동 배정 (CLAUDE.md Task-Type Routing 참조)
-   - 코드 구현/수정 → `codex` (CLI 존재 시) 또는 `claude:sonnet`
-   - 검색/분석/대용량 컨텍스트 → `gemini` (CLI 존재 시) 또는 `claude:sonnet`
-   - 설계/보안/리뷰 → `claude:opus`
-   - 데이터 조회/상태 확인 → `claude:haiku`
+4. Routing: If `--model` is explicit, apply uniformly. Otherwise, auto-assign by task type (see CLAUDE.md Task-Type Routing):
+   - Code implementation/fix → `codex` (if CLI available) or `claude:sonnet`
+   - Search/analysis/large context → `gemini` (if CLI available) or `claude:sonnet`
+   - Design/security/review → `claude:opus`
+   - Data lookup/status check → `claude:haiku`
 
 ### Step 4: Generate Wrapper Script
 
@@ -232,9 +232,9 @@ esac
 cmux notify --title "cmux-delegate" --body "Task completed: {short_task}" 2>/dev/null || true
 ```
 
-`{provider}`와 `{sub_model}`은 Step 1의 provider resolution 결과에서 치환합니다.
-`{claude_env}`는 account가 지정된 경우 `CLAUDE_CONFIG_DIR=~/.{account}`로 치환합니다 (claude provider만 해당).
-`{budget_flag}`는 budget이 지정된 경우에만 `--max-budget-usd {budget}`로 치환합니다 (claude provider만 해당, codex/gemini는 budget 미지원).
+`{provider}` and `{sub_model}` are substituted from the provider resolution result in Step 1.
+`{claude_env}` is substituted with `CLAUDE_CONFIG_DIR=~/.{account}` when account is specified (claude provider only).
+`{budget_flag}` is substituted with `--max-budget-usd {budget}` when budget is specified (claude provider only — codex/gemini do not support budget limits).
 
 **이 파일도 `Write` 도구로 생성합니다.** 단, 파일 내용 자체에 shell 변수(`$PROMPT_FILE` 등)가 포함되므로 이는 의도된 것입니다 — 중요한 것은 사용자 프롬프트가 이 스크립트를 거치지 않는다는 점입니다.
 
@@ -338,7 +338,7 @@ cmux에서 {session_name} 탭을 확인하세요.
 ### 단일 세션 (기본)
 
 ```
-사용자: /cmux-delegate "전체 검수" --model claude:opus --account claude-2
+user: /cmux-delegate "full code review" --model claude:opus --account claude-2
   │
   ├── Step 1.6: Account Resolution
   │     └── CLAUDE_CONFIG_DIR=~/.claude-2

--- a/skills/cmux-orchestrator/SKILL.md
+++ b/skills/cmux-orchestrator/SKILL.md
@@ -38,9 +38,9 @@ Never pipe worker output directly into the orchestrator process — the master c
      ┌─────────┼─────────┐    │
      ▼         ▼         ▼    ▼
   [ws:1]    [ws:2]    [ws:3]  results/
-  claude    claude    claude   ├─ w1.jsonl
-  --sonnet  --haiku   --opus   ├─ w2.jsonl
-  task-1    task-2    task-3   └─ w3.jsonl
+  claude    codex     gemini   ├─ w1.jsonl
+  :sonnet   (default) (default)├─ w2.jsonl
+  review    implement analyze  └─ w3.jsonl
 ```
 
 ## When to Use
@@ -74,23 +74,43 @@ Or a structured task file:
 
 ## Process
 
-### Step 1: Parse Tasks + Route Models
+### Step 1: Parse Tasks + Route Provider & Model
 
-For each task, determine complexity and assign model:
+Two-phase routing (from CLAUDE.md Provider Routing):
+
+**Phase 1 — Task type → Provider:**
 
 ```
-Task → Complexity Router → Model Assignment
-  "code review"     → medium  → sonnet
-  "implement"       → medium  → sonnet
-  "status check"    → low     → haiku
-  "architecture"    → high    → opus
+Task → Provider Router
+  "implement", "fix", "refactor", "code generation"  → codex
+  "search", "analyze", "summarize", "large context"   → gemini
+  "review", "design", "architecture", "security"      → claude
+  "status", "check", "list"                           → claude
+  Default                                              → claude
 ```
 
-**Routing rules (from CLAUDE.md Model Routing Rules):**
-- `find`, `search`, `list`, `status`, `check` → **haiku**
-- `implement`, `fix`, `test`, `review`, `refactor` → **sonnet**
-- `architect`, `design`, `security`, `incident`, `debug` → **opus**
-- Default: **sonnet**
+**Phase 2 — Provider + Complexity → Model:**
+
+```
+claude + low    → haiku     (find, search, list, status, check)
+claude + medium → sonnet    (review, test, refactor)
+claude + high   → opus      (architect, design, security, debug)
+codex           → default   (or explicit: codex:o3)
+gemini          → default   (or explicit: gemini:flash)
+```
+
+**Pre-flight availability check:**
+
+```bash
+for provider in codex gemini; do
+  command -v "$provider" >/dev/null 2>&1 || {
+    echo "⚠ ${provider} CLI not found — tasks will fall back to claude:sonnet"
+    FALLBACK["$provider"]=true
+  }
+done
+```
+
+If a provider is unavailable, tasks assigned to it fall back to `claude:sonnet` with a warning in the dispatch plan.
 
 Present the dispatch plan and ask for confirmation:
 
@@ -99,12 +119,12 @@ Present the dispatch plan and ask for confirmation:
  Dispatch Plan
 ═══════════════════════════════════════════════
 
- #  Task                          Model    Budget
- 1  PR #42 code review             sonnet   $0.50
- 2  issue #100 implementation     sonnet   $1.00
- 3  issue #55 status check        haiku    $0.10
+ #  Task                          Provider  Model      Budget
+ 1  PR #42 code review             claude    sonnet     $0.50
+ 2  issue #100 implementation     codex     (default)  $1.00
+ 3  codebase search + analysis    gemini    (default)  $0.30
 
- Total budget: $1.60
+ Total budget: $1.80
  Max concurrent workers: 3
 
  Proceed? (y/n)
@@ -115,7 +135,7 @@ Present the dispatch plan and ask for confirmation:
 
 ```bash
 ORCH_DIR="/tmp/cmux-orchestrator-$(date +%s)"
-mkdir -p "$ORCH_DIR/logs" "$ORCH_DIR/results"
+mkdir -p "$ORCH_DIR/logs" "$ORCH_DIR/results" "$ORCH_DIR/prompts"
 ```
 
 Create state files:
@@ -128,32 +148,55 @@ Create state files:
 
 ### Step 3: Dispatch Workers
 
-For each task, create a cmux workspace:
+For each task, create a cmux workspace with provider-specific CLI invocation:
 
 ```bash
 dispatch_worker() {
-  local task_id="$1" description="$2" model="$3" cwd="$4" budget="$5"
+  local task_id="$1" description="$2" provider="$3" model="$4" cwd="$5" budget="$6"
   local log_file="$ORCH_DIR/logs/${task_id}.jsonl"
+  local prompt_file="$ORCH_DIR/prompts/${task_id}.md"
 
-  local cmd="claude -p '${description}' \
-    --output-format stream-json --verbose \
-    --permission-mode auto \
-    --model ${model} \
-    --max-budget-usd ${budget} \
-    2>&1 | tee ${log_file}; \
-    echo '===WORKER_DONE===' >> ${log_file}"
+  # Write prompt to file (avoid shell escaping — file-based delivery)
+  echo "${description}" > "$prompt_file"
+
+  # Construct provider-specific command (from CLAUDE.md Provider CLI Spec)
+  local cmd
+  case "$provider" in
+    claude)
+      cmd="cat '${prompt_file}' | claude \
+        --output-format stream-json --verbose \
+        --permission-mode auto \
+        --model ${model} \
+        ${budget:+--max-budget-usd ${budget}} \
+        2>&1 | tee ${log_file}; \
+        echo '===WORKER_DONE===' >> ${log_file}"
+      ;;
+    codex)
+      cmd="cat '${prompt_file}' | codex exec \
+        ${model:+-m ${model}} \
+        2>&1 | tee ${log_file}; \
+        echo '===WORKER_DONE===' >> ${log_file}"
+      ;;
+    gemini)
+      cmd="gemini -p \"\$(cat '${prompt_file}')\" \
+        --approval-mode yolo \
+        ${model:+-m ${model}} \
+        2>&1 | tee ${log_file}; \
+        echo '===WORKER_DONE===' >> ${log_file}"
+      ;;
+  esac
 
   local raw=$(cmux new-workspace --cwd "$cwd" --command "$cmd")
   local ws=$(echo "$raw" | sed 's/^OK //')
 
-  cmux rename-workspace --workspace "$ws" "[w${task_id}] ${description:0:25}"
+  cmux rename-workspace --workspace "$ws" "[w${task_id}:${provider}] ${description:0:20}"
 
   # Get surface ref for monitoring
   local surface=$(cmux list-pane-surfaces --workspace "$ws" 2>/dev/null \
     | grep -oP 'surface:\d+' | head -1)
 
-  # Register worker
-  echo "{\"id\":\"${task_id}\",\"ws\":\"${ws}\",\"surface\":\"${surface}\",\"status\":\"running\",\"log\":\"${log_file}\"}"
+  # Register worker (provider field for result parsing and crash recovery)
+  echo "{\"id\":\"${task_id}\",\"ws\":\"${ws}\",\"surface\":\"${surface}\",\"provider\":\"${provider}\",\"model\":\"${model}\",\"status\":\"running\",\"log\":\"${log_file}\"}"
 }
 ```
 
@@ -218,22 +261,60 @@ collect_result() {
   local log="$ORCH_DIR/logs/${task_id}.jsonl"
   local result_file="$ORCH_DIR/results/${task_id}.json"
 
-  # Extract final result from stream-json
+  # Read provider from workers.json
+  local provider=$(jq -r ".[] | select(.id==\"${task_id}\") | .provider" "$ORCH_DIR/workers.json")
+
+  # Extract result — provider-aware parsing
   python3 -c "
 import json
+
+provider = '${provider}'
+log_file = '${log}'
+task_id = '${task_id}'
+
 result = None
 cost = 0
-with open('${log}') as f:
-    for line in f:
-        try:
-            obj = json.loads(line)
-            if obj.get('type') == 'result':
-                result = obj.get('result', '')
-                cost = obj.get('total_cost_usd', 0)
-        except: pass
-json.dump({'task_id': '${task_id}', 'result': result, 'cost': cost}, 
-          open('${result_file}', 'w'), ensure_ascii=False, indent=2)
-print(f'Task ${task_id}: \${cost:.4f} — {(result or \"\")[:80]}')
+
+if provider == 'claude':
+    with open(log_file) as f:
+        for line in f:
+            try:
+                obj = json.loads(line)
+                if obj.get('type') == 'result':
+                    result = obj.get('result', '')
+                    cost = obj.get('total_cost_usd', 0)
+            except: pass
+
+elif provider == 'codex':
+    # Codex: parse JSONL for last content, or read plain text output
+    with open(log_file) as f:
+        for line in f:
+            try:
+                obj = json.loads(line)
+                if 'content' in obj:
+                    result = obj['content']
+            except:
+                if line.strip() and '===WORKER_DONE===' not in line:
+                    result = line.strip()
+
+elif provider == 'gemini':
+    with open(log_file) as f:
+        for line in f:
+            try:
+                obj = json.loads(line)
+                if obj.get('type') == 'result' or 'result' in obj:
+                    result = obj.get('result', obj.get('text', ''))
+            except:
+                if line.strip() and '===WORKER_DONE===' not in line:
+                    result = line.strip()
+
+json.dump({
+    'task_id': task_id,
+    'provider': provider,
+    'result': result,
+    'cost': cost
+}, open('$ORCH_DIR/results/${task_id}.json', 'w'), ensure_ascii=False, indent=2)
+print(f'Task {task_id} [{provider}]: \${cost:.4f} -- {(result or \"\")[:80]}')
   "
 }
 ```
@@ -245,12 +326,13 @@ print(f'Task ${task_id}: \${cost:.4f} — {(result or \"\")[:80]}')
  Orchestration Complete
 ═══════════════════════════════════════════════
 
- #  Task                    Status     Cost     Result
- 1  PR #42 review            ✅ done    $0.24    "3 issues found, 1 critical..."
- 2  issue #100 impl         ✅ done    $0.45    "Feature implemented, tests pass..."
- 3  issue #55 check         ✅ done    $0.03    "Status: all tasks completed..."
+ #  Task                    Provider  Status     Cost     Result
+ 1  PR #42 review            claude    ✅ done    $0.24    "3 issues found..."
+ 2  issue #100 impl         codex     ✅ done    $0.45    "Feature implemented..."
+ 3  codebase analysis       gemini    ✅ done    $0.03    "Architecture uses..."
 
  Total: 3 tasks, 0 failed, $0.72 total cost
+ Providers: claude×1, codex×1, gemini×1
  Duration: 4m 32s
 ═══════════════════════════════════════════════
 ```
@@ -270,16 +352,19 @@ recover_orchestrator() {
   local orch_dir="$1"
 
   # Find worker workspaces still alive
+  # Provider is encoded in workspace name: [w{id}:{provider}]
+  # If workers.json survives, provider is also recoverable from disk
   cmux list-workspaces 2>/dev/null | grep '\[w' | while read line; do
     local ws=$(echo "$line" | grep -oP 'workspace:\d+')
+    local provider=$(echo "$line" | grep -oP '(?<=:)(claude|codex|gemini)' || echo "claude")
     local screen=$(cmux read-screen --workspace "$ws" --lines 3 2>/dev/null)
 
     if echo "$screen" | grep -q "===WORKER_DONE==="; then
-      echo "COMPLETED: $ws"
+      echo "COMPLETED [$provider]: $ws"
     elif echo "$screen" | grep -q "❯"; then
-      echo "IDLE: $ws (may need re-dispatch)"
+      echo "IDLE [$provider]: $ws (may need re-dispatch)"
     else
-      echo "RUNNING: $ws"
+      echo "RUNNING [$provider]: $ws"
     fi
   done
 }
@@ -291,15 +376,17 @@ Chain turbo-setup → execute → turbo-completion per worker:
 
 ```bash
 # Each worker runs the full lifecycle
+# Full pipeline always uses claude (turbo-* skills require Claude Code)
+# Provider routing applies only to standalone task dispatch (Step 3)
 full_pipeline_cmd() {
   local task="$1" model="$2" budget="$3"
   echo "claude -p '
     Phase 1: Run /turbo-setup for: ${task}
-    Phase 2: Implement the task
+    Phase 2: Implement the task (use /cmux-delegate --model codex if pure implementation)
     Phase 3: Run /turbo-completion
   ' --output-format stream-json --verbose \
     --permission-mode auto \
-    --model ${model} \
+    --model ${model:-sonnet} \
     --max-budget-usd ${budget}"
 }
 ```
@@ -309,6 +396,7 @@ full_pipeline_cmd() {
 | Excuse | Reality |
 |--------|---------|
 | "Just run workers in-process, it's simpler" | Master crash = all workers lost. File-based state is the only safe path. |
+| "Skip provider routing, use claude for everything" | Codex generates code faster. Gemini handles large context better. Route by task type. |
 | "Skip model routing, use opus for all workers" | Wastes 80% of budget on tasks haiku can do. Route by complexity. |
 | "Don't need a poll loop, workers will notify on done" | Notifications get lost on crash. Polling is boring and reliable. |
 | "Skip result collection, I'll read logs manually" | Results scattered across N log files. Collect into `results/` for downstream use. |
@@ -334,5 +422,7 @@ full_pipeline_cmd() {
 
 **Environment:**
 - cmux must be running (`cmux ping`)
-- Claude Code CLI available (`claude -p`)
+- Claude Code CLI available (`claude -p`) — required
+- Codex CLI available (`codex exec`) — optional, for code generation tasks
+- Gemini CLI available (`gemini -p`) — optional, for analysis tasks
 - `/tmp/cmux-orchestrator-*` for state files

--- a/skills/turbo-implement/SKILL.md
+++ b/skills/turbo-implement/SKILL.md
@@ -82,6 +82,7 @@ How should this be implemented?
 2. Ralph — persistence loop until all acceptance criteria pass
 3. Autopilot — full autonomous: plan → implement → QA → validate
 4. Guided — implement step-by-step with verification after each change
+5. Codex — delegate implementation to codex CLI via cmux-delegate
 ```
 
 **Mode routing heuristics (suggest but don't force):**
@@ -92,6 +93,7 @@ How should this be implemented?
 | Plan file exists with implementation steps | Autopilot (plan-driven execution) |
 | Simple task (1-2 files, clear scope) | Guided |
 | No spec, no plan, complex task | Manual (needs more planning first) |
+| Pure implementation + codex CLI available | Codex (fast code generation via external CLI) |
 
 ### Step 3: Execute
 
@@ -141,6 +143,36 @@ Interactive step-by-step implementation:
    - Show results, ask to proceed
 3. After all steps: run full verification
 
+#### Mode: Codex
+
+Delegate implementation to Codex CLI via cmux-delegate:
+
+**Pre-flight:** `command -v codex` — if unavailable, hide this mode option.
+
+1. Generate implementation prompt from spec/issue body:
+   ```
+   Task: Implement issue #<N> — <title>
+   Context: <spec body or issue body>
+   Working directory: <WORKTREE_PATH>
+   Instructions: Implement the changes, run tests after each change.
+   ```
+
+2. Invoke cmux-delegate with codex provider:
+   ```
+   /cmux-delegate "{implementation prompt}" --model codex --cwd {WORKTREE_PATH}
+   ```
+
+3. Monitor workspace for completion (cmux notify or manual check)
+
+4. On completion: pull changes into worktree, run verification (Stage 1 from turbo-completion)
+   - If verification passes → chain to delivery (Step 4)
+   - If verification fails → fall back to Guided mode for manual fix, with codex output as context
+
+**Limitations:**
+- Codex runs in an isolated workspace — may not have full project context
+- Budget control not available (codex CLI has no `--max-budget-usd` equivalent)
+- Best for self-contained implementation tasks with clear specs
+
 ### Step 4: Chain to Delivery
 
 After implementation completes (any mode except Manual):
@@ -162,6 +194,8 @@ If "Not yet": show `git diff --stat` and wait.
 | No issue number in branch | Ask user for issue reference |
 | Spec/plan file not found | Proceed without — suggest Manual or Guided mode |
 | Ralph/autopilot not available | Fall back to Guided mode |
+| Codex CLI not available | Hide Codex mode option, suggest Ralph or Guided instead |
+| Codex mode fails or produces bad output | Fall back to Guided mode with codex output as context |
 | Implementation fails mid-way | Save progress, report status, suggest `/debug` |
 | Tests fail after implementation | Invoke `debug` skill for root cause analysis |
 
@@ -173,6 +207,7 @@ If "Not yet": show `git diff --stat` and wait.
 | "Ralph is always better, pick it by default" | Ralph without acceptance criteria loops without progress. Use it only when criteria exist. |
 | "I'll chain to turbo-completion later" | Later never comes. Chain immediately or the worktree accumulates stale changes. |
 | "Autopilot on a no-spec task" | Autopilot without a spec invents scope. Pick Guided or write a spec first. |
+| "Codex for everything, it's faster" | Codex lacks project context and can't run turbo-* skills. Use for pure implementation only. |
 | "Skip verification, tests will run in CI" | CI finds the failure 10 minutes later, across a PR review cycle. Run locally first. |
 
 ## Pipeline Visualization
@@ -191,6 +226,7 @@ If "Not yet": show `git diff --stat` and wait.
                     · ralph (loop)
                     · autopilot (autonomous)
                     · guided (interactive)
+                    · codex (external CLI)
 ```
 
 ## Chaining Interface


### PR DESCRIPTION
## Summary

- Codex/Gemini CLI 라우팅 정책 추가 (AGENTS.md Provider Routing 섹션 신설)
- cmux-delegate, cmux-orchestrator에 provider-aware dispatch 지원
- turbo-implement에 5번째 Codex 실행 모드 추가
- 통합 `--model` notation: `codex`, `gemini:flash`, `claude:opus` (기존 `opus`/`sonnet`/`haiku` 100% 하위 호환)
- Fallback 정책: CLI 미설치 시 자동 claude 대체, 런타임 실패 시에도 claude로 재배정

## Changed Files

| File | Change |
|------|--------|
| `AGENTS.md` | Provider Routing 정책 섹션 (CLI Spec, Model Notation, Task-Type Routing, Fallback, Resolution Logic), Prerequisites 행 추가 |
| `skills/cmux-delegate/SKILL.md` | provider resolution, wrapper script `case` 분기, distribute 라우팅, report Provider 필드 |
| `skills/cmux-orchestrator/SKILL.md` | Two-phase routing, provider별 dispatch/result collector, workers.json 스키마, crash recovery |
| `skills/turbo-implement/SKILL.md` | Mode: Codex 추가, heuristics/error handling/rationalization 보강 |

## Test plan

- [ ] `--model sonnet` 으로 cmux-delegate 호출 시 기존과 동일하게 claude 사용 확인
- [ ] `--model codex` 로 cmux-delegate 호출 시 wrapper script에 `codex exec` 포함 확인
- [ ] notation parsing: `codex`, `codex:o3`, `gemini`, `gemini:flash`, `opus`, `claude:opus` 올바르게 resolve
- [ ] codex/gemini 미설치 환경에서 에러 없이 claude fallback 확인
- [ ] turbo-implement에서 Codex 모드 선택 시 cmux-delegate --model codex 위임 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)