### PR TITLE
fix(gitignore): scope docs/ rule correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,3 @@ __pycache__/
 # OMC (oh-my-claudecode local state)
 .omc/
 .omx/
-
-# Documentation (local only)
-docs/


### PR DESCRIPTION
## 요약

PR #258 (B2) 구현 중 발견된 `.gitignore` 함정을 정정합니다. follow-up #261.

## 문제

`.gitignore:28`의 `docs/` 규칙(commit `417fa17` / PR #7, "Documentation (local only)" 주석)이 신규 `docs/hook/*.md` 파일을 silently 무시. 기존 22개 spec은 그 규칙 도입 전부터 tracked라 영향 없지만, **새 hook 추가 시 spec을 `git add` 하면 silently 누락**되는 함정.

```bash
# 함정 재현
$ touch docs/hook/new-spec.md
$ git status --short      # 비어 있음 — 새 파일 보이지 않음
$ git add docs/hook/new-spec.md  # silent no-op
$ git commit -m "..."     # spec 누락 채로 머지 가능
```

`AGENTS.md`의 hook design contract는 "Every hook ships with full spec in `docs/hook/<name>.md`"를 명시하지만, 작업 흐름 자체가 이 계약을 어기기 쉬운 구조.

## 조사

`git log --all --diff-filter=A --name-only -- 'docs/*'` 결과:
- **모든** 추가된 파일이 `docs/hook/*.md` (현재 22개 + 과거 삭제 5개 모두 동일 경로)
- `docs/`의 다른 하위 디렉터리는 이 repo 역사에서 한 번도 존재하지 않음
- "local only" 의도는 실질적으로 폐기됨 — `docs/hook/`는 canonical

→ 옵션 (b) 채택: 규칙 자체를 제거. 옵션 (a) (`!docs/hook/` 부정 패턴)은 다음 하위 디렉터리 추가 시 같은 모양 함정을 다시 만듦.

## 변경

`.gitignore`에서 `docs/` 라인 + 주석 제거. 3 lines 삭제.

```diff
 # OMC (oh-my-claudecode local state)
 .omc/
 .omx/
-
-# Documentation (local only)
-docs/
```

## 검증

```
$ git ls-files docs/ | wc -l
22                        # 기존 tracked 영향 없음

$ touch docs/hook/__test-untracked.md
$ git status --short
 M .gitignore
?? docs/hook/__test-untracked.md   # 정상 untracked 표시 (Before: invisible)

$ ./scripts/check-plugin-manifests.py
plugin-manifest check OK
```

## 코드 리뷰

`oh-my-claudecode:code-reviewer` 통과 (APPROVE):
- Critical/High/Medium: 0
- NIT 1 (skip): CONTRIBUTING.md 수정 — 기존 문구가 `-f`를 언급하지 않아 이번 fix로 그대로 작동, 변경 불필요
- 4개 확인 질문 모두 OK: 옵션 (b) 정합 / 역사적 노출 없음 / CI/script 의존 없음 / 추가 doc 수정 불필요

## Closes

Closes #261

Caller chain verified: N/A -- gitignore config change with no symbol/function/API touched
