### PR TITLE
docs: add SECURITY.md and PRIVACY.md

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,64 @@
+# Privacy Policy
+
+Praxis is a local-only Claude Code plugin. It does not collect, transmit, or
+store data on any external server. All state lives in the user's own filesystem.
+
+## Transcript Reading
+
+Certain hooks read the Claude Code session transcript (a `.jsonl` file whose
+path is passed by the Claude Code runtime in the hook payload as
+`transcript_path`). This is done entirely locally to inspect the most-recent
+user message or recent Bash commands.
+
+| Hook | What it reads | Purpose |
+|------|--------------|---------|
+| `completion-verify.sh` | Last ~400 lines of transcript | Verify that a Bash verification command was run in the same turn as a completion claim |
+| `retrospect-mix-check.sh` | Last ~400 lines of transcript | Confirm that retrospect Stage 3 outputs include non-memory action types |
+| `block-ask-end-option.py` | Most recent user message | Detect whether the user sent a stop signal before blocking an end-option menu item |
+| `block-manufactured-action-menu.py` | Most recent user message | Detect command-intent signals to suppress unnecessary confirmation menus |
+| `external-write-falsify-check.py` | Recent Bash commands | Confirm a verification call precedes an external write |
+
+Transcript data is read locally only, never forwarded or stored beyond the
+hook's in-process execution.
+
+## Session State Files
+
+Hooks persist lightweight per-session state in the OS temporary directory
+(`${TMPDIR:-/tmp}`) using the `session_id` field from the Claude Code hook
+payload as the key. When `session_id` is unavailable, `PPID` is used as a
+back-compat fallback.
+
+| Hook | State file | Contents |
+|------|-----------|---------|
+| `trino-describe-first.py` | `${TMPDIR:-/tmp}/praxis-describe-history-<session_id>.json` | Set of Trino table names that have been `DESCRIBE`d in this session |
+| `session-intent.py` | `${TMPDIR:-/tmp}/praxis-session-intent-<session_id>.json` | Detected session intent flag (read vs. mutation) |
+| `pre-edit-md-escape-advisory.py` | `${TMPDIR:-/tmp}/praxis-md-read-history-<session_id>.json` | Set of `.md` file paths Read in this session |
+
+Strike counter state is stored in a dedicated directory:
+
+| Hook | State file | Contents |
+|------|-----------|---------|
+| `strike-counter.sh` | `${PRAXIS_STATE_DIR:-$HOME/.claude/state/praxis}/strikes/<session_id>` | Strike count and violation reasons for the active session |
+
+All state files contain only session-scoped metadata (table names, path sets,
+counters). They never contain the text of user messages or assistant responses.
+
+## Memory Access
+
+`memory-hint.py` reads `*.md` files from the project memory directory
+(`~/.claude/projects/<slugified-cwd>/memory/`, or `PRAXIS_MEMORY_DIR` if set).
+This is a read-only scan to surface relevant memory entry descriptions as
+advisory stderr output. Hooks never modify memory files.
+
+## External CLI Invocations
+
+Praxis hooks invoke `git` and `gh` with the user's own credentials and
+environment (see [SECURITY.md — Hook External-Command Allowlist](SECURITY.md)).
+Praxis does not intercept, log, or store the output of these commands beyond
+the hook's in-process execution. Third-party CLI privacy policies apply.
+
+## No Telemetry
+
+Praxis does not include any analytics, telemetry, error reporting, or
+network calls of its own. There is no phone-home, no usage tracking, and
+no data ever leaves the local machine via praxis code.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ you commit here land in the version that actually runs at the shell.
 See [AGENTS.md → Local Development](AGENTS.md#local-development) for the full
 list of shipped CLI wrappers and drift-recovery rationale.
 
+## Security & Privacy
+
+- [SECURITY.md](SECURITY.md) — vulnerability reporting and supported versions
+- [PRIVACY.md](PRIVACY.md) — what praxis reads, executes, and never transmits
+
 ## License
 
 MIT License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Report via GitHub Security Advisory:
+**[devseunggwan/praxis/security/advisories/new](https://github.com/devseunggwan/praxis/security/advisories/new)**
+
+Include:
+- Description of the vulnerability and its impact
+- Steps to reproduce
+- Any suggested fix (optional)
+
+### Disclosure Timeline
+
+| Severity | Target response | Public disclosure |
+|----------|----------------|-------------------|
+| Critical | 48 hours | After patch is released |
+| High | 7 days | 30 days after report |
+| Medium / Low | 30 days | 90 days after report |
+
+Expedited disclosure is available for actively exploited vulnerabilities.
+
+## Supported Versions
+
+Only the latest version on the `main` branch receives security patches.
+Prior versions are best-effort only — upgrade to `main` to receive fixes.
+
+## Hook External-Command Allowlist
+
+Praxis hooks invoke the following external commands during normal operation.
+Every entry was verified against the hook source files listed.
+
+### `git` — repository state queries
+
+| Hook | Command | Purpose |
+|------|---------|---------|
+| `pre-gh-pr-create-dedup-gate.py` | `git remote get-url origin` | Resolve the repo owner/name for the dedup search |
+| `cross-repo-worktree-preflight.py` | `git -C <cwd> worktree list --porcelain` | Enumerate registered worktrees to detect cross-repo remove |
+| `pre-edit-protected-branch-guard.py` | `git rev-parse --show-toplevel` | Locate the git repo root |
+| `pre-edit-protected-branch-guard.py` | `git rev-parse --abbrev-ref HEAD` | Read the current branch name |
+| `pre-edit-protected-branch-guard.py` | `git status --porcelain` | Check for a dirty working tree |
+| `pre-edit-protected-branch-guard.py` | `git log --oneline -3` | Detect recent PR-suffix commits on a clean tree |
+
+### `gh` — GitHub CLI
+
+| Hook | Command | Purpose |
+|------|---------|---------|
+| `pre-gh-pr-create-dedup-gate.py` | `gh pr list --repo <r> --state all --search <kw> --json ...` | Search existing PRs before creating a new one |
+
+All `git` and `gh` invocations are **read-only**. No hook writes to remote
+state. Hooks fail-open (exit 0) when the binary is missing or times out.
+
+## Out of Scope
+
+Praxis invokes third-party CLIs (`gh`, `cmux`, `codex`, `kubectl`, etc.)
+using the user's own credentials and environment. Vulnerabilities in those
+tools are upstream concerns — report them to their respective maintainers.
+Praxis is not responsible for the security of tools it delegates to.


### PR DESCRIPTION
Closes #273

## 변경 내용

- `SECURITY.md` 신규 추가: 취약점 신고 절차(GitHub Security Advisory), 지원 버전 정책(main 브랜치 최신 버전만), 공개 일정(Critical 48h ~ Low 90일), hook이 실행하는 외부 명령 allowlist, 범위 외(third-party CLI 취약점은 upstream 담당) 명시
- `PRIVACY.md` 신규 추가: transcript 읽기 범위(어느 hook이 무슨 목적으로 읽는지), 세션 상태 파일 경로(`${TMPDIR:-/tmp}/praxis-*`, `${PRAXIS_STATE_DIR:-$HOME/.claude/state/praxis}/strikes/`), memory-hint.py의 읽기 전용 메모리 접근, 외부 CLI 실행 시 자격증명 흐름, 텔레메트리 없음 명시
- `README.md`: License 섹션 위에 "Security & Privacy" 섹션 추가, 두 파일로의 링크 삽입

## 검증

allowlist에 열거된 모든 외부 명령은 hook 소스 파일 grep으로 실제 존재를 확인함:
- `git remote get-url origin` → `pre-gh-pr-create-dedup-gate.py:156`
- `git -C <cwd> worktree list --porcelain` → `cross-repo-worktree-preflight.py:272`
- `git rev-parse --show-toplevel` / `--abbrev-ref HEAD` → `pre-edit-protected-branch-guard.py:165,182`
- `git status --porcelain` → `pre-edit-protected-branch-guard.py:219`
- `git log --oneline -3` → `pre-edit-protected-branch-guard.py:234`
- `gh pr list --repo ... --state all --search ...` → `pre-gh-pr-create-dedup-gate.py:213`

transcript 읽기 훅(completion-verify, retrospect-mix-check, block-ask-end-option, block-manufactured-action-menu, external-write-falsify-check)도 동일하게 소스 grep으로 확인.

Caller chain verified: 위 모든 allowlist 항목은 hook 소스 파일 내 실제 subprocess.run / grep 결과로 확인되었으며, 추정 없이 작성됨.
