### PR TITLE
feat(turbo-setup): add next-step branching guide

### DIFF
--- a/skills/turbo-setup/SKILL.md
+++ b/skills/turbo-setup/SKILL.md
@@ -63,7 +63,10 @@ After successful setup, report these values (used by `turbo-completion`):
  Repo:      <target-repo>
  Deps:      <installed|skipped>
 
- Next: Implement the feature, then run /turbo-completion
+ Next steps (choose one):
+ • Same session:  implement inline → /turbo-completion
+ • Auto mode:     /turbo-implement (ralph/autopilot)
+ • New session:   /cmux-delegate --cwd <worktree> --model <provider>
 ═══════════════════════════════════════════════
 ```
 
@@ -213,21 +216,31 @@ issue → gh issue close (with /cancel comment)
 ## Chaining Interface
 
 ```
-turbo-setup → [user implements] → turbo-completion
-                                   ↓ receives:
-                                   - ISSUE_NUMBER (from git branch name)
-                                   - WORKTREE_PATH (from cwd)
-                                   - TARGET_REPO (from git remote)
+turbo-setup → [choose execution path]
+               │
+               ├─ same session  → implement inline → turbo-completion
+               ├─ auto mode     → turbo-implement  → turbo-completion
+               └─ new session   → cmux-delegate --cwd <worktree> --model <provider>
+                                    ↓ receives:
+                                    - ISSUE_NUMBER (from git branch name)
+                                    - WORKTREE_PATH (from cwd)
+                                    - TARGET_REPO (from git remote)
 ```
 
 `turbo-completion` auto-detects these from the current git state — no explicit handoff needed.
+`cmux-delegate` spawns an independent session in the worktree; handoff is via `--cwd` flag.
 
 ## Integration
 
 **Workflow position:**
 ```
-[user request] → [turbo-setup] → [EXECUTE] → [turbo-completion] → [done]
+[user request] → [turbo-setup] → [choose path] ─┬─ inline impl    → [turbo-completion] → [done]
+                                                  ├─ turbo-implement → [turbo-completion] → [done]
+                                                  └─ cmux-delegate  → [new session]       → [done]
 ```
 
 **Previous step:** User request (task description or URL)
-**Next step:** Implementation (manual or via `ralph`/`executor`)
+**Next step (options):**
+- Inline: implement in same session, then `/turbo-completion`
+- Auto: `/turbo-implement` (selects ralph or autopilot)
+- Delegated: `/cmux-delegate --cwd <worktree> --model <provider>`


### PR DESCRIPTION
## 개요

turbo-setup Output 섹션이 단일 경로(`/turbo-completion`)만 안내해서 사용자가 cmux-delegate 분기를 2번 질문한 문제를 수정합니다.

## 변경 내용

### 1. Output 섹션 — 3가지 분기 안내로 확장
기존 한 줄 안내를 사용자가 선택 가능한 3가지 경로로 교체:
- **Same session**: 인라인 구현 후 `/turbo-completion`
- **Auto mode**: `/turbo-implement` (ralph/autopilot 자동 선택)
- **New session**: `/cmux-delegate --cwd <worktree> --model <provider>`

### 2. Chaining Interface 섹션 — cmux-delegate 경로 추가
단선 다이어그램을 3-way 분기 트리로 재작성하고, `cmux-delegate` 핸드오프 방식(`--cwd` 플래그)을 명시.

### 3. Integration 섹션 — 다이어그램 및 Next step 목록 갱신
단선 워크플로우 다이어그램을 3분기 ASCII 트리로 교체하고, "Next step" 항목을 3가지 옵션으로 구체화.

## Acceptance Criteria

- [x] Output 섹션이 3가지 분기를 명확히 안내
- [x] Chaining Interface에 cmux-delegate 경로 추가
- [x] Integration 다이어그램에 3가지 옵션 반영

Closes #90