### PR TITLE
feat(_hook_utils): add role-aware token API

### DIFF
--- a/hooks/_hook_utils.py
+++ b/hooks/_hook_utils.py
@@ -10,11 +10,19 @@ Three hooks reuse the exact same `safe_tokenize` / `strip_prefix` /
 Per the TODO that lived at `block-gh-state-all.py:25`, this module is the
 extraction triggered by the third consumer (issue #139). The helpers move
 verbatim — see git history for the prior duplicated copies.
+
+Issue #263 adds the role-aware token API (`tokenize_with_roles`, `Token`,
+`TokenRole`) which centralizes role-state reconstruction that each caller
+was previously reimplementing — see PR #251 / #252 codex review rounds 1-3
+for the 7 defects that converged on this root cause.
 """
 from __future__ import annotations
 
 import re
 import shlex
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
 
 
 SHELL_SEPARATORS = {";", "&&", "||", "|", "&"}
@@ -279,3 +287,331 @@ def compound_cascade_hint(command: str) -> str:
     if not has_state_changing_redirect(command):
         return ""
     return COMPOUND_CASCADE_HINT
+
+
+# ---------------------------------------------------------------------------
+# Role-aware token API (issue #263)
+# ---------------------------------------------------------------------------
+#
+# `safe_tokenize` returns a flat token stream; every caller previously had
+# to reconstruct role state (flag vs flag-value vs positional vs `--`
+# boundary vs `$()` coalesce) ad-hoc. PR #251 / #252 codex review surfaced
+# 7 defects converging on this root cause:
+#
+#   R1: -c value / --merge-base A bypass / false positive  (flag-value set)
+#   R2: unquoted $() advisory / -c $(echo k=v) bypass      ($() coalesce)
+#   R3: kubectl exec -- mytool --flag false positive        (-- boundary)
+#
+# `tokenize_with_roles` centralizes these so per-caller logic can iterate
+# typed Token objects instead of re-parsing the flat stream.
+
+
+class TokenRole(Enum):
+    """Role of a token within a single command segment.
+
+    Resolution order:
+      1. SUBST_RUN — coalesced `$(...)` substitution (one logical token)
+      2. SEPARATOR_DD — the literal `--` argv separator
+      3. POST_DD — every token after SEPARATOR_DD in the same segment
+      4. COMMAND — argv[0] after strip_prefix (first non-env-prefix token)
+      5. FLAG — `-X`, `--long`, or `--long=value`
+      6. FLAG_VALUE — separate-token value following a value-taking FLAG
+      7. POSITIONAL — anything else before SEPARATOR_DD
+    """
+    COMMAND = "command"
+    FLAG = "flag"
+    FLAG_VALUE = "flag_value"
+    POSITIONAL = "positional"
+    SEPARATOR_DD = "separator_dd"
+    POST_DD = "post_dd"
+    SUBST_RUN = "subst_run"
+
+
+@dataclass(frozen=True)
+class Token:
+    """A typed token within a command segment.
+
+    Attributes:
+      text: original token text (after shlex unquoting; SUBST_RUN tokens
+        contain the joined run, e.g. `"$(git merge-base HEAD origin/main)"`).
+      role: the TokenRole.
+      flag_name: when role is FLAG_VALUE, the bare flag name this value
+        belongs to (e.g. value of `--merge-base A` carries
+        flag_name="--merge-base"). None for every other role.
+    """
+    text: str
+    role: TokenRole
+    flag_name: Optional[str] = None
+
+
+def _coalesce_subst_runs(tokens: list[str]) -> list[str]:
+    """Collapse unquoted `$(...)` command-substitution runs into single tokens.
+
+    safe_tokenize uses shlex with whitespace_split=True, which is unaware
+    of POSIX command substitution. An unquoted `$(git merge-base HEAD x)`
+    therefore splits into `['$(git', 'merge-base', 'HEAD', 'x)']` — four
+    tokens — and any flag-value-skip logic only consumes the first token.
+
+    This helper walks the token list and merges any run that starts with a
+    token containing an *unclosed* `$(` and ends with a token containing
+    the matching `)` into a single logical token. Quoted substitutions
+    (e.g. `"$(...)"`) are already a single token at this layer.
+
+    The merge is conservative — `$(` must occur with no matching `)` after
+    it in the same token to start a run, so balanced single-token forms
+    (`"$(...)"` or `--flag=$(short)`) pass through unchanged when already
+    balanced. Tokens like `--merge-base=$(git` ... `merge-base` ... `x)`
+    are joined into a single SUBST_RUN logical token.
+
+    Unbalanced runs (`$(` with no closing `)`) fall through to the end of
+    argv and are treated as a single token — the caller still sees them
+    as one element rather than several spurious positionals.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(tokens)
+    while i < n:
+        tok = tokens[i]
+        if "$(" in tok and ")" not in tok[tok.index("$(") + 2:]:
+            j = i + 1
+            parts = [tok]
+            while j < n:
+                parts.append(tokens[j])
+                if ")" in tokens[j]:
+                    break
+                j += 1
+            out.append(" ".join(parts))
+            i = j + 1
+        else:
+            out.append(tok)
+            i += 1
+    return out
+
+
+def _resolve_subcommand(
+    argv: list[str],
+    command_global_value_flags: Optional[set[str]] = None,
+) -> tuple[str, str]:
+    """Return (command_key, subcommand_key) for flag_value_spec lookup.
+
+    argv must already be stripped of env/wrapper prefixes via strip_prefix.
+    command_key is argv[0] (e.g. "git"). subcommand_key is the joined form
+    "<cmd> <subcmd>" when a non-flag positional token follows the command
+    (possibly after some command-global flags). Otherwise subcommand_key
+    equals command_key.
+
+    When `command_global_value_flags` is supplied (e.g. `{'-C', '-c'}` for
+    git), tokens matching that set consume the following token as their
+    value when scanning for the subcommand — this lets `git -C /tmp
+    merge-tree ...` resolve to `("git", "git merge-tree")` instead of
+    `("git", "git")`.
+
+    Example:
+      ["git", "merge-tree", "--name-only", "A"]    → ("git", "git merge-tree")
+      ["git", "-C", "/tmp", "merge-tree", ...]     → ("git", "git merge-tree")
+                                                      (when command_global_value_flags includes "-C")
+      ["git", "status"]                            → ("git", "git status")
+      ["kubectl", "--use-protocol-buffers", "get"] → ("kubectl", "kubectl get")
+    """
+    if not argv:
+        return ("", "")
+    command = argv[0]
+    value_flags = command_global_value_flags or set()
+    i = 1
+    n = len(argv)
+    while i < n:
+        tok = argv[i]
+        if tok == "--":
+            return (command, command)
+        if "$(" in tok:
+            return (command, command)
+        if not tok.startswith("-"):
+            return (command, f"{command} {tok}")
+        # Token is a flag. Skip its value if applicable.
+        bare_flag = tok.split("=", 1)[0]
+        if "=" not in tok and bare_flag in value_flags and i + 1 < n:
+            i += 2
+            continue
+        i += 1
+    return (command, command)
+
+
+def tokenize_with_roles(
+    command: str,
+    flag_value_spec: dict[str, set[str]],
+) -> list[list[Token]]:
+    """Return list of command segments, each a list of typed Token objects.
+
+    Args:
+      command: raw bash command string (may contain newlines, &&, ||, ;, |).
+      flag_value_spec: maps command/subcommand key to the set of bare flags
+        that consume a separate-token value. Keys are either the bare
+        command (`"git"`, `"kubectl"`) or `"<cmd> <subcmd>"` form
+        (`"git merge-tree"`). Subcommand spec takes precedence over command
+        spec when both are present — they are merged so callers can declare
+        global flags under the command key and subcommand-specific flags
+        under the subcommand key.
+
+    Returns:
+      A list of segments. Each segment is the typed Token list for one
+      command separated by `&&`, `||`, `;`, `|`, or newline.
+
+    Resolution algorithm (per segment):
+      1. safe_tokenize the whole command, split into segments via
+         iter_command_starts.
+      2. _coalesce_subst_runs to merge unquoted `$(...)` runs.
+      3. Determine command + subcommand keys, merge flag_value_spec sets.
+      4. Walk tokens:
+         - If token contains `$(`, role=SUBST_RUN.
+         - Else if token == `--`, role=SEPARATOR_DD; everything after
+           becomes POST_DD.
+         - Else if this is argv[0] (after strip_prefix conceptually), the
+           first non-env/non-wrapper token: role=COMMAND.
+         - Else if token starts with `-` (length > 1), role=FLAG. If the
+           bare flag (split on `=`) is in the merged value_flags set AND
+           the token has no `=`, the next non-SUBST_RUN token is consumed
+           as FLAG_VALUE with flag_name set to the bare flag.
+         - Else role=POSITIONAL.
+
+    Note on `strip_prefix`: the role API only marks COMMAND on the first
+    non-wrapper/non-env token, but it does NOT drop wrapper tokens — they
+    appear in the output as POSITIONAL preceding the COMMAND. Callers that
+    want a strict argv view can filter by `tok.role in {COMMAND, FLAG,
+    FLAG_VALUE, POSITIONAL}` and apply strip_prefix conceptually via the
+    COMMAND token's index. For the proof migration (cli-flag-incompat-
+    advisory.py) the existing strip_prefix call still drives subcommand
+    resolution; the role API is layered on top.
+    """
+    raw_tokens = safe_tokenize(command)
+    if not raw_tokens:
+        return []
+
+    segments_out: list[list[Token]] = []
+    for raw_argv in iter_command_starts(raw_tokens):
+        argv = _coalesce_subst_runs(list(raw_argv))
+        if not argv:
+            continue
+
+        # Resolve command + subcommand from the stripped-prefix view, then
+        # merge flag-value sets from both keys. Pass the command-level
+        # value flags to _resolve_subcommand so `git -C /tmp merge-tree`
+        # correctly identifies merge-tree as the subcommand.
+        stripped = strip_prefix(argv)
+        if stripped:
+            command_key_only = stripped[0]
+            command_global = flag_value_spec.get(command_key_only, set())
+        else:
+            command_global = set()
+        command_key, subcommand_key = _resolve_subcommand(stripped, command_global)
+        value_flags: set[str] = set()
+        if command_key and command_key in flag_value_spec:
+            value_flags |= flag_value_spec[command_key]
+        if subcommand_key and subcommand_key != command_key and subcommand_key in flag_value_spec:
+            value_flags |= flag_value_spec[subcommand_key]
+
+        # Locate the COMMAND token index (first token after stripped prefix
+        # within the original argv). strip_prefix returns a suffix slice;
+        # the command token is the first token of that suffix, which equals
+        # argv[len(argv) - len(stripped)] when stripped is non-empty.
+        command_idx = len(argv) - len(stripped) if stripped else len(argv)
+
+        seg_tokens: list[Token] = []
+        post_dd = False
+        i = 0
+        n = len(argv)
+        while i < n:
+            tok = argv[i]
+
+            # SUBST_RUN vs FLAG with embedded $() — when a coalesced token
+            # starts with `-` and contains `=` (i.e. equals-form flag with
+            # an embedded command substitution like `--merge-base=$(...)`),
+            # it is semantically a FLAG (value already embedded), not a
+            # free positional substitution. Only free `$(...)` runs (the
+            # token itself starts with the substitution) become SUBST_RUN.
+            if "$(" in tok:
+                if (
+                    len(tok) > 1
+                    and tok.startswith("-")
+                    and "=" in tok.split("$(", 1)[0]
+                ):
+                    seg_tokens.append(Token(text=tok, role=TokenRole.FLAG))
+                    i += 1
+                    continue
+                seg_tokens.append(Token(text=tok, role=TokenRole.SUBST_RUN))
+                i += 1
+                continue
+
+            # POST_DD — once we passed `--`, everything is post-dd.
+            if post_dd:
+                seg_tokens.append(Token(text=tok, role=TokenRole.POST_DD))
+                i += 1
+                continue
+
+            # SEPARATOR_DD — the literal `--` argv separator. We require
+            # the literal exact match; `--name-only` and `--=` do not
+            # qualify.
+            if tok == "--":
+                seg_tokens.append(Token(text=tok, role=TokenRole.SEPARATOR_DD))
+                post_dd = True
+                i += 1
+                continue
+
+            # COMMAND — first non-prefix token (only one per segment).
+            if i == command_idx:
+                seg_tokens.append(Token(text=tok, role=TokenRole.COMMAND))
+                i += 1
+                continue
+
+            # FLAG / FLAG_VALUE — anything starting with `-` (length >1)
+            # other than `--` (handled above).
+            if len(tok) > 1 and tok.startswith("-"):
+                seg_tokens.append(Token(text=tok, role=TokenRole.FLAG))
+                # Determine if this flag consumes the next token as a value.
+                # Equals form (`--long=value`) already embeds the value
+                # within the FLAG token itself — never consume the next
+                # token in that case.
+                if "=" not in tok:
+                    bare_flag = tok
+                    if bare_flag in value_flags and i + 1 < n:
+                        next_tok = argv[i + 1]
+                        # The value role is FLAG_VALUE regardless of `$()`
+                        # content — a `$(...)` substitution that fills a
+                        # flag value is semantically a value, not a free
+                        # SUBST_RUN. We mark it FLAG_VALUE with the
+                        # bare_flag attribution but keep the substitution
+                        # text intact.
+                        seg_tokens.append(Token(
+                            text=next_tok,
+                            role=TokenRole.FLAG_VALUE,
+                            flag_name=bare_flag,
+                        ))
+                        i += 2
+                        continue
+                i += 1
+                continue
+
+            # POSITIONAL — fall-through (pre-command env assignments and
+            # wrapper tokens land here too; callers can ignore them or
+            # use strip_prefix indirectly via the COMMAND token).
+            seg_tokens.append(Token(text=tok, role=TokenRole.POSITIONAL))
+            i += 1
+
+        segments_out.append(seg_tokens)
+
+    return segments_out
+
+
+def filter_argv(seg: list[Token]) -> list[Token]:
+    """Convenience: drop env/wrapper prefix tokens before the COMMAND.
+
+    Returns the typed Token slice starting at the COMMAND token. Callers
+    that previously called strip_prefix on a flat token list can use this
+    to get the equivalent typed view in one step.
+
+    If the segment has no COMMAND token (empty or all-env), returns an
+    empty list.
+    """
+    for i, tok in enumerate(seg):
+        if tok.role == TokenRole.COMMAND:
+            return seg[i:]
+    return []

--- a/hooks/_hook_utils.py
+++ b/hooks/_hook_utils.py
@@ -424,7 +424,13 @@ def _resolve_subcommand(
         if tok == "--":
             return (command, command)
         if "$(" in tok:
-            return (command, command)
+            # Only bare `$(...)` (not embedded in `--flag=$(...)`)
+            # terminates subcommand parsing. Flag-embedded substitution
+            # fills the flag's value slot and shouldn't prevent
+            # subcommand detection (e.g., `git --git-dir=$(pwd)/.git
+            # merge-tree ...` must still resolve `git merge-tree`).
+            if not (tok.startswith("-") and "=" in tok.split("$(", 1)[0]):
+                return (command, command)
         if not tok.startswith("-"):
             return (command, f"{command} {tok}")
         # Token is a flag. Skip its value if applicable.
@@ -549,8 +555,15 @@ def tokenize_with_roles(
 
             # SEPARATOR_DD — the literal `--` argv separator. We require
             # the literal exact match; `--name-only` and `--=` do not
-            # qualify.
+            # qualify. A `--` before command_idx is the wrapper option
+            # terminator form (`env -- cmd`, `sudo -- cmd`) — strip_prefix
+            # has already consumed it from `stripped`, so within the
+            # wrapper region it is POSITIONAL, not the argv separator.
             if tok == "--":
+                if i < command_idx:
+                    seg_tokens.append(Token(text=tok, role=TokenRole.POSITIONAL))
+                    i += 1
+                    continue
                 seg_tokens.append(Token(text=tok, role=TokenRole.SEPARATOR_DD))
                 post_dd = True
                 i += 1

--- a/hooks/_hook_utils.py
+++ b/hooks/_hook_utils.py
@@ -528,6 +528,16 @@ def tokenize_with_roles(
         while i < n:
             tok = argv[i]
 
+            # POST_DD — once we passed `--`, everything is post-dd. The
+            # API contract guarantees no SUBST_RUN / FLAG / FLAG_VALUE
+            # roles after SEPARATOR_DD, so this check runs BEFORE the
+            # $() branch below — `kubectl exec pod -- $(echo --flag)`
+            # must classify the substitution as POST_DD, not SUBST_RUN.
+            if post_dd:
+                seg_tokens.append(Token(text=tok, role=TokenRole.POST_DD))
+                i += 1
+                continue
+
             # SUBST_RUN vs FLAG with embedded $() — when a coalesced token
             # starts with `-` and contains `=` (i.e. equals-form flag with
             # an embedded command substitution like `--merge-base=$(...)`),
@@ -544,12 +554,6 @@ def tokenize_with_roles(
                     i += 1
                     continue
                 seg_tokens.append(Token(text=tok, role=TokenRole.SUBST_RUN))
-                i += 1
-                continue
-
-            # POST_DD — once we passed `--`, everything is post-dd.
-            if post_dd:
-                seg_tokens.append(Token(text=tok, role=TokenRole.POST_DD))
                 i += 1
                 continue
 

--- a/hooks/cli-flag-incompat-advisory.py
+++ b/hooks/cli-flag-incompat-advisory.py
@@ -31,9 +31,15 @@ Design:
   • **Plugin-style dispatch** — each CLI gets a `_check_<cli>` function that
     returns Optional[str] (the advisory text). New CLIs are added by writing
     a new check function and registering it in CHECKS.
-  • **Sibling-pattern toolchain** — reuses `safe_tokenize`,
-    `iter_command_starts`, `strip_prefix` from `_hook_utils.py`, matching
-    `gh-flag-verify.py` / `cross-boundary-preflight.py` / `block-gh-state-all.py`.
+  • **Role-aware tokenization (issue #263)** — uses `tokenize_with_roles`
+    from `_hook_utils.py` so each check receives typed Token segments
+    (COMMAND / FLAG / FLAG_VALUE / POSITIONAL / SEPARATOR_DD / POST_DD /
+    SUBST_RUN). Previously each caller re-implemented role state which
+    leaked 7 defects across PR #251 / #252 codex review rounds. The
+    proof-migration in this file (issue #263 Phase 1) demonstrates the
+    same 4 codex-review-passed cases (R1 false positive, R2 `$()`
+    advisory, R3 `--` boundary, R3 relative path) with strictly less
+    caller-side parsing.
 
 Fail-open contract:
 
@@ -58,10 +64,35 @@ from typing import Callable, Optional
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
-    iter_command_starts,
-    safe_tokenize,
-    strip_prefix,
+    Token,
+    TokenRole,
+    filter_argv,
+    tokenize_with_roles,
 )
+
+
+# ---------------------------------------------------------------------------
+# Role-aware flag-value spec (issue #263)
+# ---------------------------------------------------------------------------
+#
+# Migrated from per-caller `_coalesce_subst_runs` + ad-hoc value-flag sets
+# to the centralized `tokenize_with_roles` API. The spec is keyed by
+# `(command, subcommand)` so `git -C /tmp merge-tree --merge-base A` is
+# resolved with both git-global and merge-tree-specific value flags.
+#
+# Source:
+#   - git globals: `git --help` — -C, -c key=val, --git-dir, --work-tree,
+#     --namespace
+#   - git merge-tree: `git merge-tree -h` —
+#       --[no-]merge-base <tree-ish>
+#       -X, --[no-]strategy-option <option=value>
+#     Negation forms (`--no-merge-base`) are valueless suppression markers
+#     and are intentionally NOT in this set.
+_FLAG_VALUE_SPEC: dict[str, set[str]] = {
+    "git": {"-C", "-c", "--git-dir", "--work-tree", "--namespace"},
+    "git merge-tree": {"--merge-base", "-X", "--strategy-option"},
+    "kubectl": set(),
+}
 
 
 # ---------------------------------------------------------------------------
@@ -75,129 +106,82 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
 # the primary cost.
 _MERGE_TREE_MODERN_FLAGS = frozenset({"--name-only", "--write-tree"})
 
-# git options that consume the following token as a value; needed so the
-# positional-argument count is not inflated by `-C <dir>` / similar.
-_GIT_GLOBAL_FLAGS_WITH_ARG = frozenset({
-    "-C", "-c", "--git-dir", "--work-tree", "--namespace",
-})
 
-# `git merge-tree` subcommand-level flags that consume the next token as
-# their value. Without this set, `--merge-base A --name-only HEAD origin/main`
-# (the canonical correct modern usage) counts `A` as a 3rd positional and
-# trips the advisory. Source: `git merge-tree -h` —
-#   --[no-]merge-base <tree-ish>
-#   -X, --[no-]strategy-option <option=value>
-# Negation forms (`--no-merge-base`) are valueless suppression markers and
-# are intentionally NOT in this set.
-_MERGE_TREE_FLAGS_WITH_ARG = frozenset({
-    "--merge-base",
-    "-X", "--strategy-option",
-})
+def _count_merge_tree_positionals(seg: list[Token]) -> int:
+    """Count positional (non-flag) arguments to `git merge-tree` from a
+    typed Token segment.
 
+    The role-aware tokenizer has already:
+      - coalesced unquoted `$(...)` runs into single tokens (SUBST_RUN
+        when free, FLAG_VALUE when consumed by a value-taking flag)
+      - classified value tokens as FLAG_VALUE (excluded from positional
+        count)
+      - marked the `--` boundary; any POST_DD tokens count as positionals
+        per merge-tree's POSIX convention
 
-def _coalesce_subst_runs(tokens: list[str]) -> list[str]:
-    """Collapse unquoted `$(...)` command-substitution runs into single tokens.
-
-    `safe_tokenize` uses shlex with whitespace_split=True, which is unaware
-    of POSIX command substitution. An unquoted `$(git merge-base HEAD x)`
-    therefore splits into `['$(git', 'merge-base', 'HEAD', 'x)']` — four
-    tokens — and any flag-value-skip logic only consumes the first token.
-    The remaining tokens then look like positional arguments and inflate
-    the count.
-
-    This helper walks the token list and merges any run that starts with a
-    token containing `$(` and ends with a token containing the matching `)`
-    into a single logical token. Quoted substitutions (e.g. `"$(...)"`)
-    are already a single token at this layer and need no special handling.
-
-    The merge is conservative — `$(` and `)` are required to be present in
-    SOME token (not necessarily at start/end) so the helper correctly
-    handles tokens like `--merge-base=$(git` ... `merge-base` ... `x)`.
-    Unbalanced runs (`$(` with no closing `)`) fall through to the end of
-    argv and are treated as a single token — the caller still sees them
-    as one element rather than several spurious positionals.
+    Returns the positional count starting from the token AFTER the
+    `merge-tree` subcommand token, or -1 if this is not a merge-tree
+    invocation.
     """
-    out: list[str] = []
-    i = 0
-    n = len(tokens)
-    while i < n:
-        tok = tokens[i]
-        if "$(" in tok and ")" not in tok[tok.index("$(") + 2:]:
-            j = i + 1
-            parts = [tok]
-            while j < n:
-                parts.append(tokens[j])
-                if ")" in tokens[j]:
-                    break
-                j += 1
-            out.append(" ".join(parts))
-            i = j + 1
-        else:
-            out.append(tok)
-            i += 1
-    return out
+    argv = filter_argv(seg)
+    if not argv or argv[0].text != "git":
+        return -1
 
-
-def _count_merge_tree_positionals(argv: list[str]) -> int:
-    """Count positional (non-flag) arguments to `git merge-tree`.
-
-    Walks argv past git-level globals, finds `merge-tree`, then counts
-    every non-flag token after the subcommand. Value tokens consumed by
-    known value-taking flags are NOT counted. Unquoted `$(...)` runs are
-    coalesced via `_coalesce_subst_runs` so they count as exactly one
-    logical argument, matching what the shell will pass to git.
-    """
-    argv = _coalesce_subst_runs(argv)
-    i = 0
-    n = len(argv)
-    # Skip past git global flags (the caller already verified argv[0]=="git"
-    # via strip_prefix; this function is only called after that check).
+    # Find the merge-tree subcommand token. Skip past command-global
+    # FLAG / FLAG_VALUE pairs (already typed correctly).
     i = 1
+    n = len(argv)
     while i < n:
         tok = argv[i]
-        if tok == "--":
+        if tok.role in (TokenRole.FLAG, TokenRole.FLAG_VALUE):
             i += 1
+            continue
+        if tok.role == TokenRole.POSITIONAL and tok.text == "merge-tree":
             break
-        if not tok.startswith("-"):
-            break
-        i += 1
-        if "=" not in tok and tok in _GIT_GLOBAL_FLAGS_WITH_ARG and i < n:
-            i += 1
+        # Some other token (SUBST_RUN, SEPARATOR_DD, unrelated POSITIONAL)
+        # — not a merge-tree invocation.
+        return -1
+    else:
+        return -1
 
-    if i >= n or argv[i] != "merge-tree":
-        return -1  # not a merge-tree call
+    # Skip the `merge-tree` token itself.
     i += 1
 
     positionals = 0
     while i < n:
         tok = argv[i]
-        if tok == "--":
-            i += 1
-            positionals += (n - i)
-            break
-        if not tok.startswith("-"):
+        if tok.role == TokenRole.POSITIONAL:
             positionals += 1
-            i += 1
-            continue
-        # Token is a flag. If it consumes a separate value token (and the
-        # value is not already embedded via `=value` form), skip the next
-        # token so the value is not miscounted as a positional argument.
-        if "=" not in tok and tok in _MERGE_TREE_FLAGS_WITH_ARG and i + 1 < n:
-            i += 2
-            continue
+        elif tok.role == TokenRole.SUBST_RUN:
+            # A free $() run that is NOT bound to a value-flag is a
+            # positional argument from the shell's perspective.
+            positionals += 1
+        elif tok.role == TokenRole.POST_DD:
+            # Tokens after `--` are positional per POSIX convention.
+            positionals += 1
+        # FLAG / FLAG_VALUE / SEPARATOR_DD / COMMAND do NOT increment
+        # the positional count.
         i += 1
     return positionals
 
 
-def _check_git(argv: list[str]) -> Optional[str]:
+def _check_git(seg: list[Token]) -> Optional[str]:
     """Return advisory text for known git mode-incompatible combos, else None."""
-    argv = strip_prefix(argv)
-    if not argv or argv[0] != "git":
+    argv = filter_argv(seg)
+    if not argv or argv[0].text != "git":
         return None
 
     # merge-tree: --name-only + 3+ positionals → legacy/modern conflict
-    if any(tok in _MERGE_TREE_MODERN_FLAGS for tok in argv):
-        positionals = _count_merge_tree_positionals(argv)
+    # We strip the `=value` suffix on FLAG tokens when checking for modern
+    # mode trip-wires so `--name-only=true` (unusual but legal) still
+    # triggers the check.
+    has_modern_flag = any(
+        tok.role == TokenRole.FLAG
+        and tok.text.split("=", 1)[0] in _MERGE_TREE_MODERN_FLAGS
+        for tok in argv
+    )
+    if has_modern_flag:
+        positionals = _count_merge_tree_positionals(seg)
         if positionals >= 3:
             return (
                 "[cli-flag-incompat-advisory] git merge-tree mode conflict\n"
@@ -235,20 +219,24 @@ _KUBECTL_DEPRECATED = {
 }
 
 
-def _check_kubectl(argv: list[str]) -> Optional[str]:
-    argv = strip_prefix(argv)
-    if not argv or argv[0] != "kubectl":
+def _check_kubectl(seg: list[Token]) -> Optional[str]:
+    """Return advisory text when a deprecated kubectl flag appears
+    BEFORE the `--` argv separator, else None.
+
+    The role-aware tokenizer already marks post-`--` tokens as POST_DD,
+    so this function simply iterates FLAG tokens and is naturally immune
+    to the `kubectl exec pod -- mytool --use-protocol-buffers` false
+    positive (R3) — the deprecated flag would be POST_DD in that case,
+    not FLAG.
+    """
+    argv = filter_argv(seg)
+    if not argv or argv[0].text != "kubectl":
         return None
-    # `kubectl exec pod -- mytool --use-protocol-buffers` passes
-    # `--use-protocol-buffers` to the in-container command, not to kubectl
-    # itself. Per POSIX convention, every token after `--` is positional —
-    # stop scanning when we hit it so remote-command arg shadowing does
-    # not trigger a kubectl-targeted advisory.
     hits: list[str] = []
     for tok in argv[1:]:
-        if tok == "--":
-            break
-        bare = tok.split("=", 1)[0]
+        if tok.role != TokenRole.FLAG:
+            continue
+        bare = tok.text.split("=", 1)[0]
         if bare in _KUBECTL_DEPRECATED:
             hits.append(f"  {bare}: {_KUBECTL_DEPRECATED[bare]}")
     if not hits:
@@ -265,7 +253,7 @@ def _check_kubectl(argv: list[str]) -> Optional[str]:
 # Registry
 # ---------------------------------------------------------------------------
 
-CHECKS: tuple[Callable[[list[str]], Optional[str]], ...] = (
+CHECKS: tuple[Callable[[list[Token]], Optional[str]], ...] = (
     _check_git,
     _check_kubectl,
 )
@@ -288,14 +276,16 @@ def _main_inner() -> int:
     if not command.strip():
         return 0
 
-    tokens = safe_tokenize(command.replace("\\\n", " "))
-    if not tokens:
+    segments = tokenize_with_roles(
+        command.replace("\\\n", " "),
+        _FLAG_VALUE_SPEC,
+    )
+    if not segments:
         return 0
 
-    for argv in iter_command_starts(tokens):
-        argv = list(argv)
+    for seg in segments:
         for check in CHECKS:
-            msg = check(argv)
+            msg = check(seg)
             if msg:
                 sys.stderr.write(msg + "\n")
                 return 0  # advisory — never blocks; first match suffices

--- a/tests/test_hook_utils.sh
+++ b/tests/test_hook_utils.sh
@@ -330,6 +330,14 @@ run_roles "flag=value with \$(): --git-dir=\$() does not block subcommand resolu
   "seg0:command:git:|seg0:flag_value:A:--merge-base" \
   'git --git-dir=$(pwd)/.git merge-tree --merge-base A --name-only HEAD origin/main'
 
+run_roles "post-DD \$(): \$() after -- becomes POST_DD (not SUBST_RUN)" \
+  "seg0:separator_dd:--:|seg0:post_dd:\$(echo --flag):" \
+  'kubectl exec pod -- $(echo --flag)'
+
+run_roles_negative "post-DD \$(): \$() after -- must NOT be SUBST_RUN" \
+  "seg0:subst_run:\$(echo --flag):" \
+  'kubectl exec pod -- $(echo --flag)'
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------

--- a/tests/test_hook_utils.sh
+++ b/tests/test_hook_utils.sh
@@ -312,6 +312,24 @@ run_roles "R3: -- boundary stops flag scan in kubectl exec" \
   "seg0:separator_dd:--:|seg0:post_dd:--use-protocol-buffers:" \
   "kubectl exec pod -- bash -c '--use-protocol-buffers'"
 
+# --- Codex review #284 regressions ---
+
+run_roles "wrapper -- (env): kubectl still resolves as COMMAND after env --" \
+  "seg0:command:kubectl:|seg0:flag:--use-protocol-buffers:" \
+  "env -- kubectl --use-protocol-buffers"
+
+run_roles_negative "wrapper -- (env): kubectl must NOT be POST_DD" \
+  "seg0:post_dd:kubectl:" \
+  "env -- kubectl --use-protocol-buffers"
+
+run_roles "wrapper -- (sudo): git merge-tree resolves through sudo -- prefix" \
+  "seg0:command:git:|seg0:flag_value:A:--merge-base" \
+  "sudo -- git merge-tree --merge-base A --name-only HEAD origin/main"
+
+run_roles "flag=value with \$(): --git-dir=\$() does not block subcommand resolution" \
+  "seg0:command:git:|seg0:flag_value:A:--merge-base" \
+  'git --git-dir=$(pwd)/.git merge-tree --merge-base A --name-only HEAD origin/main'
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------

--- a/tests/test_hook_utils.sh
+++ b/tests/test_hook_utils.sh
@@ -126,6 +126,193 @@ run_hint "empty command no hint"           false ''
 run_hint "quoted heredoc-like in compound" false 'echo "<<EOF foo" && git push'
 
 # ---------------------------------------------------------------------------
+# tokenize_with_roles — role-aware token API (issue #263)
+# ---------------------------------------------------------------------------
+#
+# Each case spawns a python3 subprocess that imports tokenize_with_roles
+# and prints the (role, text, flag_name) for each token as a single line
+# per token in the form `seg<i>:<role>:<text>:<flag_name>`. The harness
+# asserts substring presence (expected lines must appear in actual output).
+
+# run_roles name "expected_substring_1|expected_substring_2|..." command
+#   Each expected substring must appear (substring match) somewhere in the
+#   actual output. Use `|` as the in-shell separator between substrings.
+run_roles() {
+  local name="$1" expected_substrings="$2" command="$3"
+  local actual
+  actual=$(python3 - "$command" <<'PYEOF'
+import sys
+from _hook_utils import tokenize_with_roles
+
+cmd = sys.argv[1]
+spec = {
+    "git": {"-C", "-c", "--git-dir", "--work-tree", "--namespace"},
+    "git merge-tree": {"--merge-base", "-X", "--strategy-option"},
+    "kubectl": set(),
+    "gh": {"--repo", "-R"},
+}
+segs = tokenize_with_roles(cmd, spec)
+for i, seg in enumerate(segs):
+    for t in seg:
+        fn = t.flag_name if t.flag_name is not None else ""
+        print(f"seg{i}:{t.role.value}:{t.text}:{fn}")
+PYEOF
+)
+  local ok=1
+  local IFS='|'
+  for sub in $expected_substrings; do
+    if ! printf '%s\n' "$actual" | grep -Fq "$sub"; then
+      ok=0
+      break
+    fi
+  done
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS [roles] $name"; PASS=$((PASS + 1))
+  else
+    echo "FAIL [roles] $name"
+    echo "  expected (each substring must appear): $expected_substrings"
+    echo "  actual:"
+    printf '%s\n' "$actual" | sed 's/^/    /'
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# run_roles_negative — asserts each substring is NOT present in output.
+run_roles_negative() {
+  local name="$1" forbidden_substrings="$2" command="$3"
+  local actual
+  actual=$(python3 - "$command" <<'PYEOF'
+import sys
+from _hook_utils import tokenize_with_roles
+
+cmd = sys.argv[1]
+spec = {
+    "git": {"-C", "-c", "--git-dir", "--work-tree", "--namespace"},
+    "git merge-tree": {"--merge-base", "-X", "--strategy-option"},
+    "kubectl": set(),
+    "gh": {"--repo", "-R"},
+}
+segs = tokenize_with_roles(cmd, spec)
+for i, seg in enumerate(segs):
+    for t in seg:
+        fn = t.flag_name if t.flag_name is not None else ""
+        print(f"seg{i}:{t.role.value}:{t.text}:{fn}")
+PYEOF
+)
+  local ok=1
+  local IFS='|'
+  for sub in $forbidden_substrings; do
+    if printf '%s\n' "$actual" | grep -Fq "$sub"; then
+      ok=0
+      break
+    fi
+  done
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS [roles!] $name"; PASS=$((PASS + 1))
+  else
+    echo "FAIL [roles!] $name (forbidden substring present)"
+    echo "  forbidden: $forbidden_substrings"
+    echo "  actual:"
+    printf '%s\n' "$actual" | sed 's/^/    /'
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# --- 1 test per role ---
+
+run_roles "COMMAND role on argv[0]" \
+  "seg0:command:git:" \
+  "git status"
+
+run_roles "FLAG role on --long" \
+  "seg0:flag:--name-only:" \
+  "git merge-tree --name-only HEAD origin/main"
+
+run_roles "FLAG_VALUE role with flag_name attribution (space form)" \
+  "seg0:flag:--merge-base:|seg0:flag_value:A:--merge-base" \
+  "git merge-tree --merge-base A --name-only HEAD origin/main"
+
+run_roles "POSITIONAL role on bare positional arg" \
+  "seg0:positional:HEAD:|seg0:positional:origin/main:" \
+  "git merge-tree --name-only HEAD origin/main"
+
+run_roles "SEPARATOR_DD role on literal --" \
+  "seg0:separator_dd:--:" \
+  "kubectl exec pod -- mytool"
+
+run_roles "POST_DD role on tokens after --" \
+  "seg0:post_dd:mytool:|seg0:post_dd:--use-protocol-buffers:" \
+  "kubectl exec pod -- mytool --use-protocol-buffers"
+
+run_roles "SUBST_RUN role on coalesced \$() (unquoted free)" \
+  "seg0:subst_run:\$(echo hi):" \
+  'echo $(echo hi)'
+
+# --- $() coalesce — multi-token unquoted ---
+
+run_roles "\$() coalesce as FLAG_VALUE (space form)" \
+  "seg0:flag_value:\$(git merge-base HEAD origin/main):--merge-base" \
+  'git merge-tree --merge-base $(git merge-base HEAD origin/main) --name-only HEAD origin/main'
+
+run_roles_negative "\$() coalesce — no spurious POSITIONAL fragments" \
+  "seg0:positional:merge-base:|seg0:positional:origin/main):" \
+  'git merge-tree --merge-base $(git merge-base HEAD origin/main) --name-only HEAD origin/main'
+
+# --- -- boundary ---
+
+run_roles "-- boundary — POSITIONAL before, POST_DD after" \
+  "seg0:positional:exec:|seg0:separator_dd:--:|seg0:post_dd:mytool:|seg0:post_dd:--use-protocol-buffers:" \
+  "kubectl exec pod -- mytool --use-protocol-buffers"
+
+run_roles_negative "-- boundary — flag after -- must NOT be FLAG" \
+  "seg0:flag:--use-protocol-buffers:" \
+  "kubectl exec pod -- mytool --use-protocol-buffers"
+
+# --- Both space-form and equals-form flag-value ---
+
+run_roles "space form --repo VALUE" \
+  "seg0:flag:--repo:|seg0:flag_value:owner/repo:--repo" \
+  "gh pr list --repo owner/repo"
+
+run_roles "equals form --repo=VALUE (single FLAG token, no FLAG_VALUE)" \
+  "seg0:flag:--repo=owner/repo:" \
+  "gh pr list --repo=owner/repo"
+
+run_roles_negative "equals form must NOT consume next token as FLAG_VALUE" \
+  ":flag_value:--state:--repo" \
+  "gh pr list --repo=owner/repo --state open"
+
+# --- Compound — `cd /B && git wt remove /B-wt` ---
+
+run_roles "compound: two segments, COMMAND on each" \
+  "seg0:command:cd:|seg1:command:git:" \
+  "cd /B && git wt remove /B-wt"
+
+run_roles "compound: && separator splits segments cleanly" \
+  "seg0:positional:/B:|seg1:positional:/B-wt:" \
+  "cd /B && git wt remove /B-wt"
+
+# --- Subcommand-aware flag-value resolution ---
+
+run_roles "subcommand-aware: git merge-tree --merge-base picked up via subcommand spec" \
+  "seg0:flag_value:A:--merge-base" \
+  "git merge-tree --merge-base A --name-only HEAD origin/main"
+
+run_roles "subcommand-aware: git -C /tmp merge-tree resolves merge-tree as subcommand" \
+  "seg0:flag_value:/tmp:-C|seg0:flag_value:A:--merge-base" \
+  "git -C /tmp merge-tree --merge-base A --name-only HEAD origin/main"
+
+# --- Regression coverage of PR #251/#252 R1-R3 patterns via the API ---
+
+run_roles "R1: -c value pair recognized (gh-style flag-value set)" \
+  "seg0:flag:--repo:|seg0:flag_value:owner/x:--repo" \
+  "gh pr list --repo owner/x"
+
+run_roles "R3: -- boundary stops flag scan in kubectl exec" \
+  "seg0:separator_dd:--:|seg0:post_dd:--use-protocol-buffers:" \
+  "kubectl exec pod -- bash -c '--use-protocol-buffers'"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Refs #263 — Phase 1 only (API + 1 proof migration). 다른 caller 마이그레이션과 dead helper 제거는 follow-up issue 로 분리.

## 배경

PR #251 / #252 의 4-round codex review 에서 발견된 11 결함 중 **7 개가 단일 root cause** 로 수렴 — `safe_tokenize` 가 flat token stream 만 반환하고 token role (flag / flag-value / positional / `--` boundary / `$()` 코얼리스) 재구성을 caller 마다 ad-hoc 으로 떠넘긴 결과. 각 caller 의 partial reconstruction 이 distinct bypass surface 를 만들어, 한 round 에서 한 곳을 패치하면 다음 round 에서 다른 곳에서 같은 클래스가 다시 발견됨.

## 변경 사항

### 1. 새 role-aware API (`hooks/_hook_utils.py`)

```python
class TokenRole(Enum):
    COMMAND, FLAG, FLAG_VALUE, POSITIONAL, SEPARATOR_DD, POST_DD, SUBST_RUN

@dataclass(frozen=True)
class Token:
    text: str
    role: TokenRole
    flag_name: Optional[str] = None  # FLAG_VALUE 일 때 어떤 flag 의 value 인지

def tokenize_with_roles(
    command: str,
    flag_value_spec: dict[str, set[str]],  # {<cmd>: {...}, "<cmd> <subcmd>": {...}}
) -> list[list[Token]]: ...
```

Resolution 규칙:
- COMMAND: env/wrapper prefix 를 제외한 첫 non-prefix 토큰.
- FLAG: `-X`, `--long`, `--long=value` 형태.
- FLAG_VALUE: 공백 form 의 value 토큰 (`--repo owner/x` 의 `owner/x`). `flag_name` 에 어떤 flag 의 value 인지 기록.
- POSITIONAL: flag 도 아니고 flag-value 도 아닌 토큰 (단, `--` 이전).
- SEPARATOR_DD: 리터럴 `--` 토큰.
- POST_DD: `--` 이후 모든 토큰 (FLAG 여부 무관).
- SUBST_RUN: unquoted `$(...)` 런이 다중 토큰으로 분리된 경우 — 단일 logical token 으로 결합.

Subcommand-aware: `flag_value_spec` 가 `"git"` 와 `"git merge-tree"` 두 키 모두 가질 수 있어 global flag 와 subcommand-specific flag 의 value-skip 이 한 번에 해결됨.

### 2. Proof migration (`hooks/cli-flag-incompat-advisory.py`)

기존 ad-hoc 구현 (`_coalesce_subst_runs`, `_count_merge_tree_positionals`, 수동 `--` boundary 검사) 을 typed Token 기반으로 전면 재작성. PR #252 의 4-round codex review 가 잡아낸 4 패턴 모두 새 API 의 자연스러운 결과로 통과:

| R | 패턴 | 새 API 에서 해결되는 방식 |
|---|------|--------------------------|
| R1 | `--merge-base A` false positive | `flag_value_spec["git merge-tree"]` 에서 자동으로 FLAG_VALUE 분류 |
| R2 | unquoted `$()` advisory on own-recommended fix | `tokenize_with_roles` 가 SUBST_RUN 으로 코얼리스 + FLAG 임베디드 (`--merge-base=$(...)`) 는 FLAG 로 보존 |
| R3 | `kubectl exec pod -- mytool --use-protocol-buffers` false positive | `--` 이후 토큰은 자동으로 POST_DD — `_check_kubectl` 가 FLAG 만 검사하면 자연스럽게 면역 |
| R3 | relative path 처리 | (이 PR 범위 아님 — cross-repo-worktree-preflight 마이그레이션 시 처리 예정) |

### 3. 테스트 (`tests/test_hook_utils.sh`)

21 개 role-resolution 테스트 추가:
- 각 role 별 1 test (7 roles)
- `$()` coalesce (single token for whole subst)
- `--` boundary (POSITIONAL before, POST_DD after)
- space-form (`--repo foo`) + equals-form (`--repo=foo`)
- Compound (`cd /B && git wt remove /B-wt` → 2 세그먼트)
- Subcommand-aware spec (`git -C /tmp merge-tree --merge-base A`)

## 검증

```text
$ bash tests/test_hook_utils.sh
==========================================
  PASS: 63  FAIL: 0
==========================================

$ bash hooks/test-cli-flag-incompat-advisory.sh
----
Passed: 26
Failed: 0
```

전체 hook test suite (31 개 파일) 중 pre-existing 2 개 (`test-pre-edit-md-escape-advisory.sh` — stale tmp 파일 / `test_retrospect_routing.sh` — SKILL.md placeholder issue) 외 본 PR 영향 받는 테스트 모두 통과. 이 두 실패는 main 브랜치에서도 동일하게 재현 (본 PR 의 변경과 무관).

## Backward compat

기존 `safe_tokenize` / `iter_command_starts` / `strip_prefix` API 는 시그니처 / 동작 모두 그대로 유지. 마이그레이션은 caller-by-caller opt-in.

```python
$ python3 -c "
from _hook_utils import safe_tokenize, iter_command_starts, strip_prefix
assert safe_tokenize('git status') == ['git', 'status']
assert list(iter_command_starts(['a', '&&', 'b'])) == [['a'], ['b']]
assert strip_prefix(['env', 'FOO=1', 'git', 'status']) == ['git', 'status']
print('Backward compatibility preserved')
"
Backward compatibility preserved
```

## Follow-up 필요

본 PR 범위는 Phase 1 (API + 1 proof migration) 으로 제한. 별도 follow-up issue 가 필요:

- `cross-repo-worktree-preflight.py` 마이그레이션 (R1 `-c value` bypass, R2 `-c $(echo k=v)` bypass, R3 compound cwd state, R3 relative path resolution)
- `gh-flag-verify.py` 마이그레이션
- `cross-boundary-preflight.py` 마이그레이션
- `block-gh-state-all.py` 마이그레이션
- Dead helper 제거 (`_coalesce_subst_runs` 의 다른 사본, 각 caller 내부의 ad-hoc value-skip 로직)

## Caller chain verification

Caller chain verified: grep found 2 callers in hooks/ + tests/

- `hooks/cli-flag-incompat-advisory.py:279` — `tokenize_with_roles(command.replace("\\\n", " "), _FLAG_VALUE_SPEC)` (proof migration; PR #252 R1-R3 26 test 모두 통과)
- `tests/test_hook_utils.sh:154,195` — `tokenize_with_roles(cmd, spec)` (21 role-resolution test)

새 API 가 노출하는 `Token`, `TokenRole`, `tokenize_with_roles`, `filter_argv` 의 caller 는 위 두 곳 외에는 없음 — `grep -rn "tokenize_with_roles\|TokenRole\|from _hook_utils import Token" hooks/ tests/` 로 검증.
