### PR TITLE
docs: clarify Agent vs Skill invocation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,11 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 
 ## Skills (11)
 
+> **Invocation**: praxis entries are *skills*, not subagents. Always call them
+> via `Skill(skill="praxis:<name>")` — `Agent(subagent_type="praxis:<name>")`
+> returns `Agent type not found`. See [RUNTIME_CONSTRAINTS.md §3](RUNTIME_CONSTRAINTS.md)
+> for the full rationale and Agent-vs-Skill mapping table.
+
 ### Development
 
 | Skill | Purpose |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Development workflow skills for Claude Code — disciplined, fast, resilient.
 
 ## Skills
 
+> **Invocation**: praxis entries are *skills*, not subagents. Always call them
+> via `Skill(skill="praxis:<name>")`. `Agent(subagent_type="praxis:<name>")`
+> returns `Agent type not found` — Agent and Skill resolve disjoint namespaces.
+> See [RUNTIME_CONSTRAINTS.md §3](RUNTIME_CONSTRAINTS.md) for the mapping table.
+
 ### Development
 
 | Skill | Description |

--- a/RUNTIME_CONSTRAINTS.md
+++ b/RUNTIME_CONSTRAINTS.md
@@ -67,7 +67,39 @@ delegation was confirmed non-viable.
 
 ---
 
-## 3. `Bash` tool — cwd resets between invocations
+## 3. `Agent(subagent_type=...)` cannot invoke a skill — `Skill(...)` is the only path
+
+**Constraint**: The `Agent` and `Skill` tools address disjoint namespaces.
+`Agent(subagent_type="praxis:<name>")` resolves only against registered
+subagent types (`general-purpose`, `Explore`, `Plan`, OMC `executor`, etc.).
+Every praxis entry under `skills/*/SKILL.md` is a *skill*, not a subagent,
+and is reachable only via `Skill(skill="praxis:<name>")`.
+
+**Why it bites skills**: Skill names look like subagent IDs (slug-style,
+plugin-prefixed), so it is natural to try `Agent(subagent_type="praxis:retrospect")`.
+The call fails with `Agent type not found: praxis:retrospect`, which gives
+no signal about the correct `Skill(...)` form. Documentation that mixes
+"agent" and "skill" interchangeably amplifies the confusion.
+
+**Workaround**: Always invoke praxis entries via `Skill(skill="praxis:<name>")`.
+This is true regardless of whether the underlying skill declares
+`disable-model-invocation: true` — that flag governs Skill→Skill nesting
+(see entry #2), not the Agent-vs-Skill distinction.
+
+| Wrong | Right |
+|-------|-------|
+| `Agent(subagent_type="praxis:codex-review-wrap")` | `Skill(skill="praxis:codex-review-wrap")` |
+| `Agent(subagent_type="praxis:retrospect")` | `Skill(skill="praxis:retrospect")` |
+| `Agent(subagent_type="praxis:cmux-delegate")` | `Skill(skill="praxis:cmux-delegate")` |
+
+**Verified**: 2026-05-17 / Claude Code (Opus 4.7) / Issue #249 — `Agent()`
+returns `Agent type not found` for every praxis skill name. Any praxis
+skill listed in the README or AGENTS.md table is reachable only through
+the `Skill(...)` tool.
+
+---
+
+## 4. `Bash` tool — cwd resets between invocations
 
 **Constraint**: Each `Bash` tool call starts with the session's original cwd.
 A `cd /some/path` in one `Bash` call does **not** persist to the next call.


### PR DESCRIPTION
## 요약

`Agent(subagent_type="praxis:<name>")` 호출이 `Agent type not found` 으로 실패하지만, 어떤 invocation 이 맞는지 surfacing 되지 않아 사용자가 혼란을 겪는 패턴을 문서로 차단.

## 변경

- `RUNTIME_CONSTRAINTS.md` §3 신규 — Agent/Skill namespace 분리 + 매핑 테이블 + 검증 일자
- `AGENTS.md` Skills 섹션 상단에 `> Invocation` 인라인 노트
- `README.md` Skills 섹션 상단에 같은 노트 (외부 시청자용)

## 설계 결정

- 이슈는 frontmatter field (`invocation: skill-only`) 와 에러 메시지 개선을 제안하지만 둘 다 Claude Code 플랫폼 변경이라 사용자/스킬 저자가 통제 불가.
- 따라서 가장 가까운 actionable 인 documentation 경로 (#3) 만 채택.
- 실제로 praxis 스킬 중 frontmatter 에 `disable-model-invocation: true` 인 것은 없음 (확인됨) — Agent 와 Skill 의 disjoint namespace 자체가 진짜 혼란의 원인이라 이슈 제목의 "disable-model-invocation" 표현보다 일반적인 frame 으로 정리.
- 기존 RUNTIME_CONSTRAINTS §2 (Skill→Skill nested `disable-model-invocation`) 과 명확히 분리해 cross-reference.

## 검증

- `./scripts/check-plugin-manifests.py` → `plugin-manifest check OK`
- `AGENTS.md ↔ CLAUDE.md` 심볼릭 링크 그대로 유지 (CLAUDE.md 는 AGENTS.md 의 심볼릭 링크)
- 본 PR 자체로 새 hook/test 가 없으므로 추가 테스트 의무 없음 (docs-only)

## 미검증 / 후속

- 없음. docs-only 변경, blast radius 최소.

Closes #249