### PR TITLE
docs(hooks): add caller note to safe_tokenize docstring

### DIFF
--- a/hooks/_hook_utils.py
+++ b/hooks/_hook_utils.py
@@ -69,6 +69,17 @@ def safe_tokenize(command: str) -> list[str]:
     synthetic `;` between line tokens so iter_command_starts sees the break.
     Lines that fail to parse (unmatched quote, runaway heredoc, etc.) are
     skipped — better a silent pass than a crashed hook.
+
+    Caller note: a multi-line value inside a quoted flag (e.g.
+    ``gh pr create --body "line1\\nline2"``) is split at the unescaped
+    newline, separating ``--body`` from its value. In test payloads, use a
+    heredoc-assigned variable instead::
+
+        BODY=$(cat <<'EOF'
+        Caller chain verified: ...
+        EOF
+        )
+        gh pr create --body "$BODY"
     """
     lines = [ln for ln in command.split("\n") if ln.strip()]
     if not lines:


### PR DESCRIPTION
## Summary

`safe_tokenize` pre-splits on newlines before `shlex`, so a multi-line value
inside a quoted flag (e.g. `--body "line1\nline2"`) is split at the newline
boundary — separating the flag from its value.

The existing docstring explained the design rationale but not the caller
implication. This PR adds a concrete example showing the heredoc worktree
pattern for writing test payloads that contain multi-line strings.

## Change

Added to `safe_tokenize` docstring in `hooks/_hook_utils.py`:

```
Caller note: a multi-line value inside a quoted flag (e.g.
``gh pr create --body "line1\nline2"``) is split at the unescaped
newline, separating ``--body`` from its value. In test payloads, use a
heredoc-assigned variable instead.
```

## Testing

All existing hook tests pass (22/22 for block-pr-without-caller-evidence,
plus other hook test suites unaffected — docs-only change).

Closes #160