### PR TITLE
feat(hook): output-block falsify advisory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,7 @@ Design contract shared by all hooks:
 | `pre-edit-protected-branch-guard` | PreToolUse | Block Edit/Write/NotebookEdit on protected branches (main/dev/prod/master) when dirty and target not already in dirty diff | [docs/hook/pre-edit-protected-branch-guard.md](docs/hook/pre-edit-protected-branch-guard.md) |
 | `external-api-literal-trigger` | PreToolUse | Advisory nudge when ALL_CAPS enum candidates or 3-part SQL identifiers are written without prior retrieval verification (issue #202) | [docs/hook/external-api-literal-trigger.md](docs/hook/external-api-literal-trigger.md) |
 | `block-manufactured-action-menu` | PreToolUse | Warn (advisory) or block (strict) when AskUserQuestion surfaces a "shall we proceed?" menu after the user already issued a command-intent signal | [docs/hook/block-manufactured-action-menu.md](docs/hook/block-manufactured-action-menu.md) |
+| `output-block-falsify-advisory` | PreToolUse | Advisory nudge to run output-block falsification gate before surfacing `(Recommended)` options or bulk-action commands (issue #221) | [docs/hook/output-block-falsify-advisory.md](docs/hook/output-block-falsify-advisory.md) |
 
 ### Hook ordering and precedence
 

--- a/docs/hook/output-block-falsify-advisory.md
+++ b/docs/hook/output-block-falsify-advisory.md
@@ -1,0 +1,118 @@
+# PreToolUse Output-Block Falsification Advisory
+
+`hooks/output-block-falsify-advisory.py` fires on every `PreToolUse` event
+for `AskUserQuestion` and `Bash` tool calls. It detects two surfaces where
+a self-authored proposal block is about to be surfaced without a falsification
+check and emits an advisory reminder.
+
+### Why this exists
+
+The global CLAUDE.md rule **"Output-Block-Level Falsification Gate"** instructs:
+
+> Before surfacing a self-authored proposal as a complete output block, run
+> an explicit falsification test on its premise. If a concrete invalidating
+> link/artifact exists — STOP. Do not surface the proposal.
+
+Despite this rule being loaded into context (4+ memory entries accumulated
+2026-05-03 through 2026-05-13), the retrieval trigger does not fire at the
+specific moment the proposal block is authored. The pattern is consistent:
+same-session repeats where a wrong-framing issue cancelled at T+0 recurs
+with an identical anti-pattern at T+1h.
+
+Text rules and MEMORY.md entries alone have proven insufficient to prevent
+recurrence. A structural hook moves the gate to the tool-call use-site.
+
+Reference: issue [#221](https://github.com/devseunggwan/praxis/issues/221).
+
+**Escalation criteria:** After ~1 month of advisory operation (target: ~2026-06-15),
+evaluate recurrence rate. If advisory is repeatedly bypassed without falsification,
+escalate to blocking (`exit 2`) for the `AskUserQuestion` `(Recommended)` surface.
+
+### What is detected
+
+| Tool | Trigger condition | Advisory emitted |
+|------|-----------------|-----------------|
+| `AskUserQuestion` | Any option `label` contains `(Recommended)` or `(추천)` (case-insensitive for English form) | Yes |
+| `Bash` | Command matches a bulk-action mutation keyword (see table below) | Yes |
+| Any other tool | — | Silent pass-through |
+| Malformed payload / missing field | — | Silent fail-open |
+
+**This hook never blocks.** Advisory mode only — exit 0 in all cases.
+
+#### AskUserQuestion: (Recommended) marker
+
+`(Recommended)` and `(추천)` in option labels are the canonical signal for a
+self-authored proposal block about to be surfaced. The CLAUDE.md rule names
+`(Recommended)` as a primary trigger for the falsification gate.
+
+#### Bash: bulk-action mutation keywords
+
+| Type | Patterns detected |
+|------|-----------------|
+| English (regex, case-insensitive) | `close\s+all`, `delete\s+all`, `merge\s+all`, `reject\s+all`, `approve\s+all` |
+| Korean (substring) | `전부 닫`, `모두 닫`, `전부 삭제`, `모두 삭제`, `전부 머지`, `모두 머지`, `다 머지`, `전부 클로즈`, `모두 클로즈` |
+
+Bulk-action commands often reflect a downstream consequence of a proposal block
+whose premise was not falsified ("close all linked issues" after a misframed
+proposal). The advisory fires conservatively: only mutation-verb patterns are
+matched; read-only commands (`git log --all`, `gh pr list`) do not fire.
+
+### Response shape
+
+**Advisory message** (emitted to stderr, never stdout):
+
+```
+[output-block-falsify-advisory] Surfacing a recommendation/bulk-action
+proposal? Run the output-block falsification gate first: is the proposal's
+premise already addressed by in-flight work, a merged PR, or a parallel
+proposal in this session? If yes — STOP and cite the invalidating link
+instead of surfacing the proposal.
+```
+
+**Exit code:** always `0` (never blocks).
+
+**JSON response:** none — the hook communicates via stderr only
+(`additionalContext` in Claude Code's terminology). Claude Code reads stderr
+from advisory PreToolUse hooks and includes it in the model's context.
+
+### Parsing guarantees
+
+| Condition | Behavior |
+|-----------|----------|
+| Malformed / missing stdin JSON | exit 0 (silent pass) |
+| `tool_name` not `AskUserQuestion` or `Bash` | exit 0 (silent pass) |
+| Missing `questions` / `options` / `command` fields | exit 0 (silent pass) |
+| `python3` unavailable | exit 0 (shell shim guards) |
+| Hook `.py` file missing | exit 0 (shell shim guards) |
+| Any uncaught exception | exit 0 (silent pass, no crash) |
+
+The hook uses no external dependencies (no PyYAML, no third-party packages).
+All parsing is done with the Python standard library only.
+
+### Tests
+
+```bash
+bash tests/test_output_block_falsify_advisory.sh
+```
+
+Covers 10 cases:
+
+**Positive (AskUserQuestion):**
+- Option label `(Recommended)` → advisory emitted
+- Option label `(추천)` → advisory emitted
+
+**Negative (AskUserQuestion):**
+- Option labels without marker → silent pass
+
+**Positive (Bash):**
+- `gh pr merge --all` with "merge all" phrasing → advisory emitted
+- `gh issue close --all` with "close all" phrasing → advisory emitted
+- Korean: `모두 삭제` → advisory emitted
+
+**Negative (Bash):**
+- `git status` → silent pass
+- `gh pr list --all` (read-only, no mutation verb) → silent pass
+
+**Edge:**
+- Malformed JSON stdin → exit 0, silent pass
+- Empty payload → exit 0, silent pass

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -86,6 +86,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-intent.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/output-block-falsify-advisory.sh",
+            "timeout": 5
           }
         ]
       },
@@ -120,6 +125,11 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-manufactured-action-menu.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/output-block-falsify-advisory.sh",
             "timeout": 5
           }
         ]

--- a/hooks/output-block-falsify-advisory.py
+++ b/hooks/output-block-falsify-advisory.py
@@ -104,17 +104,14 @@ def _has_recommended_marker(labels: list[str]) -> bool:
 #
 # Strategy: search for the verb phrase with "all" nearby. Using a regex with
 # ASCII lookaround avoids `\b` issues when Korean text appears nearby.
-_BULK_PHRASES_EN = (
-    r"close\s+all",
-    r"delete\s+all",
-    r"merge\s+all",
-    r"reject\s+all",
-    r"approve\s+all",
-)
+_BULK_VERBS_EN = ("close", "delete", "merge", "reject", "approve")
 
-# Compiled pattern: any English bulk phrase (case-insensitive).
+# ASCII lookaround instead of `\b`: Python's `\b` is Unicode-aware and would
+# misfire when Korean text sits adjacent to ASCII (no boundary between Hangul
+# and ASCII word chars). Explicit ASCII boundaries prevent false matches like
+# `disclose all` / `enclose all` triggering on the `close all` substring.
 _BULK_PATTERN_EN = re.compile(
-    "|".join(_BULK_PHRASES_EN),
+    r"(?<![A-Za-z])(?:" + "|".join(_BULK_VERBS_EN) + r")\s+all(?![A-Za-z])",
     re.IGNORECASE,
 )
 
@@ -151,7 +148,7 @@ def _is_bulk_action_command(command: str) -> bool:
 # Main
 # ---------------------------------------------------------------------------
 
-def main() -> int:
+def _main_inner() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -173,14 +170,23 @@ def main() -> int:
             fire = True
 
     elif tool_name == "Bash":
-        command = tool_input.get("command") or ""
-        if _is_bulk_action_command(command):
+        command = tool_input.get("command")
+        if isinstance(command, str) and _is_bulk_action_command(command):
             fire = True
 
     if fire:
         sys.stderr.write(ADVISORY_MSG + "\n")
 
     return 0
+
+
+def main() -> int:
+    """Advisory hook — must NEVER break tool execution. Any uncaught exception
+    in the inner logic is swallowed and the hook fails open (exit 0)."""
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/output-block-falsify-advisory.py
+++ b/hooks/output-block-falsify-advisory.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""PreToolUse advisory: nudge output-block falsification gate.
+
+Issue #221. Recurring failure mode: the "Output-Block-Level Falsification Gate"
+rule in CLAUDE.md (4+ memory entries accumulated 2026-05-03 through 2026-05-13)
+fails to fire at output time because rule retrieval is not structural — the rule
+is loaded but not re-triggered at the moment the proposal block is authored.
+
+This hook adds a structural enforcement point at two surfaces:
+
+  1. AskUserQuestion — option labels containing "(Recommended)" or "(추천)"
+     These markers are the canonical signal for a self-authored proposal block
+     about to be surfaced to the user.
+
+  2. Bash — bulk-action commands containing patterns like "close all",
+     "delete all", "merge all" (+ Korean equivalents), which may reflect a
+     consequence of a proposal block whose premise was not falsified.
+
+When detected, an advisory stderr reminder is emitted asking whether the
+output-block falsification gate has been run. The hook NEVER blocks (exit 0
+always). Advisory mode is the only mode; escalation to blocking will be
+evaluated after ~1 month of advisory operation.
+
+Fail-open contract (project hook design):
+  - Malformed / missing stdin JSON → exit 0
+  - Unknown tool_name → exit 0
+  - Missing target field (questions / command) → exit 0
+  - Any uncaught exception → exit 0
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+# ---------------------------------------------------------------------------
+# Advisory message
+# ---------------------------------------------------------------------------
+
+ADVISORY_MSG = (
+    "[output-block-falsify-advisory] Surfacing a recommendation/bulk-action "
+    "proposal? Run the output-block falsification gate first: is the proposal's "
+    "premise already addressed by in-flight work, a merged PR, or a parallel "
+    "proposal in this session? If yes — STOP and cite the invalidating link "
+    "instead of surfacing the proposal."
+)
+
+# ---------------------------------------------------------------------------
+# AskUserQuestion: (Recommended) / (추천) marker detection
+# ---------------------------------------------------------------------------
+
+# Substrings to search for in option labels (case-insensitive for English form).
+RECOMMENDED_MARKERS_EN = ("(Recommended)",)
+RECOMMENDED_MARKERS_KO = ("(추천)",)
+
+
+def _collect_option_labels(tool_input: dict) -> list[str]:
+    """Walk questions[].options[].label and return all label strings.
+
+    Tolerant of partial schemas — any missing field returns an empty list.
+    Hook must never crash on malformed payloads.
+    """
+    labels: list[str] = []
+    questions = tool_input.get("questions") or []
+    if not isinstance(questions, list):
+        return labels
+    for q in questions:
+        if not isinstance(q, dict):
+            continue
+        options = q.get("options") or []
+        if not isinstance(options, list):
+            continue
+        for o in options:
+            if not isinstance(o, dict):
+                continue
+            label = o.get("label")
+            if isinstance(label, str):
+                labels.append(label)
+    return labels
+
+
+def _has_recommended_marker(labels: list[str]) -> bool:
+    """True if any option label contains a (Recommended) / (추천) marker."""
+    if not labels:
+        return False
+    for label in labels:
+        lower = label.lower()
+        for marker in RECOMMENDED_MARKERS_EN:
+            if marker.lower() in lower:
+                return True
+        for marker in RECOMMENDED_MARKERS_KO:
+            if marker in label:
+                return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Bash: bulk-action keyword detection
+# ---------------------------------------------------------------------------
+
+# English bulk-action phrases. Matched as case-insensitive substrings after
+# a word-boundary check on the verb part. The "all" / "all " suffix is kept
+# as a plain substring to avoid over-matching on common non-bulk commands.
+#
+# Strategy: search for the verb phrase with "all" nearby. Using a regex with
+# ASCII lookaround avoids `\b` issues when Korean text appears nearby.
+_BULK_PHRASES_EN = (
+    r"close\s+all",
+    r"delete\s+all",
+    r"merge\s+all",
+    r"reject\s+all",
+    r"approve\s+all",
+)
+
+# Compiled pattern: any English bulk phrase (case-insensitive).
+_BULK_PATTERN_EN = re.compile(
+    "|".join(_BULK_PHRASES_EN),
+    re.IGNORECASE,
+)
+
+# Korean bulk-action substrings. Plain substring match is safe because Hangul
+# has no ASCII word-boundary issue — these tokens don't appear as substrings
+# of unrelated words.
+_BULK_SUBSTRINGS_KO = (
+    "전부 닫",
+    "모두 닫",
+    "전부 삭제",
+    "모두 삭제",
+    "전부 머지",
+    "모두 머지",
+    "다 머지",
+    "전부 클로즈",
+    "모두 클로즈",
+)
+
+# Mutation verbs that qualify a bulk command as write-side (not read-only).
+# The goal is to avoid firing on `git log --all` / `gh pr list --all` etc.
+# We require that the command contains at least one of these mutation verbs
+# so that a plain `list all` or `show all` doesn't fire.
+_MUTATION_VERBS = re.compile(
+    r"\b(close|delete|remove|merge|reject|approve|push|drop|닫|삭제|머지|클로즈)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_bulk_action_command(command: str) -> bool:
+    """True if the Bash command contains a bulk-action mutation keyword."""
+    if not command:
+        return False
+    # English bulk phrases (close all / delete all / merge all / etc.)
+    if _BULK_PATTERN_EN.search(command):
+        return True
+    # Korean substrings
+    for kw in _BULK_SUBSTRINGS_KO:
+        if kw in command:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0  # fail-open on malformed stdin
+
+    if not isinstance(payload, dict):
+        return 0
+
+    tool_name = payload.get("tool_name") or ""
+    tool_input = payload.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return 0
+
+    fire = False
+
+    if tool_name == "AskUserQuestion":
+        labels = _collect_option_labels(tool_input)
+        if _has_recommended_marker(labels):
+            fire = True
+
+    elif tool_name == "Bash":
+        command = tool_input.get("command") or ""
+        if _is_bulk_action_command(command):
+            fire = True
+
+    if fire:
+        sys.stderr.write(ADVISORY_MSG + "\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/output-block-falsify-advisory.py
+++ b/hooks/output-block-falsify-advisory.py
@@ -133,16 +133,6 @@ _BULK_SUBSTRINGS_KO = (
     "모두 클로즈",
 )
 
-# Mutation verbs that qualify a bulk command as write-side (not read-only).
-# The goal is to avoid firing on `git log --all` / `gh pr list --all` etc.
-# We require that the command contains at least one of these mutation verbs
-# so that a plain `list all` or `show all` doesn't fire.
-_MUTATION_VERBS = re.compile(
-    r"\b(close|delete|remove|merge|reject|approve|push|drop|닫|삭제|머지|클로즈)\b",
-    re.IGNORECASE,
-)
-
-
 def _is_bulk_action_command(command: str) -> bool:
     """True if the Bash command contains a bulk-action mutation keyword."""
     if not command:

--- a/hooks/output-block-falsify-advisory.sh
+++ b/hooks/output-block-falsify-advisory.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# output-block-falsify-advisory.sh — thin shim (praxis #221)
+# Logic in .py; shim keeps hooks.json entry stable across refactors.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="$SCRIPT_DIR/output-block-falsify-advisory.py"
+command -v python3 >/dev/null 2>&1 || exit 0
+[ -f "$PY" ] || exit 0
+exec python3 "$PY"

--- a/tests/test_output_block_falsify_advisory.sh
+++ b/tests/test_output_block_falsify_advisory.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# test_output_block_falsify_advisory.sh — coverage for output-block-falsify-advisory hook
+#
+# Synthesizes Claude Code PreToolUse payloads and asserts:
+#   advisory → exit 0 + stderr non-empty (contains advisory keyword)
+#   pass     → exit 0 + stderr empty
+#
+# Usage: bash tests/test_output_block_falsify_advisory.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$ROOT_DIR/hooks/output-block-falsify-advisory.sh"
+
+if [ ! -f "$HOOK" ]; then
+  echo "FAIL: hook not found: $HOOK" >&2
+  exit 1
+fi
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable: $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+# run_case name expectation payload
+#   expectation:
+#     "advisory:<substring>" — exit 0 + stderr contains <substring>
+#     "pass"                  — exit 0 + stderr empty
+run_case() {
+  local name="$1" expectation="$2" payload="$3"
+
+  local err_file
+  err_file=$(mktemp)
+  printf '%s' "$payload" | "$HOOK" >/dev/null 2>"$err_file"
+  local rc=$?
+  local err
+  err=$(cat "$err_file")
+  rm -f "$err_file"
+
+  local ok=1
+  case "$expectation" in
+    advisory:*)
+      local needle="${expectation#advisory:}"
+      [ "$rc" -eq 0 ] || ok=0
+      case "$err" in
+        *"$needle"*) ;;
+        *) ok=0 ;;
+      esac
+      ;;
+    pass)
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$err" ]   || ok=0
+      ;;
+    *)
+      echo "FAIL  [$name] unknown expectation: $expectation"
+      FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name"); return
+      ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expectation=$expectation rc=$rc stderr=${err:-<empty>}"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Payload builders
+# ---------------------------------------------------------------------------
+
+make_ask_payload() {
+  # $1 = JSON array of option label strings (already JSON-encoded)
+  python3 -c "
+import json, sys
+labels = json.loads(sys.argv[1])
+options = [{'label': l} for l in labels]
+payload = {
+    'session_id': 'test-session',
+    'tool_name': 'AskUserQuestion',
+    'tool_input': {
+        'questions': [
+            {
+                'question': 'What should we do?',
+                'options': options,
+            }
+        ]
+    },
+    'cwd': '/tmp',
+}
+print(json.dumps(payload))
+" "$1"
+}
+
+make_bash_payload() {
+  # $1 = command string
+  python3 -c "
+import json, sys
+payload = {
+    'session_id': 'test-session',
+    'tool_name': 'Bash',
+    'tool_input': {
+        'command': sys.argv[1],
+    },
+    'cwd': '/tmp',
+}
+print(json.dumps(payload))
+" "$1"
+}
+
+# ---------------------------------------------------------------------------
+# AskUserQuestion positive cases
+# ---------------------------------------------------------------------------
+
+run_case "AskUserQuestion: (Recommended) English marker fires" \
+  "advisory:output-block-falsify-advisory" \
+  "$(make_ask_payload '["Option A (Recommended)", "Option B"]')"
+
+run_case "AskUserQuestion: (추천) Korean marker fires" \
+  "advisory:output-block-falsify-advisory" \
+  "$(make_ask_payload '["옵션 A (추천)", "옵션 B"]')"
+
+run_case "AskUserQuestion: (recommended) lowercase also fires" \
+  "advisory:output-block-falsify-advisory" \
+  "$(make_ask_payload '["use existing approach (recommended)"]')"
+
+# ---------------------------------------------------------------------------
+# AskUserQuestion negative cases
+# ---------------------------------------------------------------------------
+
+run_case "AskUserQuestion: no marker — silent pass" \
+  pass \
+  "$(make_ask_payload '["Option A", "Option B", "Option C"]')"
+
+run_case "AskUserQuestion: empty options — silent pass" \
+  pass \
+  "$(make_ask_payload '[]')"
+
+# ---------------------------------------------------------------------------
+# Bash positive cases
+# ---------------------------------------------------------------------------
+
+run_case "Bash: merge all — English bulk phrase fires" \
+  "advisory:output-block-falsify-advisory" \
+  "$(make_bash_payload 'gh pr merge --all  # merge all open PRs')"
+
+run_case "Bash: close all — English bulk phrase fires" \
+  "advisory:output-block-falsify-advisory" \
+  "$(make_bash_payload 'close all open issues via gh cli')"
+
+run_case "Bash: delete all — English bulk phrase fires" \
+  "advisory:output-block-falsify-advisory" \
+  "$(make_bash_payload 'aws s3 rm s3://bucket/ --recursive # delete all objects')"
+
+run_case "Bash: 모두 삭제 — Korean substring fires" \
+  "advisory:output-block-falsify-advisory" \
+  "$(make_bash_payload 'gh issue list | xargs gh issue close  # 모두 삭제')"
+
+run_case "Bash: 전부 머지 — Korean substring fires" \
+  "advisory:output-block-falsify-advisory" \
+  "$(make_bash_payload '# 전부 머지 처리')"
+
+run_case "Bash: 다 머지 — Korean substring fires" \
+  "advisory:output-block-falsify-advisory" \
+  "$(make_bash_payload 'echo "다 머지 할게요"')"
+
+# ---------------------------------------------------------------------------
+# Bash negative cases
+# ---------------------------------------------------------------------------
+
+run_case "Bash: git status — silent pass" \
+  pass \
+  "$(make_bash_payload 'git status')"
+
+run_case "Bash: gh pr list — read-only, no bulk mutation — silent pass" \
+  pass \
+  "$(make_bash_payload 'gh pr list --state open')"
+
+run_case "Bash: git log --all — --all flag but not a bulk mutation — silent pass" \
+  pass \
+  "$(make_bash_payload 'git log --all --oneline')"
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+run_case "Edge: malformed JSON stdin — silent pass" \
+  pass \
+  'not valid json at all'
+
+run_case "Edge: empty JSON object — silent pass" \
+  pass \
+  '{}'
+
+run_case "Edge: unknown tool_name — silent pass" \
+  pass \
+  "$(python3 -c 'import json; print(json.dumps({"tool_name": "Read", "tool_input": {"file_path": "/tmp/x"}}))')"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ ${#FAILED_NAMES[@]} -gt 0 ]; then
+  echo "Failed:"
+  for n in "${FAILED_NAMES[@]}"; do
+    echo "  - $n"
+  done
+  exit 1
+fi
+exit 0

--- a/tests/test_output_block_falsify_advisory.sh
+++ b/tests/test_output_block_falsify_advisory.sh
@@ -187,6 +187,16 @@ run_case "Bash: git log --all — --all flag but not a bulk mutation — silent 
   pass \
   "$(make_bash_payload 'git log --all --oneline')"
 
+# Codex #225 P3: word-boundary regression — `disclose all` / `enclose all`
+# must NOT match the `close all` substring.
+run_case "Bash: disclose all — word-boundary regression — silent pass" \
+  pass \
+  "$(make_bash_payload 'echo we will disclose all findings')"
+
+run_case "Bash: enclose all — word-boundary regression — silent pass" \
+  pass \
+  "$(make_bash_payload 'echo enclose all attachments in the email')"
+
 # ---------------------------------------------------------------------------
 # Edge cases
 # ---------------------------------------------------------------------------
@@ -202,6 +212,16 @@ run_case "Edge: empty JSON object — silent pass" \
 run_case "Edge: unknown tool_name — silent pass" \
   pass \
   "$(python3 -c 'import json; print(json.dumps({"tool_name": "Read", "tool_input": {"file_path": "/tmp/x"}}))')"
+
+# Codex #225 P2: fail-open on non-string command (number instead of string).
+# Hook contract: advisory hooks NEVER break tool execution on malformed payloads.
+run_case "Edge: non-string command (int) — fail-open silent pass" \
+  pass \
+  '{"tool_name":"Bash","tool_input":{"command":123}}'
+
+run_case "Edge: non-string command (null) — fail-open silent pass" \
+  pass \
+  '{"tool_name":"Bash","tool_input":{"command":null}}'
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## 변경 사항
- 신규 PreToolUse advisory hook 추가: `output-block-falsify-advisory`
- AskUserQuestion `(Recommended)` / `(추천)` 마커 + Bash bulk-action 키워드 감지
- hooks.json 등록 (Bash + AskUserQuestion 양쪽 matcher) + AGENTS.md 인덱스 행 추가 + docs/hook/ 스펙 작성

## 원인
- CLAUDE.md "Output-Block-Level Falsification Gate" 규칙이 텍스트 retrieval 만으로는 출력 시점에 발화 실패 (4+ memory 항목 반복, 2026-05-03~2026-05-13)
- 같은 세션 내 T+0에서 취소된 wrong-framing 이슈가 T+1h에 동일한 anti-pattern으로 재발
- retrospect 분석에서 구조적 enforcement 가 필요하다는 결론 → advisory 부터 시작, ~1개월 후 blocking 승격 검토 (목표: 2026-06-15)

## 감지 대상
- `AskUserQuestion`: option label에 `(Recommended)` 또는 `(추천)` 포함 시 발화
- `Bash`: `close all`, `delete all`, `merge all`, `reject all`, `approve all` (영문 regex, 대소문자 무관) + `전부 닫`, `모두 닫`, `전부 삭제`, `모두 삭제`, `전부 머지`, `모두 머지`, `다 머지` 등 한국어 substring

## 검증
```
PASS  [AskUserQuestion: (Recommended) English marker fires]
PASS  [AskUserQuestion: (추천) Korean marker fires]
PASS  [AskUserQuestion: (recommended) lowercase also fires]
PASS  [AskUserQuestion: no marker — silent pass]
PASS  [AskUserQuestion: empty options — silent pass]
PASS  [Bash: merge all — English bulk phrase fires]
PASS  [Bash: close all — English bulk phrase fires]
PASS  [Bash: delete all — English bulk phrase fires]
PASS  [Bash: 모두 삭제 — Korean substring fires]
PASS  [Bash: 전부 머지 — Korean substring fires]
PASS  [Bash: 다 머지 — Korean substring fires]
PASS  [Bash: git status — silent pass]
PASS  [Bash: gh pr list — read-only, no bulk mutation — silent pass]
PASS  [Bash: git log --all — --all flag but not a bulk mutation — silent pass]
PASS  [Edge: malformed JSON stdin — silent pass]
PASS  [Edge: empty JSON object — silent pass]
PASS  [Edge: unknown tool_name — silent pass]

Results: 17 passed, 0 failed
```

scripts/check-plugin-manifests.py: `plugin-manifest check OK`

Caller chain verified: 신규 hook — Claude Code PreToolUse 만 진입점. 외부 의존성 없음.

Closes #221
