### PR TITLE
fix(cli): add cmux-browser wrapper with --selector usage hints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 | **Full** | + all cmux-* skills | + cmux |
 | **Multi-provider** | + codex/gemini routing in cmux-*, turbo-implement | + codex-cli, gemini-cli |
 
-## Skills (15)
+## Skills (16)
 
 ### Workflow Lifecycle
 
@@ -29,6 +29,7 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 |-------|---------|
 | `debug` | Systematic 4-phase debugging — root cause investigation before any fix |
 | `retrospect` | Session retrospect — find friction root causes, propose improvements |
+| `cmux-browser` | CLI wrapper for `cmux browser` — adds `--selector` usage hints to `get html/text/value/attr/count/box/styles` errors |
 
 ### Discipline
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 | **Full** | + all cmux-* skills | + cmux |
 | **Multi-provider** | + codex/gemini routing in cmux-*, turbo-implement | + codex-cli, gemini-cli |
 
-## Skills (16)
+## Skills (15)
 
 ### Workflow Lifecycle
 
@@ -29,7 +29,6 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 |-------|---------|
 | `debug` | Systematic 4-phase debugging — root cause investigation before any fix |
 | `retrospect` | Session retrospect — find friction root causes, propose improvements |
-| `cmux-browser` | CLI wrapper for `cmux browser` — adds `--selector` usage hints to `get html/text/value/attr/count/box/styles` errors |
 
 ### Discipline
 
@@ -334,11 +333,20 @@ build run. No skill, hook, or existing-platform changes required.
 ### Canonical clone path
 
 This repository should live at **`~/projects/praxis`**. The CLI tools shipped
-by skills (e.g. `cmux-recover-sessions`, `claude-recover`, `cmux-save-sessions`)
-are symlinked from `~/.local/bin` into this clone, so patches you commit here
-land in the version that actually runs at the shell. Keeping a second clone
-under a legacy name risks `~/.local/bin` symlinks pointing at stale code —
-a real failure mode previously hit during recover-sessions debugging.
+by skills (e.g. `cmux-recover-sessions`, `claude-recover`, `cmux-save-sessions`,
+`cmux-browser`) are symlinked from `~/.local/bin` into this clone, so patches
+you commit here land in the version that actually runs at the shell. Keeping a
+second clone under a legacy name risks `~/.local/bin` symlinks pointing at stale
+code — a real failure mode previously hit during recover-sessions debugging.
+
+### CLI tools (not skills)
+
+These are shell wrappers installed via `scripts/install.sh` into `~/.local/bin`.
+They are not AI skills — they have no `SKILL.md` and cannot be invoked as `/praxis:*`.
+
+| Binary | Source | Purpose |
+|--------|--------|---------|
+| `cmux-browser` | `skills/cmux-browser/cmux-browser` | Pass-through for `cmux browser`; intercepts selector-missing errors and adds subcommand-specific usage hints |
 
 ### Install / refresh CLI symlinks
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -50,6 +50,7 @@ CLI_SCRIPTS=(
   "skills/cmux-recover-sessions/cmux-recover-sessions"
   "skills/cmux-session-manager/cmux-session-status"
   "skills/cmux-session-manager/cmux-session-cleanup"
+  "skills/cmux-browser/cmux-browser"
 )
 
 mkdir -p "$BIN_DIR"

--- a/scripts/verify-symlinks.sh
+++ b/scripts/verify-symlinks.sh
@@ -20,6 +20,7 @@ CLI_SCRIPTS=(
   "skills/cmux-recover-sessions/cmux-recover-sessions"
   "skills/cmux-session-manager/cmux-session-status"
   "skills/cmux-session-manager/cmux-session-cleanup"
+  "skills/cmux-browser/cmux-browser"
 )
 
 drift=0

--- a/skills/cmux-browser/cmux-browser
+++ b/skills/cmux-browser/cmux-browser
@@ -1,9 +1,13 @@
 #!/bin/bash
 # cmux-browser: thin pass-through for `cmux browser` with enhanced error messages
 #
-# When `cmux browser get <type>` is called without --selector, the stock error
-# is "Error: browser get html requires a selector" — no usage hint.  This wrapper
-# intercepts that specific error and appends a usage block with examples.
+# When a `cmux browser` subcommand requires --selector but none is provided,
+# the stock error is a bare one-liner with no usage hint:
+#   Error: browser get html requires a selector
+#   Error: browser click requires a selector
+#
+# This wrapper intercepts any "requires a selector" error and appends a
+# subcommand-specific usage block with examples.
 #
 # Usage (identical to cmux browser):
 #   cmux-browser [--surface <id>] <subcommand> [args]
@@ -26,18 +30,34 @@ cmux browser "$@" 2>"$TMPFILE" || exit_code=$?
 [ "$exit_code" -eq 0 ] && exit 0
 
 if grep -q "requires a selector" "$TMPFILE"; then
-  get_type=$(grep -oE 'get [a-z]+' "$TMPFILE" | head -1 | awk '{print $2}')
-  get_type="${get_type:-<type>}"
+  # Extract subcommand from "Error: browser <subcmd> requires a selector".
+  # sed handles single-token ("click") and two-token ("get html") forms,
+  # as well as hyphenated names ("scroll-into-view").
+  subcmd=$(sed -n 's/.*browser \(.*\) requires a selector.*/\1/p' "$TMPFILE" \
+    | head -1 || true)
+  subcmd="${subcmd:-<subcommand>}"
 
-  printf 'Error: cmux browser get %s requires --selector\n\n' "$get_type" >&2
+  printf 'Error: cmux browser %s requires --selector\n\n' "$subcmd" >&2
   printf 'Usage:\n' >&2
-  printf '  cmux browser <surface> get %s --selector <css>        # first match\n' "$get_type" >&2
-  printf '  cmux browser <surface> get %s --selector <css> --all  # all matches\n\n' "$get_type" >&2
-  printf 'Examples:\n' >&2
-  printf "  cmux browser surface:1 get %s --selector 'h1.title'\n" "$get_type" >&2
-  printf "  cmux browser surface:1 get %s --selector 'a[href]' --all\n\n" "$get_type" >&2
-  printf 'Note: selector can also be passed positionally:\n' >&2
-  printf "  cmux browser surface:1 get %s 'h1.title'\n\n" "$get_type" >&2
+
+  # `get <type>` supports --all and a positional selector.
+  # Action commands (click, hover, type…) take only --selector <css> or <css>.
+  if echo "$subcmd" | grep -q '^get '; then
+    printf '  cmux browser surface:1 %s --selector <css>        # first match\n' "$subcmd" >&2
+    printf '  cmux browser surface:1 %s --selector <css> --all  # all matches\n\n' "$subcmd" >&2
+    printf 'Examples:\n' >&2
+    printf "  cmux browser surface:1 %s --selector 'h1.title'\n" "$subcmd" >&2
+    printf "  cmux browser surface:1 %s --selector 'a[href]' --all\n\n" "$subcmd" >&2
+    printf 'Note: selector can also be passed positionally:\n' >&2
+    printf "  cmux browser surface:1 %s 'h1.title'\n\n" "$subcmd" >&2
+  else
+    printf '  cmux browser surface:1 %s --selector <css>\n' "$subcmd" >&2
+    printf '  cmux browser surface:1 %s <css>               # positional shorthand\n\n' "$subcmd" >&2
+    printf 'Examples:\n' >&2
+    printf "  cmux browser surface:1 %s --selector 'button.submit'\n" "$subcmd" >&2
+    printf "  cmux browser surface:1 %s 'button.submit'\n\n" "$subcmd" >&2
+  fi
+
   printf 'See `cmux browser --help` for all options.\n' >&2
 else
   cat "$TMPFILE" >&2

--- a/skills/cmux-browser/cmux-browser
+++ b/skills/cmux-browser/cmux-browser
@@ -40,12 +40,14 @@ if grep -q "requires a selector" "$TMPFILE"; then
   printf 'Error: cmux browser %s requires --selector\n\n' "$subcmd" >&2
   printf 'Usage:\n' >&2
 
-  # Three usage branches based on subcommand interface (from `cmux browser --help`):
-  #   get attr        — selector + --attr <name>
-  #   get <other>     — selector (+ --all for multi-match) + positional shorthand
-  #   type|fill       — selector + --text <text>
-  #   select          — selector + --value <value>
-  #   action cmds     — selector only (click, hover, focus, dblclick, …)
+  # Usage branches per subcommand interface (verified against `cmux browser --help`):
+  #   get attr   — selector + --attr <name> (both required)
+  #   get <rest> — selector only; no --all flag in get (--all is cookies-only)
+  #   type       — selector + --text <text> (binary errors without text too)
+  #   fill       — selector only (text is optional; binary does not enforce it)
+  #   select     — selector + --value <value>
+  #   others     — selector only (click, hover, focus, frame sub-errors not
+  #                intercepted here — those produce different error strings)
   if [ "$subcmd" = "get attr" ]; then
     printf '  cmux browser surface:1 get attr --selector <css> --attr <name>\n' >&2
     printf '  cmux browser surface:1 get attr <css> <name>   # positional shorthand\n\n' >&2
@@ -53,19 +55,18 @@ if grep -q "requires a selector" "$TMPFILE"; then
     printf "  cmux browser surface:1 get attr --selector 'a.link' --attr href\n" >&2
     printf "  cmux browser surface:1 get attr 'img.logo' src\n\n" >&2
   elif echo "$subcmd" | grep -q '^get '; then
-    printf '  cmux browser surface:1 %s --selector <css>        # first match\n' "$subcmd" >&2
-    printf '  cmux browser surface:1 %s --selector <css> --all  # all matches\n\n' "$subcmd" >&2
+    printf '  cmux browser surface:1 %s --selector <css>\n' "$subcmd" >&2
+    printf '  cmux browser surface:1 %s <css>               # positional shorthand\n\n' "$subcmd" >&2
     printf 'Examples:\n' >&2
     printf "  cmux browser surface:1 %s --selector 'h1.title'\n" "$subcmd" >&2
-    printf "  cmux browser surface:1 %s --selector 'a[href]' --all\n\n" "$subcmd" >&2
-    printf 'Note: selector can also be passed positionally:\n' >&2
     printf "  cmux browser surface:1 %s 'h1.title'\n\n" "$subcmd" >&2
-  elif [ "$subcmd" = "type" ] || [ "$subcmd" = "fill" ]; then
-    printf '  cmux browser surface:1 %s --selector <css> --text <text>\n' "$subcmd" >&2
-    printf '  cmux browser surface:1 %s <css> <text>    # positional shorthand\n\n' "$subcmd" >&2
+  elif [ "$subcmd" = "type" ]; then
+    # `type` requires both selector and text; the binary errors on missing text too.
+    printf '  cmux browser surface:1 type --selector <css> --text <text>\n' >&2
+    printf '  cmux browser surface:1 type <css> <text>    # positional shorthand\n\n' >&2
     printf 'Examples:\n' >&2
-    printf "  cmux browser surface:1 %s --selector '#email' --text 'user@example.com'\n" "$subcmd" >&2
-    printf "  cmux browser surface:1 %s '#email' 'user@example.com'\n\n" "$subcmd" >&2
+    printf "  cmux browser surface:1 type --selector '#search' --text 'query'\n" >&2
+    printf "  cmux browser surface:1 type '#search' 'query'\n\n" >&2
   elif [ "$subcmd" = "select" ]; then
     printf '  cmux browser surface:1 select --selector <css> --value <value>\n' >&2
     printf '  cmux browser surface:1 select <css> <value>   # positional shorthand\n\n' >&2

--- a/skills/cmux-browser/cmux-browser
+++ b/skills/cmux-browser/cmux-browser
@@ -27,7 +27,10 @@ trap 'rm -f "$TMPFILE"' EXIT
 # exists, so $? after the if block would be 0 regardless of cmux's exit code.
 exit_code=0
 cmux browser "$@" 2>"$TMPFILE" || exit_code=$?
-[ "$exit_code" -eq 0 ] && exit 0
+if [ "$exit_code" -eq 0 ]; then
+  cat "$TMPFILE" >&2  # replay any warnings cmux wrote to stderr on success
+  exit 0
+fi
 
 if grep -q "requires a selector" "$TMPFILE"; then
   # Extract subcommand from "Error: browser <subcmd> requires a selector".

--- a/skills/cmux-browser/cmux-browser
+++ b/skills/cmux-browser/cmux-browser
@@ -1,0 +1,46 @@
+#!/bin/bash
+# cmux-browser: thin pass-through for `cmux browser` with enhanced error messages
+#
+# When `cmux browser get <type>` is called without --selector, the stock error
+# is "Error: browser get html requires a selector" — no usage hint.  This wrapper
+# intercepts that specific error and appends a usage block with examples.
+#
+# Usage (identical to cmux browser):
+#   cmux-browser [--surface <id>] <subcommand> [args]
+#
+# Install: scripts/install.sh symlinks this into ~/.local/bin/cmux-browser
+
+set -euo pipefail
+
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
+# stdout goes straight to the terminal; only stderr is captured for inspection.
+# This keeps large outputs (full-page HTML, etc.) streaming without buffering.
+#
+# NOTE: do NOT use `if cmux ...; then ...; fi; exit_code=$?` here.
+# In bash, `if <false-condition>; then ...; fi` exits 0 when no else branch
+# exists, so $? after the if block would be 0 regardless of cmux's exit code.
+exit_code=0
+cmux browser "$@" 2>"$TMPFILE" || exit_code=$?
+[ "$exit_code" -eq 0 ] && exit 0
+
+if grep -q "requires a selector" "$TMPFILE"; then
+  get_type=$(grep -oE 'get [a-z]+' "$TMPFILE" | head -1 | awk '{print $2}')
+  get_type="${get_type:-<type>}"
+
+  printf 'Error: cmux browser get %s requires --selector\n\n' "$get_type" >&2
+  printf 'Usage:\n' >&2
+  printf '  cmux browser <surface> get %s --selector <css>        # first match\n' "$get_type" >&2
+  printf '  cmux browser <surface> get %s --selector <css> --all  # all matches\n\n' "$get_type" >&2
+  printf 'Examples:\n' >&2
+  printf "  cmux browser surface:1 get %s --selector 'h1.title'\n" "$get_type" >&2
+  printf "  cmux browser surface:1 get %s --selector 'a[href]' --all\n\n" "$get_type" >&2
+  printf 'Note: selector can also be passed positionally:\n' >&2
+  printf "  cmux browser surface:1 get %s 'h1.title'\n\n" "$get_type" >&2
+  printf 'See `cmux browser --help` for all options.\n' >&2
+else
+  cat "$TMPFILE" >&2
+fi
+
+exit "$exit_code"

--- a/skills/cmux-browser/cmux-browser
+++ b/skills/cmux-browser/cmux-browser
@@ -40,9 +40,19 @@ if grep -q "requires a selector" "$TMPFILE"; then
   printf 'Error: cmux browser %s requires --selector\n\n' "$subcmd" >&2
   printf 'Usage:\n' >&2
 
-  # `get <type>` supports --all and a positional selector.
-  # Action commands (click, hover, type…) take only --selector <css> or <css>.
-  if echo "$subcmd" | grep -q '^get '; then
+  # Three usage branches based on subcommand interface (from `cmux browser --help`):
+  #   get attr        — selector + --attr <name>
+  #   get <other>     — selector (+ --all for multi-match) + positional shorthand
+  #   type|fill       — selector + --text <text>
+  #   select          — selector + --value <value>
+  #   action cmds     — selector only (click, hover, focus, dblclick, …)
+  if [ "$subcmd" = "get attr" ]; then
+    printf '  cmux browser surface:1 get attr --selector <css> --attr <name>\n' >&2
+    printf '  cmux browser surface:1 get attr <css> <name>   # positional shorthand\n\n' >&2
+    printf 'Examples:\n' >&2
+    printf "  cmux browser surface:1 get attr --selector 'a.link' --attr href\n" >&2
+    printf "  cmux browser surface:1 get attr 'img.logo' src\n\n" >&2
+  elif echo "$subcmd" | grep -q '^get '; then
     printf '  cmux browser surface:1 %s --selector <css>        # first match\n' "$subcmd" >&2
     printf '  cmux browser surface:1 %s --selector <css> --all  # all matches\n\n' "$subcmd" >&2
     printf 'Examples:\n' >&2
@@ -50,6 +60,18 @@ if grep -q "requires a selector" "$TMPFILE"; then
     printf "  cmux browser surface:1 %s --selector 'a[href]' --all\n\n" "$subcmd" >&2
     printf 'Note: selector can also be passed positionally:\n' >&2
     printf "  cmux browser surface:1 %s 'h1.title'\n\n" "$subcmd" >&2
+  elif [ "$subcmd" = "type" ] || [ "$subcmd" = "fill" ]; then
+    printf '  cmux browser surface:1 %s --selector <css> --text <text>\n' "$subcmd" >&2
+    printf '  cmux browser surface:1 %s <css> <text>    # positional shorthand\n\n' "$subcmd" >&2
+    printf 'Examples:\n' >&2
+    printf "  cmux browser surface:1 %s --selector '#email' --text 'user@example.com'\n" "$subcmd" >&2
+    printf "  cmux browser surface:1 %s '#email' 'user@example.com'\n\n" "$subcmd" >&2
+  elif [ "$subcmd" = "select" ]; then
+    printf '  cmux browser surface:1 select --selector <css> --value <value>\n' >&2
+    printf '  cmux browser surface:1 select <css> <value>   # positional shorthand\n\n' >&2
+    printf 'Examples:\n' >&2
+    printf "  cmux browser surface:1 select --selector 'select#category' --value 'option-a'\n" >&2
+    printf "  cmux browser surface:1 select 'select#category' 'option-a'\n\n" >&2
   else
     printf '  cmux browser surface:1 %s --selector <css>\n' "$subcmd" >&2
     printf '  cmux browser surface:1 %s <css>               # positional shorthand\n\n' "$subcmd" >&2

--- a/skills/cmux-browser/cmux-browser
+++ b/skills/cmux-browser/cmux-browser
@@ -49,11 +49,13 @@ if grep -q "requires a selector" "$TMPFILE"; then
   #   get attr   — selector + --attr <name> (both required)
   #   get <rest> — selector only; no --all flag in get (--all is cookies-only)
   #   find nth   — selector + --index <n> (both required)
+  #   frame      — binary has TWO error strings; one ("requires a selector or 'main'")
+  #                is intercepted here; needs <main|selector> mode in the hint
   #   type       — selector + --text <text> (binary errors without text too)
   #   fill       — selector only (text is optional; binary does not enforce it)
   #   select     — selector + --value <value>
-  #   others     — selector only (click, hover, focus; frame/find non-nth errors
-  #                produce different strings, not intercepted here)
+  #   others     — selector only (click, hover, focus; non-intercepted frame variant
+  #                "requires <selector|main>" passes through unchanged)
   if [ "$subcmd" = "get attr" ]; then
     printf '  cmux browser surface:1 get attr --selector <css> --attr <name>\n' >&2
     printf '  cmux browser surface:1 get attr <css> <name>   # positional shorthand\n\n' >&2
@@ -66,6 +68,12 @@ if grep -q "requires a selector" "$TMPFILE"; then
     printf 'Examples:\n' >&2
     printf "  cmux browser surface:1 %s --selector 'h1.title'\n" "$subcmd" >&2
     printf "  cmux browser surface:1 %s 'h1.title'\n\n" "$subcmd" >&2
+  elif [ "$subcmd" = "frame" ]; then
+    # frame takes a required mode before an optional --selector.
+    printf '  cmux browser surface:1 frame <main|selector> [--selector <css>]\n\n' >&2
+    printf 'Examples:\n' >&2
+    printf "  cmux browser surface:1 frame main\n" >&2
+    printf "  cmux browser surface:1 frame selector --selector 'iframe.content'\n\n" >&2
   elif [ "$subcmd" = "find nth" ]; then
     printf '  cmux browser surface:1 find nth --index <n> --selector <css>\n' >&2
     printf '  cmux browser surface:1 find nth <n> <css>    # positional shorthand\n\n' >&2

--- a/skills/cmux-browser/cmux-browser
+++ b/skills/cmux-browser/cmux-browser
@@ -16,7 +16,9 @@
 
 set -euo pipefail
 
-TMPFILE=$(mktemp)
+# If mktemp fails (read-only sandbox, restricted /tmp), fall back to running
+# cmux directly without any wrapping — preserves the original CLI behavior.
+TMPFILE=$(mktemp 2>/dev/null) || exec cmux browser "$@"
 trap 'rm -f "$TMPFILE"' EXIT
 
 # stdout goes straight to the terminal; only stderr is captured for inspection.
@@ -46,11 +48,12 @@ if grep -q "requires a selector" "$TMPFILE"; then
   # Usage branches per subcommand interface (verified against `cmux browser --help`):
   #   get attr   — selector + --attr <name> (both required)
   #   get <rest> — selector only; no --all flag in get (--all is cookies-only)
+  #   find nth   — selector + --index <n> (both required)
   #   type       — selector + --text <text> (binary errors without text too)
   #   fill       — selector only (text is optional; binary does not enforce it)
   #   select     — selector + --value <value>
-  #   others     — selector only (click, hover, focus, frame sub-errors not
-  #                intercepted here — those produce different error strings)
+  #   others     — selector only (click, hover, focus; frame/find non-nth errors
+  #                produce different strings, not intercepted here)
   if [ "$subcmd" = "get attr" ]; then
     printf '  cmux browser surface:1 get attr --selector <css> --attr <name>\n' >&2
     printf '  cmux browser surface:1 get attr <css> <name>   # positional shorthand\n\n' >&2
@@ -63,6 +66,12 @@ if grep -q "requires a selector" "$TMPFILE"; then
     printf 'Examples:\n' >&2
     printf "  cmux browser surface:1 %s --selector 'h1.title'\n" "$subcmd" >&2
     printf "  cmux browser surface:1 %s 'h1.title'\n\n" "$subcmd" >&2
+  elif [ "$subcmd" = "find nth" ]; then
+    printf '  cmux browser surface:1 find nth --index <n> --selector <css>\n' >&2
+    printf '  cmux browser surface:1 find nth <n> <css>    # positional shorthand\n\n' >&2
+    printf 'Examples:\n' >&2
+    printf "  cmux browser surface:1 find nth --index 2 --selector 'li.item'\n" >&2
+    printf "  cmux browser surface:1 find nth 2 'li.item'\n\n" >&2
   elif [ "$subcmd" = "type" ]; then
     # `type` requires both selector and text; the binary errors on missing text too.
     printf '  cmux browser surface:1 type --selector <css> --text <text>\n' >&2

--- a/tests/test_cmux_browser.sh
+++ b/tests/test_cmux_browser.sh
@@ -76,10 +76,19 @@ if [[ "${1:-}" == "browser" ]]; then
         ;;
       click|hover|focus|dblclick|check|uncheck|scroll-into-view|highlight|type|fill|select)
         subcmd="$1"; shift
-        # These cmux subcommands require a positional or --selector arg
+        # These cmux subcommands require --selector (or a positional CSS value).
+        # --text/--value/--attr/--index values must NOT count as selectors — they
+        # are payload flags whose values are consumed by the next iteration.
         has_selector=false
+        skip_next=false
         for arg in "$@"; do
-          case "$arg" in --selector|-s) has_selector=true ;; --*) ;; *) has_selector=true ;; esac
+          if $skip_next; then skip_next=false; continue; fi
+          case "$arg" in
+            --selector|-s) has_selector=true; skip_next=true ;;
+            --text|--value|--attr|--property|--index|--name) skip_next=true ;;
+            --*) ;;
+            *) has_selector=true ;;  # positional CSS selector
+          esac
         done
         if ! $has_selector; then
           echo "Error: browser ${subcmd} requires a selector" >&2; exit 1
@@ -225,6 +234,16 @@ run_wrapper surface:1 get attr
 assert_exit     "exit-code:get-attr-missing-selector"  1  "$_ec"
 assert_contains "hint:--selector:get-attr"  "\-\-selector"  "$_stderr"
 assert_contains "hint:--attr:get-attr"      "\-\-attr"      "$_stderr"
+
+# 5e. Payload-without-selector: --text/--value must NOT suppress the selector hint
+# (mock bug would treat these as selectors and return success — this verifies the fix)
+run_wrapper surface:1 type --text "hello"
+assert_exit     "exit-code:type-payload-no-selector"  1  "$_ec"
+assert_contains "hint:type-payload-no-selector"  "\-\-selector"  "$_stderr"
+
+run_wrapper surface:1 select --value "option-a"
+assert_exit     "exit-code:select-payload-no-selector"  1  "$_ec"
+assert_contains "hint:select-payload-no-selector"  "\-\-selector"  "$_stderr"
 
 # ── 6. Non-selector error passes through unchanged ────────────────────────────
 

--- a/tests/test_cmux_browser.sh
+++ b/tests/test_cmux_browser.sh
@@ -74,6 +74,17 @@ if [[ "${1:-}" == "browser" ]]; then
         echo "mock-output-for-${get_type}"
         exit 0
         ;;
+      click|hover|focus|dblclick|check|uncheck|scroll-into-view|highlight|type|fill|select)
+        subcmd="$1"; shift
+        # These cmux subcommands require a positional or --selector arg
+        has_selector=false
+        for arg in "$@"; do
+          case "$arg" in --selector|-s) has_selector=true ;; --*) ;; *) has_selector=true ;; esac
+        done
+        if ! $has_selector; then
+          echo "Error: browser ${subcmd} requires a selector" >&2; exit 1
+        fi
+        echo "mock-output-for-${subcmd}"; exit 0 ;;
       *) break ;;
     esac
     # NOTE: no trailing shift — each case above manages its own shift(s).
@@ -177,7 +188,20 @@ run_wrapper --surface surface:1 get html --selector "body"
 assert_exit         "exit-code:--surface-variant:with-selector"  0  "$_ec"
 assert_not_contains "no-hint:--surface-variant:with-selector"    "Usage:"  "$_stderr"
 
-# ── 5. Non-selector error passes through unchanged ────────────────────────────
+# ── 5. Non-get selector-required subcommands (click, hover, type…) ────────────
+# The wrapper must extract the correct subcommand name, not fall back to "get <type>".
+
+for subcmd in click hover type fill; do
+  run_wrapper surface:1 "$subcmd"
+
+  assert_exit     "exit-code:${subcmd}-missing-selector"    1  "$_ec"
+  assert_contains "hint:--selector:${subcmd}"   "\-\-selector"    "$_stderr"
+  assert_contains "hint:usage:${subcmd}"        "Usage:"          "$_stderr"
+  # Must show the actual subcommand, NOT "get <type>" or "get <subcommand>"
+  assert_contains "hint:subcmd-name:${subcmd}"  "${subcmd}"       "$_stderr"
+done
+
+# ── 6. Non-selector error passes through unchanged ────────────────────────────
 
 run_wrapper surface:999 navigate https://example.com
 assert_contains     "passthrough:non-selector-error:has-not_found"  "not_found"  "$_stderr"

--- a/tests/test_cmux_browser.sh
+++ b/tests/test_cmux_browser.sh
@@ -200,15 +200,17 @@ for subcmd in click hover; do
   assert_contains "hint:subcmd-name:${subcmd}" "${subcmd}"     "$_stderr"
 done
 
-# 5b. type/fill: hint must include --text payload
-for subcmd in type fill; do
-  run_wrapper surface:1 "$subcmd"
+# 5b. type: hint must include --text payload (binary errors without text too)
+run_wrapper surface:1 type
+assert_exit     "exit-code:type-missing-selector"   1  "$_ec"
+assert_contains "hint:--selector:type"   "\-\-selector"  "$_stderr"
+assert_contains "hint:text-payload:type" "\-\-text"      "$_stderr"
 
-  assert_exit     "exit-code:${subcmd}-missing-selector"   1  "$_ec"
-  assert_contains "hint:--selector:${subcmd}"  "\-\-selector"  "$_stderr"
-  assert_contains "hint:text-payload:${subcmd}" "\-\-text"     "$_stderr"
-  assert_contains "hint:subcmd-name:${subcmd}" "${subcmd}"     "$_stderr"
-done
+# 5c. fill: selector only — text is optional and not enforced by the binary
+run_wrapper surface:1 fill
+assert_exit         "exit-code:fill-missing-selector"   1  "$_ec"
+assert_contains     "hint:--selector:fill"   "\-\-selector"  "$_stderr"
+assert_not_contains "no-text-hint:fill"      "\-\-text"      "$_stderr"
 
 # 5c. select: hint must include --value payload
 run_wrapper surface:1 select

--- a/tests/test_cmux_browser.sh
+++ b/tests/test_cmux_browser.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+# tests/test_cmux_browser.sh — cmux-browser wrapper coverage
+#
+# Uses a mock `cmux` to simulate selector-required errors without needing a
+# real browser surface.  Verifies that the wrapper adds --selector usage hints
+# and that non-selector errors pass through unchanged.
+#
+# Run:  ./tests/test_cmux_browser.sh
+# Exit: 0 on success, 1 on first failure (after summary).
+
+set +e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WRAPPER="$REPO_ROOT/skills/cmux-browser/cmux-browser"
+
+if [ ! -x "$WRAPPER" ]; then
+  echo "FAIL: wrapper not executable: $WRAPPER" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+MOCK_DIR=$(mktemp -d)
+STDERR_FILE=$(mktemp)
+trap 'rm -rf "$MOCK_DIR" "$STDERR_FILE"' EXIT
+
+# ── Mock cmux ────────────────────────────────────────────────────────────────
+#
+# Simulates two behaviors:
+#   browser <surface> get <type>              → exit 1, "requires a selector"
+#   browser <surface> get <type> [selector]  → exit 0, "mock-output-for-<type>"
+#   everything else                           → exit 1, "not_found"
+#
+# The key: after consuming "get" and <type>, any remaining non-flag token is a
+# positional selector, and --selector/-s also counts.
+#
+cat > "$MOCK_DIR/cmux" << 'MOCK'
+#!/bin/bash
+if [[ "${1:-}" == "browser" ]]; then
+  shift
+  # Consume optional surface specifier(s)
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --surface) shift 2 ;;
+      surface:*|workspace:*) shift ;;
+      get)
+        shift                  # consume "get"
+        get_type="${1:-}"
+        shift                  # consume the type — MUST shift before scanning rest
+        # Only these types require --selector in real cmux
+        needs_selector=false
+        case "$get_type" in
+          html|text|value|attr|count|box|styles) needs_selector=true ;;
+        esac
+        if $needs_selector; then
+          has_selector=false
+          skip_next=false
+          for arg in "$@"; do
+            if $skip_next; then skip_next=false; continue; fi
+            case "$arg" in
+              --selector|-s) has_selector=true; skip_next=true ;;
+              --attr|--property|--index) skip_next=true ;;
+              --*) ;;
+              *) has_selector=true ;;
+            esac
+          done
+          if ! $has_selector; then
+            echo "Error: browser get ${get_type} requires a selector" >&2
+            exit 1
+          fi
+        fi
+        echo "mock-output-for-${get_type}"
+        exit 0
+        ;;
+      *) break ;;
+    esac
+    # NOTE: no trailing shift — each case above manages its own shift(s).
+    # A trailing shift here would double-consume tokens after surface:* or --surface.
+  done
+fi
+# fallback for non-get commands or unrecognised paths
+echo "Error: not_found: Surface not found or not a browser" >&2
+exit 1
+MOCK
+chmod +x "$MOCK_DIR/cmux"
+
+export PATH="$MOCK_DIR:$PATH"
+
+# ── Test helpers ──────────────────────────────────────────────────────────────
+
+pass() { echo "PASS  [$1]"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL  [$1] $2"; FAIL=$((FAIL + 1)); FAILED_NAMES+=("$1"); }
+
+assert_contains() {
+  local name="$1" pattern="$2" actual="$3"
+  if echo "$actual" | grep -q "$pattern"; then
+    pass "$name"
+  else
+    fail "$name" "expected /$pattern/ in: ${actual:0:200}"
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" pattern="$2" actual="$3"
+  if ! echo "$actual" | grep -q "$pattern"; then
+    pass "$name"
+  else
+    fail "$name" "did NOT expect /$pattern/ in: ${actual:0:200}"
+  fi
+}
+
+assert_exit() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    pass "$name"
+  else
+    fail "$name" "exit code: expected $expected, got $actual"
+  fi
+}
+
+# run_wrapper: run wrapper, capture stdout + stderr separately, return exit code
+# Usage: run_wrapper [args...]
+# Sets: _stdout, _stderr, _ec
+run_wrapper() {
+  _stdout=$("$WRAPPER" "$@" 2>"$STDERR_FILE")
+  _ec=$?
+  _stderr=$(cat "$STDERR_FILE")
+}
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== cmux-browser wrapper tests ==="
+echo ""
+
+# ── 1. Selector-required types: missing --selector triggers usage hint ─────────
+
+for type in html text value attr count box styles; do
+  run_wrapper surface:1 get "$type"
+
+  assert_exit     "exit-code:get-${type}-missing-selector"   1  "$_ec"
+  assert_contains "hint:--selector:get-${type}"  "\-\-selector"          "$_stderr"
+  assert_contains "hint:usage:get-${type}"       "Usage:"                "$_stderr"
+  assert_contains "hint:example:get-${type}"     "surface:1 get ${type}" "$_stderr"
+  assert_contains "hint:type-name:get-${type}"   "get ${type}"           "$_stderr"
+done
+
+# ── 2. Positional selector: no hint, command succeeds ─────────────────────────
+
+for type in html text; do
+  run_wrapper surface:1 get "$type" "h1.title"
+
+  assert_exit         "exit-code:positional-selector:${type}" 0  "$_ec"
+  assert_contains     "stdout:positional-selector:${type}"    "mock-output-for-${type}" "$_stdout"
+  assert_not_contains "no-hint:positional-selector:${type}"   "\-\-selector"            "$_stderr"
+done
+
+# ── 3. --selector flag: no hint, command succeeds ─────────────────────────────
+
+for type in html text; do
+  run_wrapper surface:1 get "$type" --selector "h1"
+
+  assert_exit         "exit-code:--selector-flag:${type}" 0  "$_ec"
+  assert_contains     "stdout:--selector-flag:${type}"    "mock-output-for-${type}" "$_stdout"
+  assert_not_contains "no-hint:--selector-flag:${type}"   "Usage:"                  "$_stderr"
+done
+
+# ── 4. --surface variant: equivalent to positional surface ────────────────────
+
+run_wrapper --surface surface:1 get html
+assert_exit     "exit-code:--surface-variant:missing-selector"  1  "$_ec"
+assert_contains "hint:--surface-variant"  "\-\-selector"  "$_stderr"
+
+run_wrapper --surface surface:1 get html --selector "body"
+assert_exit         "exit-code:--surface-variant:with-selector"  0  "$_ec"
+assert_not_contains "no-hint:--surface-variant:with-selector"    "Usage:"  "$_stderr"
+
+# ── 5. Non-selector error passes through unchanged ────────────────────────────
+
+run_wrapper surface:999 navigate https://example.com
+assert_contains     "passthrough:non-selector-error:has-not_found"  "not_found"  "$_stderr"
+assert_not_contains "no-hint:non-selector-error"                     "Usage:"     "$_stderr"
+
+# ── 6. get url / get title: no selector required (different error) ─────────────
+
+run_wrapper surface:1 get url
+assert_not_contains "no-hint:get-url"   "requires \-\-selector"  "$_stderr"
+
+run_wrapper surface:1 get title
+assert_not_contains "no-hint:get-title" "requires \-\-selector"  "$_stderr"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "═══════════════════════════════════════════════════════════════"
+echo " PASS: $PASS   FAIL: $FAIL"
+echo "═══════════════════════════════════════════════════════════════"
+
+if [ ${#FAILED_NAMES[@]} -gt 0 ]; then
+  echo ""
+  echo "Failed tests:"
+  for n in "${FAILED_NAMES[@]}"; do
+    echo "  - $n"
+  done
+  echo ""
+  exit 1
+fi

--- a/tests/test_cmux_browser.sh
+++ b/tests/test_cmux_browser.sh
@@ -188,18 +188,41 @@ run_wrapper --surface surface:1 get html --selector "body"
 assert_exit         "exit-code:--surface-variant:with-selector"  0  "$_ec"
 assert_not_contains "no-hint:--surface-variant:with-selector"    "Usage:"  "$_stderr"
 
-# ── 5. Non-get selector-required subcommands (click, hover, type…) ────────────
-# The wrapper must extract the correct subcommand name, not fall back to "get <type>".
+# ── 5. Non-get selector-required subcommands ──────────────────────────────────
 
-for subcmd in click hover type fill; do
+# 5a. Action commands (click, hover): selector only, no payload
+for subcmd in click hover; do
   run_wrapper surface:1 "$subcmd"
 
-  assert_exit     "exit-code:${subcmd}-missing-selector"    1  "$_ec"
-  assert_contains "hint:--selector:${subcmd}"   "\-\-selector"    "$_stderr"
-  assert_contains "hint:usage:${subcmd}"        "Usage:"          "$_stderr"
-  # Must show the actual subcommand, NOT "get <type>" or "get <subcommand>"
-  assert_contains "hint:subcmd-name:${subcmd}"  "${subcmd}"       "$_stderr"
+  assert_exit     "exit-code:${subcmd}-missing-selector"   1  "$_ec"
+  assert_contains "hint:--selector:${subcmd}"  "\-\-selector"  "$_stderr"
+  assert_contains "hint:usage:${subcmd}"       "Usage:"        "$_stderr"
+  assert_contains "hint:subcmd-name:${subcmd}" "${subcmd}"     "$_stderr"
 done
+
+# 5b. type/fill: hint must include --text payload
+for subcmd in type fill; do
+  run_wrapper surface:1 "$subcmd"
+
+  assert_exit     "exit-code:${subcmd}-missing-selector"   1  "$_ec"
+  assert_contains "hint:--selector:${subcmd}"  "\-\-selector"  "$_stderr"
+  assert_contains "hint:text-payload:${subcmd}" "\-\-text"     "$_stderr"
+  assert_contains "hint:subcmd-name:${subcmd}" "${subcmd}"     "$_stderr"
+done
+
+# 5c. select: hint must include --value payload
+run_wrapper surface:1 select
+
+assert_exit     "exit-code:select-missing-selector"   1  "$_ec"
+assert_contains "hint:--selector:select"  "\-\-selector"  "$_stderr"
+assert_contains "hint:value-payload:select" "\-\-value"   "$_stderr"
+
+# 5d. get attr: hint must include both --selector and --attr
+run_wrapper surface:1 get attr
+
+assert_exit     "exit-code:get-attr-missing-selector"  1  "$_ec"
+assert_contains "hint:--selector:get-attr"  "\-\-selector"  "$_stderr"
+assert_contains "hint:--attr:get-attr"      "\-\-attr"      "$_stderr"
 
 # ── 6. Non-selector error passes through unchanged ────────────────────────────
 

--- a/tests/test_cmux_browser.sh
+++ b/tests/test_cmux_browser.sh
@@ -74,6 +74,12 @@ if [[ "${1:-}" == "browser" ]]; then
         echo "mock-output-for-${get_type}"
         exit 0
         ;;
+      frame)
+        shift  # consume "frame"
+        # Simulate the "requires a selector" variant of the frame error.
+        # (The binary has two strings; the one intercepted by the wrapper is
+        #  "requires a selector or 'main'", not "requires <selector|main>".)
+        echo "Error: browser frame requires a selector or 'main'" >&2; exit 1 ;;
       find)
         shift  # consume "find"
         find_type="${1:-}"; shift  # consume the find sub-type (nth, first, …)
@@ -257,7 +263,21 @@ assert_exit     "exit-code:get-attr-missing-selector"  1  "$_ec"
 assert_contains "hint:--selector:get-attr"  "\-\-selector"  "$_stderr"
 assert_contains "hint:--attr:get-attr"      "\-\-attr"      "$_stderr"
 
-# 5f. find nth (index given, selector missing): hint must include both --index and --selector
+# 5f. frame: binary has "requires a selector or 'main'" variant that IS intercepted;
+#     hint must show <main|selector> mode, NOT just --selector <css>
+# Simulate: "Error: browser frame requires a selector or 'main'"
+_fake_tmpfile=$(mktemp)
+echo "Error: browser frame requires a selector or 'main'" > "$_fake_tmpfile"
+_frame_subcmd=$(sed -n 's/.*browser \(.*\) requires a selector.*/\1/p' "$_fake_tmpfile" | head -1)
+rm -f "$_fake_tmpfile"
+assert_contains "frame-subcmd-extraction"  "^frame$"  "$_frame_subcmd"
+
+run_wrapper surface:1 frame   # triggers "requires a selector" variant
+assert_exit     "exit-code:frame-missing-mode"   1  "$_ec"
+assert_contains "hint:frame-has-main"     "main"        "$_stderr"
+assert_contains "hint:frame-has-selector" "selector"    "$_stderr"
+
+# 5g. find nth (index given, selector missing): hint must include both --index and --selector
 # Mock: find nth with an index token but no --selector still reports "requires a selector"
 run_wrapper surface:1 find nth 2
 

--- a/tests/test_cmux_browser.sh
+++ b/tests/test_cmux_browser.sh
@@ -74,6 +74,28 @@ if [[ "${1:-}" == "browser" ]]; then
         echo "mock-output-for-${get_type}"
         exit 0
         ;;
+      find)
+        shift  # consume "find"
+        find_type="${1:-}"; shift  # consume the find sub-type (nth, first, …)
+        # find nth: needs both --index and --selector; simulate selector-missing error
+        # when --selector/-s is absent.
+        # Pure integers are treated as positional --index values, NOT selectors.
+        has_selector=false
+        skip_next=false
+        for arg in "$@"; do
+          if $skip_next; then skip_next=false; continue; fi
+          case "$arg" in
+            --selector|-s) has_selector=true; skip_next=true ;;
+            --index|--name) skip_next=true ;;
+            --*) ;;
+            [0-9]*) ;;          # bare integer = positional index, not a selector
+            *) has_selector=true ;;
+          esac
+        done
+        if ! $has_selector; then
+          echo "Error: browser find ${find_type} requires a selector" >&2; exit 1
+        fi
+        echo "mock-output-for-find-${find_type}"; exit 0 ;;
       click|hover|focus|dblclick|check|uncheck|scroll-into-view|highlight|type|fill|select)
         subcmd="$1"; shift
         # These cmux subcommands require --selector (or a positional CSS value).
@@ -234,6 +256,14 @@ run_wrapper surface:1 get attr
 assert_exit     "exit-code:get-attr-missing-selector"  1  "$_ec"
 assert_contains "hint:--selector:get-attr"  "\-\-selector"  "$_stderr"
 assert_contains "hint:--attr:get-attr"      "\-\-attr"      "$_stderr"
+
+# 5f. find nth (index given, selector missing): hint must include both --index and --selector
+# Mock: find nth with an index token but no --selector still reports "requires a selector"
+run_wrapper surface:1 find nth 2
+
+assert_exit     "exit-code:find-nth-missing-selector"  1  "$_ec"
+assert_contains "hint:--selector:find-nth"  "\-\-selector"  "$_stderr"
+assert_contains "hint:--index:find-nth"     "\-\-index"     "$_stderr"
 
 # 5e. Payload-without-selector: --text/--value must NOT suppress the selector hint
 # (mock bug would treat these as selectors and return success — this verifies the fix)


### PR DESCRIPTION
## 배경

Closes #131

`cmux browser get html` (및 text/value/attr/count/box/styles)를 `--selector` 없이 실행하면 바이너리가 아무 힌트 없는 1줄 에러만 출력합니다:

```
Error: browser get html requires a selector
```

사용자/Claude가 정확한 인자 형식을 시행착오로 추측해야 하는 마찰이 발생합니다.

## 변경사항

### 새 파일: `skills/cmux-browser/cmux-browser`
- `cmux browser` 얇은 pass-through wrapper
- stderr를 temp file로 캡처 → "requires a selector" 패턴 감지 시 usage block 추가 출력
- stdout은 버퍼 없이 터미널로 직접 전달 (대용량 HTML 스트리밍 지원)
- 비-selector 에러는 그대로 pass-through

**Before:**
```
Error: browser get html requires a selector
```

**After:**
```
Error: cmux browser get html requires --selector

Usage:
  cmux browser <surface> get html --selector <css>        # first match
  cmux browser <surface> get html --selector <css> --all  # all matches

Examples:
  cmux browser surface:1 get html --selector 'h1.title'
  cmux browser surface:1 get html --selector 'a[href]' --all

Note: selector can also be passed positionally:
  cmux browser surface:1 get html 'h1.title'

See `cmux browser --help` for all options.
```

### 수정: `scripts/install.sh`
- `skills/cmux-browser/cmux-browser` → `~/.local/bin/cmux-browser` 심링크 추가

### 새 파일: `tests/test_cmux_browser.sh`
- 55개 케이스 커버: 7개 selector-required 타입 × 5 assertion + pass-through + non-selector 에러

### 수정: `AGENTS.md`
- Skills (15 → 16), cmux-browser 항목 추가

## 기술 노트

**bash `if-then-fi` $? 함정**: `if cmd; then ...; fi; exit_code=$?` 패턴에서 condition이 false고 else가 없으면 $?는 0이 됩니다. `exit_code=0; cmd || exit_code=$?` 패턴으로 수정.

## 검증
```
bash tests/test_cmux_browser.sh
# PASS: 55   FAIL: 0
```