### PR TITLE
feat(hook): cli flag incompat advisory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,7 @@ Design contract shared by all hooks:
 |------|-------|---------|------|
 | `block-gh-state-all` | PreToolUse | Hard-block invalid `gh search ... --state all` flag combo | [docs/hook/block-gh-state-all.md](docs/hook/block-gh-state-all.md) |
 | `gh-flag-verify` | PreToolUse | Block `gh <subcmd>` calls with flags not in the subcommand's accepted set | [docs/hook/gh-flag-verify.md](docs/hook/gh-flag-verify.md) |
+| `cli-flag-incompat-advisory` | PreToolUse | Advisory nudge for known mode-incompatible flag combos in other CLIs (`git merge-tree --name-only` 3-arg form, `kubectl --use-protocol-buffers`) — issue #248 | [docs/hook/cli-flag-incompat-advisory.md](docs/hook/cli-flag-incompat-advisory.md) |
 | `side-effect-scan` | PreToolUse | Ask before commands with collateral side effects (`git commit/push`, `gh pr merge/create`, `kubectl apply`) | [docs/hook/side-effect-scan.md](docs/hook/side-effect-scan.md) |
 | `memory-hint` | PreToolUse | Surface hookable memory entries by keyword at decision-construction time (advisory, never blocks) | [docs/hook/memory-hint.md](docs/hook/memory-hint.md) |
 | `codex-review-route` | UserPromptSubmit | Warn when `/codex:review` runs in a multi-worktree repo (cwd mismatch risk) | [docs/hook/codex-review-route.md](docs/hook/codex-review-route.md) |

--- a/docs/hook/cli-flag-incompat-advisory.md
+++ b/docs/hook/cli-flag-incompat-advisory.md
@@ -39,7 +39,9 @@ though the operator never wrote `--trivial-merge`.
 | `git merge-tree --name-only $(git merge-base HEAD origin/main) HEAD origin/main` | **ADVISORY** (3 positionals expanded) |
 | `git -C /tmp merge-tree --name-only A B C` | **ADVISORY** — `-C` is git global |
 | `git merge-tree --name-only HEAD origin/main` | **SILENT** — 2 positionals, modern OK |
-| `git merge-tree --merge-base=A --name-only HEAD origin/main` | **SILENT** — explicit merge-base |
+| `git merge-tree --merge-base=A --name-only HEAD origin/main` | **SILENT** — explicit merge-base (equals form) |
+| `git merge-tree --merge-base A --name-only HEAD origin/main` | **SILENT** — explicit merge-base (space form) |
+| `git merge-tree -X ours --name-only HEAD origin/main` | **SILENT** — `-X` consumes one value token |
 | `git merge-tree abc HEAD origin/main` | **SILENT** — no modern flag (legacy form) |
 
 #### `kubectl` deprecated flag
@@ -107,6 +109,7 @@ walks every command segment, runs every check, and emits the first hit.
 bash hooks/test-cli-flag-incompat-advisory.sh
 ```
 
-18 cases: 6 advisory (4 git merge-tree variants, 2 kubectl), 10 silent
-(correct merge-tree usage, unrelated commands, comment), 2 infrastructure
+21 cases: 6 advisory (4 git merge-tree variants, 2 kubectl), 13 silent
+(correct merge-tree usage including space-form `--merge-base`, `-X`,
+`--strategy-option`, unrelated commands, comment), 2 infrastructure
 (non-Bash passthrough, malformed JSON fail-open).

--- a/docs/hook/cli-flag-incompat-advisory.md
+++ b/docs/hook/cli-flag-incompat-advisory.md
@@ -1,0 +1,112 @@
+# PreToolUse CLI Flag Incompatibility Advisory
+
+`hooks/cli-flag-incompat-advisory.sh` is the **advisory** counterpart to the
+deny-mode `gh-flag-verify.sh`. It nudges `<cli> <subcmd> --help` before known
+mode-incompatible flag combinations land on external CLIs whose surface area
+is too large or too version-fluid to safely hard-block.
+
+### Why this exists
+
+`gh-flag-verify.sh` blocks unknown flags on a maintained `gh` COMPAT table.
+The same friction recurs on other CLIs (`git`, `kubectl`), but:
+
+- their subcommand surface is larger
+- their flag tables shift across versions
+- a hard block would have unacceptable false-positive cost
+
+Memory entry `feedback_external_cli_verify_first` covers the "always run
+`--help` before guessing flag combinations" rule and has been refreshed
+for ≥1 prior incident, but the retrieval moment (command composition)
+keeps failing. This hook moves a fragment of the enforcement to the Bash
+boundary as a low-cost reminder (issue #248).
+
+### What is detected
+
+#### `git merge-tree` mode conflict
+
+`git merge-tree` has a modern `--write-tree` mode and a deprecated
+`--trivial-merge` mode. Modern flags (`--name-only`, `--write-tree`) only
+work in modern mode, which is selected by **1 or 2** positional branch
+arguments. Three positionals drops merge-tree into legacy mode and the
+modern flag is rejected with the confusing message
+`fatal: --trivial-merge is incompatible with all other options` — even
+though the operator never wrote `--trivial-merge`.
+
+| Command | Action |
+|---------|--------|
+| `git merge-tree --name-only abc HEAD origin/main` | **ADVISORY** — 3 positionals + modern flag |
+| `git merge-tree --write-tree A B C` | **ADVISORY** |
+| `git merge-tree --name-only $(git merge-base HEAD origin/main) HEAD origin/main` | **ADVISORY** (3 positionals expanded) |
+| `git -C /tmp merge-tree --name-only A B C` | **ADVISORY** — `-C` is git global |
+| `git merge-tree --name-only HEAD origin/main` | **SILENT** — 2 positionals, modern OK |
+| `git merge-tree --merge-base=A --name-only HEAD origin/main` | **SILENT** — explicit merge-base |
+| `git merge-tree abc HEAD origin/main` | **SILENT** — no modern flag (legacy form) |
+
+#### `kubectl` deprecated flag
+
+Known deprecations:
+
+| Flag | Reason |
+|------|--------|
+| `--use-protocol-buffers` | Removed in kubectl ≥1.27 — protobuf is auto-negotiated |
+
+| Command | Action |
+|---------|--------|
+| `kubectl --use-protocol-buffers get pods` | **ADVISORY** |
+| `kubectl --use-protocol-buffers=true get pods` | **ADVISORY** (`=value` form) |
+| `kubectl get pods -n default` | **SILENT** |
+
+### Response format
+
+```
+stderr: "[cli-flag-incompat-advisory] <cli> <category>\n<body>"
+exit 0
+```
+
+Advisory-only: the hook **never blocks** and never emits JSON. The user
+sees the stderr text and decides whether to re-run with the suggested
+fix or proceed.
+
+### Adding a new CLI
+
+The hook uses a plugin-style registry:
+
+```python
+def _check_<cli>(argv: list[str]) -> Optional[str]:
+    argv = strip_prefix(argv)
+    if not argv or argv[0] != "<cli>":
+        return None
+    # Return advisory text or None
+    ...
+
+CHECKS = (_check_git, _check_kubectl, _check_<new_cli>)
+```
+
+Each check function returns `Optional[str]` (the advisory text). The hook
+walks every command segment, runs every check, and emits the first hit.
+
+### Parsing guarantees (fail-open)
+
+- malformed JSON stdin → exit 0
+- non-Bash tool → exit 0
+- empty / whitespace command → exit 0
+- uncaught exception in inner logic → swallowed, exit 0
+- `python3` unavailable → shell wrapper exits 0
+
+### Relationship to sibling hooks
+
+| Hook | Scope | Overlap |
+|------|-------|---------|
+| `gh-flag-verify` | `gh <subcmd>` — deny on unknown flag from COMPAT table | None — gh-only, this hook covers other CLIs |
+| `block-gh-state-all` | `gh search --state all` | None — gh-only |
+| `verify-commit-flag-override` | `git commit --no-verify` etc. | Complementary — covers commit safety, this hook covers shape errors |
+
+### Tests
+
+```bash
+bash hooks/test-cli-flag-incompat-advisory.sh
+```
+
+18 cases: 6 advisory (4 git merge-tree variants, 2 kubectl), 10 silent
+(correct merge-tree usage, unrelated commands, comment), 2 infrastructure
+(non-Bash passthrough, malformed JSON fail-open).

--- a/docs/hook/cli-flag-incompat-advisory.md
+++ b/docs/hook/cli-flag-incompat-advisory.md
@@ -58,6 +58,8 @@ Known deprecations:
 |---------|--------|
 | `kubectl --use-protocol-buffers get pods` | **ADVISORY** |
 | `kubectl --use-protocol-buffers=true get pods` | **ADVISORY** (`=value` form) |
+| `kubectl --use-protocol-buffers exec pod -- mytool` | **ADVISORY** — flag is kubectl-side, before `--` |
+| `kubectl exec pod -- mytool --use-protocol-buffers` | **SILENT** — flag is the in-container command's arg, after `--` |
 | `kubectl get pods -n default` | **SILENT** |
 
 ### Response format
@@ -111,8 +113,10 @@ walks every command segment, runs every check, and emits the first hit.
 bash hooks/test-cli-flag-incompat-advisory.sh
 ```
 
-24 cases: 6 advisory (4 git merge-tree variants, 2 kubectl), 16 silent
-(correct merge-tree usage including space-form `--merge-base`, `-X`,
-`--strategy-option`, unquoted `$(...)` command substitution, equals-form
-`--merge-base=$(...)`, quoted `"$(...)"`, unrelated commands, comment),
-2 infrastructure (non-Bash passthrough, malformed JSON fail-open).
+26 cases: 7 advisory (4 git merge-tree variants, 3 kubectl including
+flag-before-`--`), 17 silent (correct merge-tree usage including
+space-form `--merge-base`, `-X`, `--strategy-option`, unquoted `$(...)`
+command substitution, equals-form `--merge-base=$(...)`, quoted
+`"$(...)"`, `kubectl exec -- mytool --flag` remote-arg shadowing,
+unrelated commands, comment), 2 infrastructure (non-Bash passthrough,
+malformed JSON fail-open).

--- a/docs/hook/cli-flag-incompat-advisory.md
+++ b/docs/hook/cli-flag-incompat-advisory.md
@@ -42,6 +42,8 @@ though the operator never wrote `--trivial-merge`.
 | `git merge-tree --merge-base=A --name-only HEAD origin/main` | **SILENT** — explicit merge-base (equals form) |
 | `git merge-tree --merge-base A --name-only HEAD origin/main` | **SILENT** — explicit merge-base (space form) |
 | `git merge-tree -X ours --name-only HEAD origin/main` | **SILENT** — `-X` consumes one value token |
+| `git merge-tree --merge-base $(git merge-base HEAD origin/main) --name-only HEAD origin/main` | **SILENT** — unquoted `$(...)` run coalesced as one value |
+| `git merge-tree --merge-base "$(...)" --name-only HEAD origin/main` | **SILENT** — quoted form already one token |
 | `git merge-tree abc HEAD origin/main` | **SILENT** — no modern flag (legacy form) |
 
 #### `kubectl` deprecated flag
@@ -109,7 +111,8 @@ walks every command segment, runs every check, and emits the first hit.
 bash hooks/test-cli-flag-incompat-advisory.sh
 ```
 
-21 cases: 6 advisory (4 git merge-tree variants, 2 kubectl), 13 silent
+24 cases: 6 advisory (4 git merge-tree variants, 2 kubectl), 16 silent
 (correct merge-tree usage including space-form `--merge-base`, `-X`,
-`--strategy-option`, unrelated commands, comment), 2 infrastructure
-(non-Bash passthrough, malformed JSON fail-open).
+`--strategy-option`, unquoted `$(...)` command substitution, equals-form
+`--merge-base=$(...)`, quoted `"$(...)"`, unrelated commands, comment),
+2 infrastructure (non-Bash passthrough, malformed JSON fail-open).

--- a/hooks/cli-flag-incompat-advisory.py
+++ b/hooks/cli-flag-incompat-advisory.py
@@ -239,8 +239,15 @@ def _check_kubectl(argv: list[str]) -> Optional[str]:
     argv = strip_prefix(argv)
     if not argv or argv[0] != "kubectl":
         return None
+    # `kubectl exec pod -- mytool --use-protocol-buffers` passes
+    # `--use-protocol-buffers` to the in-container command, not to kubectl
+    # itself. Per POSIX convention, every token after `--` is positional —
+    # stop scanning when we hit it so remote-command arg shadowing does
+    # not trigger a kubectl-targeted advisory.
     hits: list[str] = []
     for tok in argv[1:]:
+        if tok == "--":
+            break
         bare = tok.split("=", 1)[0]
         if bare in _KUBECTL_DEPRECATED:
             hits.append(f"  {bare}: {_KUBECTL_DEPRECATED[bare]}")

--- a/hooks/cli-flag-incompat-advisory.py
+++ b/hooks/cli-flag-incompat-advisory.py
@@ -78,7 +78,20 @@ _MERGE_TREE_MODERN_FLAGS = frozenset({"--name-only", "--write-tree"})
 # git options that consume the following token as a value; needed so the
 # positional-argument count is not inflated by `-C <dir>` / similar.
 _GIT_GLOBAL_FLAGS_WITH_ARG = frozenset({
-    "-C", "--git-dir", "--work-tree", "--namespace",
+    "-C", "-c", "--git-dir", "--work-tree", "--namespace",
+})
+
+# `git merge-tree` subcommand-level flags that consume the next token as
+# their value. Without this set, `--merge-base A --name-only HEAD origin/main`
+# (the canonical correct modern usage) counts `A` as a 3rd positional and
+# trips the advisory. Source: `git merge-tree -h` —
+#   --[no-]merge-base <tree-ish>
+#   -X, --[no-]strategy-option <option=value>
+# Negation forms (`--no-merge-base`) are valueless suppression markers and
+# are intentionally NOT in this set.
+_MERGE_TREE_FLAGS_WITH_ARG = frozenset({
+    "--merge-base",
+    "-X", "--strategy-option",
 })
 
 
@@ -118,6 +131,14 @@ def _count_merge_tree_positionals(argv: list[str]) -> int:
             break
         if not tok.startswith("-"):
             positionals += 1
+            i += 1
+            continue
+        # Token is a flag. If it consumes a separate value token (and the
+        # value is not already embedded via `=value` form), skip the next
+        # token so the value is not miscounted as a positional argument.
+        if "=" not in tok and tok in _MERGE_TREE_FLAGS_WITH_ARG and i + 1 < n:
+            i += 2
+            continue
         i += 1
     return positionals
 
@@ -144,7 +165,9 @@ def _check_git(argv: list[str]) -> Optional[str]:
                 "\n"
                 "  Fix: pass 1 or 2 branches (modern mode), e.g.\n"
                 "    git merge-tree --name-only HEAD origin/main\n"
-                "  or pass --merge-base explicitly:\n"
+                "  or pass --merge-base explicitly (either form works):\n"
+                "    git merge-tree --merge-base $(git merge-base HEAD origin/main) "
+                "--name-only HEAD origin/main\n"
                 "    git merge-tree --merge-base=$(git merge-base HEAD origin/main) "
                 "--name-only HEAD origin/main\n"
                 "\n"

--- a/hooks/cli-flag-incompat-advisory.py
+++ b/hooks/cli-flag-incompat-advisory.py
@@ -95,13 +95,59 @@ _MERGE_TREE_FLAGS_WITH_ARG = frozenset({
 })
 
 
+def _coalesce_subst_runs(tokens: list[str]) -> list[str]:
+    """Collapse unquoted `$(...)` command-substitution runs into single tokens.
+
+    `safe_tokenize` uses shlex with whitespace_split=True, which is unaware
+    of POSIX command substitution. An unquoted `$(git merge-base HEAD x)`
+    therefore splits into `['$(git', 'merge-base', 'HEAD', 'x)']` — four
+    tokens — and any flag-value-skip logic only consumes the first token.
+    The remaining tokens then look like positional arguments and inflate
+    the count.
+
+    This helper walks the token list and merges any run that starts with a
+    token containing `$(` and ends with a token containing the matching `)`
+    into a single logical token. Quoted substitutions (e.g. `"$(...)"`)
+    are already a single token at this layer and need no special handling.
+
+    The merge is conservative — `$(` and `)` are required to be present in
+    SOME token (not necessarily at start/end) so the helper correctly
+    handles tokens like `--merge-base=$(git` ... `merge-base` ... `x)`.
+    Unbalanced runs (`$(` with no closing `)`) fall through to the end of
+    argv and are treated as a single token — the caller still sees them
+    as one element rather than several spurious positionals.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(tokens)
+    while i < n:
+        tok = tokens[i]
+        if "$(" in tok and ")" not in tok[tok.index("$(") + 2:]:
+            j = i + 1
+            parts = [tok]
+            while j < n:
+                parts.append(tokens[j])
+                if ")" in tokens[j]:
+                    break
+                j += 1
+            out.append(" ".join(parts))
+            i = j + 1
+        else:
+            out.append(tok)
+            i += 1
+    return out
+
+
 def _count_merge_tree_positionals(argv: list[str]) -> int:
     """Count positional (non-flag) arguments to `git merge-tree`.
 
     Walks argv past git-level globals, finds `merge-tree`, then counts
     every non-flag token after the subcommand. Value tokens consumed by
-    known value-taking flags are NOT counted.
+    known value-taking flags are NOT counted. Unquoted `$(...)` runs are
+    coalesced via `_coalesce_subst_runs` so they count as exactly one
+    logical argument, matching what the shell will pass to git.
     """
+    argv = _coalesce_subst_runs(argv)
     i = 0
     n = len(argv)
     # Skip past git global flags (the caller already verified argv[0]=="git"
@@ -165,10 +211,11 @@ def _check_git(argv: list[str]) -> Optional[str]:
                 "\n"
                 "  Fix: pass 1 or 2 branches (modern mode), e.g.\n"
                 "    git merge-tree --name-only HEAD origin/main\n"
-                "  or pass --merge-base explicitly (either form works):\n"
-                "    git merge-tree --merge-base $(git merge-base HEAD origin/main) "
+                "  or pass --merge-base explicitly — quote any command\n"
+                "  substitution so the shell does not word-split the value:\n"
+                "    git merge-tree --merge-base \"$(git merge-base HEAD origin/main)\" "
                 "--name-only HEAD origin/main\n"
-                "    git merge-tree --merge-base=$(git merge-base HEAD origin/main) "
+                "    git merge-tree --merge-base=\"$(git merge-base HEAD origin/main)\" "
                 "--name-only HEAD origin/main\n"
                 "\n"
                 "  Verify with: git merge-tree --help"

--- a/hooks/cli-flag-incompat-advisory.py
+++ b/hooks/cli-flag-incompat-advisory.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""PreToolUse(Bash) advisory: nudge `<cli> <subcmd> --help` before known
+mode-incompatible flag combinations land on external CLIs.
+
+Companion to `gh-flag-verify.py` — that hook hard-blocks (exit 2) when a
+gh subcommand sees an unknown flag, leveraging the deterministic gh COMPAT
+table. This hook is the **advisory** counterpart for other CLIs (`git`,
+`kubectl`) where:
+
+  • the surface area is much larger than gh
+  • flag-subcommand tables are not as cleanly versioned
+  • false-positives on a hard block would cost more than a missed nudge
+
+Trigger surface (issue #248):
+
+  • `git merge-tree --name-only <3+ positional args>`
+    `--name-only` is part of the modern `--write-tree` mode, but supplying
+    3 positional args drops merge-tree into the deprecated `--trivial-merge`
+    mode which does NOT accept `--name-only`. The resulting error message
+    references `--trivial-merge` even though the caller never wrote it,
+    making the failure non-obvious.
+
+  • `kubectl --use-protocol-buffers`
+    Deprecated since Kubernetes 1.27 — kubectl prints a deprecation warning
+    but still accepts the flag, so the warning often goes unnoticed in long
+    pipelines.
+
+Design:
+
+  • **Advisory only** — writes to stderr, exits 0. Never blocks the command.
+  • **Plugin-style dispatch** — each CLI gets a `_check_<cli>` function that
+    returns Optional[str] (the advisory text). New CLIs are added by writing
+    a new check function and registering it in CHECKS.
+  • **Sibling-pattern toolchain** — reuses `safe_tokenize`,
+    `iter_command_starts`, `strip_prefix` from `_hook_utils.py`, matching
+    `gh-flag-verify.py` / `cross-boundary-preflight.py` / `block-gh-state-all.py`.
+
+Fail-open contract:
+
+  • malformed JSON / non-Bash payload → exit 0
+  • empty command → exit 0
+  • any uncaught exception in the inner logic → swallowed, exit 0
+
+Relationship to memory entry `feedback_external_cli_verify_first` —
+memory has documented the rule for ≥1 prior incident, but retrieval at
+command-composition time keeps failing. This hook moves a fragment of
+the enforcement to the Bash boundary. The memory entry still covers the
+broader "verify with --help before guessing" rule for CLIs not enumerated
+here.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Callable, Optional
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    iter_command_starts,
+    safe_tokenize,
+    strip_prefix,
+)
+
+
+# ---------------------------------------------------------------------------
+# git merge-tree advisory
+# ---------------------------------------------------------------------------
+
+# `--name-only` is the canonical trip-wire flag of modern merge-tree. Other
+# modern-mode flags (`--write-tree`, `--[no-]messages`, `--no-stat`) trigger
+# the same legacy/modern conflict but `--name-only` accounts for ~all of the
+# observed friction. Keep the trip-wire set small — false-positives here are
+# the primary cost.
+_MERGE_TREE_MODERN_FLAGS = frozenset({"--name-only", "--write-tree"})
+
+# git options that consume the following token as a value; needed so the
+# positional-argument count is not inflated by `-C <dir>` / similar.
+_GIT_GLOBAL_FLAGS_WITH_ARG = frozenset({
+    "-C", "--git-dir", "--work-tree", "--namespace",
+})
+
+
+def _count_merge_tree_positionals(argv: list[str]) -> int:
+    """Count positional (non-flag) arguments to `git merge-tree`.
+
+    Walks argv past git-level globals, finds `merge-tree`, then counts
+    every non-flag token after the subcommand. Value tokens consumed by
+    known value-taking flags are NOT counted.
+    """
+    i = 0
+    n = len(argv)
+    # Skip past git global flags (the caller already verified argv[0]=="git"
+    # via strip_prefix; this function is only called after that check).
+    i = 1
+    while i < n:
+        tok = argv[i]
+        if tok == "--":
+            i += 1
+            break
+        if not tok.startswith("-"):
+            break
+        i += 1
+        if "=" not in tok and tok in _GIT_GLOBAL_FLAGS_WITH_ARG and i < n:
+            i += 1
+
+    if i >= n or argv[i] != "merge-tree":
+        return -1  # not a merge-tree call
+    i += 1
+
+    positionals = 0
+    while i < n:
+        tok = argv[i]
+        if tok == "--":
+            i += 1
+            positionals += (n - i)
+            break
+        if not tok.startswith("-"):
+            positionals += 1
+        i += 1
+    return positionals
+
+
+def _check_git(argv: list[str]) -> Optional[str]:
+    """Return advisory text for known git mode-incompatible combos, else None."""
+    argv = strip_prefix(argv)
+    if not argv or argv[0] != "git":
+        return None
+
+    # merge-tree: --name-only + 3+ positionals → legacy/modern conflict
+    if any(tok in _MERGE_TREE_MODERN_FLAGS for tok in argv):
+        positionals = _count_merge_tree_positionals(argv)
+        if positionals >= 3:
+            return (
+                "[cli-flag-incompat-advisory] git merge-tree mode conflict\n"
+                "\n"
+                "  --name-only / --write-tree are modern-mode options. Supplying\n"
+                "  3+ positional args drops merge-tree into the deprecated\n"
+                "  --trivial-merge mode which does NOT accept --name-only.\n"
+                "\n"
+                "  Error you will see:\n"
+                "    fatal: --trivial-merge is incompatible with all other options\n"
+                "\n"
+                "  Fix: pass 1 or 2 branches (modern mode), e.g.\n"
+                "    git merge-tree --name-only HEAD origin/main\n"
+                "  or pass --merge-base explicitly:\n"
+                "    git merge-tree --merge-base=$(git merge-base HEAD origin/main) "
+                "--name-only HEAD origin/main\n"
+                "\n"
+                "  Verify with: git merge-tree --help"
+            )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# kubectl deprecation advisory (nice-to-have per issue #248 AC)
+# ---------------------------------------------------------------------------
+
+_KUBECTL_DEPRECATED = {
+    "--use-protocol-buffers": (
+        "Removed in kubectl ≥1.27 — kubectl now negotiates protobuf "
+        "automatically and the flag is rejected as unknown."
+    ),
+}
+
+
+def _check_kubectl(argv: list[str]) -> Optional[str]:
+    argv = strip_prefix(argv)
+    if not argv or argv[0] != "kubectl":
+        return None
+    hits: list[str] = []
+    for tok in argv[1:]:
+        bare = tok.split("=", 1)[0]
+        if bare in _KUBECTL_DEPRECATED:
+            hits.append(f"  {bare}: {_KUBECTL_DEPRECATED[bare]}")
+    if not hits:
+        return None
+    return (
+        "[cli-flag-incompat-advisory] kubectl deprecated flag\n"
+        "\n"
+        + "\n".join(hits)
+        + "\n\n  Verify with: kubectl --help | grep <flag>"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+CHECKS: tuple[Callable[[list[str]], Optional[str]], ...] = (
+    _check_git,
+    _check_kubectl,
+)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def _main_inner() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    command = payload.get("tool_input", {}).get("command", "") or ""
+    if not command.strip():
+        return 0
+
+    tokens = safe_tokenize(command.replace("\\\n", " "))
+    if not tokens:
+        return 0
+
+    for argv in iter_command_starts(tokens):
+        argv = list(argv)
+        for check in CHECKS:
+            msg = check(argv)
+            if msg:
+                sys.stderr.write(msg + "\n")
+                return 0  # advisory — never blocks; first match suffices
+
+    return 0
+
+
+def main() -> int:
+    """Advisory hook — must NEVER break tool execution."""
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/cli-flag-incompat-advisory.sh
+++ b/hooks/cli-flag-incompat-advisory.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# PreToolUse(Bash) hook — delegates to the Python implementation.
+# Advisory-only: writes to stderr, exits 0. Never blocks tool execution.
+
+set +e
+
+if ! command -v python3 >/dev/null 2>&1; then
+  exit 0
+fi
+
+exec python3 "$(dirname "$0")/cli-flag-incompat-advisory.py"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -84,6 +84,11 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/cli-flag-incompat-advisory.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/verify-commit-flag-override.sh",
             "timeout": 5
           },

--- a/hooks/test-cli-flag-incompat-advisory.sh
+++ b/hooks/test-cli-flag-incompat-advisory.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# test-cli-flag-incompat-advisory.sh — coverage for the advisory hook.
+#
+# Synthesizes Claude Code PreToolUse(Bash) payloads and asserts:
+#   advisory → exit 0 + stderr contains the advisory marker
+#   silent   → exit 0 + stderr empty
+#
+# Usage: bash hooks/test-cli-flag-incompat-advisory.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/cli-flag-incompat-advisory.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable: $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+# run_case name expected command
+#   expected: "advisory"  (exit 0, stderr contains the marker substring)
+#             "silent"    (exit 0, stderr empty)
+run_case() {
+  local name="$1" expected="$2" command="$3"
+
+  local payload
+  payload=$(python3 -c '
+import json, sys
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {"command": sys.argv[1]},
+}))' "$command")
+
+  local out_file err_file
+  out_file=$(mktemp)
+  err_file=$(mktemp)
+  echo "$payload" | "$HOOK" >"$out_file" 2>"$err_file"
+  local rc=$?
+  local out err
+  out=$(cat "$out_file")
+  err=$(cat "$err_file")
+  rm -f "$out_file" "$err_file"
+
+  local ok=1
+  case "$expected" in
+    advisory)
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$out" ]   || ok=0
+      echo "$err" | grep -q "\[cli-flag-incompat-advisory\]" || ok=0
+      ;;
+    silent)
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$out" ]   || ok=0
+      [ -z "$err" ]   || ok=0
+      ;;
+    *)
+      echo "FAIL  [$name] unknown expected: $expected"
+      FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name"); return
+      ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  [$name]"; PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expected=$expected rc=$rc"
+    [ -n "$out" ] && echo "        stdout: $out"
+    [ -n "$err" ] && echo "        stderr: $err"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# === ADVISORY paths (git merge-tree mode conflict) =========================
+
+run_case "merge-tree --name-only with 3 positionals" \
+  advisory \
+  "git merge-tree --name-only abc123 HEAD origin/main"
+
+run_case "merge-tree --name-only chained via && (3 positionals)" \
+  advisory \
+  "git merge-tree --name-only A B C && echo done"
+
+run_case "merge-tree --write-tree with 3 positionals" \
+  advisory \
+  "git merge-tree --write-tree A B C"
+
+run_case "merge-tree --name-only with -C global flag (3 positionals)" \
+  advisory \
+  "git -C /tmp merge-tree --name-only A B C"
+
+# === ADVISORY paths (kubectl deprecated flag) ==============================
+
+run_case "kubectl --use-protocol-buffers" \
+  advisory \
+  "kubectl --use-protocol-buffers get pods"
+
+run_case "kubectl --use-protocol-buffers=true" \
+  advisory \
+  "kubectl --use-protocol-buffers=true get pods"
+
+# === SILENT paths (correct merge-tree usage) ===============================
+
+run_case "merge-tree --name-only with 2 positionals (correct modern usage)" \
+  silent \
+  "git merge-tree --name-only HEAD origin/main"
+
+run_case "merge-tree --name-only with 1 positional" \
+  silent \
+  "git merge-tree --name-only origin/main"
+
+run_case "merge-tree with no modern flag (legacy 3-arg form)" \
+  silent \
+  "git merge-tree abc123 HEAD origin/main"
+
+run_case "merge-tree --name-only with --merge-base + 2 positionals" \
+  silent \
+  "git merge-tree --merge-base=A --name-only HEAD origin/main"
+
+# === SILENT paths (unrelated commands) =====================================
+
+run_case "git status (different subcommand)" \
+  silent \
+  "git status"
+
+run_case "git log (different subcommand)" \
+  silent \
+  "git log --oneline -10"
+
+run_case "kubectl get pods (no deprecated flag)" \
+  silent \
+  "kubectl get pods -n default"
+
+run_case "non-git non-kubectl command" \
+  silent \
+  "echo merge-tree --name-only A B C"
+
+run_case "empty command" \
+  silent \
+  ""
+
+run_case "merge-tree mention in echo" \
+  silent \
+  "echo 'use git merge-tree --name-only A B C'"
+
+# === Infrastructure passthrough ============================================
+
+# Non-Bash tool → silent pass.
+ipayload=$(python3 -c '
+import json
+print(json.dumps({
+    "tool_name": "Write",
+    "tool_input": {"command": "any"},
+}))')
+i_out=$(mktemp); i_err=$(mktemp)
+echo "$ipayload" | "$HOOK" >"$i_out" 2>"$i_err"
+i_rc=$?
+i_out_v=$(cat "$i_out"); i_err_v=$(cat "$i_err")
+rm -f "$i_out" "$i_err"
+if [ "$i_rc" -eq 0 ] && [ -z "$i_out_v" ] && [ -z "$i_err_v" ]; then
+  echo "PASS  [non-Bash passthrough]"; PASS=$((PASS + 1))
+else
+  echo "FAIL  [non-Bash passthrough] rc=$i_rc out='$i_out_v' err='$i_err_v'"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("non-Bash passthrough")
+fi
+
+# Malformed JSON → fail-open.
+mpayload="{not-json"
+m_out=$(mktemp); m_err=$(mktemp)
+echo "$mpayload" | "$HOOK" >"$m_out" 2>"$m_err"
+m_rc=$?
+m_out_v=$(cat "$m_out"); m_err_v=$(cat "$m_err")
+rm -f "$m_out" "$m_err"
+if [ "$m_rc" -eq 0 ] && [ -z "$m_out_v" ] && [ -z "$m_err_v" ]; then
+  echo "PASS  [malformed JSON fail-open]"; PASS=$((PASS + 1))
+else
+  echo "FAIL  [malformed JSON fail-open] rc=$m_rc out='$m_out_v' err='$m_err_v'"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("malformed JSON fail-open")
+fi
+
+echo
+echo "----"
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:"
+  for n in "${FAILED_NAMES[@]}"; do echo "  - $n"; done
+  exit 1
+fi
+exit 0

--- a/hooks/test-cli-flag-incompat-advisory.sh
+++ b/hooks/test-cli-flag-incompat-advisory.sh
@@ -167,6 +167,18 @@ run_case "kubectl get pods (no deprecated flag)" \
   silent \
   "kubectl get pods -n default"
 
+# Regression — codex review round 3 F1: tokens after `--` are passed to
+# the in-container command, not to kubectl. Advisory must not fire on
+# remote-command flag shadowing.
+run_case "kubectl exec pod -- mytool --use-protocol-buffers (remote arg)" \
+  silent \
+  "kubectl exec pod -- mytool --use-protocol-buffers"
+
+# Counter-case: the same deprecated flag BEFORE -- still triggers advisory.
+run_case "kubectl --use-protocol-buffers exec pod -- mytool (kubectl-side)" \
+  advisory \
+  "kubectl --use-protocol-buffers exec pod -- mytool"
+
 run_case "non-git non-kubectl command" \
   silent \
   "echo merge-tree --name-only A B C"

--- a/hooks/test-cli-flag-incompat-advisory.sh
+++ b/hooks/test-cli-flag-incompat-advisory.sh
@@ -136,6 +136,23 @@ run_case "merge-tree --name-only with --strategy-option (space) + 2 positionals"
   silent \
   "git merge-tree --strategy-option ours --name-only HEAD origin/main"
 
+# Regression — codex review round 2 F1: unquoted command substitution
+# `$(...)` was previously split by safe_tokenize across multiple tokens,
+# so --merge-base only consumed `$(git` as its value and the remaining
+# tokens (`merge-base`, `HEAD`, `origin/main)`) were counted as positionals.
+# Coalesce + skip must treat the whole $(...) run as one logical value.
+run_case "merge-tree --merge-base \$(...) (unquoted) + 2 positionals" \
+  silent \
+  "git merge-tree --merge-base \$(git merge-base HEAD origin/main) --name-only HEAD origin/main"
+
+run_case "merge-tree --merge-base=\$(...) (equals form, unquoted)" \
+  silent \
+  "git merge-tree --merge-base=\$(git merge-base HEAD origin/main) --name-only HEAD origin/main"
+
+run_case "merge-tree --merge-base \"\$(...)\" (quoted)" \
+  silent \
+  "git merge-tree --merge-base \"\$(git merge-base HEAD origin/main)\" --name-only HEAD origin/main"
+
 # === SILENT paths (unrelated commands) =====================================
 
 run_case "git status (different subcommand)" \

--- a/hooks/test-cli-flag-incompat-advisory.sh
+++ b/hooks/test-cli-flag-incompat-advisory.sh
@@ -116,9 +116,25 @@ run_case "merge-tree with no modern flag (legacy 3-arg form)" \
   silent \
   "git merge-tree abc123 HEAD origin/main"
 
-run_case "merge-tree --name-only with --merge-base + 2 positionals" \
+run_case "merge-tree --name-only with --merge-base=A (equals form)" \
   silent \
   "git merge-tree --merge-base=A --name-only HEAD origin/main"
+
+# Regression — codex review round 1 F1: --merge-base in space-separated form
+# (`--merge-base A`) was counting `A` as a 3rd positional and falsely
+# tripping the advisory. The merge-tree flag-with-arg set must include
+# --merge-base / -X / --strategy-option.
+run_case "merge-tree --name-only with --merge-base A (space form)" \
+  silent \
+  "git merge-tree --merge-base A --name-only HEAD origin/main"
+
+run_case "merge-tree --name-only with -X strategy-opt + 2 positionals" \
+  silent \
+  "git merge-tree -X ours --name-only HEAD origin/main"
+
+run_case "merge-tree --name-only with --strategy-option (space) + 2 positionals" \
+  silent \
+  "git merge-tree --strategy-option ours --name-only HEAD origin/main"
 
 # === SILENT paths (unrelated commands) =====================================
 


### PR DESCRIPTION
## 요약

`gh-flag-verify` 의 deny 패턴을 다른 외부 CLI 로 확장 — `git` / `kubectl` 등은 surface 가 크고 버전 fluctuation 이 있어 hard-block 대신 advisory 로 운영. `feedback_external_cli_verify_first` 메모리만으로 retrieval 이 반복 실패하는 패턴을 Bash 경계로 옮긴다.

## 배경

```bash
git merge-tree --name-only $(git merge-base HEAD origin/main) HEAD origin/main
# → fatal: --trivial-merge is incompatible with all other options
```

`--name-only` 는 modern `--write-tree` mode 옵션. 3 positional 을 주면 legacy `--trivial-merge` mode 가 선택되고 modern 플래그는 거부됨. 에러 메시지는 사용자가 쓰지도 않은 `--trivial-merge` 를 언급하므로 비-자명. 2026-05-16 retrospect 에서 1차 학습 사이클 소비, family-level 2회 재발.

## 변경

| 파일 | 내용 |
|---|---|
| `hooks/cli-flag-incompat-advisory.py` | hook 본체. 플러그인 스타일 `CHECKS = (_check_git, _check_kubectl)`. 새 CLI 는 `_check_<cli>` 추가 |
| `hooks/cli-flag-incompat-advisory.sh` | shell wrapper |
| `hooks/test-cli-flag-incompat-advisory.sh` | 18 케이스 (6 advisory, 10 silent, 2 infra) |
| `docs/hook/cli-flag-incompat-advisory.md` | spec + adding new CLI 가이드 |
| `hooks/hooks.json` | `gh-flag-verify` 직후 등록 |
| `AGENTS.md` | hook index row |

## 설계 결정

- **Advisory only, never block**: 이슈 AC 의 차선책 채택. false-positive 비용이 hard-block 보다 작음. stderr 에 advisory 출력 + exit 0.
- **Plugin-style dispatch**: `CHECKS` 튜플에 함수 등록만 하면 새 CLI 추가. `_check_<cli>` 는 `Optional[str]` 반환.
- **Trip-wire 최소 집합**: `--name-only`, `--write-tree` 2 개. 다른 modern 플래그는 친화적이지만 false-positive 위험. 보수적 시작.
- **kubectl 은 nice-to-have**: `--use-protocol-buffers` 1 개. `kubectl` deprecation 은 ≥1.27 에서 hard-remove.
- **`gh-flag-verify` 무영향**: deny hook 그대로 유지. 본 hook 은 advisory only, gh 는 안 건드림.
- **Sibling convention**: `safe_tokenize → iter_command_starts → strip_prefix` 재사용, `advisory-wrapper-signature-verify.py` 의 stderr-only 패턴 흡수.

## 검증

```
bash hooks/test-cli-flag-incompat-advisory.sh
→ Passed: 18  Failed: 0
```

회귀:
```
bash tests/test_gh_flag_verify.sh
→ Result: 35 passed, 0 failed
bash hooks/test-block-gh-state-all.sh
→ Passed: 29  Failed: 0
```

Manifest:
```
./scripts/check-plugin-manifests.py
→ plugin-manifest check OK
```

## Acceptance Criteria 매칭

- [x] `git merge-tree --name-only` 3-arg form advisory
- [x] `git merge-tree --write-tree` 3-arg form advisory
- [x] `kubectl --use-protocol-buffers` advisory (nice-to-have 달성)
- [x] `gh-flag-verify` 호환 — test suite 35/35 통과
- [x] `docs/hook/cli-flag-incompat-advisory.md` 작성

## 미검증 / 후속

- `git worktree` / `git log` 의 mode-incompatible 조합: 이슈 AC 에 언급됐으나 실 사례 미수집. trip-wire 만 확립한 단계, 후속 retrospect 에서 실제 마찰 패턴 누적 시 추가.

Closes #248
