### PR TITLE
feat(hooks): warn on /codex:review in multi-worktree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -436,6 +436,7 @@ False-positive guards:
 | `please /codex:review later` (mid-sentence) | silent — regex anchored to start-of-prompt |
 | `/codex:status` (different command) | silent |
 | Single-worktree repo | silent — bare invocation works correctly |
+| Bare repo + 1 linked worktree | silent — `bare` blocks excluded from the count, only the linked worktree is active |
 | Not a git repo | silent — `git worktree list` returns nothing |
 | Empty prompt | silent |
 
@@ -471,12 +472,13 @@ denies).
 bash tests/test_codex_review_route.sh
 ```
 
-Covers 13 cases: 4 warn paths (bare, with flag, with `--model`,
-hyphenated form), 7 silent paths (single-worktree, plain text, different
+Covers 14 cases: 4 warn paths (bare, with flag, with `--model`,
+hyphenated form), 8 silent paths (single-worktree, plain text, different
 slash command, false-positive trailing chars, empty prompt, hyphenated
-suffix, mid-sentence mention), 2 fail-safe paths (malformed JSON,
-non-git cwd). Worktree state is fixtured via temporary `git init` repos
-to keep tests isolated from the running praxis tree.
+suffix, mid-sentence mention, bare-repo + 1 linked worktree), 2 fail-safe
+paths (malformed JSON, non-git cwd). Worktree state is fixtured via
+temporary `git init` (and `git init --bare` for the bare-repo case) to
+keep tests isolated from the running praxis tree.
 
 ## PostToolUse Built-in Task Classification
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,6 +397,87 @@ Covers 21 cases: hit/silent core paths, frontmatter gates, noise cap, mtime
 ordering, discovery fail-safes, malformed inputs, AC-21 (no description),
 AC-22 (scalar rejection), AC-23 (case sensitivity).
 
+## UserPromptSubmit Codex Review Worktree Disambiguation
+
+`hooks/codex-review-route.sh` fires on every `UserPromptSubmit` event and
+emits an `additionalContext` warning when the user invokes `/codex:review`
+in a multi-worktree repository.
+
+### Why this exists
+
+`/codex:review` (owned by the external `openai-codex` plugin) executes its
+companion script through Claude Code's Bash tool, whose cwd resets to the
+session root between calls. In a multi-worktree session — common when a
+parent worktree holds `main` and a sibling worktree holds an issue branch —
+the companion's `git diff` runs from the parent cwd, not the issue
+worktree. The result is an empty or wrong-target review.
+
+`praxis:codex-review-wrap` solves this by enumerating worktrees, prompting
+for explicit selection, and delegating to `/codex:review` with the correct
+cwd. But users routinely forget to use it and reach for `/codex:review`
+directly. This hook detects that pattern and primes Claude to redirect.
+
+### What is warned
+
+Hook emits `additionalContext` only when **all** the following hold:
+
+| Gate | Condition |
+|------|-----------|
+| Prompt prefix | `/codex:review` or `/codex-review` (whitespace-separated args allowed) |
+| Worktree count | `git worktree list --porcelain` reports `>= 2` non-bare worktrees |
+| jq available | Hook fail-opens silently when `jq` is missing |
+
+False-positive guards:
+
+| Input | Action |
+|-------|--------|
+| `/codex:reviews` (trailing char) | silent — regex requires whitespace or end-of-line after `review` |
+| `/codex:review-thing` (hyphenated suffix) | silent — same guard |
+| `please /codex:review later` (mid-sentence) | silent — regex anchored to start-of-prompt |
+| `/codex:status` (different command) | silent |
+| Single-worktree repo | silent — bare invocation works correctly |
+| Not a git repo | silent — `git worktree list` returns nothing |
+| Empty prompt | silent |
+
+### Response
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit",
+    "additionalContext": "⚠️ Multi-worktree detected ... ask the user to run /praxis:codex-review-wrap ..."
+  }
+}
+```
+
+Claude reads the `additionalContext` alongside the user prompt and is
+expected to redirect the user to the wrapper rather than dispatch the
+codex companion against the wrong cwd. The hook does **not** block the
+prompt — Claude can still proceed if the user has explicitly confirmed
+the target worktree in the same turn.
+
+### Why warn instead of block
+
+Blocking would cause false positives in legitimate single-target reviews
+where the user has already run `cd <target>` mentally / explicitly. The
+warning gives Claude the discretion to redirect or proceed, which matches
+how the rest of the praxis hook suite handles similar discretionary
+escalations (memory-hint emits hints, side-effect-scan asks rather than
+denies).
+
+### Tests
+
+```bash
+bash tests/test_codex_review_route.sh
+```
+
+Covers 13 cases: 4 warn paths (bare, with flag, with `--model`,
+hyphenated form), 7 silent paths (single-worktree, plain text, different
+slash command, false-positive trailing chars, empty prompt, hyphenated
+suffix, mid-sentence mention), 2 fail-safe paths (malformed JSON,
+non-git cwd). Worktree state is fixtured via temporary `git init` repos
+to keep tests isolated from the running praxis tree.
+
 ## PostToolUse Built-in Task Classification
 
 `hooks/builtin-task-postuse.py` fires after any built-in task **management**

--- a/hooks/codex-review-route.sh
+++ b/hooks/codex-review-route.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# codex-review-route.sh — UserPromptSubmit hook
+#
+# When the user invokes `/codex:review` in a multi-worktree environment, the
+# bare command runs through Claude Code's Bash tool whose cwd resets to the
+# session root (typically the parent/main worktree). The codex companion
+# script then computes its diff from that cwd, often producing an empty or
+# wrong-target review when the user actually wanted to review a sibling
+# issue worktree.
+#
+# This hook emits an `additionalContext` warning whenever:
+#   1. The user prompt starts with `/codex:review` (or `/codex-review`)
+#   2. AND `git worktree list` reports >= 2 active (non-bare) worktrees
+#
+# The warning instructs Claude to redirect the user to
+# `/praxis:codex-review-wrap` (which forces explicit worktree selection
+# before delegating). If only one worktree exists, the hook stays silent —
+# bare invocation is correct in that case.
+#
+# Fail-safe: jq missing, malformed JSON, no git repo, or any unexpected
+# error all exit 0 silently. The hook never blocks a prompt.
+
+set +e
+
+# jq guard — Claude Code session must keep functioning even without jq
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+INPUT=$(cat)
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null)
+
+if [ -z "$PROMPT" ]; then
+  exit 0
+fi
+
+# Match `/codex:review` or `/codex-review`, optionally followed by args.
+# Trailing space requirement avoids false positives on `/codex:reviews`
+# or `/codex:review-thing` (defensive — none currently exist, but cheap).
+if ! [[ "$PROMPT" =~ ^/codex(:|-)review([[:space:]]|$) ]]; then
+  exit 0
+fi
+
+# Count active non-bare worktrees. `git worktree list --porcelain` emits
+# one `worktree <path>` line per entry (bare entries are followed by a
+# `bare` line; we count `worktree` lines and let bare entries resolve
+# on the consumer side — bare worktrees are rare and the wrapper handles
+# them correctly).
+WT_COUNT=$(git worktree list --porcelain 2>/dev/null | awk '/^worktree /' | wc -l | tr -d ' ')
+
+if ! [[ "$WT_COUNT" =~ ^[0-9]+$ ]]; then
+  exit 0
+fi
+
+if [ "$WT_COUNT" -lt 2 ] 2>/dev/null; then
+  exit 0
+fi
+
+read -r -d '' MSG <<EOF
+⚠️ Multi-worktree detected (${WT_COUNT} active worktrees) for a /codex:review invocation.
+
+Bare /codex:review uses the Bash tool's session-default cwd, which often differs from the worktree the user actually wants to review — producing an empty or wrong-target diff.
+
+Recommended action: instead of dispatching /codex:review directly, ask the user to run /praxis:codex-review-wrap. The wrapper enumerates worktrees, prompts for explicit selection, and delegates to /codex:review with the correct cwd.
+
+If the user explicitly confirms the target worktree in this turn, you may proceed — but state the resolved cwd in your reply so the choice is visible.
+EOF
+
+jq -n --arg ctx "$MSG" \
+  '{hookSpecificOutput: {hookEventName: "UserPromptSubmit", additionalContext: $ctx}}'
+
+exit 0

--- a/hooks/codex-review-route.sh
+++ b/hooks/codex-review-route.sh
@@ -41,12 +41,26 @@ if ! [[ "$PROMPT" =~ ^/codex(:|-)review([[:space:]]|$) ]]; then
   exit 0
 fi
 
-# Count active non-bare worktrees. `git worktree list --porcelain` emits
-# one `worktree <path>` line per entry (bare entries are followed by a
-# `bare` line; we count `worktree` lines and let bare entries resolve
-# on the consumer side — bare worktrees are rare and the wrapper handles
-# them correctly).
-WT_COUNT=$(git worktree list --porcelain 2>/dev/null | awk '/^worktree /' | wc -l | tr -d ' ')
+# Count active non-bare, non-prunable worktrees. `git worktree list
+# --porcelain` emits one block per entry (blank-line separated), each
+# starting with `worktree <path>`. Bare repos have a `bare` line; stale
+# worktrees have a `prunable` line. Both must be excluded — counting raw
+# `worktree` lines would over-count bare-repo + linked-worktree setups
+# and trigger false-positive warnings on single-target reviews.
+WT_COUNT=$(git worktree list --porcelain 2>/dev/null | awk '
+  /^$/ {
+    if (in_block && !is_bare && !is_prunable) count++
+    in_block = 0; is_bare = 0; is_prunable = 0
+    next
+  }
+  /^worktree / { in_block = 1 }
+  /^bare$/ { is_bare = 1 }
+  /^prunable( |$)/ { is_prunable = 1 }
+  END {
+    if (in_block && !is_bare && !is_prunable) count++
+    print count + 0
+  }
+')
 
 if ! [[ "$WT_COUNT" =~ ^[0-9]+$ ]]; then
   exit 0

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "praxis hooks: Stop gate for completion-without-evidence, retrospect memory-bias gate, session-scoped three-strike discipline, PreToolUse(Bash) side-effect scan / gh search --state all block / memory-hint, PostToolUse correction for built-in task management tools",
+  "description": "praxis hooks: Stop gate for completion-without-evidence, retrospect memory-bias gate, session-scoped three-strike discipline, PreToolUse(Bash) side-effect scan / gh search --state all block / memory-hint, PostToolUse correction for built-in task management tools, UserPromptSubmit codex-review worktree disambiguation",
   "hooks": {
     "SessionStart": [
       {
@@ -18,6 +18,11 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/strike-counter.sh preprompt",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/codex-review-route.sh",
             "timeout": 5
           }
         ]

--- a/tests/test_codex_review_route.sh
+++ b/tests/test_codex_review_route.sh
@@ -57,6 +57,27 @@ make_single_wt_repo() {
   cd - >/dev/null || true
 }
 
+# --- bare + 1 linked worktree fixture ---------------------------------------
+# Reproduces the false-positive case: `git worktree list --porcelain` shows
+# 2 `worktree <path>` lines (bare repo + 1 linked), but only the linked one
+# is an active non-bare worktree. The hook must count it as 1 and stay
+# silent on /codex:review invocations.
+make_bare_plus_linked_repo() {
+  local base="$1"
+  mkdir -p "$base"
+  local seed="$base/_seed"
+  mkdir -p "$seed"
+  ( cd "$seed" \
+      && git init -q -b main \
+      && git config user.email "test@example.com" \
+      && git config user.name "Test" \
+      && echo "x" > a.txt \
+      && git add a.txt \
+      && git commit -qm "init" )
+  git clone -q --bare "$seed" "$base/bare" 2>/dev/null
+  ( cd "$base/bare" && git worktree add -q "$base/linked" main 2>/dev/null )
+}
+
 run_case() {
   local name="$1" expectation="$2" cwd="$3" prompt="$4"
 
@@ -106,14 +127,17 @@ print(json.dumps({"prompt": sys.argv[1], "session_id": "test-sid"}))' "$prompt")
 TMPROOT=$(mktemp -d)
 MULTI="$TMPROOT/multi"
 SINGLE="$TMPROOT/single"
+BARE_LINKED="$TMPROOT/bare-plus-linked"
 
 make_multi_wt_repo "$MULTI"
 make_single_wt_repo "$SINGLE"
+make_bare_plus_linked_repo "$BARE_LINKED"
 
-# Sanity check: verify worktree counts are as expected
+# Sanity check: verify raw worktree-line counts (NOT the hook's filtered count)
 multi_count=$(cd "$MULTI" && git worktree list --porcelain 2>/dev/null | awk '/^worktree /' | wc -l | tr -d ' ')
 single_count=$(cd "$SINGLE" && git worktree list --porcelain 2>/dev/null | awk '/^worktree /' | wc -l | tr -d ' ')
-echo "fixture: multi=$multi_count worktrees, single=$single_count worktree"
+bare_raw_count=$(cd "$BARE_LINKED/linked" && git worktree list --porcelain 2>/dev/null | awk '/^worktree /' | wc -l | tr -d ' ')
+echo "fixture: multi=$multi_count, single=$single_count, bare-plus-linked raw=$bare_raw_count (hook should filter to 1)"
 
 # --- /codex:review trigger paths --------------------------------------------
 run_case "1 warn: bare /codex:review in multi-worktree"          warn   "$MULTI"  "/codex:review"
@@ -129,6 +153,9 @@ run_case "8 silent: /codex:reviews (false-positive guard)"         silent "$MULT
 run_case "9 silent: empty prompt"                                  silent "$MULTI"  ""
 run_case "10 silent: /codex:review-thing trailing chars"           silent "$MULTI"  "/codex:review-thing"
 run_case "11 silent: prompt mentions /codex:review mid-sentence"   silent "$MULTI"  "use /codex:review later"
+
+# --- bare-repo + linked worktree (false-positive guard) ---------------------
+run_case "11b silent: bare repo + 1 linked worktree counts as 1"   silent "$BARE_LINKED/linked" "/codex:review"
 
 # --- malformed input fail-safe ----------------------------------------------
 malformed_json_test() {

--- a/tests/test_codex_review_route.sh
+++ b/tests/test_codex_review_route.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# test_codex_review_route.sh — coverage for hooks/codex-review-route.sh
+#
+# Synthesizes Claude Code UserPromptSubmit hook payloads and asserts:
+#   warn   → exit 0 + stdout contains JSON additionalContext substring
+#   silent → exit 0 + stdout empty
+#
+# Multi-worktree state is simulated by running the hook from inside a
+# temporary repo with N synthesized worktrees, NOT against the real
+# praxis tree (test isolation).
+#
+# Usage: bash tests/test_codex_review_route.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$ROOT_DIR/hooks/codex-review-route.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable: $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+# --- multi-worktree fixture --------------------------------------------------
+make_multi_wt_repo() {
+  local base="$1"
+  mkdir -p "$base"
+  cd "$base" || return 1
+  git init -q
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  echo "x" > a.txt
+  git add a.txt
+  git commit -qm "init"
+  # add a second worktree (counts as 2 total: base + sibling)
+  git worktree add -q -b feat-side "$base/../feat-side" >/dev/null 2>&1
+  cd - >/dev/null || true
+}
+
+# --- single-worktree fixture -------------------------------------------------
+make_single_wt_repo() {
+  local base="$1"
+  mkdir -p "$base"
+  cd "$base" || return 1
+  git init -q
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  echo "y" > b.txt
+  git add b.txt
+  git commit -qm "init"
+  cd - >/dev/null || true
+}
+
+run_case() {
+  local name="$1" expectation="$2" cwd="$3" prompt="$4"
+
+  local payload
+  payload=$(python3 -c '
+import json, sys
+print(json.dumps({"prompt": sys.argv[1], "session_id": "test-sid"}))' "$prompt")
+
+  local out_file
+  out_file=$(mktemp)
+  ( cd "$cwd" && echo "$payload" | "$HOOK" ) > "$out_file" 2>/dev/null
+  local rc=$?
+  local out
+  out=$(cat "$out_file")
+  rm -f "$out_file"
+
+  local ok=1
+  case "$expectation" in
+    silent)
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$out" ]   || ok=0
+      ;;
+    warn)
+      [ "$rc" -eq 0 ] || ok=0
+      case "$out" in
+        *"codex-review-wrap"*"additionalContext"*) ;;
+        *"additionalContext"*"codex-review-wrap"*) ;;
+        *) ok=0 ;;
+      esac
+      ;;
+    *)
+      echo "FAIL  [$name] unknown expectation: $expectation"
+      FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name"); return
+      ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expectation=$expectation rc=$rc stdout=${out:-<empty>}"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# --- setup fixture repos -----------------------------------------------------
+TMPROOT=$(mktemp -d)
+MULTI="$TMPROOT/multi"
+SINGLE="$TMPROOT/single"
+
+make_multi_wt_repo "$MULTI"
+make_single_wt_repo "$SINGLE"
+
+# Sanity check: verify worktree counts are as expected
+multi_count=$(cd "$MULTI" && git worktree list --porcelain 2>/dev/null | awk '/^worktree /' | wc -l | tr -d ' ')
+single_count=$(cd "$SINGLE" && git worktree list --porcelain 2>/dev/null | awk '/^worktree /' | wc -l | tr -d ' ')
+echo "fixture: multi=$multi_count worktrees, single=$single_count worktree"
+
+# --- /codex:review trigger paths --------------------------------------------
+run_case "1 warn: bare /codex:review in multi-worktree"          warn   "$MULTI"  "/codex:review"
+run_case "2 warn: /codex:review with --background flag"           warn   "$MULTI"  "/codex:review --background"
+run_case "3 warn: /codex:review --model opus"                     warn   "$MULTI"  "/codex:review --model opus"
+run_case "4 warn: /codex-review (hyphenated)"                     warn   "$MULTI"  "/codex-review"
+
+# --- silent paths ------------------------------------------------------------
+run_case "5 silent: single-worktree repo"                          silent "$SINGLE" "/codex:review"
+run_case "6 silent: prompt is plain text, not slash command"       silent "$MULTI"  "please review the changes"
+run_case "7 silent: different slash command"                       silent "$MULTI"  "/codex:status"
+run_case "8 silent: /codex:reviews (false-positive guard)"         silent "$MULTI"  "/codex:reviews"
+run_case "9 silent: empty prompt"                                  silent "$MULTI"  ""
+run_case "10 silent: /codex:review-thing trailing chars"           silent "$MULTI"  "/codex:review-thing"
+run_case "11 silent: prompt mentions /codex:review mid-sentence"   silent "$MULTI"  "use /codex:review later"
+
+# --- malformed input fail-safe ----------------------------------------------
+malformed_json_test() {
+  local name="12 silent: malformed JSON stdin"
+  local out_file
+  out_file=$(mktemp)
+  ( cd "$MULTI" && echo "not-valid-json" | "$HOOK" ) > "$out_file" 2>/dev/null
+  local rc=$?
+  local out
+  out=$(cat "$out_file")
+  rm -f "$out_file"
+  if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] rc=$rc stdout=${out:-<empty>}"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+malformed_json_test
+
+not_in_repo_test() {
+  local name="13 silent: cwd not a git repo"
+  local nogit
+  nogit=$(mktemp -d)
+  local payload
+  payload=$(python3 -c '
+import json, sys
+print(json.dumps({"prompt": "/codex:review", "session_id": "test-sid"}))')
+  local out_file
+  out_file=$(mktemp)
+  ( cd "$nogit" && echo "$payload" | "$HOOK" ) > "$out_file" 2>/dev/null
+  local rc=$?
+  local out
+  out=$(cat "$out_file")
+  rm -f "$out_file"
+  rm -rf "$nogit"
+  if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] rc=$rc stdout=${out:-<empty>}"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+not_in_repo_test
+
+# --- cleanup ---------------------------------------------------------------
+rm -rf "$TMPROOT"
+
+# --- summary -----------------------------------------------------------------
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed tests:"
+  for t in "${FAILED_NAMES[@]}"; do
+    echo "  - $t"
+  done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 배경

`/codex:review` (외부 `openai-codex` plugin 소유)는 Claude Code Bash tool로 codex companion 스크립트를 실행합니다. Bash tool의 cwd는 호출 사이에 session root로 reset되므로, multi-worktree 세션(parent=main + sibling=issue branch)에서는 companion이 parent cwd 기준으로 `git diff`를 계산해 **빈/잘못된 타겟 리뷰**가 생성됩니다.

`praxis:codex-review-wrap`은 이 문제를 worktree 선택 프롬프트로 해결하지만, 사용자가 wrapper 호출을 잊는 경우가 반복됩니다 (이번 세션에서만 2회 발생).

`/codex:review` 자체는 외부 plugin 소유라 직접 수정 불가능 → praxis 측 UserPromptSubmit hook으로 가로채는 접근 (이슈 #149 제안 #2).

## 변경

### 신규 `hooks/codex-review-route.sh` — UserPromptSubmit hook

다음 **모든** 조건을 만족할 때 `additionalContext` warning emit:

1. Prompt가 `/codex:review` 또는 `/codex-review`로 시작 (whitespace 또는 EOL boundary)
2. `git worktree list --porcelain`에서 non-bare worktree 2개 이상

Warning은 Claude에게 `/praxis:codex-review-wrap` 사용을 권유하도록 지시합니다 (block이 아닌 redirect 권장 — single-target review를 명시 확정한 경우 진행 가능).

**False positive 방어:**
- `/codex:reviews` (trailing char) → silent (regex word boundary)
- `/codex:review-thing` → silent
- `please /codex:review later` (중간 등장) → silent (start-of-prompt anchor)
- single-worktree, non-git cwd, 빈 prompt, jq 부재 → silent

### `hooks/hooks.json`

UserPromptSubmit 배열에 `codex-review-route.sh` 등록 (timeout 5s). 기존 `strike-counter.sh preprompt` 다음에 위치.

### `AGENTS.md` (= CLAUDE.md)

`## UserPromptSubmit Codex Review Worktree Disambiguation` 섹션 추가 (~70줄): Why exists, What is warned, false-positive guards, Why warn instead of block, tests.

### `tests/test_codex_review_route.sh` — 신규 (13 cases)

- 4 warn: bare, --background, --model opus, /codex-review
- 7 silent: single-worktree, plain text, /codex:status, /codex:reviews, empty, /codex:review-thing, mid-sentence
- 2 fail-safe: malformed JSON, non-git cwd

Worktree 상태는 `mktemp -d` + `git init` + `git worktree add`로 isolation, 실 praxis tree와 분리.

## 검증

- `tests/test_codex_review_route.sh` 13/13 PASS
- 회귀: memory-hint 27/27, side-effect-scan 54/54, completion-verify 12/12, builtin-task-postuse 18/18, block-gh-state-all 22/22 모두 PASS
- `scripts/check-plugin-manifests.py` PASS — manifest drift 없음

## 회귀 위험

- jq 미설치 → silent (existing strike-counter pattern과 동일)
- 단일 worktree 사용자 → silent (조건 미충족)
- `/codex:review` 외 prompt → silent (regex 미매칭)

## Refs

- 발견 세션: 본 세션 (2026-05-04, 2회 hit)
- 관련 PR: #141 (`codex-review-wrap` skill), #151 (`turbo-completion` worktree-aware cleanup, #148 sibling)
- 메모리: `feedback_worktree_context_pre_git_op.md`

Closes #149