### PR TITLE
fix(hook): align _has_repo_flag docstring/impl

### DIFF
--- a/hooks/block-pr-without-caller-evidence.py
+++ b/hooks/block-pr-without-caller-evidence.py
@@ -202,7 +202,13 @@ def _is_pr_create(argv: list[str]) -> bool:
 
 
 def _has_repo_flag(argv: list[str]) -> bool:
-    """True if --repo/-R is explicitly set (cross-project PR)."""
+    """True if --repo/-R is present (any value).
+
+    NOTE: Does NOT compare the value against the current repo. Passing
+    --repo with the current repo's owner/name also satisfies this gate.
+    Treat the flag's presence as an explicit operator assertion that
+    the caller-chain step was done out-of-band.
+    """
     for i, t in enumerate(argv):
         if t in ("-R", "--repo") and i + 1 < len(argv):
             return True


### PR DESCRIPTION
Closes #260

docstring 을 실제 구현과 일치하도록 수정했습니다.

## Caller chain verified:
grep 으로 호출자 확인: block-pr-without-caller-evidence.py:282, cross-boundary-preflight.py