### PR TITLE
feat(hooks): nested mcp body + positional gh body

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -827,12 +827,14 @@ Inherited from `_hook_utils.safe_tokenize` (same primitive as
 bash tests/test_external_write_falsify_check.sh
 ```
 
-Covers 29 cases across the warn / silent / strict-block dimensions:
+Covers 25 cases across the warn / silent / strict-block dimensions:
 `gh` write subcommands (`comment`, `create`, `edit`, `review`) with each
-body flag form (`--body`, `-b`, `--body-file`, `-F`, `--body=value`) and
-positional body (`gh issue comment <num> "body"`), MCP slack / notion
-writes including nested shapes (Notion `children[].paragraph.rich_text[].text.content`,
-Slack `blocks[].text.text`), Korean marker, verified-claim silent paths,
+body flag form (`--body`, `-b`, `--body-file`, `-F`, `--body=value`),
+MCP slack / notion writes including nested shapes (Notion
+`children[].paragraph.rich_text[].text.content`, Slack
+`blocks[].text.text`) gated to recognized container/leaf entry points so
+that property metadata (`properties.{name}.title[].text.content`) does
+not surface as body, Korean marker, verified-claim silent paths,
 non-write commands (`gh list` / `gh search`), chained Bash writes,
 strict env toggle, and malformed-JSON fail-open.
 
@@ -843,9 +845,13 @@ separate issue. The decision to flip default-on (or to roll back this
 opt-in hook entirely) is gated on that trail.
 
 Code-level preconditions for any future default-on flip are tracked in
-issue #174. P2 (MCP nested-body recursive walker) and P3 (positional
-`gh` body detection) have shipped; P1 (false-positive frequency data
-accumulation) remains open and gates the default-on flip.
+issue #174. P2 (MCP nested-body extraction, gated to recognized
+container/leaf entry points) has shipped. P3 (positional `gh` body
+detection) was dropped after `gh --help` confirmed positional body is
+not a supported gh CLI shape (`gh issue comment` accepts a single
+positional, rejecting `<num> <body>` with `accepts 1 arg(s)`). P1
+(false-positive frequency data accumulation) remains open and gates
+the default-on flip.
 
 ## Multi-Platform Packaging
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -799,15 +799,6 @@ default-on flip — see follow-up tracking issue):
 - **`likely` / `potential ` markers prone to false positives.** Phrases
   like "Most likely cause: stale cache" (a verified RCA write-up) or
   "Potential customers list: 5 brands" (business term) trip the warning.
-- **MCP nested-body shapes silent-pass.** The body extractor walks the
-  top-level `tool_input` dict; nested shapes such as Notion's
-  `children[].paragraph.rich_text[].text.content` or Slack's
-  `blocks[].text.text` are not traversed, so a hypothesis marker buried
-  inside those structures does NOT fire the warning. Flat-shape writes
-  (`body`, `text`, `content` at top level) work as expected.
-- **Positional `gh issue comment <num> "body"` form silent-passes.** The
-  hook inspects flag-style body sources only (`--body`, `-b`, `--body-file`, `-F`).
-  Positional body arguments are not detected.
 - **Literal `\n` inside a quoted `--body` value splits the body.** The
   shared `_hook_utils.safe_tokenize` treats literal `\n` characters as
   command separators inside quoted strings. Use `--body-file` or a
@@ -836,12 +827,14 @@ Inherited from `_hook_utils.safe_tokenize` (same primitive as
 bash tests/test_external_write_falsify_check.sh
 ```
 
-Covers 14 cases across the warn / silent / strict-block dimensions:
-`gh` write subcommands (`comment`, `create`, `edit`) with each body flag
-form (`--body`, `-b`, `--body-file`, `-F`, `--body=value`), MCP
-slack / notion writes, Korean marker, verified-claim silent paths,
-non-write commands (`gh list` / `gh search`), strict env toggle, and
-malformed-JSON fail-open.
+Covers 29 cases across the warn / silent / strict-block dimensions:
+`gh` write subcommands (`comment`, `create`, `edit`, `review`) with each
+body flag form (`--body`, `-b`, `--body-file`, `-F`, `--body=value`) and
+positional body (`gh issue comment <num> "body"`), MCP slack / notion
+writes including nested shapes (Notion `children[].paragraph.rich_text[].text.content`,
+Slack `blocks[].text.text`), Korean marker, verified-claim silent paths,
+non-write commands (`gh list` / `gh search`), chained Bash writes,
+strict env toggle, and malformed-JSON fail-open.
 
 ### Evidence-trail follow-up
 
@@ -850,8 +843,9 @@ separate issue. The decision to flip default-on (or to roll back this
 opt-in hook entirely) is gated on that trail.
 
 Code-level preconditions for any future default-on flip are tracked in
-issue #174 (P1 false-positive frequency data, P2 MCP nested-body
-extractor, P3 positional `gh` body detection).
+issue #174. P2 (MCP nested-body recursive walker) and P3 (positional
+`gh` body detection) have shipped; P1 (false-positive frequency data
+accumulation) remains open and gates the default-on flip.
 
 ## Multi-Platform Packaging
 

--- a/hooks/external-write-falsify-check.py
+++ b/hooks/external-write-falsify-check.py
@@ -93,8 +93,15 @@ def _resolve_body(flag: str, value: str) -> str:
     return value
 
 
-def _extract_gh_flag_body(argv: list[str]) -> str | None:
-    """Pull body text from --body / --body-file in a gh argv. None if absent."""
+def _extract_gh_body(argv: list[str]) -> str | None:
+    """Pull body text from --body / --body-file in a gh argv. None if absent.
+
+    `gh issue/pr comment` and friends only accept body via flags (--body / -b
+    / --body-file / -F per `gh <subcmd> --help`); positional form
+    `gh issue comment <num> "body"` is rejected by gh itself with
+    `accepts 1 arg(s)`. Detecting positional shape would only add noise on
+    already-invalid invocations, so this extractor is flag-only.
+    """
     for i, tok in enumerate(argv):
         if "=" in tok:
             key, _, val = tok.partition("=")
@@ -104,69 +111,6 @@ def _extract_gh_flag_body(argv: list[str]) -> str | None:
         if tok in GH_BODY_FLAGS_WITH_ARG and i + 1 < len(argv):
             return _resolve_body(tok, argv[i + 1])
     return None
-
-
-def _gh_positional_tokens(argv: list[str]) -> list[str]:
-    """Return positional (non-flag) tokens from a gh argv, with flag-with-arg pairs peeled.
-
-    Global flags (`--repo` / `-R` / `--hostname` / `--color`) and body flags
-    (`--body` / `-b` / `--body-file` / `-F`) that take a value consume the
-    following token. Other flags are assumed bare — adequate for picking out
-    the `<obj> <sub> <num> <body>` positional spine.
-    """
-    argv = strip_prefix(argv)
-    if not argv or argv[0] != "gh":
-        return []
-    flags_with_arg = GH_GLOBAL_FLAGS_WITH_ARG | GH_BODY_FLAGS_WITH_ARG
-    positional: list[str] = []
-    i = 1
-    while i < len(argv):
-        tok = argv[i]
-        if tok == "--":
-            positional.extend(argv[i + 1:])
-            break
-        if tok.startswith("-"):
-            i += 1
-            if "=" not in tok and tok in flags_with_arg and i < len(argv):
-                i += 1
-            continue
-        positional.append(tok)
-        i += 1
-    return positional
-
-
-def _is_number_like(token: str) -> bool:
-    """Issue/PR positional argument shape: bare integer or github URL."""
-    return token.isdigit() or "://" in token
-
-
-# [PR #179] P3: gh CLIs that take `<obj> <sub> <num> <body>` positional form
-# (e.g. `gh issue comment 1 "body"`) bypassed flag-only body extraction.
-# Detect positional body for write subcommands when the 3rd positional is
-# number-like (issue/PR id or URL) and a 4th positional follows.
-def _extract_gh_positional_body(argv: list[str]) -> str | None:
-    """Positional body form: `gh <obj> <sub> <num-like> <body>`.
-
-    Restricted to known write subcommands so that read-only chains like
-    `gh issue list 1 2` cannot surface a stray positional as body.
-    """
-    positional = _gh_positional_tokens(argv)
-    if len(positional) < 4:
-        return None
-    obj, sub, num, body = positional[0], positional[1], positional[2], positional[3]
-    if (obj, sub) not in GH_WRITE_SUBCOMMANDS:
-        return None
-    if not _is_number_like(num):
-        return None
-    return body
-
-
-def _extract_gh_body(argv: list[str]) -> str | None:
-    """Pull body text from gh argv. Flag-style takes precedence; falls back to positional."""
-    flag_body = _extract_gh_flag_body(argv)
-    if flag_body is not None:
-        return flag_body
-    return _extract_gh_positional_body(argv)
 
 
 def _is_gh_external_write(argv: list[str]) -> bool:
@@ -211,44 +155,72 @@ def _is_mcp_external_write(tool_name: str) -> bool:
     return any(p.match(tool_name) for p in MCP_EXTERNAL_WRITE_PATTERNS)
 
 
-# Keys whose value (and entire subtree) is treated as body content.
-BODY_TEXT_KEYS = frozenset({
-    "text", "content", "body", "message", "page_content", "rich_text",
+# Leaf keys whose value is body content (collect descendant strings).
+BODY_LEAF_KEYS = frozenset({
+    "text", "content", "body", "message", "page_content",
+})
+
+# Container keys that wrap block/rich-text lists. Inside a container we
+# traverse wrapper dicts (paragraph, heading_1, section, ...) until we hit
+# a body leaf or another container.
+BODY_CONTAINER_KEYS = frozenset({
+    "children", "blocks", "rich_text",
 })
 
 
 # [PR #179] P2: MCP payloads nest body text under shapes like Notion's
 # `children[].paragraph.rich_text[].text.content` (3 levels deep) and Slack's
-# `blocks[].text.text`. A flat top-level scan missed both. Recursive walk:
-# once a body-text key is entered, every descendant string is collected.
-# `mrkdwn` and similar type strings inside Slack's nested text dicts can be
-# false-collected, but they don't match hypothesis markers — harmless.
-def _walk_collect_body(node, parts: list[str], in_body_subtree: bool) -> None:
+# `blocks[].text.text`. A flat top-level scan missed both. An unconstrained
+# recursive walk (earlier revision) over-collected siblings — page property
+# titles like `properties.Name.title[].text.content` would surface and trip
+# markers like "potential" / "likely" inside legitimate titles. So entry into
+# body subtrees is gated: top level accepts BODY_LEAF_KEYS or BODY_CONTAINER_KEYS;
+# inside containers, wrapper dicts (paragraph / section / heading_X) are
+# transparent — recursion continues until a leaf is reached.
+def _collect_under_leaf(node, parts: list[str]) -> None:
+    """Collect every string descendant. Called once a leaf key is entered."""
     if isinstance(node, str):
-        if in_body_subtree:
-            parts.append(node)
-        return
-    if isinstance(node, dict):
-        for key, val in node.items():
-            child_in_body = in_body_subtree or (
-                isinstance(key, str) and key.lower() in BODY_TEXT_KEYS
-            )
-            _walk_collect_body(val, parts, child_in_body)
+        parts.append(node)
     elif isinstance(node, list):
         for item in node:
-            _walk_collect_body(item, parts, in_body_subtree)
+            _collect_under_leaf(item, parts)
+    elif isinstance(node, dict):
+        for val in node.values():
+            _collect_under_leaf(val, parts)
+
+
+def _walk_in_container(node, parts: list[str]) -> None:
+    """Inside `children` / `blocks` / `rich_text`: traverse wrapper dicts
+    (paragraph / section / heading_X) and nested containers transparently,
+    switching to leaf-collection only at body keys."""
+    if isinstance(node, list):
+        for item in node:
+            _walk_in_container(item, parts)
+    elif isinstance(node, dict):
+        for key, val in node.items():
+            if isinstance(key, str) and key.lower() in BODY_LEAF_KEYS:
+                _collect_under_leaf(val, parts)
+            else:
+                _walk_in_container(val, parts)
 
 
 def _extract_mcp_body(tool_input: dict) -> str:
-    """Recursive body extraction from MCP tool_input.
+    """Body extraction from MCP tool_input gated by recognized entry points.
 
-    Walks the entire payload tree. Once a key in BODY_TEXT_KEYS is entered,
-    every descendant string is collected as body content. Non-body siblings
-    (channel id, block id, subject lines) are ignored. Returns empty string
-    when no body keys are present.
+    At the top level only BODY_LEAF_KEYS and BODY_CONTAINER_KEYS are
+    entered — sibling keys like `properties`, `parent`, `channel`, `title`
+    are ignored so that property metadata (e.g. Notion page property
+    titles under `properties.Name.title`) does not surface as body.
     """
     parts: list[str] = []
-    _walk_collect_body(tool_input, parts, in_body_subtree=False)
+    for key, val in tool_input.items():
+        if not isinstance(key, str):
+            continue
+        kl = key.lower()
+        if kl in BODY_LEAF_KEYS:
+            _collect_under_leaf(val, parts)
+        elif kl in BODY_CONTAINER_KEYS:
+            _walk_in_container(val, parts)
     return "\n".join(parts)
 
 

--- a/hooks/external-write-falsify-check.py
+++ b/hooks/external-write-falsify-check.py
@@ -140,7 +140,7 @@ def _is_number_like(token: str) -> bool:
     return token.isdigit() or "://" in token
 
 
-# [PR #N] P3: gh CLIs that take `<obj> <sub> <num> <body>` positional form
+# [PR #179] P3: gh CLIs that take `<obj> <sub> <num> <body>` positional form
 # (e.g. `gh issue comment 1 "body"`) bypassed flag-only body extraction.
 # Detect positional body for write subcommands when the 3rd positional is
 # number-like (issue/PR id or URL) and a 4th positional follows.
@@ -217,7 +217,7 @@ BODY_TEXT_KEYS = frozenset({
 })
 
 
-# [PR #N] P2: MCP payloads nest body text under shapes like Notion's
+# [PR #179] P2: MCP payloads nest body text under shapes like Notion's
 # `children[].paragraph.rich_text[].text.content` (3 levels deep) and Slack's
 # `blocks[].text.text`. A flat top-level scan missed both. Recursive walk:
 # once a body-text key is entered, every descendant string is collected.

--- a/hooks/external-write-falsify-check.py
+++ b/hooks/external-write-falsify-check.py
@@ -93,7 +93,7 @@ def _resolve_body(flag: str, value: str) -> str:
     return value
 
 
-def _extract_gh_body(argv: list[str]) -> str | None:
+def _extract_gh_flag_body(argv: list[str]) -> str | None:
     """Pull body text from --body / --body-file in a gh argv. None if absent."""
     for i, tok in enumerate(argv):
         if "=" in tok:
@@ -104,6 +104,69 @@ def _extract_gh_body(argv: list[str]) -> str | None:
         if tok in GH_BODY_FLAGS_WITH_ARG and i + 1 < len(argv):
             return _resolve_body(tok, argv[i + 1])
     return None
+
+
+def _gh_positional_tokens(argv: list[str]) -> list[str]:
+    """Return positional (non-flag) tokens from a gh argv, with flag-with-arg pairs peeled.
+
+    Global flags (`--repo` / `-R` / `--hostname` / `--color`) and body flags
+    (`--body` / `-b` / `--body-file` / `-F`) that take a value consume the
+    following token. Other flags are assumed bare — adequate for picking out
+    the `<obj> <sub> <num> <body>` positional spine.
+    """
+    argv = strip_prefix(argv)
+    if not argv or argv[0] != "gh":
+        return []
+    flags_with_arg = GH_GLOBAL_FLAGS_WITH_ARG | GH_BODY_FLAGS_WITH_ARG
+    positional: list[str] = []
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        if tok == "--":
+            positional.extend(argv[i + 1:])
+            break
+        if tok.startswith("-"):
+            i += 1
+            if "=" not in tok and tok in flags_with_arg and i < len(argv):
+                i += 1
+            continue
+        positional.append(tok)
+        i += 1
+    return positional
+
+
+def _is_number_like(token: str) -> bool:
+    """Issue/PR positional argument shape: bare integer or github URL."""
+    return token.isdigit() or "://" in token
+
+
+# [PR #N] P3: gh CLIs that take `<obj> <sub> <num> <body>` positional form
+# (e.g. `gh issue comment 1 "body"`) bypassed flag-only body extraction.
+# Detect positional body for write subcommands when the 3rd positional is
+# number-like (issue/PR id or URL) and a 4th positional follows.
+def _extract_gh_positional_body(argv: list[str]) -> str | None:
+    """Positional body form: `gh <obj> <sub> <num-like> <body>`.
+
+    Restricted to known write subcommands so that read-only chains like
+    `gh issue list 1 2` cannot surface a stray positional as body.
+    """
+    positional = _gh_positional_tokens(argv)
+    if len(positional) < 4:
+        return None
+    obj, sub, num, body = positional[0], positional[1], positional[2], positional[3]
+    if (obj, sub) not in GH_WRITE_SUBCOMMANDS:
+        return None
+    if not _is_number_like(num):
+        return None
+    return body
+
+
+def _extract_gh_body(argv: list[str]) -> str | None:
+    """Pull body text from gh argv. Flag-style takes precedence; falls back to positional."""
+    flag_body = _extract_gh_flag_body(argv)
+    if flag_body is not None:
+        return flag_body
+    return _extract_gh_positional_body(argv)
 
 
 def _is_gh_external_write(argv: list[str]) -> bool:
@@ -148,26 +211,44 @@ def _is_mcp_external_write(tool_name: str) -> bool:
     return any(p.match(tool_name) for p in MCP_EXTERNAL_WRITE_PATTERNS)
 
 
-def _extract_mcp_body(tool_input: dict) -> str:
-    """Best-effort body extraction from MCP tool_input.
+# Keys whose value (and entire subtree) is treated as body content.
+BODY_TEXT_KEYS = frozenset({
+    "text", "content", "body", "message", "page_content", "rich_text",
+})
 
-    Different MCP servers use different field names. Cover common shapes:
-    text / content / body / message / page_content / rich_text (concatenated).
-    Returns empty string when nothing matches — body-less calls are not flagged.
+
+# [PR #N] P2: MCP payloads nest body text under shapes like Notion's
+# `children[].paragraph.rich_text[].text.content` (3 levels deep) and Slack's
+# `blocks[].text.text`. A flat top-level scan missed both. Recursive walk:
+# once a body-text key is entered, every descendant string is collected.
+# `mrkdwn` and similar type strings inside Slack's nested text dicts can be
+# false-collected, but they don't match hypothesis markers — harmless.
+def _walk_collect_body(node, parts: list[str], in_body_subtree: bool) -> None:
+    if isinstance(node, str):
+        if in_body_subtree:
+            parts.append(node)
+        return
+    if isinstance(node, dict):
+        for key, val in node.items():
+            child_in_body = in_body_subtree or (
+                isinstance(key, str) and key.lower() in BODY_TEXT_KEYS
+            )
+            _walk_collect_body(val, parts, child_in_body)
+    elif isinstance(node, list):
+        for item in node:
+            _walk_collect_body(item, parts, in_body_subtree)
+
+
+def _extract_mcp_body(tool_input: dict) -> str:
+    """Recursive body extraction from MCP tool_input.
+
+    Walks the entire payload tree. Once a key in BODY_TEXT_KEYS is entered,
+    every descendant string is collected as body content. Non-body siblings
+    (channel id, block id, subject lines) are ignored. Returns empty string
+    when no body keys are present.
     """
     parts: list[str] = []
-    for key in ("text", "content", "body", "message", "page_content", "rich_text"):
-        val = tool_input.get(key)
-        if isinstance(val, str):
-            parts.append(val)
-        elif isinstance(val, list):
-            for item in val:
-                if isinstance(item, str):
-                    parts.append(item)
-                elif isinstance(item, dict):
-                    inner = item.get("text") or item.get("content") or ""
-                    if isinstance(inner, str):
-                        parts.append(inner)
+    _walk_collect_body(tool_input, parts, in_body_subtree=False)
     return "\n".join(parts)
 
 

--- a/tests/test_external_write_falsify_check.sh
+++ b/tests/test_external_write_falsify_check.sh
@@ -169,34 +169,22 @@ run_case "MCP slack blocks nested verified text (silent)" \
   "silent" "advisory" \
   '{"tool_name":"mcp__laplace-slack__slack_send_message","tool_input":{"channel":"C123","blocks":[{"type":"section","text":{"type":"mrkdwn","text":"Verified 100 percent."}}]}}'
 
-run_case "MCP notion non-body fields ignored (silent)" \
+run_case "MCP notion non-body top-level fields ignored (silent)" \
   "silent" "advisory" \
   '{"tool_name":"mcp__notion__notion_create_page","tool_input":{"parent_id":"likely-channel-id","title":"Potential customers list"}}'
 
-# --- P3: gh positional body argument (issue #174)
-run_case "gh issue comment positional body + marker (warn)" \
-  "warn" "advisory" \
-  '{"tool_name":"Bash","tool_input":{"command":"gh issue comment 1 \"This might fail.\""}}'
-
-run_case "gh issue comment positional verified body (silent)" \
+# Codex F2 regression: Notion page property titles live under
+# `properties.{name}.title[].text.content` (NOT body content). A naive
+# recursive walker would collect the title text and trip "potential " marker.
+run_case "MCP notion property title not collected as body (silent)" \
   "silent" "advisory" \
-  '{"tool_name":"Bash","tool_input":{"command":"gh issue comment 1 \"Confirmed by tests.\""}}'
+  '{"tool_name":"mcp__notion__notion_create_page","tool_input":{"parent":{"database_id":"abc"},"properties":{"Name":{"title":[{"text":{"content":"Potential customers list"}}]}}}}'
 
-run_case "gh pr comment positional body + marker (warn)" \
+# Notion page with property title (marker-ish string) AND children body (real
+# marker) → only children body should be collected → warn.
+run_case "MCP notion property title silent + children body warn" \
   "warn" "advisory" \
-  '{"tool_name":"Bash","tool_input":{"command":"gh pr comment 50 \"This appears to fail.\""}}'
-
-run_case "gh issue comment URL positional body + marker (warn)" \
-  "warn" "advisory" \
-  '{"tool_name":"Bash","tool_input":{"command":"gh issue comment https://github.com/foo/bar/issues/1 \"hypothesis: stale\""}}'
-
-run_case "gh issue comment positional num only (silent)" \
-  "silent" "advisory" \
-  '{"tool_name":"Bash","tool_input":{"command":"gh issue comment 1"}}'
-
-run_case "gh issue list positional args (not a write, silent)" \
-  "silent" "advisory" \
-  '{"tool_name":"Bash","tool_input":{"command":"gh issue list 1 might-fail"}}'
+  '{"tool_name":"mcp__notion__notion_create_page","tool_input":{"properties":{"Name":{"title":[{"text":{"content":"safe title"}}]}},"children":[{"paragraph":{"rich_text":[{"text":{"content":"This might fail."}}]}}]}}'
 
 # --- malformed input → fail-open silent
 run_case "malformed JSON → silent" \

--- a/tests/test_external_write_falsify_check.sh
+++ b/tests/test_external_write_falsify_check.sh
@@ -152,6 +152,52 @@ run_case "chained gh writes — all bodies verified (silent)" \
   "silent" "advisory" \
   '{"tool_name":"Bash","tool_input":{"command":"gh issue comment 1 --body \"Verified.\"; gh issue comment 2 --body \"Confirmed by query.\""}}'
 
+# --- P2: MCP nested-body recursive extraction (issue #174)
+run_case "MCP notion_append_blocks nested rich_text + marker (warn)" \
+  "warn" "advisory" \
+  '{"tool_name":"mcp__notion__notion_append_blocks","tool_input":{"block_id":"abc","children":[{"paragraph":{"rich_text":[{"text":{"content":"This might fail under load."}}]}}]}}'
+
+run_case "MCP notion_append_blocks nested verified content (silent)" \
+  "silent" "advisory" \
+  '{"tool_name":"mcp__notion__notion_append_blocks","tool_input":{"block_id":"abc","children":[{"paragraph":{"rich_text":[{"text":{"content":"Confirmed: 819 rows."}}]}}]}}'
+
+run_case "MCP slack send_message blocks nested text + marker (warn)" \
+  "warn" "advisory" \
+  '{"tool_name":"mcp__laplace-slack__slack_send_message","tool_input":{"channel":"C123","blocks":[{"type":"section","text":{"type":"mrkdwn","text":"이건 가설인데 prod 지연 가능성."}}]}}'
+
+run_case "MCP slack blocks nested verified text (silent)" \
+  "silent" "advisory" \
+  '{"tool_name":"mcp__laplace-slack__slack_send_message","tool_input":{"channel":"C123","blocks":[{"type":"section","text":{"type":"mrkdwn","text":"Verified 100 percent."}}]}}'
+
+run_case "MCP notion non-body fields ignored (silent)" \
+  "silent" "advisory" \
+  '{"tool_name":"mcp__notion__notion_create_page","tool_input":{"parent_id":"likely-channel-id","title":"Potential customers list"}}'
+
+# --- P3: gh positional body argument (issue #174)
+run_case "gh issue comment positional body + marker (warn)" \
+  "warn" "advisory" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue comment 1 \"This might fail.\""}}'
+
+run_case "gh issue comment positional verified body (silent)" \
+  "silent" "advisory" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue comment 1 \"Confirmed by tests.\""}}'
+
+run_case "gh pr comment positional body + marker (warn)" \
+  "warn" "advisory" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr comment 50 \"This appears to fail.\""}}'
+
+run_case "gh issue comment URL positional body + marker (warn)" \
+  "warn" "advisory" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue comment https://github.com/foo/bar/issues/1 \"hypothesis: stale\""}}'
+
+run_case "gh issue comment positional num only (silent)" \
+  "silent" "advisory" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue comment 1"}}'
+
+run_case "gh issue list positional args (not a write, silent)" \
+  "silent" "advisory" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue list 1 might-fail"}}'
+
 # --- malformed input → fail-open silent
 run_case "malformed JSON → silent" \
   "silent" "advisory" \


### PR DESCRIPTION
Caller chain verified: all new symbols (`BODY_LEAF_KEYS`, `BODY_CONTAINER_KEYS`, `_collect_under_leaf`, `_walk_in_container`) are private helpers within `hooks/external-write-falsify-check.py`; only `_extract_gh_body` / `_extract_mcp_body` reach `main()`. `grep -rn` across the repo confirms zero external callers.

## 변경 사항

이슈 #174 에서 트래킹한 default-on flip precondition 중 **P2 만** 적용. P3 는 codex review 에서 falsified (gh CLI 미지원).

### P2 — MCP body extraction with gated entry

기존 `_extract_mcp_body` 는 `tool_input` top-level 만 스캔 + 1-level deep dict 만 처리. 다음 케이스는 silent pass 했음:

- Notion `notion_append_blocks` 의 `children[].paragraph.rich_text[].text.content`
- Slack `blocks[].text.text`

→ container-gated traversal 로 교체:
- Top level: `BODY_LEAF_KEYS = {text, content, body, message, page_content}` 또는 `BODY_CONTAINER_KEYS = {children, blocks, rich_text}` 만 진입.
- Container 내부: wrapper dict (paragraph / section / heading_X) 는 transparent — leaf 만날 때까지 재귀.
- Leaf 진입 후: 모든 descendant string 수집.

**왜 unconstrained recursive walk 가 아니라 gated 인가** — codex review F2 가 falsify. Naive 재귀는 `properties.{name}.title[].text.content` 같은 Notion property metadata 까지 잡아서 "Potential customers list" 같은 정당한 제목에서 marker hit. Top-level 에 `properties` / `parent` / `channel` 같은 sibling 키는 무시.

### P3 — Dropped after premise falsification

**원래 spec**: `gh issue comment 1 "body"` 형식의 positional body 감지.

**Codex F1 검증**: `gh issue comment --help` USAGE 는 `{<number> | <url>} [flags]`. body 는 flags-only. `gh issue comment 1 "x"` → **`accepts 1 arg(s), received 2`** (gh 가 reject).

→ 이슈 #174 의 P3 spec ("valid gh 호출") 이 사실 오류. positional 감지를 추가하면 이미 invalid 인 호출에만 noise 가 생김. P3 코드 + 테스트 6개 제거. 이슈 #174 의 P3 항목은 "won't fix — gh CLI 미지원" 으로 close 권장.

### AGENTS.md Heuristic limits

해소된 두 항목 (MCP nested-body, Positional gh body) 제거. 테스트 수 14 → 25 갱신. issue #174 reference 도 "P2 shipped, P3 dropped (gh 미지원), P1 remaining" 으로 갱신.

## 테스트

```
bash tests/test_external_write_falsify_check.sh
```

총 25 cases (기존 18 + 신규 7 P2) 모두 통과.

| # | Case |
|---|------|
| P2-1 | notion_append_blocks nested rich_text + marker → warn |
| P2-2 | notion_append_blocks nested verified content → silent |
| P2-3 | slack send_message blocks nested text + KO marker → warn |
| P2-4 | slack blocks nested verified text → silent |
| P2-5 | notion non-body top-level fields ignored → silent |
| P2-6 | notion property title not collected as body (Codex F2 regression) → silent |
| P2-7 | notion property title silent + children body warn → warn (mixed shape) |

회귀 검증: 다른 praxis hook 테스트 (`block-gh-state-all`, `side-effect-scan`, `memory-hint`, `codex-review-route`, `completion-verify`, `retrospect-mix-check`, `builtin-task-postuse`, `cmux-browser`) 전부 통과.

## Codex review trail

PR 첫 push (commit `94256b8`) 에 대한 `/codex:review` 결과:

- **F1 (P2)** `[hooks/external-write-falsify-check.py:156-161]` — Drop unsupported gh positional body parsing → **APPLIED** (P3 코드 제거)
- **F2 (P2)** `[hooks/external-write-falsify-check.py:231-236]` — Avoid treating Notion properties as body text → **APPLIED** (container-gated walker)

Premise verification:
- F1: `gh issue comment --help` + 직접 실행 `gh issue comment 1 "x"` → `accepts 1 arg(s), received 2`
- F2: Notion `properties.{name}.title[].text.content` 는 페이지 제목 metadata, body 가 아님. 동일 marker 가 children 안에 있으면 잡아야 하지만 properties 에 있으면 무시해야 함

Commit message trailers (`Premise-Verified:`) 에 검증 evidence 기록.

## Out of Scope

- **P1** (false-positive frequency 측정): longitudinal usage data 누적 필요 — 별도 후속.
- **hooks.json default 등록**: DoD 에 "별도 PR" 명시 — P1 해소 후 진행.

## DoD 진척

- [ ] P1 measurement → marker 리스트 결정 (별도 추적)
- [x] P2 nested-body extraction (container-gated) + 회귀 테스트
- [~] P3 dropped — gh CLI 미지원으로 falsified (이슈 항목 close 권장)
- [x] AGENTS.md "Heuristic limits" 갱신
- [ ] `hooks/hooks.json` default 등록 (별도 PR)

Closes #174 partial — P2 closed + P3 falsified/won't-fix, P1/default-on 추적은 issue open 유지.
