### PR TITLE
docs(privacy): acknowledge CLI egress paths

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -59,6 +59,20 @@ the hook's in-process execution. Third-party CLI privacy policies apply.
 
 ## No Telemetry
 
-Praxis does not include any analytics, telemetry, error reporting, or
-network calls of its own. There is no phone-home, no usage tracking, and
-no data ever leaves the local machine via praxis code.
+Praxis itself does not include analytics, telemetry, or error reporting.
+There is no phone-home and no usage tracking embedded in praxis code.
+
+However, praxis hooks and skills DO invoke external CLIs (`git`, `gh`,
+`cmux`, `claude`, `codex`, `gemini`) with the user's own credentials.
+Some of those invocations make network calls — most notably:
+
+- `hooks/pre-gh-pr-create-dedup-gate.py` runs `gh pr list` against the
+  target repo's PR search API to detect duplicate PRs.
+- `skills/cmux-delegate` forwards prompt files to `claude` / `codex` /
+  `gemini` CLIs, each of which sends the prompt to its respective
+  provider's API.
+
+These egress paths are visible in the hook/skill source (see SECURITY.md
+"Hook External-Command Allowlist") and run under the user's environment.
+Praxis does not intercept, store, or transmit additional data via its
+own code paths beyond what the invoked CLI requires.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -72,9 +72,14 @@ Some of those invocations make network calls — most notably:
 
 - `hooks/pre-gh-pr-create-dedup-gate.py` runs `gh pr list` against the
   target repo's PR search API to detect duplicate PRs.
-- `skills/cmux-delegate` forwards prompt files to `claude` / `codex` /
-  `gemini` CLIs, each of which sends the prompt to its respective
-  provider's API.
+- `skills/cmux-delegate` performs two distinct egress steps when run
+  in a GitHub-backed repo:
+  1. **Context collection** — calls `gh pr list --head <branch>` and
+     `gh api repos/<owner>/<repo>/pulls/<num>/comments` to enrich the
+     delegated prompt with current PR metadata.
+  2. **Prompt forwarding** — pipes the resulting prompt file to
+     `claude` / `codex` / `gemini` CLIs, each of which sends the
+     prompt to its respective provider's API.
 
 These egress paths are visible in the hook/skill source (see SECURITY.md
 "Hook External-Command Allowlist") and run under the user's environment.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,7 +1,11 @@
 # Privacy Policy
 
-Praxis is a local-only Claude Code plugin. It does not collect, transmit, or
-store data on any external server. All state lives in the user's own filesystem.
+Praxis is a local-only Claude Code plugin. Praxis code itself stores state
+only on the user's filesystem and does not transmit data on its own. However,
+praxis invokes external CLIs (`git`, `gh`, `cmux`, `claude`, `codex`,
+`gemini`) on the user's behalf, and some of those CLIs make network calls —
+see the [No Telemetry](#no-telemetry) section below for the enumerated egress
+paths.
 
 ## Transcript Reading
 


### PR DESCRIPTION
## 배경

PR #282 (docs: add SECURITY.md and PRIVACY.md) 머지 후 codex-review-wrap에서 P2 finding 1건 식별:

> [P2] Do not claim there are no network calls — `PRIVACY.md:62-64`
>
> 이 문구는 `pre-gh-pr-create-dedup-gate.py`가 `gh pr list`로 GitHub에 repo/search 정보를 보내는 경우나 `cmux-delegate`가 prompt 파일을 `claude`/`codex`/`gemini` CLI로 전달하는 경우와 맞지 않습니다.

## Premise 검증

```
$ grep -nE "gh pr list|subprocess" hooks/pre-gh-pr-create-dedup-gate.py
21:  4. Run `gh pr list --repo <r> --state all --search "<kw>" --limit 20
155:        proc = subprocess.run(
205:    """Run `gh pr list --repo <r> --state all --search <kw> --json ...`.
221:        proc = subprocess.run(

$ grep -nE "claude --model|codex exec|gemini -p" skills/cmux-delegate/*.md
215:    cat "$PROMPT_FILE" | {claude_env} claude \
221:    cat "$PROMPT_FILE" | codex exec \
225:    gemini -p "$(cat "$PROMPT_FILE")" \
```

→ 실제 egress 경로 확인됨. PRIVACY.md의 "no network calls" 주장은 너무 강함.

## 변경

`PRIVACY.md` "No Telemetry" 섹션을 두 부분으로 분리:

1. **유지** — praxis 자체는 analytics/telemetry/error reporting을 포함하지 않음
2. **추가** — hooks/skills가 외부 CLI를 호출할 때의 egress 경로 명시:
   - `pre-gh-pr-create-dedup-gate.py` → GitHub PR search API
   - `cmux-delegate` → claude/codex/gemini provider API

## Verification

- 모든 인용된 hook/skill source line이 실제로 grep으로 확인됨
- SECURITY.md "Hook External-Command Allowlist" reference 보강

Premise-Verified: grep -nE "gh pr list|subprocess" hooks/pre-gh-pr-create-dedup-gate.py; grep -nE "claude --model|codex exec|gemini -p" skills/cmux-delegate/*.md

Caller chain verified: docs-only edit; no code path depends on the prior wording.

Refs #273
Follow-up from PR #282 codex-review-wrap session.
