### PR TITLE
feat(praxis): add runtime constraints gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,134 @@
+# Contributing to Praxis
+
+Praxis is a personal toolbox — contributions are primarily self-directed, but
+the conventions below keep the repo coherent across sessions and prevent the
+class of drift bugs that have cost the most debugging time.
+
+## Adding or modifying a skill
+
+### Directory structure
+
+```
+skills/<skill-name>/
+  SKILL.md          # spec — frontmatter + prose steps
+```
+
+The `name` and `description` fields in the SKILL.md frontmatter are surfaced by
+the Claude Code plugin runtime. Keep `description` under 500 characters; the
+runtime truncates beyond that.
+
+### Skill spec drift prevention
+
+> **This is the most important section if you are wrapping an external CLI.**
+
+Five independent drift incidents (Issue #208) established that skill specs
+authored without a live runtime round-trip contain silent contract violations
+that block execution on the very first use. The structural gate below prevents
+the sixth.
+
+#### Rule: verify before publishing
+
+Any skill that:
+- wraps an external CLI (`codex`, `gh`, `kubectl`, `hubctl`, or any binary not
+  shipped in this repo), **or**
+- calls `AskUserQuestion` with a dynamic option list, **or**
+- delegates to another skill via `Skill(...)`
+
+**must** complete a live round-trip invocation before the spec is merged.
+
+#### Frontmatter requirement
+
+After a live verification round-trip, add these three fields to the SKILL.md
+frontmatter:
+
+```yaml
+verified-against-runtime: true
+runtime-verified-at: YYYY-MM-DD
+runtime-verified-note: "<cli-name> <version> — one-line description of observed behavior"
+```
+
+Example (from `codex-review-wrap`):
+
+```yaml
+verified-against-runtime: true
+runtime-verified-at: 2026-05-13
+runtime-verified-note: "codex-companion 1.0.4 — ARGUMENTS rejected for non-flag string; AskUserQuestion maxItems:4 blocks worktree list >3 items"
+```
+
+#### Commit body requirement
+
+The commit that introduces or significantly revises a skill spec must include
+a one-line runtime note in the commit body. Use the same text as
+`runtime-verified-note`:
+
+```
+feat(skills): add my-new-skill
+
+verified: my-cli 2.3.1 — --flag-name accepted; output shape confirmed
+```
+
+This embeds the verification evidence in `git log` so it survives frontmatter
+refactors and is visible to `git blame`.
+
+#### Known runtime constraints
+
+Read [`RUNTIME_CONSTRAINTS.md`](RUNTIME_CONSTRAINTS.md) before writing a new
+spec. It lists fixed Claude Code limits that every skill must work within:
+
+| Constraint | Short form |
+|------------|------------|
+| `AskUserQuestion.options` max 4 items | Truncate dynamic lists to 3 + cancel |
+| `Skill(...)` cannot invoke `disable-model-invocation: true` skills | Use the underlying binary directly |
+| `Bash` cwd resets between calls | Chain with `&&` or use absolute paths |
+
+#### Pre-commit hook (planned)
+
+A pre-commit hook that validates `verified-against-runtime: true` + commit body
+note for `skills/*/SKILL.md` changes is planned as a follow-up to Issue #208.
+It is not yet enforced — the frontmatter + commit body convention above is the
+current gate.
+
+## Adding or modifying a hook
+
+1. Survey ≥ 2 sibling implementations under `hooks/` for established conventions
+   (state-key naming, payload field access, exit-code semantics) before writing
+   your spec. See the **Convention Survey Before Design** rule in `CLAUDE.md`.
+2. Write the hook + tests, register in `hooks/hooks.json`.
+3. Create `docs/hook/<name>.md` (use an existing spec as a template).
+4. Add a row to the hook index table in `CLAUDE.md`.
+5. Run `./scripts/check-plugin-manifests.py` to confirm packaging is clean.
+
+## Packaging
+
+**Do not edit generated files directly.** The following are generated outputs:
+
+- `.claude-plugin/plugin.json`
+- `.claude-plugin/marketplace.json`
+- `.agents/plugins/marketplace.json`
+- `plugins/praxis/.codex-plugin/plugin.json`
+
+To regenerate after changing `manifests/*.json` or `VERSION`:
+
+```bash
+./scripts/build-plugin-manifests.py
+./scripts/check-plugin-manifests.py   # verify no drift
+```
+
+## Commit conventions
+
+- Format: `type(scope): description` (Conventional Commits)
+- Title: max 50 characters, lowercase, no trailing period
+- Body: written in English; include a `verified:` line when the change touches
+  a skill spec (see above)
+- Never commit directly to `main`; always use a branch + PR
+
+## Testing
+
+```bash
+# Run the full test suite from the repo root
+python -m pytest tests/
+```
+
+New hooks must ship with tests under `tests/`. New skills do not require
+automated tests, but must satisfy the live runtime verification requirement
+described above.

--- a/RUNTIME_CONSTRAINTS.md
+++ b/RUNTIME_CONSTRAINTS.md
@@ -1,0 +1,105 @@
+# Runtime Constraints
+
+Fixed limits of the Claude Code runtime and related CLIs that affect every skill.
+Skill spec authors: read this **before** writing a spec that calls external tools
+or surfaces options to the user. These are not bugs — they are stable constraints
+that will not change without a major Claude Code release.
+
+Each entry follows this structure:
+- **Constraint**: one-line summary
+- **Why it bites skills**: which pattern silently fails
+- **Workaround**: the safe alternative
+- **Verified**: verification date / Claude Code version / source
+
+---
+
+## 1. `AskUserQuestion.options` — hard cap of 4 items
+
+**Constraint**: `AskUserQuestion` enforces `maxItems: 4` on the `options` array.
+Any spec that surfaces N > 4 options is structurally impossible — the schema
+rejects it before the tool runs.
+
+**Why it bites skills**: Skills that enumerate dynamic lists (e.g., all active
+worktrees, all open issues, all provider names) and pass them directly as options
+will fail when N > 4. The spec looks correct in isolation but breaks in any
+realistic session with more than 3 enumerated items.
+
+**Workaround**: Truncate to at most 3 meaningful options, then add a 4th option
+that is either:
+- `"취소"` — abort the flow; or
+- `"Other (직접 입력)"` — fall through to a free-form follow-up question.
+
+For a dynamic list longer than 3 items, surface the top 3 most likely candidates
+(e.g., most-recently modified worktrees, most-recently touched issues) and use
+the 4th slot for "Other / cancel". Never silently drop items without telling the
+user that the list was truncated.
+
+**Verified**: 2026-05-13 / Claude Code (Sonnet 4.6) / Issue #208 — observed
+failure: `codex-review-wrap` Step 2 attempted to surface all 8 active worktrees
+as options, which is impossible per the `maxItems: 4` JSON schema constraint.
+
+---
+
+## 2. `Skill(...)` cannot invoke a skill that declares `disable-model-invocation: true`
+
+**Constraint**: Claude Code prevents a skill invoked via `Skill(...)` from
+internally calling another skill that declares `disable-model-invocation: true`
+in its frontmatter (e.g., `/codex:review`).
+
+**Why it bites skills**: A wrapper skill that delegates to `codex:review` via
+`Skill("codex:review")` will fail silently or with an opaque error. The wrapper
+appears correct in spec — the delegation step is never reached at runtime.
+
+**Workaround**: Instead of `Skill(...)`, invoke the underlying binary directly.
+For `codex:review`, that means:
+1. Resolve the `codex-companion.mjs` path from `installed_plugins.json`.
+2. Call `node "{companion_path}" review {{ARGUMENTS}}` via `Bash`.
+
+This matches what `/codex:review` does in its own foreground flow and is the
+canonical pattern already implemented in `codex-review-wrap` Step 4.
+
+If the companion binary is not found, surface alternatives via `AskUserQuestion`
+(see `codex-review-wrap` Step 4a for the reference implementation).
+
+**Verified**: 2026-05-13 / Claude Code (Sonnet 4.6) / Issue #208 — `codex-review-wrap`
+redesigned to use `node codex-companion.mjs` directly after `Skill("codex:review")`
+delegation was confirmed non-viable.
+
+---
+
+## 3. `Bash` tool — cwd resets between invocations
+
+**Constraint**: Each `Bash` tool call starts with the session's original cwd.
+A `cd /some/path` in one `Bash` call does **not** persist to the next call.
+
+**Why it bites skills**: Skills that split a multi-step operation across two
+`Bash` calls (cd in the first, use the new cwd in the second) will silently
+run the second command in the wrong directory. This causes incorrect `git`
+operations, wrong file reads, and misrouted CLI invocations — all without an
+error message, because the wrong directory is still a valid path.
+
+**Workaround**: Use one of:
+- **Single `Bash` call with `&&` chaining**: `cd /path && git status && node script.mjs`
+- **Absolute paths throughout**: pass the full path to every command rather than
+  relying on cwd — `git -C /path status`, `node /path/script.mjs`.
+
+Never split a cwd-sensitive operation across multiple `Bash` calls. If the
+operation is too long for one call, restructure it to use absolute paths.
+
+**Verified**: 2026-05-13 / Claude Code (Sonnet 4.6) / Issue #208 / global
+`CLAUDE.md` rule "Bash Redirect on Existing Path Requires Read-First" and
+"worktree-context-pre-git-op" memory — the per-call cwd reset is the root
+cause of the class of bugs these rules address.
+
+---
+
+## Adding a new entry
+
+1. Observe a constraint that is **fixed by the runtime** (not a project
+   convention or a configurable setting).
+2. Verify it by hitting the constraint in a live session.
+3. Add an entry using the four-field structure above.
+4. Open a PR referencing the issue where you observed it.
+
+Pre-commit hook validation for this file: planned for a future PR (tracked in
+Issue #208).

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -11,6 +11,9 @@ description: >
   in the session ledger.
   Triggers on "codex review", "review codex", "safe review", "/codex-review-wrap",
   "premise verification", "flip detection", "sibling defect", "sibling cross-check".
+verified-against-runtime: true
+runtime-verified-at: 2026-05-13
+runtime-verified-note: "codex-companion 1.0.4 — ARGUMENTS rejected for non-flag string; AskUserQuestion maxItems:4 blocks worktree list >3 items; Skill() cannot delegate to disable-model-invocation skill"
 ---
 
 # codex-review-wrap

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -89,15 +89,25 @@ Skip selection. Proceed directly to Step 3 using cwd.
 
 **Case B — 2 or more non-bare worktrees:**
 
-Call `AskUserQuestion` with:
+Call `AskUserQuestion` with at most **3** worktree options + `"취소"` to
+respect the `AskUserQuestion.options` `maxItems: 4` runtime cap (see
+`RUNTIME_CONSTRAINTS.md`). When more than 3 worktrees are active, rank
+by recency (most recent HEAD commit time first) and surface the top 3;
+the runtime's automatic "Other" slot lets the user type any worktree
+path not in the list.
 
 ```
 title: "어느 worktree 를 review 할까요?"
-question: "현재 활성 worktrees:\n{numbered list}\n\n번호를 입력하거나 경로를 직접 입력하세요."
-options: [{path}: ({branch}) for each worktree] + ["취소"]
+question: "현재 활성 worktrees:\n{numbered list of ALL worktrees}\n\n번호를 선택하거나 'Other' 에 경로를 직접 입력하세요."
+options: [{path}: ({branch}) for top 3 most-recently-updated worktrees] + ["취소"]
 ```
 
-Wait for user response. If "취소" or no selection → abort with message:
+The full worktree list still appears in the `question` body so the user
+can read every path even when only the top 3 are surfaced as options.
+If the user picks `"Other"` and types a path, validate it against the
+full `git worktree list` output before proceeding.
+
+Wait for user response. If `"취소"` or no selection → abort with message:
 "Review 취소됨. 대상을 선택하지 않았습니다."
 
 ### Step 3: Confirm Selected Target


### PR DESCRIPTION
## 요약

이슈 #208에서 식별된 스킬 스펙 드리프트 문제를 구조적으로 방지하기 위한 게이트를 추가합니다.

## 변경 사항

### 1. `RUNTIME_CONSTRAINTS.md` 신규 추가 (repo root)

Claude Code 런타임의 고정 제약 사항을 문서화합니다. 스킬 스펙 작성자가 이를 사전에 인지하여 드리프트를 방지할 수 있도록 합니다.

초기 3개 항목:
- `AskUserQuestion.options` 최대 4개 제한 — N>3 옵션은 상위 3개 + 취소/기타로 truncate 필수
- `Skill(...)` 로 `disable-model-invocation: true` 스킬 호출 불가 — 직접 바이너리 실행 필요
- `Bash` tool의 cwd가 호출 간 reset됨 — `&&` 체이닝 또는 절대경로 사용 필수

### 2. `skills/codex-review-wrap/SKILL.md` frontmatter 보강 (canary)

외부 CLI를 wrap하는 스킬의 런타임 검증 frontmatter 필드를 추가합니다:
- `verified-against-runtime: true`
- `runtime-verified-at: 2026-05-13`
- `runtime-verified-note: "codex-companion 1.0.4 — ARGUMENTS rejected for non-flag string; AskUserQuestion maxItems:4 blocks worktree list >3 items; Skill() cannot delegate to disable-model-invocation skill"`

### 3. `CONTRIBUTING.md` 신규 추가

스킬 작성 가이드라인을 문서화합니다:
- "Skill spec drift prevention" 섹션 — 외부 CLI를 wrap하는 스킬의 live round-trip 검증 의무화
- frontmatter 필드 요구사항 및 커밋 본문 요구사항 명시
- `RUNTIME_CONSTRAINTS.md` 참조 및 constraint 요약 테이블

## Acceptance Criteria

- [x] `RUNTIME_CONSTRAINTS.md` 추가 — 초기 3개 항목 포함
- [x] `codex-review-wrap` (canary) `verified-against-runtime: true` frontmatter 및 커밋 본문 runtime 노트 추가
- [ ] pre-commit hook 구현 — **followup 작업 (별도 이슈 권장)**. `CONTRIBUTING.md` 에 "planned" 으로 명시됨.
- [x] 스킬 작성 가이드라인(`CONTRIBUTING.md`) 신규 추가 — `RUNTIME_CONSTRAINTS.md` 참조 섹션 포함

## Out of scope (이 PR)

- pre-commit hook 구현: `CONTRIBUTING.md`에 followup 작업으로 명시. 별도 이슈로 추적 권장.
- 다른 스킬들의 frontmatter 일괄 적용: `codex-review-wrap`만 canary로 적용.

Closes #208
