### PR TITLE
feat(hook): advisory for external API literals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,7 @@ Design contract shared by all hooks:
 | `session-intent` | UserPromptSubmit + PreToolUse | Gate read-intent → mutation-pivot session drift on `gh` mutating commands | [docs/hook/session-intent.md](docs/hook/session-intent.md) |
 | `trino-describe-first` | PreToolUse + PostToolUse | Require `DESCRIBE <table>` before Trino MCP query references that table | [docs/hook/trino-describe-first.md](docs/hook/trino-describe-first.md) |
 | `pre-edit-protected-branch-guard` | PreToolUse | Block Edit/Write/NotebookEdit on protected branches (main/dev/prod/master) when dirty and target not already in dirty diff | [docs/hook/pre-edit-protected-branch-guard.md](docs/hook/pre-edit-protected-branch-guard.md) |
+| `external-api-literal-trigger` | PreToolUse | Advisory nudge when ALL_CAPS enum candidates or 3-part SQL identifiers are written without prior retrieval verification (issue #202) | [docs/hook/external-api-literal-trigger.md](docs/hook/external-api-literal-trigger.md) |
 
 ### Hook ordering and precedence
 

--- a/docs/hook/external-api-literal-trigger.md
+++ b/docs/hook/external-api-literal-trigger.md
@@ -1,0 +1,131 @@
+# PreToolUse External API Literal Use-Site Trigger
+
+`hooks/external-api-literal-trigger.py` fires on every `PreToolUse` event
+for `Write`, `Edit`, and `Bash` tool calls. It scans the content being
+written or the command being issued for external API enum / literal patterns
+and emits an advisory reminder to verify the value against an authoritative
+source before proceeding.
+
+### Why this exists
+
+The global CLAUDE.md rule `Loaded ≠ Retrieved` instructs:
+> Before using an external API enum / literal / catalog name / configuration
+> constant, retrieve a verified source (vendor docs, `SHOW CATALOGS`,
+> `--help` output) — never write a value that "looks right" based on naming
+> pattern.
+
+Three observed instances (30 days) where the rule was loaded into context
+but the retrieval trigger did not fire at use-site:
+
+1. Trino catalog name guessed (`mysql.auth.tb_*`) without prior
+   `SHOW CATALOGS` enumeration → 6× `CATALOG_NOT_FOUND` retries
+2. Vendor API enum values written from naming-pattern recall → 3 of 5 enum
+   values rejected by vendor with `INVALID_VALUE`
+3. Date-range literal (`LAST_365_DAYS` style) guessed from a related vendor
+   family → `INVALID_DATE_RANGE_FORMAT`
+
+The pattern is consistent: the rule is in context, but the conversational
+flow does not re-trigger retrieval at the specific moment the value is
+committed to a tool call or file edit. A structural hook moves the gate to
+the use-site.
+
+Reference: issue [#202](https://github.com/devseunggwan/praxis/issues/202).
+
+### What is warned
+
+| Tool | Scanned field | Pattern | Advisory emitted |
+|------|--------------|---------|-----------------|
+| `Write` | `tool_input.content` | ALL_CAPS_WITH_UNDERSCORES (≥6 chars, compound) | Yes |
+| `Write` | `tool_input.content` | 3-part SQL identifier in SQL context | Yes |
+| `Edit` | `tool_input.new_string` | ALL_CAPS_WITH_UNDERSCORES (≥6 chars, compound) | Yes |
+| `Edit` | `tool_input.new_string` | 3-part SQL identifier in SQL context | Yes |
+| `Bash` | `tool_input.command` | ALL_CAPS_WITH_UNDERSCORES (≥6 chars, compound) | Yes |
+| `Bash` | `tool_input.command` | 3-part SQL identifier in SQL context | Yes |
+| Any other tool | — | — | Silent pass-through |
+| Malformed payload / missing field | — | — | Silent fail-open |
+
+**This hook never blocks.** It is advisory-only: exit 0 in all cases.
+Up to 3 findings are reported per invocation to avoid advisory overload.
+
+### Detected patterns
+
+#### ALL_CAPS enum candidates
+
+Tokens matching `\b[A-Z][A-Z0-9_]{5,}\b` that additionally contain at
+least one underscore or digit (compound structure). Pure SQL keywords
+(`SELECT`, `INSERT`, `UPDATE`, `DELETE`, `WHERE`) are excluded by the
+compound-structure requirement.
+
+Examples that fire: `LAST_365_DAYS`, `THIS_WEEK_OF_MONTH`,
+`SHOPBY_AUTH_TOKEN`, `PAYMENT_STATUS_APPROVED`
+
+#### 3-part SQL identifiers
+
+Tokens matching `<catalog>.<schema>.<table>` that appear after a SQL
+context keyword (`FROM`, `JOIN`, `TABLE`, `INTO`, `UPDATE`). The SQL
+context gate prevents false positives on Python attribute chains like
+`os.environ.get` or `module.sub.attribute`.
+
+Examples that fire: `mysql.auth.tb_user` (in `FROM mysql.auth.tb_user`),
+`hive.warehouse.orders` (in `SELECT * FROM hive.warehouse.orders`)
+
+### Stop-words (excluded from ALL_CAPS scan)
+
+The following tokens are excluded to suppress noise on common source-code
+constants:
+
+| Category | Excluded tokens |
+|----------|----------------|
+| Code markers | `TODO`, `FIXME`, `HACK`, `NOTE`, `WARN`, `WARNING`, `DEBUG` |
+| Licenses | `LICENSE`, `README`, `AUTHORS`, `CHANGELOG`, `CONTRIBUTORS`, `MIT`, `BSD`, `GNU`, `GPL`, `APACHE`, `MPL`, `AGPL` |
+| Format names | `JSON`, `XML`, `CSV`, `YAML`, `TOML`, `SQL`, `HTML`, `UTF8`, `ASCII`, `UNICODE` |
+| Protocol / network | `HTTP`, `HTTPS`, `FTP`, `SSH`, `TCP`, `UDP`, `URL`, `URI`, `UUID`, `GUID` |
+| Generic programming | `API`, `SDK`, `CLI`, `GUI`, `EOF`, `NULL`, `NONE`, `TRUE`, `FALSE` |
+| Shell / env | `PATH`, `HOME`, `USER`, `SHELL`, `TERM` |
+| Python / general | `PYTHONPATH`, `VIRTUAL`, `STDERR`, `STDOUT`, `STDIN` |
+
+### Advisory message
+
+```
+⚠ External API literal detected: `<token>` (<kind>)
+   Has this value been verified against an authoritative source
+   (vendor doc, SHOW CATALOGS, --help) in this session?
+   If yes, proceed. If no, retrieve before write.
+```
+
+`<kind>` is one of: `ALL_CAPS enum candidate`, `3-part SQL identifier`.
+
+### Fail-open contract
+
+| Condition | Behavior |
+|-----------|----------|
+| Malformed / missing stdin JSON | exit 0 (silent pass) |
+| `tool_name` not in `Write`, `Edit`, `Bash` | exit 0 (silent pass) |
+| Missing target field (`content` / `new_string` / `command`) | exit 0 (silent pass) |
+| `python3` unavailable | exit 0 (shell shim guards) |
+| Hook `.py` file missing | exit 0 (shell shim guards) |
+| Any uncaught exception | exit 0 (silent pass) |
+
+### Tests
+
+```bash
+bash hooks/test-external-api-literal-trigger.sh
+```
+
+Covers (20 cases):
+
+- Write `content`: `LAST_365_DAYS` → advisory fire
+- Write `content`: `THIS_WEEK_OF_MONTH` → advisory fire
+- Edit `new_string`: `mysql.auth.tb_user` in SQL context → advisory fire
+- Bash `command`: `SHOPBY_AUTH_TOKEN` → advisory fire
+- Write `content`: `PAYMENT_STATUS_APPROVED` → advisory fire
+- Edit `new_string`: `hive.warehouse.orders` in SQL context → advisory fire
+- `TODO`, `FIXME`, `README`, `LICENSE`, `MIT` stop-words → pass
+- Short ALL_CAPS `OS`, `URL` (length < 6) → pass
+- Plain lowercase text → pass
+- 2-part SQL identifier (not 3-part) → pass
+- `Read` tool (not in scope) → pass
+- `NotebookEdit` tool (not in scope) → pass
+- Pure ALL_CAPS without compound structure (`SELECT`) → pass
+- Malformed JSON input → pass
+- Empty content field → pass

--- a/docs/hook/external-api-literal-trigger.md
+++ b/docs/hook/external-api-literal-trigger.md
@@ -66,8 +66,18 @@ context keyword (`FROM`, `JOIN`, `TABLE`, `INTO`, `UPDATE`). The SQL
 context gate prevents false positives on Python attribute chains like
 `os.environ.get` or `module.sub.attribute`.
 
+Three quoting shapes are recognized; quoted forms are normalized
+(delimiters stripped) before reporting:
+
+| Form | Example |
+|------|---------|
+| Bare | `mysql.auth.tb_user` |
+| ANSI double-quoted | `"mysql"."auth"."tb_user"` |
+| MySQL / Hive backticked | `` `mysql`.`auth`.`tb_user` `` |
+
 Examples that fire: `mysql.auth.tb_user` (in `FROM mysql.auth.tb_user`),
-`hive.warehouse.orders` (in `SELECT * FROM hive.warehouse.orders`)
+`hive.warehouse.orders` (in `SELECT * FROM hive.warehouse.orders`),
+`"mysql"."auth"."tb_user"` (in `FROM "mysql"."auth"."tb_user"`)
 
 ### Stop-words (excluded from ALL_CAPS scan)
 

--- a/hooks/external-api-literal-trigger.py
+++ b/hooks/external-api-literal-trigger.py
@@ -62,9 +62,18 @@ SQL_3PART_RE = re.compile(
 
 # SQL context keywords: the 3-part identifier must be preceded by one of these
 # within a short window to qualify as a SQL table reference.
+# Three identifier shapes are recognized after the keyword:
+#   bare:        catalog.schema.table
+#   double-quoted: "catalog"."schema"."table"     (ANSI SQL quoted form)
+#   backticked:  `catalog`.`schema`.`table`       (MySQL / Hive form)
 SQL_CONTEXT_RE = re.compile(
-    r"\b(?:FROM|JOIN|TABLE|INTO|UPDATE)\s+[a-z_][a-z0-9_]{1,}\.[a-z_][a-z0-9_]{1,}\.[a-z_][a-z0-9_]{1,}\b",
-    re.IGNORECASE,
+    r"""\b(?:FROM|JOIN|TABLE|INTO|UPDATE)\s+
+        (?:
+            [a-z_][a-z0-9_]{1,}\.[a-z_][a-z0-9_]{1,}\.[a-z_][a-z0-9_]{1,}\b
+          | "[^"]+"\."[^"]+"\."[^"]+"
+          | `[^`]+`\.`[^`]+`\.`[^`]+`
+        )""",
+    re.IGNORECASE | re.VERBOSE,
 )
 
 # Stop-words: common code constants that are NOT external API literals.
@@ -148,24 +157,33 @@ def find_sql_3part_identifiers(text: str) -> list[str]:
     (preceded by FROM / JOIN / TABLE / INTO / UPDATE). This avoids
     false positives on Python attribute chains like `os.environ.get`,
     `module.sub.method`, etc.
+
+    Supports three identifier shapes:
+      bare:           catalog.schema.table
+      double-quoted:  "catalog"."schema"."table"
+      backticked:     `catalog`.`schema`.`table`
+    Quoted forms are returned with their delimiters stripped so the
+    advisory message displays the logical name only.
     """
     found: list[str] = []
     seen: set[str] = set()
     for m in SQL_CONTEXT_RE.finditer(text):
-        # Extract the 3-part identifier from the context match.
-        # The match includes the keyword (FROM/JOIN/...) followed by the identifier.
+        # The match includes the keyword (FROM/JOIN/...) followed by the
+        # identifier; the identifier is the last whitespace-separated token.
         full = m.group(0)
-        # The identifier is the last token after the keyword and whitespace.
         parts = full.split()
         identifier = parts[-1] if parts else ""
-        if not identifier or identifier in seen:
+        if not identifier:
             continue
-        # Validate structure: 3 parts separated by dots.
-        dot_parts = identifier.split(".")
-        if len(dot_parts) != 3:
+        # Normalize quoted forms by stripping wrapping `"` or `` ` ``.
+        normalized = identifier.replace('"', "").replace("`", "")
+        dot_parts = normalized.split(".")
+        if len(dot_parts) != 3 or not all(dot_parts):
             continue
-        seen.add(identifier)
-        found.append(identifier)
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        found.append(normalized)
     return found
 
 

--- a/hooks/external-api-literal-trigger.py
+++ b/hooks/external-api-literal-trigger.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""PreToolUse advisory: nudge retrieval when external API literals are detected.
+
+Issue #202. Recurring failure mode: enum values, catalog names, and date-range
+literals are written into tool calls or file edits based on naming-pattern
+recall (plausibility from a related vendor family) rather than verified
+retrieval (vendor doc, SHOW CATALOGS, --help).
+
+Three observed instances in 30 days:
+  1. Trino catalog name guessed → 6× CATALOG_NOT_FOUND retries
+  2. Vendor API enum values from recall → 3 of 5 rejected by vendor
+  3. Date-range literal style guessed → INVALID_DATE_RANGE_FORMAT
+
+This hook fires on Write / Edit / Bash PreToolUse events and scans the
+relevant content field for external API enum / literal patterns:
+
+  - ALL_CAPS_WITH_UNDERSCORES tokens of length ≥ 6 (likely enum candidates)
+  - 3-part SQL identifiers (<catalog>.<schema>.<table>) appearing in strings
+
+When detected, it emits an advisory stderr reminder — it does NOT block.
+Advisory mode is the only mode: false-positive cost is low and enforcement
+is not the goal. The goal is to shift retrieval earlier in the conversation.
+
+Fail-open contract (project hook design):
+  - Malformed / missing stdin JSON → exit 0
+  - Unknown tool_name → exit 0
+  - Missing target field (content / new_string / command) → exit 0
+  - Any uncaught exception → exit 0
+
+Stop-words: obvious code-file constants (TODO, FIXME, README, LICENSE, MIT,
+BSD, GNU, API, URL, URI, SQL, JSON, CSV, XML, HTML, HTTP, HTTPS, UTF, ASCII)
+are excluded to avoid noise on internal source-code literals.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+# ---------------------------------------------------------------------------
+# Pattern definitions
+# ---------------------------------------------------------------------------
+
+# ALL_CAPS_WITH_UNDERSCORES tokens of length ≥ 6.
+# Requires at least one underscore or digit (pure ALL_CAPS words like "SELECT"
+# are excluded by requiring the compound structure).
+# The boundary \b ensures we don't match inside longer identifiers.
+ALLCAPS_RE = re.compile(r"\b([A-Z][A-Z0-9_]{5,})\b")
+
+# 3-part SQL identifiers: catalog.schema.table (all lowercase / underscore).
+# Matches only when all three parts follow SQL identifier conventions AND the
+# match is not immediately followed by `(` (which would indicate a method /
+# function call like `os.environ.get(...)` rather than a table reference).
+# Each part must be at least 2 characters to avoid matching short Python
+# attribute chains (e.g., `os.path.sep` where `os` is only 2 chars but
+# `environ.get` is a common accessor, not a catalog name).
+# Additional context gate: must appear after FROM/JOIN keywords (case-insensitive)
+# OR be surrounded by quotes — this avoids firing on Python attribute chains.
+SQL_3PART_RE = re.compile(
+    r"\b([a-z_][a-z0-9_]{1,}\.[a-z_][a-z0-9_]{1,}\.[a-z_][a-z0-9_]{1,})\b(?!\s*\()"
+)
+
+# SQL context keywords: the 3-part identifier must be preceded by one of these
+# within a short window to qualify as a SQL table reference.
+SQL_CONTEXT_RE = re.compile(
+    r"\b(?:FROM|JOIN|TABLE|INTO|UPDATE)\s+[a-z_][a-z0-9_]{1,}\.[a-z_][a-z0-9_]{1,}\.[a-z_][a-z0-9_]{1,}\b",
+    re.IGNORECASE,
+)
+
+# Stop-words: common code constants that are NOT external API literals.
+# Matched against the full token (case-sensitive after uppercasing).
+STOP_WORDS: frozenset[str] = frozenset({
+    # Code markers
+    "TODO", "FIXME", "HACK", "NOTE", "WARN", "WARNING", "DEBUG",
+    # Licenses
+    "LICENSE", "README", "AUTHORS", "CHANGELOG", "CONTRIBUTORS",
+    "MIT", "BSD", "GNU", "GPL", "APACHE", "MPL", "AGPL",
+    # Format names
+    "JSON", "XML", "CSV", "YAML", "TOML", "SQL", "HTML",
+    "UTF8", "ASCII", "UNICODE",
+    # Protocol / network
+    "HTTP", "HTTPS", "FTP", "SSH", "TCP", "UDP",
+    "URL", "URI", "UUID", "GUID",
+    # Generic programming
+    "API", "SDK", "CLI", "GUI", "EOF",
+    "NULL", "NONE", "TRUE", "FALSE",
+    # Shell / env
+    "PATH", "HOME", "USER", "SHELL", "TERM",
+    # Python / general
+    "PYTHONPATH", "VIRTUAL", "STDERR", "STDOUT", "STDIN",
+})
+
+# Minimum length for ALL_CAPS token to trigger (6 = already baked into regex,
+# this is a secondary guard in case the regex is adjusted).
+MIN_TOKEN_LEN = 6
+
+# Advisory message template. {kind} = "ALL_CAPS enum" or "3-part SQL identifier".
+ADVISORY_TEMPLATE = (
+    "⚠ External API literal detected: `{token}` ({kind})\n"
+    "   Has this value been verified against an authoritative source\n"
+    "   (vendor doc, SHOW CATALOGS, --help) in this session?\n"
+    "   If yes, proceed. If no, retrieve before write.\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# Scanning helpers
+# ---------------------------------------------------------------------------
+
+def _is_stop_word(token: str) -> bool:
+    """True if the token is a known non-external-API constant."""
+    return token.upper() in STOP_WORDS
+
+
+def _has_compound_structure(token: str) -> bool:
+    """True if the ALL_CAPS token contains at least one underscore or digit.
+
+    Pure letter words like SELECT, INSERT, UPDATE, DELETE are common SQL
+    keywords and should not fire. Compound tokens like LAST_365_DAYS,
+    SHOPBY_AUTH_TOKEN, AUTH_SERVICE_URL are the target pattern.
+    """
+    return "_" in token or any(c.isdigit() for c in token)
+
+
+def find_allcaps_literals(text: str) -> list[str]:
+    """Return ALL_CAPS_WITH_UNDERSCORES tokens that are likely external literals."""
+    found: list[str] = []
+    seen: set[str] = set()
+    for m in ALLCAPS_RE.finditer(text):
+        token = m.group(1)
+        if token in seen:
+            continue
+        seen.add(token)
+        if len(token) < MIN_TOKEN_LEN:
+            continue
+        if _is_stop_word(token):
+            continue
+        if not _has_compound_structure(token):
+            continue
+        found.append(token)
+    return found
+
+
+def find_sql_3part_identifiers(text: str) -> list[str]:
+    """Return 3-part SQL identifiers (catalog.schema.table).
+
+    Only fires when the 3-part identifier appears in a SQL context
+    (preceded by FROM / JOIN / TABLE / INTO / UPDATE). This avoids
+    false positives on Python attribute chains like `os.environ.get`,
+    `module.sub.method`, etc.
+    """
+    found: list[str] = []
+    seen: set[str] = set()
+    for m in SQL_CONTEXT_RE.finditer(text):
+        # Extract the 3-part identifier from the context match.
+        # The match includes the keyword (FROM/JOIN/...) followed by the identifier.
+        full = m.group(0)
+        # The identifier is the last token after the keyword and whitespace.
+        parts = full.split()
+        identifier = parts[-1] if parts else ""
+        if not identifier or identifier in seen:
+            continue
+        # Validate structure: 3 parts separated by dots.
+        dot_parts = identifier.split(".")
+        if len(dot_parts) != 3:
+            continue
+        seen.add(identifier)
+        found.append(identifier)
+    return found
+
+
+def scan_content(text: str) -> list[tuple[str, str]]:
+    """Return a list of (token, kind) advisory pairs from `text`.
+
+    kind is one of: "ALL_CAPS enum candidate", "3-part SQL identifier".
+    Returns at most 3 findings to avoid advisory overload.
+    """
+    if not text:
+        return []
+    findings: list[tuple[str, str]] = []
+
+    for token in find_allcaps_literals(text):
+        findings.append((token, "ALL_CAPS enum candidate"))
+        if len(findings) >= 3:
+            return findings
+
+    for token in find_sql_3part_identifiers(text):
+        findings.append((token, "3-part SQL identifier"))
+        if len(findings) >= 3:
+            return findings
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Tool input extraction
+# ---------------------------------------------------------------------------
+
+# Map tool_name → field to scan.
+TOOL_FIELD_MAP: dict[str, str] = {
+    "Write": "content",
+    "Edit": "new_string",
+    "Bash": "command",
+}
+
+
+def extract_scan_target(tool_name: str, tool_input: dict) -> str | None:
+    """Return the text to scan for the given tool, or None if not applicable."""
+    field = TOOL_FIELD_MAP.get(tool_name)
+    if field is None:
+        return None
+    value = tool_input.get(field)
+    if not isinstance(value, str):
+        return None
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0  # fail-open on malformed stdin
+
+    if not isinstance(payload, dict):
+        return 0
+
+    tool_name = payload.get("tool_name") or ""
+    tool_input = payload.get("tool_input") or {}
+
+    if not isinstance(tool_input, dict):
+        return 0
+
+    text = extract_scan_target(tool_name, tool_input)
+    if text is None:
+        return 0  # unknown tool or missing field — pass through
+
+    findings = scan_content(text)
+    if not findings:
+        return 0
+
+    for token, kind in findings:
+        sys.stderr.write(ADVISORY_TEMPLATE.format(token=token, kind=kind))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/external-api-literal-trigger.sh
+++ b/hooks/external-api-literal-trigger.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# external-api-literal-trigger.sh — thin shim (praxis #202)
+# Logic in .py; shim keeps hooks.json entry stable across refactors.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="$SCRIPT_DIR/external-api-literal-trigger.py"
+command -v python3 >/dev/null 2>&1 || exit 0
+[ -f "$PY" ] || exit 0
+exec python3 "$PY"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -90,6 +90,16 @@
         ]
       },
       {
+        "matcher": "Write|Edit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/external-api-literal-trigger.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Edit|Write|NotebookEdit",
         "hooks": [
           {

--- a/hooks/test-external-api-literal-trigger.sh
+++ b/hooks/test-external-api-literal-trigger.sh
@@ -152,6 +152,16 @@ run_case "Write: PAYMENT_STATUS_APPROVED enum" advisory \
 run_case "Edit: 3-part SQL hive.warehouse.orders" advisory \
   "$(make_edit_payload 'SELECT * FROM hive.warehouse.orders LIMIT 10')"
 
+# Quoted / backticked 3-part SQL identifiers (ANSI / MySQL / Hive forms)
+run_case "Edit: quoted 3-part SQL \"mysql\".\"auth\".\"tb_user\"" advisory \
+  "$(make_edit_payload 'SELECT * FROM "mysql"."auth"."tb_user" WHERE id = 1')"
+
+run_case "Edit: backticked 3-part SQL \`mysql\`.\`auth\`.\`tb_user\`" advisory \
+  "$(make_edit_payload 'SELECT * FROM `mysql`.`auth`.`tb_user` WHERE id = 1')"
+
+run_case "Edit: JOIN with quoted 3-part \"hive\".\"warehouse\".\"orders\"" advisory \
+  "$(make_edit_payload 'SELECT a.id FROM t a JOIN "hive"."warehouse"."orders" o ON a.id=o.id')"
+
 # ---------------------------------------------------------------------------
 # Pass cases: should NOT emit advisory
 # ---------------------------------------------------------------------------

--- a/hooks/test-external-api-literal-trigger.sh
+++ b/hooks/test-external-api-literal-trigger.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# test-external-api-literal-trigger.sh — coverage for external-api-literal-trigger hook
+#
+# Synthesizes Claude Code PreToolUse payloads and asserts:
+#   advisory → exit 0 + stderr non-empty
+#   pass     → exit 0 + stderr empty
+#
+# Usage: bash hooks/test-external-api-literal-trigger.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/external-api-literal-trigger.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable: $HOOK" >&2
+  exit 1
+fi
+
+PASS=0; FAIL=0; FAILED_NAMES=()
+
+# Run a single test case.
+# $1 = name
+# $2 = expected: "advisory" (exit 0 + stderr non-empty) | "pass" (exit 0 + stderr empty)
+# $3 = JSON payload (string)
+run_case() {
+  local name="$1" expected="$2" payload="$3"
+  local err_file rc
+  err_file=$(mktemp)
+  echo "$payload" | "$HOOK" >/dev/null 2>"$err_file"
+  rc=$?
+  local err_content
+  err_content=$(cat "$err_file"); rm -f "$err_file"
+
+  local ok=1
+  case "$expected" in
+    advisory)
+      # exit 0 + stderr non-empty
+      [ "$rc" -eq 0 ] && [ -n "$err_content" ] || ok=0
+      ;;
+    pass)
+      # exit 0 + stderr empty
+      [ "$rc" -eq 0 ] && [ -z "$err_content" ] || ok=0
+      ;;
+    *)
+      echo "FAIL: unknown expected: $expected" >&2
+      ok=0
+      ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (rc=$rc, stderr='${err_content:0:80}')"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Helper: build a payload for a given tool_name + content field
+# ---------------------------------------------------------------------------
+make_write_payload() {
+  # $1 = content string
+  python3 -c "
+import json, sys
+payload = {
+    'session_id': 'test-session',
+    'tool_name': 'Write',
+    'tool_input': {
+        'file_path': '/tmp/test.py',
+        'content': sys.argv[1],
+    },
+    'cwd': '/tmp',
+}
+print(json.dumps(payload))
+" "$1"
+}
+
+make_edit_payload() {
+  # $1 = new_string value
+  python3 -c "
+import json, sys
+payload = {
+    'session_id': 'test-session',
+    'tool_name': 'Edit',
+    'tool_input': {
+        'file_path': '/tmp/test.py',
+        'old_string': 'foo',
+        'new_string': sys.argv[1],
+    },
+    'cwd': '/tmp',
+}
+print(json.dumps(payload))
+" "$1"
+}
+
+make_bash_payload() {
+  # $1 = command string
+  python3 -c "
+import json, sys
+payload = {
+    'session_id': 'test-session',
+    'tool_name': 'Bash',
+    'tool_input': {
+        'command': sys.argv[1],
+    },
+    'cwd': '/tmp',
+}
+print(json.dumps(payload))
+" "$1"
+}
+
+make_other_tool_payload() {
+  # $1 = tool_name, $2 = content
+  python3 -c "
+import json, sys
+payload = {
+    'session_id': 'test-session',
+    'tool_name': sys.argv[1],
+    'tool_input': {
+        'file_path': '/tmp/test.py',
+        'content': sys.argv[2],
+    },
+    'cwd': '/tmp',
+}
+print(json.dumps(payload))
+" "$1" "$2"
+}
+
+# ---------------------------------------------------------------------------
+# Fire cases: should emit advisory
+# ---------------------------------------------------------------------------
+
+run_case "Write: LAST_365_DAYS enum in content" advisory \
+  "$(make_write_payload 'period = "LAST_365_DAYS"')"
+
+run_case "Write: THIS_WEEK_OF_MONTH date literal" advisory \
+  "$(make_write_payload 'date_range = "THIS_WEEK_OF_MONTH"')"
+
+run_case "Edit: 3-part SQL identifier mysql.auth.tb_user" advisory \
+  "$(make_edit_payload 'SELECT * FROM mysql.auth.tb_user WHERE id = 1')"
+
+run_case "Bash: SHOPBY_AUTH_TOKEN env var usage" advisory \
+  "$(make_bash_payload 'curl -H "Authorization: Bearer $SHOPBY_AUTH_TOKEN" https://api.example.com')"
+
+run_case "Write: PAYMENT_STATUS_APPROVED enum" advisory \
+  "$(make_write_payload 'status = "PAYMENT_STATUS_APPROVED"')"
+
+run_case "Edit: 3-part SQL hive.warehouse.orders" advisory \
+  "$(make_edit_payload 'SELECT * FROM hive.warehouse.orders LIMIT 10')"
+
+# ---------------------------------------------------------------------------
+# Pass cases: should NOT emit advisory
+# ---------------------------------------------------------------------------
+
+run_case "Pass: TODO stop-word excluded" pass \
+  "$(make_write_payload '# TODO: refactor this function')"
+
+run_case "Pass: FIXME stop-word excluded" pass \
+  "$(make_write_payload '# FIXME: handle edge case')"
+
+run_case "Pass: README stop-word excluded" pass \
+  "$(make_write_payload 'with open("README") as f: pass')"
+
+run_case "Pass: LICENSE stop-word excluded" pass \
+  "$(make_write_payload 'license = "LICENSE"')"
+
+run_case "Pass: MIT stop-word excluded" pass \
+  "$(make_write_payload 'license = "MIT"')"
+
+run_case "Pass: short ALL_CAPS OS (length < 6)" pass \
+  "$(make_write_payload 'import os; os.environ.get("OS")')"
+
+run_case "Pass: short ALL_CAPS URL (length < 6)" pass \
+  "$(make_write_payload 'base_url = URL')"
+
+run_case "Pass: plain lowercase text" pass \
+  "$(make_write_payload 'def hello_world(): return "hello"')"
+
+run_case "Pass: 2-part SQL identifier (not 3-part)" pass \
+  "$(make_write_payload 'SELECT * FROM schema.table_name')"
+
+run_case "Pass: tool_name Read (not in scope)" pass \
+  "$(make_other_tool_payload "Read" 'SHOPBY_AUTH_TOKEN is the key')"
+
+run_case "Pass: tool_name NotebookEdit (not in scope)" pass \
+  "$(make_other_tool_payload "NotebookEdit" 'LAST_365_DAYS')"
+
+run_case "Pass: pure ALL_CAPS without underscore or digit (SQL keyword SELECT)" pass \
+  "$(make_write_payload 'query = "SELECT * FROM users"')"
+
+run_case "Pass: malformed JSON input" pass \
+  'not valid json at all'
+
+run_case "Pass: empty content field" pass \
+  "$(make_write_payload '')"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ ${#FAILED_NAMES[@]} -gt 0 ]; then
+  echo "Failed:"
+  for n in "${FAILED_NAMES[@]}"; do
+    echo "  - $n"
+  done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 개요

`Loaded ≠ Retrieved` 규칙이 컨텍스트에 로드되어 있어도, 실제로 값을 파일/명령에 쓰는 순간(use-site)에 retrieval trigger가 발동하지 않아 외부 API enum/literal을 naming-pattern 추론으로 작성하는 패턴이 3건 관찰되었습니다(이슈 #202).

이 PR은 해당 use-site에 advisory hook을 추가합니다.

## 변경 파일

- `hooks/external-api-literal-trigger.py` — 신규 PreToolUse hook 본체
- `hooks/external-api-literal-trigger.sh` — shell shim (hooks.json 안정성 유지)
- `hooks/test-external-api-literal-trigger.sh` — 테스트 스크립트 (20 케이스)
- `hooks/hooks.json` — Write|Edit|Bash matcher에 신규 hook 등록
- `AGENTS.md` — hook index 테이블에 신규 row 추가
- `docs/hook/external-api-literal-trigger.md` — hook 명세 문서

## 동작

`Write`, `Edit`, `Bash` PreToolUse 이벤트에서 아래 패턴을 스캔합니다:

1. **ALL_CAPS_WITH_UNDERSCORES 토큰** (길이 ≥ 6, underscore 또는 숫자 포함) — 외부 enum 후보
2. **3-part SQL identifier** (`catalog.schema.table`) — SQL 문맥(FROM/JOIN/...) 근처에서만 발동

발동 시 advisory stderr 메시지를 출력합니다 (exit 0 — 절대 block하지 않음):

```
⚠ External API literal detected: `LAST_365_DAYS` (ALL_CAPS enum candidate)
   Has this value been verified against an authoritative source
   (vendor doc, SHOW CATALOGS, --help) in this session?
   If yes, proceed. If no, retrieve before write.
```

## False positive 회피

- `TODO`, `FIXME`, `README`, `LICENSE`, `MIT`, `BSD`, `JSON`, `URL`, `API` 등 코드 상수는 stop-word로 제외
- 3-part SQL: SQL 문맥(FROM/JOIN/TABLE/INTO/UPDATE) 뒤에서만 발동 → Python 속성 체인(`os.environ.get`)은 제외
- 순수 ALL_CAPS 단어 (underscore/숫자 없는 `SELECT`, `WHERE` 등) 제외

## Acceptance criteria

- [x] Hook fires on `Write`/`Edit`/`Bash` content containing ALL_CAPS_WITH_UNDERSCORES tokens of length ≥ 6
- [x] Hook fires on 3-part SQL identifiers (`<catalog>.<schema>.<table>`)
- [x] Hook emits advisory only (does not block)
- [x] Test fixtures demonstrate both fire and no-fire cases (20/20 PASS)
- [x] Documentation in `docs/hook/external-api-literal-trigger.md` explains the rule it enforces

Closes #202