### PR TITLE
feat(hooks): add verify-commit-flag-override with shlex tokenization

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -74,6 +74,11 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/verify-commit-flag-override.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-intent.sh",
             "timeout": 5
           }

--- a/hooks/verify-commit-flag-override.py
+++ b/hooks/verify-commit-flag-override.py
@@ -53,6 +53,22 @@ PROBLEM_CONFIG_PREFIXES: tuple[str, ...] = (
     "commit.template=",
 )
 
+# Git global options that take a value as the NEXT argv token (not `=`-joined).
+# Skipping just the flag without its value would let the value be misread as the
+# subcommand — e.g. `git -C /tmp commit -n` would treat `/tmp` as the subcommand
+# and bail out before the `commit` check, allowing the `-n` override through.
+GLOBAL_VALUE_FLAGS: frozenset[str] = frozenset(
+    {
+        "-C",
+        "--git-dir",
+        "--work-tree",
+        "--namespace",
+        "--config-env",
+        "--exec-path",
+        "--super-prefix",
+    }
+)
+
 # Token -> human-readable description (used in deny reason).
 COMMIT_FLAG_TOKENS: dict[str, str] = {
     "-n": "-n (short form of --no-verify)",
@@ -116,11 +132,21 @@ def detect_overrides(argv: list[str]) -> list[str]:
                     break
             i += 1
             continue
+        # Value-bearing global with value as the NEXT token (e.g. `-C /tmp`,
+        # `--git-dir /tmp/foo`). Skip both flag AND value, otherwise the value
+        # gets misread as the subcommand and the `commit` check below fails,
+        # allowing the override through silently (Codex review P2, PR #194).
+        if tok in GLOBAL_VALUE_FLAGS and i + 1 < len(argv):
+            i += 2
+            continue
+        # `=`-joined global (e.g. `--git-dir=/path`). Value is already attached;
+        # advance one token.
+        if tok.startswith("--") and "=" in tok:
+            i += 1
+            continue
         if tok.startswith("-"):
-            # Some other git global flag — skip it (and possibly its value).
-            # Conservative: just advance one token; if this misses a value
-            # token the worst case is a false-positive on the next token,
-            # but practical git globals before `commit` are rare.
+            # Boolean / bare-flag global (`--bare`, `--no-replace-objects`, etc.)
+            # — skip one token only.
             i += 1
             continue
         # First non-flag token: must be the subcommand.

--- a/hooks/verify-commit-flag-override.py
+++ b/hooks/verify-commit-flag-override.py
@@ -75,6 +75,10 @@ COMMIT_FLAG_TOKENS: dict[str, str] = {
     "--no-verify": "--no-verify",
     "--no-gpg-sign": "--no-gpg-sign",
     "-S": "-S (force signing)",
+    # Codex review P2: bare `--gpg-sign` (no keyid) was undetected — only
+    # `--gpg-sign=<keyid>` and `-S<keyid>` were matched by the elif branches.
+    # Bare form is a complete, valid invocation, so list it explicitly.
+    "--gpg-sign": "-S (force signing)",
 }
 
 # Why each override is blocked (one line per distinct override).

--- a/hooks/verify-commit-flag-override.py
+++ b/hooks/verify-commit-flag-override.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""PreToolUse(Bash) guard: block commit-flag overrides without verification.
+
+Blocks `git commit` invocations that override commit hooks or signing
+without the operator having verified the environment first:
+
+  - `--no-verify`, `-n`            (skip pre-commit hooks)
+  - `--no-gpg-sign`                (force unsigned commit)
+  - `-S`, `-S<keyid>`, `--gpg-sign=<keyid>`  (force signing)
+  - `-c commit.gpgsign=true|false` (config-level signing override)
+  - `-c core.hooksPath=...`        (redirect pre-commit hooks)
+  - `-c commit.template=...`       (override commit template)
+
+Uses shlex tokenization (same approach as block-gh-state-all.py and
+gh-flag-verify.py) so that pattern references inside quoted strings,
+heredoc bodies, command substitutions, or echo arguments are not
+mistakenly blocked. This is the principal motivation for porting the
+hook into praxis: the project-local predecessor regex-matched the bare
+substring `-n` anywhere in the bash command, producing false positives
+on benign invocations like `echo -n "$VAR"`, `head -n 5`, `sed -n`, or
+heredoc message bodies containing such expressions (see #184).
+
+Allow conditions:
+  - `PRAXIS_SKIP_COMMIT_FLAG_CHECK=1` env var (justify the bypass in
+    the commit message body or PR description).
+  - Operator manually verifies the environment with the commands listed
+    in the deny message, then re-runs.
+
+Exits 2 (PreToolUse blocking code) when a live `git commit` override
+without verification is detected. Exits 0 otherwise.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    iter_command_starts,
+    safe_tokenize,
+    strip_prefix,
+)
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+PROBLEM_CONFIG_PREFIXES: tuple[str, ...] = (
+    "commit.gpgsign=",
+    "core.hooksPath=",
+    "commit.template=",
+)
+
+# Token -> human-readable description (used in deny reason).
+COMMIT_FLAG_TOKENS: dict[str, str] = {
+    "-n": "-n (short form of --no-verify)",
+    "--no-verify": "--no-verify",
+    "--no-gpg-sign": "--no-gpg-sign",
+    "-S": "-S (force signing)",
+}
+
+# Why each override is blocked (one line per distinct override).
+ENV_ISSUE_FOR: dict[str, str] = {
+    "-n (short form of --no-verify)": (
+        "--no-verify / -n: bypasses pre-commit hooks (lint/test/format). "
+        "Global rule: never skip hooks unless user explicitly asked."
+    ),
+    "--no-verify": (
+        "--no-verify / -n: bypasses pre-commit hooks (lint/test/format). "
+        "Global rule: never skip hooks unless user explicitly asked."
+    ),
+    "--no-gpg-sign": (
+        "--no-gpg-sign: bypasses commit signing without env verification. "
+        "Confirm the repo policy permits unsigned commits before using."
+    ),
+    "-S (force signing)": (
+        "-S / --gpg-sign: forces signing. Confirm a secret key is available "
+        "(gpg --list-secret-keys) and the repo expects signing."
+    ),
+}
+
+
+def detect_overrides(argv: list[str]) -> list[str]:
+    """Return human-readable override tokens found in a `git commit` argv.
+
+    Returns an empty list when argv is not a `git commit` invocation or
+    has no problematic overrides.
+    """
+    argv = strip_prefix(argv)
+    if not argv or argv[0] != "git":
+        return []
+
+    overrides: list[str] = []
+
+    # Step 1: scan git-level global options before the subcommand. The
+    # `-c key=value` form can appear here (e.g. `git -c commit.gpgsign=false
+    # commit -m "..."`). Stop at the first non-flag token.
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        if tok == "-c" and i + 1 < len(argv):
+            kv = argv[i + 1]
+            for prefix in PROBLEM_CONFIG_PREFIXES:
+                if kv.startswith(prefix):
+                    overrides.append(f"-c {kv}")
+                    break
+            i += 2
+            continue
+        if tok.startswith("-c") and "=" in tok and len(tok) > 2:
+            kv = tok[2:]
+            for prefix in PROBLEM_CONFIG_PREFIXES:
+                if kv.startswith(prefix):
+                    overrides.append(f"-c {kv}")
+                    break
+            i += 1
+            continue
+        if tok.startswith("-"):
+            # Some other git global flag — skip it (and possibly its value).
+            # Conservative: just advance one token; if this misses a value
+            # token the worst case is a false-positive on the next token,
+            # but practical git globals before `commit` are rare.
+            i += 1
+            continue
+        # First non-flag token: must be the subcommand.
+        break
+
+    # Step 2: only flag if the subcommand is actually `commit`. A non-commit
+    # invocation like `git -c commit.gpgsign=false log` is irrelevant — git
+    # config overrides only matter for commit-time policy.
+    if i >= len(argv) or argv[i] != "commit":
+        return []
+
+    # Step 3: scan commit's args for short/long flag overrides.
+    j = i + 1
+    while j < len(argv):
+        tok = argv[j]
+        if tok in COMMIT_FLAG_TOKENS:
+            overrides.append(COMMIT_FLAG_TOKENS[tok])
+        elif tok.startswith("-S") and len(tok) > 2:
+            # `-S<keyid>` (signing with explicit keyid, no space).
+            overrides.append("-S (force signing)")
+        elif tok.startswith("--gpg-sign="):
+            overrides.append("-S (force signing)")
+        j += 1
+
+    return overrides
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+DENY_TEMPLATE = """BLOCKED: Commit-flag override(s) failed environment verification.
+
+Detected override(s): {overrides}
+
+Environment issues:
+{env_issues}
+
+Required verification before this command:
+  1. git config --get commit.gpgsign            (repo default)
+  2. gpg --list-secret-keys                     (key availability, for signing)
+  3. git log --pretty=format:%G? -1             (recent commit signing status)
+  4. git config --get core.hooksPath            (hook path default, for hooks.path override)
+
+Why this is blocked:
+  - Global rule: 'Never skip hooks (--no-verify) or bypass signing
+    (--no-gpg-sign, -c commit.gpgsign=false) unless the user has explicitly
+    asked for it.'
+
+Allow conditions:
+  - Verify each override matches your environment using the commands above,
+    then re-run with confidence.
+  - Set env PRAXIS_SKIP_COMMIT_FLAG_CHECK=1 (justify the bypass in the
+    commit message body).
+"""
+
+
+def _emit_deny(reason: str) -> None:
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason,
+            }
+        },
+        sys.stdout,
+    )
+    sys.stdout.write("\n")
+
+
+def _build_reason(overrides: list[str]) -> str:
+    # De-duplicate while preserving order.
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for ov in overrides:
+        if ov not in seen:
+            seen.add(ov)
+            ordered.append(ov)
+
+    env_issue_lines: list[str] = []
+    env_seen: set[str] = set()
+    for ov in ordered:
+        msg = ENV_ISSUE_FOR.get(ov)
+        if msg is None:
+            # Generic message for `-c key=value` overrides.
+            if ov.startswith("-c commit.gpgsign="):
+                msg = (
+                    "-c commit.gpgsign: forces signing policy. Verify gpg "
+                    "key availability and repo expectation before use."
+                )
+            elif ov.startswith("-c core.hooksPath="):
+                msg = (
+                    "-c core.hooksPath: redirects pre-commit hooks. "
+                    "Confirm the target path exists and is intentional."
+                )
+            elif ov.startswith("-c commit.template="):
+                msg = (
+                    "-c commit.template: overrides commit template. "
+                    "Confirm intent."
+                )
+            else:
+                msg = f"{ov}: bypasses normal commit policy."
+        if msg not in env_seen:
+            env_seen.add(msg)
+            env_issue_lines.append(f"  - {msg}")
+
+    return DENY_TEMPLATE.format(
+        overrides=", ".join(ordered),
+        env_issues="\n".join(env_issue_lines),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    # Operator-justified bypass.
+    if os.environ.get("PRAXIS_SKIP_COMMIT_FLAG_CHECK") == "1":
+        return 0
+
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0  # fail-open on malformed stdin
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    command = payload.get("tool_input", {}).get("command", "") or ""
+    if not command.strip():
+        return 0
+
+    # Backslash line continuation → single space so tokenizer sees one line.
+    command = command.replace("\\\n", " ")
+
+    tokens = safe_tokenize(command)
+    if not tokens:
+        return 0
+
+    all_overrides: list[str] = []
+    for argv in iter_command_starts(tokens):
+        all_overrides.extend(detect_overrides(argv))
+
+    if not all_overrides:
+        return 0
+
+    _emit_deny(_build_reason(all_overrides))
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/verify-commit-flag-override.sh
+++ b/hooks/verify-commit-flag-override.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# PreToolUse(Bash) hook entry — delegates to the Python implementation.
+#
+# Fail-safe: if python3 is unavailable, exit 0 (pass) rather than break the
+# Claude Code session.
+
+set +e
+
+if ! command -v python3 >/dev/null 2>&1; then
+  exit 0
+fi
+
+exec python3 "$(dirname "$0")/verify-commit-flag-override.py"

--- a/tests/test_verify_commit_flag_override.sh
+++ b/tests/test_verify_commit_flag_override.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+# test_verify_commit_flag_override.sh — coverage for hooks/verify-commit-flag-override.py
+#
+# Synthesizes Claude Code PreToolUse hook payloads and asserts:
+#   deny   → exit 2 + stdout JSON has permissionDecision "deny"
+#   silent → exit 0 + stdout empty (no JSON, no permissionDecision)
+#
+# Coverage focuses on the lexical false-positive cases that motivated the
+# port from a project-local hook (see #184): the prior regex-based
+# implementation matched `-n` as a bare substring anywhere in the command,
+# so heredoc bodies, echo arguments, head/sed/grep flags, and command
+# substitutions all tripped it. The shlex tokenization here must not
+# repeat that mistake.
+#
+# Usage: bash tests/test_verify_commit_flag_override.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$ROOT_DIR/hooks/verify-commit-flag-override.py"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable: $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+# run_case name expectation payload_json
+#   expectation:
+#     "deny"   — stdout JSON has permissionDecision "deny", rc=2
+#     "silent" — stdout empty, rc=0
+run_case() {
+  local name="$1" expectation="$2" payload="$3"
+
+  local out_file
+  out_file=$(mktemp)
+
+  # Unset bypass env so the test exercises the real detection path.
+  PRAXIS_SKIP_COMMIT_FLAG_CHECK= \
+    echo "$payload" | PRAXIS_SKIP_COMMIT_FLAG_CHECK= python3 "$HOOK" >"$out_file" 2>/dev/null
+  local rc=$?
+  local out
+  out=$(cat "$out_file")
+  rm -f "$out_file"
+
+  local ok=1
+  case "$expectation" in
+    deny)
+      [ "$rc" -eq 2 ] || ok=0
+      echo "$out" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    decision = d.get('hookSpecificOutput', {}).get('permissionDecision', '')
+    sys.exit(0 if decision == 'deny' else 1)
+except Exception:
+    sys.exit(1)
+" 2>/dev/null || ok=0
+      ;;
+    silent)
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$out" ] || ok=0
+      ;;
+    *)
+      echo "UNKNOWN expectation: $expectation" >&2
+      ok=0
+      ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (rc=$rc, out=$out)"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+# helper: build a Bash PreToolUse payload with the given command string.
+payload() {
+  python3 -c "
+import json, sys
+print(json.dumps({
+    'tool_name': 'Bash',
+    'tool_input': {'command': sys.argv[1]},
+}))
+" "$1"
+}
+
+# ---------------------------------------------------------------------------
+# Block cases (must deny)
+# ---------------------------------------------------------------------------
+
+run_case "B01: git commit -n -m msg" deny \
+  "$(payload 'git commit -n -m "msg"')"
+
+run_case "B02: git commit --no-verify -m msg" deny \
+  "$(payload 'git commit --no-verify -m "msg"')"
+
+run_case "B03: git -c commit.gpgsign=false commit -m msg" deny \
+  "$(payload 'git -c commit.gpgsign=false commit -m "msg"')"
+
+run_case "B04: git commit --no-gpg-sign -m msg" deny \
+  "$(payload 'git commit --no-gpg-sign -m "msg"')"
+
+run_case "B05: git commit -S -m msg" deny \
+  "$(payload 'git commit -S -m "msg"')"
+
+run_case "B06: git -c core.hooksPath=/tmp/x commit -m msg" deny \
+  "$(payload 'git -c core.hooksPath=/tmp/x commit -m "msg"')"
+
+run_case "B07: short combined -Skeyid" deny \
+  "$(payload 'git commit -Sabc123 -m "msg"')"
+
+# ---------------------------------------------------------------------------
+# Pass cases (must NOT deny) — these are the lexical false-positives the
+# port is meant to eliminate. The prior regex-based hook tripped on every
+# one of these.
+# ---------------------------------------------------------------------------
+
+run_case "P01: echo -n followed by git commit (no override)" silent \
+  "$(payload 'echo -n "len" | wc -c && git commit -m "msg"')"
+
+run_case "P02: head -n 5 then git commit (no override)" silent \
+  "$(payload 'head -n 5 file && git commit -m "msg"')"
+
+run_case "P03: grep -n in pipe before commit" silent \
+  "$(payload 'grep -n pattern file && git commit -m "msg"')"
+
+run_case "P04: sed -n inside message body" silent \
+  "$(payload 'git commit -m "Premise-Verified: sed -n 35,55p src/cli/_common.py"')"
+
+run_case "P05: -n inside command substitution body" silent \
+  "$(payload 'git commit -m "$([ -n \"\$X\" ] && echo a || echo b)"')"
+
+run_case "P06: git commit -F- with heredoc body containing -n" silent \
+  "$(payload '
+git commit -F- <<EOF
+Premise-Verified: ran sed -n 35,55p file
+EOF
+')"
+
+run_case "P07: plain git commit -m" silent \
+  "$(payload 'git commit -m "regular message"')"
+
+run_case "P08: git log -n 5 (not commit)" silent \
+  "$(payload 'git log -n 5')"
+
+run_case "P09: not a git command at all" silent \
+  "$(payload 'tail -n 10 file.txt')"
+
+run_case "P10: gh issue create with --body containing -n example" silent \
+  "$(payload 'gh issue create --body "use sed -n to read lines"')"
+
+# ---------------------------------------------------------------------------
+# Bypass case (PRAXIS_SKIP_COMMIT_FLAG_CHECK=1 must short-circuit to pass)
+# ---------------------------------------------------------------------------
+
+bypass_payload=$(payload 'git commit -n -m "msg"')
+bypass_out=$(mktemp)
+PRAXIS_SKIP_COMMIT_FLAG_CHECK=1 echo "$bypass_payload" | PRAXIS_SKIP_COMMIT_FLAG_CHECK=1 python3 "$HOOK" >"$bypass_out" 2>/dev/null
+bypass_rc=$?
+bypass_content=$(cat "$bypass_out")
+rm -f "$bypass_out"
+
+if [ "$bypass_rc" -eq 0 ] && [ -z "$bypass_content" ]; then
+  echo "PASS: X01: PRAXIS_SKIP_COMMIT_FLAG_CHECK=1 bypasses block"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: X01: PRAXIS_SKIP_COMMIT_FLAG_CHECK=1 bypasses block (rc=$bypass_rc, out=$bypass_content)"
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("X01")
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo
+echo "==========================="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:"
+  for n in "${FAILED_NAMES[@]}"; do
+    echo "  - $n"
+  done
+  exit 1
+fi
+exit 0

--- a/tests/test_verify_commit_flag_override.sh
+++ b/tests/test_verify_commit_flag_override.sh
@@ -190,6 +190,27 @@ run_case "G07: git -C /tmp log (not commit)" silent \
   "$(payload 'git -C /tmp log -n 5')"
 
 # ---------------------------------------------------------------------------
+# Bare --gpg-sign long form (Codex review P2 followup).
+#
+# Prior matching covered `-S`, `-S<keyid>` (via startswith), and
+# `--gpg-sign=<keyid>`. Bare `--gpg-sign` (no keyid attached, no separate
+# argument) fell through to allow.
+# ---------------------------------------------------------------------------
+
+run_case "S01: bare --gpg-sign" deny \
+  "$(payload 'git commit --gpg-sign -m "msg"')"
+
+run_case "S02: --gpg-sign after -m" deny \
+  "$(payload 'git commit -m "msg" --gpg-sign')"
+
+run_case "S03: --gpg-sign=DEADBEEF (keyid form, regression)" deny \
+  "$(payload 'git commit --gpg-sign=DEADBEEF -m "msg"')"
+
+# Sanity: --gpg-sign text inside message body must NOT deny.
+run_case "S04: --gpg-sign text inside -m body" silent \
+  "$(payload 'git commit -m "discuss --gpg-sign policy in docs"')"
+
+# ---------------------------------------------------------------------------
 # Bypass case (PRAXIS_SKIP_COMMIT_FLAG_CHECK=1 must short-circuit to pass)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_verify_commit_flag_override.sh
+++ b/tests/test_verify_commit_flag_override.sh
@@ -159,6 +159,37 @@ run_case "P10: gh issue create with --body containing -n example" silent \
   "$(payload 'gh issue create --body "use sed -n to read lines"')"
 
 # ---------------------------------------------------------------------------
+# Value-bearing git globals before `commit` (Codex review P1 followup).
+#
+# `git -C <path> commit ...` / `git --git-dir <path> commit ...` etc.
+# The prior implementation advanced one token on any `-`-prefixed flag,
+# letting the value get misread as the subcommand and bailing out before
+# the override scan ran.
+# ---------------------------------------------------------------------------
+
+run_case "G01: git -C /tmp commit --no-verify" deny \
+  "$(payload 'git -C /tmp commit --no-verify -m "msg"')"
+
+run_case "G02: git --git-dir /tmp/foo commit -n" deny \
+  "$(payload 'git --git-dir /tmp/foo commit -n -m "msg"')"
+
+run_case "G03: git --git-dir=/tmp/foo commit --no-verify (= form)" deny \
+  "$(payload 'git --git-dir=/tmp/foo commit --no-verify -m "msg"')"
+
+run_case "G04: git --work-tree /tmp commit --no-gpg-sign" deny \
+  "$(payload 'git --work-tree /tmp commit --no-gpg-sign -m "msg"')"
+
+run_case "G05: git -C /tmp -c commit.gpgsign=false commit" deny \
+  "$(payload 'git -C /tmp -c commit.gpgsign=false commit -m "msg"')"
+
+run_case "G06: git -C /tmp commit -S (force sign)" deny \
+  "$(payload 'git -C /tmp commit -S -m "msg"')"
+
+# Sanity: value-bearing global + non-commit subcommand must NOT deny.
+run_case "G07: git -C /tmp log (not commit)" silent \
+  "$(payload 'git -C /tmp log -n 5')"
+
+# ---------------------------------------------------------------------------
 # Bypass case (PRAXIS_SKIP_COMMIT_FLAG_CHECK=1 must short-circuit to pass)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Adds `verify-commit-flag-override` PreToolUse(Bash) hook that catches `git commit` invocations overriding pre-commit hooks or signing policy without environment verification.

Detected overrides:
- `--no-verify`, `-n` (skip pre-commit hooks)
- `--no-gpg-sign` (force unsigned)
- `-S`, `-S<keyid>`, `--gpg-sign=` (force signing)
- `-c commit.gpgsign=...`
- `-c core.hooksPath=...`
- `-c commit.template=...`

Bypass: `PRAXIS_SKIP_COMMIT_FLAG_CHECK=1` (justify the bypass in the commit message body).

## Why

A project-local hook with the same intent has been running in `laplace-dev-hub` for some time. It regex-matched the bare substring `-n` anywhere in the bash command, producing false-positives on benign invocations:

```bash
echo -n "$VAR" | wc -c && git commit -m "msg"
head -n 5 file && git commit -m "msg"
grep -n pattern file && git commit -m "msg"
git commit -m "Premise-Verified: sed -n 35,55p src/foo.py"
git commit -F- <<EOF
fix(deps): drop uvloop windows env marker

Premise-Verified: grep -n uvloop pyproject.toml … sed -n '35,55p' …
EOF
```

That last form bit twice within ~5 hours on different inputs (the second case is the additional reproduction posted to #184 today). The workaround — write the body to a tempfile and use `-F /tmp/msg.txt` — was captured in downstream memory ~3 days ago but retrieval was unreliable.

The architecturally correct fix is upstream-in-praxis (this PR), not yet-another local patch — the same defect exists in 9 other Laplace repos that share the same Claude Code setup, so a properly-tokenized praxis version benefits all of them once they install/update the plugin.

## How

Uses the existing `_hook_utils` helpers (`safe_tokenize`, `iter_command_starts`, `strip_prefix`) — the same shlex-based approach that `block-gh-state-all.py` and `gh-flag-verify.py` already use:

1. `safe_tokenize` runs the command through `shlex.split` with `;|&` punctuation chars (so each shell-command boundary becomes its own token).
2. `iter_command_starts` yields argv slices at those separators.
3. For each argv whose first token is `git`, scan git-level `-c key=value` globals before the subcommand, then — only if the subcommand is actually `commit` — scan its flags.

This means `-n` inside an `echo` argument, a heredoc body, a `sed` invocation, or a command substitution body is just a token of some other command and never reaches the `git commit` argv scanner.

## Test coverage

`tests/test_verify_commit_flag_override.sh` — 18 cases:

- 7 deny cases (`-n`, `--no-verify`, `-c commit.gpgsign=false`, `--no-gpg-sign`, `-S`, `-c core.hooksPath`, short-combined `-Sabc123`)
- 10 silent cases — exactly the lexical false-positives the prior regex tripped on:
  - `echo -n "len" | wc -c && git commit -m "msg"`
  - `head -n 5 file && git commit -m "msg"`
  - `grep -n pattern file && git commit -m "msg"`
  - `git commit -m "Premise-Verified: sed -n 35,55p src/cli/_common.py"` (today's exact bite)
  - `git commit -m "$([ -n \"\$X\" ] && echo a || echo b)"`
  - `git commit -F- <<EOF … sed -n 35,55p … EOF` (heredoc body — #184's second reproduction)
  - plain `git commit -m`
  - `git log -n 5` (subcommand isn't `commit`)
  - `tail -n 10 file.txt` (not git at all)
  - `gh issue create --body "use sed -n to read lines"`
- 1 bypass case (`PRAXIS_SKIP_COMMIT_FLAG_CHECK=1`)

All 18 pass. Full praxis regression suite passes (other tests/test_*.sh unchanged).

## Files

- `hooks/verify-commit-flag-override.py` — new, 9.6 KB
- `hooks/verify-commit-flag-override.sh` — new, standard shim
- `hooks/hooks.json` — registration entry under PreToolUse(Bash), after `gh-flag-verify.sh`, before `session-intent.sh`
- `tests/test_verify_commit_flag_override.sh` — new, 18 cases

Caller chain verified: grep found 1 caller in hooks/hooks.json (PreToolUse Bash matcher registration)

Closes #184
