### PR TITLE
feat(hook): block manufactured action-menu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,7 @@ Design contract shared by all hooks:
 | `trino-describe-first` | PreToolUse + PostToolUse | Require `DESCRIBE <table>` before Trino MCP query references that table | [docs/hook/trino-describe-first.md](docs/hook/trino-describe-first.md) |
 | `pre-edit-protected-branch-guard` | PreToolUse | Block Edit/Write/NotebookEdit on protected branches (main/dev/prod/master) when dirty and target not already in dirty diff | [docs/hook/pre-edit-protected-branch-guard.md](docs/hook/pre-edit-protected-branch-guard.md) |
 | `external-api-literal-trigger` | PreToolUse | Advisory nudge when ALL_CAPS enum candidates or 3-part SQL identifiers are written without prior retrieval verification (issue #202) | [docs/hook/external-api-literal-trigger.md](docs/hook/external-api-literal-trigger.md) |
+| `block-manufactured-action-menu` | PreToolUse | Warn (advisory) or block (strict) when AskUserQuestion surfaces a "shall we proceed?" menu after the user already issued a command-intent signal | [docs/hook/block-manufactured-action-menu.md](docs/hook/block-manufactured-action-menu.md) |
 
 ### Hook ordering and precedence
 

--- a/docs/hook/block-manufactured-action-menu.md
+++ b/docs/hook/block-manufactured-action-menu.md
@@ -103,7 +103,21 @@ Detected destructive tokens in option labels:
 
 - Korean: `머지`, `푸시`, `삭제`, `지우`, `드롭`, `초기화`, `force`, `프로덕션`
 - English: `merge`, `push`, `delete`, `drop`, `truncate`, `force`,
-  `prod`, `production`, `destroy`
+  `prod`, `destroy` (matched with ASCII-letter lookaround rather than
+  `\b` so mixed-script labels like `push할까요` match while
+  `production-ready` / `Product plan` do not — `production` is
+  intentionally not a separate token because it overlaps with
+  non-destructive adjectives)
+
+Additionally, the hook ignores status-query / question messages so
+phrasings like `진행 상황 알려줘` or `where should we go from here?`
+do not register as command-intent and therefore never reach the
+manufactured-marker check. Detected query forms:
+
+- Korean: `진행 상황`, `진행 중`, `진행 정도`, `진행률`, `어디까지`,
+  `어떻게 진행`, `상황 알려`, `상태 확인`, `상태 알려`
+- English: trailing `?`, or any of `where should we`, `where do we`,
+  `where to go`, `from here`, `how do we`, `what do we`, `should we`
 
 For other legitimate cases (substantive alternatives, less obvious
 destructive contexts) the advisory mode will warn but not block; the

--- a/docs/hook/block-manufactured-action-menu.md
+++ b/docs/hook/block-manufactured-action-menu.md
@@ -1,0 +1,135 @@
+# PreToolUse AskUserQuestion Manufactured Action-Menu Gate
+
+`hooks/block-manufactured-action-menu.py` fires on every PreToolUse(AskUserQuestion)
+event and inspects `options[].label` for manufactured action-menu markers — option
+labels that re-ask "shall we proceed?" ("진행할까요", "계속할까요", "proceed",
+"continue", "go ahead"). When a marker is found, the most recent user message in
+the transcript is checked for a command-intent signal. If a command-intent signal
+is present, the user has already given direction — the confirmation menu is
+manufactured friction.
+
+### Why this exists
+
+2026-05-13 retrospect Strike 1: agent completed an action then automatically emitted
+an AskUserQuestion 4-option menu ("다음 액션 진행할까요?") even when the user's
+immediately prior message was a direct command ("진행", "go ahead", "실행"). This
+pattern fragments decisions, ignores established user intent, and adds an unnecessary
+confirmation roundtrip.
+
+The existing `block-ask-end-option` hook catches *termination* menu misuse (mechanical
+"end here" boilerplate). This hook is its sibling: it catches *continuation* menu
+misuse — surfacing a "shall we proceed?" confirmation when the user has already said
+"yes, proceed".
+
+`feedback_no_premature_option_delegation.md` recorded the same pattern but memory
+alone was insufficient — the same session saw repeated recurrences. This hook enforces
+the rule at the tool boundary, where the check runs mechanically regardless of
+retrieval state.
+
+### What is blocked
+
+| Scenario | Action |
+|----------|--------|
+| Default mode, manufactured marker in any option label, command signal in prior user msg | exit 0 + advisory stderr |
+| `PRAXIS_BLOCK_MANUFACTURED_MENU_STRICT=1`, marker present, command signal in prior msg | exit 2 (block) |
+| Any tool name other than `AskUserQuestion` | silent pass-through |
+| Marker present BUT no command-intent signal in prior user message | silent pass-through |
+| Missing / unreadable transcript | silent pass-through (graceful degrade) |
+| No options match any manufactured-menu marker | silent pass-through |
+
+### Detect patterns
+
+#### Manufactured-menu option label markers (Korean)
+
+- `진행할까요`
+- `계속할까요`
+- `다음 액션`
+- `머지할까요`
+- `push할까요`
+
+#### Manufactured-menu option label markers (English)
+
+- `proceed`
+- `continue`
+- `go ahead`
+
+All matches are case-insensitive substring checks against the option label.
+
+### Command-intent signals (user message)
+
+The hook walks the transcript in reverse to find the most recent human-authored
+user message (skipping `tool_result`-only entries). Command-intent is detected when:
+
+**Korean** (substring match):
+- `진행`, `실행`, `머지`, `커밋`, `push`, `푸시`
+
+**English** (whole-word match, case-insensitive):
+- `go`, `go ahead`, `proceed`, `continue`, `merge`, `commit`, `push`
+
+English tokens use `\b` word-boundary matching to prevent false positives from
+substrings (e.g. "continuing" → "continue", "progress" does not match "go").
+
+### Mode and env var behavior
+
+| Env var state | Mode | Exit code on match |
+|---------------|------|-------------------|
+| Neither var set (default) | **Advisory** | 0 + stderr warning |
+| `PRAXIS_BLOCK_MANUFACTURED_MENU_STRICT=1` | Strict | 2 (block) |
+
+Default is advisory because this hook is new and exceptions
+(irreversible/destructive actions, genuine multiple alternatives) need to be
+learned before strict promotion. Set `PRAXIS_BLOCK_MANUFACTURED_MENU_STRICT=1`
+to enable hard blocking.
+
+### When manufactured menus are legitimate
+
+This hook fires only when the prior user message contains a command-intent
+signal. When no command signal is present, the hook passes silently — the
+AskUserQuestion may be a genuine first-time decision point.
+
+Legitimate cases that survive the hook even with a command signal:
+- Multiple real alternatives with meaningful trade-offs (not just "proceed" vs "cancel")
+- Destructive / irreversible actions requiring explicit confirmation
+
+For these cases the advisory mode will warn but not block; the designer should
+ensure options present substantive decision information rather than a bare
+continuation marker.
+
+### Response
+
+Advisory response (exit 0 + stderr message only — no JSON output):
+
+```
+[advisory] AskUserQuestion includes a manufactured action-menu option ...
+```
+
+Block response (exit 2):
+
+```json
+{
+  "decision": "block",
+  "reason": "AskUserQuestion includes a manufactured action-menu option..."
+}
+```
+
+### Parsing guarantees
+
+- Malformed JSON payload → exit 0 (fail-open)
+- `tool_name != "AskUserQuestion"` → exit 0
+- Missing / unreadable transcript → exit 0 (fail-open)
+- `questions` absent or not a list → exit 0
+- `options` absent or not a list in a question → that question skipped
+- `tool_result`-only user entries → skipped when walking backward for human text
+
+### Tests
+
+```bash
+bash hooks/test-block-manufactured-action-menu.sh
+```
+
+Covers: Korean manufactured markers (advisory + strict block), English markers
+(proceed, continue, go ahead), command-intent signals in prior user message,
+pass when no command signal present, pass when no manufactured marker, non-AskUserQuestion
+tool pass-through, missing transcript fail-open, malformed payload fail-open,
+tool_result-only entry skip, multi-question payload, false-positive avoidance
+(normal work options only).

--- a/docs/hook/block-manufactured-action-menu.md
+++ b/docs/hook/block-manufactured-action-menu.md
@@ -112,7 +112,16 @@ Detected destructive tokens in option labels:
 Additionally, the hook ignores status-query / question messages so
 phrasings like `진행 상황 알려줘` or `where should we go from here?`
 do not register as command-intent and therefore never reach the
-manufactured-marker check. Detected query forms:
+manufactured-marker check. Negated directives (`don't proceed yet`,
+`do not continue`, `진행하지 마`, `계속하지 말아줘`) are also rejected:
+Korean tokens require the following 12 chars to not contain
+`하지 마` / `하지 말`, and English tokens require the preceding 30
+chars to not contain a negation marker (`don't`, `do not`, `won't`,
+`will not`, `cannot`, `should not`, `never`, ` not `, ...).
+
+The Korean command-signal list also includes `계속` so that
+continuation messages like `계속해` / `계속 진행` correctly pair with
+the `계속할까요` manufactured marker. Detected query forms:
 
 - Korean: `진행 상황`, `진행 중`, `진행 정도`, `진행률`, `어디까지`,
   `어떻게 진행`, `상황 알려`, `상태 확인`, `상태 알려`

--- a/docs/hook/block-manufactured-action-menu.md
+++ b/docs/hook/block-manufactured-action-menu.md
@@ -91,9 +91,24 @@ Legitimate cases that survive the hook even with a command signal:
 - Multiple real alternatives with meaningful trade-offs (not just "proceed" vs "cancel")
 - Destructive / irreversible actions requiring explicit confirmation
 
-For these cases the advisory mode will warn but not block; the designer should
-ensure options present substantive decision information rather than a bare
-continuation marker.
+#### Destructive-confirmation exception (automatic, even in strict mode)
+
+When ANY option label contains a destructive / irreversible action token,
+the hook passes regardless of mode. The user's prior generic command does
+not absorb per-action approval for shared-state mutations — surfacing a
+confirmation menu is required by the project CLAUDE.md
+"Pre-Merge Reporting" + "Executing actions with care" rules.
+
+Detected destructive tokens in option labels:
+
+- Korean: `머지`, `푸시`, `삭제`, `지우`, `드롭`, `초기화`, `force`, `프로덕션`
+- English: `merge`, `push`, `delete`, `drop`, `truncate`, `force`,
+  `prod`, `production`, `destroy`
+
+For other legitimate cases (substantive alternatives, less obvious
+destructive contexts) the advisory mode will warn but not block; the
+designer should ensure options present substantive decision information
+rather than a bare continuation marker.
 
 ### Response
 

--- a/hooks/block-manufactured-action-menu.py
+++ b/hooks/block-manufactured-action-menu.py
@@ -79,6 +79,36 @@ COMMAND_SIGNALS_EN_TOKENS = (
     "push",
 )
 
+# Destructive-confirmation labels — option labels that name an irreversible
+# / shared-state action (merge, push, delete, drop, prod write, force).
+# When ANY option label contains one of these tokens, the menu is treated
+# as a legitimate confirmation gate even in strict mode: per the project
+# CLAUDE.md "Pre-Merge Reporting" + "Executing actions with care" rules,
+# destructive actions require explicit per-action confirmation that the
+# user's prior command alone does not absorb. Surfacing such a menu is
+# justified, not manufactured.
+DESTRUCTIVE_LABEL_TOKENS_KO = (
+    "머지",
+    "푸시",
+    "삭제",
+    "지우",
+    "드롭",
+    "초기화",
+    "force",
+    "프로덕션",
+)
+DESTRUCTIVE_LABEL_TOKENS_EN = (
+    "merge",
+    "push",
+    "delete",
+    "drop",
+    "truncate",
+    "force",
+    "prod",
+    "production",
+    "destroy",
+)
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -204,6 +234,28 @@ def _read_last_user_message(transcript_path: str) -> str | None:
     return ""
 
 
+def _has_destructive_label(labels: list[str]) -> bool:
+    """True if any option label names a destructive / irreversible action.
+
+    Per the project CLAUDE.md rules (Pre-Merge Reporting, "Executing
+    actions with care"), destructive actions need explicit per-action
+    confirmation that a prior generic command does not absorb. When the
+    menu contains such a label, treat it as a legitimate confirmation
+    gate even when other markers and a command signal coexist.
+    """
+    if not labels:
+        return False
+    for label in labels:
+        lower = label.lower()
+        for token in DESTRUCTIVE_LABEL_TOKENS_KO:
+            if token in label or token.lower() in lower:
+                return True
+        for token in DESTRUCTIVE_LABEL_TOKENS_EN:
+            if token.lower() in lower:
+                return True
+    return False
+
+
 def _has_command_signal(user_message: str) -> bool:
     """True if the user message contains a command-intent directive.
 
@@ -301,6 +353,15 @@ def main() -> int:
     if not _has_command_signal(user_message):
         # No command-intent in prior message — manufactured menu may be
         # legitimate (first interaction, genuine multiple-choice). Pass.
+        return 0
+
+    # Destructive-confirmation exception — even in strict mode, a menu
+    # whose options name a destructive / irreversible action (merge, push,
+    # delete, prod write, force) is a legitimate confirmation gate and
+    # must not be blocked. The user's prior generic command does not
+    # absorb per-action approval for shared-state mutations (see project
+    # CLAUDE.md "Pre-Merge Reporting" + "Executing actions with care").
+    if _has_destructive_label(labels):
         return 0
 
     # Mode resolution.

--- a/hooks/block-manufactured-action-menu.py
+++ b/hooks/block-manufactured-action-menu.py
@@ -68,6 +68,35 @@ COMMAND_SIGNALS_KO = (
     "커밋",
     "push",
     "푸시",
+    "계속",
+)
+
+# Negation markers that, when found following a Korean signal token,
+# convert the directive into "do not <action>" — must NOT register as
+# command-intent. Examples: "진행하지 마", "계속하지 마", "머지하지 마".
+NEGATION_FOLLOWUP_KO = (
+    "하지 마",
+    "하지 말",
+    "하지마",
+    "하지말",
+)
+
+# English negation window: # of chars to scan before an EN command token.
+# If any negation marker appears in that window, the match is rejected.
+NEGATION_WINDOW_EN = 30
+NEGATION_MARKERS_EN = (
+    "don't",
+    "do not",
+    "won't",
+    "will not",
+    "cannot",
+    "can't",
+    "should not",
+    "shouldn't",
+    "must not",
+    "mustn't",
+    "never",
+    " not ",
 )
 COMMAND_SIGNALS_EN_TOKENS = (
     "go",
@@ -333,18 +362,29 @@ def _has_command_signal(user_message: str) -> bool:
     if _is_status_query(user_message):
         return False
 
-    # Korean: substring match.
+    # Korean: substring match, but reject when the token is followed by a
+    # negation pattern ("진행하지 마", "계속하지 말아줘", ...).
     for ko in COMMAND_SIGNALS_KO:
-        if ko in user_message:
-            return True
+        start = 0
+        while True:
+            idx = user_message.find(ko, start)
+            if idx < 0:
+                break
+            tail = user_message[idx + len(ko): idx + len(ko) + 12]
+            if not any(neg in tail for neg in NEGATION_FOLLOWUP_KO):
+                return True
+            start = idx + len(ko)
 
-    # English: whole-word match (case-insensitive).
+    # English: whole-word match (case-insensitive) with negation guard on
+    # the preceding window ("don't proceed", "do not continue").
     lower = user_message.lower()
     import re
     for token in COMMAND_SIGNALS_EN_TOKENS:
         pattern = r"\b" + re.escape(token.lower()) + r"\b"
-        if re.search(pattern, lower):
-            return True
+        for m in re.finditer(pattern, lower):
+            prefix = lower[max(0, m.start() - NEGATION_WINDOW_EN):m.start()]
+            if not any(neg in prefix for neg in NEGATION_MARKERS_EN):
+                return True
 
     return False
 

--- a/hooks/block-manufactured-action-menu.py
+++ b/hooks/block-manufactured-action-menu.py
@@ -97,6 +97,10 @@ DESTRUCTIVE_LABEL_TOKENS_KO = (
     "force",
     "프로덕션",
 )
+# English destructive tokens. `production` intentionally omitted — it
+# is lexically ambiguous with `production-ready` / `Product plan`-style
+# adjectives. Use the short form `prod` for destructive intent (matches
+# `prod deploy`, `prod rollback`).
 DESTRUCTIVE_LABEL_TOKENS_EN = (
     "merge",
     "push",
@@ -105,7 +109,6 @@ DESTRUCTIVE_LABEL_TOKENS_EN = (
     "truncate",
     "force",
     "prod",
-    "production",
     "destroy",
 )
 
@@ -242,17 +245,75 @@ def _has_destructive_label(labels: list[str]) -> bool:
     confirmation that a prior generic command does not absorb. When the
     menu contains such a label, treat it as a legitimate confirmation
     gate even when other markers and a command signal coexist.
+
+    English tokens are matched with ASCII-letter lookaround rather than
+    `\\b` word boundaries: this rejects `Product plan` / `production-
+    ready` (token followed by another ASCII letter) while still matching
+    mixed-script labels like `push할까요` (token followed by a Korean
+    character, which `\\b` would not split on because Python's
+    Unicode-aware `\\w` treats Korean as a word character).
     """
     if not labels:
         return False
+    import re
     for label in labels:
         lower = label.lower()
         for token in DESTRUCTIVE_LABEL_TOKENS_KO:
             if token in label or token.lower() in lower:
                 return True
         for token in DESTRUCTIVE_LABEL_TOKENS_EN:
-            if token.lower() in lower:
+            pattern = r"(?<![a-z])" + re.escape(token.lower()) + r"(?![a-z])"
+            if re.search(pattern, lower):
                 return True
+    return False
+
+
+# Status-query / question phrasings — explicit command intent is absent
+# even though an action verb appears as a substring. These exclude the
+# message from command-signal detection so legitimate status checks
+# ("진행 상황 알려줘", "where should we go from here?") are not treated
+# as imperatives.
+STATUS_QUERY_PATTERNS_KO = (
+    "진행 상황",
+    "진행 중",
+    "진행 정도",
+    "진행률",
+    "어디까지",
+    "어떻게 진행",
+    "상황 알려",
+    "상태 확인",
+    "상태 알려",
+)
+STATUS_QUERY_PATTERNS_EN = (
+    "where should we",
+    "where do we",
+    "where to go",
+    "from here",
+    "how do we",
+    "what do we",
+    "should we",
+)
+
+
+def _is_status_query(user_message: str) -> bool:
+    """True if the message reads as a status query / question rather
+    than an imperative command. Filters out 'progress check' /
+    'where should we go' style messages that would otherwise false-
+    trigger via the substring or word-boundary match on `진행` / `go`.
+    """
+    if not user_message:
+        return False
+    # Korean status-query phrases.
+    for kw in STATUS_QUERY_PATTERNS_KO:
+        if kw in user_message:
+            return True
+    # English: trailing question mark or interrogative leads.
+    lower = user_message.lower().strip()
+    if lower.endswith("?"):
+        return True
+    for kw in STATUS_QUERY_PATTERNS_EN:
+        if kw in lower:
+            return True
     return False
 
 
@@ -262,8 +323,14 @@ def _has_command_signal(user_message: str) -> bool:
     Korean tokens: substring match (CJK has low collision risk for these
     specific action verbs). English tokens: whole-word match (prevents
     "continuing" → "continue", "progress" → "go", etc.).
+
+    Status-query / question messages are excluded up-front so that
+    `진행 상황 알려줘` does not match `진행` and
+    `where should we go from here?` does not match `go`.
     """
     if not user_message:
+        return False
+    if _is_status_query(user_message):
         return False
 
     # Korean: substring match.

--- a/hooks/block-manufactured-action-menu.py
+++ b/hooks/block-manufactured-action-menu.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""PreToolUse(AskUserQuestion) guard: warn on manufactured action-menu surfacing.
+
+When AskUserQuestion is invoked with `options` whose labels match
+manufactured-menu markers (e.g. "진행할까요", "계속할까요", "proceed",
+"continue", "go ahead"), check the most recent user message in the
+transcript for a command-intent signal. If a command-intent signal is
+present, the user has already given direction — re-asking via menu is
+redundant manufactured friction.
+
+Background:
+  2026-05-13 retrospect Strike 1: agent completed an action then automatically
+  emitted an AskUserQuestion 4-option menu ("다음 액션 진행할까요?") even when
+  the user's immediately prior message was a direct command ("진행", "go ahead",
+  "실행"). This pattern fragments decisions, ignores established user intent, and
+  adds roundtrip latency on simple continuations.
+
+  The existing `block-ask-end-option` hook catches *termination* menu misuse.
+  This hook is its sibling: it catches *continuation* menu misuse — surfacing
+  "shall we proceed?" confirmation when the user has already said "yes, proceed".
+
+Default mode: advisory (exit 0 + stderr warning).
+Strict mode (PRAXIS_BLOCK_MANUFACTURED_MENU_STRICT=1): block (exit 2).
+
+Allow conditions (no block/advisory emitted):
+  1. tool_name != "AskUserQuestion"
+  2. No options match any manufactured-menu marker
+  3. Most recent user message does NOT contain a command-intent signal
+  4. transcript_path is missing or unreadable (graceful degrade — suppress to
+     avoid noise when transcript inspection is impossible)
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+# ---------------------------------------------------------------------------
+# Pattern definitions
+# ---------------------------------------------------------------------------
+
+# Manufactured-menu markers in option labels. Case-insensitive.
+# These are "shall we proceed?" style option labels that are typically
+# redundant when the user has already issued a command.
+MANUFACTURED_MARKERS_KO = (
+    "진행할까요",
+    "계속할까요",
+    "다음 액션",
+    "머지할까요",
+    "push할까요",
+)
+MANUFACTURED_MARKERS_EN = (
+    "proceed",
+    "continue",
+    "go ahead",
+)
+
+# Command-intent signals in the most recent user message. Case-insensitive.
+#
+# Korean entries are substring-matched (CJK has low collision risk for these
+# specific action tokens). English entries are phrase- or token-matched to
+# avoid false positives from substrings (e.g. "continuing" in an explanation
+# vs "continue" as a command).
+COMMAND_SIGNALS_KO = (
+    "진행",
+    "실행",
+    "머지",
+    "커밋",
+    "push",
+    "푸시",
+)
+COMMAND_SIGNALS_EN_TOKENS = (
+    "go",
+    "go ahead",
+    "proceed",
+    "continue",
+    "merge",
+    "commit",
+    "push",
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _all_markers() -> tuple[str, ...]:
+    return MANUFACTURED_MARKERS_KO + MANUFACTURED_MARKERS_EN
+
+
+def _collect_option_labels(tool_input: dict) -> list[str]:
+    """Walk questions[].options[].label and return all label strings.
+
+    Tolerant of partial schemas — any missing field results in an empty
+    return rather than an exception. Hook must never crash on malformed
+    payloads.
+    """
+    labels: list[str] = []
+    questions = tool_input.get("questions") or []
+    if not isinstance(questions, list):
+        return labels
+    for q in questions:
+        if not isinstance(q, dict):
+            continue
+        options = q.get("options") or []
+        if not isinstance(options, list):
+            continue
+        for o in options:
+            if not isinstance(o, dict):
+                continue
+            label = o.get("label")
+            if isinstance(label, str):
+                labels.append(label)
+    return labels
+
+
+def _has_manufactured_marker(labels: list[str]) -> bool:
+    if not labels:
+        return False
+    markers = _all_markers()
+    for label in labels:
+        lower = label.lower()
+        for marker in markers:
+            if marker.lower() in lower:
+                return True
+    return False
+
+
+def _read_last_user_message(transcript_path: str) -> str | None:
+    """Return the text of the most recent user-authored message in the transcript.
+
+    Returns None when the transcript is missing or unreadable — the caller
+    must fail open per the project hook design contract (`Fail-open on
+    infrastructure errors`). Returns empty string when the transcript was
+    read successfully but no user message contained extractable human
+    text — that is a real "no command-signal" answer and may be acted on.
+
+    Transcript format: JSONL where each line is a JSON object with at
+    least `type` ('user' / 'assistant' / 'system') and either `message`
+    (an Anthropic API message dict with `role` + `content`) or a flatter
+    `content` field. Both shapes are handled.
+
+    tool_result handling: an Anthropic user role message may carry only
+    `tool_result` content blocks when the assistant invoked tools in the
+    same turn before invoking AskUserQuestion. Such entries are NOT human
+    authored — they are the runtime's bridge for tool outputs. We must
+    skip them and keep walking backward until we find a user entry that
+    contains actual `type: text` content.
+    """
+    if not transcript_path or not os.path.isfile(transcript_path):
+        return None
+    try:
+        with open(transcript_path, "r", encoding="utf-8", errors="replace") as f:
+            lines = f.readlines()
+    except OSError:
+        return None
+
+    for raw in reversed(lines):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            entry = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+
+        role = entry.get("type") or entry.get("role")
+        message = entry.get("message")
+        if isinstance(message, dict) and not role:
+            role = message.get("role")
+
+        if role != "user":
+            continue
+
+        content = None
+        if isinstance(message, dict):
+            content = message.get("content")
+        if content is None:
+            content = entry.get("content")
+
+        text = ""
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list):
+            parts: list[str] = []
+            for item in content:
+                if isinstance(item, dict):
+                    item_type = item.get("type")
+                    if item_type and item_type != "text":
+                        continue
+                    t = item.get("text")
+                    if isinstance(t, str):
+                        parts.append(t)
+                elif isinstance(item, str):
+                    parts.append(item)
+            text = "\n".join(parts)
+
+        if text.strip():
+            return text
+        continue
+
+    return ""
+
+
+def _has_command_signal(user_message: str) -> bool:
+    """True if the user message contains a command-intent directive.
+
+    Korean tokens: substring match (CJK has low collision risk for these
+    specific action verbs). English tokens: whole-word match (prevents
+    "continuing" → "continue", "progress" → "go", etc.).
+    """
+    if not user_message:
+        return False
+
+    # Korean: substring match.
+    for ko in COMMAND_SIGNALS_KO:
+        if ko in user_message:
+            return True
+
+    # English: whole-word match (case-insensitive).
+    lower = user_message.lower()
+    import re
+    for token in COMMAND_SIGNALS_EN_TOKENS:
+        pattern = r"\b" + re.escape(token.lower()) + r"\b"
+        if re.search(pattern, lower):
+            return True
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+ADVISORY_MSG = """\
+[advisory] AskUserQuestion includes a manufactured action-menu option ("진행할까요",
+"proceed", "go ahead", etc.) but the most recent user message already contains
+a command-intent signal ("진행", "실행", "go ahead", "proceed", etc.).
+
+Re-asking "shall we proceed?" when the user has already said "proceed" is
+manufactured friction — it fragments decisions and adds an unnecessary
+confirmation roundtrip.
+
+Remove the manufactured-menu option or replace with a substantive decision
+point (multiple real alternatives with trade-offs, or a destructive/irreversible
+action requiring explicit confirmation).
+
+Strict mode disabled. Set PRAXIS_BLOCK_MANUFACTURED_MENU_STRICT=1 to block.
+"""
+
+BLOCK_MSG = """\
+BLOCKED: AskUserQuestion includes a manufactured action-menu option without
+a substantive decision point.
+
+Manufactured-menu markers detected in options[].label:
+  Korean: "진행할까요", "계속할까요", "다음 액션", "머지할까요", "push할까요"
+  English: "proceed", "continue", "go ahead"
+
+Most recent user message already contains a command-intent signal
+("진행", "실행", "go", "proceed", "continue", "merge", "commit", "push",
+"머지", "커밋", "푸시").
+
+Why:
+  Re-asking confirmation when the user has already given a directive is
+  manufactured friction. The user's prior "proceed" / "진행" / "go ahead"
+  covers the continuation. Surface only genuine decision points: multiple
+  real alternatives with trade-offs, or destructive / irreversible actions
+  requiring explicit confirmation.
+
+To opt out: unset PRAXIS_BLOCK_MANUFACTURED_MENU_STRICT (default is advisory).
+"""
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    if not isinstance(payload, dict):
+        return 0
+    if payload.get("tool_name") != "AskUserQuestion":
+        return 0
+
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return 0
+
+    labels = _collect_option_labels(tool_input)
+    if not _has_manufactured_marker(labels):
+        return 0
+
+    transcript_path = payload.get("transcript_path") or ""
+    user_message = _read_last_user_message(transcript_path)
+    if user_message is None:
+        # Fail open per project hook design contract — transcript missing
+        # or unreadable, cannot verify command-signal presence.
+        return 0
+    if not _has_command_signal(user_message):
+        # No command-intent in prior message — manufactured menu may be
+        # legitimate (first interaction, genuine multiple-choice). Pass.
+        return 0
+
+    # Mode resolution.
+    strict_env = os.environ.get("PRAXIS_BLOCK_MANUFACTURED_MENU_STRICT", "")
+    strict_set = strict_env not in ("", "0", "false", "False")
+
+    if strict_set:
+        sys.stderr.write(BLOCK_MSG)
+        return 2
+
+    sys.stderr.write(ADVISORY_MSG)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/block-manufactured-action-menu.sh
+++ b/hooks/block-manufactured-action-menu.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# block-manufactured-action-menu.sh — thin shim (praxis #210)
+# Logic in .py; shim keeps hooks.json entry stable across refactors.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="$SCRIPT_DIR/block-manufactured-action-menu.py"
+command -v python3 >/dev/null 2>&1 || exit 0
+[ -f "$PY" ] || exit 0
+exec python3 "$PY"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "praxis hooks: Stop gate for completion-without-evidence, retrospect memory-bias gate, session-scoped three-strike discipline, PreToolUse(Bash) side-effect scan / gh search --state all block / memory-hint / caller-chain evidence gate on gh pr create / pre-merge approval gate / cross-boundary pre-flight (heredoc block + cross-repo ask), PreToolUse(AskUserQuestion) end-option mechanical-transcribe advisory, PostToolUse correction for built-in task management tools, UserPromptSubmit codex-review worktree disambiguation",
+  "description": "praxis hooks: Stop gate for completion-without-evidence, retrospect memory-bias gate, session-scoped three-strike discipline, PreToolUse(Bash) side-effect scan / gh search --state all block / memory-hint / caller-chain evidence gate on gh pr create / pre-merge approval gate / cross-boundary pre-flight (heredoc block + cross-repo ask), PreToolUse(AskUserQuestion) end-option mechanical-transcribe advisory + manufactured action-menu continuation guard, PostToolUse correction for built-in task management tools, UserPromptSubmit codex-review worktree disambiguation",
   "hooks": {
     "SessionStart": [
       {
@@ -115,6 +115,11 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-ask-end-option.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-manufactured-action-menu.sh",
             "timeout": 5
           }
         ]

--- a/hooks/test-block-manufactured-action-menu.sh
+++ b/hooks/test-block-manufactured-action-menu.sh
@@ -409,6 +409,40 @@ P_wb3=$(build_payload "$T_wb3" '["proceed", "prod deploy"]')
 run_case "[wb] standalone 'prod deploy' triggers exempt + cmd + strict → pass" pass strict "$P_wb3"
 
 # ---------------------------------------------------------------------------
+# (h) Negation guard — explicit "don't / 진행하지 마" must NOT register
+#     as command-intent even though the action verb appears.
+# ---------------------------------------------------------------------------
+
+T_ng1=$(build_transcript "don't proceed yet")
+P_ng1=$(build_payload "$T_ng1" '["Plan A", "proceed"]')
+run_case "[negation-EN] \"don't proceed yet\" + 'proceed' → pass" pass default "$P_ng1"
+
+T_ng2=$(build_transcript "do not continue")
+P_ng2=$(build_payload "$T_ng2" '["Plan A", "continue"]')
+run_case "[negation-EN] 'do not continue' + 'continue' → pass" pass default "$P_ng2"
+
+T_ng3=$(build_transcript "진행하지 마")
+P_ng3=$(build_payload "$T_ng3" '["Plan A", "진행할까요"]')
+run_case "[negation-KO] '진행하지 마' + '진행할까요' → pass" pass default "$P_ng3"
+
+T_ng4=$(build_transcript "계속하지 말아줘")
+P_ng4=$(build_payload "$T_ng4" '["Plan A", "계속할까요"]')
+run_case "[negation-KO] '계속하지 말아줘' + '계속할까요' → pass" pass default "$P_ng4"
+
+# ---------------------------------------------------------------------------
+# (i) Korean signal `계속` — must be recognized as command-intent so
+#     `계속할까요` manufactured menu is detected.
+# ---------------------------------------------------------------------------
+
+T_ks1=$(build_transcript "계속해")
+P_ks1=$(build_payload "$T_ks1" '["Plan A", "계속할까요"]')
+run_case "[KO-signal] '계속해' + '계속할까요' → advisory" advisory default "$P_ks1"
+
+T_ks2=$(build_transcript "계속 진행")
+P_ks2=$(build_payload "$T_ks2" '["Plan A", "계속할까요"]')
+run_case "[KO-signal] '계속 진행' + '계속할까요' → advisory" advisory default "$P_ks2"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/hooks/test-block-manufactured-action-menu.sh
+++ b/hooks/test-block-manufactured-action-menu.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+# test-block-manufactured-action-menu.sh — coverage for the manufactured action-menu gate
+#
+# Synthesizes Claude Code PreToolUse(AskUserQuestion) payloads and asserts:
+#   advisory → exit 0 + stderr non-empty  (default mode)
+#   block    → exit 2 + stderr non-empty  (PRAXIS_BLOCK_MANUFACTURED_MENU_STRICT=1)
+#   pass     → exit 0 + stderr empty
+#
+# Usage: bash hooks/test-block-manufactured-action-menu.sh
+# Exit:  0 = all pass; 1 = at least one fail
+#
+# Hook is ADVISORY by default — "manufactured marker present + command signal
+# in prior message" cases expect exit 0 + non-empty stderr.
+# Strict cases (PRAXIS_BLOCK_MANUFACTURED_MENU_STRICT=1) expect exit 2.
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/block-manufactured-action-menu.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable: $HOOK" >&2
+  exit 1
+fi
+
+PASS=0; FAIL=0; FAILED_NAMES=()
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# Build a transcript JSONL file from a single user message.
+# $1 = user message text (empty string → no user entries written)
+build_transcript() {
+  local msg="$1"
+  local path="$WORK/transcript-$$-$RANDOM.jsonl"
+  if [ -n "$msg" ]; then
+    python3 -c '
+import json, sys
+print(json.dumps({"type": "user", "message": {"role": "user", "content": sys.argv[1]}}))
+' "$msg" > "$path"
+  else
+    : > "$path"
+  fi
+  echo "$path"
+}
+
+# Build a JSON payload for AskUserQuestion tool call.
+# $1 = transcript_path
+# $2 = options JSON array (e.g., '["Plan A", "진행할까요"]')
+build_payload() {
+  local transcript="$1" options_json="$2"
+  python3 - <<PY
+import json, sys
+options = json.loads('''$options_json''')
+payload = {
+    "session_id": "test-session",
+    "transcript_path": "$transcript",
+    "tool_name": "AskUserQuestion",
+    "tool_input": {
+        "questions": [
+            {
+                "question": "Next step?",
+                "header": "Next",
+                "multiSelect": False,
+                "options": [{"label": opt, "description": "test desc"} for opt in options],
+            }
+        ]
+    },
+    "cwd": "/tmp",
+}
+print(json.dumps(payload))
+PY
+}
+
+run_case() {
+  local name="$1" expected="$2" mode="$3" payload="$4"
+  local err_file rc
+
+  err_file=$(mktemp)
+  case "$mode" in
+    strict)
+      echo "$payload" | PRAXIS_BLOCK_MANUFACTURED_MENU_STRICT=1 "$HOOK" >/dev/null 2>"$err_file"
+      ;;
+    advisory|default|*)
+      echo "$payload" | "$HOOK" >/dev/null 2>"$err_file"
+      ;;
+  esac
+  rc=$?
+  local err_content
+  err_content=$(cat "$err_file"); rm -f "$err_file"
+
+  local ok=1
+  case "$expected" in
+    advisory)
+      [ "$rc" -eq 0 ] && [ -n "$err_content" ] || ok=0
+      ;;
+    block)
+      [ "$rc" -eq 2 ] && [ -n "$err_content" ] || ok=0
+      ;;
+    pass)
+      [ "$rc" -eq 0 ] && [ -z "$err_content" ] || ok=0
+      ;;
+    *)
+      echo "INTERNAL: unknown expected '$expected'" >&2
+      ok=0
+      ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS [$expected] $name"; PASS=$((PASS+1))
+  else
+    echo "FAIL [$expected→rc=$rc,stderr=$([ -n "$err_content" ] && echo non-empty || echo empty)] $name"
+    FAIL=$((FAIL+1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# (a) ADVISORY cases — default mode, manufactured marker + command signal
+# ---------------------------------------------------------------------------
+
+T1=$(build_transcript "진행해주세요")
+P1=$(build_payload "$T1" '["Plan A", "Plan B", "진행할까요"]')
+run_case "korean command signal + korean manufactured marker → advisory" advisory default "$P1"
+
+T2=$(build_transcript "go ahead and implement it")
+P2=$(build_payload "$T2" '["Step 1", "Step 2", "proceed"]')
+run_case "english command signal + proceed marker → advisory" advisory default "$P2"
+
+T3=$(build_transcript "실행해줘")
+P3=$(build_payload "$T3" '["Option A", "Option B", "계속할까요"]')
+run_case "korean command + 계속할까요 → advisory" advisory default "$P3"
+
+T4=$(build_transcript "merge it now")
+P4=$(build_payload "$T4" '["Plan A", "머지할까요"]')
+run_case "english merge command + 머지할까요 → advisory" advisory default "$P4"
+
+T5=$(build_transcript "proceed with the implementation")
+P5=$(build_payload "$T5" '["Plan A", "go ahead"]')
+run_case "'proceed' in user message + 'go ahead' marker → advisory" advisory default "$P5"
+
+T6=$(build_transcript "continue please")
+P6=$(build_payload "$T6" '["Step A", "Step B", "continue"]')
+run_case "'continue' command + 'continue' marker → advisory" advisory default "$P6"
+
+T7=$(build_transcript "push the changes")
+P7=$(build_payload "$T7" '["Plan A", "push할까요"]')
+run_case "push command + push할까요 → advisory" advisory default "$P7"
+
+T8=$(build_transcript "다음 액션 진행해")
+P8=$(build_payload "$T8" '["Step 1", "다음 액션"]')
+run_case "진행 in message + 다음 액션 marker → advisory" advisory default "$P8"
+
+# ---------------------------------------------------------------------------
+# (b) BLOCK cases — strict mode, manufactured marker + command signal
+# ---------------------------------------------------------------------------
+
+T_s1=$(build_transcript "진행해주세요")
+P_s1=$(build_payload "$T_s1" '["Plan A", "진행할까요"]')
+run_case "strict mode + korean command + manufactured marker → block" block strict "$P_s1"
+
+T_s2=$(build_transcript "go ahead")
+P_s2=$(build_payload "$T_s2" '["Step 1", "proceed"]')
+run_case "strict mode + go ahead + proceed marker → block" block strict "$P_s2"
+
+T_s3=$(build_transcript "실행해줘")
+P_s3=$(build_payload "$T_s3" '["Option A", "계속할까요"]')
+run_case "strict mode + 실행 + 계속할까요 → block" block strict "$P_s3"
+
+# ---------------------------------------------------------------------------
+# (c) PASS cases — manufactured marker present but NO command signal in prior msg
+# ---------------------------------------------------------------------------
+
+# When there is no command signal in the prior user message, the manufactured
+# menu may be legitimate (genuine first-time decision point).
+
+T_p1=$(build_transcript "어떤 방식으로 구현할까요?")
+P_p1=$(build_payload "$T_p1" '["Plan A", "Plan B", "진행할까요"]')
+run_case "question user msg, no command → pass (legitimate menu)" pass default "$T_p1 $P_p1" && true
+# Re-run with correct payload passing
+run_case "question user msg, no command → pass" pass default "$P_p1"
+
+T_p2=$(build_transcript "what options do we have?")
+P_p2=$(build_payload "$T_p2" '["Option A", "Option B", "proceed"]')
+run_case "query user msg, no command → pass" pass default "$P_p2"
+
+T_p3=$(build_transcript "어떻게 처리하면 좋을까요")
+P_p3=$(build_payload "$T_p3" '["방법 A", "방법 B", "계속할까요"]')
+run_case "open-ended question, no command → pass" pass default "$P_p3"
+
+# Empty transcript: no user message found → fail open
+T_p4=$(build_transcript "")
+P_p4=$(build_payload "$T_p4" '["Plan A", "진행할까요"]')
+run_case "empty transcript + manufactured marker → pass (fail-open)" pass default "$P_p4"
+
+# ---------------------------------------------------------------------------
+# (d) PASS cases — no manufactured marker in options
+# ---------------------------------------------------------------------------
+
+T_nm1=$(build_transcript "진행해주세요")
+P_nm1=$(build_payload "$T_nm1" '["이슈 생성", "PR 생성", "테스트 실행"]')
+run_case "command signal but no manufactured marker → pass" pass default "$P_nm1"
+
+T_nm2=$(build_transcript "go ahead")
+P_nm2=$(build_payload "$T_nm2" '["Plan A", "Plan B", "Plan C"]')
+run_case "go ahead but normal options only → pass" pass default "$P_nm2"
+
+# ---------------------------------------------------------------------------
+# (e) PASS cases — not AskUserQuestion tool
+# ---------------------------------------------------------------------------
+
+P_t1=$(python3 -c '
+import json
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {"command": "echo proceed"},
+}))')
+run_case "Bash tool passes through" pass default "$P_t1"
+
+P_t2=$(python3 -c '
+import json
+print(json.dumps({
+    "tool_name": "Edit",
+    "tool_input": {"old_string": "진행할까요", "new_string": "proceed"},
+}))')
+run_case "Edit tool with marker in args passes through" pass default "$P_t2"
+
+# ---------------------------------------------------------------------------
+# (f) PASS cases — missing / unreadable transcript → fail-open
+# ---------------------------------------------------------------------------
+
+P_missing=$(build_payload "/nonexistent/transcript-$$.jsonl" '["Plan A", "진행할까요"]')
+run_case "missing transcript file + manufactured marker → pass (fail-open)" pass default "$P_missing"
+
+# ---------------------------------------------------------------------------
+# (g) Graceful degrade — malformed payload pieces
+# ---------------------------------------------------------------------------
+
+run_case "malformed JSON payload → graceful exit 0" pass default "not even json"
+
+P_noq=$(python3 -c '
+import json
+print(json.dumps({
+    "tool_name": "AskUserQuestion",
+    "tool_input": {},
+}))')
+run_case "AskUserQuestion with no questions → pass" pass default "$P_noq"
+
+P_badopts=$(python3 -c '
+import json
+print(json.dumps({
+    "tool_name": "AskUserQuestion",
+    "tool_input": {"questions": [{"options": "not-a-list"}]},
+}))')
+run_case "questions with non-list options → pass" pass default "$P_badopts"
+
+# ---------------------------------------------------------------------------
+# (h) tool_result-only user entry must be skipped (same pattern as sibling)
+# ---------------------------------------------------------------------------
+
+build_tool_result_transcript() {
+  local human_text="$1"
+  local path="$WORK/transcript-tr-$$-$RANDOM.jsonl"
+  python3 - "$human_text" > "$path" <<'PY'
+import json, sys
+human_text = sys.argv[1]
+print(json.dumps({"type": "user", "message": {"role": "user", "content": human_text}}))
+print(json.dumps({"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Working on it."}]}}))
+print(json.dumps({
+    "type": "user",
+    "message": {
+        "role": "user",
+        "content": [
+            {"type": "tool_result", "tool_use_id": "abc123", "content": "command output text"}
+        ],
+    },
+}))
+PY
+  echo "$path"
+}
+
+# tool_result-only most-recent entry, prior human message has command signal
+T_tr1=$(build_tool_result_transcript "진행해주세요")
+P_tr1=$(build_payload "$T_tr1" '["Step 1", "진행할까요"]')
+run_case "[tool-result] skip tool_result entry, prior '진행해주세요' → advisory" advisory default "$P_tr1"
+
+# tool_result-only most-recent, prior message has NO command signal
+T_tr2=$(build_tool_result_transcript "어떤 방법이 좋을까요?")
+P_tr2=$(build_payload "$T_tr2" '["Plan A", "진행할까요"]')
+run_case "[tool-result] skip tool_result entry, prior msg has no command → pass" pass default "$P_tr2"
+
+# ---------------------------------------------------------------------------
+# (i) False-positive avoidance — legitimate work options must NOT trigger
+# ---------------------------------------------------------------------------
+
+# "continue" appearing inside a longer label phrase that is not a simple
+# menu continuation option — substring check should still catch it, but
+# let's verify that work options with unrelated text don't false-trigger.
+
+T_fp1=$(build_transcript "진행")
+P_fp1=$(build_payload "$T_fp1" '["이슈 생성", "PR 검토", "배포"]')
+run_case "[false-pos] normal work options only, no manufactured marker → pass" pass default "$P_fp1"
+
+# "progress" does NOT contain "proceed" as whole word
+T_fp2=$(build_transcript "check progress")
+P_fp2=$(build_payload "$T_fp2" '["Plan A", "continue monitoring"]')
+# "continue monitoring" contains "continue" → this WILL trigger advisory
+# This is expected behavior: "continue" is a manufactured marker
+run_case "[false-pos] 'continue monitoring' label + 'check progress' user msg → pass (no command signal)" pass default "$P_fp2"
+
+# Multi-question: marker only in second question
+T_mq1=$(build_transcript "진행해줘")
+P_mq1=$(python3 - <<PY
+import json
+print(json.dumps({
+    "session_id": "test-session",
+    "transcript_path": "$T_mq1",
+    "tool_name": "AskUserQuestion",
+    "tool_input": {
+        "questions": [
+            {
+                "question": "A?",
+                "options": [{"label": "yes"}, {"label": "no"}],
+            },
+            {
+                "question": "B?",
+                "options": [{"label": "Plan A"}, {"label": "진행할까요"}],
+            },
+        ]
+    },
+}))
+PY
+)
+run_case "multi-question payload, marker in second question + command signal → advisory" advisory default "$P_mq1"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=========================================="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "Failed cases:"
+  for n in "${FAILED_NAMES[@]}"; do
+    echo "  - $n"
+  done
+fi
+
+[ "$FAIL" -eq 0 ]

--- a/hooks/test-block-manufactured-action-menu.sh
+++ b/hooks/test-block-manufactured-action-menu.sh
@@ -369,6 +369,46 @@ P_de6=$(build_payload "$T_de6" '["진행할까요", "머지할까요"]')
 run_case "[destructive-exempt-KO] '머지할까요' label + cmd + advisory → pass" pass default "$P_de6"
 
 # ---------------------------------------------------------------------------
+# (f) Status-query / question filter — messages that look like progress
+#     checks or questions must NOT trigger command-signal detection,
+#     even when an action verb appears as a substring.
+# ---------------------------------------------------------------------------
+
+T_sq1=$(build_transcript "진행 상황 알려줘")
+P_sq1=$(build_payload "$T_sq1" '["Plan A", "진행할까요"]')
+run_case "[status-query-KO] '진행 상황 알려줘' + marker → pass" pass default "$P_sq1"
+
+T_sq2=$(build_transcript "where should we go from here?")
+P_sq2=$(build_payload "$T_sq2" '["Plan A", "proceed"]')
+run_case "[status-query-EN] 'where should we go from here?' + marker → pass" pass default "$P_sq2"
+
+T_sq3=$(build_transcript "어디까지 진행됐어?")
+P_sq3=$(build_payload "$T_sq3" '["Plan A", "계속할까요"]')
+run_case "[status-query-KO] '어디까지 진행됐어?' + marker → pass" pass default "$P_sq3"
+
+T_sq4=$(build_transcript "should we continue?")
+P_sq4=$(build_payload "$T_sq4" '["Plan A", "continue"]')
+run_case "[status-query-EN] 'should we continue?' + marker → pass" pass default "$P_sq4"
+
+# ---------------------------------------------------------------------------
+# (g) Destructive-token word-boundary — `prod` substring must NOT
+#     match `Product plan` / `production-ready docs`.
+# ---------------------------------------------------------------------------
+
+T_wb1=$(build_transcript "go ahead")
+P_wb1=$(build_payload "$T_wb1" '["proceed", "Product plan"]')
+run_case "[wb] 'Product plan' should NOT trigger prod-exempt + cmd + strict → block" block strict "$P_wb1"
+
+T_wb2=$(build_transcript "go ahead")
+P_wb2=$(build_payload "$T_wb2" '["proceed", "production-ready docs"]')
+run_case "[wb] 'production-ready docs' should NOT trigger prod-exempt + cmd + strict → block" block strict "$P_wb2"
+
+# Sanity: standalone `prod` word still triggers exempt.
+T_wb3=$(build_transcript "go ahead")
+P_wb3=$(build_payload "$T_wb3" '["proceed", "prod deploy"]')
+run_case "[wb] standalone 'prod deploy' triggers exempt + cmd + strict → pass" pass strict "$P_wb3"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/hooks/test-block-manufactured-action-menu.sh
+++ b/hooks/test-block-manufactured-action-menu.sh
@@ -131,7 +131,9 @@ run_case "korean command + 계속할까요 → advisory" advisory default "$P3"
 
 T4=$(build_transcript "merge it now")
 P4=$(build_payload "$T4" '["Plan A", "머지할까요"]')
-run_case "english merge command + 머지할까요 → advisory" advisory default "$P4"
+# Destructive label "머지할까요" triggers the destructive-confirmation
+# exception even though command + manufactured marker both match.
+run_case "english merge command + 머지할까요 → pass (destructive-exempt)" pass default "$P4"
 
 T5=$(build_transcript "proceed with the implementation")
 P5=$(build_payload "$T5" '["Plan A", "go ahead"]')
@@ -143,7 +145,9 @@ run_case "'continue' command + 'continue' marker → advisory" advisory default 
 
 T7=$(build_transcript "push the changes")
 P7=$(build_payload "$T7" '["Plan A", "push할까요"]')
-run_case "push command + push할까요 → advisory" advisory default "$P7"
+# Destructive label "push할까요" triggers the destructive-confirmation
+# exception even though command + manufactured marker both match.
+run_case "push command + push할까요 → pass (destructive-exempt)" pass default "$P7"
 
 T8=$(build_transcript "다음 액션 진행해")
 P8=$(build_payload "$T8" '["Step 1", "다음 액션"]')
@@ -330,6 +334,39 @@ print(json.dumps({
 PY
 )
 run_case "multi-question payload, marker in second question + command signal → advisory" advisory default "$P_mq1"
+
+# ---------------------------------------------------------------------------
+# (e) Destructive-confirmation exception — strict mode must pass when any
+#     option label names a destructive / irreversible action (merge, push,
+#     delete, drop, prod, force). The user's prior command does not absorb
+#     per-action approval for shared-state mutations.
+# ---------------------------------------------------------------------------
+
+T_de1=$(build_transcript "머지해줘")
+P_de1=$(build_payload "$T_de1" '["진행할까요", "머지할까요"]')
+run_case "[destructive-exempt-KO] '머지할까요' label + cmd + strict → pass" pass strict "$P_de1"
+
+T_de2=$(build_transcript "push the changes")
+P_de2=$(build_payload "$T_de2" '["proceed", "push to main"]')
+run_case "[destructive-exempt-EN] 'push to main' label + cmd + strict → pass" pass strict "$P_de2"
+
+T_de3=$(build_transcript "삭제 진행")
+P_de3=$(build_payload "$T_de3" '["진행할까요", "데이터 삭제 확정"]')
+run_case "[destructive-exempt-KO] '삭제' label + cmd + strict → pass" pass strict "$P_de3"
+
+T_de4=$(build_transcript "go ahead")
+P_de4=$(build_payload "$T_de4" '["proceed", "force-push the rebase"]')
+run_case "[destructive-exempt-EN] 'force-push' label + cmd + strict → pass" pass strict "$P_de4"
+
+T_de5=$(build_transcript "prod 배포")
+P_de5=$(build_payload "$T_de5" '["proceed", "prod deploy 확정"]')
+run_case "[destructive-exempt-EN] 'prod' label + cmd + strict → pass" pass strict "$P_de5"
+
+# Advisory mode also passes for destructive labels — the exception applies
+# at the marker stage, before mode resolution.
+T_de6=$(build_transcript "머지해줘")
+P_de6=$(build_payload "$T_de6" '["진행할까요", "머지할까요"]')
+run_case "[destructive-exempt-KO] '머지할까요' label + cmd + advisory → pass" pass default "$P_de6"
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## 개요

직전 사용자 발화에 명령형 의도 신호가 있는 상태에서 `AskUserQuestion`이 "진행할까요?", "proceed" 등의 manufactured action-menu를 표시하는 패턴을 차단하는 PreToolUse hook을 추가합니다.

## 배경

2026-05-13 retrospect Strike 1 발동. 사용자가 "진행", "go ahead" 등으로 이미 지시한 직후에도 "다음 액션 진행할까요?" 4-option 메뉴를 자동 발행하는 패턴이 반복됨. `feedback_no_premature_option_delegation.md` 메모리 단독으로는 enforcement 부족 — hook으로 강제합니다.

## 변경 사항

- `hooks/block-manufactured-action-menu.sh` — thin shim (sibling `block-ask-end-option.sh` 패턴 동일)
- `hooks/block-manufactured-action-menu.py` — 핵심 로직
  - Manufactured marker 탐지: `진행할까요`, `계속할까요`, `다음 액션`, `머지할까요`, `push할까요`, `proceed`, `continue`, `go ahead`
  - 직전 사용자 메시지에서 command-intent 신호 추출: `진행`, `실행`, `머지`, `go`, `proceed`, `continue`, `merge`, `commit`, `push` 등
  - Default: advisory (exit 0 + stderr 경고)
  - Strict: `PRAXIS_BLOCK_MANUFACTURED_MENU_STRICT=1` → exit 2 (block)
  - Fail-open: transcript 미존재, malformed payload → exit 0
- `hooks/test-block-manufactured-action-menu.sh` — 29개 케이스 (advisory / block / pass 전경로)
- `hooks/hooks.json` — AskUserQuestion matcher에 신규 hook 등록
- `AGENTS.md` — hook index 테이블 신규 row 추가
- `docs/hook/block-manufactured-action-menu.md` — 전체 spec 문서

## 테스트 결과

```
PASS: 29
FAIL: 0
```

모든 케이스 통과:
- advisory 모드 8케이스 (한국어/영어 command signal + manufactured marker 조합)
- strict 모드 3케이스 (block 경로)
- pass 케이스 18케이스 (no marker, no command signal, non-AskUserQuestion, fail-open, malformed)

## 관련 이슈

Closes #210