### PR TITLE
feat(hook): advisory wrapper signature verify

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,7 @@ Design contract shared by all hooks:
 | `block-manufactured-action-menu` | PreToolUse | Warn (advisory) or block (strict) when AskUserQuestion surfaces a "shall we proceed?" menu after the user already issued a command-intent signal | [docs/hook/block-manufactured-action-menu.md](docs/hook/block-manufactured-action-menu.md) |
 | `output-block-falsify-advisory` | PreToolUse | Advisory nudge to run output-block falsification gate before surfacing `(Recommended)` options or bulk-action commands (issue #221) | [docs/hook/output-block-falsify-advisory.md](docs/hook/output-block-falsify-advisory.md) |
 | `pre-gh-pr-create-dedup-gate` | PreToolUse | Run `gh pr list --search` against the resolved target repo before `gh pr create`; surface artifact unconditionally to stderr, hard-block on repo-resolution / gh-call failure (issue #234) | [docs/hook/pre-gh-pr-create-dedup-gate.md](docs/hook/pre-gh-pr-create-dedup-gate.md) |
+| `advisory-wrapper-signature-verify` | PreToolUse | Advisory nudge to verify wrapped function signatures before writing wrapper/client code with delegation patterns (issue #235) | [docs/hook/advisory-wrapper-signature-verify.md](docs/hook/advisory-wrapper-signature-verify.md) |
 
 ### Hook ordering and precedence
 

--- a/docs/hook/advisory-wrapper-signature-verify.md
+++ b/docs/hook/advisory-wrapper-signature-verify.md
@@ -1,0 +1,144 @@
+# PreToolUse Wrapper Signature Verification Advisory
+
+`hooks/advisory-wrapper-signature-verify.py` fires on `PreToolUse` events for
+`Write` / `Edit` tool calls. It detects writes of wrapper/client code that
+delegate to another module's functions and emits an advisory reminder to
+verify the wrapped signatures by reading source before authoring the wrapper.
+
+### Why this exists
+
+A recurring failure mode (4 occurrences across different sessions) has been
+identified: when writing wrapper/client classes that delegate to underlying
+functions, parameter names and return types are inferred from function
+names rather than verified by reading the actual source — leading to
+multiple wrong signatures per session.
+
+Documented occurrences:
+
+1. Exception attribute name inferred from class name (wrong attribute used).
+2. Internal utility behavior assumed without reading source (pre-split mismatch).
+3. Generic multi-package wrapper assuming identical factory signatures
+   (3/4 packages failed silently).
+4. Query wrapper class with 6 wrong signatures (non-existent params, wrong
+   return types).
+
+Root cause: no enforcement gate fires before writing wrapper code to prompt
+reading the wrapped function signatures first. Memory entries and CLAUDE.md
+rules exist for this pattern but are not retrieved at execution time.
+
+Reference: issue [#235](https://github.com/devseunggwan/praxis/issues/235).
+
+**Escalation criteria:** After ~1 month of advisory operation, evaluate
+recurrence rate. If advisory is repeatedly bypassed without verification,
+re-evaluate either (a) a stricter content heuristic, or (b) escalation to
+`ask` for a narrower trigger set. Blocking outright remains undesirable —
+not all `client.py` writes are wrappers.
+
+### What is detected
+
+The advisory fires when **all** of these conditions hold:
+
+| Condition | Description |
+|-----------|-------------|
+| Tool name | `Write` or `Edit` |
+| File extension | Path ends with `.py` |
+| Not a test file | Path does **not** match `tests?/`, `test_*.py`, or `*_test.py` |
+| Wrapper-shape path | Path ends with `client.py` **or** contains `_wrapper` |
+| Body content | Matches at least one delegation pattern (see below) |
+
+If any condition fails — silent pass-through (exit 0, empty stderr).
+
+**Test-file exclusion rationale:** real codebases routinely write wrapper
+assertions inside `tests/` or `test_*.py` files (mocks, fixtures, fake
+clients). Firing the advisory there is noise, not signal — the test author
+is intentionally re-stating a signature, not authoring a production wrapper.
+
+#### Delegation patterns (any match fires)
+
+| Pattern | Matches |
+|---------|---------|
+| `return\s+get_\w+\s*\(` | `return get_user(id)`, `return get_session_token()` |
+| `return\s+create_\w+\s*\(` | `return create_order(data)` |
+| `from\s+[\w.]+\.queries\s+import` | `from foo.queries import get_user` |
+| `from\s+[\w.]+\.client\s+import` | `from acme.client import APIClient` |
+
+For `Edit`, the body checked is `tool_input.new_string` (the proposed
+replacement, not the pre-edit text). For `Write`, it is `tool_input.content`.
+
+**This hook never blocks.** Advisory mode only — exit 0 in all cases.
+
+### Response shape
+
+**Advisory message** (emitted to stderr, never stdout):
+
+```
+[advisory-wrapper-signature-verify] Wrapper/client write detected
+File: <file_path>
+
+Before writing, verify actual function signatures:
+  grep -n '^def ' <wrapped_module>.py
+  or use Read tool to inspect the module directly
+
+Common mistake patterns:
+  - Adding non-existent parameters
+  - Wrong return type (list[TypedObject] vs list[dict])
+  - Parameter name typo (e.g., hours vs days, id vs data_id)
+```
+
+**Exit code:** always `0` (never blocks).
+
+**JSON response:** none — the hook communicates via stderr only
+(`additionalContext` in Claude Code's terminology). Claude Code reads stderr
+from advisory `PreToolUse` hooks and includes it in the model's context.
+
+### Parsing guarantees
+
+| Condition | Behavior |
+|-----------|----------|
+| Malformed / missing stdin JSON | exit 0 (silent pass) |
+| `tool_name` not `Write` or `Edit` | exit 0 (silent pass) |
+| Missing `file_path` or non-string value | exit 0 (silent pass) |
+| Path not wrapper-shape | exit 0 (silent pass) |
+| Content missing or no delegation match | exit 0 (silent pass) |
+| `python3` unavailable | exit 0 (shell shim guards) |
+| Hook `.py` file missing | exit 0 (shell shim guards) |
+| Any uncaught exception | exit 0 (silent pass, no crash) |
+
+The hook uses no external dependencies (no PyYAML, no third-party packages).
+All parsing is done with the Python standard library only.
+
+### Tests
+
+```bash
+bash hooks/test-advisory-wrapper-signature-verify.sh
+```
+
+Covers 22 cases:
+
+**Positive (advisory emitted):**
+- `Write` `client.py` with `return get_*(` delegation
+- `Write` `client.py` with `return create_*(` delegation
+- `Write` `_wrapper` path with `from foo.queries import`
+- `Edit` `client.py` with `from acme.client import`
+- `Edit` `_wrapper` path with `return get_*(`
+- `Write` `user_client.py` (path endswith `client.py`)
+
+**Negative (silent pass):**
+- `client.py` without any delegation pattern
+- Regular `.py` path without `_wrapper` / `client.py`
+- `README.md` path (not Python)
+- `Read` tool (out of scope)
+- `NotebookEdit` tool (out of scope)
+- `client.py` with `return` that is not `get_` / `create_` prefixed
+- File where `queries` appears only in a comment, not as an import
+- `_wrapper` path but `.md` extension (non-Python file)
+- Test file under `tests/`
+- `test_*.py` file
+- `*_test.py` file
+- File under `test/` directory
+
+**Edge (fail-open):**
+- Malformed JSON stdin → exit 0, silent pass
+- Empty content field → exit 0, silent pass
+- Missing `file_path` → exit 0, silent pass
+- `Edit` payload missing `new_string` → exit 0, silent pass

--- a/hooks/advisory-wrapper-signature-verify.py
+++ b/hooks/advisory-wrapper-signature-verify.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""PreToolUse advisory: nudge wrapper/client signature verification.
+
+Issue #235. Recurring failure mode (4+ occurrences across sessions): when
+writing wrapper/client classes that delegate to underlying functions,
+parameter names and return types are inferred from function names rather
+than verified by reading the actual source. Result: multiple wrong
+signatures per session (non-existent params, wrong return types, name
+typos like ``hours`` vs ``days``).
+
+This hook fires on ``Write`` / ``Edit`` to file paths that match the
+wrapper-shape heuristic AND whose body contains delegation patterns. It
+emits an advisory reminder to stderr and exits 0 (never blocks).
+
+Memory entries and CLAUDE.md rules alone failed to prevent recurrence —
+the retrieval trigger does not fire at the specific moment the wrapper
+body is authored. Moving the gate to the tool-call use-site adds a
+structural reminder.
+
+Fail-open contract (project hook design):
+
+* Malformed / missing stdin JSON  → exit 0
+* Unknown ``tool_name``           → exit 0
+* Missing ``file_path``           → exit 0
+* No matching wrapper pattern     → exit 0
+* Any uncaught exception          → exit 0
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+
+# ---------------------------------------------------------------------------
+# Advisory message
+# ---------------------------------------------------------------------------
+
+ADVISORY_HEADER = (
+    "[advisory-wrapper-signature-verify] Wrapper/client write detected"
+)
+ADVISORY_BODY = (
+    "Before writing, verify actual function signatures:\n"
+    "  grep -n '^def ' <wrapped_module>.py\n"
+    "  or use Read tool to inspect the module directly\n"
+    "\n"
+    "Common mistake patterns:\n"
+    "  - Adding non-existent parameters\n"
+    "  - Wrong return type (list[TypedObject] vs list[dict])\n"
+    "  - Parameter name typo (e.g., hours vs days, id vs data_id)"
+)
+
+
+# ---------------------------------------------------------------------------
+# File-path heuristic: wrapper / client shape
+# ---------------------------------------------------------------------------
+
+def _is_wrapper_shape_path(file_path: str) -> bool:
+    """True if the path looks like a wrapper/client *Python* file.
+
+    Two heuristics, matching the issue spec:
+
+    * ends with ``client.py`` (e.g. ``foo_client.py``, ``bar/client.py``)
+    * contains ``_wrapper`` anywhere in the path *and* ends with ``.py``
+
+    The hook is specifically aimed at Python wrapper code (function signatures,
+    return types). Non-Python files that incidentally contain ``_wrapper`` in
+    their name (e.g. ``foo_wrapper.md`` notes) are out of scope.
+
+    Test-file paths are excluded to suppress the most common false-positive
+    surface: real codebases routinely write wrapper assertions inside
+    ``tests/`` or ``test_*.py`` files, where the delegation-pattern reminder
+    is noise rather than signal.
+    """
+    if not file_path:
+        return False
+    if not file_path.endswith(".py"):
+        return False
+    if _is_test_path(file_path):
+        return False
+    if file_path.endswith("client.py"):
+        return True
+    if "_wrapper" in file_path:
+        return True
+    return False
+
+
+# Test-file path heuristic. Matches both pytest-style (``test_foo.py``,
+# ``foo_test.py``) and directory-style (``/tests/``, ``/test/``) locations.
+_TEST_PATH_PATTERN = re.compile(
+    r"(?:/|^)tests?/"            # /tests/, /test/, tests/foo.py, test/foo.py
+    r"|/test_[^/]*\.py$"         # /test_foo.py
+    r"|_test\.py$"               # foo_test.py
+)
+
+
+def _is_test_path(file_path: str) -> bool:
+    """True if the path is recognisably a test file/dir."""
+    return bool(_TEST_PATH_PATTERN.search(file_path))
+
+
+# ---------------------------------------------------------------------------
+# Content patterns: delegation shape
+# ---------------------------------------------------------------------------
+
+# Patterns indicating the new code delegates to another module's function.
+# Conservative set — only fires on common wrapper shapes.
+_DELEGATION_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"return\s+get_\w+\s*\("),
+    re.compile(r"return\s+create_\w+\s*\("),
+    re.compile(r"from\s+[\w.]+\.queries\s+import"),
+    re.compile(r"from\s+[\w.]+\.client\s+import"),
+)
+
+
+def _has_delegation_pattern(content: str) -> bool:
+    """True if any delegation pattern appears in ``content``."""
+    if not content:
+        return False
+    for pattern in _DELEGATION_PATTERNS:
+        if pattern.search(content):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Tool input extraction
+# ---------------------------------------------------------------------------
+
+def _extract_content(tool_name: str, tool_input: dict) -> str:
+    """Return the body to scan for the given Write/Edit tool input.
+
+    * ``Write`` → ``tool_input.content``
+    * ``Edit``  → ``tool_input.new_string`` (the proposed replacement)
+    """
+    if tool_name == "Write":
+        value = tool_input.get("content")
+    elif tool_name == "Edit":
+        value = tool_input.get("new_string")
+    else:
+        return ""
+    return value if isinstance(value, str) else ""
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def _main_inner() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0  # fail-open on malformed stdin
+
+    if not isinstance(payload, dict):
+        return 0
+
+    tool_name = payload.get("tool_name") or ""
+    if tool_name not in ("Write", "Edit"):
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return 0
+
+    file_path = tool_input.get("file_path")
+    if not isinstance(file_path, str) or not _is_wrapper_shape_path(file_path):
+        return 0
+
+    content = _extract_content(tool_name, tool_input)
+    if not _has_delegation_pattern(content):
+        return 0
+
+    sys.stderr.write(
+        f"{ADVISORY_HEADER}\nFile: {file_path}\n\n{ADVISORY_BODY}\n"
+    )
+    return 0
+
+
+def main() -> int:
+    """Advisory hook — must NEVER break tool execution. Any uncaught
+    exception in the inner logic is swallowed and the hook fails open
+    (exit 0)."""
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/advisory-wrapper-signature-verify.sh
+++ b/hooks/advisory-wrapper-signature-verify.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# advisory-wrapper-signature-verify.sh — thin shim (praxis #235)
+# Logic in .py; shim keeps hooks.json entry stable across refactors.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="$SCRIPT_DIR/advisory-wrapper-signature-verify.py"
+command -v python3 >/dev/null 2>&1 || exit 0
+[ -f "$PY" ] || exit 0
+exec python3 "$PY"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -130,6 +130,16 @@
         ]
       },
       {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/advisory-wrapper-signature-verify.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "AskUserQuestion",
         "hooks": [
           {

--- a/hooks/test-advisory-wrapper-signature-verify.sh
+++ b/hooks/test-advisory-wrapper-signature-verify.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# test-advisory-wrapper-signature-verify.sh — coverage for the wrapper-signature advisory hook
+#
+# Synthesizes Claude Code PreToolUse payloads and asserts:
+#   advisory → exit 0 + stderr non-empty
+#   pass     → exit 0 + stderr empty
+#
+# Usage: bash hooks/test-advisory-wrapper-signature-verify.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/advisory-wrapper-signature-verify.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable: $HOOK" >&2
+  exit 1
+fi
+
+PASS=0; FAIL=0; FAILED_NAMES=()
+
+# Run a single test case.
+# $1 = name
+# $2 = expected: "advisory" (exit 0 + stderr non-empty) | "pass" (exit 0 + stderr empty)
+# $3 = JSON payload (string)
+run_case() {
+  local name="$1" expected="$2" payload="$3"
+  local err_file rc
+  err_file=$(mktemp)
+  printf '%s' "$payload" | "$HOOK" >/dev/null 2>"$err_file"
+  rc=$?
+  local err_content
+  err_content=$(cat "$err_file"); rm -f "$err_file"
+
+  local ok=1
+  case "$expected" in
+    advisory)
+      [ "$rc" -eq 0 ] && [ -n "$err_content" ] || ok=0
+      ;;
+    pass)
+      [ "$rc" -eq 0 ] && [ -z "$err_content" ] || ok=0
+      ;;
+    *)
+      echo "FAIL: unknown expected: $expected" >&2
+      ok=0
+      ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (rc=$rc, stderr='${err_content:0:120}')"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Payload builders
+# ---------------------------------------------------------------------------
+
+make_write_payload() {
+  # $1 = file_path, $2 = content
+  python3 -c "
+import json, sys
+payload = {
+    'session_id': 'test-session',
+    'tool_name': 'Write',
+    'tool_input': {
+        'file_path': sys.argv[1],
+        'content': sys.argv[2],
+    },
+    'cwd': '/tmp',
+}
+print(json.dumps(payload))
+" "$1" "$2"
+}
+
+make_edit_payload() {
+  # $1 = file_path, $2 = new_string
+  python3 -c "
+import json, sys
+payload = {
+    'session_id': 'test-session',
+    'tool_name': 'Edit',
+    'tool_input': {
+        'file_path': sys.argv[1],
+        'old_string': 'foo',
+        'new_string': sys.argv[2],
+    },
+    'cwd': '/tmp',
+}
+print(json.dumps(payload))
+" "$1" "$2"
+}
+
+make_other_tool_payload() {
+  # $1 = tool_name, $2 = file_path, $3 = content
+  python3 -c "
+import json, sys
+payload = {
+    'session_id': 'test-session',
+    'tool_name': sys.argv[1],
+    'tool_input': {
+        'file_path': sys.argv[2],
+        'content': sys.argv[3],
+    },
+    'cwd': '/tmp',
+}
+print(json.dumps(payload))
+" "$1" "$2" "$3"
+}
+
+# ---------------------------------------------------------------------------
+# ADVISORY cases (wrapper shape path + delegation pattern)
+# ---------------------------------------------------------------------------
+
+run_case "Write client.py with return get_*( delegation" advisory \
+  "$(make_write_payload '/repo/foo/client.py' 'def fetch():
+    return get_user(id)')"
+
+run_case "Write client.py with return create_*( delegation" advisory \
+  "$(make_write_payload '/repo/foo/client.py' 'def make():
+    return create_session(user_id)')"
+
+run_case "Write *_wrapper path with from queries import" advisory \
+  "$(make_write_payload '/repo/orders_wrapper.py' 'from foo.queries import get_order
+def run(): return get_order(1)')"
+
+run_case "Edit client.py with from *.client import" advisory \
+  "$(make_edit_payload '/repo/svc/client.py' 'from acme.client import APIClient
+client = APIClient()')"
+
+run_case "Edit *_wrapper path with return get_*(" advisory \
+  "$(make_edit_payload '/repo/pkg/auth_wrapper/main.py' 'return get_token(scope)')"
+
+run_case "Write user_client.py (endswith client.py)" advisory \
+  "$(make_write_payload '/repo/user_client.py' 'from a.queries import x')"
+
+# ---------------------------------------------------------------------------
+# PASS cases — wrong shape OR no delegation pattern OR wrong tool
+# ---------------------------------------------------------------------------
+
+run_case "Pass: client.py without delegation patterns" pass \
+  "$(make_write_payload '/repo/foo/client.py' 'def hello():
+    return \"hello\"')"
+
+run_case "Pass: regular .py path without _wrapper/client.py" pass \
+  "$(make_write_payload '/repo/foo/service.py' 'from a.queries import get_x
+return get_x(1)')"
+
+run_case "Pass: README.md path" pass \
+  "$(make_write_payload '/repo/README.md' 'return get_x()')"
+
+run_case "Pass: Read tool not in scope" pass \
+  "$(make_other_tool_payload 'Read' '/repo/foo/client.py' 'return get_x()')"
+
+run_case "Pass: NotebookEdit not in scope" pass \
+  "$(make_other_tool_payload 'NotebookEdit' '/repo/foo/client.py' 'return get_x()')"
+
+run_case "Pass: client.py with return without get_/create_ prefix" pass \
+  "$(make_write_payload '/repo/foo/client.py' 'def run():
+    return self.value')"
+
+run_case "Pass: similar substring 'queries' not as full module path" pass \
+  "$(make_write_payload '/repo/foo/client.py' '# notes about queries import patterns')"
+
+run_case "Pass: _wrapper path but .md file (not Python)" pass \
+  "$(make_write_payload '/repo/foo_wrapper.md' 'return get_user(id)')"
+
+run_case "Pass: test file under /tests/ excluded" pass \
+  "$(make_write_payload '/repo/tests/test_client.py' 'return get_user(1)')"
+
+run_case "Pass: test_*.py file excluded" pass \
+  "$(make_write_payload '/repo/foo/test_client.py' 'from a.queries import x')"
+
+run_case "Pass: *_test.py file excluded" pass \
+  "$(make_write_payload '/repo/foo/client_test.py' 'from a.queries import x')"
+
+run_case "Pass: /test/ directory excluded" pass \
+  "$(make_write_payload '/repo/test/foo_wrapper.py' 'return create_x(1)')"
+
+# ---------------------------------------------------------------------------
+# EDGE cases — fail-open
+# ---------------------------------------------------------------------------
+
+run_case "Edge: malformed JSON" pass \
+  'not valid json at all'
+
+run_case "Edge: empty content field" pass \
+  "$(make_write_payload '/repo/foo/client.py' '')"
+
+run_case "Edge: missing file_path" pass \
+  "$(python3 -c "
+import json
+print(json.dumps({
+    'session_id': 't',
+    'tool_name': 'Write',
+    'tool_input': {'content': 'return get_x()'},
+}))
+")"
+
+run_case "Edge: Edit with missing new_string on client.py" pass \
+  "$(python3 -c "
+import json
+print(json.dumps({
+    'session_id': 't',
+    'tool_name': 'Edit',
+    'tool_input': {'file_path': '/repo/foo/client.py', 'old_string': 'a'},
+}))
+")"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ ${#FAILED_NAMES[@]} -gt 0 ]; then
+  echo "Failed:"
+  for n in "${FAILED_NAMES[@]}"; do
+    echo "  - $n"
+  done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Implements issue #235: a non-blocking `PreToolUse` advisory that nudges the model to verify wrapped function signatures before authoring wrapper/client code with delegation patterns.

- `hooks/advisory-wrapper-signature-verify.py` — Python logic
- `hooks/advisory-wrapper-signature-verify.sh` — shell shim (project convention)
- `hooks/test-advisory-wrapper-signature-verify.sh` — 22-case test harness
- `docs/hook/advisory-wrapper-signature-verify.md` — spec doc
- `hooks/hooks.json` — registration under a new `Write|Edit` matcher block
- `AGENTS.md` — hook index row

### Deviation from issue spec

The issue proposed a Node.js (`.mjs`) implementation. Every existing praxis hook is Python + a thin `.sh` shim — I ported the logic to match project convention. Detection semantics are preserved.

### Detection (all conditions must hold)

| Condition | Description |
|-----------|-------------|
| Tool | `Write` or `Edit` |
| Extension | Path ends with `.py` |
| Not a test file | Path does not match `tests?/`, `test_*.py`, `*_test.py` |
| Wrapper shape | Path ends with `client.py` or contains `_wrapper` |
| Content | Matches `return get_*(`, `return create_*(`, `from *.queries import`, or `from *.client import` |

**Test-file exclusion** suppresses the most common false-positive surface — mock/fake clients in test files. Added after self-review flagged the noise.

### Failure modes

Fail-open on every error path (malformed JSON, unknown tool, missing fields, exceptions). Exit code is always 0; the hook never blocks tool execution.

## Test plan

- [x] `bash hooks/test-advisory-wrapper-signature-verify.sh` — 22/22 pass
- [x] `python3 -c "import json; json.load(open('hooks/hooks.json'))"` — valid JSON
- [x] `./scripts/check-plugin-manifests.py` — packaging clean
- [ ] Smoke: trigger live by writing a `client.py` with a `return get_*(` delegation and observe the advisory in stderr

Closes #235.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PacseZSfyKeR46MP1PJ2Na)_