### PR TITLE
feat(hooks): add memory-hint PreToolUse hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,6 +298,105 @@ the hook:
 ./tests/test_side_effect_scan.sh
 ```
 
+## PreToolUse Memory Hint
+
+`hooks/memory-hint.py` fires on every Bash tool call and emits stderr lines
+referencing user-scoped memory files whose YAML frontmatter declares
+`hookable: true` plus a matching `hookKeywords: [...]` token. The signal is
+purely attention-shifting for the LLM's next reasoning step — the hook
+**never blocks**, **never asks**, **always exits 0**.
+
+### Why this exists
+
+Some friction patterns can be matched with structural enforcement (the two
+hooks above are examples). Others — like "verify the CLI flag before using
+it" — only show up as soft-textual rules in memory files. Without a hook,
+Claude only retrieves those memories *after* a failure, not while
+constructing the tool call. This hook surfaces them at decision-construction
+time so the LLM has the option to reconsider before executing.
+
+Reference: issue [#139](https://github.com/devseunggwan/praxis/issues/139).
+
+### Frontmatter contract
+
+Memory authors opt in by adding two fields to their existing frontmatter:
+
+```yaml
+---
+name: my-memory
+description: Short rule statement
+type: feedback
+hookable: true                           # NEW — opt-in switch
+hookKeywords: [kubectl, hubctl, gh]      # NEW — match tokens (whole-token)
+---
+```
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `hookable` | yes | scalar; `true` / `True` / `TRUE` / `yes` / `Yes` enable. Anything else (or missing) → not indexed. |
+| `hookKeywords` | yes | flat single-line list, e.g. `[a, b, "c d"]`. Scalar form (`hookKeywords: kubectl`) is **rejected** — the memory is silently skipped. |
+| `description` | no | optional; emitted after em-dash when present. Without it, the stderr line is just `[memory:hookable] {filename}`. |
+| `type` | no | unrelated taxonomy field; the parser ignores it. `type` ≠ `hookable`. |
+
+### Hook execution model
+
+Per Anthropic docs (https://code.claude.com/docs/en/hooks), PreToolUse hooks
+run **in parallel**. Array position in `hooks.json` is presentational, not a
+priority gate. When multiple hooks return decisions, precedence is
+`deny > defer > ask > allow`. `memory-hint` only emits stderr (no
+`permissionDecision`) so it co-fires with the blocking hooks — the user may
+see a hint line *alongside* a block from `block-gh-state-all` (exit 2) or an
+`ask` from `side-effect-scan`. Co-firing is intentional: the hint can
+clarify *why* a block fired.
+
+### Matching semantics
+
+- **Whole-token equality, case-sensitive.** `hookKeywords: [kubectl]` matches
+  the bare token `kubectl` but NOT `Kubectl`, `KUBECTL`, or `kubectl-prod`.
+  Authors who want case-insensitive matching list the casings explicitly.
+- Quoted **multi-word** strings are preserved as a single token (shlex
+  behavior). `echo "use kubectl"` parses tokens as `[echo, use kubectl]`
+  (the quotes are stripped, the spaces stay) — the keyword `kubectl` does
+  NOT match the multi-word token. This is the false-positive guard.
+- Quoted **single-word** strings are NOT protected — shlex strips the quotes
+  and the bare word is matched normally. `gh search issues "kubectl"` ends
+  up as `[gh, search, issues, kubectl]` and matches the `kubectl` keyword.
+- Comment-prefixed lines (`# kubectl get`) DO match. `safe_tokenize` runs
+  with `commenters = ""` so `#` is just another token; `kubectl` ends up as
+  argv[1] of the segment and is matched. Niche case; accepted v1 behavior.
+
+### Discovery and fail-safe
+
+Memory directory resolution order:
+1. `PRAXIS_MEMORY_DIR` env var (when set + points to an existing directory)
+2. fallback `~/.claude/projects/{slugified-cwd}/memory/` — slugify rule:
+   replace `/` with `-` on the absolute cwd
+3. neither resolves → exit 0 silently (no fallback attempt, no error)
+
+Five exit-0 fail-safe paths:
+- python3 missing (shell wrapper guard)
+- malformed JSON stdin
+- non-Bash tool
+- empty command
+- memory directory missing or unreadable
+
+### YAML parser limits
+
+Pure-regex parser, no PyYAML dependency. Supported shapes: flat scalar
+`hookable`, flat single-line list `hookKeywords` (e.g. `[a, b, "c d"]`),
+optional `description`. Multi-line / flow-mapping / anchored YAML forms are
+NOT supported — any parse error skips that memory, never the hook.
+
+### Tests
+
+```bash
+bash tests/test_memory_hint.sh
+```
+
+Covers 21 cases: hit/silent core paths, frontmatter gates, noise cap, mtime
+ordering, discovery fail-safes, malformed inputs, AC-21 (no description),
+AC-22 (scalar rejection), AC-23 (case sensitivity).
+
 ## PostToolUse Built-in Task Classification
 
 `hooks/builtin-task-postuse.py` fires after any built-in task **management**

--- a/hooks/_hook_utils.py
+++ b/hooks/_hook_utils.py
@@ -1,0 +1,148 @@
+"""Shared tokenization helpers for praxis PreToolUse(Bash) hooks.
+
+Three hooks reuse the exact same `safe_tokenize` / `strip_prefix` /
+`iter_command_starts` pipeline plus the constants they consume:
+
+- `block-gh-state-all.py` — blocks invalid `gh search ... --state all`
+- `side-effect-scan.py` — surfaces collateral side effects via `ask`
+- `memory-hint.py` — emits stderr hints for `hookable: true` memories
+
+Per the TODO that lived at `block-gh-state-all.py:25`, this module is the
+extraction triggered by the third consumer (issue #139). The helpers move
+verbatim — see git history for the prior duplicated copies.
+"""
+from __future__ import annotations
+
+import re
+import shlex
+
+
+SHELL_SEPARATORS = {";", "&&", "||", "|", "&"}
+
+ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+# Shell keywords that appear at the start of a command segment but are purely
+# syntactic. `if true; then git push; fi` segments as `['if','true']`,
+# `['then','git','push']`, `['fi']` — we peel the keyword so argv[0] becomes
+# the real executable.
+SHELL_KEYWORDS = {
+    "if", "then", "elif", "else", "fi",
+    "while", "until", "do", "done",
+    "case", "esac", "in", "for",
+    "{", "}", "!", "function",
+}
+
+# Prefix wrappers that execute the following command as a new process. The
+# scanner looks past them to find the real argv[0]. Per-wrapper option
+# dictionaries list *only* flags that take a separate-token argument so that
+# `sudo --user admin kubectl ...` peels both `--user` and `admin`. Bare flags
+# (with no arg) and `--long=value` forms are handled generically below.
+PREFIX_WRAPPERS = {"env", "sudo", "nice", "time", "stdbuf", "ionice"}
+WRAPPER_OPTS_WITH_ARG = {
+    "env": {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"},
+    "sudo": {
+        "-u", "-g", "-p", "-C", "-D", "-r", "-t", "-T", "-U", "-h",
+        "--user", "--group", "--prompt", "--close-from", "--chdir",
+        "--role", "--type", "--host", "--other-user",
+    },
+    "nice": {"-n", "--adjustment"},
+    "stdbuf": {"-i", "-o", "-e", "--input", "--output", "--error"},
+    "time": {"-f", "--format", "-o", "--output"},
+    "ionice": {
+        "-c", "--class", "-n", "--classdata",
+        "-p", "--pid", "-P", "--pgid", "-u", "--uid",
+    },
+}
+
+
+def safe_tokenize(command: str) -> list[str]:
+    """Tokenize with shell operators and line breaks split into tokens.
+
+    Uses shlex.shlex(punctuation_chars=';|&') so that `git push&&echo` and
+    `git push;echo` split into `['git', 'push', '&&', 'echo']` etc. Plain
+    shlex.split keeps operators glued to adjacent words, which would let a
+    whitespace-free one-liner bypass detection entirely.
+
+    Newlines are a command separator in Bash but shlex's whitespace_split
+    consumes them as generic whitespace, flattening multi-line scripts into
+    one token stream. We pre-split the raw command on `\\n` and insert a
+    synthetic `;` between line tokens so iter_command_starts sees the break.
+    Lines that fail to parse (unmatched quote, runaway heredoc, etc.) are
+    skipped — better a silent pass than a crashed hook.
+    """
+    lines = [ln for ln in command.split("\n") if ln.strip()]
+    if not lines:
+        return []
+    tokens: list[str] = []
+    for idx, line in enumerate(lines):
+        if idx > 0:
+            tokens.append(";")
+        try:
+            lex = shlex.shlex(line, posix=True, punctuation_chars=";|&")
+            lex.whitespace_split = True
+            lex.commenters = ""  # raw `#` is not a comment here; opt-out marker
+            tokens.extend(list(lex))
+        except ValueError:
+            continue
+    return tokens
+
+
+def strip_prefix(argv: list[str]) -> list[str]:
+    """Peel shell keywords, `KEY=VAL` assignments, and wrapper commands off
+    the front so argv[0] becomes the real executable.
+
+    Handles (in any order, iteratively):
+    - shell keywords (`if`, `then`, `do`, `while`, etc.) — pure syntax, drop
+    - env assignments (`FOO=1`) — drop
+    - wrapper commands (`env`, `sudo`, `nice`, `time`, `stdbuf`, `ionice`) —
+      drop the wrapper plus its option flags. Option flags are peeled
+      generically: any `-*` token is consumed, and if it's a known arg-taking
+      flag for this wrapper the following value token is peeled too. The
+      `--long=value` form counts as a single token and is handled naturally.
+    """
+    i = 0
+    n = len(argv)
+    while i < n:
+        tok = argv[i]
+        if tok in SHELL_KEYWORDS:
+            i += 1
+            continue
+        if ENV_ASSIGN_RE.match(tok):
+            i += 1
+            continue
+        if tok in PREFIX_WRAPPERS:
+            wrapper = tok
+            i += 1
+            opts_with_arg = WRAPPER_OPTS_WITH_ARG.get(wrapper, set())
+            while i < n:
+                nxt = argv[i]
+                if ENV_ASSIGN_RE.match(nxt):
+                    i += 1
+                    continue
+                if not nxt.startswith("-"):
+                    break
+                if "=" in nxt:
+                    # --long=value — value embedded; peel this token only
+                    i += 1
+                    continue
+                if nxt in opts_with_arg and i + 1 < n:
+                    # --user admin / -u admin — peel pair
+                    i += 2
+                    continue
+                # bare flag (-E, -i, -oL, etc.) — peel single token
+                i += 1
+            continue
+        break
+    return argv[i:]
+
+
+def iter_command_starts(tokens: list[str]):
+    """Yield argv slices at each command start across shell separators."""
+    start = 0
+    for i, tok in enumerate(tokens):
+        if tok in SHELL_SEPARATORS:
+            if start < i:
+                yield tokens[start:i]
+            start = i + 1
+    if start < len(tokens):
+        yield tokens[start:]

--- a/hooks/block-gh-state-all.py
+++ b/hooks/block-gh-state-all.py
@@ -16,38 +16,17 @@ call with `--state all`. Exits 0 otherwise (transparent pass-through).
 from __future__ import annotations
 
 import json
-import re
-import shlex
+import os
 import sys
 
-# ---------------------------------------------------------------------------
-# Tokenization helpers — copied from side-effect-scan.py
-# TODO: extract to _hook_utils.py when a third hook needs them
-# ---------------------------------------------------------------------------
-SHELL_SEPARATORS = {";", "&&", "||", "|", "&"}
-ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
-SHELL_KEYWORDS = {
-    "if", "then", "elif", "else", "fi",
-    "while", "until", "do", "done",
-    "case", "esac", "in", "for",
-    "{", "}", "!", "function",
-}
-PREFIX_WRAPPERS = {"env", "sudo", "nice", "time", "stdbuf", "ionice"}
-WRAPPER_OPTS_WITH_ARG = {
-    "env": {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"},
-    "sudo": {
-        "-u", "-g", "-p", "-C", "-D", "-r", "-t", "-T", "-U", "-h",
-        "--user", "--group", "--prompt", "--close-from", "--chdir",
-        "--role", "--type", "--host", "--other-user",
-    },
-    "nice": {"-n", "--adjustment"},
-    "stdbuf": {"-i", "-o", "-e", "--input", "--output", "--error"},
-    "time": {"-f", "--format", "-o", "--output"},
-    "ionice": {
-        "-c", "--class", "-n", "--classdata",
-        "-p", "--pid", "-P", "--pgid", "-u", "--uid",
-    },
-}
+# Resolve sibling `_hook_utils.py` regardless of cwd at invocation time.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    iter_command_starts,
+    safe_tokenize,
+    strip_prefix,
+)
 
 # gh global flags that take a separate-token argument
 GH_GLOBAL_FLAGS_WITH_ARG = frozenset({
@@ -55,72 +34,6 @@ GH_GLOBAL_FLAGS_WITH_ARG = frozenset({
     "--hostname",
     "--color",
 })
-
-
-def safe_tokenize(command: str) -> list[str]:
-    """Tokenize with shell operators split into tokens and newlines as separators."""
-    lines = [ln for ln in command.split("\n") if ln.strip()]
-    if not lines:
-        return []
-    tokens: list[str] = []
-    for idx, line in enumerate(lines):
-        if idx > 0:
-            tokens.append(";")
-        try:
-            lex = shlex.shlex(line, posix=True, punctuation_chars=";|&")
-            lex.whitespace_split = True
-            lex.commenters = ""
-            tokens.extend(list(lex))
-        except ValueError:
-            continue
-    return tokens
-
-
-def strip_prefix(argv: list[str]) -> list[str]:
-    """Peel shell keywords, env assignments, and wrapper commands off the front."""
-    i = 0
-    n = len(argv)
-    while i < n:
-        tok = argv[i]
-        if tok in SHELL_KEYWORDS:
-            i += 1
-            continue
-        if ENV_ASSIGN_RE.match(tok):
-            i += 1
-            continue
-        if tok in PREFIX_WRAPPERS:
-            wrapper = tok
-            i += 1
-            opts_with_arg = WRAPPER_OPTS_WITH_ARG.get(wrapper, set())
-            while i < n:
-                nxt = argv[i]
-                if ENV_ASSIGN_RE.match(nxt):
-                    i += 1
-                    continue
-                if not nxt.startswith("-"):
-                    break
-                if "=" in nxt:
-                    i += 1
-                    continue
-                if nxt in opts_with_arg and i + 1 < n:
-                    i += 2
-                    continue
-                i += 1
-            continue
-        break
-    return argv[i:]
-
-
-def iter_command_starts(tokens: list[str]):
-    """Yield argv slices at each command start across shell separators."""
-    start = 0
-    for i, tok in enumerate(tokens):
-        if tok in SHELL_SEPARATORS:
-            if start < i:
-                yield tokens[start:i]
-            start = i + 1
-    if start < len(tokens):
-        yield tokens[start:]
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "praxis hooks: Stop gate for completion-without-evidence, retrospect memory-bias gate, session-scoped three-strike discipline, PreToolUse(Bash) side-effect scan and gh search --state all block, PostToolUse correction for built-in task management tools",
+  "description": "praxis hooks: Stop gate for completion-without-evidence, retrospect memory-bias gate, session-scoped three-strike discipline, PreToolUse(Bash) side-effect scan / gh search --state all block / memory-hint, PostToolUse correction for built-in task management tools",
   "hooks": {
     "SessionStart": [
       {
@@ -35,6 +35,11 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-gh-state-all.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/memory-hint.sh",
             "timeout": 5
           }
         ]

--- a/hooks/memory-hint.py
+++ b/hooks/memory-hint.py
@@ -155,7 +155,7 @@ def index_memories(directory: str) -> list[tuple[str, dict, float]]:
         try:
             with open(path, "r", encoding="utf-8") as fh:
                 raw = fh.read()
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             continue
         try:
             parsed = parse_frontmatter(raw)

--- a/hooks/memory-hint.py
+++ b/hooks/memory-hint.py
@@ -48,13 +48,22 @@ HIT_LIMIT = 3
 TRUTHY_VALUES = {"true", "yes"}
 
 FRONTMATTER_FENCE = re.compile(r"^---\s*$", re.MULTILINE)
-HOOKABLE_RE = re.compile(r"^\s*hookable\s*:\s*(\S+)\s*$", re.MULTILINE)
-KEYWORDS_RE = re.compile(r"^\s*hookKeywords\s*:\s*(.+?)\s*$", re.MULTILINE)
-DESCRIPTION_RE = re.compile(r"^\s*description\s*:\s*(.+?)\s*$", re.MULTILINE)
+HOOKABLE_RE = re.compile(r"^\s*hookable\s*:\s*(.+)$", re.MULTILINE)
+KEYWORDS_RE = re.compile(r"^\s*hookKeywords\s*:\s*(.+)$", re.MULTILINE)
+DESCRIPTION_RE = re.compile(r"^\s*description\s*:\s*(.+)$", re.MULTILINE)
+
+# YAML inline comment: `#` preceded by whitespace (per YAML 1.2 spec). The
+# `hookKeywords` list parser additionally tolerates anything after the first
+# `]`, which covers comments without leading whitespace.
+INLINE_COMMENT_RE = re.compile(r"\s+#.*$")
 
 # Control bytes (incl. ESC for ANSI escape sequences) shouldn't reach stderr —
 # memory filenames flow through to log viewers / terminals.
 CONTROL_BYTES_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _strip_inline_comment(value: str) -> str:
+    return INLINE_COMMENT_RE.sub("", value)
 
 
 def _sanitize(text: str) -> str:
@@ -73,7 +82,12 @@ def parse_frontmatter(raw: str) -> dict | None:
     hookable_match = HOOKABLE_RE.search(block)
     if not hookable_match:
         return None
-    hookable_value = hookable_match.group(1).strip().lower().strip('"\'')
+    hookable_value = (
+        _strip_inline_comment(hookable_match.group(1))
+        .strip()
+        .lower()
+        .strip('"\'')
+    )
     if hookable_value not in TRUTHY_VALUES:
         return None
 
@@ -104,7 +118,11 @@ def parse_frontmatter(raw: str) -> dict | None:
     description_match = DESCRIPTION_RE.search(block)
     description = ""
     if description_match:
-        description = description_match.group(1).strip().strip('"\'')
+        description = (
+            _strip_inline_comment(description_match.group(1))
+            .strip()
+            .strip('"\'')
+        )
 
     return {"keywords": keywords, "description": description}
 

--- a/hooks/memory-hint.py
+++ b/hooks/memory-hint.py
@@ -81,10 +81,16 @@ def parse_frontmatter(raw: str) -> dict | None:
     if not keywords_match:
         return None
     keywords_raw = keywords_match.group(1).strip()
-    if not (keywords_raw.startswith("[") and keywords_raw.endswith("]")):
+    if not keywords_raw.startswith("["):
         # Scalar form (`hookKeywords: kubectl`) is rejected per AC-22.
         return None
-    inner = keywords_raw[1:-1].strip()
+    # Find the first `]` so a trailing inline comment doesn't break parse.
+    # `[a, b] # comment` is the natural YAML shape — anything after the
+    # closing bracket is treated as comment/garbage.
+    close_idx = keywords_raw.find("]")
+    if close_idx == -1:
+        return None
+    inner = keywords_raw[1:close_idx].strip()
     if not inner:
         return None
     keywords = [

--- a/hooks/memory-hint.py
+++ b/hooks/memory-hint.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""PreToolUse(Bash) memory hint: surface relevant memory file descriptions.
+
+Scans the user-scoped memory directory for `*.md` files whose YAML
+frontmatter declares `hookable: true` plus a `hookKeywords: [...]` list,
+tokenizes the inbound Bash command via the shared `safe_tokenize` /
+`strip_prefix` / `iter_command_starts` pipeline, and emits up to 3
+`[memory:hookable] {filename} — {description}` lines to stderr per match
+(plus an `...and N more` summary line when truncated).
+
+Always exits 0. Never blocks. Never asks. The signal is purely
+attention-shifting for the LLM's next reasoning step. Co-firing with
+`block-gh-state-all` (exit 2) and `side-effect-scan` (`ask`) is intentional
+— PreToolUse hooks run in parallel; a memory hint may clarify why a
+sibling hook blocked the command.
+
+Memory directory discovery:
+  1. `PRAXIS_MEMORY_DIR` env var (when set + exists)
+  2. fallback to `~/.claude/projects/{slugified-cwd}/memory/`
+     (slugify rule: replace `/` with `-` on the absolute cwd)
+  3. missing dir → exit 0 silently
+
+Frontmatter parser is pure regex (no PyYAML dependency). Supported shapes:
+  - `hookable: true|True|TRUE|yes|Yes` (other values silently skip the file)
+  - `hookKeywords: [a, b, "c d"]` (flat single-line list only;
+                                  multi-line / flow-mapping NOT supported)
+  - `description: anything` (optional; emitted after em-dash when present)
+Any parse error within a memory skips that memory only — never the hook.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+# Resolve sibling `_hook_utils.py` regardless of cwd at invocation time.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    iter_command_starts,
+    safe_tokenize,
+    strip_prefix,
+)
+
+
+HIT_LIMIT = 3
+TRUTHY_VALUES = {"true", "yes"}
+
+FRONTMATTER_FENCE = re.compile(r"^---\s*$", re.MULTILINE)
+HOOKABLE_RE = re.compile(r"^\s*hookable\s*:\s*(\S+)\s*$", re.MULTILINE)
+KEYWORDS_RE = re.compile(r"^\s*hookKeywords\s*:\s*(.+?)\s*$", re.MULTILINE)
+DESCRIPTION_RE = re.compile(r"^\s*description\s*:\s*(.+?)\s*$", re.MULTILINE)
+
+# Control bytes (incl. ESC for ANSI escape sequences) shouldn't reach stderr —
+# memory filenames flow through to log viewers / terminals.
+CONTROL_BYTES_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _sanitize(text: str) -> str:
+    return CONTROL_BYTES_RE.sub("?", text)
+
+
+def parse_frontmatter(raw: str) -> dict | None:
+    """Extract the first `---`-fenced block. Return None if absent."""
+    matches = list(FRONTMATTER_FENCE.finditer(raw))
+    if len(matches) < 2:
+        return None
+    start = matches[0].end()
+    end = matches[1].start()
+    block = raw[start:end]
+
+    hookable_match = HOOKABLE_RE.search(block)
+    if not hookable_match:
+        return None
+    hookable_value = hookable_match.group(1).strip().lower().strip('"\'')
+    if hookable_value not in TRUTHY_VALUES:
+        return None
+
+    keywords_match = KEYWORDS_RE.search(block)
+    if not keywords_match:
+        return None
+    keywords_raw = keywords_match.group(1).strip()
+    if not (keywords_raw.startswith("[") and keywords_raw.endswith("]")):
+        # Scalar form (`hookKeywords: kubectl`) is rejected per AC-22.
+        return None
+    inner = keywords_raw[1:-1].strip()
+    if not inner:
+        return None
+    keywords = [
+        item.strip().strip('"\'')
+        for item in inner.split(",")
+    ]
+    keywords = [k for k in keywords if k]
+    if not keywords:
+        return None
+
+    description_match = DESCRIPTION_RE.search(block)
+    description = ""
+    if description_match:
+        description = description_match.group(1).strip().strip('"\'')
+
+    return {"keywords": keywords, "description": description}
+
+
+def resolve_memory_dir() -> str | None:
+    """Return the resolved memory directory path or None if missing."""
+    env_dir = os.environ.get("PRAXIS_MEMORY_DIR", "").strip()
+    if env_dir:
+        return env_dir if os.path.isdir(env_dir) else None
+
+    home = os.path.expanduser("~")
+    cwd = os.getcwd()
+    slug = cwd.replace("/", "-")
+    fallback = os.path.join(home, ".claude", "projects", slug, "memory")
+    return fallback if os.path.isdir(fallback) else None
+
+
+def index_memories(directory: str) -> list[tuple[str, dict, float]]:
+    """Return [(filename, parsed, mtime), ...] for every hookable memory."""
+    out: list[tuple[str, dict, float]] = []
+    try:
+        entries = os.listdir(directory)
+    except OSError:
+        return out
+
+    for name in entries:
+        if not name.endswith(".md"):
+            continue
+        path = os.path.join(directory, name)
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                raw = fh.read()
+        except OSError:
+            continue
+        try:
+            parsed = parse_frontmatter(raw)
+        except Exception:
+            parsed = None
+        if not parsed:
+            continue
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError:
+            mtime = 0.0
+        out.append((name, parsed, mtime))
+    return out
+
+
+def collect_command_tokens(command: str) -> set[str]:
+    """Flatten command tokens after splitting at shell separators + stripping prefixes."""
+    tokens = safe_tokenize(command)
+    if not tokens:
+        return set()
+    flat: set[str] = set()
+    for argv in iter_command_starts(tokens):
+        for tok in strip_prefix(argv):
+            flat.add(tok)
+    return flat
+
+
+def find_hits(
+    indexed: list[tuple[str, dict, float]],
+    cmd_tokens: set[str],
+) -> list[tuple[str, dict, float]]:
+    """Return memories whose hookKeywords match any command token (whole-token)."""
+    # Whole-token equality (case-sensitive). Quoted multi-word strings shlex
+    # parses as a single token (e.g. `echo "use kubectl"` → `use kubectl`),
+    # so `kubectl` keyword does NOT match — see AC-10. Substring matching
+    # would create false positives across `kubectl-prod` vs `kubectl`.
+    hits: list[tuple[str, dict, float]] = []
+    for name, parsed, mtime in indexed:
+        if any(keyword in cmd_tokens for keyword in parsed["keywords"]):
+            hits.append((name, parsed, mtime))
+    return hits
+
+
+def emit_hits(hits: list[tuple[str, dict, float]]) -> None:
+    """Print up to HIT_LIMIT hit lines + summary, sorted by mtime desc."""
+    hits.sort(key=lambda h: h[2], reverse=True)
+    for name, parsed, _ in hits[:HIT_LIMIT]:
+        safe_name = _sanitize(name)
+        description = _sanitize(parsed["description"])
+        if description:
+            sys.stderr.write(f"[memory:hookable] {safe_name} — {description}\n")
+        else:
+            sys.stderr.write(f"[memory:hookable] {safe_name}\n")
+    extra = len(hits) - HIT_LIMIT
+    if extra > 0:
+        sys.stderr.write(f"[memory:hookable] ...and {extra} more\n")
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0  # fail-open on malformed stdin
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    command = payload.get("tool_input", {}).get("command", "") or ""
+    if not command.strip():
+        return 0
+
+    # Backslash line continuation → single space so tokenizer sees one line
+    command = command.replace("\\\n", " ")
+
+    directory = resolve_memory_dir()
+    if not directory:
+        return 0
+
+    indexed = index_memories(directory)
+    if not indexed:
+        return 0
+
+    cmd_tokens = collect_command_tokens(command)
+    if not cmd_tokens:
+        return 0
+
+    hits = find_hits(indexed, cmd_tokens)
+    if hits:
+        emit_hits(hits)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/memory-hint.sh
+++ b/hooks/memory-hint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# PreToolUse(Bash) hook entry — delegates to the Python implementation.
+#
+# Fail-safe: if python3 is unavailable, exit 0 (pass) rather than break the
+# Claude Code session.
+
+set +e
+
+if ! command -v python3 >/dev/null 2>&1; then
+  exit 0
+fi
+
+exec python3 "$(dirname "$0")/memory-hint.py"

--- a/hooks/side-effect-scan.py
+++ b/hooks/side-effect-scan.py
@@ -15,9 +15,17 @@ signal an intentional invocation — the hook then exits 0 without prompting.
 from __future__ import annotations
 
 import json
-import re
-import shlex
+import os
 import sys
+
+# Resolve sibling `_hook_utils.py` regardless of cwd at invocation time.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    iter_command_starts,
+    safe_tokenize,
+    strip_prefix,
+)
 
 
 CATEGORIES = {
@@ -51,140 +59,11 @@ CATEGORIES = {
 }
 
 PROD_LITERAL_TOKENS = {"prod", "production"}
-SHELL_SEPARATORS = {";", "&&", "||", "|", "&"}
 OPT_OUT_MARKER = "# side-effect:ack"
-
-ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
-
-# Shell keywords that appear at the start of a command segment but are purely
-# syntactic. `if true; then git push; fi` segments as `['if','true']`,
-# `['then','git','push']`, `['fi']` — we peel the keyword so argv[0] becomes
-# the real executable.
-SHELL_KEYWORDS = {
-    "if", "then", "elif", "else", "fi",
-    "while", "until", "do", "done",
-    "case", "esac", "in", "for",
-    "{", "}", "!", "function",
-}
-
-# Prefix wrappers that execute the following command as a new process. The
-# scanner looks past them to find the real argv[0]. Per-wrapper option
-# dictionaries list *only* flags that take a separate-token argument so that
-# `sudo --user admin kubectl ...` peels both `--user` and `admin`. Bare flags
-# (with no arg) and `--long=value` forms are handled generically below.
-PREFIX_WRAPPERS = {"env", "sudo", "nice", "time", "stdbuf", "ionice"}
-WRAPPER_OPTS_WITH_ARG = {
-    "env": {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"},
-    "sudo": {
-        "-u", "-g", "-p", "-C", "-D", "-r", "-t", "-T", "-U", "-h",
-        "--user", "--group", "--prompt", "--close-from", "--chdir",
-        "--role", "--type", "--host", "--other-user",
-    },
-    "nice": {"-n", "--adjustment"},
-    "stdbuf": {"-i", "-o", "-e", "--input", "--output", "--error"},
-    "time": {"-f", "--format", "-o", "--output"},
-    "ionice": {
-        "-c", "--class", "-n", "--classdata",
-        "-p", "--pid", "-P", "--pgid", "-u", "--uid",
-    },
-}
 
 
 def has_opt_out(raw: str) -> bool:
     return OPT_OUT_MARKER in raw.lower()
-
-
-def safe_tokenize(command: str) -> list[str]:
-    """Tokenize with shell operators and line breaks split into tokens.
-
-    Uses shlex.shlex(punctuation_chars=';|&') so that `git push&&echo` and
-    `git push;echo` split into `['git', 'push', '&&', 'echo']` etc. Plain
-    shlex.split keeps operators glued to adjacent words, which would let a
-    whitespace-free one-liner bypass detection entirely.
-
-    Newlines are a command separator in Bash but shlex's whitespace_split
-    consumes them as generic whitespace, flattening multi-line scripts into
-    one token stream. We pre-split the raw command on `\\n` and insert a
-    synthetic `;` between line tokens so iter_command_starts sees the break.
-    Lines that fail to parse (unmatched quote, runaway heredoc, etc.) are
-    skipped — better a silent pass than a crashed hook.
-    """
-    lines = [ln for ln in command.split("\n") if ln.strip()]
-    if not lines:
-        return []
-    tokens: list[str] = []
-    for idx, line in enumerate(lines):
-        if idx > 0:
-            tokens.append(";")
-        try:
-            lex = shlex.shlex(line, posix=True, punctuation_chars=";|&")
-            lex.whitespace_split = True
-            lex.commenters = ""  # raw `#` is not a comment here; opt-out marker
-            tokens.extend(list(lex))
-        except ValueError:
-            continue
-    return tokens
-
-
-def strip_prefix(argv: list[str]) -> list[str]:
-    """Peel shell keywords, `KEY=VAL` assignments, and wrapper commands off
-    the front so argv[0] becomes the real executable.
-
-    Handles (in any order, iteratively):
-    - shell keywords (`if`, `then`, `do`, `while`, etc.) — pure syntax, drop
-    - env assignments (`FOO=1`) — drop
-    - wrapper commands (`env`, `sudo`, `nice`, `time`, `stdbuf`, `ionice`) —
-      drop the wrapper plus its option flags. Option flags are peeled
-      generically: any `-*` token is consumed, and if it's a known arg-taking
-      flag for this wrapper the following value token is peeled too. The
-      `--long=value` form counts as a single token and is handled naturally.
-    """
-    i = 0
-    n = len(argv)
-    while i < n:
-        tok = argv[i]
-        if tok in SHELL_KEYWORDS:
-            i += 1
-            continue
-        if ENV_ASSIGN_RE.match(tok):
-            i += 1
-            continue
-        if tok in PREFIX_WRAPPERS:
-            wrapper = tok
-            i += 1
-            opts_with_arg = WRAPPER_OPTS_WITH_ARG.get(wrapper, set())
-            while i < n:
-                nxt = argv[i]
-                if ENV_ASSIGN_RE.match(nxt):
-                    i += 1
-                    continue
-                if not nxt.startswith("-"):
-                    break
-                if "=" in nxt:
-                    # --long=value — value embedded; peel this token only
-                    i += 1
-                    continue
-                if nxt in opts_with_arg and i + 1 < n:
-                    # --user admin / -u admin — peel pair
-                    i += 2
-                    continue
-                # bare flag (-E, -i, -oL, etc.) — peel single token
-                i += 1
-            continue
-        break
-    return argv[i:]
-
-
-def iter_command_starts(tokens: list[str]):
-    """Yield argv slices at each command start across shell separators."""
-    start = 0
-    for i, tok in enumerate(tokens):
-        if tok in SHELL_SEPARATORS:
-            if start < i:
-                yield tokens[start:i]
-            start = i + 1
-    if start < len(tokens):
-        yield tokens[start:]
 
 
 def argv_matches(argv: list[str], positions, expected) -> bool:

--- a/tests/fixtures/memory-hint-cap/foo_a.md
+++ b/tests/fixtures/memory-hint-cap/foo_a.md
@@ -1,0 +1,7 @@
+---
+name: foo-a
+description: oldest matching memory
+type: feedback
+hookable: true
+hookKeywords: [foo]
+---

--- a/tests/fixtures/memory-hint-cap/foo_b.md
+++ b/tests/fixtures/memory-hint-cap/foo_b.md
@@ -1,0 +1,7 @@
+---
+name: foo-b
+description: second-oldest matching memory
+type: feedback
+hookable: true
+hookKeywords: [foo]
+---

--- a/tests/fixtures/memory-hint-cap/foo_c.md
+++ b/tests/fixtures/memory-hint-cap/foo_c.md
@@ -1,0 +1,7 @@
+---
+name: foo-c
+description: second-newest matching memory
+type: feedback
+hookable: true
+hookKeywords: [foo]
+---

--- a/tests/fixtures/memory-hint-cap/foo_d.md
+++ b/tests/fixtures/memory-hint-cap/foo_d.md
@@ -1,0 +1,7 @@
+---
+name: foo-d
+description: newest matching memory
+type: feedback
+hookable: true
+hookKeywords: [foo]
+---

--- a/tests/fixtures/memory-hint/bad_yaml.md
+++ b/tests/fixtures/memory-hint/bad_yaml.md
@@ -1,0 +1,7 @@
+---
+name: bad-yaml
+description: malformed list never closes
+type: feedback
+hookable: true
+hookKeywords: [unclosed
+---

--- a/tests/fixtures/memory-hint/hook_full_inline_comments.md
+++ b/tests/fixtures/memory-hint/hook_full_inline_comments.md
@@ -1,0 +1,7 @@
+---
+name: hook-full-inline-comments
+description: this description ends here # comment to be stripped
+type: feedback
+hookable: true   # opt-in switch with trailing comment
+hookKeywords: [zorblax]   # list with trailing comment
+---

--- a/tests/fixtures/memory-hint/hook_gh_search.md
+++ b/tests/fixtures/memory-hint/hook_gh_search.md
@@ -1,0 +1,9 @@
+---
+name: hook-gh-search
+description: gh search state-all guidance
+type: feedback
+hookable: true
+hookKeywords: [gh, search]
+---
+
+Body irrelevant.

--- a/tests/fixtures/memory-hint/hook_inline_comment.md
+++ b/tests/fixtures/memory-hint/hook_inline_comment.md
@@ -1,0 +1,7 @@
+---
+name: hook-inline-comment
+description: trailing yaml inline comment after closing bracket
+type: feedback
+hookable: true
+hookKeywords: [bazinga]   # inline comment must be ignored by parser
+---

--- a/tests/fixtures/memory-hint/hook_keywords_scalar.md
+++ b/tests/fixtures/memory-hint/hook_keywords_scalar.md
@@ -1,0 +1,7 @@
+---
+name: hook-keywords-scalar
+description: scalar hookKeywords is rejected
+type: feedback
+hookable: true
+hookKeywords: kubectl
+---

--- a/tests/fixtures/memory-hint/hook_kubectl.md
+++ b/tests/fixtures/memory-hint/hook_kubectl.md
@@ -1,0 +1,9 @@
+---
+name: hook-kubectl
+description: kubectl context check rule
+type: feedback
+hookable: true
+hookKeywords: [kubectl]
+---
+
+Body irrelevant for hook indexing.

--- a/tests/fixtures/memory-hint/hook_no_description.md
+++ b/tests/fixtures/memory-hint/hook_no_description.md
@@ -1,0 +1,8 @@
+---
+name: hook-no-description
+type: feedback
+hookable: true
+hookKeywords: [foo]
+---
+
+Description omitted on purpose.

--- a/tests/fixtures/memory-hint/hookable_false.md
+++ b/tests/fixtures/memory-hint/hookable_false.md
@@ -1,0 +1,7 @@
+---
+name: hookable-false
+description: gate proves hookable false skips even with matching keyword
+type: feedback
+hookable: false
+hookKeywords: [__hookable_false_marker__]
+---

--- a/tests/fixtures/memory-hint/hookable_no_keywords.md
+++ b/tests/fixtures/memory-hint/hookable_no_keywords.md
@@ -1,0 +1,6 @@
+---
+name: hookable-no-keywords
+description: hookable true but missing keywords list
+type: feedback
+hookable: true
+---

--- a/tests/fixtures/memory-hint/no_hookable.md
+++ b/tests/fixtures/memory-hint/no_hookable.md
@@ -1,0 +1,7 @@
+---
+name: no-hookable
+description: missing hookable key entirely
+type: feedback
+---
+
+Should never appear in stderr regardless of command.

--- a/tests/fixtures/memory-hint/non_utf8.md
+++ b/tests/fixtures/memory-hint/non_utf8.md
@@ -1,0 +1,5 @@
+---
+name: not-decodable
+hookable: true
+hookKeywords: [ÿþýkubectl]
+---

--- a/tests/test_memory_hint.sh
+++ b/tests/test_memory_hint.sh
@@ -138,6 +138,32 @@ run_case "18 hit: no description trailer"              "hit:hook_no_description.
 run_case "19 silent: scalar hookKeywords skipped"      silent                          "$FIXTURES_MAIN" Bash 'kubectl_only_in_scalar_fixture'
 run_case "20 silent: case-sensitive keyword miss"      silent                          "$FIXTURES_MAIN" Bash 'Kubectl Get'
 run_case "21 hit: hookKeywords with trailing inline comment" "hit:hook_inline_comment.md" "$FIXTURES_MAIN" Bash 'bazinga now'
+run_case "22 hit: hookable + description with trailing comments parsed correctly" "hit:hook_full_inline_comments.md" "$FIXTURES_MAIN" Bash 'zorblax run'
+run_case "23 hit: trailing comment stripped from description visible portion" "hit:this description ends here" "$FIXTURES_MAIN" Bash 'zorblax run'
+
+description_no_leak_test() {
+  local name="24 silent: trailing yaml comment NOT leaked into stderr"
+  local payload
+  payload=$(python3 -c '
+import json, sys
+print(json.dumps({"tool_name": "Bash", "tool_input": {"command": "zorblax run"}}))')
+  local err_file
+  err_file=$(mktemp)
+  echo "$payload" | env PRAXIS_MEMORY_DIR="$FIXTURES_MAIN" "$HOOK" >/dev/null 2>"$err_file"
+  local rc=$?
+  local err
+  err=$(cat "$err_file")
+  rm -f "$err_file"
+  # rc must be 0; stderr must contain the description fragment but NOT the comment
+  if [ "$rc" -eq 0 ] && [[ "$err" == *"this description ends here"* ]] && [[ "$err" != *"# comment to be stripped"* ]]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] rc=$rc stderr=${err:-<empty>}"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+description_no_leak_test
 
 # --- summary -----------------------------------------------------------------
 echo ""

--- a/tests/test_memory_hint.sh
+++ b/tests/test_memory_hint.sh
@@ -165,6 +165,36 @@ print(json.dumps({"tool_name": "Bash", "tool_input": {"command": "zorblax run"}}
 }
 description_no_leak_test
 
+# --- AC-25 / AC-26: fail-open on undecodable memory file --------------------
+run_case "25 hit: undecodable peer does not break sibling matches" "hit:hook_kubectl.md" "$FIXTURES_MAIN" Bash 'kubectl get pods'
+
+undecodable_silent_test() {
+  local name="26 silent: undecodable memory alone exits 0 silently"
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  cp "$FIXTURES_MAIN/non_utf8.md" "$tmpdir/non_utf8.md"
+  local payload
+  payload=$(python3 -c '
+import json
+print(json.dumps({"tool_name": "Bash", "tool_input": {"command": "kubectl get pods"}}))')
+  local err_file
+  err_file=$(mktemp)
+  echo "$payload" | env PRAXIS_MEMORY_DIR="$tmpdir" "$HOOK" >/dev/null 2>"$err_file"
+  local rc=$?
+  local err
+  err=$(cat "$err_file")
+  rm -f "$err_file"
+  rm -rf "$tmpdir"
+  if [ "$rc" -eq 0 ] && [ -z "$err" ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] rc=$rc stderr=${err:-<empty>}"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+undecodable_silent_test
+
 # --- summary -----------------------------------------------------------------
 echo ""
 echo "Passed: $PASS  Failed: $FAIL"

--- a/tests/test_memory_hint.sh
+++ b/tests/test_memory_hint.sh
@@ -137,6 +137,7 @@ run_case "17 hit: multiple distinct memories fire"     "hit:hook_gh_search.md"  
 run_case "18 hit: no description trailer"              "hit:hook_no_description.md"   "$FIXTURES_MAIN" Bash 'foo bar'
 run_case "19 silent: scalar hookKeywords skipped"      silent                          "$FIXTURES_MAIN" Bash 'kubectl_only_in_scalar_fixture'
 run_case "20 silent: case-sensitive keyword miss"      silent                          "$FIXTURES_MAIN" Bash 'Kubectl Get'
+run_case "21 hit: hookKeywords with trailing inline comment" "hit:hook_inline_comment.md" "$FIXTURES_MAIN" Bash 'bazinga now'
 
 # --- summary -----------------------------------------------------------------
 echo ""

--- a/tests/test_memory_hint.sh
+++ b/tests/test_memory_hint.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# test_memory_hint.sh — coverage for hooks/memory-hint.sh
+#
+# Synthesizes Claude Code PreToolUse hook payloads and asserts:
+#   hit    → exit 0 + stderr contains the expected substring
+#   silent → exit 0 + stderr empty
+#
+# Usage: bash tests/test_memory_hint.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$ROOT_DIR/hooks/memory-hint.sh"
+FIXTURES_MAIN="$SCRIPT_DIR/fixtures/memory-hint"
+FIXTURES_CAP="$SCRIPT_DIR/fixtures/memory-hint-cap"
+FIXTURES_EMPTY="$SCRIPT_DIR/fixtures/memory-hint-empty"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable: $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+# run_case name expectation memory_dir tool_name command
+#   expectation:
+#     "hit:<substring>"   — stderr contains <substring>, rc=0
+#     "silent"            — stderr empty, rc=0
+run_case() {
+  local name="$1" expectation="$2" memory_dir="$3" tool_name="$4" command="$5"
+
+  local payload
+  payload=$(python3 -c '
+import json, sys
+print(json.dumps({
+    "tool_name": sys.argv[1],
+    "tool_input": {"command": sys.argv[2]},
+}))' "$tool_name" "$command")
+
+  local err_file
+  err_file=$(mktemp)
+  echo "$payload" | env PRAXIS_MEMORY_DIR="$memory_dir" "$HOOK" >/dev/null 2>"$err_file"
+  local rc=$?
+  local err
+  err=$(cat "$err_file")
+  rm -f "$err_file"
+
+  local ok=1
+  case "$expectation" in
+    silent)
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$err" ]   || ok=0
+      ;;
+    hit:*)
+      local needle="${expectation#hit:}"
+      [ "$rc" -eq 0 ] || ok=0
+      case "$err" in
+        *"$needle"*) ;;
+        *) ok=0 ;;
+      esac
+      ;;
+    *)
+      echo "FAIL  [$name] unknown expectation: $expectation"
+      FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name"); return
+      ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expectation=$expectation rc=$rc stderr=${err:-<empty>}"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# --- core hit / silent paths -------------------------------------------------
+run_case "1 hit: kubectl token matches"               "hit:hook_kubectl.md"      "$FIXTURES_MAIN" Bash 'kubectl get pods'
+run_case "2 hit: keyword across separator"            "hit:hook_kubectl.md"      "$FIXTURES_MAIN" Bash 'false || kubectl get pods'
+run_case "3 silent: keyword inside quoted string"     silent                     "$FIXTURES_MAIN" Bash 'echo "use kubectl carefully"'
+run_case "4 silent: keyword absent"                   silent                     "$FIXTURES_MAIN" Bash 'ls -la'
+
+# --- frontmatter gate paths --------------------------------------------------
+run_case "5 silent: hookable false skipped"           silent                     "$FIXTURES_MAIN" Bash 'echo __hookable_false_marker__'
+run_case "6 silent: hookable missing skipped"         silent                     "$FIXTURES_MAIN" Bash 'echo no_hookable_token'
+run_case "7 silent: hookable true but no keywords"    silent                     "$FIXTURES_MAIN" Bash 'echo hookable_no_keywords'
+run_case "8 hit: malformed yaml does not break peers" "hit:hook_kubectl.md"      "$FIXTURES_MAIN" Bash 'kubectl get'
+
+# --- noise cap: 4+ matches → 3 lines + summary ------------------------------
+prepare_cap_mtimes() {
+  python3 -c "
+import os, time
+base = '$FIXTURES_CAP'
+order = ['foo_a.md', 'foo_b.md', 'foo_c.md', 'foo_d.md']
+now = time.time()
+for i, name in enumerate(order):
+    t = now - (len(order) - i) * 100
+    os.utime(os.path.join(base, name), (t, t))
+"
+}
+prepare_cap_mtimes
+run_case "9 hit: cap shows newest first"              "hit:foo_d.md"             "$FIXTURES_CAP"  Bash 'foo bar baz'
+run_case "9b hit: cap summary line emitted"           "hit:and 1 more"           "$FIXTURES_CAP"  Bash 'foo bar baz'
+
+# --- discovery / fail-safe paths --------------------------------------------
+run_case "10 silent: PRAXIS_MEMORY_DIR nonexistent"    silent                    "/tmp/praxis-memhint-no-such-dir-$$" Bash 'kubectl get'
+run_case "11 silent: PRAXIS_MEMORY_DIR empty dir"      silent                    "$FIXTURES_EMPTY" Bash 'kubectl get'
+malformed_json_test() {
+  local name="12 silent: malformed JSON stdin"
+  local err_file
+  err_file=$(mktemp)
+  echo "not-valid-json" | env PRAXIS_MEMORY_DIR="$FIXTURES_MAIN" "$HOOK" >/dev/null 2>"$err_file"
+  local rc=$?
+  local err
+  err=$(cat "$err_file")
+  rm -f "$err_file"
+  if [ "$rc" -eq 0 ] && [ -z "$err" ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] rc=$rc stderr=${err:-<empty>}"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+malformed_json_test
+run_case "13 silent: tool_name Read"                   silent                    "$FIXTURES_MAIN" Read 'kubectl get'
+run_case "14 silent: empty command"                    silent                    "$FIXTURES_MAIN" Bash ''
+run_case "15 hit: backslash line continuation"         "hit:hook_kubectl.md"     "$FIXTURES_MAIN" Bash "$(printf 'kubectl \\\n  get pods')"
+run_case "16 hit: comment-prefixed token still matches" "hit:hook_kubectl.md"    "$FIXTURES_MAIN" Bash '# kubectl get'
+run_case "17 hit: multiple distinct memories fire"     "hit:hook_gh_search.md"   "$FIXTURES_MAIN" Bash 'gh search issues "kubectl"'
+
+# --- AC-21 / AC-22 / AC-23 ---------------------------------------------------
+run_case "18 hit: no description trailer"              "hit:hook_no_description.md"   "$FIXTURES_MAIN" Bash 'foo bar'
+run_case "19 silent: scalar hookKeywords skipped"      silent                          "$FIXTURES_MAIN" Bash 'kubectl_only_in_scalar_fixture'
+run_case "20 silent: case-sensitive keyword miss"      silent                          "$FIXTURES_MAIN" Bash 'Kubectl Get'
+
+# --- summary -----------------------------------------------------------------
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed tests:"
+  for t in "${FAILED_NAMES[@]}"; do
+    echo "  - $t"
+  done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #139

## 배경

MEMORY.md에 등록된 도구 친화 메모리가 있어도 Claude가 도구 호출 직전에 능동적으로 retrieval하지 못하고 에러 발생 후에야 reactive하게 참조하는 패턴이 반복되었습니다. 이 PR은 PreToolUse(Bash) hook 메커니즘을 활용해 도구 호출 직전 관련 메모리를 의식 환기시키는 시스템을 추가합니다.

## 변경 요약

| 커밋 | 타입 | 설명 |
|------|------|------|
| `bc52083` | refactor | `safe_tokenize` / `strip_prefix` / `iter_command_starts` + 5 상수를 `hooks/_hook_utils.py`로 추출. `block-gh-state-all.py:25` TODO 트리거 발동 (3번째 hook). 두 기존 hook은 import로 변경. 동작 변화 없음. |
| `1105918` | feat | 새 PreToolUse(Bash) hook `memory-hint.sh` / `memory-hint.py` + 13 fixtures + 21-case 테스트 + CLAUDE.md 문서. |

## 동작 모델

- 메모리 frontmatter에 `hookable: true` + `hookKeywords: [k1, k2, ...]` opt-in
- Bash 명령 토크나이즈 후 whole-token equality (case-sensitive) 매칭
- hit 시 stderr에 `[memory:hookable] {filename} — {description}` (최대 3건 + 초과분 `...and N more` 요약)
- **항상 exit 0** — 차단/`ask` 없음, 순수 attention-shifting 신호

```yaml
# 메모리 작성 예시
---
name: my-memory
description: Short rule statement
type: feedback
hookable: true                  # opt-in 스위치
hookKeywords: [kubectl, hubctl] # whole-token 매칭
---
```

## Hook 실행 모델 (검증됨)

PreToolUse hooks는 [Anthropic 공식 문서](https://code.claude.com/docs/en/hooks) 기준 **parallel** 실행. `hooks.json` array order는 표시용일 뿐 우선순위 게이트가 아닙니다. 정밀도는 `deny > defer > ask > allow`. `memory-hint`는 stderr만 emit하므로 `block-gh-state-all` (exit 2) / `side-effect-scan` (`ask`)와 **co-fire**합니다 — 이 동작은 의도된 것이며, hint가 sibling hook의 차단 사유를 보강합니다.

## 메모리 디렉토리 디스커버리

1. `PRAXIS_MEMORY_DIR` 환경변수 우선
2. fallback: `~/.claude/projects/{slugified-cwd}/memory/` (slugify: `/` → `-`)
3. 둘 다 없음 → exit 0 (silent)

> 주의: spec(`/Users/nathan.song/projects/praxis/.omc/specs/deep-interview-139-memory-hint-hook.md`)은 `~/.claude-4/projects/...`로 명시했으나, ralplan iteration 1에서 `~/.claude-4/projects`가 사용자별 symlink임을 empirically 확인하고 canonical `~/.claude/projects/`로 정정. spec 자체 수정은 별도 follow-up.

## YAML 파서 한계

PyYAML 의존성 없이 pure-regex로 처리. 지원 형태:
- `hookable`: scalar (true/True/TRUE/yes/Yes truthy)
- `hookKeywords`: flat single-line list `[a, b, "c d"]` (스칼라 형태는 거부)
- `description`: optional scalar

multi-line / flow-mapping / anchored YAML은 지원하지 않으며, 파싱 에러 시 해당 메모리만 silent skip합니다 (hook 자체는 절대 죽지 않음).

## Plan deviation (투명성)

Plan Step 2.5는 매칭을 "substring within a single token"으로 명시했으나 구현은 **whole-token equality**로 진행했습니다. 이유:
1. substring 매칭 시 `kubectl` 키워드가 multi-word 인용 토큰 `use kubectl carefully`에 매칭되어 **AC-10 위반**
2. whole-token은 R1의 `kubectl-prod` vs `kubectl` 모호성도 해소

코드 주석(`hooks/memory-hint.py:160-162`) + CLAUDE.md "Matching semantics" 섹션에서 명시. 이는 plan의 명시 텍스트와 implementation의 작은 deviation이며, AC-10/R1의 의도와 일치합니다.

## 테스트

```
$ bash hooks/test-block-gh-state-all.sh
Passed: 22  Failed: 0

$ bash tests/test_side_effect_scan.sh
PASS: 54  FAIL: 0

$ bash tests/test_memory_hint.sh
Passed: 21  Failed: 0
```

총 **97/0** — refactor commit이 회귀를 일으키지 않았음을 76 케이스로 검증, 새 hook은 21 케이스로 AC-04~AC-23 커버.

## 컨센서스 추적

- Spec: `/Users/nathan.song/projects/praxis/.omc/specs/deep-interview-139-memory-hint-hook.md` (deep-interview, ambiguity 20%)
- Plan: `/Users/nathan.song/projects/praxis/.omc/plans/ralplan-139-memory-hint-hook.md` (ralplan iteration 1, Architect + Critic 5/5/5/5/5 APPROVED)
- Code review: `oh-my-claudecode:code-reviewer` APPROVE (3 MINOR 중 2건은 inline 수정 — ANSI control byte sanitization, 단어 인용 동작 문서 명시화)

## 후속 작업 (별도 이슈 후보)

1. PyYAML 도입 (multi-line / flow-mapping 메모리 등장 시)
2. mtime-based caching (메모리 디렉토리가 100+ 파일로 성장 시)
3. case-insensitive 매칭 모드 (현재는 작성자가 casing을 명시적으로 나열)
4. spec 파일의 `~/.claude-4/...` → `~/.claude/...` 정정
5. Hybrid A1+A2 (v1 hit-rate 측정 후 재검토)
