### PR TITLE
feat(turbo-setup): open cmux workspace after worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Most skills delegate to external agents or session managers. Install the depende
 |------|-----------|---------------|
 | **Standalone** | turbo-setup, recover-sessions | `gh` CLI only |
 | **Enhanced** | + turbo-implement, turbo-completion, debug, retrospect | + oh-my-claudecode |
-| **Full** | + all cmux-* skills | + cmux |
+| **Full** | + all cmux-* skills, + turbo-setup auto-opens cmux workspace after worktree creation | + cmux |
 
 > Skills in higher tiers fall back to manual/built-in alternatives when their dependencies are missing, but with reduced functionality.
 

--- a/skills/turbo-setup/SKILL.md
+++ b/skills/turbo-setup/SKILL.md
@@ -38,6 +38,7 @@ When a project's `CLAUDE.md` does not provide routing, these built-in defaults a
 | Branch creation | — (built-in) | `issue-<N>-<type>-<desc>` on base branch |
 | Worktree creation | — (built-in) | `git worktree add ../<branch> -b <branch>` |
 | Dependency install | — (built-in auto-detect) | `npm install` / `pip install -r requirements.txt` / `go mod download` / `pip install -e .` |
+| cmux workspace open | — (built-in, auto-skip if cmux absent) | `cmux <worktree-path>` — opens a cmux workspace so the sidebar shows the new branch with git metadata |
 
 Projects override these by declaring routing in their `CLAUDE.md`.
 
@@ -129,7 +130,7 @@ BRANCH="issue-${ISSUE_NUMBER}-${TYPE}-${SHORT_DESC}"
 | Feature / Refactor / Docs | `dev` (or `main` if no `dev`) |
 | Hotfix | `prod` (or `main`) |
 
-### Step 4: Create Worktree
+### Step 4: Create Worktree (+ optional cmux workspace)
 
 ```bash
 # Determine target repo path
@@ -139,6 +140,12 @@ cd "$TARGET_REPO"
 git fetch origin
 git worktree add "../${BRANCH}" -b "$BRANCH" "origin/${BASE_BRANCH}"
 WORKTREE_PATH=$(realpath "../${BRANCH}")
+
+# Open cmux workspace (optional — skipped gracefully if cmux is not installed).
+# Rationale: if the user runs cmux (macOS), the new worktree appears as a
+# sidebar workspace immediately, so branch/PR metadata and agent notifications
+# are visible without a manual "File > Open" step.
+command -v cmux >/dev/null 2>&1 && cmux "$WORKTREE_PATH" || true
 ```
 
 ### Step 5: Install Dependencies
@@ -179,6 +186,12 @@ echo "Issue: $(gh issue view $ISSUE_NUMBER --json number,title --jq '.number')"
 echo "Branch: $(git branch --show-current)"
 echo "Worktree: $(pwd)"
 echo "Deps: $(ls node_modules 2>/dev/null && echo 'npm' || ls .venv 2>/dev/null && echo 'pip' || echo 'none')"
+# cmux workspace status (only meaningful on macOS with cmux installed)
+if command -v cmux >/dev/null 2>&1; then
+  echo "cmux: workspace opened at $WORKTREE_PATH"
+else
+  echo "cmux: skipped (not installed)"
+fi
 ```
 
 ## Error Handling


### PR DESCRIPTION
## Summary

- `turbo-setup` Step 4에 cmux workspace 자동 오픈 추가 (2줄, guard + `|| true`)
- Step 6 verify에 cmux 상태 리포트 추가
- Pluggable Steps 테이블에 cmux workspace 항목 추가
- README Full tier 설명에 turbo-setup cmux 오픈 언급

Closes #91

## Portability (다중 머신 호환성)

- **macOS + cmux 설치**: worktree 생성 직후 cmux workspace 자동 오픈 → sidebar에 new branch metadata 즉시 표시
- **Linux / cmux 미설치**: `command -v cmux` guard + `|| true`로 skip, turbo-setup 기존 동작 유지
- 중복 실행: cmux가 같은 경로면 기존 workspace focus (cmux 동작)

## Context

BP-9 (git worktree ↔ cmux workspace 1:1 매핑)를 개인 셸 함수(cwt)로 구현했다가, turbo-setup이 이미 issue+plan+branch+worktree+deps를 묶는 compound skill임을 발견. cwt의 기능이 turbo-setup에 흡수되면서 **개인 셸 함수 vs 재사용 가능한 skill** 이분법이 해소됨.

## Test plan

- [x] `command -v cmux` guard로 미설치 환경에서 fail 없이 skip 확인
- [x] diff 최소 변경 (Step 4 + Step 6 + table + README)
- [x] 기존 turbo-setup 사용자 영향 0 (cmux 없으면 기존과 동일)
- [ ] macOS + cmux 있는 실제 환경에서 sidebar 오픈 확인 (머지 후)
- [ ] Linux 머신에서 guard skip 확인 (향후 검증)

## Related

- Follow-up: #92 (cmux-hook-install skill 설계 검토)
- second-brain #45 (cmux best practices BP-9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)