### PR TITLE
fix(orchestrator): harden codex result parsing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Skills that dispatch external CLI workers (`cmux-orchestrator`, `cmux-delegate`,
 | Provider | Non-interactive command | Output format | Stdin prompt | Write access |
 |----------|----------------------|---------------|-------------|-------------|
 | `claude` | `cat $F \| claude --model {m} --output-format stream-json --permission-mode auto` | stream-json (JSONL) | `cat file \| claude` | Full |
-| `codex` | `cat $F \| codex exec {m:+-m m}` | stdout text / `--json` JSONL | `cat file \| codex exec` | Sandbox-restricted — explicit fallback required |
+| `codex` | `cat $F \| codex exec {m:+-m m} -o $RESULT_FILE` | stdout verbose logs + last message isolated in `$RESULT_FILE` (preferred); `--json` JSONL also supported | `cat file \| codex exec` | Sandbox-restricted — explicit fallback required |
 | `gemini` | `gemini -p "$(cat $F)" --approval-mode yolo {m:+-m m}` | stream-json (`-o stream-json`) | via `-p` flag | Full |
 
 All providers share the same completion sentinel: `; echo '===WORKER_DONE===' >> $LOG` appended after the CLI exits.

--- a/skills/cmux-orchestrator/SKILL.md
+++ b/skills/cmux-orchestrator/SKILL.md
@@ -172,8 +172,12 @@ dispatch_worker() {
         echo '===WORKER_DONE===' >> ${log_file}"
       ;;
     codex)
+      # `-o` writes only the final agent message to a separate file, bypassing
+      # verbose stdout logs. `collect_result()` prefers this file over log parsing.
+      local codex_result_file="$ORCH_DIR/results/${task_id}.codex.last.txt"
       cmd="cat '${prompt_file}' | codex exec \
         ${model:+-m ${model}} \
+        -o '${codex_result_file}' \
         2>&1 | tee ${log_file}; \
         echo '===WORKER_DONE===' >> ${log_file}"
       ;;
@@ -286,16 +290,29 @@ if provider == 'claude':
             except: pass
 
 elif provider == 'codex':
-    # Codex: parse JSONL for last content, or read plain text output
-    with open(log_file) as f:
-        for line in f:
-            try:
-                obj = json.loads(line)
-                if 'content' in obj:
-                    result = obj['content']
-            except:
-                if line.strip() and '===WORKER_DONE===' not in line:
-                    result = line.strip()
+    # Codex: prefer dedicated --output-last-message file (only the final agent
+    # message, no verbose logs). Fall back to log scan only if the file is
+    # missing or empty — in that case accept JSONL 'content' but never overwrite
+    # a previously parsed JSON result with a stray plain text log line.
+    import os
+    codex_last = log_file.replace('/logs/', '/results/').replace('.jsonl', '.codex.last.txt')
+    if os.path.exists(codex_last):
+        with open(codex_last) as f:
+            text = f.read().strip()
+        if text:
+            result = text
+    if result is None:
+        parsed_json = False
+        with open(log_file) as f:
+            for line in f:
+                try:
+                    obj = json.loads(line)
+                    if 'content' in obj:
+                        result = obj['content']
+                        parsed_json = True
+                except:
+                    if not parsed_json and line.strip() and '===WORKER_DONE===' not in line:
+                        result = line.strip()
 
 elif provider == 'gemini':
     with open(log_file) as f:


### PR DESCRIPTION
## Summary

`cmux-orchestrator`의 `collect_result()`가 codex provider에 대해 trailing verbose log 라인을 실제 결과로 덮어쓰는 문제를 수정합니다.

## Root Cause

기존 파서는 JSONL을 라인 단위로 파싱하되, JSON 디코딩 실패 시 plain-text fallback으로 마지막 비어있지 않은 라인을 `result`에 덮어썼습니다. codex가 verbose 로그를 stdout에 흘리면 (예: `DEBUG: finalize step`, `INFO: cleanup`), 마지막 로그 라인이 진짜 결과 JSON을 덮어쓰는 회귀가 발생합니다.

## Fix

1. **Dispatch (`dispatch_worker`)**: `codex exec` 호출에 `-o '${codex_result_file}'` 추가. `$ORCH_DIR/results/{task_id}.codex.last.txt`에 최종 agent 메시지만 분리 기록.
2. **Parser (`collect_result`)**: 이 결과 파일이 존재하면 우선 사용. 파일이 비어있거나 없을 때만 log 파싱으로 fallback하되, JSON에서 한 번이라도 `content`가 파싱되면 plain-text fallback이 그 값을 덮어쓰지 못하도록 `parsed_json` 가드 추가.
3. **AGENTS.md**: Provider CLI Spec 표에 `-o $RESULT_FILE` 규약을 반영.

## Verification

codex CLI `--help` 확인 (근거 있는 플래그 사용):
- `-o, --output-last-message <FILE>` — "Specifies file where the last message from the agent should be written"
- `--json` — "Print events to stdout as JSONL" (보조 수단으로 기록 유지)

Python 스모크 테스트 5 케이스 PASS (로컬):

| Case | 시나리오 | 기대 | 결과 |
|------|---------|------|------|
| 1 | `-o` 파일에 결과 있음 | 파일 내용 사용 | PASS |
| 2 | `-o` 파일 비어있음, 로그에 JSON | JSON `content` 사용 | PASS |
| 3 | `-o` 없음, plain text만 | 마지막 non-sentinel 라인 | PASS |
| 4 | `-o` 없음, JSON 뒤에 verbose log (원본 버그 재현) | JSON 유지, 로그에 덮이지 않음 | PASS |
| 5 | 로그에 sentinel만 | `None` | PASS |

스킬 본체는 LLM이 해석하는 pseudo-code라 자동 회귀 테스트 하네스는 없지만, 파서 Python 블록은 위 스모크로 동작 검증됨.

## Notes

- 버전 bump 미포함 — 별도 릴리스 시점에 묶어서 bump 예정.
- 기존 경로 규약(`logs/*.jsonl` ↔ `results/*.codex.last.txt`)은 파서가 `.replace()`로 유도.

Closes #84
