### PR TITLE
feat(skills): extract 4 lazy-load skills from CLAUDE.md

### DIFF
--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: pr-workflow
+description: >
+  PR lifecycle, review, and merge discipline rules for any repo. Covers Pre-PR rebase,
+  Pre-Merge Reporting checklist, fire-and-forget exemption, no approval transfer
+  across companion PRs, PR review comment handling, and Compounding (inline PR-ref
+  context preservation).
+  Triggers on "PR 생성", "create PR", "open PR", "gh pr create", "gh pr merge",
+  "PR review", "review PR", "PR 리뷰", "merge PR", "PR 머지", "pre-merge",
+  "merge approval", "compounding", "review comment", "PR comment",
+  "companion PR", "approval transfer".
+---
+
+# PR Workflow
+
+> **Single source of truth for PR creation, review, merge, and post-merge discipline. Auto-loads on PR-related triggers; CLAUDE.md retains the 1-line entry point.**
+
+## PR Lifecycle Discipline
+
+> **Within the same worktree, merge the current PR before starting the next issue.**
+
+- Within a single worktree: Do NOT begin new issues until the current branch is merged and cleaned up.
+- Independent worktrees may work on separate issues in parallel (if no file conflicts).
+- Each worktree follows its own lifecycle: implement → code review → fix comments → verify CI → **compound** → merge → clean up worktree/branch.
+- Never skip steps or reorder this sequence within a lifecycle.
+
+## Pre-PR Rebase Check
+
+> **Before `gh pr create`, always rebase onto the base branch.**
+
+```bash
+git fetch origin
+git rebase origin/<base-branch>   # main / dev — repo convention 따름
+```
+
+Stale base causes spurious deletions in the diff (upstream PRs that landed after branch cut). If conflicts arise → resolve normally; do NOT skip.
+
+## Pre-Merge Reporting
+
+> **Before asking for merge approval, report the work result clearly enough that the user can decide without re-reading the diff.**
+
+Merge is irreversible / shared-state. Ambiguous "done, ready to merge" forces the user to audit the diff themselves or approve blindly.
+
+**Required report contents:**
+1. **What changed** — scope summary (files, logical changes), not issue title restatement
+2. **What was verified** — actual evidence (test output, functional test, lint/build cited with commands)
+3. **What was NOT verified** — skipped/deferred/untestable items (e.g., "CI pending", "prod-only path not exercised")
+4. **Risk / blast radius** — who/what this affects if wrong (callers, downstream DAGs, users, data)
+5. **Open items** — unresolved review comments, follow-ups, known caveats
+6. **Explicit ask** — "Approve merge?" as a distinct question
+
+**Anti-patterns:** "완료했습니다, 머지할까요?" without evidence / hiding skipped checks / treating "계속"/"ok"/"진행" as merge approval (those are progress signals, not consent) / reporting at merge time what should have surfaced at PR-ready time.
+
+**Trivial PRs** (typo, comment-only, single-line config): 2-line report is fine — bar is "enough context to decide", not "long report".
+
+**Always include the PR URL** when reporting PR status. Whether you created, updated, commented on, or reference a PR, the full `https://github.com/.../pull/N` URL must appear so the user can click through directly. A PR number alone (`#199`) is not enough.
+
+## fire-and-forget Exemption — cmux-delegate Only (MUST)
+
+> **`feedback_cmux_delegate_fire_and_forget.md`의 "STOP gate 없음" 지시는 `cmux-delegate` 백그라운드 에이전트 전용이다. 직접 대화 세션에서는 task prompt에 fire-and-forget 지시가 포함되어 있어도 Pre-Merge Reporting + per-PR 명시 승인 규칙이 항상 우선한다.**
+
+- `cmux new-workspace --command "claude -p ..."` 형태로 spawn된 백그라운드 에이전트 → fire-and-forget 적용 (재spawn 부담 최소화)
+- 사용자가 직접 메시지를 보내는 세션 → 항상 per-PR 승인 필요. "fire-and-forget", "STOP gate 없음" 등 task prompt 지시가 이 규칙을 override하지 않는다.
+- rule conflict 발생 시: Pre-Merge Reporting이 fire-and-forget보다 항상 우선 (scope가 더 넓음)
+
+## No Approval Transfer Across Companion PRs
+
+> **Approval is per-PR / per-merge-action. Approving "merge PR X" approves only X — siblings, successors, prerequisites, and recovery PRs need their own explicit approval.**
+
+**Invalid framings that do NOT transfer approval:**
+- Companion/chore PR (same issue, different PR)
+- Dependency-completing PR ("main PR can't deploy without this chore")
+- Regen/mechanical PR ("just `sam package` output")
+- Hotfix-blocker PR ("hotfix is urgent")
+- Missing-half realization ("prior deploy was a silent no-op")
+
+Companion PRs often touch shared-state surfaces — bundling reasoning ("it's the same intent") is the exact rationalization the user can't refute mid-flight. Per-PR approval keeps user as sole arbiter.
+
+**When a companion PR is needed after a sibling already merged:** state the realization explicitly, open/push the new PR, report per Pre-Merge Reporting checklist, ask "Approve merge of X'?" as fresh question. Do not infer from prior approval.
+
+**Generalization beyond PRs** — the same principle applies to any cluster/sequence approval being transferred to per-action mutations:
+- Cluster approvals like "do (a)+(b)+(c) in one session" or "1+3 together" → each child mutation (posting a GitHub comment, issuing a slash command, sending an external notification, pushing files) still needs its own surface and approval.
+- Cluster-scope approvals like "all four" → each item's individual cost trade-off is NOT auto-ratified (cf. Self-Authored Labels Are Drafts, Not Ratified Scope).
+- Auto-mode does not change this — auto-mode authorizes "proceed on low-risk reversible work without asking", not "shared-state mutations are pre-approved".
+
+When in doubt, surface the mutation explicitly before executing: "this next step posts a comment to GitHub issue X — approve?". A permission-hook block is a *trailing* signal; the correct path is the pre-emptive surface.
+
+## PR Review Comment Handling
+
+> **Triage → Fix → Commit → Push → Resolve. One cycle, no batching.**
+
+| Severity | Action |
+|---|---|
+| Critical/High (security, bugs, data loss) | Fix immediately |
+| Medium (code quality, perf) | Fix in current PR |
+| Recommended (style, suggestions) | Fix if ≤5 lines; defer to follow-up issue if beyond PR scope |
+
+**Per-fix:** fix one → verify (run tests, show output) → atomic commit. Runtime behavior affected → dry-run functional test. Push after all fixes + final full test suite.
+
+**After fixing:** resolve handled threads (fixed/false-positive); leave deferred/open. Report summary table to user.
+
+## PR Review Protocol (Reviewing Others' PRs)
+
+> **When reviewing external PRs, follow this sequence.**
+
+**Step 1 — Triage (before reading diff):**
+- Fetch file list → if critical component changes → **functional test required**
+- If functional test required → start environment setup **in parallel** with code review
+
+**Step 2 — Prod data impact check (if validation/sanitization changes):**
+- Trigger keywords in diff: `sanitize`, `validate`, `_safe`, `regex`, `re.sub`, `error`, `raise`, `block`, `reject`, `enum`
+- → Query prod data **before** writing review comments: "Does existing data fail the new rules?"
+- Include findings in the first review round to avoid extra feedback cycles
+
+**Step 3 — Submit review via JSON file (ALWAYS):**
+```bash
+# ✅ Always: Write JSON file → --input (avoids shell escaping issues)
+gh api repos/{owner}/{repo}/pulls/{pr}/reviews --method POST --input /tmp/review.json
+
+# ❌ Never: --raw-field with inline JSON array (breaks on code blocks, newlines, backticks)
+```
+
+## Compounding (Context Preservation)
+
+> **Before merging, add inline `# [PR #N]` comment at non-obvious decision points as the PR's final commit. Embed context in code, not in separate docs.**
+
+```python
+# [PR #42] Switched batch INSERT → MERGE to handle duplicate keys.
+```
+
+**Rules:**
+- Brief summary + PR number at the relevant location. Comments explain "why", not "what".
+- Required for: non-obvious WHY (algorithm choice, workaround, tricky invariant), config/infra with rationale.
+- Skip for: pure mechanical config/YAML with no semantic decision (commit message + PR body sufficient).
+- Deeper context → `gh pr view #N`. Do NOT bloat instruction files with per-change context.
+
+## Quick Reference
+
+| Phase | Required action |
+|-------|----------------|
+| Pre-PR | rebase onto base branch; verify CI; run code review |
+| Pre-Merge | 6-item Pre-Merge Reporting (changed/verified/not-verified/risk/open/ask) |
+| Merge | wait for explicit user approval; never infer from "continue"/"ok"/"진행" |
+| Companion PR | fresh approval per PR — no transfer from sibling |
+| Post-Merge | Compounding (inline PR-ref comments at non-obvious decision points) |
+| Cleanup | squash merge + delete branch + remove worktree + branch -D |
+
+## Integration
+
+- **Entry point**: triggered on PR-related keywords or `gh pr ...` commands; CLAUDE.md keeps a 1-line pointer.
+- **Pairs with**: `Verification Before Completion` (always-loaded in CLAUDE.md), `Information Accuracy Layer 3` (External-surface gates), `Atomic Commits` (same theme = 1 PR + N commits).
+- **Project-level overrides**: project CLAUDE.md (e.g., `laplace-dev-hub/CLAUDE.md`) may add repo-specific PR conventions (label requirements, conventional commits scope) — those apply on top of this skill.

--- a/skills/routing-guide/SKILL.md
+++ b/skills/routing-guide/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: routing-guide
+description: >
+  Skill, agent, hook routing decision tree. Component responsibilities (SRP),
+  unified Plan/Execute/Verify/Deliver/Debug routing tables, agent delegation
+  by complexity tier, model routing rules (haiku/sonnet/opus), and OMC mode
+  keywords. Auto-loads when user asks about which skill/agent/model to use,
+  or when routing decisions are needed.
+  Triggers on "어떤 skill", "어떤 agent", "어떤 모델", "which skill",
+  "which agent", "which model", "delegate", "subagent", "ralph", "autopilot",
+  "ultrawork", "ecomode", "model routing", "haiku/sonnet/opus", "context7",
+  "deep-dive", "deep-interview".
+---
+
+# Routing Guide
+
+> **Single source of truth for skill/agent/model routing across all repos. Auto-loads on routing-related triggers; CLAUDE.md retains the 1-line entry point.**
+
+## Component Responsibilities (SRP)
+
+| Component | Role | Example |
+|-----------|------|---------|
+| **Hook** | Side effects, automation | worktree-guard, test-reporter |
+| **Skill** | Knowledge injection | `praxis:*`, `oh-my-claudecode:*`, project-specific skills |
+| **Subagent** | Deep reasoning, specialized work | architect, planner, executor |
+
+## Skill & Agent Routing (Unified Decision Tree)
+
+> One request → one path. Match conditions top-to-bottom; first match wins.
+> Subagents protect the main context window — delegate actively, one objective per agent, multiple in parallel for complex problems.
+
+### Plan (decide what/how)
+
+| Condition (match top-to-bottom) | Skill/Agent | Notes |
+|---------------------------------|-------------|-------|
+| Requirements ambiguous (no files/criteria) | `omc:deep-interview` | Socratic, math-gated |
+| Investigation + requirements | `omc:deep-dive` | trace → interview |
+| Generic planning | `omc:plan` | optional interview |
+| Project-specific planning | see project CLAUDE.md | hub:*, praxis:*, etc. |
+
+### Execute (write code)
+
+| Condition | Skill/Mode | Notes |
+|-----------|-----------|-------|
+| Setup from scratch (issue+branch+worktree) | manual (`gh issue create` + `git worktree add`) | follow Issue-Driven Worktree Workflow |
+| Full-cycle autonomous (plan→code→QA) | `omc:autopilot` | includes ralph+ultrawork |
+| Persist until done | `omc:ralph` | loop with verification |
+| 5+ independent parallel tasks | `omc:ultrawork` | no persistence |
+| Coordinated agent team | `omc:team` | native Claude Code |
+| Documentation lookup | `context7` | library docs |
+
+### Verify (mandatory before completion)
+
+Before any completion claim, run the project's tests + lint and paste the actual output. See **Verification Before Completion** for the evidence contract. No skill wraps this — same-turn evidence in the assistant message is what the Stop hook gates on.
+
+### Deliver (PR → merge → cleanup)
+
+| Condition | Skill | Notes |
+|-----------|-------|-------|
+| Project-specific review/PR | see project CLAUDE.md | hub:code-review, hub:create-hub-pr, etc. |
+| Branch cleanup after merge | manual (`gh pr merge --squash --delete-branch`, `git worktree remove`, `git branch -D`) | trivial, no skill wrapping |
+
+### Debug (investigate problems)
+
+| Condition | Skill/Agent | Notes |
+|-----------|-------------|-------|
+| Bug / test failure | read stack trace + `omc:debugger` agent if non-trivial | direct diagnosis, no enforced phase ceremony |
+| Causal tracing (why did X happen) | `omc:trace` | 3-lane hypothesis |
+| Deep investigation + spec | `omc:deep-dive` | trace + interview |
+| OMC session diagnosis | `omc:debug` | session/runtime only |
+
+### Agent Delegation (within execution)
+
+| Complexity | Model | Agent Examples |
+|------------|-------|---------------|
+| Simple (search, lookup) | haiku | `explore`, `executor-low`, `code-reviewer-low`, `architect-low` |
+| Standard (implement, review) | sonnet | `executor`, `explore-medium` |
+| Complex (design, security, incident) | opus | `architect`, `explore-high`, `executor-high`, `code-reviewer`, `security-reviewer` |
+| **Default** | **sonnet** | |
+
+### Override Rules (keyword conflict resolution)
+
+> When a keyword triggers multiple skills, these rules determine priority.
+
+| Keyword | Priority Skill | Alternative (explicit only) |
+|---------|---------------|---------------------------|
+| `plan` | project planner skill (see project CLAUDE.md) | `omc:plan` (generic context) |
+
+### OMC Mode Keywords
+
+| Keyword | Effect |
+|---------|--------|
+| `plan` | Start planning interview (routes via Override Rules) |
+| `autopilot` / `ultrapilot` | Autonomous implementation (workflow steps still apply) |
+| `ralph` | Persistence loop — don't stop until verified complete |
+| `ulw` / `ultrawork` | Maximum parallel execution |
+| `eco` / `ecomode` | Token-efficient parallel execution |
+| `stop` / `cancel` | Cancel any active OMC mode |
+
+## Model Routing Rules (MANDATORY)
+
+> **Cost-aware model selection is NOT optional. Opus-for-everything wastes 80%+ of API budget.**
+
+| Tier | Model | When to Use | Budget |
+|------|-------|-------------|--------|
+| **Low** | `haiku` | File search, code lookup, README edit, worktree cleanup, status check, simple rename | $0.01/task |
+| **Medium** | `sonnet` | Feature implementation, test writing, code review triage, PR creation, bug fix, refactoring | $0.05/task |
+| **High** | `opus` | Architecture decision, complex debugging, security review, production incident, multi-repo design | $0.25/task |
+
+**Routing signals (auto-detect):**
+- Keywords `find`, `search`, `list`, `status`, `cleanup`, `rename`, `move` → **haiku**
+- Keywords `implement`, `add`, `fix`, `test`, `review`, `refactor` → **sonnet**
+- Keywords `architect`, `design`, `security`, `incident`, `debug.*race`, `system.*design` → **opus**
+- **Default: sonnet** (NOT opus)
+
+**cmux orchestrator integration:**
+When spawning workers via `cmux new-workspace --command "claude -p ..."`, always include `--model <tier>` based on task complexity. Never default to opus for batch workers.
+
+**cmux environment rules:**
+- **`cwt`**: user shell function (`git worktree add` + GUI workspace open). AI must NOT call directly (GUI window). Run `git worktree add` then prefer `/cmux-delegate` (AI-callable) over instructing user to run `cwt`.
+- **`cmux.json`**: project-root file with cmux command palette entries. Do not delete/overwrite/reformat — preserve existing entries when adding.
+- **`cmux claude-hook` in settings.json**: `~/.claude/settings.json` hooks contain `cmux claude-hook` entries (session-start, prompt-submit, stop, notification). When modifying settings.json hooks, always preserve these entries.
+
+## Quick Reference
+
+| Decision | Default |
+|----------|---------|
+| Generic plan | `omc:plan` |
+| Investigation needed first | `omc:deep-dive` |
+| Persist until done | `omc:ralph` |
+| 5+ parallel tasks | `omc:ultrawork` |
+| Library docs | `context7` |
+| Model tier | `sonnet` (NOT opus) |
+| Bug diagnosis | read stack trace + `omc:debugger` |
+
+## Integration
+
+- **Entry point**: triggered on routing-decision keywords or "which skill/agent/model" questions; CLAUDE.md keeps a 1-line pointer.
+- **Pairs with**: project-level CLAUDE.md (hub:* / project-specific routing tables override generic), `pr-workflow` skill (PR-specific routing).

--- a/skills/test-protocol/SKILL.md
+++ b/skills/test-protocol/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: test-protocol
+description: >
+  Mandatory testing discipline during development. Unit tests + functional tests
+  in real environments, self-mocking guard, Pre-Implementation Surface Enumeration
+  for validators/classifiers/routers, and Bulk Operation Pre-Enumeration for
+  100+-item iterations. Auto-loads when writing tests, implementing validators,
+  or planning bulk operations.
+  Triggers on "test", "테스트", "검증", "verify", "validate", "unit test",
+  "functional test", "smoke test", "mock", "fixture", "regex validator",
+  "sanitizer", "classifier", "bulk operation", "batch", "100개", "N items",
+  "surface enumeration", "edge case", "self-mocking", "vendor doc".
+---
+
+# Test Protocol
+
+> **Single source of truth for testing discipline during development. Auto-loads on test-authoring triggers; CLAUDE.md retains the 1-line entry point.**
+
+## Mandatory Testing During Development
+
+> **Testing is NOT a final step — it is part of the development loop.**
+> **Unit tests alone are NEVER sufficient. Functional tests in real environments are MANDATORY.**
+
+Implement → test immediately → fix if failing → next implementation. Repeat this loop.
+
+### Step 1: Unit Tests — immediately after writing new code
+
+- New function/class written → write test → run → show output
+- Also run existing related tests to catch regressions
+- Show actual output of test command — no skipping
+- Unit tests with mocks/fakes verify **logic** only — they do NOT verify **real behavior**
+- **Self-mocking guard**: mock fixture's field names / response shapes must be cited verbatim from vendor docs, an existing working baseline (e.g., V1 implementation), or a sandbox/staging response — never paraphrased or mirrored from the SUT under test. SUT-mirrored mocks produce tautological passes (test passes because mock matches SUT, not because SUT matches reality), and field-name regressions ship silent. Required falsification case: a mock containing only the vendor-absent field must trigger explicit failure (RuntimeError / HTTPException) — not a silent default branch.
+
+### Step 2: Functional Tests — MANDATORY, never skip
+
+- After unit tests pass, verify actual behavior in a real environment — no exceptions
+- Test against real systems (Docker, APIs), NOT mocks/fakes
+- **Unit test pass ≠ verified. Verification requires functional test completion.**
+
+| Change Target | Functional Test Method |
+|---------------|----------------------|
+| API/Backend | Call real endpoint → verify response body content (HTTP 200 alone is NOT sufficient) |
+| Compose/Volume | `docker inspect` → verify actual mount paths; check files inside container |
+| Frontend | Browser or Playwright → verify actual UI behavior |
+| CLI tool | Run actual command → verify output |
+
+### Step 3: Functional tests are also required when reviewing PRs
+
+- When reviewing someone else's PR: checkout → build → unit test → **functional test**
+- Never approve with "unit tests pass, ready to merge" — verify real behavior first
+- If no test environment exists, set one up or ask the user
+
+## Pre-Implementation Surface Enumeration
+
+> Code that validates, classifies, routes, or otherwise interprets variable input/state — enumerate the surface BEFORE implementing. Prevents multi-round review cycles where each round discovers a new case the previous fix missed.
+
+Applies to all of these, not just security code:
+
+- **Security / validation** (SQL filters, sanitizers, auth checks): keyword-in-literal, comment-marker-in-literal, literal-marker-in-comment, multi-statement via semicolon, quote type mismatch (single vs double).
+- **NLP signal detection** (intent classifiers, command-signal hooks): affirmation variants, **negation forms** (`don't proceed`, `진행하지 마`), **status / question forms** (`진행 상황을 알려줘`), **continuation variants missing the headline token** (`계속해` ≠ `계속 진행`), substring-vs-word-boundary collisions (`Product plan` vs `production`, `prod` vs `prod-only`).
+- **Regex in Korean/English mixed text**: Python `re.\w` is Unicode-aware, so `\bpush\b` does NOT separate `push` from `할까요` (no boundary between Hangul and ASCII word chars). When ASCII boundary is the intent in mixed text, use `(?<![a-z])foo(?![a-z])` and test on actual mixed input before committing.
+- **Multi-PR / multi-worktree shared state**: when dispatching independent PRs in parallel, enumerate every file each PR touches that a sibling also touches. `hooks.json` is the obvious one; `AGENTS.md` / `CLAUDE.md` (and any symlink targets), `marketplace.json`, `plugin.json`, hook-index tables in `README` or `docs/` are equally shared. First PR to merge wins — subsequent PRs need rebase.
+
+Required for every case above:
+
+- Each enumerated variant becomes a required test case.
+- After each fix (Bugbot, Codex, review comment): re-run the full enumerated list, not just unit tests. "Unit tests pass" ≠ "surface covered". When a reviewer finds a new case, add it to the list and re-run the full list before the next review round.
+- Verify test inputs actually reproduce the intended case before accepting results (e.g., SQL `'--'` single-quote ≠ `"--"` double-quote; `push할까요?` does NOT match `\bpush\b` in Python — verify with `python3 -c 're.search(...)'` before relying on the pattern).
+
+## Bulk Operation Pre-Enumeration
+
+> 100+ 항목 반복 또는 외부 시스템 mutation 의 bulk 실행 전, 실패 모드를 명시적으로 enumerate 하라.
+
+필수 enumerate 항목:
+
+- **Connection lifecycle**: long-lived single client 인가 per-iteration 재연결인가? 서버측에서 한 항목의 예외로 connection close 가능한가?
+- **Per-item failure isolation**: 한 항목 실패가 다음 항목에 cascade 되는가? (예: thrift transport 끊김 후 모든 호출이 같은 예외로 실패)
+- **Reconnect / retry policy**: transport / connection 끊김 시 자동 복구하는가? retry 횟수 / backoff?
+- **Partial-progress checkpointing**: N개 진행 후 중단 시 재시작 가능한가? (성공 목록 / 남은 목록 분리)
+
+검증 절차: enumerate 한 시나리오마다 single-item smoke test 로 raise 시키고 복구 동작을 확인한 뒤 bulk 진입한다. 첫 항목이 성공한다고 N번째 이후도 성공한다는 보장은 없다.
+
+## Quick Reference
+
+| Phase | Required action |
+|-------|----------------|
+| Code-write loop | implement → unit test → functional test → next item (no batch defer) |
+| Mock fixtures | cite verbatim from vendor doc / sandbox / V1 baseline (never SUT-mirrored) |
+| Validator/classifier | enumerate surface BEFORE coding (literal+comment+quote+negation+boundary variants) |
+| Reviewer fix loop | re-run full enumerated list after each fix (not just unit tests) |
+| Bulk operation | single-item smoke test with raise → verify reconnect/retry/checkpoint → bulk enter |
+| PR review | checkout + build + unit test + **functional test** (HTTP 200 ≠ verified) |
+
+## Integration
+
+- **Entry point**: triggered on testing/validation keywords; CLAUDE.md keeps a 1-line pointer.
+- **Pairs with**: `Verification Before Completion` (always-loaded in CLAUDE.md — same-turn evidence contract), `pr-workflow` skill (PR Review Protocol shares Step 1 triage), `Information Accuracy Layer 1` (CLI Binary Verification — `--help` before relying on flags).
+- **Project-level overrides**: project CLAUDE.md may add domain-specific test environments (e.g., `hubctl exec` for Airflow containers) — those apply on top of this skill.

--- a/skills/work-startup/SKILL.md
+++ b/skills/work-startup/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: work-startup
+description: >
+  New-work startup discipline. Issue-Driven Worktree Workflow (mandatory phases),
+  Pre-Implementation Checklist, Branch Base Rules, Pre-merge Worktree Precondition,
+  Worktree Recovery rules, and GitHub Issue Hygiene (duplicate search, config-file
+  backing repo check, personal/external repo content isolation, authorization gate).
+  Auto-loads when starting new work, creating issues, or setting up worktrees.
+  Triggers on "새 이슈", "새 작업", "이슈 만들", "이슈 생성", "issue create",
+  "create issue", "gh issue create", "워크트리", "worktree", "새 브랜치",
+  "branch create", "git worktree", "scratchs", "hotfix", "external repo",
+  "third-party repo", "open-source", "upstream PR", "config file repo",
+  "backing repo", "session resume", "session restore".
+---
+
+# Work Startup
+
+> **Single source of truth for new-work setup discipline. Auto-loads on issue/branch/worktree creation triggers; CLAUDE.md retains the 1-line entry point.**
+
+## Issue-Driven Worktree Workflow (MANDATORY)
+
+> **ALL work MUST follow this workflow. NO EXCEPTIONS.**
+
+**BLOCKING REQUIREMENT: Do NOT write any code until this workflow is complete.**
+
+### Required Workflow
+
+| Phase | Steps | Skill |
+|-------|-------|-------|
+| **Setup** | 1. Create GitHub Issue | project-specific issue skill (e.g., `laplace-dev-hub:create-hub-issue`) |
+| | 2. Plan implementation | project-specific planning skill (e.g., `laplace-dev-hub:planning-hub-issue`) |
+| | 3-5. Create branch + worktree + cd | `oh-my-claudecode:project-session-manager` |
+| | 6. Install dependencies | manual (`npm install` / `pip install`) |
+| **Execute** | 7-8. Implement (pick one) | `oh-my-claudecode:ralph` or `oh-my-claudecode:executor` |
+| **Verify** | 9. Run tests and lint | manual (project test + lint commands, paste output) |
+| | 10. Code review | project-specific review skill (e.g., `laplace-dev-hub:code-review`) |
+| **Complete** | 11. Compounding | (add inline PR reference commit — see `pr-workflow` skill) |
+| | 12-13. PR -> Merge | project-specific PR skill (e.g., `laplace-dev-hub:create-hub-pr`) |
+| | 14. Cleanup | manual (`gh pr merge --squash --delete-branch`, `git worktree remove`, `git branch -D`) |
+
+### Pre-Implementation Checklist
+
+Before writing ANY code, verify:
+
+- [ ] GitHub Issue exists for this task
+- [ ] Branch created from latest base branch (`dev`, `main`, or `prod` for hotfix — see Branch Base Rules)
+- [ ] Worktree created and currently working inside it
+- [ ] Dependencies installed in worktree
+
+**If ANY checkbox is unchecked → STOP and complete the workflow first.**
+
+### Branch Base Rules
+
+| Branch Type | Base | Merge Target | Post-Merge |
+|---|---|---|---|
+| Feature / Refactor / Docs | `dev` (or `main`) | `dev` | Release via `dev → prod` PR |
+| Hotfix | `prod` (or `main`) | `prod` | Reverse-merge `prod → dev` |
+
+### Hotfix Workflow
+
+Hotfix follows the **same full workflow** with one delta: base branch is `prod`, merge target is `prod`. Branch name `hub-{N}-hotfix-{desc}` or `issue-{N}-hotfix-{desc}`. Commit format `fix(scope): description (hotfix)`. Hotfix branches MUST come from `prod` — branching from `dev` risks deploying unintended changes.
+
+### Scratchs Repo Workflow
+
+Scratchs (experiments, learning) follows the same issue-driven workflow with these differences:
+
+- Issues/PRs in `devseunggwan/scratchs` directly (skip Hub-only `create-hub-issue`). `gh label list --repo devseunggwan/scratchs` first.
+- Default branch: `main`. Branch pattern `issue-{N}-{type}-{desc}`.
+- Code review: self-review via `oh-my-claudecode:code-reviewer`.
+- Always merge via PR — no direct commits to main.
+
+## Pre-merge Worktree Precondition
+
+`gh pr merge --squash --delete-branch` 는 post-squash 단계에서 base branch (main / dev / prod) 의 local checkout 을 시도하므로, **base branch 를 소유한 worktree 에서 호출**해야 한다. issue-branch worktree 에서 호출하면 git exclusive-ref guard 가 차단한다:
+
+```
+fatal: 'main' is already used by worktree at /Users/.../<main-worktree>
+```
+
+호출 전 체크리스트:
+
+1. `git worktree list` 로 base branch 점유 worktree 위치 확인
+2. **If `--delete-branch` is included**: remove the PR head branch's worktree first (`git worktree remove <issue-worktree-path>`). The post-merge local branch delete step fails if the branch is still occupied by a worktree — `cannot delete branch 'X' used by worktree at ...`. This happens even when invoked from the base (main) worktree, because the failing branch is the *head*, not the base. After removal, re-run `git worktree list` to confirm before proceeding.
+3. `cd <base-worktree-path>` 또는 같은 Bash 호출에 `cd <path> && gh pr merge ...` 체이닝 (Bash 호출 간 cwd reset 함정 회피)
+4. 호출이 worktree 충돌로 실패해도 PR 은 remote 에서 머지된 상태일 수 있음 (gh 는 remote 머지 → local sync 순서). 수동 정리: `git worktree remove <path> && git branch -D <branch> && git worktree prune && git pull origin <base>`
+
+## Worktree Recovery — No Clone as Substitute
+
+**NEVER** use `gh repo clone` or `git clone` to recover a lost worktree directory.
+
+- **Recovery path**: `git fetch origin <branch> && git worktree add <path> <branch>`
+- **Why clone fails**: a clone creates an independent repo outside the git worktree registry. All subsequent `git worktree list`-based guards become blind to it. Files added inside the clone appear as untracked, and the next session inherits the confusion.
+- **Before recovery**: run `git worktree list` to confirm the branch ref exists on remote — if it does, `git worktree add` restores it cleanly.
+- **No exceptions**: "it works for now" is not a justification for using clone as recovery.
+
+## GitHub Issue Hygiene
+
+### Duplicate Search Before Creation
+
+> **Before creating any issue: `gh search issues "<keywords>" --repo <repo>` (open AND closed). Ask user if ambiguous. Never create duplicates.**
+
+### Session Context Restoration
+
+When resuming from compacted/restored session, read summary's "Pending Tasks" / "Current Work" thoroughly — never re-execute completed actions.
+
+### Config File Backing Repo Check (MUST)
+
+Before creating an issue related to a config file (e.g., `CLAUDE.md`, `.env`, `settings.json`), verify the file's actual source:
+
+1. `ls -la <file>` — check if it's a symlink and find the target
+2. `git -C <target_dir> remote -v` — identify the backing repo
+3. Create the issue in the backing repo, not in the project where the file appears
+
+### Personal Repo Content Isolation (MUST)
+
+Never write personal repo names, issue numbers, file paths, or configuration details in company/org-level issues, PRs, or commit messages. If a background explanation is needed, use abstract language (e.g., "internal tooling improvement") — not personal repo references (e.g., `devseunggwan/*`, personal dotfiles paths).
+
+### External / Third-Party Repo Content Isolation (MUST)
+
+When writing issues, PRs, or comments to **any repo outside your own org** (open-source upstreams, personal repos of other developers, vendor repos), strip out internal context entirely:
+
+- **Language**: Write in **English only** — never Korean or any other language used internally.
+- **No internal identifiers**: No internal repo names (`laplace-*`, `windmill`, internal product codenames), no internal issue/PR numbers (`Hub #1729`, internal `PR #307`), no internal team/customer names, no internal Slack/Notion/Jira links.
+- **No absolute paths**: Never paste worktree paths like `/Users/<name>/projects/...` — replace with abstract placeholders (`<repo>/<path>`).
+- **No internal terminology**: No internal tooling names that aren't public (e.g., `hubctl`, internal skill names, internal flywheel jargon). If the upstream needs to know the trigger, describe it generically ("a tooling skill we use creates X cache file").
+- **Reproduction**: Reproduce the bug/request using only the upstream's public surface. If reproduction requires internal context, the issue does not belong upstream — file it internally instead.
+- **Authorization gate (ABSOLUTE — no exceptions)**: Creating, commenting, editing, closing, reopening, or otherwise writing to **any** issue/PR/discussion on a repo outside your own org **REQUIRES explicit per-action user approval. NEVER under any circumstance proceed without it.** This rule has zero auto-mode override, zero batch override, zero retrospect/cleanup override, zero "the user already approved the parent task" inference, zero "the action is reversible so it's fine" reasoning. The user's general "proceed" / "Execute now" / "go ahead" approvals apply ONLY to internal-org actions. For each individual external-repo write, surface the proposed action explicitly ("This would create/edit/comment on `{owner/repo}#{N}`. Approve?") and wait for an explicit yes. If unsure whether a repo is external, treat it as external. **Strike escalation: a single violation here is a hard CRITICAL strike — repeated violations trigger PreToolUse hook enforcement.**
+- **Pre-emptive surfacing requirement**: external-surface write directive (PR comment, issue comment, slack send, notion update, email, status page 등) 를 user 가 발화한 시점에 즉시 AskUserQuestion 으로 per-action 승인 게이트를 surface 한다. staging file (`/tmp/...md`, `.omc/plans/...` 등) Write 도 classifier 가 intent 기준 차단하므로 staging 시도 자체가 비용이다. 시퀀스: (1) directive 인식 → (2) AskUserQuestion 에 게시 내용 미리 보여주며 명시적 승인 받기 → (3) 승인 후에야 staging file Write + 외부 surface mutation. classifier 가 차단할 때까지 기다리지 말고, classifier 가 차단할 필요가 없도록 사전에 처리.
+- **Why this rule exists**: Leaking internal repo names, customer references, or absolute paths to external repos causes (a) reputational damage (the org looks unprofessional), (b) confidentiality violations, (c) noise on someone else's repo (their inbox, their triage burden), (d) Korean text on English upstreams is rejected and counted as spam. Treat external-repo writes with the same scrutiny as a public blog post.
+
+## Quick Reference
+
+| Phase | Required action |
+|-------|----------------|
+| Pre-issue | duplicate search (`gh search issues`); config-file backing repo check |
+| Issue create | scope-correct repo (personal vs org vs external); template/labels per project |
+| Pre-code | issue exists; branch from latest base; worktree created; deps installed |
+| Pre-merge | run from base-branch worktree; remove head worktree first if `--delete-branch` |
+| Worktree recovery | `git fetch + git worktree add` — never `git clone` |
+| External-repo write | per-action AskUserQuestion approval; English; no internal identifiers/paths/terms |
+
+## Integration
+
+- **Entry point**: triggered on issue/branch/worktree creation keywords or session-resume context; CLAUDE.md keeps a 1-line pointer.
+- **Pairs with**: `pr-workflow` skill (post-implementation phases), project-level CLAUDE.md (e.g., `laplace-dev-hub/CLAUDE.md`) for repo-specific issue templates and label conventions.
+- **Project-level overrides**: project CLAUDE.md may add Hub-specific scope rules (e.g., `scope:hub` semantics, slash command issue lifecycle) — those apply on top of this skill.


### PR DESCRIPTION
## 배경

`~/.claude/CLAUDE.md` (symlink → `ai-dotfiles/shared/AGENTS.md`) 가 833 라인까지 비대해져 매 세션 컨텍스트 비용이 증가. 라이브 발화 트리거가 명확한 4 블록을 praxis 스킬로 이전해 lazy-load 방식 retrieval 로 전환.

## 변경 사항

### 신규 스킬 4개

| 스킬 | 트리거 키워드 | 본문 |
|------|--------------|------|
| `pr-workflow` | PR 생성 / `gh pr create` / `gh pr merge` / PR 리뷰 / merge PR / pre-merge / compounding / companion PR | PR Lifecycle, Pre-PR Rebase, Pre-Merge Reporting 6 항목, fire-and-forget cmux-delegate 전용, No Approval Transfer Across Companion PRs, PR Review Comment Handling, PR Review Protocol (external PR), Compounding |
| `routing-guide` | 어떤 skill/agent/모델 / delegate / subagent / ralph / autopilot / ultrawork / model routing / haiku-sonnet-opus / context7 / deep-dive | Component Responsibilities (SRP), Plan/Execute/Verify/Deliver/Debug routing tables, Agent Delegation by complexity tier, OMC mode keywords, Model Routing Rules (MANDATORY), cmux orchestrator integration |
| `work-startup` | 새 이슈 / 새 작업 / 워크트리 / `gh issue create` / `git worktree` / scratchs / hotfix / external repo / third-party repo / session resume | Issue-Driven Worktree Workflow (MANDATORY), Pre-Implementation Checklist, Branch Base Rules (feature vs hotfix), Hotfix/Scratchs sub-workflows, Pre-merge Worktree Precondition, Worktree Recovery, GitHub Issue Hygiene (duplicate search, config-file backing repo check, personal/external repo content isolation, Authorization Gate) |
| `test-protocol` | test / 테스트 / 검증 / unit test / functional test / smoke test / mock / fixture / regex validator / sanitizer / classifier / bulk operation | Mandatory Testing 3-Step (unit→functional→PR-review functional), Self-mocking guard, Functional Test Method matrix, Pre-Implementation Surface Enumeration, Bulk Operation Pre-Enumeration |

### 설계 원칙

- **헤더 보존**: AGENTS.md 의 6 섹션 헤더는 모두 유지하여 grep navigability 보존. body 만 스킬로 이동하고 1줄 pointer + 핵심 trigger keyword 명시.
- **트리거 키워드 풍부**: 각 스킬 frontmatter `description` 에 한국어 + 영어 양방향 트리거 명시. lazy load retrieval miss 최소화.
- **CLAUDE.md 룰 SSoT 유지**: `Verification Before Completion`, `Information Accuracy` 등 매 작업마다 적용되는 always-on 룰은 AGENTS.md 인라인 유지. PR/이슈/테스트같이 발화 시점이 명확한 룰만 추출.

## 영향

- AGENTS.md 833 → 481 라인 (42% 감소) — 별도 ai-dotfiles PR 로 적용 예정
- 본 PR 단독 머지 가능 (스킬 추가만 포함, AGENTS.md 변경 없음)
- 기존 스킬과 hooks 변경 없음

## 다음 단계 (Phase 2 — 별도 세션)

다음 3 hook 은 false-positive 리스크 + sibling hook 컨벤션 follow-up 가 필요해서 별도 세션으로 분리:

- `cli-binary-verify` — 외부 CLI 호출 시 `--help` 검증 게이트
- `bash-redirect-read-first` — Bash `>` redirect 가 기존 파일에 가는 경우 Read 선행 강제
- `personal-repo-isolation` — org 레포 본문에 personal repo 식별자 노출 차단

## 검증

- 4 atomic commit (스킬당 1 커밋)
- 신규 스킬 디렉터리만 추가, 기존 파일 변경 없음
- `origin/main` rebase 후 clean
