### PR TITLE
feat(strike): gate 3/3 reset on reflection and persuasion

### DIFF
--- a/hooks/strike-counter.sh
+++ b/hooks/strike-counter.sh
@@ -105,9 +105,10 @@ load_reasons_plain() {
   fi
 }
 
-# Reflection gating helpers. A reflection is valid only if the file exists
-# AND is non-empty — empty markers would let the user bypass the gate by
-# just `touch`ing the path. `[ -s file ]` covers both conditions atomically.
+# [PR #105] Reflection gating helpers. A reflection is valid only if the
+# file exists AND is non-empty — empty markers would let the user bypass
+# the gate by just `touch`ing the path. `[ -s file ]` covers both
+# conditions atomically. Gate applies only at count>=3 in `reset` mode.
 reflection_valid() {
   [ -s "$REFLECTION_FILE" ]
 }

--- a/hooks/strike-counter.sh
+++ b/hooks/strike-counter.sh
@@ -12,7 +12,9 @@
 #   stop           Hook: if count>=3, emit {"decision":"block"} JSON
 #   strike <rsn>   Slash: increment count, echo level-specific message
 #   status         Slash: echo current count + reason list
-#   reset          Slash: clear state for current session
+#   reset          Slash: clear state for current session; at count>=3,
+#                  requires a non-empty reflection file at
+#                  $STATE_DIR/${SID}.reflection.md before clearing.
 
 # Fail-safe posture: we never want this script to break a Claude Code session.
 # Instead of relying on `trap ... ERR` (which is a no-op under `set +e`), we
@@ -38,8 +40,10 @@ mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
 LATCH="$STATE_DIR/.current-session"
 BLOCK_LOG="$STATE_DIR/last-block.log"
 
-# TTL cleanup — drop sessions older than 7 days (best-effort)
-find "$STATE_DIR" -maxdepth 1 -name '*.json' -mtime +7 -delete 2>/dev/null || true
+# TTL cleanup — drop sessions older than 7 days (best-effort).
+# Covers both state JSON and any orphan reflection markdown so stale
+# reflections from abandoned cycles cannot linger indefinitely.
+find "$STATE_DIR" -maxdepth 1 \( -name '*.json' -o -name '*.reflection.md' \) -mtime +7 -delete 2>/dev/null || true
 
 # ---- session_id resolution -------------------------------------------------
 # Hook modes consume stdin once (into $INPUT) so downstream code can reuse it.
@@ -81,6 +85,7 @@ if [ -z "$SID" ]; then
 fi
 
 STATE_FILE="$STATE_DIR/${SID}.json"
+REFLECTION_FILE="$STATE_DIR/${SID}.reflection.md"
 
 # ---- helpers ---------------------------------------------------------------
 load_count() {
@@ -98,6 +103,35 @@ load_reasons_plain() {
   if [ -f "$STATE_FILE" ]; then
     jq -r '.reasons // [] | to_entries | map("  \(.key + 1). \(.value)") | join("\n")' "$STATE_FILE" 2>/dev/null
   fi
+}
+
+# Reflection gating helpers. A reflection is valid only if the file exists
+# AND is non-empty — empty markers would let the user bypass the gate by
+# just `touch`ing the path. `[ -s file ]` covers both conditions atomically.
+reflection_valid() {
+  [ -s "$REFLECTION_FILE" ]
+}
+
+reflection_requirement_msg() {
+  cat <<MSG
+Recovery is a two-step trust process — write, then persuade.
+
+Step 1 — Write a reflection document at the path below.
+Path: $REFLECTION_FILE
+
+Reflection must cover:
+1. Summary of the three recorded violations this session
+2. Root cause of each violation (which CLAUDE.md rule/section was breached)
+3. Concrete behavioral changes to prevent recurrence (checklist form)
+
+Step 2 — Present the reflection to the user and make an explicit appeal:
+- Quote or summarize the reflection in-chat (do not just point at the file)
+- Acknowledge the specific harm each violation caused
+- Commit to the preventive checklist in concrete terms
+- Explicitly ask the user to run /praxis:reset-strikes as a trust decision
+
+/praxis:reset-strikes will be refused if the reflection file is missing or empty, and should only be invoked by the user after your appeal — never implicitly.
+MSG
 }
 
 # ---- mode handlers ---------------------------------------------------------
@@ -167,9 +201,11 @@ Before your next action, re-read the relevant sections of ~/.claude/CLAUDE.md an
       REASONS=$(load_reasons_plain)
       ts=$(date -u +%FT%TZ)
       echo "[$ts] session=$SID count=$COUNT block" >> "$BLOCK_LOG" 2>/dev/null || true
+      REQUIREMENT=$(reflection_requirement_msg)
       REASON_MSG="🔴 Praxis strike 3/3 — response blocked. Violations this session:
 $REASONS
-Ask the user to run /praxis:reset-strikes and acknowledge the retrospective before continuing."
+
+$REQUIREMENT"
       jq -n --arg r "$REASON_MSG" '{decision: "block", reason: $r}'
     fi
     exit 0
@@ -189,23 +225,25 @@ Ask the user to run /praxis:reset-strikes and acknowledge the retrospective befo
     # Distinguish expected counts (1/2/>=3) from unexpected values (0,
     # non-numeric, empty). COUNT=0 after a strike usually means the write
     # failed silently (jq parse error on corrupt state, mv failure, etc.);
-    # announcing "3진 block" in that case is a lie since the Stop hook
-    # only blocks when count>=3. Route unexpected values through a distinct
-    # error branch so UX matches actual enforcement state.
+    # announcing "strike 3 — blocked" in that case is a lie since the Stop
+    # hook only blocks when count>=3. Route unexpected values through a
+    # distinct error branch so UX matches actual enforcement state.
     if ! [[ "$COUNT" =~ ^[0-9]+$ ]] || [ "$COUNT" -eq 0 ] 2>/dev/null; then
-      echo "⚠️ Strike 상태 이상: count='$COUNT' — state 파일 손상 또는 쓰기 실패 가능." >&2
-      echo "복구: /praxis:reset-strikes 후 재시도 권장." >&2
+      echo "⚠️ Strike state error: count='$COUNT' — state file corrupt or write failed." >&2
+      echo "Recovery: run /praxis:reset-strikes and retry." >&2
     elif [ "$COUNT" -eq 1 ] 2>/dev/null; then
-      echo "⚠️ 1진 경고: $REASON (다음 응답부터 주의 강화)"
+      echo "⚠️ Strike 1 warning: $REASON (tighten rule adherence from next response)"
     elif [ "$COUNT" -eq 2 ] 2>/dev/null; then
-      echo "🔶 2진 회고 필요: $REASON. 누적 목록:"
+      echo "🔶 Strike 2 — review required: $REASON. Cumulative list:"
       load_reasons_plain
-      echo "관련 CLAUDE.md 섹션 재독 후 응답."
+      echo "Re-read the relevant CLAUDE.md section before replying."
     else
       # COUNT >= 3
-      echo "🔴 3진 block 상태: $REASON. 누적 목록:"
+      echo "🔴 Strike 3 — blocked: $REASON. Cumulative list:"
       load_reasons_plain
-      echo "다음 응답은 Stop hook으로 차단됩니다. /praxis:reset-strikes 로 해제."
+      echo "The next response will be blocked by the Stop hook."
+      echo ""
+      reflection_requirement_msg
     fi
     exit 0
     ;;
@@ -221,12 +259,27 @@ Ask the user to run /praxis:reset-strikes and acknowledge the retrospective befo
     ;;
 
   reset)
-    if [ -f "$STATE_FILE" ]; then
-      rm -f "$STATE_FILE"
-      echo "Strikes reset (session=$SID)."
-    else
+    if [ ! -f "$STATE_FILE" ]; then
       echo "No active strikes to reset."
+      exit 0
     fi
+    # Reflection gate applies only at count>=3 (the block threshold).
+    # At lower counts the user may want to clear accidental or exploratory
+    # strikes without ceremony, so we keep reset free in that range.
+    COUNT=$(load_count)
+    if [ "$COUNT" -ge 3 ] 2>/dev/null; then
+      if ! reflection_valid; then
+        echo "❌ Reset refused — reflection missing or empty."
+        echo ""
+        reflection_requirement_msg
+        exit 0
+      fi
+      # On successful gated reset, remove the reflection too so the next
+      # next strike-3 cycle starts from a clean slate and cannot reuse a stale doc.
+      rm -f "$REFLECTION_FILE"
+    fi
+    rm -f "$STATE_FILE"
+    echo "Strikes reset (session=$SID)."
     exit 0
     ;;
 

--- a/hooks/test-strike-counter.sh
+++ b/hooks/test-strike-counter.sh
@@ -7,6 +7,11 @@
 # Usage: bash hooks/test-strike-counter.sh
 # Exit:  0 = all pass; 1 = at least one fail (per-test output shown)
 
+# shellcheck disable=SC2329
+# All test_* and helper functions are invoked indirectly via `run "<name>" test_fn`
+# at the bottom of this file. Shellcheck can't trace indirect dispatch, so its
+# "never invoked" warning is a false positive for this test harness.
+
 set -u
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 STRIKE="$SCRIPT_DIR/strike-counter.sh"
@@ -40,27 +45,29 @@ cleanup_env() {
   unset CLAUDE_PLUGIN_DATA CLAUDE_SESSION_ID
 }
 
-# ---- AC1: /strike prints 1진 on first call ---------------------------------
+# ---- AC1: /strike prints strike 1 warning on first call --------------------
 test_ac1_first_strike_warning() {
   fresh_env
   local out
   out=$("$STRIKE" strike "worktree bypass" 2>&1)
   local code=$?
   cleanup_env
-  [ "$code" -eq 0 ] && echo "$out" | grep -q "1진 경고"
+  [ "$code" -eq 0 ] && echo "$out" | grep -q "Strike 1 warning"
 }
 
-# ---- AC2: second strike triggers 2진 회고 ----------------------------------
+# ---- AC2: second strike triggers strike 2 review ---------------------------
 test_ac2_second_strike_review() {
   fresh_env
   "$STRIKE" strike "one" >/dev/null
   local out code
   out=$("$STRIKE" strike "two" 2>&1); code=$?
   cleanup_env
-  [ "$code" -eq 0 ] && echo "$out" | grep -q "2진 회고" && echo "$out" | grep -q "CLAUDE.md"
+  [ "$code" -eq 0 ] \
+    && echo "$out" | grep -q "Strike 2 — review required" \
+    && echo "$out" | grep -q "CLAUDE.md"
 }
 
-# ---- AC3: third strike marks 3진 block state -------------------------------
+# ---- AC3: third strike marks strike 3 blocked state ------------------------
 test_ac3_third_strike_block_state() {
   fresh_env
   "$STRIKE" strike "one" >/dev/null
@@ -71,7 +78,7 @@ test_ac3_third_strike_block_state() {
   status_out=$("$STRIKE" status 2>&1)
   cleanup_env
   [ "$code" -eq 0 ] \
-    && echo "$out" | grep -q "3진 block" \
+    && echo "$out" | grep -q "Strike 3 — blocked" \
     && echo "$status_out" | grep -q "Strikes: 3/3" \
     && echo "$status_out" | grep -q "one" \
     && echo "$status_out" | grep -q "two" \
@@ -194,7 +201,7 @@ test_ac10_latch_fallback() {
   local out code
   out=$("$STRIKE" strike "via latch" 2>&1); code=$?
   cleanup_env
-  [ "$code" -eq 0 ] && echo "$out" | grep -q "1진 경고"
+  [ "$code" -eq 0 ] && echo "$out" | grep -q "Strike 1 warning"
 }
 
 # ---- AC11: missing session_id fails cleanly --------------------------------
@@ -274,7 +281,7 @@ test_ac16_skill_files_exist() {
   [ "$ok" -eq 1 ]
 }
 
-# ---- AC18 (codex P2): corrupt state file → error branch, not false 3진 ----
+# ---- AC18 (codex P2): corrupt state → error branch, not false block --------
 test_ac18_corrupt_state_not_false_block() {
   fresh_env
   mkdir -p "$CLAUDE_PLUGIN_DATA/strikes"
@@ -288,7 +295,7 @@ test_ac18_corrupt_state_not_false_block() {
   rm -f /tmp/err.$$
 
   # Confirm stop hook does NOT block (count<3), confirming the UX/enforcement
-  # asymmetry is fixed — error message on stderr, not false 3진 on stdout
+  # asymmetry is fixed — error message on stderr, not a false block on stdout
   local stop_out
   local json_in
   json_in=$(printf '{"session_id":"%s","stop_hook_active":false}' "$CLAUDE_SESSION_ID")
@@ -296,9 +303,113 @@ test_ac18_corrupt_state_not_false_block() {
   cleanup_env
 
   [ "$code" -eq 0 ] \
-    && [ -z "$(echo "$out" | grep '3진 block')" ] \
-    && echo "$err" | grep -q "Strike 상태 이상" \
+    && ! echo "$out" | grep -q 'Strike 3 — blocked' \
+    && echo "$err" | grep -q "Strike state error" \
     && [ -z "$stop_out" ]
+}
+
+# ---- AC19: reset at count>=3 refused when reflection missing ---------------
+test_ac19_reset_blocked_without_reflection() {
+  fresh_env
+  "$STRIKE" strike "one" >/dev/null
+  "$STRIKE" strike "two" >/dev/null
+  "$STRIKE" strike "three" >/dev/null
+  local out code
+  out=$("$STRIKE" reset 2>&1); code=$?
+  # State must still exist (reset was refused)
+  local state_file="$CLAUDE_PLUGIN_DATA/strikes/${CLAUDE_SESSION_ID}.json"
+  local state_kept=0
+  [ -f "$state_file" ] && state_kept=1
+  cleanup_env
+  [ "$code" -eq 0 ] \
+    && echo "$out" | grep -q "Reset refused" \
+    && echo "$out" | grep -q "reflection.md" \
+    && [ "$state_kept" -eq 1 ]
+}
+
+# ---- AC20: reset at count>=3 refused when reflection file is empty ---------
+test_ac20_reset_blocked_when_reflection_empty() {
+  fresh_env
+  "$STRIKE" strike "one" >/dev/null
+  "$STRIKE" strike "two" >/dev/null
+  "$STRIKE" strike "three" >/dev/null
+  local reflection="$CLAUDE_PLUGIN_DATA/strikes/${CLAUDE_SESSION_ID}.reflection.md"
+  : > "$reflection"  # zero-byte file
+  local out code
+  out=$("$STRIKE" reset 2>&1); code=$?
+  cleanup_env
+  [ "$code" -eq 0 ] && echo "$out" | grep -q "Reset refused"
+}
+
+# ---- AC21: reset at count>=3 succeeds when reflection is non-empty ---------
+test_ac21_reset_succeeds_with_reflection() {
+  fresh_env
+  "$STRIKE" strike "one" >/dev/null
+  "$STRIKE" strike "two" >/dev/null
+  "$STRIKE" strike "three" >/dev/null
+  local reflection="$CLAUDE_PLUGIN_DATA/strikes/${CLAUDE_SESSION_ID}.reflection.md"
+  local state_file="$CLAUDE_PLUGIN_DATA/strikes/${CLAUDE_SESSION_ID}.json"
+  printf '# Reflection\n\nRoot causes and prevention checklist.\n' > "$reflection"
+  local out code
+  out=$("$STRIKE" reset 2>&1); code=$?
+  # Both state and reflection must be removed after a successful gated reset
+  local state_gone=1
+  [ -f "$state_file" ] && state_gone=0
+  local reflection_gone=1
+  [ -f "$reflection" ] && reflection_gone=0
+  cleanup_env
+  [ "$code" -eq 0 ] \
+    && echo "$out" | grep -q "Strikes reset" \
+    && [ "$state_gone" -eq 1 ] \
+    && [ "$reflection_gone" -eq 1 ]
+}
+
+# ---- AC22: reset at count<3 is NOT gated (no reflection required) ----------
+test_ac22_reset_not_gated_under_3() {
+  fresh_env
+  "$STRIKE" strike "one" >/dev/null
+  local out code
+  out=$("$STRIKE" reset 2>&1); code=$?
+  cleanup_env
+  [ "$code" -eq 0 ] && echo "$out" | grep -q "Strikes reset"
+}
+
+# ---- AC23: stop hook block message includes reflection instructions --------
+test_ac23_stop_block_has_reflection_instructions() {
+  fresh_env
+  "$STRIKE" strike "one" >/dev/null
+  "$STRIKE" strike "two" >/dev/null
+  "$STRIKE" strike "three" >/dev/null
+  local json_in
+  json_in=$(printf '{"session_id":"%s","stop_hook_active":false}' "$CLAUDE_SESSION_ID")
+  local out
+  out=$(echo "$json_in" | "$STRIKE" stop 2>&1)
+  local reason
+  reason=$(echo "$out" | jq -r '.reason // empty' 2>/dev/null)
+  cleanup_env
+  echo "$reason" | grep -q "reflection" \
+    && echo "$reason" | grep -q "reflection.md" \
+    && echo "$reason" | grep -q "Root cause"
+}
+
+# ---- AC24: block message includes persuasion step instructions -------------
+test_ac24_block_message_has_persuasion_step() {
+  fresh_env
+  "$STRIKE" strike "one" >/dev/null
+  "$STRIKE" strike "two" >/dev/null
+  local strike_out
+  strike_out=$("$STRIKE" strike "three" 2>&1)
+  local json_in
+  json_in=$(printf '{"session_id":"%s","stop_hook_active":false}' "$CLAUDE_SESSION_ID")
+  local stop_out
+  stop_out=$(echo "$json_in" | "$STRIKE" stop 2>&1)
+  local stop_reason
+  stop_reason=$(echo "$stop_out" | jq -r '.reason // empty' 2>/dev/null)
+  cleanup_env
+  # Both the strike-time and stop-hook messages must name the persuasion step
+  # so Claude cannot skip the user-facing appeal after writing the reflection.
+  echo "$strike_out" | grep -qi "persuade\|trust\|appeal" \
+    && echo "$stop_reason" | grep -qi "persuade\|trust\|appeal"
 }
 
 # ---- AC17 (plan Step 1.5): TTL cleanup removes stale state files -----------
@@ -337,14 +448,14 @@ test_ac17_ttl_cleanup() {
 # ---------- runner ----------------------------------------------------------
 echo "strike-counter.sh tests"
 echo "------------------------"
-run "AC1  first strike → 1진 warning" test_ac1_first_strike_warning
-run "AC2  second strike → 2진 review + CLAUDE.md" test_ac2_second_strike_review
-run "AC3  third strike → 3진 block state + status" test_ac3_third_strike_block_state
+run "AC1  first strike → strike 1 warning" test_ac1_first_strike_warning
+run "AC2  second strike → strike 2 review + CLAUDE.md" test_ac2_second_strike_review
+run "AC3  third strike → strike 3 blocked state + status" test_ac3_third_strike_block_state
 run "AC4  stop hook blocks at count≥3 (JSON decision + log)" test_ac4_stop_hook_blocks_at_3
 run "AC5  stop hook silent at count<3" test_ac5_stop_hook_silent_under_3
 run "AC6  stop_hook_active=true short-circuits" test_ac6_stop_active_short_circuit
 run "AC7  reset clears state" test_ac7_reset_clears
-run "AC8  preprompt emits 1/2진 additionalContext" test_ac8_preprompt_contexts
+run "AC8  preprompt emits strike 1/2 additionalContext" test_ac8_preprompt_contexts
 run "AC9  session-start writes latch + emits context" test_ac9_session_start_latch
 run "AC10 slash command uses latch when env var unset" test_ac10_latch_fallback
 run "AC11 missing session_id → silent fail-safe exit 0" test_ac11_missing_session_id
@@ -354,7 +465,13 @@ run "AC14 session-start exports CLAUDE_SESSION_ID via \$CLAUDE_ENV_FILE" test_ac
 run "AC15 jq missing → stdout+stderr guidance + exit 0" test_ac15_jq_missing_guidance
 run "AC16 skill files exist + reference strike-counter.sh" test_ac16_skill_files_exist
 run "AC17 TTL cleanup removes stale state files" test_ac17_ttl_cleanup
-run "AC18 corrupt state → error branch, not false 3진 (codex P2)" test_ac18_corrupt_state_not_false_block
+run "AC18 corrupt state → error branch, not false block (codex P2)" test_ac18_corrupt_state_not_false_block
+run "AC19 reset at 3/3 refused without reflection file" test_ac19_reset_blocked_without_reflection
+run "AC20 reset at 3/3 refused when reflection file is empty" test_ac20_reset_blocked_when_reflection_empty
+run "AC21 reset at 3/3 succeeds with reflection + clears both files" test_ac21_reset_succeeds_with_reflection
+run "AC22 reset at count<3 not gated by reflection" test_ac22_reset_not_gated_under_3
+run "AC23 stop hook block message includes reflection instructions" test_ac23_stop_block_has_reflection_instructions
+run "AC24 block message includes persuasion step instructions" test_ac24_block_message_has_persuasion_step
 
 echo "------------------------"
 echo "Passed: $PASS  Failed: $FAIL"

--- a/skills/reset-strikes/SKILL.md
+++ b/skills/reset-strikes/SKILL.md
@@ -15,6 +15,19 @@ Clear the session strike counter so the discipline signals restart from 0.
    ```
 2. Report the output verbatim. If the session was blocked at 3/3, acknowledge the reset and confirm that future responses will proceed normally until a new strike is declared.
 
+## Reflection gate at 3/3
+
+When the session is blocked at 3/3, reset is **conditional on a written reflection + an explicit user trust decision**.
+
+The strike/stop-hook output names an exact file path (`$STATE_DIR/${SID}.reflection.md`) and the required content structure (violations summary, root cause per violation mapped to a CLAUDE.md rule/section, preventive checklist). Recovery is a two-step process:
+
+1. **Reflection file** — written by Claude, gates the file check. If missing or empty when reset is called, the script prints `❌ Reset refused — reflection missing or empty.` and re-states the path and required contents. The counter is not cleared.
+2. **Persuasion turn** — before the user invokes this skill, Claude must present the reflection in-chat (quote or summarize, do not just point at the path), acknowledge each violation's harm, state concrete behavioral commitments, and explicitly ask the user to run `/praxis:reset-strikes`. This is a trust decision, not a mechanical unlock — the user may decline and require more.
+
+Additional behavior:
+- On a successful 3/3 reset, the reflection file is removed alongside the state so the next cycle starts clean and cannot reuse a stale document.
+- Below 3/3, reset is not gated — the reflection + persuasion requirement only applies at the block threshold.
+
 ## Reinforcement after reset
 
 - Do not treat reset as absolution — the violations happened. Briefly summarize what went wrong this session (if known from the transcript) and state one concrete behavioral adjustment before continuing with user work.

--- a/skills/strike/SKILL.md
+++ b/skills/strike/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: strike
-description: Declare a rule violation in the current Claude Code session. Use ONLY when the user says "/strike", "/praxis:strike", "strike 1/2/3", "삼진", or explicitly asks to record a rule violation. Do NOT activate on colloquial uses like "strike a balance" or "strike that". Escalates — 1진 warning, 2진 forced review, 3진 response block.
+description: Declare a rule violation in the current Claude Code session. Use ONLY when the user says "/strike", "/praxis:strike", "strike 1/2/3", "삼진", or explicitly asks to record a rule violation. Do NOT activate on colloquial uses like "strike a balance" or "strike that". Escalates — strike 1 warning, strike 2 forced review, strike 3 response block.
 ---
 
 # Praxis Strike
@@ -18,9 +18,11 @@ Record a single rule violation against the current session's strike counter.
 
 ## Reinforcement after the call
 
-- If the script output starts with `⚠️ 1진`, internalize the recorded reason and commit to stricter rule adherence for the rest of the session.
-- If the script output starts with `🔶 2진`, **stop any in-flight work**, list the cumulative violations, identify the matching CLAUDE.md section, re-read it, and state explicitly how you will avoid another strike before resuming.
-- If the script output starts with `🔴 3진`, announce that the next response will be blocked by the Stop hook, and ask the user whether to run `/praxis:reset-strikes`.
+- If the script output starts with `⚠️ Strike 1`, internalize the recorded reason and commit to stricter rule adherence for the rest of the session.
+- If the script output starts with `🔶 Strike 2`, **stop any in-flight work**, list the cumulative violations, identify the matching CLAUDE.md section, re-read it, and state explicitly how you will avoid another strike before resuming.
+- If the script output starts with `🔴 Strike 3`, recovery is a **two-step trust process**:
+  1. **Write the reflection** at the path the script printed — violations summary, root cause per violation tied to a specific CLAUDE.md rule/section, and a concrete preventive checklist. The file must be non-empty or `/praxis:reset-strikes` will be refused.
+  2. **Persuade the user** before asking for reset: quote or summarize the reflection in-chat (do not just point at the file path), acknowledge the specific harm each violation caused, commit to the preventive checklist in concrete terms, then explicitly ask the user to run `/praxis:reset-strikes` as a trust decision. Do not treat the user's approval as mechanical — it is a judgment call based on your appeal.
 
 ## Non-goals
 


### PR DESCRIPTION
Closes #104

## 변경 요약

3진 차단 후 \`/praxis:reset-strikes\`가 **반성문 파일 + 사용자 설득**이라는 2단계 신뢰 절차를 통과해야만 카운터를 초기화하도록 수정.

## 동작 변화

### Before
- 3진 차단 시 사용자가 \`/praxis:reset-strikes\` 호출 → 즉시 초기화
- 반성 절차가 세션 컨텍스트에 남지 않고 \"형식적 일시 정지\"에 그침

### After
- 3진 차단 시 hook이 반성문 경로(\`\$STATE_DIR/\${SID}.reflection.md\`)와 필수 항목(위반 요약 / 근본 원인 / 예방 체크리스트)을 명시
- \`reset\`은 count≥3에서 반성문 파일이 비어있지 않아야 허용 (missing/empty → \`Reset refused\`)
- 반성문 작성 후 Claude가 **사용자를 설득하는 단계**(인용 요약, 위반별 영향 인정, 행동 변경 약속, 명시적 reset 요청) 필수
- 성공적 3/3 reset 시 state + reflection 모두 삭제하여 다음 사이클 클린 시작
- count<3 reset은 기존처럼 gating 없음 (탐색적 초기화 허용)

## 부수 변경

- 출력 문자열 영어 통일: \`1진/2진/3진\` → \`Strike 1 warning / Strike 2 — review required / Strike 3 — blocked\`
- TTL cleanup에 \`*.reflection.md\` 추가하여 고아 반성문도 7일 후 정리
- \`Strike 상태 이상\` → \`Strike state error\`

## 테스트

\`hooks/test-strike-counter.sh\` 24/24 통과 (기존 18 + 신규 6):

| AC | 검증 |
|----|------|
| AC19 | 반성문 없이 3/3 reset → 거부, state 유지 |
| AC20 | 반성문 비어있는 상태 3/3 reset → 거부 |
| AC21 | 반성문 존재 시 3/3 reset → 성공 + state/reflection 모두 삭제 |
| AC22 | count<3 reset은 gating 없음 |
| AC23 | stop hook block 메시지에 반성문 지시 포함 |
| AC24 | strike/stop 메시지에 설득(persuade/trust/appeal) 단계 포함 |

\`\`\`
Passed: 24  Failed: 0
\`\`\`

shellcheck 클린 (exit 0).

## 수동 시나리오 출력

\`\`\`
🔴 Strike 3 — blocked: wrong base branch. Cumulative list:
  1. ignored worktree discipline
  2. skipped verification
  3. wrong base branch
The next response will be blocked by the Stop hook.

Recovery is a two-step trust process — write, then persuade.

Step 1 — Write a reflection document at the path below.
Path: …/\${SID}.reflection.md

Reflection must cover:
1. Summary of the three recorded violations this session
2. Root cause of each violation (which CLAUDE.md rule/section was breached)
3. Concrete behavioral changes to prevent recurrence (checklist form)

Step 2 — Present the reflection to the user and make an explicit appeal:
- Quote or summarize the reflection in-chat (do not just point at the file)
- Acknowledge the specific harm each violation caused
- Commit to the preventive checklist in concrete terms
- Explicitly ask the user to run /praxis:reset-strikes as a trust decision

/praxis:reset-strikes will be refused if the reflection file is missing or empty, and should only be invoked by the user after your appeal — never implicitly.
\`\`\`

## 완료 조건 체크

- [x] 3진 도달 시 hook 메시지가 반성문 경로와 필수 항목 포함
- [x] 반성문 없이 reset 호출 시 초기화 거부 + 작성 요구 출력
- [x] 반성문 존재 상태에서 reset 호출 시 정상 초기화 + 반성문 파일도 삭제
- [x] \`hooks/test-strike-counter.sh\`에 반성문 gating 테스트 케이스 추가
- [x] 설득 단계 요구를 hook/skill 문서에 명시

## 남긴 것

트리거 키워드로 쓰이는 한국어 (\`\"몇 진\"\`, \`\"삼진\"\`)는 사용자 입력용이라 skill 설명에 보존했습니다 (출력 문자열은 전부 영어).