### PR TITLE
feat(hook): pre-gh-pr-create dedup gate (#234)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,7 @@ Design contract shared by all hooks:
 | `external-api-literal-trigger` | PreToolUse | Advisory nudge when ALL_CAPS enum candidates or 3-part SQL identifiers are written without prior retrieval verification (issue #202) | [docs/hook/external-api-literal-trigger.md](docs/hook/external-api-literal-trigger.md) |
 | `block-manufactured-action-menu` | PreToolUse | Warn (advisory) or block (strict) when AskUserQuestion surfaces a "shall we proceed?" menu after the user already issued a command-intent signal | [docs/hook/block-manufactured-action-menu.md](docs/hook/block-manufactured-action-menu.md) |
 | `output-block-falsify-advisory` | PreToolUse | Advisory nudge to run output-block falsification gate before surfacing `(Recommended)` options or bulk-action commands (issue #221) | [docs/hook/output-block-falsify-advisory.md](docs/hook/output-block-falsify-advisory.md) |
+| `pre-gh-pr-create-dedup-gate` | PreToolUse | Run `gh pr list --search` against the resolved target repo before `gh pr create`; surface artifact unconditionally to stderr, hard-block on repo-resolution / gh-call failure (issue #234) | [docs/hook/pre-gh-pr-create-dedup-gate.md](docs/hook/pre-gh-pr-create-dedup-gate.md) |
 
 ### Hook ordering and precedence
 

--- a/docs/hook/pre-gh-pr-create-dedup-gate.md
+++ b/docs/hook/pre-gh-pr-create-dedup-gate.md
@@ -1,0 +1,185 @@
+# PreToolUse `gh pr create` Duplicate-Search Gate
+
+`hooks/pre-gh-pr-create-dedup-gate.sh` intercepts every Bash tool call and,
+when it sees `gh pr create` (or `gh pr new`), runs a duplicate-PR search
+against the *target* repo and surfaces the result unconditionally to stderr
+before the create command executes.
+
+### Why this exists
+
+An agent completed a full implement-and-PR cycle that turned out to be
+byte-identical to a merged PR from another author 3 hours earlier (praxis
+issue #234). The agent's pre-creation duplicate check existed only as a
+prompt-layer reasoning instruction ("check for in-flight work before
+creating a PR"). Under task momentum (plan approved, mid-implementation),
+that instruction was not retrieved. A contributing factor: the agent
+searched the wrong repo — the repo where the tracking issue lived, not the
+repo where the PR would actually land.
+
+This is the same class of failure as `block-pr-without-caller-evidence`
+(praxis #158) and `cross-boundary-preflight` (praxis #199): a rule that
+exists in context but has no execution-time retrieval trigger at the
+action boundary. Memory entries alone fail to enforce; structural gates do.
+
+### What the hook does
+
+| Phase | Action |
+|-------|--------|
+| 1. Match | `gh [global flags] pr create/new` — skips `--help`, non-pr-create, non-Bash |
+| 2. Resolve repo | `--repo`/`-R` flag first; fall back to `git remote get-url origin` |
+| 3. Extract keywords | Strip Conventional Commits prefix from `--title`, drop stop-words, keep up to 6 tokens |
+| 4. Run dedup search | `gh pr list --repo <r> --state all --search "<kw>" --limit 20 --json ...` (4s timeout) |
+| 5. Emit artifact | Unconditional stderr block — header + match table (or `no matches`) |
+
+### Pass / block matrix
+
+| Command | Action |
+|---------|--------|
+| `gh pr create --repo o/r --title "feat: add dedup gate"` | **PASS** — artifact emitted, exit 0 |
+| `gh pr create --title "fix(hooks): x"` (origin resolves) | **PASS** — artifact emitted, exit 0 |
+| `gh pr create --title "fix: x"` (no `--repo`, no origin) | **BLOCK (exit 2)** — `cannot resolve PR target repo` |
+| `gh pr create --repo o/r` (no `--title`) | **PASS** — notice that dedup was skipped; manual command suggested |
+| `gh pr create --repo o/r --title "WIP"` (all stop-words) | **PASS** — same skip notice |
+| `gh pr create --repo bogus/nonexistent --title "x"` | **BLOCK (exit 2)** — `gh exit: <rc>` + raw stderr from gh |
+| `gh pr create --help` | **PASS** — help is read-only |
+| `gh pr list --state all` | **PASS** — not `pr create` |
+| `gh issue create --title "x"` | **PASS** — different subcommand |
+| `FOO=1 sudo gh pr create --repo o/r --title "fix: x"` | **PASS** — env/sudo wrappers peeled |
+| Non-Bash tool | **PASS** — exits 0 |
+| Malformed stdin JSON | **PASS** — fail-open, exit 0 |
+| `gh` binary missing on PATH | **PASS** — fail-open, exit 0 (cannot enforce dedup search without gh) |
+
+### Artifact format (emitted to stderr)
+
+```
+[pre-gh-pr-create-dedup-gate] Duplicate-PR search
+  repo : owner/name
+  query: dedup gate
+
+  matches: 2 (review before creating PR)
+  #214   [MERGED] @alice  feat(hooks): dedup gate prototype
+         https://github.com/owner/name/pull/214
+  #220   [OPEN  ] @bob    feat(hooks): add pre-gh-pr-create dedup gate
+         https://github.com/owner/name/pull/220
+```
+
+No-matches branch:
+
+```
+[pre-gh-pr-create-dedup-gate] Duplicate-PR search
+  repo : owner/name
+  query: dedup gate
+  result: no matches
+```
+
+The header (repo + query) appears in **both** branches — that's what the
+issue spec means by "the artifact must be visible whether or not a match
+is found." It demonstrates that the hook ran against the correct repo with
+the correct query, removing the silent-failure mode where the dedup check
+exists in prompt but never executes.
+
+### Match-found behavior: advisory, not blocking
+
+Per the issue's open question, the hook leans **advisory** on a match
+(exit 0 with the artifact rendered). Topic-keyword matching has false
+positives — same-topic follow-up PRs are legitimate and common. Hard-
+blocking on match would remove agency for those. The agent (or human
+reviewer of the agent's transcript) reads the artifact and decides.
+
+Escalation to hard-block on match is deferred until empirical data on
+false-positive vs true-positive rates accumulates.
+
+### Block-on-failure rationale
+
+The hook **does** hard-block when:
+
+1. The target repo cannot be resolved (`--repo` absent and `git remote
+   get-url origin` fails or output is unparseable). This is the exact
+   failure mode the issue cites — a worktree's `origin` differing from
+   the PR target repo. Silent fallthrough would defeat the hook.
+2. `gh pr list` itself errors (auth failure, repo not found, timeout).
+   A silently-failing dedup check is the failure this hook exists to
+   prevent. Block surfaces the issue loudly.
+3. `gh pr list` returns valid JSON that is not a list (error envelope
+   such as `{"message":"Bad credentials"}`, future schema change).
+   Same rationale — silent fall-through would defeat the gate.
+
+### Repo resolution algorithm
+
+1. Scan argv for `--repo <r>`, `-R <r>`, `--repo=<r>`, `-R<r>` —
+   honoring both the `pr create` subcommand position and the `gh`
+   global flag position.
+2. If not found, exec `git remote get-url origin` (2s timeout).
+3. Parse `owner/repo` from URL forms:
+   - `git@github.com:owner/repo.git`
+   - `https://github.com/owner/repo.git`
+   - `ssh://git@github.com/owner/repo`
+4. Unparseable / missing → block.
+
+### Keyword extraction
+
+1. Strip Conventional Commits prefix matching `^[a-z]+(\([^)]+\))?:\s*`
+   (`feat:`, `fix(scope):`, `chore(hooks/foo):`, etc.).
+2. Tokenize on non-alphanumeric to handle punctuation, slashes,
+   apostrophes uniformly.
+3. Lowercase, drop stop-words (`a/the/and/of/for/to/in/on/with/add/fix/
+   update/remove/make/use/set/new/wip` plus common inflections).
+4. Deduplicate, keep first `MAX_KEYWORDS=6` tokens.
+5. Empty result → skip search with a notice (exit 0).
+
+### Known limits (parity with sibling hooks)
+
+All praxis Bash gates use `_hook_utils` structural tokenization, not full
+shell semantics. The following bypass patterns are accepted limits shared
+with `block-pr-without-caller-evidence` and `block-gh-state-all`:
+
+- Variable command name: `SUB=create; gh pr $SUB --title ...`
+- Subshell: `(gh pr create --title ...)`
+- `eval`: `eval gh pr create --title ...`
+- Wrapper indirection: `command gh pr create`, `xargs gh pr`
+- Re-entry via `bash -c "gh pr create ..."`
+- Shell function/alias shadowing of `gh`
+
+Closing these would require a real shell parser. Empirically the failure
+modes the hook targets (forgotten dedup check under task momentum) do not
+involve such patterns; the cost/benefit doesn't favor full coverage.
+
+### Relationship to sibling hooks
+
+| Hook | Overlap |
+|------|---------|
+| `cross-boundary-preflight` | None — orthogonal: format/cross-repo gate vs. dedup search |
+| `block-pr-without-caller-evidence` | None — orthogonal: body content gate vs. dedup search |
+| `side-effect-scan` | Same surface (`gh pr create` triggers `gh-merge` category ask) — complementary: side-effect-scan surfaces a generic intent-confirm ask; this hook surfaces the dedup artifact |
+| `pre-merge-approval-gate` | None — different subcommand (`gh pr merge`) |
+
+The four together gate `gh pr create` from four orthogonal angles. Each
+runs in parallel; their stderr / decisions compose at the tool-decision
+layer.
+
+### Performance & timeouts
+
+- Hook `timeout` in `hooks.json`: **8 seconds** (longer than the default
+  5s used by other Bash gates because this hook makes two subprocess
+  calls — `git remote get-url` then `gh pr list`).
+- `gh pr list` subprocess timeout: **4 seconds** (caps network wait;
+  treated as a gh-error block).
+- `git remote get-url`: **2 seconds**.
+- Hook fast-paths to exit 0 on every code path before issuing
+  subprocesses, so non-`gh pr create` Bash calls add only tokenization
+  cost.
+
+### Tests
+
+```bash
+bash hooks/test-pre-gh-pr-create-dedup-gate.sh
+```
+
+Covers 27 cases: repo resolution (flag form, short form, equals form,
+gh global flag form, origin fallback, unresolved-block), keyword
+extraction (Conventional Commits prefix strip, all-stop-words, empty
+title, "WIP"), artifact emission (no-matches header, matches table,
+MERGED tag, PR URL), gh failure modes (non-zero exit + stderr surfaced,
+unparseable JSON, JSON object instead of list), passthroughs (`--help`,
+`pr list`, `issue create`, env/sudo wrapper transparency, chained
+command, gh-missing fail-open, non-Bash tool, malformed stdin fail-open).

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -64,6 +64,11 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-gh-pr-create-dedup-gate.sh",
+            "timeout": 8
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/commit-title-length-check.sh",
             "timeout": 5
           },

--- a/hooks/pre-gh-pr-create-dedup-gate.py
+++ b/hooks/pre-gh-pr-create-dedup-gate.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""PreToolUse(Bash) gate: force a duplicate-PR search before `gh pr create`.
+
+Issue #234. An agent completed a full implement-and-PR cycle that turned out
+to be byte-identical to a merged PR from another author 3 hours earlier; the
+agent's pre-creation dedup check existed only as a prompt-layer reasoning
+instruction. A contributing factor was searching the wrong repo — the tracking
+issue's repo, not the PR target repo.
+
+This hook converts the reasoning obligation into an execution-time tool call
+whose output is unconditionally surfaced. The dedup search runs against the
+*target* repo (resolved from `--repo`/`-R`, falling back to `git remote get-url
+origin` only as a last resort).
+
+Behavior:
+  1. Match `gh pr create` / `gh pr new`. Skip --help, non-pr-create, non-Bash.
+  2. Resolve target repo from --repo/-R/--repo= flag (incl. gh global flag form).
+     Fall back to `git remote get-url origin`. If neither resolves → block.
+  3. Extract title keywords from --title/-t/--title= (Conventional Commits
+     prefix stripped, stop-words dropped, up to 6 tokens).
+  4. Run `gh pr list --repo <r> --state all --search "<kw>" --limit 20
+     --json number,title,state,author,url,mergedAt`. Surface JSON output to
+     stderr unconditionally — the artifact must be visible whether matches
+     are found or not.
+  5. On `gh` failure (auth, repo not found, timeout) → block (exit 2) naming
+     the unresolved repo.
+  6. Match-found → advisory only (per issue spec leaning advisory; topic-
+     keyword matching has false positives). The agent decides.
+
+Fail-open contract:
+  - Malformed stdin JSON → exit 0
+  - `gh` binary missing → exit 0 (cannot enforce dedup search if gh is absent)
+  - python3 missing → handled by .sh shim
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _hook_utils import (  # type: ignore[import-not-found]
+    iter_command_starts,
+    safe_tokenize,
+    strip_prefix,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+GH_GLOBAL_FLAGS_WITH_ARG = frozenset({"-R", "--repo", "--hostname", "--color"})
+
+# Conventional Commits prefix: `type` or `type(scope)` followed by `:`.
+CONVENTIONAL_PREFIX_RE = re.compile(r"^[a-z]+(?:\([^)]+\))?:\s*", re.IGNORECASE)
+
+# Stop-words dropped from title before search — generic verbs and articles
+# that produce noise in `gh pr list --search`.
+STOPWORDS = frozenset({
+    "a", "an", "the", "and", "or", "of", "for", "to", "in", "on", "with",
+    "add", "adds", "added", "adding",
+    "fix", "fixes", "fixed", "fixing",
+    "update", "updates", "updated", "updating",
+    "remove", "removes", "removed", "removing",
+    "make", "makes", "made", "making",
+    "use", "uses", "used", "using",
+    "set", "sets", "setting",
+    "new",
+    "wip",
+})
+
+MAX_KEYWORDS = 6
+GH_TIMEOUT_SEC = 4
+GIT_TIMEOUT_SEC = 2
+
+# Owner/repo extracted from common origin URL forms:
+#   git@github.com:owner/repo.git
+#   https://github.com/owner/repo.git
+#   ssh://git@github.com/owner/repo
+_ORIGIN_URL_RE = re.compile(
+    r"(?:github\.com[:/])([A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+?)(?:\.git)?/?$"
+)
+
+# ---------------------------------------------------------------------------
+# Argv inspection
+# ---------------------------------------------------------------------------
+
+def _is_pr_create(argv: list[str]) -> bool:
+    """True if argv is `gh [global flags] pr create/new` (not --help)."""
+    argv = strip_prefix(argv)
+    if not argv or argv[0] != "gh":
+        return False
+    if any(t in ("--help", "-h") or t.startswith(("--help=", "-h="))
+           for t in argv):
+        return False
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        if tok == "--":
+            i += 1
+            break
+        if not tok.startswith("-"):
+            break
+        i += 1
+        if "=" not in tok and tok in GH_GLOBAL_FLAGS_WITH_ARG and i < len(argv):
+            i += 1
+    return (
+        i + 1 < len(argv)
+        and argv[i] == "pr"
+        and argv[i + 1] in ("create", "new")
+    )
+
+
+def _flag_value(argv: list[str], names: tuple[str, ...]) -> str | None:
+    """Return the value of the first matching flag, or None.
+
+    Handles `--flag value`, `-x value`, `--flag=value`, `-Rvalue` (for short
+    flags only).
+    """
+    for i, t in enumerate(argv):
+        if t in names and i + 1 < len(argv):
+            return argv[i + 1]
+        for name in names:
+            if t.startswith(name + "="):
+                return t.split("=", 1)[1]
+        # `-Rvalue` short-flag concatenation
+        for name in names:
+            if len(name) == 2 and name.startswith("-") and t.startswith(name) and len(t) > 2 and not t.startswith("--"):
+                return t[2:]
+    return None
+
+
+def _extract_repo(argv: list[str]) -> str | None:
+    return _flag_value(argv, ("--repo", "-R"))
+
+
+def _extract_title(argv: list[str]) -> str | None:
+    return _flag_value(argv, ("--title", "-t"))
+
+
+# ---------------------------------------------------------------------------
+# Repo resolution
+# ---------------------------------------------------------------------------
+
+def _resolve_origin_repo() -> str | None:
+    """Run `git remote get-url origin` and parse owner/repo from URL.
+
+    Returns None on any failure (no git, no origin, unparseable URL).
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=GIT_TIMEOUT_SEC,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    url = (proc.stdout or "").strip()
+    if not url:
+        return None
+    m = _ORIGIN_URL_RE.search(url)
+    return m.group(1) if m else None
+
+
+# ---------------------------------------------------------------------------
+# Keyword extraction
+# ---------------------------------------------------------------------------
+
+def _extract_keywords(title: str) -> list[str]:
+    """Return up to MAX_KEYWORDS lowercase tokens for the dedup search."""
+    stripped = CONVENTIONAL_PREFIX_RE.sub("", title).strip()
+    if not stripped:
+        return []
+    # Split on non-alphanumeric so `feat:` and parenthetical scopes don't bleed
+    # into the keyword set after partial regex misses.
+    raw = re.findall(r"[A-Za-z0-9]+", stripped)
+    out: list[str] = []
+    seen: set[str] = set()
+    for tok in raw:
+        lower = tok.lower()
+        if lower in STOPWORDS:
+            continue
+        if lower in seen:
+            continue
+        seen.add(lower)
+        out.append(lower)
+        if len(out) >= MAX_KEYWORDS:
+            break
+    return out
+
+
+# ---------------------------------------------------------------------------
+# gh dedup-search call
+# ---------------------------------------------------------------------------
+
+def _run_gh_search(repo: str, keywords: list[str]) -> tuple[int, str, str]:
+    """Run `gh pr list --repo <r> --state all --search <kw> --json ...`.
+
+    Returns (returncode, stdout, stderr). On infrastructure failure
+    (binary missing, timeout) returns (-1, "", "<reason>") so callers can
+    distinguish from real gh errors.
+    """
+    query = " ".join(keywords)
+    cmd = [
+        "gh", "pr", "list",
+        "--repo", repo,
+        "--state", "all",
+        "--search", query,
+        "--limit", "20",
+        "--json", "number,title,state,author,url,mergedAt",
+    ]
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=GH_TIMEOUT_SEC,
+            check=False,
+        )
+    except FileNotFoundError:
+        return -1, "", "gh binary not found"
+    except subprocess.TimeoutExpired:
+        return -1, "", f"gh pr list timed out after {GH_TIMEOUT_SEC}s"
+    return proc.returncode, proc.stdout or "", proc.stderr or ""
+
+
+def _format_artifact(
+    repo: str,
+    keywords: list[str],
+    rows: list[dict],
+) -> str:
+    """Render the unconditional artifact emitted to stderr.
+
+    Always surfaces the search header (repo + query); rows table only if
+    rows present; otherwise an explicit "no matches" line. The header
+    presence under both branches is what makes the artifact "unconditional"
+    per the issue spec.
+    """
+    header = (
+        f"[pre-gh-pr-create-dedup-gate] Duplicate-PR search\n"
+        f"  repo : {repo}\n"
+        f"  query: {' '.join(keywords) if keywords else '(empty)'}\n"
+    )
+    if not rows:
+        return header + "  result: no matches\n"
+
+    lines = [header, f"  matches: {len(rows)} (review before creating PR)"]
+    for r in rows:
+        num = r.get("number", "?")
+        state = (r.get("state") or "").lower()
+        merged_at = r.get("mergedAt")
+        if state == "merged" or merged_at:
+            tag = "MERGED"
+        elif state == "open":
+            tag = "OPEN"
+        elif state == "closed":
+            tag = "CLOSED"
+        else:
+            tag = state.upper() or "?"
+        author_field = r.get("author") or {}
+        author = (
+            author_field.get("login")
+            if isinstance(author_field, dict)
+            else None
+        ) or "?"
+        title = r.get("title") or ""
+        url = r.get("url") or ""
+        lines.append(f"  #{num:<5} [{tag:<6}] @{author}  {title}")
+        if url:
+            lines.append(f"         {url}")
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+BLOCK_REPO_MSG = (
+    "BLOCKED: [pre-gh-pr-create-dedup-gate] cannot resolve PR target repo.\n"
+    "  Tried: --repo/-R flag (absent), `git remote get-url origin` (failed).\n"
+    "  Pass --repo owner/name explicitly so the dedup search hits the\n"
+    "  correct repo. A worktree's origin can differ from the PR target,\n"
+    "  which is exactly how the bypass in praxis #234 happened.\n"
+)
+
+
+def _block_gh_error(repo: str, rc: int, stderr_text: str) -> str:
+    return (
+        "BLOCKED: [pre-gh-pr-create-dedup-gate] dedup search failed.\n"
+        f"  repo: {repo}\n"
+        f"  gh exit: {rc}\n"
+        f"  gh stderr: {stderr_text.strip() or '(empty)'}\n"
+        "  This is a hard block because a silently-failing dedup check is\n"
+        "  the failure mode this hook exists to prevent. Verify auth /\n"
+        "  repo name and retry.\n"
+    )
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0  # fail-open on malformed stdin (infrastructure error)
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    command = payload.get("tool_input", {}).get("command", "") or ""
+    if not command.strip():
+        return 0
+
+    command = command.replace("\\\n", " ")
+    tokens = safe_tokenize(command)
+    if not tokens:
+        return 0
+
+    for argv_raw in iter_command_starts(tokens):
+        argv = list(argv_raw)
+        if not _is_pr_create(argv):
+            continue
+        argv = strip_prefix(argv)
+
+        # Fail-open when gh isn't installed — the hook cannot enforce a dedup
+        # search without it, and blocking would penalize environments where
+        # `gh pr create` itself would fail with a clearer error.
+        if shutil.which("gh") is None:
+            return 0
+
+        repo = _extract_repo(argv) or _resolve_origin_repo()
+        if not repo:
+            sys.stderr.write(BLOCK_REPO_MSG)
+            return 2
+
+        title = _extract_title(argv) or ""
+        keywords = _extract_keywords(title)
+        if not keywords:
+            sys.stderr.write(
+                "[pre-gh-pr-create-dedup-gate] no usable --title keywords\n"
+                f"  repo : {repo}\n"
+                "  Dedup search skipped (no title or only stop-words).\n"
+                "  Run `gh pr list --repo "
+                f"{repo} --state all --search '<topic>'` manually before\n"
+                "  creating the PR.\n"
+            )
+            return 0
+
+        rc, stdout, stderr_text = _run_gh_search(repo, keywords)
+        if rc != 0:
+            sys.stderr.write(_block_gh_error(repo, rc, stderr_text))
+            return 2
+
+        try:
+            rows = json.loads(stdout) if stdout.strip() else []
+        except json.JSONDecodeError:
+            sys.stderr.write(_block_gh_error(repo, rc, "unparseable gh JSON output"))
+            return 2
+        if not isinstance(rows, list):
+            # gh returning a JSON object (error envelope, schema change, etc.)
+            # would crash _format_artifact's row iteration. Treat as a hard
+            # block — silent fail-through is exactly the failure mode this
+            # hook exists to prevent.
+            sys.stderr.write(_block_gh_error(
+                repo, rc,
+                f"gh returned JSON {type(rows).__name__} (expected list); "
+                f"first 200 chars: {stdout[:200]!r}",
+            ))
+            return 2
+
+        sys.stderr.write(_format_artifact(repo, keywords, rows))
+        # Match-found is advisory only — agent must read the artifact and
+        # decide. Hard-blocking would remove agency for legitimate same-topic
+        # follow-up PRs (issue #234 open question).
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/pre-gh-pr-create-dedup-gate.sh
+++ b/hooks/pre-gh-pr-create-dedup-gate.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# pre-gh-pr-create-dedup-gate.sh — thin shim (praxis #234)
+# Logic in .py; shim keeps hooks.json entry stable across refactors.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="$SCRIPT_DIR/pre-gh-pr-create-dedup-gate.py"
+command -v python3 >/dev/null 2>&1 || exit 0
+[ -f "$PY" ] || exit 0
+exec python3 "$PY"

--- a/hooks/test-pre-gh-pr-create-dedup-gate.sh
+++ b/hooks/test-pre-gh-pr-create-dedup-gate.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+# test-pre-gh-pr-create-dedup-gate.sh — coverage for the dedup-search gate
+#
+# Synthesizes Claude Code PreToolUse(Bash) payloads and asserts:
+#   block → exit 2 + stderr non-empty
+#   pass  → exit 0 + stderr matches optional pattern (or empty)
+#
+# Real `gh` / `git` calls are short-circuited via a per-case fake-bin dir
+# prepended to PATH. This makes the test deterministic and offline-safe.
+#
+# Usage: bash hooks/test-pre-gh-pr-create-dedup-gate.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/pre-gh-pr-create-dedup-gate.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable: $HOOK" >&2
+  exit 1
+fi
+
+PASS=0; FAIL=0; FAILED_NAMES=()
+
+# ---------------------------------------------------------------------------
+# Fake-bin helpers
+# ---------------------------------------------------------------------------
+
+# Args:
+#   $1: scenario name — one of:
+#         pass         (gh returns []          / git returns owner/repo)
+#         pass-matches (gh returns 2 rows      / git returns owner/repo)
+#         gh-err       (gh exits 1 with stderr / git returns owner/repo)
+#         gh-bad-json  (gh returns unparseable / git returns owner/repo)
+#         no-git       (gh ok                  / git remote get-url fails)
+#         no-gh        (gh missing             / git returns owner/repo)
+make_fake_bin() {
+  local scenario="$1"
+  local d
+  d=$(mktemp -d)
+
+  # git shim — returns origin URL unless `no-git` scenario.
+  if [ "$scenario" = "no-git" ]; then
+    cat >"$d/git" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1 $2 $3" = "remote get-url origin" ]; then
+  echo "fatal: no upstream configured" >&2
+  exit 128
+fi
+exec /usr/bin/env -i PATH=/usr/bin:/bin git "$@"
+EOF
+  else
+    cat >"$d/git" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1 $2 $3" = "remote get-url origin" ]; then
+  echo "git@github.com:test-org/test-repo.git"
+  exit 0
+fi
+exec /usr/bin/env -i PATH=/usr/bin:/bin git "$@"
+EOF
+  fi
+  chmod +x "$d/git"
+
+  # gh shim — varies by scenario; for `no-gh` we omit entirely.
+  case "$scenario" in
+    no-gh)
+      ;;
+    pass|no-git)
+      cat >"$d/gh" <<'EOF'
+#!/usr/bin/env bash
+# Only respond to `gh pr list ... --json ...` shape; anything else error.
+for arg in "$@"; do
+  if [ "$arg" = "--json" ]; then
+    echo "[]"
+    exit 0
+  fi
+done
+echo "fake-gh: unexpected args: $*" >&2
+exit 99
+EOF
+      ;;
+    pass-matches)
+      cat >"$d/gh" <<'EOF'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  if [ "$arg" = "--json" ]; then
+    cat <<JSON
+[
+  {"number":214,"title":"feat(hooks): dedup gate prototype","state":"MERGED","author":{"login":"alice"},"url":"https://github.com/test-org/test-repo/pull/214","mergedAt":"2026-05-13T10:00:00Z"},
+  {"number":220,"title":"feat(hooks): add pre-gh-pr-create dedup gate","state":"OPEN","author":{"login":"bob"},"url":"https://github.com/test-org/test-repo/pull/220","mergedAt":null}
+]
+JSON
+    exit 0
+  fi
+done
+echo "fake-gh: unexpected args: $*" >&2
+exit 99
+EOF
+      ;;
+    gh-err)
+      cat >"$d/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "GraphQL: Could not resolve to a Repository with the name 'x/y'." >&2
+exit 1
+EOF
+      ;;
+    gh-bad-json)
+      cat >"$d/gh" <<'EOF'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  if [ "$arg" = "--json" ]; then
+    echo "not json at all <<<"
+    exit 0
+  fi
+done
+exit 99
+EOF
+      ;;
+    gh-json-object)
+      cat >"$d/gh" <<'EOF'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  if [ "$arg" = "--json" ]; then
+    echo '{"message":"Bad credentials","documentation_url":"https://docs.github.com"}'
+    exit 0
+  fi
+done
+exit 99
+EOF
+      ;;
+  esac
+  [ -f "$d/gh" ] && chmod +x "$d/gh"
+
+  echo "$d"
+}
+
+# Args:
+#   $1: case name
+#   $2: expected outcome — "block" or "pass"
+#   $3: tool_name (Bash / Edit / ...)
+#   $4: command string
+#   $5: scenario (selects fake-bin behavior; default: pass)
+#   $6: optional grep regex that MUST appear in stderr (only checked on pass+grep cases or block cases)
+run_case() {
+  local name="$1" expected="$2" tool_name="$3" command="$4"
+  local scenario="${5:-pass}" need_grep="${6:-}"
+
+  local payload err_file rc fake_bin
+  fake_bin=$(make_fake_bin "$scenario")
+  payload=$(python3 -c '
+import json, sys
+print(json.dumps({
+    "tool_name": sys.argv[1],
+    "tool_input": {"command": sys.argv[2]},
+}))' "$tool_name" "$command")
+  err_file=$(mktemp)
+  echo "$payload" | env PATH="$fake_bin:/usr/bin:/bin" "$HOOK" >/dev/null 2>"$err_file"
+  rc=$?
+  local err_content
+  err_content=$(cat "$err_file"); rm -f "$err_file"
+  rm -rf "$fake_bin"
+
+  local ok=1
+  if [ "$expected" = "block" ]; then
+    { [ "$rc" -eq 2 ] && [ -n "$err_content" ]; } || ok=0
+  else
+    { [ "$rc" -eq 0 ]; } || ok=0
+  fi
+  if [ "$ok" -eq 1 ] && [ -n "$need_grep" ]; then
+    printf '%s' "$err_content" | grep -Eq "$need_grep" || ok=0
+  fi
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS [$expected] $name"; ((PASS++))
+  else
+    echo "FAIL [$expected→rc=$rc] $name"
+    printf '  stderr: %s\n' "$err_content" | head -5
+    ((FAIL++)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Repo resolution
+# ---------------------------------------------------------------------------
+
+run_case "repo from --repo flag" pass Bash \
+  'gh pr create --repo owner/name --title "feat(hooks): add dedup gate" --body "x"' \
+  pass 'repo : owner/name'
+
+run_case "repo from -R short flag" pass Bash \
+  'gh pr create -R owner/name --title "feat(hooks): add dedup gate"' \
+  pass 'repo : owner/name'
+
+run_case "repo from --repo= equals form" pass Bash \
+  'gh pr create --repo=owner/name --title "feat: dedup gate"' \
+  pass 'repo : owner/name'
+
+run_case "repo from gh global -R flag" pass Bash \
+  'gh -R owner/name pr create --title "feat: dedup gate"' \
+  pass 'repo : owner/name'
+
+run_case "repo from git origin fallback" pass Bash \
+  'gh pr create --title "feat(hooks): add dedup gate"' \
+  pass 'repo : test-org/test-repo'
+
+run_case "unresolved repo blocks" block Bash \
+  'gh pr create --title "feat: x"' \
+  no-git 'cannot resolve PR target repo'
+
+# ---------------------------------------------------------------------------
+# Keyword extraction
+# ---------------------------------------------------------------------------
+
+run_case "conventional commits prefix stripped" pass Bash \
+  'gh pr create --repo o/r --title "feat(hooks): add dedup gate"' \
+  pass 'query: dedup gate'
+
+run_case "title with only stop-words skips search" pass Bash \
+  'gh pr create --repo o/r --title "fix"' \
+  pass 'no usable --title keywords'
+
+run_case "missing title skips search with notice" pass Bash \
+  'gh pr create --repo o/r --body "no title"' \
+  pass 'no usable --title keywords'
+
+run_case "WIP title is stop-word skip" pass Bash \
+  'gh pr create --repo o/r --title "WIP"' \
+  pass 'no usable --title keywords'
+
+# ---------------------------------------------------------------------------
+# Artifact emission
+# ---------------------------------------------------------------------------
+
+run_case "no-matches artifact has header + 'no matches'" pass Bash \
+  'gh pr create --repo o/r --title "feat: dedup gate"' \
+  pass 'result: no matches'
+
+run_case "matches artifact lists PRs" pass Bash \
+  'gh pr create --repo test-org/test-repo --title "feat: dedup gate"' \
+  pass-matches 'matches: 2'
+
+run_case "matches artifact shows merged tag" pass Bash \
+  'gh pr create --repo test-org/test-repo --title "feat: dedup gate"' \
+  pass-matches '\[MERGED'
+
+run_case "matches artifact shows pr URL" pass Bash \
+  'gh pr create --repo test-org/test-repo --title "feat: dedup gate"' \
+  pass-matches 'https://github.com/test-org/test-repo/pull/214'
+
+# ---------------------------------------------------------------------------
+# gh failure modes — blocks
+# ---------------------------------------------------------------------------
+
+run_case "gh returns non-zero blocks" block Bash \
+  'gh pr create --repo bogus/repo --title "feat: dedup gate"' \
+  gh-err 'dedup search failed'
+
+run_case "gh non-zero block includes gh stderr" block Bash \
+  'gh pr create --repo bogus/repo --title "feat: dedup gate"' \
+  gh-err 'Could not resolve'
+
+run_case "gh unparseable JSON blocks" block Bash \
+  'gh pr create --repo o/r --title "feat: dedup gate"' \
+  gh-bad-json 'unparseable gh JSON output'
+
+run_case "gh JSON object (not list) blocks" block Bash \
+  'gh pr create --repo o/r --title "feat: dedup gate"' \
+  gh-json-object 'expected list'
+
+# ---------------------------------------------------------------------------
+# Passthroughs
+# ---------------------------------------------------------------------------
+
+run_case "gh pr create --help passes" pass Bash \
+  'gh pr create --help'
+
+run_case "gh pr list is not pr create" pass Bash \
+  'gh pr list --state all'
+
+run_case "gh issue create is different subcommand" pass Bash \
+  'gh issue create --title "feat: x" --body "y"'
+
+run_case "non-Bash tool passes" pass Edit \
+  'gh pr create --repo o/r --title "feat: x"'
+
+run_case "env wrapper transparent" pass Bash \
+  'env GH_TOKEN=xyz gh pr create --repo owner/name --title "feat: dedup gate"' \
+  pass 'repo : owner/name'
+
+run_case "sudo wrapper transparent" pass Bash \
+  'sudo gh pr create --repo owner/name --title "feat: dedup gate"' \
+  pass 'repo : owner/name'
+
+run_case "gh missing fails open" pass Bash \
+  'gh pr create --repo o/r --title "feat: dedup gate"' \
+  no-gh
+
+run_case "chained command, gh part dedup-checked" pass Bash \
+  'echo go && gh pr create --repo owner/name --title "feat: dedup gate"' \
+  pass 'repo : owner/name'
+
+# ---------------------------------------------------------------------------
+# Fail-open infrastructure
+# ---------------------------------------------------------------------------
+
+bad_json_err=$(mktemp)
+printf 'not-json\n' | env PATH="/usr/bin:/bin" "$HOOK" >/dev/null 2>"$bad_json_err"
+bad_rc=$?
+if [ "$bad_rc" -eq 0 ]; then
+  echo "PASS [pass] malformed stdin fails open"; ((PASS++))
+else
+  echo "FAIL [pass→rc=$bad_rc] malformed stdin"; ((FAIL++))
+  FAILED_NAMES+=("malformed stdin")
+fi
+rm -f "$bad_json_err"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "${#FAILED_NAMES[@]}" -gt 0 ]; then
+  echo "Failed cases:"
+  for n in "${FAILED_NAMES[@]}"; do echo "  - $n"; done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #234

## Summary

PreToolUse(Bash) hook that runs `gh pr list --search` against the resolved target repo before `gh pr create` and surfaces the result unconditionally to stderr. Converts the dedup-search obligation from a prompt-layer reasoning instruction into an execution-time tool call with an observable artifact.

Caller chain verified: new hook — no internal callers expected. Registered in `hooks/hooks.json` PreToolUse(Bash) matcher; runs in parallel with sibling gh-create gates.

## How it behaves

| Path | Action |
|------|--------|
| `gh pr create --repo o/r --title "feat: x"` | runs search, emits artifact, exit 0 |
| `gh pr create --title "fix: x"` (origin resolves) | runs search against origin, exit 0 |
| `gh pr create --title "fix: x"` (no `--repo`, no origin) | **block (exit 2)** — `cannot resolve PR target repo` |
| `gh pr create --repo bogus/x --title "..."` (gh non-zero) | **block (exit 2)** — surfaces gh stderr |
| `gh pr list --state all` | passthrough — not `pr create` |
| `gh` binary missing | fail-open exit 0 |
| Match found in search | advisory only — agent reads artifact and decides |

The advisory-on-match decision matches the issue's stated lean — topic-keyword matching has false positives, and same-topic follow-up PRs are legitimate.

## Hard-block surfaces

- Target repo unresolvable (`--repo` absent + `git remote get-url origin` failure). This is the exact failure mode #234 cites — a worktree's `origin` differing from the PR target.
- `gh pr list` non-zero exit (auth / repo not found / timeout).
- `gh pr list` returns valid JSON that is not a list (error envelope, schema change). Silent fall-through would defeat the gate.

## Files

- `hooks/pre-gh-pr-create-dedup-gate.sh` — shim
- `hooks/pre-gh-pr-create-dedup-gate.py` — logic (~390 lines incl. docstrings)
- `hooks/test-pre-gh-pr-create-dedup-gate.sh` — 27 tests, all pass; offline-safe via per-case PATH-injected `gh` / `git` shims
- `docs/hook/pre-gh-pr-create-dedup-gate.md` — spec + known-limits section
- `hooks/hooks.json` — registered under PreToolUse(Bash), 8s timeout (2 subprocess calls)
- `AGENTS.md` — hook index row

## Test plan

- [x] `bash hooks/test-pre-gh-pr-create-dedup-gate.sh` → 27 passed, 0 failed
- [x] `bash hooks/test-block-pr-without-caller-evidence.sh` → 34 passed, 0 failed (sibling regression check)
- [x] `./scripts/check-plugin-manifests.py` → clean
- [x] `./scripts/build-plugin-manifests.py` → no drift
- [ ] Live exercise: run an actual `gh pr create` against this PR with the hook installed to verify artifact appears in the agent transcript
