### PR TITLE
fix(cli): document codex exec write permissions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,11 +83,11 @@ Skills that dispatch external CLI workers (`cmux-orchestrator`, `cmux-delegate`,
 
 ### Provider CLI Spec
 
-| Provider | Non-interactive command | Output format | Stdin prompt |
-|----------|----------------------|---------------|-------------|
-| `claude` | `cat $F \| claude --model {m} --output-format stream-json --permission-mode auto` | stream-json (JSONL) | `cat file \| claude` |
-| `codex` | `cat $F \| codex exec {m:+-m m}` | stdout text / `--json` JSONL | `cat file \| codex exec` |
-| `gemini` | `gemini -p "$(cat $F)" --approval-mode yolo {m:+-m m}` | stream-json (`-o stream-json`) | via `-p` flag |
+| Provider | Non-interactive command | Output format | Stdin prompt | Write access |
+|----------|----------------------|---------------|-------------|-------------|
+| `claude` | `cat $F \| claude --model {m} --output-format stream-json --permission-mode auto` | stream-json (JSONL) | `cat file \| claude` | Full |
+| `codex` | `cat $F \| codex exec {m:+-m m}` | stdout text / `--json` JSONL | `cat file \| codex exec` | Sandbox-restricted — explicit fallback required |
+| `gemini` | `gemini -p "$(cat $F)" --approval-mode yolo {m:+-m m}` | stream-json (`-o stream-json`) | via `-p` flag | Full |
 
 All providers share the same completion sentinel: `; echo '===WORKER_DONE===' >> $LOG` appended after the CLI exits.
 
@@ -132,6 +132,9 @@ Two-phase routing: task keywords select the provider, then complexity selects th
 1. **Pre-flight**: `command -v <cli>` before dispatch. If missing → fall back to `claude:sonnet` with warning.
 2. **Runtime**: Worker failure → re-dispatch with `claude` as fallback provider.
 3. **Graceful**: If only `claude` is installed, all routing resolves to claude. Original behavior preserved.
+
+> **codex write detection**: After a codex worker completes, run `git status` to verify files were actually written. An empty diff after a code-generation task is a strong signal of sandbox write failure — trigger a claude fallback re-dispatch immediately.
+> <!-- TODO: automate re-dispatch on empty git diff -->
 
 ### Provider Resolution Logic
 

--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -404,3 +404,4 @@ user: /cmux-delegate "full code review" --model claude:opus --account claude-2
 - 결과 파일 자동 수집/보고 미지원 → 사용자가 cmux에서 직접 확인
 - 작업 유형별 템플릿 미지원 → 사용자가 프롬프트에 직접 명시
 - distribute 모드의 자동 분할은 섹션 헤더 기반 — 비정형 프롬프트는 수동 분할 필요
+- **codex 쓰기 제약**: `codex exec`는 샌드박스 환경으로 인해 파일 쓰기가 실패해도 오류 없이 종료될 수 있음 — 완료 후 반드시 `git status`로 실제 변경 여부를 확인할 것. 빈 diff가 나오면 즉시 `claude` fallback으로 재위임.


### PR DESCRIPTION
## 요약

`codex exec`는 샌드박스 환경으로 인해 파일 쓰기가 실패해도 오류 없이 종료될 수 있습니다. 2026-04-16 retrospect에서 발견된 이 제약이 Provider CLI Spec에 문서화되어 있지 않아 발생한 도구 결함입니다.

## 변경 내용

- **AGENTS.md** (= `CLAUDE.md` symlink): Provider CLI Spec 테이블에 `Write access` 컬럼 추가 — codex 행에 "Sandbox-restricted — explicit fallback required" 명시
- **AGENTS.md**: Fallback Policy 섹션에 codex 쓰기 감지 가이드 및 TODO 주석 추가
- **skills/cmux-delegate/SKILL.md**: Limitations 섹션에 codex 쓰기 실패 경고 추가 — 완료 후 `git status` 확인 및 빈 diff 시 claude fallback 재위임 안내

## 검증

- 코드 변경 없음 (markdown 문서 한정)
- `git diff` 확인 완료 — 두 파일 모두 의도한 내용으로 수정됨

Closes #89