### PR TITLE
feat(hook): shared compound-Bash cascade advisory (#229)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,16 @@ Design contract shared by all hooks:
   intentionally has no marker; `completion-verify` and `retrospect-mix-check`
   same. Bypass marker (`# side-effect:ack`, `# title-length:ack`) exists only
   where the false-positive cost outweighs the silent-bypass risk.
+- **Compound-Bash cascade advisory (issue #229).** When a PreToolUse(Bash)
+  hook rejects (block) or asks-and-may-deny a compound command (`&&`, `||`,
+  `;`, `|`, newline) containing a state-changing step (`> file`, `<<EOF >`,
+  `mkdir`, `tee`, `cp`/`mv`/`rm`/`touch`, `curl -o`, `wget -O`), every hook
+  appends the shared `_hook_utils.compound_cascade_hint(command)` text to
+  its block/ask message. The advisory clarifies that bash never executed
+  ANY part of the rejected command — files the redirect/mkdir/download
+  would have created do NOT exist on disk — so the agent should not retry
+  the second half expecting the first half to have landed. Single-command
+  rejections receive no suffix (no cascade to warn about).
 
 ### Hook index
 

--- a/docs/hook/block-gh-state-all.md
+++ b/docs/hook/block-gh-state-all.md
@@ -35,6 +35,15 @@ arguments are transparent pass-throughs.
 | `grep -- "--state all" docs.md` | **PASS** (grep pattern) |
 | `echo "--state all is invalid"` | **PASS** (echo argument) |
 
+### Compound cascade advisory (issue #229)
+
+If the blocked `gh search` segment is part of a compound Bash command that
+also contains a state-changing step (e.g. `mkdir -p /tmp/cache && gh search
+... --state all`), the stderr block message is suffixed with the shared
+`_hook_utils.compound_cascade_hint` text. The cascade reminder makes clear
+that the preceding `mkdir`/redirect/download also did not run, so retries
+should not assume the partial side-effects landed.
+
 ### Workarounds when --state all is needed
 
 - Omit `--state` entirely — `gh search` returns results regardless of state by default.

--- a/docs/hook/commit-title-length-check.md
+++ b/docs/hook/commit-title-length-check.md
@@ -59,6 +59,15 @@ a 72-char convention) without disabling the hook.
 }
 ```
 
+### Compound cascade advisory (issue #229)
+
+When the ask fires on a compound Bash command containing a state-changing
+step (e.g. `mkdir -p /tmp/log && git commit -m "$(cat /tmp/log/very-long-..."`),
+the ask reason is suffixed with the shared
+`_hook_utils.compound_cascade_hint` text. If the user denies the prompt, the
+chained `mkdir`/redirect/download also did not run — retries must materialize
+those files first.
+
 ### Opt-out marker
 
 Embed `# title-length:ack` anywhere in the command to bypass the check for

--- a/docs/hook/cross-boundary-preflight.md
+++ b/docs/hook/cross-boundary-preflight.md
@@ -87,6 +87,18 @@ exit 2
 exit 0
 ```
 
+### Compound cascade advisory (issue #229)
+
+Both response paths (HEREDOC_BODY block, CROSS_REPO_WRITE ask) append the
+shared `_hook_utils.compound_cascade_hint` suffix when the parent Bash command
+is compound AND contains a state-changing step (`> file`, `mkdir`, `tee`,
+`cp`/`mv`/`rm`, `curl -o`). The classic shape is
+`cat <<EOF > /tmp/body.md && gh pr create --body-file /tmp/body.md` — the
+heredoc redirect side-effect is aborted together with the gh call, leaving the
+agent's retry with `No such file or directory`. The hint instructs the caller
+to use the Write tool to materialize the body file first, then issue gh in a
+separate Bash call. Single-command rejections do not receive the suffix.
+
 ### Opt-out
 
 Known-intentional cross-repo writes can bypass the ASK gate by appending

--- a/docs/hook/pre-merge-approval-gate.md
+++ b/docs/hook/pre-merge-approval-gate.md
@@ -77,6 +77,15 @@ prompt — that single confirmation is the approval the rule requires.
 }
 ```
 
+### Compound cascade advisory (issue #229)
+
+When the ask fires on a compound Bash command that also contains a
+state-changing step (e.g. `git fetch && gh pr merge 42` chained with an
+`mkdir`/redirect/`curl -o`), the ask reason is suffixed with the shared
+`_hook_utils.compound_cascade_hint` text. If the user denies the prompt, all
+chained side-effects abort with the merge. Single-command merges (just
+`gh pr merge 42`) do not receive the suffix.
+
 ### Tests
 
 ```bash

--- a/docs/hook/side-effect-scan.md
+++ b/docs/hook/side-effect-scan.md
@@ -37,6 +37,20 @@ If any token on the command line matches `prod`, `production`,
 `--env prod`/`--environment=prod`, the reason is prefixed with a
 `⚠️  PROD scope` warning so the reviewer treats it with extra care.
 
+### Compound cascade advisory (issue #229)
+
+When the `ask` is raised on a compound Bash command (`&&`, `||`, `;`, `|`,
+newline) that also contains a state-changing step (`mkdir`, `tee`, `cp`/`mv`/
+`rm`/`touch`, `> file`, `<<EOF > file`, `curl -o`, `wget -O`), the ask reason
+is suffixed with the shared cascade advisory from
+`_hook_utils.compound_cascade_hint`. If the user denies the prompt, bash never
+runs ANY part of the command — including the side-effects the agent might have
+assumed already executed. The advisory reminds the caller to materialize files
+with the Write tool first, then issue the side-effect command separately.
+
+Single-command asks do NOT receive the suffix — there is no cascade to warn
+about when the rejection covers exactly one effect.
+
 ### Opt-out marker
 
 Known-intentional invocations can bypass the hook by embedding the literal

--- a/hooks/_hook_utils.py
+++ b/hooks/_hook_utils.py
@@ -157,3 +157,125 @@ def iter_command_starts(tokens: list[str]):
             start = i + 1
     if start < len(tokens):
         yield tokens[start:]
+
+
+# ---------------------------------------------------------------------------
+# Compound-Bash cascade advisory (issue #229)
+# ---------------------------------------------------------------------------
+#
+# When a PreToolUse(Bash) hook rejects a compound command (block, or denied
+# ask), bash never runs ANY part — including state-changing redirects, mkdir,
+# download-to-file, etc. The classic failure mode is
+# `cat <<EOF > /tmp/body.md && gh pr create --body-file /tmp/body.md` where
+# the agent assumes the file was written by the rejected redirect and retries
+# the second half, hitting `No such file or directory`.
+
+STATE_CHANGING_COMMANDS = frozenset({
+    "mkdir", "tee", "cp", "mv", "ln", "rm", "touch",
+    "rsync", "dd", "install",
+})
+
+# curl: -o/-O/--output/--remote-name write the response body to a file.
+# wget: -O/--output-document write the response body. wget's -o is the log
+# file, NOT a download target — excluded to avoid false positives on
+# `wget -o log.txt URL` (which writes only the log, not a file the agent
+# would assume exists at the URL's name).
+_CURL_OUTPUT_FLAGS = frozenset({"-o", "-O", "--output", "--remote-name"})
+_WGET_OUTPUT_FLAGS = frozenset({"-O", "--output-document"})
+
+
+def _segment_has_redirect(argv: list[str]) -> bool:
+    """True iff argv contains an unquoted `>`, `>>`, or `<<` redirect.
+
+    safe_tokenize strips quotes but preserves internal whitespace, so a token
+    containing whitespace cannot be an unquoted shell word — any redirect-like
+    substring is literal (e.g. `--body "<<EOF foo"` tokenizes to `<<EOF foo`,
+    which is a quoted string, not a heredoc). Tokens without whitespace that
+    start with or embed `<<` / `>` / `>>` are treated as redirects, covering
+    standalone (`>`, `<<EOF`), attached (`>file`, `<<EOF`), and embedded
+    (`foo<<EOF`, `foo>file`) forms.
+    """
+    for tok in argv:
+        if " " in tok or "\t" in tok:
+            continue
+        if "<<" in tok or ">" in tok:
+            return True
+    return False
+
+
+def _segment_has_state_change(argv: list[str]) -> bool:
+    argv = strip_prefix(argv)
+    if not argv:
+        return False
+    cmd = argv[0].rsplit("/", 1)[-1]
+    if cmd in STATE_CHANGING_COMMANDS:
+        return True
+    if cmd == "curl":
+        for tok in argv[1:]:
+            if tok in _CURL_OUTPUT_FLAGS or tok.startswith("--output="):
+                return True
+    if cmd == "wget":
+        for tok in argv[1:]:
+            if tok in _WGET_OUTPUT_FLAGS or tok.startswith("--output-document="):
+                return True
+    return _segment_has_redirect(argv)
+
+
+def is_compound_command(command: str) -> bool:
+    """True iff `command` tokenizes into ≥2 command segments.
+
+    Compound means at least one shell separator (`&&`, `||`, `;`, `|`, or a
+    newline-induced synthetic `;`) splits the command into multiple segments.
+    Separators inside quoted strings do NOT split (shlex preserves quoting).
+    """
+    tokens = safe_tokenize(command)
+    if not tokens:
+        return False
+    segments = list(iter_command_starts(tokens))
+    return len(segments) >= 2
+
+
+def has_state_changing_redirect(command: str) -> bool:
+    """True iff any segment of `command` performs a file/dir mutation.
+
+    Detects the side-effects that vanish silently when the parent compound
+    invocation is rejected at PreToolUse: redirects (`> file`, `>> file`,
+    `<<EOF > file`), `mkdir`, `tee`, `cp`/`mv`/`ln`/`rm`/`touch`/`rsync`,
+    `curl -o`, `wget -O`.
+    """
+    tokens = safe_tokenize(command)
+    if not tokens:
+        return False
+    for argv in iter_command_starts(tokens):
+        if _segment_has_state_change(argv):
+            return True
+    return False
+
+
+COMPOUND_CASCADE_HINT = (
+    "\n"
+    "Note: this command chains a state-changing step (`> file`, `mkdir`, "
+    "`curl -o`, `<<EOF > file`, `tee file`) with another step. PreToolUse "
+    "rejection (block or denied ask) aborts ALL parts atomically — files the "
+    "redirect/mkdir/download would have created do NOT exist. Before retrying, "
+    "use the Write tool to materialize the file first, then issue a separate "
+    "Bash call.\n"
+)
+
+
+def compound_cascade_hint(command: str) -> str:
+    """Return the canonical cascade-abort hint when applicable, else `""`.
+
+    Called by every PreToolUse(Bash) hook that may reject a command, so the
+    same advisory text appears consistently across the chain (issue #229).
+    Returns empty string for single commands or compound commands without a
+    state-changing segment — the hint is only useful when the cascade was
+    likely to leave the agent's mental model out of sync with disk state.
+    """
+    if not command or not command.strip():
+        return ""
+    if not is_compound_command(command):
+        return ""
+    if not has_state_changing_redirect(command):
+        return ""
+    return COMPOUND_CASCADE_HINT

--- a/hooks/block-gh-state-all.py
+++ b/hooks/block-gh-state-all.py
@@ -23,6 +23,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    compound_cascade_hint,
     iter_command_starts,
     safe_tokenize,
     strip_prefix,
@@ -113,7 +114,7 @@ def main() -> int:
 
     for argv in iter_command_starts(tokens):
         if is_blocked_gh_search(argv):
-            sys.stderr.write(STDERR_MESSAGE)
+            sys.stderr.write(STDERR_MESSAGE + compound_cascade_hint(command))
             return 2
 
     return 0

--- a/hooks/block-pr-without-caller-evidence.py
+++ b/hooks/block-pr-without-caller-evidence.py
@@ -51,6 +51,7 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from _hook_utils import (  # type: ignore[import-not-found]
+    compound_cascade_hint,
     iter_command_starts,
     safe_tokenize,
     strip_prefix,
@@ -245,10 +246,6 @@ Why (praxis #158):
   hard gate at the last checkpoint before shared-state mutation.
 
 Cross-project PRs (--repo other/org) are not blocked.
-
-Note: if you used `cat <<EOF > /tmp/body.md && gh pr create --body-file \
-/tmp/body.md` and got blocked, the heredoc redirect was also aborted — the \
-file does NOT exist. Use Write tool first, then a separate Bash call.
 """
 
 
@@ -283,7 +280,7 @@ def main() -> int:
         body = _get_effective_body(argv, hmap, command)
         if CALLER_CHAIN_RE.search(_strip_fenced_blocks(body)):
             continue  # evidence present
-        sys.stderr.write(BLOCK_MSG)
+        sys.stderr.write(BLOCK_MSG + compound_cascade_hint(command))
         return 2
 
     return 0

--- a/hooks/commit-title-length-check.py
+++ b/hooks/commit-title-length-check.py
@@ -33,6 +33,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    compound_cascade_hint,
     iter_command_starts,
     safe_tokenize,
     strip_prefix,
@@ -331,6 +332,7 @@ def main() -> int:
                     f"Commit title too long: {length} chars (max {max_len}).\n"
                     f"Title: {title!r}\n"
                     "Shorten to ≤50 chars, or embed `# title-length:ack` to bypass."
+                    + compound_cascade_hint(command)
                 )
                 return 0  # ask emitted; only report first violation
 

--- a/hooks/cross-boundary-preflight.py
+++ b/hooks/cross-boundary-preflight.py
@@ -32,6 +32,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    compound_cascade_hint,
     iter_command_starts,
     safe_tokenize,
     strip_prefix,
@@ -281,7 +282,7 @@ def main() -> int:
 
         # Check 1: heredoc in same segment → hard block (marker-independent)
         if _has_heredoc(argv):
-            sys.stderr.write(HEREDOC_BLOCK_MSG)
+            sys.stderr.write(HEREDOC_BLOCK_MSG + compound_cascade_hint(command))
             return 2
 
         # Check 2: --repo flag present → surface pre-flight checklist
@@ -290,7 +291,7 @@ def main() -> int:
             return 0
         has_repo, repo_val = _has_repo_flag(argv)
         if has_repo:
-            _emit_ask(_build_checklist(subcommand, repo_val))
+            _emit_ask(_build_checklist(subcommand, repo_val) + compound_cascade_hint(command))
             return 0
 
     return 0

--- a/hooks/pre-merge-approval-gate.py
+++ b/hooks/pre-merge-approval-gate.py
@@ -40,6 +40,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    compound_cascade_hint,
     iter_command_starts,
     safe_tokenize,
     strip_prefix,
@@ -134,7 +135,7 @@ def main() -> int:
     if os.environ.get("CMUX_DELEGATE") == "1":
         return 0
 
-    emit_ask(REASON)
+    emit_ask(REASON + compound_cascade_hint(command))
     return 0
 
 

--- a/hooks/side-effect-scan.py
+++ b/hooks/side-effect-scan.py
@@ -22,6 +22,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    compound_cascade_hint,
     iter_command_starts,
     safe_tokenize,
     strip_prefix,
@@ -152,7 +153,7 @@ def has_prod_scope(tokens: list[str]) -> bool:
     return False
 
 
-def build_reason(categories: list[str], prod: bool) -> str:
+def build_reason(categories: list[str], prod: bool, command: str) -> str:
     parts = [f"[{c}] {CATEGORIES[c]['reason']}." for c in categories]
     msg = " ".join(parts)
     if prod:
@@ -160,6 +161,7 @@ def build_reason(categories: list[str], prod: bool) -> str:
     msg += (
         " 의도한 실행이면 command 에 '# side-effect:ack' 주석을 포함해 재호출하세요."
     )
+    msg += compound_cascade_hint(command)
     return msg
 
 
@@ -207,7 +209,7 @@ def main() -> int:
     if not matched:
         return 0
 
-    reason = build_reason(matched, has_prod_scope(tokens))
+    reason = build_reason(matched, has_prod_scope(tokens), command)
     emit_ask(reason)
     return 0
 

--- a/hooks/test-block-pr-without-caller-evidence.sh
+++ b/hooks/test-block-pr-without-caller-evidence.sh
@@ -210,23 +210,40 @@ run_case "body-file tee-overwritten in same command blocks" block Bash \
 
 rm -f "$TOCTOU_FILE"
 
-# (f) block message contains heredoc cascade hint
-run_case "block msg heredoc hint" block Bash \
-  'gh pr create --body "no marker"'
-# The run_case above already checks block; separately verify the hint appears.
-_hint_err=$(python3 -c '
+# (f) block message contains shared cascade hint when command is compound +
+#     has a state-changing redirect (issue #229). Single-command blocks do NOT
+#     get the hint — the agent already knows the single bash call didn't run.
+
+_capture_stderr() {
+  python3 -c '
 import json, sys
 payload = json.dumps({
     "tool_name": "Bash",
-    "tool_input": {"command": "gh pr create --body \"no marker\""},
+    "tool_input": {"command": sys.argv[1]},
 })
 sys.stdout.write(payload)
-' | python3 "$(dirname "$0")/block-pr-without-caller-evidence.py" 2>&1 >/dev/null || true)
-if printf '%s' "$_hint_err" | grep -q "heredoc redirect was also aborted"; then
-  echo "PASS [hint] block message contains heredoc-cascade hint"; ((PASS++))
+' "$1" | python3 "$(dirname "$0")/block-pr-without-caller-evidence.py" 2>&1 >/dev/null || true
+}
+
+# Positive: compound bash with heredoc redirect → hint appears
+_hint_err=$(_capture_stderr 'cat <<EOF > /tmp/body.md
+no marker here
+EOF
+gh pr create --body-file /tmp/body.md')
+if printf '%s' "$_hint_err" | grep -q "PreToolUse rejection (block or denied ask) aborts ALL parts atomically"; then
+  echo "PASS [hint] compound block message contains cascade hint"; ((PASS++))
 else
-  echo "FAIL [hint] block message missing heredoc-cascade hint"; ((FAIL++))
-  FAILED_NAMES+=("block msg heredoc-cascade hint text")
+  echo "FAIL [hint] compound block message missing cascade hint"; ((FAIL++))
+  FAILED_NAMES+=("compound block missing cascade hint")
+fi
+
+# Negative: single-command block → hint does NOT appear (no cascade to warn about)
+_hint_err=$(_capture_stderr 'gh pr create --body "no marker"')
+if printf '%s' "$_hint_err" | grep -q "PreToolUse rejection"; then
+  echo "FAIL [hint] single-command block leaked cascade hint"; ((FAIL++))
+  FAILED_NAMES+=("single-command block leaked cascade hint")
+else
+  echo "PASS [hint] single-command block has no cascade hint"; ((PASS++))
 fi
 
 # ---------------------------------------------------------------------------

--- a/hooks/verify-commit-flag-override.py
+++ b/hooks/verify-commit-flag-override.py
@@ -38,6 +38,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    compound_cascade_hint,
     iter_command_starts,
     safe_tokenize,
     strip_prefix,
@@ -300,7 +301,7 @@ def main() -> int:
     if not all_overrides:
         return 0
 
-    _emit_deny(_build_reason(all_overrides))
+    _emit_deny(_build_reason(all_overrides) + compound_cascade_hint(command))
     return 2
 
 

--- a/tests/test_cross_boundary_preflight.sh
+++ b/tests/test_cross_boundary_preflight.sh
@@ -281,6 +281,26 @@ run_case "var-heredoc then gh pr create passes" pass \
   'gh pr create --title "t" --body "$BODY"'
 
 # ---------------------------------------------------------------------------
+# Cascade-hint suffix (issue #229) — shared cascade advisory text appears in
+# stderr when the heredoc block fires on a compound bash with a state-change.
+# ---------------------------------------------------------------------------
+
+_cascade_err=$(mk_payload 'echo seed > /tmp/x && gh pr create --title t <<EOF' | "$HOOK" 2>&1 >/dev/null)
+if printf '%s' "$_cascade_err" | grep -q "PreToolUse rejection (block or denied ask) aborts ALL parts atomically"; then
+  echo "PASS  [cascade hint on compound heredoc block]"; PASS=$((PASS+1))
+else
+  echo "FAIL  [cascade hint missing on compound heredoc block]"; FAIL=$((FAIL+1)); FAILED_NAMES+=("cascade hint on heredoc block")
+fi
+
+# Single-command heredoc block: no compound chain → no cascade hint
+_single_err=$(mk_payload 'gh pr create --title "t" <<EOF' | "$HOOK" 2>&1 >/dev/null)
+if printf '%s' "$_single_err" | grep -q "PreToolUse rejection (block or denied ask) aborts ALL parts atomically"; then
+  echo "FAIL  [cascade hint leaked on single-command heredoc block]"; FAIL=$((FAIL+1)); FAILED_NAMES+=("cascade hint leaked single heredoc")
+else
+  echo "PASS  [no cascade hint on single-command heredoc block]"; PASS=$((PASS+1))
+fi
+
+# ---------------------------------------------------------------------------
 # Infrastructure
 # ---------------------------------------------------------------------------
 

--- a/tests/test_hook_utils.sh
+++ b/tests/test_hook_utils.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# tests/test_hook_utils.sh — unit coverage for the shared helpers in
+# hooks/_hook_utils.py. Currently focused on the compound-cascade advisory
+# primitives added for issue #229:
+#
+#   is_compound_command(command) -> bool
+#   has_state_changing_redirect(command) -> bool
+#   compound_cascade_hint(command) -> str  (empty unless both above are True)
+#
+# Each case spawns a python3 subprocess that imports the helper, prints the
+# result, and the harness asserts expected==actual.
+#
+# Usage: bash tests/test_hook_utils.sh
+# Exit:  0 = all pass, 1 = at least one fail
+
+set +e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOKS_DIR="$REPO_ROOT/hooks"
+export PYTHONPATH="$HOOKS_DIR${PYTHONPATH:+:$PYTHONPATH}"
+
+if [ ! -f "$HOOKS_DIR/_hook_utils.py" ]; then
+  echo "FAIL: _hook_utils.py not found at $HOOKS_DIR" >&2
+  exit 1
+fi
+
+PASS=0; FAIL=0; FAILED_NAMES=()
+
+# Generic bool-helper runner.
+#   $1 name   $2 helper   $3 expected (true|false)   $4 command
+run_bool() {
+  local name="$1" helper="$2" expected="$3" command="$4"
+  local actual
+  actual=$(python3 -c '
+import sys
+import _hook_utils as h
+print(str(getattr(h, sys.argv[1])(sys.argv[2])).lower())
+' "$helper" "$command")
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS [$helper:$expected] $name"; PASS=$((PASS + 1))
+  else
+    echo "FAIL [$helper:expected=$expected got=$actual] $name"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# Hint runner — expect = true (non-empty hint) | false (empty hint).
+run_hint() {
+  local name="$1" expect="$2" command="$3"
+  local actual
+  actual=$(python3 -c '
+import sys
+import _hook_utils as h
+print("true" if h.compound_cascade_hint(sys.argv[1]) else "false")
+' "$command")
+  if [ "$actual" = "$expect" ]; then
+    echo "PASS [hint:$expect] $name"; PASS=$((PASS + 1))
+  else
+    echo "FAIL [hint:expected=$expect got=$actual] $name"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# is_compound_command
+# ---------------------------------------------------------------------------
+
+run_bool "single command"               is_compound_command false 'git status'
+run_bool "&& separator"                 is_compound_command true  'mkdir /x && cp a b'
+run_bool "|| separator"                 is_compound_command true  'test -d /x || mkdir /x'
+run_bool "; separator"                  is_compound_command true  'echo a; echo b'
+run_bool "| pipe separator"             is_compound_command true  'echo a | grep b'
+run_bool "newline separator"            is_compound_command true  $'echo a\necho b'
+run_bool "&& inside quotes"             is_compound_command false 'echo "a && b"'
+run_bool "; inside quotes"              is_compound_command false 'echo "foo;bar"'
+run_bool "empty command"                is_compound_command false ''
+run_bool "whitespace only"              is_compound_command false '   '
+
+# ---------------------------------------------------------------------------
+# has_state_changing_redirect
+# ---------------------------------------------------------------------------
+
+run_bool "single > redirect"            has_state_changing_redirect true  'echo hi > /tmp/x'
+run_bool "single >> redirect"           has_state_changing_redirect true  'echo hi >> /tmp/x'
+run_bool "attached redirect >/tmp/x"    has_state_changing_redirect true  'echo hi >/tmp/x'
+run_bool "embedded foo>/tmp/x"          has_state_changing_redirect true  'cat foo>/tmp/x'
+run_bool "heredoc <<EOF"                has_state_changing_redirect true  $'cat <<EOF\nx\nEOF'
+run_bool "mkdir as state change"        has_state_changing_redirect true  'mkdir -p /tmp/x'
+run_bool "tee writes file"              has_state_changing_redirect true  'echo y | tee /tmp/x'
+run_bool "cp mutates fs"                has_state_changing_redirect true  'cp a b'
+run_bool "mv mutates fs"                has_state_changing_redirect true  'mv a b'
+run_bool "rm mutates fs"                has_state_changing_redirect true  'rm /tmp/x'
+run_bool "touch creates file"           has_state_changing_redirect true  'touch /tmp/x'
+run_bool "curl -o downloads"            has_state_changing_redirect true  'curl -o /tmp/x https://e.com'
+run_bool "curl --output downloads"      has_state_changing_redirect true  'curl --output /tmp/x https://e.com'
+run_bool "wget -O downloads"            has_state_changing_redirect true  'wget -O /tmp/x https://e.com'
+run_bool "cat file is read-only"        has_state_changing_redirect false 'cat /tmp/x'
+run_bool "git status read-only"         has_state_changing_redirect false 'git status'
+run_bool "echo > inside quotes"         has_state_changing_redirect false 'echo "a > b"'
+run_bool "grep arrow in pattern"        has_state_changing_redirect false 'grep "a => b" /tmp/x'
+run_bool "curl without -o"              has_state_changing_redirect false 'curl https://e.com'
+# Reviewer-flagged false-positive regressions (review #229)
+run_bool "echo quoted heredoc literal"  has_state_changing_redirect false 'echo "<<EOF something"'
+run_bool "wget -o is log file"          has_state_changing_redirect false 'wget -o log.txt https://e.com'
+
+# ---------------------------------------------------------------------------
+# compound_cascade_hint — both detectors must be true
+# ---------------------------------------------------------------------------
+
+# Positives: compound + state-change
+run_hint "heredoc redirect then pr create" true \
+  $'cat <<EOF > /tmp/body.md\nbody\nEOF\ngh pr create --body-file /tmp/body.md'
+run_hint "mkdir && cp"                     true 'mkdir -p /x && cp a /x/'
+run_hint "curl -o && bash"                 true 'curl -o /tmp/run.sh https://e.com && bash /tmp/run.sh'
+run_hint "rm && git push"                  true 'rm /tmp/x && git push'
+run_hint "echo > file && cmd"              true 'echo new > /tmp/x && cat /tmp/x'
+
+# Negatives: missing one of the two conditions
+run_hint "single mkdir no hint"            false 'mkdir -p /tmp/x'
+run_hint "single redirect no hint"         false 'echo hi > /tmp/x'
+run_hint "compound no state change"        false 'git status && git log -3'
+run_hint "compound cat | grep no hint"     false 'cat /tmp/x | grep foo'
+run_hint "single gh pr create no hint"     false 'gh pr create --body "no marker"'
+run_hint "empty command no hint"           false ''
+# Reviewer-flagged: quoted "<<EOF" in compound command must NOT trigger hint
+run_hint "quoted heredoc-like in compound" false 'echo "<<EOF foo" && git push'
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo
+echo "=========================================="
+echo "  PASS: $PASS  FAIL: $FAIL"
+echo "=========================================="
+if [ "$FAIL" -gt 0 ]; then
+  printf '  failed: %s\n' "${FAILED_NAMES[@]}"
+  exit 1
+fi
+exit 0

--- a/tests/test_side_effect_scan.sh
+++ b/tests/test_side_effect_scan.sh
@@ -209,6 +209,36 @@ cmux_run "delegate git push still asks"       ask  "git push origin main"
 cmux_run "delegate git commit still asks"     ask  "git commit -m wip"
 cmux_run "delegate kubectl apply still ask"   ask  "kubectl apply -f x.yaml"
 
+# --- compound cascade-hint suffix (issue #229) -----------------------------
+# When the ask fires on a compound command containing a state-changing step
+# (mkdir, redirect, tee, curl -o, …), the ask reason must include the shared
+# cascade advisory text from _hook_utils.compound_cascade_hint.
+
+_hint_payload=$(python3 -c '
+import json, sys
+print(json.dumps({"tool_name":"Bash","tool_input":{"command":sys.argv[1]}}))
+' 'mkdir -p /tmp/staged && git push origin main')
+_hint_out=$(echo "$_hint_payload" | "$HOOK" 2>/dev/null)
+if echo "$_hint_out" | grep -q "PreToolUse rejection (block or denied ask) aborts ALL parts atomically"; then
+  echo "PASS  [cascade hint on compound git push ask]"; PASS=$((PASS + 1))
+else
+  echo "FAIL  [cascade hint missing on compound git push ask]"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("cascade hint compound git push")
+fi
+
+# Single-command ask (no compound chain) → reason must NOT carry the cascade hint
+_single_payload=$(python3 -c '
+import json, sys
+print(json.dumps({"tool_name":"Bash","tool_input":{"command":sys.argv[1]}}))
+' 'git push origin main')
+_single_out=$(echo "$_single_payload" | "$HOOK" 2>/dev/null)
+if echo "$_single_out" | grep -q "PreToolUse rejection (block or denied ask) aborts ALL parts atomically"; then
+  echo "FAIL  [cascade hint leaked on single-command ask]"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("cascade hint leaked single command")
+else
+  echo "PASS  [no cascade hint on single-command ask]"; PASS=$((PASS + 1))
+fi
+
 # --- non-Bash tool passthrough ---------------------------------------------
 non_bash_out=$(echo '{"tool_name":"Read","tool_input":{"file_path":"/tmp/x"}}' | "$HOOK" 2>/dev/null)
 if [ -z "$non_bash_out" ]; then


### PR DESCRIPTION
Closes #229. Sub-task (1) of epic #219.

## Summary

Generalize the heredoc-cascade hint that PR #226 baked into `block-pr-without-caller-evidence` so every PreToolUse(Bash) hook that rejects (block) or asks-and-may-deny a compound command surfaces the same advisory.

When the agent issues `cat <<EOF > /tmp/body.md && gh pr create --body-file /tmp/body.md` and the gh part is rejected at PreToolUse, the heredoc redirect side-effect ALSO aborts — bash never ran any part. The agent's retry of just the gh half then hits `No such file or directory`. The advisory makes this cascade behavior explicit at the rejection site.

## What changed

- `hooks/_hook_utils.py` — add `compound_cascade_hint(command)` plus the supporting `is_compound_command` / `has_state_changing_redirect` predicates. Returns the canonical advisory text when the command is compound (shell separator outside quotes) AND contains a state-changing step (`> file`, `<<EOF >`, `mkdir`, `tee`, `cp`/`mv`/`rm`/`touch`, `curl -o`, `wget -O`); empty string otherwise.
- 7 PreToolUse(Bash) hooks now suffix the shared hint to their block/ask message:
  - `block-pr-without-caller-evidence` (replaces ad-hoc hint from PR #226)
  - `cross-boundary-preflight` (HEREDOC_BLOCK_MSG + CROSS_REPO ask)
  - `block-gh-state-all`
  - `side-effect-scan`
  - `pre-merge-approval-gate`
  - `commit-title-length-check`
  - `verify-commit-flag-override`
- `docs/hook/*.md` — add "Compound cascade advisory" subsection to each affected hook spec; root `AGENTS.md` Design contract gains a paragraph documenting the shared primitive.

## Design choice

Option (a) from the issue — single utility in `_hook_utils.py`, suffix applied at rejection sites — chosen over option (b) standalone advisory hook. Reasons: precisely targeted (only surfaces when a hook is actually rejecting), avoids noise on every `mkdir -p && ...` command, and reuses existing tokenization infrastructure (`safe_tokenize` / `iter_command_starts` / `strip_prefix`).

Single-command rejections do NOT receive the suffix — no cascade to warn about.

## Caller chain verified

`compound_cascade_hint` callers: grep found 7 hook files in `hooks/` (block-pr-without-caller-evidence.py, cross-boundary-preflight.py, block-gh-state-all.py, side-effect-scan.py, pre-merge-approval-gate.py, commit-title-length-check.py, verify-commit-flag-override.py). The helper is new symbol; no other callers expected outside the hook surface.

## Test plan

- [x] `tests/test_hook_utils.sh` — 43 cases covering `is_compound_command` (10), `has_state_changing_redirect` (19 including reviewer-flagged regressions for quoted `<<EOF` literals and `wget -o` log file), `compound_cascade_hint` (14 combining both detectors).
- [x] `tests/test_cross_boundary_preflight.sh` — added 2 cases: cascade hint present on compound heredoc block, absent on single-command heredoc block. (43 total)
- [x] `tests/test_side_effect_scan.sh` — added 2 cases: cascade hint present on compound `mkdir && git push` ask, absent on single `git push` ask. (64 total)
- [x] `hooks/test-block-pr-without-caller-evidence.sh` — replaced the old "heredoc redirect was also aborted" assertion with two: compound block contains new shared text, single-command block does NOT. (34 total)
- [x] All existing hook test suites pass with no regressions (commit-title-length-check 47, verify-commit-flag-override 29, pre-merge-approval-gate 25, block-gh-state-all 29).
- [x] `./scripts/check-plugin-manifests.py` — clean.

## Acceptance criteria

- [x] Heredoc/mkdir/curl redirect compound Bash commands receive consistent cascade messaging across all PreToolUse hooks (single source of truth in `_hook_utils.py`).
- [x] Unit tests for compound pattern detection + message inclusion.
- [x] Docs in `docs/hook/` for each affected hook updated with cascade-advisory subsection.

## References

- Closes #229
- Parent epic: #219
- Companion (partial precedent): #226

---
_Generated by [Claude Code](https://claude.ai/code/session_018Ez3fYbeWZMh6Vx37X1prb)_