### PR TITLE
feat(hook): extend external-write-falsify to cluster-approval

### DIFF
--- a/docs/hook/external-write-falsify-check.md
+++ b/docs/hook/external-write-falsify-check.md
@@ -26,16 +26,17 @@ question.
 
 ### What is warned
 
-| Tool call shape | Warned when body contains hypothesis marker |
-|----------------|----------------------------------------------|
-| `gh issue comment --body <text>` | yes |
-| `gh pr comment -b <text>` | yes |
-| `gh pr review --comment --body <text>` (or `--approve` / `--request-changes`) | yes |
-| `gh issue create --body-file <path>` | yes (file contents read) |
-| `gh pr edit -F <path>` | yes |
-| `mcp__*slack*__*send*` / `*post*message*` | yes (body field) |
-| `mcp__*notion*__*create_page*` / `*update_page*` | yes (text fields concatenated) |
-| `gh issue list` / `gh search issues` / Read tool | passthrough silent |
+| Tool call shape | Condition | Advisory |
+|----------------|-----------|----------|
+| `gh issue comment --body <text>` | body contains hypothesis marker | Check 1 |
+| `gh pr comment -b <text>` | body contains hypothesis marker | Check 1 |
+| `gh pr review --comment --body <text>` (or `--approve` / `--request-changes`) | body contains hypothesis marker | Check 1 |
+| `gh issue create --body-file <path>` | body contains hypothesis marker (file contents read) | Check 1 |
+| `gh pr edit -F <path>` | body contains hypothesis marker | Check 1 |
+| `mcp__*slack*__*send*` / `*post*message*` | body field contains hypothesis marker | Check 1 |
+| `mcp__*notion*__*create_page*` / `*update_page*` | text fields contain hypothesis marker | Check 1 |
+| `Write` to staging path (`/tmp/*-issue-*.md`, `/tmp/*-pr-*.md`, `.omc/plans/*.md`) | cluster-approval language in last 5 user messages | Check 3 |
+| `gh issue list` / `gh search issues` / Read tool | — | passthrough silent |
 
 Hypothesis markers (whole-segment substring match): English 16 —
 `might`, `could be`, `could fail`, `could break`, `potentially`,
@@ -59,14 +60,15 @@ want the gate to fire on the user's behalf.
 ### How to enable
 
 Add an entry to your `~/.claude/settings.json` or `.claude/settings.json`
-under `hooks.PreToolUse`:
+under `hooks.PreToolUse`. Include `Write` in the matcher to enable
+cluster-approval staging detection (Check 3):
 
 ```json
 {
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash|mcp__.*slack.*|mcp__.*notion.*",
+        "matcher": "Bash|Write|mcp__.*slack.*|mcp__.*notion.*",
         "hooks": [
           { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/external-write-falsify-check.sh" }
         ]
@@ -79,11 +81,14 @@ under `hooks.PreToolUse`:
 For strict mode (hard block):
 
 ```bash
-export PRAXIS_EXTERNAL_WRITE_STRICT=1
+export PRAXIS_EXTERNAL_WRITE_STRICT=1   # Check 1: hypothesis markers
+export PRAXIS_AUTHOR_EXEMPT_STRICT=1    # Check 2: author-exempt identifiers
+export PRAXIS_CLUSTER_APPROVAL_STRICT=1 # Check 3: cluster-approval staging
 ```
 
-Strict-mode env var accepts the **literal value `1` only** — `true` / `yes` / `on`
-do NOT activate strict mode (defaults to advisory).
+Each env var controls its own check independently. All accept the **literal
+value `1` only** — `true` / `yes` / `on` do NOT activate strict mode (defaults
+to advisory).
 
 Restart Claude Code after adding the entry.
 
@@ -182,13 +187,70 @@ Inherited from `_hook_utils.safe_tokenize` (same primitive as
 - Subshells (`$(...)`) are opaque to shlex — not decomposed (same
   acknowledged limitation as the sibling hooks).
 
+### Cluster-approval detection (issue #276)
+
+A third advisory fires when:
+
+1. **Tool call**: `Write` tool targeting a staging path
+   - `/tmp/*-issue-*.md`
+   - `/tmp/*-pr-*.md`
+   - `.omc/plans/*.md`
+2. **Transcript signal**: cluster-approval language appears in any of the
+   last 5 user messages in the transcript.
+
+This catches the CLAUDE.md `No Approval Transfer Across Companion PRs`
+violation pattern: a user approves multiple tasks in bulk ("all 4 together",
+"1+3 같이"), and the agent begins writing per-child staging files without
+per-action AskUserQuestion surfacing.
+
+#### Cluster-approval patterns (English)
+
+- `\b\d+ buckets? together\b` — e.g., "4 buckets together"
+- `\ball \d+ as separate\b` — e.g., "all 4 as separate"
+- `\bas approved above\b`
+- `\bcluster (i|we) approved\b`
+- `\ball \d+\b.{0,50}\bapprov\w*` — e.g., "all 4 approved", "all 4 go ahead and approv*"
+
+#### Cluster-approval patterns (Korean)
+
+- `\d+개\s*모두` — e.g., "4개 모두"
+- `\d+\s*\+\s*\d+\s*같이` — e.g., "1+3 같이"
+- `모두\s*승인`
+
+#### Advisory text
+
+```text
+REMINDER (External-Surface Write / Cluster-Approval): cluster-approval
+language detected in a recent user message.
+Cluster approvals ("all N together", "1+3 같이", "as approved above")
+do NOT auto-transfer to per-action staging writes.
+Each child mutation (issue draft, PR body) requires its own explicit
+per-action surfacing via AskUserQuestion.
+Surface a dedicated AskUserQuestion for this specific action before
+writing to a staging path.
+Set PRAXIS_CLUSTER_APPROVAL_STRICT=1 to convert this advisory into a
+hard block (exit 2).
+```
+
+Default: advisory (exit 0). Set `PRAXIS_CLUSTER_APPROVAL_STRICT=1` for
+hard block (exit 2).
+
+#### Known limits
+
+- Requires `transcript_path` in the hook payload and a readable transcript
+  file. If absent, the check fails-open (no advisory).
+- Only the last 5 user messages (within the last 400 JSONL lines) are
+  scanned — cluster approval signaled longer ago may not be detected.
+- Staging path matching is suffix-based (`$` anchor). Paths that embed
+  the pattern mid-string are not matched.
+
 ### Tests
 
 ```bash
 bash tests/test_external_write_falsify_check.sh
 ```
 
-Covers 28 cases across the warn / silent / strict-block dimensions:
+Covers 34 cases across the warn / silent / strict-block dimensions:
 `gh` write subcommands (`comment`, `create`, `edit`, `review`) with each
 body flag form (`--body`, `-b`, `--body-file`, `-F`, `--body=value`),
 MCP slack / notion writes including nested shapes (Notion
@@ -197,9 +259,12 @@ MCP slack / notion writes including nested shapes (Notion
 that property metadata (`properties.{name}.title[].text.content`) does
 not surface as body, Korean marker, verified-claim silent paths,
 non-write commands (`gh list` / `gh search`), chained Bash writes,
-strict env toggle, malformed-JSON fail-open, and 3 author-exempt cases
+strict env toggle, malformed-JSON fail-open, 3 author-exempt cases
 (mapping table without verification, mapping table with transcript
-`gh label list`, bash code block with column name).
+`gh label list`, bash code block with column name), and 6 cluster-approval
+cases (EN pattern + staging path, KO pattern + staging path, EN pattern +
+non-staging path, staging path without cluster-approval language, strict
+mode block, no-transcript fail-open).
 
 ### Evidence-trail follow-up
 

--- a/hooks/external-write-falsify-check.py
+++ b/hooks/external-write-falsify-check.py
@@ -11,6 +11,9 @@ This hook detects:
     flag (`--body`, `-b`, `--body-file`, `-F`)
   - MCP tool calls writing to chat / docs surfaces (slack send/post,
     notion create_page / update_page)
+  - Write tool calls to staging paths (/tmp/*-issue-*.md, /tmp/*-pr-*.md,
+    .omc/plans/*.md) when cluster-approval language is found in recent user
+    messages (issue #276)
 
 When the body contains hypothesis markers (might / could / potentially / appears
 to / is failing / 가설 / 추정), it emits a stderr advisory reminding the user
@@ -24,7 +27,8 @@ it emits a separate advisory (issue #183).
 Exits 0 by default — this is an advisory, not a block. Set
 `PRAXIS_EXTERNAL_WRITE_STRICT=1` to convert hypothesis-marker detection into a
 hard block (exit 2). Set `PRAXIS_AUTHOR_EXEMPT_STRICT=1` to convert author-exempt
-detection into a hard block (exit 2).
+detection into a hard block (exit 2). Set `PRAXIS_CLUSTER_APPROVAL_STRICT=1` to
+convert cluster-approval staging detection into a hard block (exit 2).
 
 Uses shlex tokenization (same approach as block-gh-state-all.py / side-effect-scan.py)
 so that pattern references inside quoted strings, echo arguments, or comments
@@ -413,6 +417,113 @@ AUTHOR_EXEMPT_ADVISORY = (
 )
 
 
+# ---------------------------------------------------------------------------
+# Cluster-approval language detection (issue #276)
+# ---------------------------------------------------------------------------
+# Detects the pattern: user approves a cluster of tasks in bulk ("all 4 together",
+# "1+3 같이"), then the agent writes directly to a staging path without
+# per-action surfacing. CLAUDE.md rule: "No Approval Transfer Across Companion PRs".
+
+_USER_MSG_SCAN_COUNT = 5
+
+# Patterns that indicate a cluster/bulk approval by the user.
+CLUSTER_APPROVAL_PATTERNS = (
+    # English — exact phrases from the issue spec
+    re.compile(r"\b\d+\s+buckets?\s+together\b", re.IGNORECASE),
+    re.compile(r"\ball\s+\d+\s+as\s+separate\b", re.IGNORECASE),
+    re.compile(r"\bas\s+approved\s+above\b", re.IGNORECASE),
+    re.compile(r"\bcluster\s+(?:i|we)\s+approved\b", re.IGNORECASE),
+    # "all N ... approv*" within 50 chars (e.g. "all 4 approved", "all 4 go ahead")
+    re.compile(r"\ball\s+\d+\b.{0,50}\bapprov\w*", re.IGNORECASE),
+    # Korean — from issue spec
+    re.compile(r"\d+개\s*모두"),
+    re.compile(r"\d+\s*\+\s*\d+\s*같이"),
+    re.compile(r"모두\s*승인"),
+)
+
+# Staging paths: intermediate draft files, not final external-surface targets.
+STAGING_PATH_PATTERNS = (
+    re.compile(r"/tmp/[^/\s]*-issue-[^/\s]*\.md$"),
+    re.compile(r"/tmp/[^/\s]*-pr-[^/\s]*\.md$"),
+    re.compile(r"\.omc/plans/[^/\s]*\.md$"),
+)
+
+CLUSTER_APPROVAL_ADVISORY = (
+    "REMINDER (External-Surface Write / Cluster-Approval): cluster-approval "
+    "language detected in a recent user message.\n"
+    "Cluster approvals (\"all N together\", \"1+3 같이\", \"as approved above\") "
+    "do NOT auto-transfer to per-action staging writes.\n"
+    "Each child mutation (issue draft, PR body) requires its own explicit "
+    "per-action surfacing via AskUserQuestion.\n"
+    "Surface a dedicated AskUserQuestion for this specific action before "
+    "writing to a staging path.\n"
+    "Set PRAXIS_CLUSTER_APPROVAL_STRICT=1 to convert this advisory into a "
+    "hard block (exit 2).\n"
+)
+
+
+def _recent_user_messages(transcript_path: str, count: int) -> list[str]:
+    """Return text from the last `count` user messages in the transcript.
+
+    Scans the last _TRANSCRIPT_SCAN_LINES JSONL entries in reverse so that
+    the most-recent user messages are returned first (index 0 = most recent).
+    """
+    if not transcript_path or not os.path.isfile(transcript_path):
+        return []
+    try:
+        with open(transcript_path, "r", encoding="utf-8", errors="replace") as fh:
+            lines = fh.readlines()
+    except OSError:
+        return []
+
+    msgs: list[str] = []
+    for line in reversed(lines[-_TRANSCRIPT_SCAN_LINES:]):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(entry, dict):
+            continue
+        msg = entry.get("message") or {}
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            continue
+        content = msg.get("content") or ""
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list):
+            parts = []
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    parts.append(block.get("text", ""))
+            text = "\n".join(parts)
+        else:
+            continue
+        if text.strip():
+            msgs.append(text)
+        if len(msgs) >= count:
+            break
+    return msgs
+
+
+def _has_cluster_approval(user_messages: list[str]) -> bool:
+    """Return True if any recent user message contains cluster-approval language."""
+    for msg in user_messages:
+        for pat in CLUSTER_APPROVAL_PATTERNS:
+            if pat.search(msg):
+                return True
+    return False
+
+
+def _is_staging_path(file_path: str) -> bool:
+    """Return True if file_path matches a recognized staging path pattern."""
+    if not file_path:
+        return False
+    return any(pat.search(file_path) for pat in STAGING_PATH_PATTERNS)
+
+
 def main() -> int:
     try:
         payload = json.load(sys.stdin)
@@ -443,6 +554,16 @@ def main() -> int:
         mcp_body = _extract_mcp_body(tool_input)
         if mcp_body:
             all_bodies.append(mcp_body)
+    elif tool_name == "Write":
+        # --- Check 3: cluster-approval + staging path (issue #276) ---
+        file_path = tool_input.get("file_path", "") or ""
+        if _is_staging_path(file_path):
+            user_msgs = _recent_user_messages(transcript_path, _USER_MSG_SCAN_COUNT)
+            if _has_cluster_approval(user_msgs):
+                sys.stderr.write(CLUSTER_APPROVAL_ADVISORY)
+                if os.environ.get("PRAXIS_CLUSTER_APPROVAL_STRICT") == "1":
+                    return 2
+        return 0
     else:
         return 0
 

--- a/tests/test_external_write_falsify_check.sh
+++ b/tests/test_external_write_falsify_check.sh
@@ -36,8 +36,10 @@ run_case() {
   err_file=$(mktemp)
   if [ "$strict" = "strict" ]; then
     echo "$payload" | PRAXIS_EXTERNAL_WRITE_STRICT=1 python3 "$HOOK" >/dev/null 2>"$err_file"
+  elif [ "$strict" = "cluster_strict" ]; then
+    echo "$payload" | PRAXIS_CLUSTER_APPROVAL_STRICT=1 python3 "$HOOK" >/dev/null 2>"$err_file"
   else
-    echo "$payload" | env -u PRAXIS_EXTERNAL_WRITE_STRICT python3 "$HOOK" >/dev/null 2>"$err_file"
+    echo "$payload" | env -u PRAXIS_EXTERNAL_WRITE_STRICT -u PRAXIS_CLUSTER_APPROVAL_STRICT python3 "$HOOK" >/dev/null 2>"$err_file"
   fi
   local rc=$?
   local err
@@ -215,6 +217,63 @@ run_case "author-exempt: bash code block column name (warn)" \
   "warn" "advisory" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh pr create --body-file $AE_BODY_FILE\"}}"
 rm -f "$AE_BODY_FILE"
+
+# --- cluster-approval: staging path detection (issue #276) ---
+
+# Cluster approval in transcript + staging path Write → advisory fires.
+CA_TRANSCRIPT=$(mktemp)
+printf '%s\n' \
+  '{"message":{"role":"user","content":[{"type":"text","text":"all 4 as separate issues, go ahead and approve them all"}]}}' \
+  > "$CA_TRANSCRIPT"
+run_case "cluster-approval: EN pattern + staging /tmp/-issue-.md Write (warn)" \
+  "warn" "advisory" \
+  "{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"/tmp/praxis-issue-b2.md\",\"content\":\"draft\"},\"transcript_path\":\"$CA_TRANSCRIPT\"}"
+rm -f "$CA_TRANSCRIPT"
+
+# Korean cluster approval ("1+3 같이") + staging path → advisory fires.
+CA_TRANSCRIPT_KO=$(mktemp)
+printf '%s\n' \
+  '{"message":{"role":"user","content":[{"type":"text","text":"1+3 같이 진행해줘"}]}}' \
+  > "$CA_TRANSCRIPT_KO"
+run_case "cluster-approval: KO pattern + staging .omc/plans/ Write (warn)" \
+  "warn" "advisory" \
+  "{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"/Users/dev/repo/.omc/plans/batch-issue.md\",\"content\":\"draft\"},\"transcript_path\":\"$CA_TRANSCRIPT_KO\"}"
+rm -f "$CA_TRANSCRIPT_KO"
+
+# Cluster approval in transcript but Write to non-staging path → no advisory.
+CA_TRANSCRIPT2=$(mktemp)
+printf '%s\n' \
+  '{"message":{"role":"user","content":[{"type":"text","text":"all 4 together approved"}]}}' \
+  > "$CA_TRANSCRIPT2"
+run_case "cluster-approval: EN pattern + non-staging path (silent)" \
+  "silent" "advisory" \
+  "{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"/Users/dev/repo/README.md\",\"content\":\"docs\"},\"transcript_path\":\"$CA_TRANSCRIPT2\"}"
+rm -f "$CA_TRANSCRIPT2"
+
+# Staging path but no cluster-approval language in recent user messages → no advisory.
+EMPTY_TRANSCRIPT=$(mktemp)
+printf '%s\n' \
+  '{"message":{"role":"user","content":[{"type":"text","text":"please write the draft for issue 42"}]}}' \
+  > "$EMPTY_TRANSCRIPT"
+run_case "cluster-approval: staging path but no cluster-approval language (silent)" \
+  "silent" "advisory" \
+  "{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"/tmp/task-issue-42.md\",\"content\":\"draft\"},\"transcript_path\":\"$EMPTY_TRANSCRIPT\"}"
+rm -f "$EMPTY_TRANSCRIPT"
+
+# Write tool, staging path, cluster approval, strict mode → block.
+CA_TRANSCRIPT_STRICT=$(mktemp)
+printf '%s\n' \
+  '{"message":{"role":"user","content":[{"type":"text","text":"4 buckets together, all approved"}]}}' \
+  > "$CA_TRANSCRIPT_STRICT"
+run_case "cluster-approval: strict mode + staging path (block)" \
+  "block" "cluster_strict" \
+  "{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"/tmp/praxis-pr-fix.md\",\"content\":\"draft\"},\"transcript_path\":\"$CA_TRANSCRIPT_STRICT\"}"
+rm -f "$CA_TRANSCRIPT_STRICT"
+
+# Write tool with no transcript_path → fail-open (no advisory).
+run_case "cluster-approval: Write + staging path + no transcript (silent)" \
+  "silent" "advisory" \
+  '{"tool_name":"Write","tool_input":{"file_path":"/tmp/praxis-issue-x.md","content":"draft"}}'
 
 echo ""
 echo "Result: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## 변경 요약

`hooks/external-write-falsify-check.py`에 **Check 3: cluster-approval 언어 감지** 로직을 추가합니다.

### 배경

CLAUDE.md 규칙 `No Approval Transfer Across Companion PRs`에 따라, 사용자가 cluster-approval 표현("all 4 as separate", "1+3 같이")으로 다단 작업을 한 번에 승인한 직후, 각 child mutation을 per-action surfacing 없이 진행하는 패턴이 반복 발생하였습니다. 기존 `external-write-falsify-check` hook은 hypothesis 언어와 author-exempt 식별자는 다루지만 cluster-approval transfer는 다루지 않았습니다.

### 구현 내용

**`hooks/external-write-falsify-check.py`**

- `CLUSTER_APPROVAL_PATTERNS`: EN/KO cluster-approval regex 패턴 8개
- `STAGING_PATH_PATTERNS`: `/tmp/*-issue-*.md`, `/tmp/*-pr-*.md`, `.omc/plans/*.md`
- `_recent_user_messages()`: transcript 마지막 5 user message 역방향 스캔
- `_has_cluster_approval()`: 패턴 매치 여부 반환
- `_is_staging_path()`: staging path 판별
- `CLUSTER_APPROVAL_ADVISORY`: advisory 메시지
- `main()` 내 `elif tool_name == "Write":` — staging path + cluster-approval 동시 감지 시 advisory emit
- `PRAXIS_CLUSTER_APPROVAL_STRICT=1`: hard block(exit 2) 전환 옵션

**`tests/test_external_write_falsify_check.sh`**

- 6개 신규 케이스 추가 (34개 전체 통과):
  - EN pattern + `/tmp/*-issue-*.md` Write → warn
  - KO pattern + `.omc/plans/*.md` Write → warn
  - EN pattern + non-staging path → silent (false positive 가드)
  - staging path + cluster-approval 없음 → silent (false positive 가드)
  - strict mode → block
  - transcript 없음 → silent (fail-open 가드)

**`docs/hook/external-write-falsify-check.md`**

- "What is warned" 테이블에 Write tool 행 추가
- strict mode 환경변수 목록 업데이트 (3개 독립 vars)
- 매처 예시에 `Write` 추가
- "Cluster-approval detection (issue #276)" 섹션 신규 추가
- 테스트 케이스 수 28→34 업데이트

### 수용 기준 검증

- [x] `hooks/external-write-falsify-check.py` — cluster-approval-language 감지 패턴 추가
- [x] 신규 테스트: cluster approval 후 staging Write → advisory fire
- [x] False-positive 가드: cluster approval 없이 staging Write → no advisory
- [x] `docs/hook/external-write-falsify-check.md` 업데이트

### 테스트 출력

```
Result: 34 passed, 0 failed
```

Caller chain verified: 이 PR은 `devseunggwan/praxis` 레포 단일 범위이며 크로스 레포 영향 없음.

Closes #276
