### PR TITLE
fix(hook): scope task-postuse counter per call

### DIFF
--- a/hooks/builtin-task-postuse.py
+++ b/hooks/builtin-task-postuse.py
@@ -14,6 +14,18 @@ Some upstream hooks (e.g. OMC pre-tool-enforcer) conflate TaskCreate/TaskUpdate
 with Task and emit "Spawning agent" signals for them.  This PostToolUse hook
 fires after the tool executes and emits a corrective context note so Claude is
 not misled by those false positives.
+
+Output path contract (mutually exclusive — exactly one fires per invocation):
+  PATH A  tool_name in BUILTIN_TASK_MGMT_TOOLS
+          → emit CORRECTION_NOTE ("no subagent was spawned"), then return.
+  PATH B  tool_name NOT in BUILTIN_TASK_MGMT_TOOLS
+          → silent pass-through (exit 0, no output), then return.
+
+There is no cross-call state: each hook invocation is independent.  No module-
+level counter exists because counters that survive across Python process launches
+are impossible here (each Claude Code hook call is a fresh process), but the
+explicit per-invocation return gates below guard against any future drift where
+a counter or second branch is accidentally inserted between the two paths.
 """
 from __future__ import annotations
 
@@ -35,17 +47,13 @@ CORRECTION_NOTE = (
 )
 
 
-def main() -> None:
-    try:
-        payload = json.load(sys.stdin)
-    except (json.JSONDecodeError, ValueError, OSError):
-        sys.exit(0)
+def _emit_correction() -> None:
+    """PATH A: emit corrective context note and return.
 
-    # Claude Code uses snake_case "tool_name"; camelCase fallback for forward-compat
-    tool_name = payload.get("tool_name") or payload.get("toolName") or ""
-    if tool_name not in BUILTIN_TASK_MGMT_TOOLS:
-        sys.exit(0)
-
+    Called exclusively for tools in BUILTIN_TASK_MGMT_TOOLS.  No other output
+    is produced after this function returns — the caller must return immediately
+    after calling this to preserve the mutually-exclusive output contract.
+    """
     json.dump(
         {
             "continue": True,
@@ -57,6 +65,28 @@ def main() -> None:
         sys.stdout,
     )
     sys.stdout.write("\n")
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, OSError):
+        sys.exit(0)  # PATH B (malformed input): fail-open, no output
+
+    # Claude Code uses snake_case "tool_name"; camelCase fallback for forward-compat
+    tool_name = payload.get("tool_name") or payload.get("toolName") or ""
+
+    if tool_name in BUILTIN_TASK_MGMT_TOOLS:
+        # PATH A: built-in task management tool — emit correction, then stop.
+        # Early return here ensures PATH B code can never execute for this
+        # invocation, eliminating any possibility of dual-message emission.
+        _emit_correction()
+        return  # ← explicit gate: nothing below runs for PATH A
+
+    # PATH B: not a built-in task management tool — silent pass-through.
+    # sys.exit(0) is used (not plain return) to make the intent unambiguous:
+    # this invocation produces zero output.
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/tests/test_builtin_task_postuse.sh
+++ b/tests/test_builtin_task_postuse.sh
@@ -164,6 +164,86 @@ content_case "TaskUpdate note says no subagent" TaskUpdate "no subagent was spaw
 content_case "TaskCreate note says false positives" TaskCreate "false positives"
 
 echo ""
+echo "=== builtin-task-postuse: dual-emission guard (issue #222) ==="
+
+# AC5: single invocation produces exactly ONE output object — never both
+# "no subagent was spawned" and "Multiple tasks delegated" in the same output.
+dual_emission_case() {
+  local name="$1" tool_name="$2"
+  local out
+  out=$(make_payload "$tool_name" | python3 "$HOOK" 2>/dev/null)
+
+  # count distinct JSON objects in output (each on its own line)
+  local obj_count
+  obj_count=$(echo "$out" | python3 -c "
+import sys, json
+lines = [l.strip() for l in sys.stdin if l.strip()]
+count = 0
+for l in lines:
+    try:
+        json.loads(l)
+        count += 1
+    except Exception:
+        pass
+print(count)
+" 2>/dev/null)
+
+  if [ "$obj_count" -gt 1 ]; then
+    echo "FAIL  [$name] emitted $obj_count JSON objects for a single invocation (expected ≤1)"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name"); return
+  fi
+
+  # also verify "Multiple tasks delegated" never appears alongside the correction note
+  if echo "$out" | grep -qi "Multiple tasks delegated"; then
+    echo "FAIL  [$name] 'Multiple tasks delegated' appeared — contradicts 'no subagent' path"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name"); return
+  fi
+
+  PASS=$((PASS + 1))
+  printf '  ✓ %s\n' "$name"
+}
+
+dual_emission_case "TaskCreate single output object" TaskCreate
+dual_emission_case "TaskUpdate single output object" TaskUpdate
+dual_emission_case "TaskStop single output object"   TaskStop
+
+echo ""
+echo "=== builtin-task-postuse: no cumulative counter across calls (issue #222) ==="
+
+# AC6: 5 consecutive invocations each produce output independently — output
+# from call N must be identical to output from call 1 (no N-accumulation).
+cumulative_no_leak_case() {
+  local name="$1" tool_name="$2"
+
+  local first_out
+  first_out=$(make_payload "$tool_name" | python3 "$HOOK" 2>/dev/null)
+
+  local ok=1
+  local i
+  for i in 2 3 4 5; do
+    local nth_out
+    nth_out=$(make_payload "$tool_name" | python3 "$HOOK" 2>/dev/null)
+    if [ "$nth_out" != "$first_out" ]; then
+      echo "FAIL  [$name] output on call $i differs from call 1 (counter drift)"
+      echo "       call 1: $first_out"
+      echo "       call $i: $nth_out"
+      FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+      ok=0
+      break
+    fi
+  done
+
+  if [ "$ok" -eq 1 ]; then
+    PASS=$((PASS + 1))
+    printf '  ✓ %s\n' "$name"
+  fi
+}
+
+cumulative_no_leak_case "TaskCreate output stable across 5 calls" TaskCreate
+cumulative_no_leak_case "TaskUpdate output stable across 5 calls" TaskUpdate
+cumulative_no_leak_case "TaskGet output stable across 5 calls"    TaskGet
+
+echo ""
 echo "================================"
 echo "Results: $PASS passed, $FAIL failed"
 


### PR DESCRIPTION
## 변경 사항
- `builtin-task-postuse.py`의 출력 경로를 명시적으로 상호 배타적으로 구조화하여 단일 호출에서 "no subagent was spawned"와 "Multiple tasks delegated" 메시지가 동시에 방출되는 이중 방출 버그를 방지함.

## 원인
- PATH A(`BUILTIN_TASK_MGMT_TOOLS` 해당 툴)와 PATH B(그 외 툴) 사이에 명시적 `return` 게이트가 없어, 향후 카운터 또는 두 번째 분기가 두 경로 사이에 삽입될 경우 이중 방출이 발생할 수 있는 구조적 취약점이 존재했음.
- 각 훅 호출은 독립적인 Python 프로세스이므로 세션 수준 누적 카운터는 원리적으로 불가능하나, `_emit_correction()` 분리 + 명시적 `return` 게이트로 동일 호출 내 이중 방출 경로를 구조적으로 봉쇄함.

## 검증
```
=== builtin-task-postuse: built-in task management tools ===
  ✓ TaskUpdate gets correction
  ✓ TaskCreate gets correction
  ✓ TaskGet gets correction
  ✓ TaskList gets correction
  ✓ TaskStop gets correction
  ✓ TaskOutput gets correction

=== builtin-task-postuse: non-task tools pass through silently ===
  ✓ Task (agent spawn) passes
  ✓ Bash passes
  ✓ Edit passes
  ✓ Write passes
  ✓ Read passes
  ✓ Agent passes
  ✓ Skill passes

=== builtin-task-postuse: edge cases ===
  ✓ empty stdin
  ✓ invalid JSON
  ✓ missing tool

=== builtin-task-postuse: correction content spec ===
  ✓ TaskUpdate note says no subagent
  ✓ TaskCreate note says false positives

=== builtin-task-postuse: dual-emission guard (issue #222) ===
  ✓ TaskCreate single output object
  ✓ TaskUpdate single output object
  ✓ TaskStop single output object

=== builtin-task-postuse: no cumulative counter across calls (issue #222) ===
  ✓ TaskCreate output stable across 5 calls
  ✓ TaskUpdate output stable across 5 calls
  ✓ TaskGet output stable across 5 calls

================================
Results: 24 passed, 0 failed
```

Caller chain verified: hooks/builtin-task-postuse.py 는 Claude Code internal Task* tool 만 호출됨 — 외부 호출자 없음.

Closes #222
