### PR TITLE
docs(agents): sync skill count + hook index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 | **Full** | + all cmux-* skills | + cmux |
 | **Multi-provider** | + codex/gemini routing in cmux-* | + codex-cli, gemini-cli |
 
-## Skills (11)
+## Skills (12)
 
 > **Invocation**: praxis entries are *skills*, not subagents. Always call them
 > via `Skill(skill="praxis:<name>")` — `Agent(subagent_type="praxis:<name>")`
@@ -25,6 +25,7 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 | Skill | Purpose |
 |-------|---------|
 | `retrospect` | Session retrospect — find friction root causes, propose improvements |
+| `codex-review-wrap` | Worktree-aware wrapper for `/codex:review` — forces explicit target selection, premise-verification gate, flip detection across rounds |
 
 ### Discipline
 
@@ -178,6 +179,7 @@ Design contract shared by all hooks:
 | `block-gh-state-all` | PreToolUse | Hard-block invalid `gh search ... --state all` flag combo | [docs/hook/block-gh-state-all.md](docs/hook/block-gh-state-all.md) |
 | `gh-flag-verify` | PreToolUse | Block `gh <subcmd>` calls with flags not in the subcommand's accepted set | [docs/hook/gh-flag-verify.md](docs/hook/gh-flag-verify.md) |
 | `cli-flag-incompat-advisory` | PreToolUse | Advisory nudge for known mode-incompatible flag combos in other CLIs (`git merge-tree --name-only` 3-arg form, `kubectl --use-protocol-buffers`) — issue #248 | [docs/hook/cli-flag-incompat-advisory.md](docs/hook/cli-flag-incompat-advisory.md) |
+| `block-ask-end-option` | PreToolUse | Block `AskUserQuestion` options carrying end-option markers when the most recent user message has no stop signal (strict default; advisory opt-out via `PRAXIS_ASK_END_ADVISORY=1`) | [docs/hook/block-ask-end-option.md](docs/hook/block-ask-end-option.md) |
 | `side-effect-scan` | PreToolUse | Ask before commands with collateral side effects (`git commit/push`, `gh pr merge/create`, `kubectl apply`) | [docs/hook/side-effect-scan.md](docs/hook/side-effect-scan.md) |
 | `memory-hint` | PreToolUse | Surface hookable memory entries by keyword at decision-construction time (advisory, never blocks) | [docs/hook/memory-hint.md](docs/hook/memory-hint.md) |
 | `codex-review-route` | UserPromptSubmit | Warn when `/codex:review` runs in a multi-worktree repo (cwd mismatch risk) | [docs/hook/codex-review-route.md](docs/hook/codex-review-route.md) |


### PR DESCRIPTION
## 요약

`/deep-dive` 전반 점검(trace: `.omc/specs/deep-dive-trace-praxis-overall-checkup.md`)에서 발견된 AGENTS.md 스테일 항목을 정리합니다.

## 변경 사항

| 위치 | Before | After |
|------|--------|-------|
| `AGENTS.md:16` | `## Skills (11)` | `## Skills (12)` |
| Development 표 | retrospect만 | + `codex-review-wrap` (commit `8453ac2` 추가분) |
| Hook 인덱스 표 | `block-ask-end-option` 누락 | 행 추가, 기존 `docs/hook/block-ask-end-option.md` 링크 |

## Scope 축소 안내 (B2 #254로 이관)

원래 이슈 본문에는 4개 hook 행 추가 예정이었으나, 다음 3개는 spec 파일 없음 → 표 row만 추가하면 broken link가 발행됨:
- `block-pr-without-caller-evidence`
- `verify-commit-flag-override`
- `strike-counter`

→ B2 (#254)에서 `docs/hook/*.md` spec 3개를 작성하면서 표 행을 함께 추가하기로 함. 이 PR은 broken link 미발생 항목 2건만 처리.

## 검증

```
$ ./scripts/check-plugin-manifests.py
plugin-manifest check OK
```

```
$ git diff --stat AGENTS.md
 AGENTS.md | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)
```

## 코드 리뷰

`oh-my-claudecode:code-reviewer` 통과 (APPROVE):
- Critical/High 0
- Medium 1: tier 표(`AGENTS.md:64`)와 새 Development 표 사이 사전 존재 inconsistency — 이 PR이 도입한 게 아니라 가시화만 됨, follow-up 후보
- NIT 2: 1건은 placement (matches `hooks.json` 등록 순서 — accepted), 1건은 description 명확화 (적용 완료, commit에 반영)

## Closes

Closes #253

Caller chain verified: N/A -- docs-only change (AGENTS.md text edits, no symbol/function/API touched)
