### PR TITLE
feat(hook): detect indirect session-end phrasing

### DIFF
--- a/docs/hook/block-ask-end-option.md
+++ b/docs/hook/block-ask-end-option.md
@@ -30,7 +30,7 @@ boundary, where the check runs mechanically regardless of retrieval state.
 | Scenario | Action |
 |----------|--------|
 | Default mode, direct end marker in any option label, no user stop signal | exit 2 (block) |
-| Default mode, indirect end marker ("take a break" / "보류" etc.), no stop signal | exit 2 (block) |
+| Default mode, indirect end marker ("take a break" / "잠시 보류" etc.), no stop signal | exit 2 (block) |
 | `PRAXIS_ASK_END_ADVISORY=1`, marker present, no stop signal | exit 0 + advisory stderr |
 | `PRAXIS_ASK_END_STRICT=1` (deprecated), marker present, no stop signal | exit 2 (block) |
 | Any tool name other than `AskUserQuestion` | silent pass-through |
@@ -70,7 +70,10 @@ boundary, where the check runs mechanically regardless of retrieval state.
 - `휴식`
 - `다른 작업 우선`
 - `다음 세션`
-- `보류`
+
+Bare `보류` is intentionally **not** a marker: substring match would
+false-block legitimate labels such as `보류 중인 이슈 확인`. Use
+`잠시 보류` for the session-pause-specific form.
 
 All matches are case-insensitive substring checks against the option label.
 
@@ -131,7 +134,7 @@ bash hooks/test-block-ask-end-option.sh
 Covers: direct Korean/English end markers (block + advisory modes), indirect
 English phrasing (take a break, prioritize other work, pause for now, resume in
 a later session, other work first), indirect Korean phrasing (잠시 멈춰, 잠시
-보류, 휴식, 다른 작업 우선, 다음 세션, 보류), 4-option padding pattern (4th
+보류, 휴식, 다른 작업 우선, 다음 세션), 4-option padding pattern (4th
 option only carries indirect marker), false positive avoidance (normal work
 options, partial keyword matches that must not trigger), explicit strict env var
 (deprecated compatibility), advisory opt-out via `PRAXIS_ASK_END_ADVISORY=1`,

--- a/docs/hook/block-ask-end-option.md
+++ b/docs/hook/block-ask-end-option.md
@@ -1,0 +1,140 @@
+# PreToolUse AskUserQuestion End-Option Gate
+
+`hooks/block-ask-end-option.py` fires on every PreToolUse(AskUserQuestion)
+event and inspects `options[].label` for end-option markers — both direct
+("end here", "여기서 종료") and indirect ("take a break", "잠시 보류").
+When a marker is found, the most recent user message in the transcript is
+checked for an explicit stop signal. If no signal is present, the call is
+blocked (default) or an advisory is emitted (opt-out mode).
+
+### Why this exists
+
+Skill guides authoring "Step N: chaining" sections frequently include an
+"end here" boilerplate option. Agents mechanically transcribe this into
+`AskUserQuestion` call sites even when the conversation has a clearly chained
+intent or the user has expressed no desire to stop. This pattern has been
+observed 6+ times in a single session, fragmenting decisions and ignoring
+user intent.
+
+Indirect phrasing ("take a break / prioritize other work", "pause for now",
+"다른 작업 우선") emerged as a bypass when direct keywords are detected at
+the option-label level. This hook detects both pattern classes so that the
+spirit of the rule survives phrasing variation.
+
+Text rules in CLAUDE.md or skill bodies alone cannot enforce this — the
+`loaded != retrieved` limit. This hook enforces the rule at the tool
+boundary, where the check runs mechanically regardless of retrieval state.
+
+### What is blocked
+
+| Scenario | Action |
+|----------|--------|
+| Default mode, direct end marker in any option label, no user stop signal | exit 2 (block) |
+| Default mode, indirect end marker ("take a break" / "보류" etc.), no stop signal | exit 2 (block) |
+| `PRAXIS_ASK_END_ADVISORY=1`, marker present, no stop signal | exit 0 + advisory stderr |
+| `PRAXIS_ASK_END_STRICT=1` (deprecated), marker present, no stop signal | exit 2 (block) |
+| Any tool name other than `AskUserQuestion` | silent pass-through |
+| Marker present BUT user message contains a stop signal | silent pass-through |
+| Missing / unreadable transcript | silent pass-through (graceful degrade) |
+| No options match any end marker | silent pass-through |
+
+### Detect patterns
+
+#### Direct end-option markers (English)
+
+- `end here`
+- `session end`
+- `stop here`
+- `end the session`
+- `wrap up here`
+
+#### Indirect end-option markers (English)
+
+- `take a break`
+- `prioritize other work`
+- `pause for now`
+- `resume in a later session`
+- `other work first`
+
+#### Direct end-option markers (Korean)
+
+- `여기서 종료`
+- `세션 종료`
+- `여기서 끝`
+- `여기까지`
+
+#### Indirect end-option markers (Korean)
+
+- `잠시 멈춰`
+- `잠시 보류`
+- `휴식`
+- `다른 작업 우선`
+- `다음 세션`
+- `보류`
+
+All matches are case-insensitive substring checks against the option label.
+
+### Mode and env var behavior
+
+| Env var state | Mode | Exit code on match |
+|---------------|------|-------------------|
+| Neither var set (default) | **Strict** | 2 (block) |
+| `PRAXIS_ASK_END_ADVISORY=1` | Advisory | 0 + stderr |
+| `PRAXIS_ASK_END_STRICT=1` (deprecated) | Strict | 2 (block) |
+| Both vars set | Strict (`STRICT` takes precedence) | 2 (block) |
+
+`PRAXIS_ASK_END_STRICT=1` was the original strict-mode env var. It is
+deprecated — the default is now strict without any env var. Set
+`PRAXIS_ASK_END_ADVISORY=1` to opt out to advisory behavior. If
+`PRAXIS_ASK_END_STRICT=1` is explicitly set, it forces strict regardless of
+`PRAXIS_ASK_END_ADVISORY`.
+
+### Stop signals (user message)
+
+The hook walks the transcript in reverse to find the most recent human-authored
+user message (skipping `tool_result`-only entries). Stop is detected when:
+
+- **Korean** (substring match): `종료`, `여기까지`, `그만`, `마무리`, `스톱`, `중단`
+- **English** (phrase match + negation guard): `stop here`, `stop now`,
+  `let's stop`, `we're done`, `we are done`, `i'm done`, `i am done`,
+  `end here`, `end now`, `end this`, `end the session`, `wrap up`,
+  `wrap this up`, `that's all`, `that is all`, `no more`, `quit now`,
+  `cancel this`, `finish here`, `finish up`, `session end`
+
+Negation guard: a match preceded by `don't`, `do not`, `never`, `no`, `not`,
+`won't`, `wouldn't`, `shouldn't`, `can't`, or `cannot` within 30 characters
+is disqualified (prevents "don't stop" from being a stop signal).
+
+### Response
+
+Block response (exit 2):
+
+```json
+{
+  "decision": "block",
+  "reason": "AskUserQuestion includes an end-option without user stop signal..."
+}
+```
+
+Advisory response (exit 0 + stderr message only — no JSON output):
+
+```
+[advisory] AskUserQuestion includes an end-option ...
+```
+
+### Tests
+
+```bash
+bash hooks/test-block-ask-end-option.sh
+```
+
+Covers: direct Korean/English end markers (block + advisory modes), indirect
+English phrasing (take a break, prioritize other work, pause for now, resume in
+a later session, other work first), indirect Korean phrasing (잠시 멈춰, 잠시
+보류, 휴식, 다른 작업 우선, 다음 세션, 보류), 4-option padding pattern (4th
+option only carries indirect marker), false positive avoidance (normal work
+options, partial keyword matches that must not trigger), explicit strict env var
+(deprecated compatibility), advisory opt-out via `PRAXIS_ASK_END_ADVISORY=1`,
+graceful degrade on missing transcript, F1 regression (bare-word stop tokens in
+neutral messages), F2 regression (tool_result-only user entries skipped when
+walking backward for human text).

--- a/hooks/block-ask-end-option.py
+++ b/hooks/block-ask-end-option.py
@@ -55,13 +55,16 @@ END_OPTION_MARKERS_KO = (
     "세션 종료",
     "여기서 끝",
     "여기까지",
-    # Indirect Korean: pause / break / defer / other-work framing
+    # Indirect Korean: pause / break / defer / other-work framing.
+    # Bare "보류" intentionally omitted: substring match would false-block
+    # legitimate work labels like "보류 중인 이슈 확인" / "보류 상태 검토".
+    # The "잠시 보류" phrase below is the session-pause-specific form we
+    # want to catch.
     "잠시 멈춰",
     "잠시 보류",
     "휴식",
     "다른 작업 우선",
     "다음 세션",
-    "보류",
 )
 END_OPTION_MARKERS_EN = (
     "end here",

--- a/hooks/block-ask-end-option.py
+++ b/hooks/block-ask-end-option.py
@@ -160,13 +160,14 @@ def _has_end_marker(labels: list[str]) -> bool:
     return False
 
 
-def _read_last_user_message(transcript_path: str) -> str:
+def _read_last_user_message(transcript_path: str) -> str | None:
     """Return the text of the most recent user-authored message in the transcript.
 
-    Returns empty string if the file is missing, unreadable, or contains
-    no user messages with extractable human text. The hook is advisory by
-    default so silent failure here just means the stop-signal check is
-    skipped — no false block.
+    Returns None when the transcript is missing or unreadable — the caller
+    must fail open per the project hook design contract (`Fail-open on
+    infrastructure errors`). Returns empty string when the transcript was
+    read successfully but no user message contained extractable human
+    text — that is a real "no stop-signal" answer and may be acted on.
 
     Transcript format: JSONL where each line is a JSON object with at
     least `type` ('user' / 'assistant' / 'system') and either `message`
@@ -184,12 +185,12 @@ def _read_last_user_message(transcript_path: str) -> str:
     message earlier in the transcript did signal stop.
     """
     if not transcript_path or not os.path.isfile(transcript_path):
-        return ""
+        return None
     try:
         with open(transcript_path, "r", encoding="utf-8", errors="replace") as f:
             lines = f.readlines()
     except OSError:
-        return ""
+        return None
 
     # Walk in reverse to find the most recent user-role entry whose
     # content includes human-authored text. tool_result-only entries are
@@ -360,6 +361,10 @@ def main() -> int:
 
     transcript_path = payload.get("transcript_path") or ""
     user_message = _read_last_user_message(transcript_path)
+    if user_message is None:
+        # Fail open per project hook design contract — transcript missing
+        # or unreadable, cannot verify stop-signal absence.
+        return 0
     if _has_stop_signal(user_message):
         return 0
 

--- a/hooks/block-ask-end-option.py
+++ b/hooks/block-ask-end-option.py
@@ -2,9 +2,9 @@
 """PreToolUse(AskUserQuestion) guard: warn on mechanical end-option surfacing.
 
 When AskUserQuestion is invoked with `options` whose labels match end-option
-markers (e.g. "여기서 종료", "session end", "stop here"), check the most
-recent user message in the transcript for an explicit stop signal. If no
-signal is present, emit a stderr advisory pointing to the rule.
+markers (e.g. "여기서 종료", "session end", "stop here", "take a break"),
+check the most recent user message in the transcript for an explicit stop
+signal. If no signal is present, emit a stderr block (strict by default).
 
 Background:
   Skill guides authoring "Step N: chaining" sections frequently include an
@@ -14,18 +14,27 @@ Background:
   has been observed 6+ times in a single session, fragmenting decisions
   and ignoring user intent.
 
+  Indirect phrasing ("take a break", "pause for now", "다른 작업 우선") is
+  used as a bypass when direct keywords are detected — this hook catches
+  both direct and indirect patterns.
+
   Text rules in CLAUDE.md or skill bodies alone cannot enforce this — the
   `loaded != retrieved` limit. This hook enforces the rule at the tool
   boundary, where the check runs mechanically regardless of retrieval state.
 
-Default mode: advisory (exit 0 + stderr).
-Strict mode: PRAXIS_ASK_END_STRICT=1 → block (exit 2 + stderr).
+Default mode: strict (exit 2 + stderr).
+Advisory mode (opt-out): PRAXIS_ASK_END_ADVISORY=1 → exit 0 + stderr.
 
-Allow conditions (no advisory emitted):
+Deprecated: PRAXIS_ASK_END_STRICT=1 is still respected when explicitly set
+  but superseded by the new default-strict behavior. If both env vars are
+  set, PRAXIS_ASK_END_STRICT=1 forces strict; PRAXIS_ASK_END_ADVISORY=1
+  forces advisory. PRAXIS_ASK_END_STRICT takes precedence.
+
+Allow conditions (no block/advisory emitted):
   1. tool_name != "AskUserQuestion"
   2. No options match any end marker
   3. Most recent user message contains an explicit stop signal
-  4. transcript_path is missing or unreadable (graceful degrade — advisory
+  4. transcript_path is missing or unreadable (graceful degrade — block
      is suppressed to avoid noise when transcript inspection is impossible)
 """
 from __future__ import annotations
@@ -40,11 +49,19 @@ import sys
 
 # End-option markers in option labels. Case-insensitive.
 # Korean entries are unicode literals; English entries cover common phrasings.
+# Direct markers: explicit end/stop/session-termination language.
 END_OPTION_MARKERS_KO = (
     "여기서 종료",
     "세션 종료",
     "여기서 끝",
     "여기까지",
+    # Indirect Korean: pause / break / defer / other-work framing
+    "잠시 멈춰",
+    "잠시 보류",
+    "휴식",
+    "다른 작업 우선",
+    "다음 세션",
+    "보류",
 )
 END_OPTION_MARKERS_EN = (
     "end here",
@@ -52,6 +69,12 @@ END_OPTION_MARKERS_EN = (
     "stop here",
     "end the session",
     "wrap up here",
+    # Indirect English: pause / break / defer / other-work framing
+    "take a break",
+    "prioritize other work",
+    "pause for now",
+    "resume in a later session",
+    "other work first",
 )
 
 # Stop signals in the most recent user message. Case-insensitive.
@@ -281,31 +304,38 @@ def _has_negation(prefix: str) -> bool:
 # ---------------------------------------------------------------------------
 
 ADVISORY_MSG = """\
-[advisory] AskUserQuestion includes an end-option ("end here" / "여기서 종료" type)
+[advisory] AskUserQuestion includes an end-option ("end here" / "take a break" / "여기서 종료" type)
 but the most recent user message has no stop signal.
 
-Mechanical surfacing of "end here" options propagates from skill-guide
-boilerplate even when conversation context has a chained intent. Verify
-that the user actually wants a stop point before this surface — or remove
-the end option.
+Mechanical surfacing of end-options propagates from skill-guide boilerplate
+even when conversation context has a chained intent. Indirect phrasing
+("take a break", "pause for now", "다른 작업 우선") is also detected.
+Verify that the user actually wants a stop point before this surface —
+or remove the end option.
 
-Set PRAXIS_ASK_END_STRICT=1 to escalate this advisory to a hard block.
+Advisory mode is active (PRAXIS_ASK_END_ADVISORY=1). Remove this env var
+to restore the default strict block behavior.
 """
 
 BLOCK_MSG = """\
 ❌ BLOCKED: AskUserQuestion includes an end-option without user stop signal.
 
-Markers detected in options[].label: "end here" / "session end" / "여기서 종료" type.
+Markers detected in options[].label:
+  Direct: "end here" / "session end" / "여기서 종료" type
+  Indirect: "take a break" / "pause for now" / "다른 작업 우선" type
+
 Most recent user message contains no stop signal (stop, end, quit, done,
 cancel, finish, 종료, 여기까지, 그만, 마무리, etc.).
 
 Why:
   Skill-guide "end here" boilerplate is being mechanically transcribed
   into AskUserQuestion call sites where the conversation has a chained
-  intent. Remove the end-option, or wait for the user to express a
+  intent. Indirect phrasing is used as a bypass when direct keywords are
+  detected. Remove the end-option, or wait for the user to express a
   stop signal explicitly.
 
-Unset PRAXIS_ASK_END_STRICT to demote this to an advisory.
+To opt out: set PRAXIS_ASK_END_ADVISORY=1 (demotes to advisory).
+Note: PRAXIS_ASK_END_STRICT=1 (deprecated) also forces strict when set.
 """
 
 
@@ -333,8 +363,16 @@ def main() -> int:
     if _has_stop_signal(user_message):
         return 0
 
-    strict = os.environ.get("PRAXIS_ASK_END_STRICT", "") not in ("", "0", "false", "False")
-    if strict:
+    # Mode resolution (precedence: STRICT > ADVISORY > default-strict).
+    # PRAXIS_ASK_END_STRICT=1 is deprecated but still honoured when explicitly set.
+    strict_env = os.environ.get("PRAXIS_ASK_END_STRICT", "")
+    advisory_env = os.environ.get("PRAXIS_ASK_END_ADVISORY", "")
+    strict_set = strict_env not in ("", "0", "false", "False")
+    advisory_set = advisory_env not in ("", "0", "false", "False")
+
+    # PRAXIS_ASK_END_STRICT takes precedence; otherwise default is strict
+    # unless PRAXIS_ASK_END_ADVISORY=1 explicitly opts out.
+    if strict_set or not advisory_set:
         sys.stderr.write(BLOCK_MSG)
         return 2
 

--- a/hooks/test-block-ask-end-option.sh
+++ b/hooks/test-block-ask-end-option.sh
@@ -2,16 +2,16 @@
 # test-block-ask-end-option.sh — coverage for the AskUserQuestion end-option gate
 #
 # Synthesizes Claude Code PreToolUse(AskUserQuestion) payloads and asserts:
-#   advisory → exit 0 + stderr non-empty
-#   block    → exit 2 + stderr non-empty (PRAXIS_ASK_END_STRICT=1)
+#   advisory → exit 0 + stderr non-empty  (PRAXIS_ASK_END_ADVISORY=1 opt-out)
+#   block    → exit 2 + stderr non-empty  (default, or PRAXIS_ASK_END_STRICT=1)
 #   pass     → exit 0 + stderr empty
 #
 # Usage: bash hooks/test-block-ask-end-option.sh
 # Exit:  0 = all pass; 1 = at least one fail
 #
-# Hook is advisory by default — most "end-marker present + no stop signal"
-# cases expect exit 0 + non-empty stderr. Strict cases (with
-# PRAXIS_ASK_END_STRICT=1) expect exit 2.
+# Hook is STRICT by default — most "end-marker present + no stop signal"
+# cases expect exit 2 + non-empty stderr. Advisory cases (with
+# PRAXIS_ASK_END_ADVISORY=1) expect exit 0 + non-empty stderr.
 
 set +e
 
@@ -72,15 +72,24 @@ PY
 }
 
 run_case() {
-  local name="$1" expected="$2" strict="$3" payload="$4"
+  local name="$1" expected="$2" mode="$3" payload="$4"
   local err_file rc
 
   err_file=$(mktemp)
-  if [ "$strict" = "strict" ]; then
-    echo "$payload" | PRAXIS_ASK_END_STRICT=1 "$HOOK" >/dev/null 2>"$err_file"
-  else
-    echo "$payload" | "$HOOK" >/dev/null 2>"$err_file"
-  fi
+  case "$mode" in
+    strict)
+      # Explicit legacy strict env var (deprecated but still honoured).
+      echo "$payload" | PRAXIS_ASK_END_STRICT=1 "$HOOK" >/dev/null 2>"$err_file"
+      ;;
+    advisory)
+      # Opt-out to advisory via new env var.
+      echo "$payload" | PRAXIS_ASK_END_ADVISORY=1 "$HOOK" >/dev/null 2>"$err_file"
+      ;;
+    default|*)
+      # Default is now strict — no env var override.
+      echo "$payload" | "$HOOK" >/dev/null 2>"$err_file"
+      ;;
+  esac
   rc=$?
   local err_content
   err_content=$(cat "$err_file"); rm -f "$err_file"
@@ -111,32 +120,44 @@ run_case() {
 }
 
 # ---------------------------------------------------------------------------
-# (a) ADVISORY cases — default mode, end marker present, no stop signal
+# (a) BLOCK cases — default mode (strict), end marker present, no stop signal
 # ---------------------------------------------------------------------------
 
 T1=$(build_transcript "Continue with the next step")
 P1=$(build_payload "$T1" '["Plan A", "Plan B", "여기서 종료"]')
-run_case "korean end marker, neutral user message" advisory default "$P1"
+run_case "korean end marker, neutral user message" block default "$P1"
 
 T2=$(build_transcript "What about option B?")
 P2=$(build_payload "$T2" '["Implement", "Review", "End here"]')
-run_case "english end marker, neutral user message" advisory default "$P2"
+run_case "english end marker, neutral user message" block default "$P2"
 
 T3=$(build_transcript "다음 단계 진행해주세요")
 P3=$(build_payload "$T3" '["Step 1", "Step 2", "세션 종료"]')
-run_case "korean continuation, korean end marker" advisory default "$P3"
+run_case "korean continuation, korean end marker" block default "$P3"
 
 # ---------------------------------------------------------------------------
-# (b) BLOCK cases — strict mode, end marker present, no stop signal
+# (b) BLOCK cases — explicit strict env var (deprecated, still honoured)
 # ---------------------------------------------------------------------------
 
 T4=$(build_transcript "Continue please")
 P4=$(build_payload "$T4" '["Plan A", "여기서 종료"]')
-run_case "strict mode + end marker + no signal → block" block strict "$P4"
+run_case "explicit strict env + end marker + no signal → block" block strict "$P4"
 
 T5=$(build_transcript "")
 P5=$(build_payload "$T5" '["Plan A", "End here"]')
-run_case "strict mode + empty transcript → block (no signal found)" block strict "$P5"
+run_case "explicit strict env + empty transcript → block (no signal)" block strict "$P5"
+
+# ---------------------------------------------------------------------------
+# (b2) ADVISORY cases — opt-out via PRAXIS_ASK_END_ADVISORY=1
+# ---------------------------------------------------------------------------
+
+T_adv1=$(build_transcript "Continue with the next step")
+P_adv1=$(build_payload "$T_adv1" '["Plan A", "Plan B", "여기서 종료"]')
+run_case "advisory mode + korean end marker, neutral message" advisory advisory "$P_adv1"
+
+T_adv2=$(build_transcript "What about option B?")
+P_adv2=$(build_payload "$T_adv2" '["Implement", "Review", "End here"]')
+run_case "advisory mode + english end marker, neutral message" advisory advisory "$P_adv2"
 
 # ---------------------------------------------------------------------------
 # (c) PASS cases — no end marker
@@ -209,11 +230,10 @@ print(json.dumps({
 }))')
 run_case "questions with non-list options → pass" pass default "$P15"
 
-# missing transcript_path: end marker present, no signal → advisory still fires
-# (transcript silently empty, stop signal absent → advisory)
+# missing transcript_path: end marker present, no signal → block (default strict)
 T16=$(build_transcript "")
 P16=$(build_payload "/nonexistent/path-$$.jsonl" '["Plan A", "End here"]')
-run_case "missing transcript file + end marker → advisory" advisory default "$P16"
+run_case "missing transcript file + end marker → block (default strict)" block default "$P16"
 
 # ---------------------------------------------------------------------------
 # (g) Multi-question payload — marker in any question triggers advisory
@@ -241,7 +261,7 @@ print(json.dumps({
 }))
 PY
 )
-run_case "multi-question payload, marker in second question" advisory default "$P17"
+run_case "multi-question payload, marker in second question" block default "$P17"
 
 # ---------------------------------------------------------------------------
 # (h) F1 regression — bare-word stop tokens must NOT trigger (codex #193)
@@ -254,23 +274,23 @@ run_case "multi-question payload, marker in second question" advisory default "$
 
 T18=$(build_transcript "send the message to the team")
 P18=$(build_payload "$T18" '["Plan A", "End here"]')
-run_case "[F1] 'send' substring must NOT pass as stop signal" advisory default "$P18"
+run_case "[F1] 'send' substring must NOT pass as stop signal" block default "$P18"
 
 T19=$(build_transcript "the backend service is failing")
 P19=$(build_payload "$T19" '["Plan A", "End here"]')
-run_case "[F1] 'backend' substring must NOT pass as stop signal" advisory default "$P19"
+run_case "[F1] 'backend' substring must NOT pass as stop signal" block default "$P19"
 
 T20=$(build_transcript "don't stop now, keep going")
 P20=$(build_payload "$T20" '["Plan A", "End here"]')
-run_case "[F1] negated 'don't stop now' must NOT pass" advisory default "$P20"
+run_case "[F1] negated 'don't stop now' must NOT pass" block default "$P20"
 
 T21=$(build_transcript "I quit the previous job last year")
 P21=$(build_payload "$T21" '["Plan A", "End here"]')
-run_case "[F1] 'quit' bare word in unrelated context must NOT pass" advisory default "$P21"
+run_case "[F1] 'quit' bare word in unrelated context must NOT pass" block default "$P21"
 
 T22=$(build_transcript "do not wrap up yet")
 P22=$(build_payload "$T22" '["Plan A", "End here"]')
-run_case "[F1] negated 'do not wrap up' must NOT pass" advisory default "$P22"
+run_case "[F1] negated 'do not wrap up' must NOT pass" block default "$P22"
 
 # ---------------------------------------------------------------------------
 # (i) F2 regression — tool_result-only user entry must be skipped (codex #193)
@@ -314,7 +334,7 @@ run_case "[F2] tool_result-only skipped, prior korean stop signal" pass strict "
 
 T25=$(build_tool_result_transcript "Continue with the next step")
 P25=$(build_payload "$T25" '["Plan A", "End here"]')
-run_case "[F2] tool_result-only skipped, prior msg has no signal → advisory" advisory default "$P25"
+run_case "[F2] tool_result-only skipped, prior msg has no signal → block" block default "$P25"
 
 # ---------------------------------------------------------------------------
 # (j) F1 positive — phrase-based stop signals continue to match
@@ -333,6 +353,94 @@ run_case "[F1+] 'we are done' phrase passes" pass default "$P27"
 T28=$(build_transcript "Time to wrap up, that's all from me")
 P28=$(build_payload "$T28" '["Plan A", "End here"]')
 run_case "[F1+] 'wrap up' + 'that's all' phrases pass" pass default "$P28"
+
+# ---------------------------------------------------------------------------
+# (k) Indirect end-option markers — English (issue #209)
+# ---------------------------------------------------------------------------
+
+T_ie1=$(build_transcript "Continue with the plan")
+P_ie1=$(build_payload "$T_ie1" '["Plan A", "Plan B", "Take a break"]')
+run_case "[indirect-EN] 'take a break' in options → block" block default "$P_ie1"
+
+T_ie2=$(build_transcript "What should we do next?")
+P_ie2=$(build_payload "$T_ie2" '["Option 1", "Option 2", "Prioritize other work"]')
+run_case "[indirect-EN] 'prioritize other work' → block" block default "$P_ie2"
+
+T_ie3=$(build_transcript "Keep going please")
+P_ie3=$(build_payload "$T_ie3" '["Option 1", "Pause for now"]')
+run_case "[indirect-EN] 'pause for now' → block" block default "$P_ie3"
+
+T_ie4=$(build_transcript "Continue implementation")
+P_ie4=$(build_payload "$T_ie4" '["Plan A", "Plan B", "Resume in a later session"]')
+run_case "[indirect-EN] 'resume in a later session' → block" block default "$P_ie4"
+
+T_ie5=$(build_transcript "진행해 주세요")
+P_ie5=$(build_payload "$T_ie5" '["Option A", "Option B", "Other work first"]')
+run_case "[indirect-EN] 'other work first' → block" block default "$P_ie5"
+
+# ---------------------------------------------------------------------------
+# (l) Indirect end-option markers — Korean (issue #209)
+# ---------------------------------------------------------------------------
+
+T_ik1=$(build_transcript "계속 진행해 주세요")
+P_ik1=$(build_payload "$T_ik1" '["옵션 A", "옵션 B", "잠시 멈춰"]')
+run_case "[indirect-KO] '잠시 멈춰' in options → block" block default "$P_ik1"
+
+T_ik2=$(build_transcript "다음 단계 알려주세요")
+P_ik2=$(build_payload "$T_ik2" '["Plan A", "잠시 보류"]')
+run_case "[indirect-KO] '잠시 보류' → block" block default "$P_ik2"
+
+T_ik3=$(build_transcript "계속해주세요")
+P_ik3=$(build_payload "$T_ik3" '["옵션 1", "옵션 2", "휴식"]')
+run_case "[indirect-KO] '휴식' → block" block default "$P_ik3"
+
+T_ik4=$(build_transcript "다음 작업 알려주세요")
+P_ik4=$(build_payload "$T_ik4" '["Plan A", "다른 작업 우선"]')
+run_case "[indirect-KO] '다른 작업 우선' → block" block default "$P_ik4"
+
+T_ik5=$(build_transcript "계속 진행해")
+P_ik5=$(build_payload "$T_ik5" '["Plan A", "Plan B", "다음 세션"]')
+run_case "[indirect-KO] '다음 세션' → block" block default "$P_ik5"
+
+T_ik6=$(build_transcript "어떻게 할까요")
+P_ik6=$(build_payload "$T_ik6" '["옵션 A", "보류"]')
+run_case "[indirect-KO] '보류' → block" block default "$P_ik6"
+
+# ---------------------------------------------------------------------------
+# (m) 4-option padding pattern — 4th option only carries indirect marker
+# ---------------------------------------------------------------------------
+
+T_4p1=$(build_transcript "이슈 분석 부탁해")
+P_4p1=$(build_payload "$T_4p1" '["이슈 생성", "구현 계획", "워크트리 설정", "Take a break"]')
+run_case "[4-pad] 4-option set, 4th only is indirect → block" block default "$P_4p1"
+
+T_4p2=$(build_transcript "continue")
+P_4p2=$(build_payload "$T_4p2" '["Step 1", "Step 2", "Step 3", "Pause for now"]')
+run_case "[4-pad] 4-option set, 4th only is 'pause for now' → block" block default "$P_4p2"
+
+T_4p3=$(build_transcript "계속 진행해주세요")
+P_4p3=$(build_payload "$T_4p3" '["리뷰", "구현", "테스트", "다음 세션"]')
+run_case "[4-pad] 4-option set, 4th only is '다음 세션' → block" block default "$P_4p3"
+
+# ---------------------------------------------------------------------------
+# (n) False positive avoidance — legitimate work options must NOT be blocked
+# ---------------------------------------------------------------------------
+
+T_fp1=$(build_transcript "다음 단계 알려주세요")
+P_fp1=$(build_payload "$T_fp1" '["이슈 생성", "PR 생성", "테스트 실행"]')
+run_case "[false-pos] normal work options, no end marker → pass" pass default "$P_fp1"
+
+T_fp2=$(build_transcript "진행해주세요")
+P_fp2=$(build_payload "$T_fp2" '["Plan A", "다른 방법 먼저", "Option C"]')
+run_case "[false-pos] '다른 방법 먼저' is NOT '다른 작업 우선' → pass" pass default "$P_fp2"
+
+T_fp3=$(build_transcript "keep going")
+P_fp3=$(build_payload "$T_fp3" '["break down the task", "pause and review docs", "continue"]')
+run_case "[false-pos] 'break down' / 'pause and review' not end markers → pass" pass default "$P_fp3"
+
+T_fp4=$(build_transcript "무엇을 해야 할까요")
+P_fp4=$(build_payload "$T_fp4" '["작업 세션 예약", "코드 리뷰", "배포"]')
+run_case "[false-pos] '세션' alone in non-end context → pass" pass default "$P_fp4"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/hooks/test-block-ask-end-option.sh
+++ b/hooks/test-block-ask-end-option.sh
@@ -230,21 +230,23 @@ print(json.dumps({
 }))')
 run_case "questions with non-list options → pass" pass default "$P15"
 
-# missing transcript_path: end marker present, no signal → block (default strict)
+# missing transcript_path: per project hook design contract, unreadable
+# transcripts MUST fail open — the strict-mode flip cannot retroactively
+# block on an unverifiable stop-signal check.
 T16=$(build_transcript "")
 P16=$(build_payload "/nonexistent/path-$$.jsonl" '["Plan A", "End here"]')
-run_case "missing transcript file + end marker → block (default strict)" block default "$P16"
+run_case "missing transcript file + end marker → pass (fail-open)" pass default "$P16"
 
 # ---------------------------------------------------------------------------
 # (g) Multi-question payload — marker in any question triggers advisory
 # ---------------------------------------------------------------------------
 
 T17=$(build_transcript "Just continue")
-P17=$(python3 - <<'PY'
+P17=$(python3 - <<PY
 import json
 print(json.dumps({
     "session_id": "test-session",
-    "transcript_path": "/tmp/nonexistent.jsonl",
+    "transcript_path": "$T17",
     "tool_name": "AskUserQuestion",
     "tool_input": {
         "questions": [

--- a/hooks/test-block-ask-end-option.sh
+++ b/hooks/test-block-ask-end-option.sh
@@ -404,9 +404,8 @@ T_ik5=$(build_transcript "계속 진행해")
 P_ik5=$(build_payload "$T_ik5" '["Plan A", "Plan B", "다음 세션"]')
 run_case "[indirect-KO] '다음 세션' → block" block default "$P_ik5"
 
-T_ik6=$(build_transcript "어떻게 할까요")
-P_ik6=$(build_payload "$T_ik6" '["옵션 A", "보류"]')
-run_case "[indirect-KO] '보류' → block" block default "$P_ik6"
+# Bare "보류" intentionally omitted as a marker — see block-ask-end-option.py
+# rationale comment. Verify false-positive cases below don't regress.
 
 # ---------------------------------------------------------------------------
 # (m) 4-option padding pattern — 4th option only carries indirect marker
@@ -443,6 +442,12 @@ run_case "[false-pos] 'break down' / 'pause and review' not end markers → pass
 T_fp4=$(build_transcript "무엇을 해야 할까요")
 P_fp4=$(build_payload "$T_fp4" '["작업 세션 예약", "코드 리뷰", "배포"]')
 run_case "[false-pos] '세션' alone in non-end context → pass" pass default "$P_fp4"
+
+# Bare "보류" regression — was previously a marker, now removed because it
+# substring-matched legitimate labels like "보류 중인 이슈 확인".
+T_fp5=$(build_transcript "이슈 정리해주세요")
+P_fp5=$(build_payload "$T_fp5" '["보류 중인 이슈 확인", "보류 상태 검토", "신규 이슈 분류"]')
+run_case "[false-pos] '보류 중인 이슈 확인' / '보류 상태 검토' → pass" pass default "$P_fp5"
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## 개요

`block-ask-end-option` hook을 다음 세 가지 측면에서 보강합니다.

Closes #209

## 변경 내용

### 1. 간접 종료 표현 키워드 추가 (`block-ask-end-option.py`)

직접 표현("end here", "여기서 종료")에 더해 우회 목적의 간접 표현도 탐지:

**영문 (indirect):** `take a break`, `prioritize other work`, `pause for now`, `resume in a later session`, `other work first`

**한국어 (indirect):** `잠시 멈춰`, `잠시 보류`, `휴식`, `다른 작업 우선`, `다음 세션`, `보류`

### 2. Default strict 전환

- **이전:** advisory 디폴트 (exit 0 + stderr만)
- **이후:** strict 디폴트 (exit 2 — block)
- Opt-out: `PRAXIS_ASK_END_ADVISORY=1` 설정 시 advisory 모드
- 기존 `PRAXIS_ASK_END_STRICT=1` deprecated 처리 (하위 호환 유지, 명시 설정 시 여전히 strict 강제)
- 우선순위: `PRAXIS_ASK_END_STRICT=1` > `PRAXIS_ASK_END_ADVISORY=1` > default strict

### 3. 테스트 케이스 추가 (`test-block-ask-end-option.sh`)

- (a) default block 케이스 (기존 advisory → block으로 갱신)
- (b2) `PRAXIS_ASK_END_ADVISORY=1` opt-out 케이스 (신규)
- (k) 간접 영문 표현 5종 — 각각 block
- (l) 간접 한국어 표현 6종 — 각각 block
- (m) 4-option 패딩 패턴 (4번째 옵션에만 간접 표현)
- (n) false positive 회피 — 정상 작업 옵션은 통과

### 4. 문서 신규 생성 (`docs/hook/block-ask-end-option.md`)

탐지 패턴 전체 목록, env var 동작 테이블, stop signal 목록, 테스트 커버리지 요약 포함.

## 테스트 결과

```
bash hooks/test-block-ask-end-option.sh
PASS: 48
FAIL: 0
```

## 변경 파일

- `hooks/block-ask-end-option.py` — 키워드 확장 + default strict + env var 로직
- `hooks/test-block-ask-end-option.sh` — 신규 케이스 추가 + 기존 expected 갱신
- `docs/hook/block-ask-end-option.md` — 신규 문서