### PR TITLE
feat(hooks): warn ask-end-option mechanical surface

### DIFF
--- a/hooks/block-ask-end-option.py
+++ b/hooks/block-ask-end-option.py
@@ -55,9 +55,16 @@ END_OPTION_MARKERS_EN = (
 )
 
 # Stop signals in the most recent user message. Case-insensitive.
-# Each entry must be a clear directive — substring matches in unrelated
-# contexts (e.g., "end of the migration") are tolerated as false positives
-# because the hook is advisory by default.
+#
+# Korean entries stay substring-matched: CJK lacks ASCII-style word boundaries
+# and these specific tokens have low collision risk inside unrelated words
+# (e.g., "그만" / "종료" rarely appear as substrings of unrelated terms).
+#
+# English entries are phrase-only (no bare-word matching) to prevent the
+# "send" → "end" / "backend" → "end" / "don't stop" → "stop" false-allow class
+# (codex review #193 F1). A negation prefix check additionally disqualifies
+# matches preceded by "don't" / "do not" / "never" / etc. within a small
+# preceding window.
 STOP_SIGNALS_KO = (
     "종료",
     "여기까지",
@@ -66,17 +73,23 @@ STOP_SIGNALS_KO = (
     "스톱",
     "중단",
 )
-STOP_SIGNALS_EN = (
-    "stop",
-    "end",
-    "quit",
-    "done",
-    "cancel",
-    "finish",
-    "wrap up",
-    "that's all",
+STOP_SIGNALS_EN_PHRASES = (
+    "stop here", "stop now", "let's stop", "lets stop",
+    "we're done", "we are done", "i'm done", "i am done",
+    "end here", "end now", "end this", "end the session",
+    "wrap up", "wrap this up",
+    "that's all", "that is all",
     "no more",
+    "quit now",
+    "cancel this",
+    "finish here", "finish up",
+    "session end",
 )
+NEGATION_PATTERNS_EN = (
+    "don't ", "do not ", "never ", "no ", "not ",
+    "won't ", "wouldn't ", "shouldn't ", "can't ", "cannot ",
+)
+NEGATION_WINDOW = 30  # characters preceding the phrase match
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -84,10 +97,6 @@ STOP_SIGNALS_EN = (
 
 def _all_markers() -> tuple[str, ...]:
     return END_OPTION_MARKERS_KO + END_OPTION_MARKERS_EN
-
-
-def _all_stop_signals() -> tuple[str, ...]:
-    return STOP_SIGNALS_KO + STOP_SIGNALS_EN
 
 
 def _collect_option_labels(tool_input: dict) -> list[str]:
@@ -129,16 +138,27 @@ def _has_end_marker(labels: list[str]) -> bool:
 
 
 def _read_last_user_message(transcript_path: str) -> str:
-    """Return the text of the most recent user message in the transcript.
+    """Return the text of the most recent user-authored message in the transcript.
 
     Returns empty string if the file is missing, unreadable, or contains
-    no user messages. The hook is advisory by default so silent failure
-    here just means the stop-signal check is skipped — no false block.
+    no user messages with extractable human text. The hook is advisory by
+    default so silent failure here just means the stop-signal check is
+    skipped — no false block.
 
     Transcript format: JSONL where each line is a JSON object with at
     least `type` ('user' / 'assistant' / 'system') and either `message`
     (an Anthropic API message dict with `role` + `content`) or a flatter
     `content` field. Both shapes are handled.
+
+    tool_result handling (codex review #193 F2): an Anthropic user role
+    message may carry only `tool_result` content blocks when the
+    assistant invoked tools in the same turn before invoking
+    AskUserQuestion. Such entries are NOT human authored — they are the
+    runtime's bridge for tool outputs. We must skip them and keep walking
+    backward until we find a user entry that contains actual `type: text`
+    content. Returning the empty string on the first tool_result-only
+    entry causes false-block in strict mode even though the real user
+    message earlier in the transcript did signal stop.
     """
     if not transcript_path or not os.path.isfile(transcript_path):
         return ""
@@ -148,7 +168,10 @@ def _read_last_user_message(transcript_path: str) -> str:
     except OSError:
         return ""
 
-    # Walk in reverse to find the most recent user-role entry.
+    # Walk in reverse to find the most recent user-role entry whose
+    # content includes human-authored text. tool_result-only entries are
+    # skipped (continue), not returned as empty (which would block the
+    # search at the wrong layer).
     for raw in reversed(lines):
         raw = raw.strip()
         if not raw:
@@ -171,6 +194,7 @@ def _read_last_user_message(transcript_path: str) -> str:
         # Extract text. Possible shapes:
         #   {"type": "user", "message": {"role": "user", "content": "text"}}
         #   {"type": "user", "message": {"role": "user", "content": [{"type":"text","text":"..."}]}}
+        #   {"type": "user", "message": {"role": "user", "content": [{"type":"tool_result", ...}]}}
         #   {"role": "user", "content": "text"}
         content = None
         if isinstance(message, dict):
@@ -178,31 +202,78 @@ def _read_last_user_message(transcript_path: str) -> str:
         if content is None:
             content = entry.get("content")
 
+        text = ""
         if isinstance(content, str):
-            return content
-        if isinstance(content, list):
+            text = content
+        elif isinstance(content, list):
             parts: list[str] = []
             for item in content:
                 if isinstance(item, dict):
-                    text = item.get("text")
-                    if isinstance(text, str):
-                        parts.append(text)
+                    # Skip non-text blocks (tool_result, image, etc.).
+                    # Only `type: text` (or items lacking a type but
+                    # carrying a `text` field) count as human content.
+                    item_type = item.get("type")
+                    if item_type and item_type != "text":
+                        continue
+                    t = item.get("text")
+                    if isinstance(t, str):
+                        parts.append(t)
                 elif isinstance(item, str):
                     parts.append(item)
-            return "\n".join(parts)
-        return ""
+            text = "\n".join(parts)
+        # else: unexpected content shape — fall through to skip
+
+        if text.strip():
+            return text
+        # No human text in this entry — keep walking backward.
+        continue
 
     return ""
 
 
 def _has_stop_signal(user_message: str) -> bool:
+    """True if the user message carries an explicit stop directive.
+
+    Korean signals stay substring-matched (CJK has low collision risk for
+    these particular tokens). English signals are phrase-only with a
+    negation guard — bare-word matching ("end", "stop", "done") caused
+    false-allow on neutral messages like "send" / "backend" / "don't stop"
+    (codex review #193 F1).
+    """
     if not user_message:
         return False
     lower = user_message.lower()
-    for signal in _all_stop_signals():
-        if signal.lower() in lower:
+
+    # Korean: substring match.
+    for ko in STOP_SIGNALS_KO:
+        if ko in user_message:
             return True
+
+    # English: phrase match with negation guard.
+    for phrase in STOP_SIGNALS_EN_PHRASES:
+        phrase_lower = phrase.lower()
+        start = 0
+        while True:
+            idx = lower.find(phrase_lower, start)
+            if idx < 0:
+                break
+            prefix = lower[max(0, idx - NEGATION_WINDOW):idx]
+            if not _has_negation(prefix):
+                return True
+            start = idx + 1
+
     return False
+
+
+def _has_negation(prefix: str) -> bool:
+    """True if the preceding window contains a negation token.
+
+    Operates on a small window (NEGATION_WINDOW chars) immediately before
+    a phrase match. Used to disqualify "don't stop here" / "I do not
+    wrap up yet" style messages where a stop phrase appears under
+    negation.
+    """
+    return any(neg in prefix for neg in NEGATION_PATTERNS_EN)
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/block-ask-end-option.py
+++ b/hooks/block-ask-end-option.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""PreToolUse(AskUserQuestion) guard: warn on mechanical end-option surfacing.
+
+When AskUserQuestion is invoked with `options` whose labels match end-option
+markers (e.g. "여기서 종료", "session end", "stop here"), check the most
+recent user message in the transcript for an explicit stop signal. If no
+signal is present, emit a stderr advisory pointing to the rule.
+
+Background:
+  Skill guides authoring "Step N: chaining" sections frequently include an
+  "end here" boilerplate option. Agents mechanically transcribe this into
+  AskUserQuestion call sites even when the conversation has a clearly
+  chained intent or the user has expressed no desire to stop. This pattern
+  has been observed 6+ times in a single session, fragmenting decisions
+  and ignoring user intent.
+
+  Text rules in CLAUDE.md or skill bodies alone cannot enforce this — the
+  `loaded != retrieved` limit. This hook enforces the rule at the tool
+  boundary, where the check runs mechanically regardless of retrieval state.
+
+Default mode: advisory (exit 0 + stderr).
+Strict mode: PRAXIS_ASK_END_STRICT=1 → block (exit 2 + stderr).
+
+Allow conditions (no advisory emitted):
+  1. tool_name != "AskUserQuestion"
+  2. No options match any end marker
+  3. Most recent user message contains an explicit stop signal
+  4. transcript_path is missing or unreadable (graceful degrade — advisory
+     is suppressed to avoid noise when transcript inspection is impossible)
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+# ---------------------------------------------------------------------------
+# Pattern definitions
+# ---------------------------------------------------------------------------
+
+# End-option markers in option labels. Case-insensitive.
+# Korean entries are unicode literals; English entries cover common phrasings.
+END_OPTION_MARKERS_KO = (
+    "여기서 종료",
+    "세션 종료",
+    "여기서 끝",
+    "여기까지",
+)
+END_OPTION_MARKERS_EN = (
+    "end here",
+    "session end",
+    "stop here",
+    "end the session",
+    "wrap up here",
+)
+
+# Stop signals in the most recent user message. Case-insensitive.
+# Each entry must be a clear directive — substring matches in unrelated
+# contexts (e.g., "end of the migration") are tolerated as false positives
+# because the hook is advisory by default.
+STOP_SIGNALS_KO = (
+    "종료",
+    "여기까지",
+    "그만",
+    "마무리",
+    "스톱",
+    "중단",
+)
+STOP_SIGNALS_EN = (
+    "stop",
+    "end",
+    "quit",
+    "done",
+    "cancel",
+    "finish",
+    "wrap up",
+    "that's all",
+    "no more",
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _all_markers() -> tuple[str, ...]:
+    return END_OPTION_MARKERS_KO + END_OPTION_MARKERS_EN
+
+
+def _all_stop_signals() -> tuple[str, ...]:
+    return STOP_SIGNALS_KO + STOP_SIGNALS_EN
+
+
+def _collect_option_labels(tool_input: dict) -> list[str]:
+    """Walk questions[].options[].label and return all label strings.
+
+    Tolerant of partial schemas — any missing field results in an empty
+    return rather than an exception. Hook must never crash on malformed
+    payloads.
+    """
+    labels: list[str] = []
+    questions = tool_input.get("questions") or []
+    if not isinstance(questions, list):
+        return labels
+    for q in questions:
+        if not isinstance(q, dict):
+            continue
+        options = q.get("options") or []
+        if not isinstance(options, list):
+            continue
+        for o in options:
+            if not isinstance(o, dict):
+                continue
+            label = o.get("label")
+            if isinstance(label, str):
+                labels.append(label)
+    return labels
+
+
+def _has_end_marker(labels: list[str]) -> bool:
+    if not labels:
+        return False
+    markers = _all_markers()
+    for label in labels:
+        lower = label.lower()
+        for marker in markers:
+            if marker.lower() in lower:
+                return True
+    return False
+
+
+def _read_last_user_message(transcript_path: str) -> str:
+    """Return the text of the most recent user message in the transcript.
+
+    Returns empty string if the file is missing, unreadable, or contains
+    no user messages. The hook is advisory by default so silent failure
+    here just means the stop-signal check is skipped — no false block.
+
+    Transcript format: JSONL where each line is a JSON object with at
+    least `type` ('user' / 'assistant' / 'system') and either `message`
+    (an Anthropic API message dict with `role` + `content`) or a flatter
+    `content` field. Both shapes are handled.
+    """
+    if not transcript_path or not os.path.isfile(transcript_path):
+        return ""
+    try:
+        with open(transcript_path, "r", encoding="utf-8", errors="replace") as f:
+            lines = f.readlines()
+    except OSError:
+        return ""
+
+    # Walk in reverse to find the most recent user-role entry.
+    for raw in reversed(lines):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            entry = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+
+        role = entry.get("type") or entry.get("role")
+        message = entry.get("message")
+        if isinstance(message, dict) and not role:
+            role = message.get("role")
+
+        if role != "user":
+            continue
+
+        # Extract text. Possible shapes:
+        #   {"type": "user", "message": {"role": "user", "content": "text"}}
+        #   {"type": "user", "message": {"role": "user", "content": [{"type":"text","text":"..."}]}}
+        #   {"role": "user", "content": "text"}
+        content = None
+        if isinstance(message, dict):
+            content = message.get("content")
+        if content is None:
+            content = entry.get("content")
+
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: list[str] = []
+            for item in content:
+                if isinstance(item, dict):
+                    text = item.get("text")
+                    if isinstance(text, str):
+                        parts.append(text)
+                elif isinstance(item, str):
+                    parts.append(item)
+            return "\n".join(parts)
+        return ""
+
+    return ""
+
+
+def _has_stop_signal(user_message: str) -> bool:
+    if not user_message:
+        return False
+    lower = user_message.lower()
+    for signal in _all_stop_signals():
+        if signal.lower() in lower:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+ADVISORY_MSG = """\
+[advisory] AskUserQuestion includes an end-option ("end here" / "여기서 종료" type)
+but the most recent user message has no stop signal.
+
+Mechanical surfacing of "end here" options propagates from skill-guide
+boilerplate even when conversation context has a chained intent. Verify
+that the user actually wants a stop point before this surface — or remove
+the end option.
+
+Set PRAXIS_ASK_END_STRICT=1 to escalate this advisory to a hard block.
+"""
+
+BLOCK_MSG = """\
+❌ BLOCKED: AskUserQuestion includes an end-option without user stop signal.
+
+Markers detected in options[].label: "end here" / "session end" / "여기서 종료" type.
+Most recent user message contains no stop signal (stop, end, quit, done,
+cancel, finish, 종료, 여기까지, 그만, 마무리, etc.).
+
+Why:
+  Skill-guide "end here" boilerplate is being mechanically transcribed
+  into AskUserQuestion call sites where the conversation has a chained
+  intent. Remove the end-option, or wait for the user to express a
+  stop signal explicitly.
+
+Unset PRAXIS_ASK_END_STRICT to demote this to an advisory.
+"""
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    if not isinstance(payload, dict):
+        return 0
+    if payload.get("tool_name") != "AskUserQuestion":
+        return 0
+
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return 0
+
+    labels = _collect_option_labels(tool_input)
+    if not _has_end_marker(labels):
+        return 0
+
+    transcript_path = payload.get("transcript_path") or ""
+    user_message = _read_last_user_message(transcript_path)
+    if _has_stop_signal(user_message):
+        return 0
+
+    strict = os.environ.get("PRAXIS_ASK_END_STRICT", "") not in ("", "0", "false", "False")
+    if strict:
+        sys.stderr.write(BLOCK_MSG)
+        return 2
+
+    sys.stderr.write(ADVISORY_MSG)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/block-ask-end-option.sh
+++ b/hooks/block-ask-end-option.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# block-ask-end-option.sh — thin shim (praxis #192)
+# Logic in .py; shim keeps hooks.json entry stable across refactors.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="$SCRIPT_DIR/block-ask-end-option.py"
+command -v python3 >/dev/null 2>&1 || exit 0
+[ -f "$PY" ] || exit 0
+exec python3 "$PY"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "praxis hooks: Stop gate for completion-without-evidence, retrospect memory-bias gate, session-scoped three-strike discipline, PreToolUse(Bash) side-effect scan / gh search --state all block / memory-hint / caller-chain evidence gate on gh pr create / pre-merge approval gate, PostToolUse correction for built-in task management tools, UserPromptSubmit codex-review worktree disambiguation",
+  "description": "praxis hooks: Stop gate for completion-without-evidence, retrospect memory-bias gate, session-scoped three-strike discipline, PreToolUse(Bash) side-effect scan / gh search --state all block / memory-hint / caller-chain evidence gate on gh pr create / pre-merge approval gate, PreToolUse(AskUserQuestion) end-option mechanical-transcribe advisory, PostToolUse correction for built-in task management tools, UserPromptSubmit codex-review worktree disambiguation",
   "hooks": {
     "SessionStart": [
       {
@@ -60,6 +60,16 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-merge-approval-gate.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-ask-end-option.sh",
             "timeout": 5
           }
         ]

--- a/hooks/test-block-ask-end-option.sh
+++ b/hooks/test-block-ask-end-option.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# test-block-ask-end-option.sh — coverage for the AskUserQuestion end-option gate
+#
+# Synthesizes Claude Code PreToolUse(AskUserQuestion) payloads and asserts:
+#   advisory → exit 0 + stderr non-empty
+#   block    → exit 2 + stderr non-empty (PRAXIS_ASK_END_STRICT=1)
+#   pass     → exit 0 + stderr empty
+#
+# Usage: bash hooks/test-block-ask-end-option.sh
+# Exit:  0 = all pass; 1 = at least one fail
+#
+# Hook is advisory by default — most "end-marker present + no stop signal"
+# cases expect exit 0 + non-empty stderr. Strict cases (with
+# PRAXIS_ASK_END_STRICT=1) expect exit 2.
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/block-ask-end-option.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable: $HOOK" >&2
+  exit 1
+fi
+
+PASS=0; FAIL=0; FAILED_NAMES=()
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# Build a transcript JSONL file from a single user message.
+# $1 = user message text (empty string → no user entries written)
+build_transcript() {
+  local msg="$1"
+  local path="$WORK/transcript-$$-$RANDOM.jsonl"
+  if [ -n "$msg" ]; then
+    python3 -c '
+import json, sys
+print(json.dumps({"type": "user", "message": {"role": "user", "content": sys.argv[1]}}))
+' "$msg" > "$path"
+  else
+    : > "$path"
+  fi
+  echo "$path"
+}
+
+# Build a JSON payload for AskUserQuestion tool call.
+# $1 = transcript_path
+# $2 = options JSON array (e.g., '["Plan A", "End here"]')
+build_payload() {
+  local transcript="$1" options_json="$2"
+  python3 - <<PY
+import json, sys
+options = json.loads('''$options_json''')
+payload = {
+    "session_id": "test-session",
+    "transcript_path": "$transcript",
+    "tool_name": "AskUserQuestion",
+    "tool_input": {
+        "questions": [
+            {
+                "question": "Next step?",
+                "header": "Next",
+                "multiSelect": False,
+                "options": [{"label": opt, "description": "test desc"} for opt in options],
+            }
+        ]
+    },
+    "cwd": "/tmp",
+}
+print(json.dumps(payload))
+PY
+}
+
+run_case() {
+  local name="$1" expected="$2" strict="$3" payload="$4"
+  local err_file rc
+
+  err_file=$(mktemp)
+  if [ "$strict" = "strict" ]; then
+    echo "$payload" | PRAXIS_ASK_END_STRICT=1 "$HOOK" >/dev/null 2>"$err_file"
+  else
+    echo "$payload" | "$HOOK" >/dev/null 2>"$err_file"
+  fi
+  rc=$?
+  local err_content
+  err_content=$(cat "$err_file"); rm -f "$err_file"
+
+  local ok=1
+  case "$expected" in
+    advisory)
+      [ "$rc" -eq 0 ] && [ -n "$err_content" ] || ok=0
+      ;;
+    block)
+      [ "$rc" -eq 2 ] && [ -n "$err_content" ] || ok=0
+      ;;
+    pass)
+      [ "$rc" -eq 0 ] && [ -z "$err_content" ] || ok=0
+      ;;
+    *)
+      echo "INTERNAL: unknown expected '$expected'" >&2
+      ok=0
+      ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS [$expected] $name"; PASS=$((PASS+1))
+  else
+    echo "FAIL [$expected→rc=$rc,stderr=$([ -n "$err_content" ] && echo non-empty || echo empty)] $name"
+    FAIL=$((FAIL+1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# (a) ADVISORY cases — default mode, end marker present, no stop signal
+# ---------------------------------------------------------------------------
+
+T1=$(build_transcript "Continue with the next step")
+P1=$(build_payload "$T1" '["Plan A", "Plan B", "여기서 종료"]')
+run_case "korean end marker, neutral user message" advisory default "$P1"
+
+T2=$(build_transcript "What about option B?")
+P2=$(build_payload "$T2" '["Implement", "Review", "End here"]')
+run_case "english end marker, neutral user message" advisory default "$P2"
+
+T3=$(build_transcript "다음 단계 진행해주세요")
+P3=$(build_payload "$T3" '["Step 1", "Step 2", "세션 종료"]')
+run_case "korean continuation, korean end marker" advisory default "$P3"
+
+# ---------------------------------------------------------------------------
+# (b) BLOCK cases — strict mode, end marker present, no stop signal
+# ---------------------------------------------------------------------------
+
+T4=$(build_transcript "Continue please")
+P4=$(build_payload "$T4" '["Plan A", "여기서 종료"]')
+run_case "strict mode + end marker + no signal → block" block strict "$P4"
+
+T5=$(build_transcript "")
+P5=$(build_payload "$T5" '["Plan A", "End here"]')
+run_case "strict mode + empty transcript → block (no signal found)" block strict "$P5"
+
+# ---------------------------------------------------------------------------
+# (c) PASS cases — no end marker
+# ---------------------------------------------------------------------------
+
+T6=$(build_transcript "Continue")
+P6=$(build_payload "$T6" '["Plan A", "Plan B", "Plan C"]')
+run_case "no end marker present" pass default "$P6"
+
+T7=$(build_transcript "Continue")
+P7=$(build_payload "$T7" '["Plan A", "Plan B", "Plan C"]')
+run_case "no end marker present (strict mode also passes)" pass strict "$P7"
+
+# ---------------------------------------------------------------------------
+# (d) PASS cases — end marker present BUT user signaled stop
+# ---------------------------------------------------------------------------
+
+T8=$(build_transcript "그만 하고 여기서 마무리하자")
+P8=$(build_payload "$T8" '["Plan A", "여기서 종료"]')
+run_case "korean stop signal in user message" pass default "$P8"
+
+T9=$(build_transcript "Stop here, we're done")
+P9=$(build_payload "$T9" '["Plan A", "End here"]')
+run_case "english stop signal in user message" pass default "$P9"
+
+T10=$(build_transcript "그만")
+P10=$(build_payload "$T10" '["Plan A", "여기서 종료"]')
+run_case "minimal korean stop signal (strict mode also passes)" pass strict "$P10"
+
+# ---------------------------------------------------------------------------
+# (e) PASS cases — not AskUserQuestion tool
+# ---------------------------------------------------------------------------
+
+P11=$(python3 -c '
+import json
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {"command": "echo end here"},
+}))')
+run_case "non-AskUserQuestion tool passes through" pass default "$P11"
+
+P12=$(python3 -c '
+import json
+print(json.dumps({
+    "tool_name": "Edit",
+    "tool_input": {"old_string": "여기서 종료", "new_string": "stop"},
+}))')
+run_case "Edit tool with end-marker in args passes through" pass default "$P12"
+
+# ---------------------------------------------------------------------------
+# (f) Graceful degrade — malformed / missing payload pieces
+# ---------------------------------------------------------------------------
+
+P13='not even json'
+run_case "malformed JSON payload → graceful exit 0" pass default "$P13"
+
+P14=$(python3 -c '
+import json
+print(json.dumps({
+    "tool_name": "AskUserQuestion",
+    "tool_input": {},
+}))')
+run_case "AskUserQuestion with no questions → pass" pass default "$P14"
+
+P15=$(python3 -c '
+import json
+print(json.dumps({
+    "tool_name": "AskUserQuestion",
+    "tool_input": {"questions": [{"options": "not-a-list"}]},
+}))')
+run_case "questions with non-list options → pass" pass default "$P15"
+
+# missing transcript_path: end marker present, no signal → advisory still fires
+# (transcript silently empty, stop signal absent → advisory)
+T16=$(build_transcript "")
+P16=$(build_payload "/nonexistent/path-$$.jsonl" '["Plan A", "End here"]')
+run_case "missing transcript file + end marker → advisory" advisory default "$P16"
+
+# ---------------------------------------------------------------------------
+# (g) Multi-question payload — marker in any question triggers advisory
+# ---------------------------------------------------------------------------
+
+T17=$(build_transcript "Just continue")
+P17=$(python3 - <<'PY'
+import json
+print(json.dumps({
+    "session_id": "test-session",
+    "transcript_path": "/tmp/nonexistent.jsonl",
+    "tool_name": "AskUserQuestion",
+    "tool_input": {
+        "questions": [
+            {
+                "question": "A?",
+                "options": [{"label": "yes"}, {"label": "no"}],
+            },
+            {
+                "question": "B?",
+                "options": [{"label": "Plan A"}, {"label": "End here"}],
+            },
+        ]
+    },
+}))
+PY
+)
+run_case "multi-question payload, marker in second question" advisory default "$P17"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=========================================="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "Failed cases:"
+  for n in "${FAILED_NAMES[@]}"; do
+    echo "  - $n"
+  done
+fi
+
+[ "$FAIL" -eq 0 ]

--- a/hooks/test-block-ask-end-option.sh
+++ b/hooks/test-block-ask-end-option.sh
@@ -244,6 +244,97 @@ PY
 run_case "multi-question payload, marker in second question" advisory default "$P17"
 
 # ---------------------------------------------------------------------------
+# (h) F1 regression — bare-word stop tokens must NOT trigger (codex #193)
+# ---------------------------------------------------------------------------
+
+# Before F1 fix, 'send' contained 'end' (substring of stop signal "end") and
+# 'backend' contained 'end' / 'don't stop' contained 'stop' — all three
+# false-allowed the surface. With phrase-only matching + negation guard,
+# these messages must NOT register as stop signals.
+
+T18=$(build_transcript "send the message to the team")
+P18=$(build_payload "$T18" '["Plan A", "End here"]')
+run_case "[F1] 'send' substring must NOT pass as stop signal" advisory default "$P18"
+
+T19=$(build_transcript "the backend service is failing")
+P19=$(build_payload "$T19" '["Plan A", "End here"]')
+run_case "[F1] 'backend' substring must NOT pass as stop signal" advisory default "$P19"
+
+T20=$(build_transcript "don't stop now, keep going")
+P20=$(build_payload "$T20" '["Plan A", "End here"]')
+run_case "[F1] negated 'don't stop now' must NOT pass" advisory default "$P20"
+
+T21=$(build_transcript "I quit the previous job last year")
+P21=$(build_payload "$T21" '["Plan A", "End here"]')
+run_case "[F1] 'quit' bare word in unrelated context must NOT pass" advisory default "$P21"
+
+T22=$(build_transcript "do not wrap up yet")
+P22=$(build_payload "$T22" '["Plan A", "End here"]')
+run_case "[F1] negated 'do not wrap up' must NOT pass" advisory default "$P22"
+
+# ---------------------------------------------------------------------------
+# (i) F2 regression — tool_result-only user entry must be skipped (codex #193)
+# ---------------------------------------------------------------------------
+
+# Build a transcript where the most recent user entry is tool_result-only,
+# preceded by a real human user message with an explicit stop signal.
+# Before F2 fix, the hook returned empty string at the tool_result entry
+# and never reached the real human message → false-block in strict mode.
+
+build_tool_result_transcript() {
+  local human_text="$1"
+  local path="$WORK/transcript-tr-$$-$RANDOM.jsonl"
+  python3 - "$human_text" > "$path" <<'PY'
+import json, sys
+human_text = sys.argv[1]
+# Order: oldest first (real human message), then assistant, then
+# tool_result-only user entry as the most recent.
+print(json.dumps({"type": "user", "message": {"role": "user", "content": human_text}}))
+print(json.dumps({"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Working on it."}]}}))
+print(json.dumps({
+    "type": "user",
+    "message": {
+        "role": "user",
+        "content": [
+            {"type": "tool_result", "tool_use_id": "abc123", "content": "command output text"}
+        ],
+    },
+}))
+PY
+  echo "$path"
+}
+
+T23=$(build_tool_result_transcript "stop here please, we are done")
+P23=$(build_payload "$T23" '["Plan A", "End here"]')
+run_case "[F2] tool_result-only user entry skipped, prior 'stop here' found" pass default "$P23"
+
+T24=$(build_tool_result_transcript "그만 하고 마무리하자")
+P24=$(build_payload "$T24" '["Plan A", "여기서 종료"]')
+run_case "[F2] tool_result-only skipped, prior korean stop signal" pass strict "$P24"
+
+T25=$(build_tool_result_transcript "Continue with the next step")
+P25=$(build_payload "$T25" '["Plan A", "End here"]')
+run_case "[F2] tool_result-only skipped, prior msg has no signal → advisory" advisory default "$P25"
+
+# ---------------------------------------------------------------------------
+# (j) F1 positive — phrase-based stop signals continue to match
+# ---------------------------------------------------------------------------
+
+# Ensure the phrase-based matching still catches legitimate stop signals.
+
+T26=$(build_transcript "let's stop here for today")
+P26=$(build_payload "$T26" '["Plan A", "End here"]')
+run_case "[F1+] 'let's stop here' phrase passes" pass default "$P26"
+
+T27=$(build_transcript "I think we are done with this discussion")
+P27=$(build_payload "$T27" '["Plan A", "End here"]')
+run_case "[F1+] 'we are done' phrase passes" pass default "$P27"
+
+T28=$(build_transcript "Time to wrap up, that's all from me")
+P28=$(build_payload "$T28" '["Plan A", "End here"]')
+run_case "[F1+] 'wrap up' + 'that's all' phrases pass" pass default "$P28"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds a PreToolUse(AskUserQuestion) advisory that detects mechanical transcription of "end here" / "여기서 종료" / "session end" boilerplate into the `options[].label` array and warns when the most recent user message contains no explicit stop signal.

Closes #192

## Background

Skill guides authoring "Step N: chaining" sections frequently include a copy-paste boilerplate suggesting an "end here" option as the last choice. Agents mechanically transcribe this into AskUserQuestion call sites even when:

1. The user has expressed no stop signal in the most recent message
2. The conversation has a clearly chained intent across 4+ steps
3. A natural next actionable step exists in the immediate context

A recent session reported 6+ inappropriate "end here" surfaces in a single conversation. Text rules in `CLAUDE.md` / `AGENTS.md` alone cannot enforce this — `loaded != retrieved` limit.

This hook runs at the tool boundary, where the check is mechanically applied regardless of retrieval state.

## Behavior

| Condition | Default mode | Strict mode (`PRAXIS_ASK_END_STRICT=1`) |
|---|---|---|
| `tool_name != AskUserQuestion` | pass | pass |
| Options contain no end marker | pass | pass |
| End marker present + user signaled stop | pass | pass |
| End marker present + no stop signal | advisory (exit 0 + stderr) | block (exit 2 + stderr) |
| Malformed JSON / missing payload | graceful pass | graceful pass |
| Missing transcript file | advisory (no signal → falls through) | block (strict) |

Markers detected (case-insensitive):

- Korean: `여기서 종료`, `세션 종료`, `여기서 끝`, `여기까지`
- English: `end here`, `session end`, `stop here`, `end the session`, `wrap up here`

Stop signals (case-insensitive substring match against most recent user message):

- Korean: `종료`, `여기까지`, `그만`, `마무리`, `스톱`, `중단`
- English: `stop`, `end`, `quit`, `done`, `cancel`, `finish`, `wrap up`, `that's all`, `no more`

## Implementation

Pattern follows existing PreToolUse hooks (`block-pr-without-caller-evidence`, `external-write-falsify-check`, `pre-merge-approval-gate`):

- `hooks/block-ask-end-option.sh` — shim entry registered in `hooks.json`
- `hooks/block-ask-end-option.py` — JSON parsing + pattern matching logic
- `hooks/test-block-ask-end-option.sh` — 17 unit test cases
- `hooks/hooks.json` — new PreToolUse matcher entry for `AskUserQuestion`

The hook introduces transcript JSONL parsing to access the most recent user-role message. The reader handles four schema shapes (`type` vs `role` at top level, `message.role` nested, `content` as string vs list of `{type: text, text: ...}` parts) and silently falls through to advisory on missing or malformed transcripts so no false block occurs.

Same advisory + strict-via-env pattern as `external-write-falsify-check` (`PRAXIS_EXTERNAL_WRITE_STRICT`).

## Test coverage

17 unit cases across:

- (a) advisory: end marker present, neutral user message (Korean + English variants)
- (b) block: strict mode, end marker present, no stop signal
- (c) pass: no end marker (default + strict)
- (d) pass: end marker present + user stop signal (Korean + English + strict)
- (e) pass: non-AskUserQuestion tool passes through (Bash, Edit)
- (f) graceful degrade: malformed JSON, empty `questions`, non-list `options`, missing transcript file
- (g) multi-question payload: marker in any question triggers advisory

All 17 cases pass on local invocation:

```
$ bash hooks/test-block-ask-end-option.sh
PASS [advisory] korean end marker, neutral user message
...
PASS: 17
FAIL: 0
```

## Why advisory default

This is a new transcript-aware hook; false positive surface area is broader than previous Bash-only hooks. The advisory default lets the hook accumulate confidence before strict enforcement.

To enable strict mode session-wide:

```
export PRAXIS_ASK_END_STRICT=1
```

## Related

Same pattern family as `external-write-falsify-check` (existing) — both enforce conversational discipline at the tool boundary rather than relying on memory rule retrieval.

Caller chain verified: new symbol, no caller expected
