### PR TITLE
feat(hook): escalate to ask on (Recommended) without Falsified:

### DIFF
--- a/docs/hook/output-block-falsify-advisory.md
+++ b/docs/hook/output-block-falsify-advisory.md
@@ -1,9 +1,9 @@
-# PreToolUse Output-Block Falsification Advisory
+# PreToolUse Output-Block Falsification Advisory + Ask-Escalation
 
 `hooks/output-block-falsify-advisory.py` fires on every `PreToolUse` event
 for `AskUserQuestion` and `Bash` tool calls. It detects two surfaces where
 a self-authored proposal block is about to be surfaced without a falsification
-check and emits an advisory reminder.
+check and either asks for confirmation or emits an advisory reminder.
 
 ### Why this exists
 
@@ -13,37 +13,50 @@ The global CLAUDE.md rule **"Output-Block-Level Falsification Gate"** instructs:
 > an explicit falsification test on its premise. If a concrete invalidating
 > link/artifact exists — STOP. Do not surface the proposal.
 
-Despite this rule being loaded into context (4+ memory entries accumulated
+And **"Self-Falsify Before Recommendation Lock"** adds:
+
+> When labeling an option as `(Recommended)`, design and execute a disconfirming
+> test of the recommendation's own premise BEFORE surfacing. State explicitly
+> 'if this recommendation is wrong, what observation should be missing?' and
+> confirm that observation is in fact missing.
+
+Despite these rules being loaded into context (4+ memory entries accumulated
 2026-05-03 through 2026-05-13), the retrieval trigger does not fire at the
-specific moment the proposal block is authored. The pattern is consistent:
-same-session repeats where a wrong-framing issue cancelled at T+0 recurs
-with an identical anti-pattern at T+1h.
+specific moment the proposal block is authored. A 2026-05-17 retrospect session
+confirmed 4/4 `(Recommended)` surfaces lacked verifiable Falsified: evidence.
 
 Text rules and MEMORY.md entries alone have proven insufficient to prevent
 recurrence. A structural hook moves the gate to the tool-call use-site.
 
-Reference: issue [#221](https://github.com/devseunggwan/praxis/issues/221).
-
-**Escalation criteria:** After ~1 month of advisory operation (target: ~2026-06-15),
-evaluate recurrence rate. If advisory is repeatedly bypassed without falsification,
-escalate to blocking (`exit 2`) for the `AskUserQuestion` `(Recommended)` surface.
+References: issue [#221](https://github.com/devseunggwan/praxis/issues/221) (advisory),
+[#290](https://github.com/devseunggwan/praxis/issues/290) (ask escalation).
 
 ### What is detected
 
-| Tool | Trigger condition | Advisory emitted |
-|------|-----------------|-----------------|
-| `AskUserQuestion` | Any option `label` contains `(Recommended)` or `(추천)` (case-insensitive for English form) | Yes |
-| `Bash` | Command matches a bulk-action mutation keyword (see table below) | Yes |
+| Tool | Trigger condition | Decision |
+|------|-----------------|----------|
+| `AskUserQuestion` | Option `label` contains exact `(Recommended)` or `(추천)` AND question body has no `Falsified:` line | `permissionDecision: ask` |
+| `AskUserQuestion` | Option `label` contains exact `(Recommended)` or `(추천)` AND question body has `Falsified:` line | Silent pass |
+| `AskUserQuestion` | Option `label` contains `(recommended)` (case-insensitive, not exact) | Advisory stderr |
+| `Bash` | Command matches a bulk-action mutation keyword (see table below) | Advisory stderr |
 | Any other tool | — | Silent pass-through |
 | Malformed payload / missing field | — | Silent fail-open |
 
-**This hook never blocks.** Advisory mode only — exit 0 in all cases.
-
-#### AskUserQuestion: (Recommended) marker
+#### AskUserQuestion: (Recommended) marker and Falsified: gate
 
 `(Recommended)` and `(추천)` in option labels are the canonical signal for a
-self-authored proposal block about to be surfaced. The CLAUDE.md rule names
-`(Recommended)` as a primary trigger for the falsification gate.
+self-authored proposal block about to be surfaced. When these exact tokens
+(case-sensitive, including parentheses) are detected, the hook checks the
+`question` field of each question object for a line that starts with `Falsified:`
+(exact prefix at line start, as in `Falsified: checked no existing PR — none found`).
+
+- **`Falsified:` present** → silent pass. The model has provided verifiable
+  evidence of a disconfirming test.
+- **`Falsified:` absent** → `permissionDecision: ask`. The model must add the
+  falsification line and retry.
+
+Only `options[].label` is scanned for the marker — `options[].description` text
+that incidentally contains `(Recommended)` does not trigger the gate.
 
 #### Bash: bulk-action mutation keywords
 
@@ -59,6 +72,24 @@ matched; read-only commands (`git log --all`, `gh pr list`) do not fire.
 
 ### Response shape
 
+#### Ask-escalation (AskUserQuestion with exact `(Recommended)` / `(추천)`, no `Falsified:`)
+
+**JSON to stdout:**
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": "(Recommended) 라벨이 있으나 question body 에 'Falsified: <disconfirming test 결과>' 가 없음. CLAUDE.md Self-Falsify Before Recommendation Lock 룰. 추가 후 재시도."
+  }
+}
+```
+
+**Exit code:** `0`.
+
+#### Advisory (Bash bulk-action, or case-insensitive `(recommended)` only)
+
 **Advisory message** (emitted to stderr, never stdout):
 
 ```
@@ -69,11 +100,7 @@ proposal in this session? If yes — STOP and cite the invalidating link
 instead of surfacing the proposal.
 ```
 
-**Exit code:** always `0` (never blocks).
-
-**JSON response:** none — the hook communicates via stderr only
-(`additionalContext` in Claude Code's terminology). Claude Code reads stderr
-from advisory PreToolUse hooks and includes it in the model's context.
+**Exit code:** `0`.
 
 ### Parsing guarantees
 
@@ -95,24 +122,33 @@ All parsing is done with the Python standard library only.
 bash tests/test_output_block_falsify_advisory.sh
 ```
 
-Covers 10 cases:
+Covers 26 cases:
 
-**Positive (AskUserQuestion):**
-- Option label `(Recommended)` → advisory emitted
-- Option label `(추천)` → advisory emitted
+**Ask-escalation (AskUserQuestion, issue #290):**
+- Option label `(Recommended)` + no `Falsified:` in question body → `permissionDecision: ask`
+- Option label `(추천)` + no `Falsified:` → `permissionDecision: ask`
+- Option label `(Recommended)` + `Falsified:` line present → silent pass
+- `(Recommended)` appears in `options[].description` only (not label) → silent pass (false positive guard)
+- Non-recommended option labels → silent pass
 
-**Negative (AskUserQuestion):**
-- Option labels without marker → silent pass
+**Advisory (AskUserQuestion, case-insensitive fallback):**
+- Option label `(recommended)` lowercase only → advisory emitted
 
-**Positive (Bash):**
-- `gh pr merge --all` with "merge all" phrasing → advisory emitted
-- `gh issue close --all` with "close all" phrasing → advisory emitted
-- Korean: `모두 삭제` → advisory emitted
+**Pass (AskUserQuestion):**
+- Option labels without any marker → silent pass
+- Empty options → silent pass
 
-**Negative (Bash):**
-- `git status` → silent pass
-- `gh pr list --all` (read-only, no mutation verb) → silent pass
+**Advisory (Bash):**
+- `merge all`, `close all`, `delete all` (English) → advisory emitted
+- Korean: `모두 삭제`, `전부 머지`, `다 머지` → advisory emitted
+
+**Pass (Bash):**
+- `git status`, `gh pr list --state open` (read-only) → silent pass
+- `git log --all` (--all flag, no mutation verb) → silent pass
+- `disclose all`, `enclose all` (word-boundary regression) → silent pass
 
 **Edge:**
 - Malformed JSON stdin → exit 0, silent pass
 - Empty payload → exit 0, silent pass
+- Unknown tool name → exit 0, silent pass
+- Non-string command (int / null) → exit 0, silent pass

--- a/hooks/output-block-falsify-advisory.py
+++ b/hooks/output-block-falsify-advisory.py
@@ -1,25 +1,24 @@
 #!/usr/bin/env python3
-"""PreToolUse advisory: nudge output-block falsification gate.
+"""PreToolUse advisory + ask-escalation: output-block falsification gate.
 
-Issue #221. Recurring failure mode: the "Output-Block-Level Falsification Gate"
-rule in CLAUDE.md (4+ memory entries accumulated 2026-05-03 through 2026-05-13)
-fails to fire at output time because rule retrieval is not structural — the rule
-is loaded but not re-triggered at the moment the proposal block is authored.
+Issue #221 (advisory), #290 (ask escalation). Recurring failure mode: the
+"Output-Block-Level Falsification Gate" rule in CLAUDE.md (4+ memory entries
+accumulated 2026-05-03 through 2026-05-13) fails to fire at output time because
+rule retrieval is not structural — the rule is loaded but not re-triggered at
+the moment the proposal block is authored.
 
 This hook adds a structural enforcement point at two surfaces:
 
-  1. AskUserQuestion — option labels containing "(Recommended)" or "(추천)"
-     These markers are the canonical signal for a self-authored proposal block
-     about to be surfaced to the user.
+  1. AskUserQuestion — option labels containing "(Recommended)" or "(추천)":
+     - Exact case-sensitive match ("(Recommended)" / "(추천)"):
+       Escalate to `permissionDecision: ask` if the question body lacks a
+       `Falsified:` line (exact prefix at line start). If `Falsified:` IS
+       present, silent pass.
+     - Case-insensitive match only (e.g. "(recommended)" lowercase):
+       Advisory stderr reminder (original behavior).
 
   2. Bash — bulk-action commands containing patterns like "close all",
-     "delete all", "merge all" (+ Korean equivalents), which may reflect a
-     consequence of a proposal block whose premise was not falsified.
-
-When detected, an advisory stderr reminder is emitted asking whether the
-output-block falsification gate has been run. The hook NEVER blocks (exit 0
-always). Advisory mode is the only mode; escalation to blocking will be
-evaluated after ~1 month of advisory operation.
+     "delete all", "merge all" (+ Korean equivalents). Advisory only.
 
 Fail-open contract (project hook design):
   - Malformed / missing stdin JSON → exit 0
@@ -34,7 +33,7 @@ import re
 import sys
 
 # ---------------------------------------------------------------------------
-# Advisory message
+# Messages
 # ---------------------------------------------------------------------------
 
 ADVISORY_MSG = (
@@ -45,11 +44,21 @@ ADVISORY_MSG = (
     "instead of surfacing the proposal."
 )
 
+ASK_MSG = (
+    "(Recommended) 라벨이 있으나 question body 에 "
+    "'Falsified: <disconfirming test 결과>' 가 없음. "
+    "CLAUDE.md Self-Falsify Before Recommendation Lock 룰. 추가 후 재시도."
+)
+
 # ---------------------------------------------------------------------------
 # AskUserQuestion: (Recommended) / (추천) marker detection
 # ---------------------------------------------------------------------------
 
-# Substrings to search for in option labels (case-insensitive for English form).
+# Exact tokens for ask-escalation (case-sensitive, includes parentheses).
+RECOMMENDED_MARKERS_EXACT_EN = ("(Recommended)",)
+RECOMMENDED_MARKERS_EXACT_KO = ("(추천)",)
+
+# Substrings for fallback advisory (case-insensitive for English form).
 RECOMMENDED_MARKERS_EN = ("(Recommended)",)
 RECOMMENDED_MARKERS_KO = ("(추천)",)
 
@@ -79,6 +88,44 @@ def _collect_option_labels(tool_input: dict) -> list[str]:
     return labels
 
 
+def _collect_question_texts(tool_input: dict) -> list[str]:
+    """Collect questions[].question text strings from all question objects."""
+    texts: list[str] = []
+    questions = tool_input.get("questions") or []
+    if not isinstance(questions, list):
+        return texts
+    for q in questions:
+        if not isinstance(q, dict):
+            continue
+        text = q.get("question")
+        if isinstance(text, str):
+            texts.append(text)
+    return texts
+
+
+def _has_exact_recommended_marker(labels: list[str]) -> bool:
+    """True if any label contains exact (Recommended) or (추천) (case-sensitive)."""
+    if not labels:
+        return False
+    for label in labels:
+        for marker in RECOMMENDED_MARKERS_EXACT_EN:
+            if marker in label:
+                return True
+        for marker in RECOMMENDED_MARKERS_EXACT_KO:
+            if marker in label:
+                return True
+    return False
+
+
+def _has_falsified_line(texts: list[str]) -> bool:
+    """True if any question text has a line beginning with 'Falsified:' (exact prefix)."""
+    for text in texts:
+        for line in text.splitlines():
+            if line.startswith("Falsified:"):
+                return True
+    return False
+
+
 def _has_recommended_marker(labels: list[str]) -> bool:
     """True if any option label contains a (Recommended) / (추천) marker."""
     if not labels:
@@ -92,6 +139,21 @@ def _has_recommended_marker(labels: list[str]) -> bool:
             if marker in label:
                 return True
     return False
+
+
+def _emit_ask(message: str) -> None:
+    """Output permissionDecision: ask JSON to stdout."""
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "ask",
+                "permissionDecisionReason": message,
+            }
+        },
+        sys.stdout,
+    )
+    sys.stdout.write("\n")
 
 
 # ---------------------------------------------------------------------------
@@ -162,20 +224,21 @@ def _main_inner() -> int:
     if not isinstance(tool_input, dict):
         return 0
 
-    fire = False
-
     if tool_name == "AskUserQuestion":
         labels = _collect_option_labels(tool_input)
-        if _has_recommended_marker(labels):
-            fire = True
+        if _has_exact_recommended_marker(labels):
+            # Ask-escalation path: check for Falsified: evidence in question body.
+            texts = _collect_question_texts(tool_input)
+            if not _has_falsified_line(texts):
+                _emit_ask(ASK_MSG)
+        elif _has_recommended_marker(labels):
+            # Fallback advisory: case-insensitive match (e.g. lowercase "(recommended)").
+            sys.stderr.write(ADVISORY_MSG + "\n")
 
     elif tool_name == "Bash":
         command = tool_input.get("command")
         if isinstance(command, str) and _is_bulk_action_command(command):
-            fire = True
-
-    if fire:
-        sys.stderr.write(ADVISORY_MSG + "\n")
+            sys.stderr.write(ADVISORY_MSG + "\n")
 
     return 0
 

--- a/hooks/output-block-falsify-advisory.py
+++ b/hooks/output-block-falsify-advisory.py
@@ -63,46 +63,6 @@ RECOMMENDED_MARKERS_EN = ("(Recommended)",)
 RECOMMENDED_MARKERS_KO = ("(추천)",)
 
 
-def _collect_option_labels(tool_input: dict) -> list[str]:
-    """Walk questions[].options[].label and return all label strings.
-
-    Tolerant of partial schemas — any missing field returns an empty list.
-    Hook must never crash on malformed payloads.
-    """
-    labels: list[str] = []
-    questions = tool_input.get("questions") or []
-    if not isinstance(questions, list):
-        return labels
-    for q in questions:
-        if not isinstance(q, dict):
-            continue
-        options = q.get("options") or []
-        if not isinstance(options, list):
-            continue
-        for o in options:
-            if not isinstance(o, dict):
-                continue
-            label = o.get("label")
-            if isinstance(label, str):
-                labels.append(label)
-    return labels
-
-
-def _collect_question_texts(tool_input: dict) -> list[str]:
-    """Collect questions[].question text strings from all question objects."""
-    texts: list[str] = []
-    questions = tool_input.get("questions") or []
-    if not isinstance(questions, list):
-        return texts
-    for q in questions:
-        if not isinstance(q, dict):
-            continue
-        text = q.get("question")
-        if isinstance(text, str):
-            texts.append(text)
-    return texts
-
-
 def _has_exact_recommended_marker(labels: list[str]) -> bool:
     """True if any label contains exact (Recommended) or (추천) (case-sensitive)."""
     if not labels:
@@ -225,14 +185,36 @@ def _main_inner() -> int:
         return 0
 
     if tool_name == "AskUserQuestion":
-        labels = _collect_option_labels(tool_input)
-        if _has_exact_recommended_marker(labels):
-            # Ask-escalation path: check for Falsified: evidence in question body.
-            texts = _collect_question_texts(tool_input)
-            if not _has_falsified_line(texts):
-                _emit_ask(ASK_MSG)
-        elif _has_recommended_marker(labels):
-            # Fallback advisory: case-insensitive match (e.g. lowercase "(recommended)").
+        questions = tool_input.get("questions") or []
+        if not isinstance(questions, list):
+            questions = []
+        ask_needed = False
+        advisory_needed = False
+        for q in questions:
+            if not isinstance(q, dict):
+                continue
+            options = q.get("options") or []
+            if not isinstance(options, list):
+                continue
+            q_labels: list[str] = []
+            for o in options:
+                if isinstance(o, dict):
+                    label = o.get("label")
+                    if isinstance(label, str):
+                        q_labels.append(label)
+            if _has_exact_recommended_marker(q_labels):
+                # Per-question check: only this question's text counts.
+                q_text = q.get("question")
+                q_texts = [q_text] if isinstance(q_text, str) else []
+                if not _has_falsified_line(q_texts):
+                    ask_needed = True
+                    break  # one missing question is enough to escalate
+            elif _has_recommended_marker(q_labels):
+                advisory_needed = True
+
+        if ask_needed:
+            _emit_ask(ASK_MSG)
+        elif advisory_needed:
             sys.stderr.write(ADVISORY_MSG + "\n")
 
     elif tool_name == "Bash":

--- a/tests/test_output_block_falsify_advisory.sh
+++ b/tests/test_output_block_falsify_advisory.sh
@@ -31,17 +31,20 @@ FAILED_NAMES=()
 # run_case name expectation payload
 #   expectation:
 #     "advisory:<substring>" — exit 0 + stderr contains <substring>
+#     "ask:<substring>"       — exit 0 + stdout JSON has permissionDecision:ask + substring
 #     "pass"                  — exit 0 + stderr empty
 run_case() {
   local name="$1" expectation="$2" payload="$3"
 
-  local err_file
+  local out_file err_file
+  out_file=$(mktemp)
   err_file=$(mktemp)
-  printf '%s' "$payload" | "$HOOK" >/dev/null 2>"$err_file"
+  printf '%s' "$payload" | "$HOOK" >"$out_file" 2>"$err_file"
   local rc=$?
-  local err
+  local out err
+  out=$(cat "$out_file")
   err=$(cat "$err_file")
-  rm -f "$err_file"
+  rm -f "$out_file" "$err_file"
 
   local ok=1
   case "$expectation" in
@@ -49,6 +52,25 @@ run_case() {
       local needle="${expectation#advisory:}"
       [ "$rc" -eq 0 ] || ok=0
       case "$err" in
+        *"$needle"*) ;;
+        *) ok=0 ;;
+      esac
+      ;;
+    ask:*)
+      local needle="${expectation#ask:}"
+      [ "$rc" -eq 0 ] || ok=0
+      local decision
+      decision=$(python3 -c "
+import json, sys
+try:
+    d = json.loads(sys.argv[1])
+    h = d.get('hookSpecificOutput', {})
+    print(h.get('permissionDecision', ''))
+except Exception:
+    print('')
+" "$out" 2>/dev/null)
+      [ "$decision" = "ask" ] || ok=0
+      case "$out" in
         *"$needle"*) ;;
         *) ok=0 ;;
       esac
@@ -99,6 +121,55 @@ print(json.dumps(payload))
 " "$1"
 }
 
+make_ask_payload_with_question() {
+  # $1 = JSON array of option label strings (already JSON-encoded)
+  # $2 = question text (plain string)
+  python3 -c "
+import json, sys
+labels = json.loads(sys.argv[1])
+question_text = sys.argv[2]
+options = [{'label': l} for l in labels]
+payload = {
+    'session_id': 'test-session',
+    'tool_name': 'AskUserQuestion',
+    'tool_input': {
+        'questions': [
+            {
+                'question': question_text,
+                'options': options,
+            }
+        ]
+    },
+    'cwd': '/tmp',
+}
+print(json.dumps(payload))
+" "$1" "$2"
+}
+
+make_ask_payload_description_only() {
+  # Payload where (Recommended) appears in options[].description, NOT in label.
+  python3 -c "
+import json
+payload = {
+    'session_id': 'test-session',
+    'tool_name': 'AskUserQuestion',
+    'tool_input': {
+        'questions': [
+            {
+                'question': 'Which approach?',
+                'options': [
+                    {'label': 'Option A', 'description': 'This is the (Recommended) path.'},
+                    {'label': 'Option B', 'description': 'Alternative'},
+                ],
+            }
+        ]
+    },
+    'cwd': '/tmp',
+}
+print(json.dumps(payload))
+"
+}
+
 make_bash_payload() {
   # $1 = command string
   python3 -c "
@@ -119,12 +190,12 @@ print(json.dumps(payload))
 # AskUserQuestion positive cases
 # ---------------------------------------------------------------------------
 
-run_case "AskUserQuestion: (Recommended) English marker fires" \
-  "advisory:output-block-falsify-advisory" \
+run_case "AskUserQuestion: (Recommended) English — no Falsified: — escalates to ask" \
+  "ask:Falsified:" \
   "$(make_ask_payload '["Option A (Recommended)", "Option B"]')"
 
-run_case "AskUserQuestion: (추천) Korean marker fires" \
-  "advisory:output-block-falsify-advisory" \
+run_case "AskUserQuestion: (추천) Korean — no Falsified: — escalates to ask" \
+  "ask:Falsified:" \
   "$(make_ask_payload '["옵션 A (추천)", "옵션 B"]')"
 
 run_case "AskUserQuestion: (recommended) lowercase also fires" \
@@ -222,6 +293,38 @@ run_case "Edge: non-string command (int) — fail-open silent pass" \
 run_case "Edge: non-string command (null) — fail-open silent pass" \
   pass \
   '{"tool_name":"Bash","tool_input":{"command":null}}'
+
+# ---------------------------------------------------------------------------
+# (Recommended) escalation cases — issue #290
+# ---------------------------------------------------------------------------
+
+# Case 1: (Recommended) label + Falsified: line present → PASS (silent)
+run_case "AskUserQuestion: (Recommended) + Falsified: line in question body → pass" \
+  pass \
+  "$(make_ask_payload_with_question \
+      '["Option A (Recommended)", "Option B"]' \
+      "Falsified: checked no existing PR for this — none found.
+What should we do?")"
+
+# Case 2: (Recommended) label + no Falsified: → ASK
+run_case "AskUserQuestion: (Recommended) + no Falsified: → ask" \
+  "ask:Falsified:" \
+  "$(make_ask_payload '["Best option (Recommended)", "Alternative"]')"
+
+# Case 3: (Recommended) appears only in options[].description, not in label → PASS
+run_case "AskUserQuestion: (Recommended) in description only — false positive — silent pass" \
+  pass \
+  "$(make_ask_payload_description_only)"
+
+# Case 4: (추천) Korean label + no Falsified: → ASK
+run_case "AskUserQuestion: (추천) Korean label + no Falsified: → ask" \
+  "ask:Falsified:" \
+  "$(make_ask_payload '["권장 방법 (추천)", "대안"]')"
+
+# Case 5: Non-recommended option — no (Recommended) label — silent pass (no advisory)
+run_case "AskUserQuestion: non-recommended option labels — silent pass" \
+  pass \
+  "$(make_ask_payload '["Option A", "Option B", "Option C"]')"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/tests/test_output_block_falsify_advisory.sh
+++ b/tests/test_output_block_falsify_advisory.sh
@@ -146,6 +146,32 @@ print(json.dumps(payload))
 " "$1" "$2"
 }
 
+make_ask_payload_multi_question_bypass() {
+  # Q1 has (Recommended) + no Falsified:; Q2 has Falsified: in its question text.
+  # A per-question check must still escalate to ask for Q1.
+  python3 - <<'PYEOF'
+import json
+payload = {
+    "session_id": "test-session",
+    "tool_name": "AskUserQuestion",
+    "tool_input": {
+        "questions": [
+            {
+                "question": "Which approach?",
+                "options": [{"label": "Option A (Recommended)"}, {"label": "Option B"}],
+            },
+            {
+                "question": "Falsified: no existing PR found.\nAnother question?",
+                "options": [{"label": "Yes"}, {"label": "No"}],
+            },
+        ]
+    },
+    "cwd": "/tmp",
+}
+print(json.dumps(payload))
+PYEOF
+}
+
 make_ask_payload_description_only() {
   # Payload where (Recommended) appears in options[].description, NOT in label.
   python3 -c "
@@ -325,6 +351,12 @@ run_case "AskUserQuestion: (추천) Korean label + no Falsified: → ask" \
 run_case "AskUserQuestion: non-recommended option labels — silent pass" \
   pass \
   "$(make_ask_payload '["Option A", "Option B", "Option C"]')"
+
+# Case 6 (regression for P2 fix): multi-question payload where Q1 has (Recommended)
+# but no Falsified:, and Q2 has Falsified: in its own question text — must still ask.
+run_case "AskUserQuestion: multi-question — Falsified: in Q2 does not cover Q1 (Recommended) → ask" \
+  "ask:Falsified:" \
+  "$(make_ask_payload_multi_question_bypass)"
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## 변경 내용

`hooks/output-block-falsify-advisory.py` 가 `AskUserQuestion` 호출에 `(Recommended)` 또는 `(추천)` 라벨이 있을 때 기존에는 advisory(stderr)만 emitting. 이제 question body 에 `Falsified:` 라인이 없으면 `permissionDecision: ask` 로 escalate.

### 동작 변경

| 조건 | 이전 | 이후 |
|------|------|------|
| `(Recommended)` 라벨 + `Falsified:` 라인 없음 | advisory(stderr) | `ask` (JSON stdout) |
| `(Recommended)` 라벨 + `Falsified:` 라인 있음 | advisory(stderr) | silent pass |
| `(recommended)` lowercase only | advisory(stderr) | advisory(stderr) (유지) |
| `options[].description` 에만 `(Recommended)` | pass | pass (유지) |
| Bash bulk-action | advisory(stderr) | advisory(stderr) (유지) |

### 구현 포인트

- `_has_exact_recommended_marker()`: 대소문자 구분 정확 토큰 검사 (`(Recommended)`, `(추천)`)
- `_collect_question_texts()`: `questions[].question` 텍스트 수집
- `_has_falsified_line()`: 줄 시작 `Falsified:` prefix 검사
- `_emit_ask()`: `side-effect-scan.py` 와 동일한 `hookSpecificOutput` JSON 형식

### 테스트

- 기존 21 케이스 유지 (케이스 1·2 expectation `advisory:` → `ask:` 업데이트 포함)
- 신규 5 케이스 추가: `ask:` expectation 지원을 위해 `run_case` 확장 + stdout 캡처
- 총 26 케이스 PASS

```
Results: 26 passed, 0 failed
```

`scripts/check-plugin-manifests.py` PASS

Caller chain verified: hook 자체 + tests + docs/hook/ spec. 외부 caller 없음.

Closes #290
