### PR TITLE
fix(turbo-completion): worktree-aware cleanup, drop --delete-branch

### DIFF
--- a/skills/turbo-completion/SKILL.md
+++ b/skills/turbo-completion/SKILL.md
@@ -47,7 +47,7 @@ When a project's `CLAUDE.md` does not provide routing, these built-in defaults a
 | Verify | — (built-in) | Auto-detect: `pytest`, `npm test`, `ruff check`, etc. |
 | Code review | Project CLAUDE.md review skill routing | `oh-my-claudecode:code-reviewer` agent |
 | PR creation | Project CLAUDE.md PR-creation skill routing | `gh pr create` with auto-detected repo |
-| Merge | — (built-in) | `gh pr merge --squash --delete-branch` |
+| Merge | — (built-in) | `gh pr merge --squash` (branch deletion handled by Stage 6, not `--delete-branch`) |
 | Compound | — (built-in) | Inline code comments with PR reference |
 | Cleanup | — (built-in) | `git worktree remove` + `git branch -d` |
 
@@ -272,7 +272,12 @@ while [ $ELAPSED -lt $MAX_WAIT ]; do
   ELAPSED=$((ELAPSED + 10))
 done
 
-gh pr merge "$PR_NUMBER" --repo "${TARGET_REPO}" --squash --delete-branch
+# Note: `--delete-branch` is intentionally omitted. From a multi-worktree
+# session, gh's local cleanup tries to checkout the default branch and fails
+# with `fatal: '<branch>' is already used by worktree at '<path>'`, leaving
+# a partial-fail (PR merged on GitHub, local branch still present). Stage 6
+# handles local + remote branch deletion explicitly instead.
+gh pr merge "$PR_NUMBER" --repo "${TARGET_REPO}" --squash
 ```
 
 ### Stage 6: Cleanup
@@ -289,11 +294,23 @@ PR #<number> merged. How to proceed?
 #### Option 1: Full Cleanup (recommended)
 
 ```bash
+# Step out of the issue worktree first so we can remove it.
 cd "$MAIN_REPO"
+
+# Remove the issue worktree, then the local branch. `-D` (force) is required
+# because squash-merged branches are not ancestors of the merge commit, so
+# `-d` (safe) refuses to delete them.
 git worktree remove "$WORKTREE_PATH"
-git branch -d "$BRANCH" 2>/dev/null
-git checkout "$DEFAULT_BRANCH"
-git pull origin "$DEFAULT_BRANCH"
+git branch -D "$BRANCH" 2>/dev/null
+
+# Best-effort remote branch delete. Silent no-op when GitHub repo settings
+# auto-delete merged branches; required for repos without that setting.
+git push origin --delete "$BRANCH" 2>/dev/null
+
+# Refresh main from origin (MAIN_REPO already has $DEFAULT_BRANCH checked
+# out, so no `git checkout` is needed and would conflict with other
+# worktrees if attempted).
+git -C "$MAIN_REPO" pull --ff-only origin "$DEFAULT_BRANCH"
 git worktree prune
 ```
 
@@ -371,7 +388,8 @@ Review this work cycle and capture reusable lessons:
 | CI | Check failure | Analyze logs, auto-fix (1x), then STOP |
 | Merge | Conflict | **STOP** — report to user |
 | Merge | Approval required | **STOP** — report to user |
-| Cleanup | Worktree busy | Report, suggest manual cleanup |
+| Cleanup | Worktree busy (cwd inside it) | `cd "$MAIN_REPO"` first, then retry — Stage 6 already does this |
+| Cleanup | Default branch checked out elsewhere | Skip local checkout step; `git -C "$MAIN_REPO" pull` updates the parent worktree directly |
 
 **Escalation pattern:**
 ```


### PR DESCRIPTION
## 배경

`praxis:turbo-completion` Stage 5의 `gh pr merge --squash --delete-branch`은 multi-worktree 세션에서 partial-fail합니다. 본 세션에서 PR #150 머지 시점에 직접 재현되었습니다.

```
fatal: 'main' is already used by worktree at '/Users/.../praxis'
exit 1
```

**Root cause:** `--delete-branch` 플래그가 머지 후 default 브랜치 로컬 checkout + `git branch -d`을 시도. parent worktree(main 체크아웃 중)와 충돌해 로컬 단계만 실패. PR은 GitHub에서 정상 머지되지만 로컬 브랜치/main이 stale 상태로 남음.

## 변경

### `skills/turbo-completion/SKILL.md`

**Stage 5 (line 275)** — `--delete-branch` 제거 + WHY 주석 추가:
```bash
gh pr merge "$PR_NUMBER" --repo "${TARGET_REPO}" --squash
```

**Stage 6 Option 1** — 명시적 4단 cleanup 시퀀스:
```bash
cd "$MAIN_REPO"
git worktree remove "$WORKTREE_PATH"
git branch -D "$BRANCH" 2>/dev/null            # -D (not -d) for squash
git push origin --delete "$BRANCH" 2>/dev/null # silent if auto-delete
git -C "$MAIN_REPO" pull --ff-only origin "$DEFAULT_BRANCH"
git worktree prune
```

`git checkout "$DEFAULT_BRANCH"` 제거 — parent worktree가 이미 default를 체크아웃 중이므로 동일 충돌 재발 위험.

**Routing table + Error Handling 표 정합성** — 같이 갱신.

## 검증

- 본 세션에서 동일 시퀀스 dry-run 통과: PR #150 머지 시 `gh pr merge --squash`(--delete-branch 없이) → `git worktree remove` → `git branch -D` → `git push origin --delete` 모두 정상
- 회귀: `test_memory_hint.sh` 27/27, `test_side_effect_scan.sh` 54/54 통과
- `scripts/check-plugin-manifests.py` 통과 (manifest drift 없음)

## 회귀 위험

- 단일 worktree 사용자: 동일하게 동작 (Stage 6의 worktree remove가 no-op은 아니지만, parent worktree에서 직접 실행할 일은 없음 — turbo-completion이 의도한 흐름은 항상 issue worktree에서 호출)
- `--delete-branch` 의존 사용자: 명시적 cleanup으로 동등 동작 보장

## Refs

- 발견 세션: 2026-05-04 PR #150 머지
- 사용자 측 행동 메모: `feedback_worktree_context_pre_git_op.md`

Closes #148