### PR TITLE
chore(install): rebind stale local-bin symlinks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,6 +268,8 @@ you commit here land in the version that actually runs at the shell. Keeping a
 second clone under a legacy name risks `~/.local/bin` symlinks pointing at stale
 code — a real failure mode previously hit during recover-sessions debugging.
 
+After every `git pull` or worktree operation, run `./scripts/verify-symlinks.sh` to confirm all `~/.local/bin` entries still resolve to this clone.
+
 ### CLI tools (not skills)
 
 These are shell wrappers installed via `scripts/install.sh` into `~/.local/bin`.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -111,6 +111,16 @@ for script in "${CLI_SCRIPTS[@]}"; do
       continue
     fi
 
+    # Log a REBIND message when the existing symlink points at a different
+    # clone (stale worktree path, legacy clone name, etc.) so operators can
+    # confirm which path is being repointed. readlink works even for dangling
+    # links so this is safe regardless of whether the old target still exists.
+    old_target="(not a symlink)"
+    if [[ -L "$dst" ]]; then
+      old_target=$(readlink "$dst")
+      echo "REBIND   $name: $old_target -> $src"
+    fi
+
     # Backup FIRST so we never lose the old binary even if the new
     # symlink write fails later. For symlinks we preserve the link
     # itself (not its target) so recovery keeps its original semantics.


### PR DESCRIPTION
Closes #255

## 변경 사항

### 문제
`verify-symlinks.sh` 실행 시 5개 심링크가 DANGLING 상태로 보고됨:
- `cmux-resume-sessions`, `cmux-save-sessions`, `cmux-session-status`, `cmux-session-cleanup`, `cmux-browser`
- 모두 삭제된 워크트리 경로 `/Users/nathan.song/projects/praxis-issue-131/` 를 가리키고 있었음

### 수정 내용

**`scripts/install.sh`**
- `--force` 실행 경로에서 기존 심링크가 다른 clone을 가리키는 경우 `REBIND <name>: <old> → <new>` 메시지를 출력하는 로직 추가
- `readlink` 로 old target을 읽어 drift 이력을 명확히 기록
- 드리프트된 심링크가 댕글링(dangling) 상태여도 `readlink` 가 동작하므로 안전하게 처리됨

**`AGENTS.md`** (CLAUDE.md symlink 대상)
- Canonical clone path 섹션에 `git pull` 또는 worktree 작업 이후 `./scripts/verify-symlinks.sh` 실행을 권장하는 한 줄 추가

### 검증 결과

```
$ ./scripts/verify-symlinks.sh
OK         claude-recover
OK         claude-recover-scan
OK         cmux-resume-sessions
OK         cmux-save-sessions
OK         cmux-recover-sessions
OK         cmux-session-status
OK         cmux-session-cleanup
OK         cmux-browser

All symlinks point at this clone.
Repo: /Users/nathan.song/projects/praxis
```

```
$ ./scripts/check-plugin-manifests.py
plugin-manifest check OK
```

Caller chain verified: `scripts/install.sh` 는 직접 실행 (`./scripts/install.sh [--force]`) 과 `scripts/verify-symlinks.sh` 에서 안내 메시지로 참조됨. 두 경로 모두 확인 완료.
