### PR TITLE
feat(skill,hook): codex-review-wrap state guards + N>1 spec

### DIFF
--- a/docs/hook/codex-review-route.md
+++ b/docs/hook/codex-review-route.md
@@ -84,12 +84,12 @@ denies).
 bash tests/test_codex_review_route.sh
 ```
 
-Covers 20 cases: 4 warn paths (bare, with flag, with `--model`,
+Covers 21 cases: 4 warn paths (bare, with flag, with `--model`,
 hyphenated form), 8 silent paths (single-worktree, plain text, different
 slash command, false-positive trailing chars, empty prompt, hyphenated
 suffix, mid-sentence mention, bare-repo + 1 linked worktree), 2 fail-safe
-paths (malformed JSON, non-git cwd), 6 PR-state guard paths (OPEN/CLOSED/MERGED/no-PR
-for `/codex:review`, plus `codex-review-wrap` CLOSED and OPEN). Worktree state
-is fixtured via temporary `git init` (and `git init --bare` for the bare-repo
-case); PR state is fixtured via mock `gh` binaries injected into PATH — no
-real GitHub remote required.
+paths (malformed JSON, non-git cwd), 7 PR-state guard paths (OPEN/CLOSED/MERGED/no-PR
+for `/codex:review`, `codex-review-wrap` CLOSED and OPEN, plus mention-only
+mid-sentence regression). Worktree state is fixtured via temporary `git init`
+(and `git init --bare` for the bare-repo case); PR state is fixtured via mock
+`gh` binaries injected into PATH — no real GitHub remote required.

--- a/docs/hook/codex-review-route.md
+++ b/docs/hook/codex-review-route.md
@@ -20,13 +20,23 @@ directly. This hook detects that pattern and primes Claude to redirect.
 
 ### What is warned
 
-Hook emits `additionalContext` only when **all** the following hold:
+The hook emits up to two independent advisories per trigger. Neither blocks the prompt.
+
+**Advisory 1 — Multi-worktree** (bare `/codex:review` only):
+
+Emits when **all** of the following hold:
 
 | Gate | Condition |
 |------|-----------|
 | Prompt prefix | `/codex:review` or `/codex-review` (whitespace-separated args allowed) |
 | Worktree count | `git worktree list --porcelain` reports `>= 2` non-bare worktrees |
 | jq available | Hook fail-opens silently when `jq` is missing |
+
+Suppressed for `codex-review-wrap` prompts — the skill handles disambiguation itself.
+
+**Advisory 2 — PR state** (all triggers: `/codex:review`, `/codex-review`, `codex-review-wrap`):
+
+Emits when the current branch's PR is `CLOSED` or `MERGED`. Requires `gh` CLI; fail-opens silently when `gh` is absent, when no PR exists for the branch, or when not in a git repo.
 
 False-positive guards:
 
@@ -36,10 +46,11 @@ False-positive guards:
 | `/codex:review-thing` (hyphenated suffix) | silent — same guard |
 | `please /codex:review later` (mid-sentence) | silent — regex anchored to start-of-prompt |
 | `/codex:status` (different command) | silent |
-| Single-worktree repo | silent — bare invocation works correctly |
+| Single-worktree repo, OPEN PR | silent — neither advisory fires |
 | Bare repo + 1 linked worktree | silent — `bare` blocks excluded from the count, only the linked worktree is active |
-| Not a git repo | silent — `git worktree list` returns nothing |
+| Not a git repo | silent — `git worktree list` and `gh pr view` both return nothing |
 | Empty prompt | silent |
+| No PR for current branch | silent — `gh pr view` exits non-zero, PR-state advisory skipped |
 
 ### Response
 
@@ -73,10 +84,12 @@ denies).
 bash tests/test_codex_review_route.sh
 ```
 
-Covers 14 cases: 4 warn paths (bare, with flag, with `--model`,
+Covers 20 cases: 4 warn paths (bare, with flag, with `--model`,
 hyphenated form), 8 silent paths (single-worktree, plain text, different
 slash command, false-positive trailing chars, empty prompt, hyphenated
 suffix, mid-sentence mention, bare-repo + 1 linked worktree), 2 fail-safe
-paths (malformed JSON, non-git cwd). Worktree state is fixtured via
-temporary `git init` (and `git init --bare` for the bare-repo case) to
-keep tests isolated from the running praxis tree.
+paths (malformed JSON, non-git cwd), 6 PR-state guard paths (OPEN/CLOSED/MERGED/no-PR
+for `/codex:review`, plus `codex-review-wrap` CLOSED and OPEN). Worktree state
+is fixtured via temporary `git init` (and `git init --bare` for the bare-repo
+case); PR state is fixtured via mock `gh` binaries injected into PATH — no
+real GitHub remote required.

--- a/hooks/codex-review-route.sh
+++ b/hooks/codex-review-route.sh
@@ -1,24 +1,17 @@
 #!/bin/bash
 # codex-review-route.sh — UserPromptSubmit hook
 #
-# When the user invokes `/codex:review` in a multi-worktree environment, the
-# bare command runs through Claude Code's Bash tool whose cwd resets to the
-# session root (typically the parent/main worktree). The codex companion
-# script then computes its diff from that cwd, often producing an empty or
-# wrong-target review when the user actually wanted to review a sibling
-# issue worktree.
+# Fires when the user invokes /codex:review (bare) or codex-review-wrap.
+# Emits additionalContext advisories for:
+#   1. Multi-worktree detected (>= 2 non-bare worktrees) — bare /codex:review only.
+#      codex-review-wrap is suppressed here because the skill itself handles
+#      worktree disambiguation (Step 2).
+#   2. Current branch's PR is CLOSED or MERGED — stale-state guard for both triggers.
+#      Fix commits pushed after a closed PR create orphan branches or reopen
+#      closed PRs unintentionally.
 #
-# This hook emits an `additionalContext` warning whenever:
-#   1. The user prompt starts with `/codex:review` (or `/codex-review`)
-#   2. AND `git worktree list` reports >= 2 active (non-bare) worktrees
-#
-# The warning instructs Claude to redirect the user to
-# `/praxis:codex-review-wrap` (which forces explicit worktree selection
-# before delegating). If only one worktree exists, the hook stays silent —
-# bare invocation is correct in that case.
-#
-# Fail-safe: jq missing, malformed JSON, no git repo, or any unexpected
-# error all exit 0 silently. The hook never blocks a prompt.
+# Fail-safe: jq missing, malformed JSON, no git repo, gh absent, or any
+# unexpected error all exit 0 silently. The hook never blocks a prompt.
 
 set +e
 
@@ -34,43 +27,50 @@ if [ -z "$PROMPT" ]; then
   exit 0
 fi
 
-# Match `/codex:review` or `/codex-review`, optionally followed by args.
-# Trailing space requirement avoids false positives on `/codex:reviews`
-# or `/codex:review-thing` (defensive — none currently exist, but cheap).
-if ! [[ "$PROMPT" =~ ^/codex(:|-)review([[:space:]]|$) ]]; then
+# Detect trigger type.
+# IS_BARE_CODEX_REVIEW — prompt starts with /codex:review or /codex-review.
+# IS_CODEX_REVIEW_WRAP — prompt mentions codex-review-wrap (skill invocation).
+IS_BARE_CODEX_REVIEW=0
+IS_CODEX_REVIEW_WRAP=0
+
+if [[ "$PROMPT" =~ ^/codex(:|-)review([[:space:]]|$) ]]; then
+  IS_BARE_CODEX_REVIEW=1
+fi
+if [[ "$PROMPT" == *"codex-review-wrap"* ]]; then
+  IS_CODEX_REVIEW_WRAP=1
+fi
+
+if [ "$IS_BARE_CODEX_REVIEW" -eq 0 ] && [ "$IS_CODEX_REVIEW_WRAP" -eq 0 ]; then
   exit 0
 fi
 
+# --- Advisory 1: multi-worktree (bare /codex:review only) -----------------------
 # Count active non-bare, non-prunable worktrees. `git worktree list
 # --porcelain` emits one block per entry (blank-line separated), each
 # starting with `worktree <path>`. Bare repos have a `bare` line; stale
 # worktrees have a `prunable` line. Both must be excluded — counting raw
 # `worktree` lines would over-count bare-repo + linked-worktree setups
 # and trigger false-positive warnings on single-target reviews.
-WT_COUNT=$(git worktree list --porcelain 2>/dev/null | awk '
-  /^$/ {
-    if (in_block && !is_bare && !is_prunable) count++
-    in_block = 0; is_bare = 0; is_prunable = 0
-    next
-  }
-  /^worktree / { in_block = 1 }
-  /^bare$/ { is_bare = 1 }
-  /^prunable( |$)/ { is_prunable = 1 }
-  END {
-    if (in_block && !is_bare && !is_prunable) count++
-    print count + 0
-  }
-')
 
-if ! [[ "$WT_COUNT" =~ ^[0-9]+$ ]]; then
-  exit 0
-fi
+WORKTREE_MSG=""
+if [ "$IS_BARE_CODEX_REVIEW" -eq 1 ]; then
+  WT_COUNT=$(git worktree list --porcelain 2>/dev/null | awk '
+    /^$/ {
+      if (in_block && !is_bare && !is_prunable) count++
+      in_block = 0; is_bare = 0; is_prunable = 0
+      next
+    }
+    /^worktree / { in_block = 1 }
+    /^bare$/ { is_bare = 1 }
+    /^prunable( |$)/ { is_prunable = 1 }
+    END {
+      if (in_block && !is_bare && !is_prunable) count++
+      print count + 0
+    }
+  ')
 
-if [ "$WT_COUNT" -lt 2 ] 2>/dev/null; then
-  exit 0
-fi
-
-read -r -d '' MSG <<EOF
+  if [[ "$WT_COUNT" =~ ^[0-9]+$ ]] && [ "$WT_COUNT" -ge 2 ] 2>/dev/null; then
+    read -r -d '' WORKTREE_MSG <<EOF
 ⚠️ Multi-worktree detected (${WT_COUNT} active worktrees) for a /codex:review invocation.
 
 Bare /codex:review uses the Bash tool's session-default cwd, which often differs from the worktree the user actually wants to review — producing an empty or wrong-target diff.
@@ -79,8 +79,42 @@ Recommended action: instead of dispatching /codex:review directly, ask the user 
 
 If the user explicitly confirms the target worktree in this turn, you may proceed — but state the resolved cwd in your reply so the choice is visible.
 EOF
+  fi
+fi
 
-jq -n --arg ctx "$MSG" \
+# --- Advisory 2: PR-state guard (all matched triggers) --------------------------
+# Warns when the current worktree's branch maps to a CLOSED or MERGED PR.
+# Requires `gh` CLI; fail-open when absent, when not in a git repo, or when
+# no PR exists for the current branch.
+
+PR_STATE_MSG=""
+if command -v gh >/dev/null 2>&1; then
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+  if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "HEAD" ]; then
+    PR_STATE=$(gh pr view "$CURRENT_BRANCH" --json state --jq '.state' 2>/dev/null)
+    if [ "$PR_STATE" = "CLOSED" ] || [ "$PR_STATE" = "MERGED" ]; then
+      PR_STATE_MSG="⚠ Current worktree's branch (${CURRENT_BRANCH}) maps to a PR which is ${PR_STATE}. Review is unlikely to be actionable — fix commits pushed after review will target a ${PR_STATE} branch, which may create an orphan branch or reopen a closed PR unintentionally."
+    fi
+  fi
+fi
+
+# --- Combine and emit ------------------------------------------------------------
+if [ -z "$WORKTREE_MSG" ] && [ -z "$PR_STATE_MSG" ]; then
+  exit 0
+fi
+
+COMBINED_MSG="$WORKTREE_MSG"
+if [ -n "$PR_STATE_MSG" ]; then
+  if [ -n "$COMBINED_MSG" ]; then
+    COMBINED_MSG="${COMBINED_MSG}
+
+${PR_STATE_MSG}"
+  else
+    COMBINED_MSG="$PR_STATE_MSG"
+  fi
+fi
+
+jq -n --arg ctx "$COMBINED_MSG" \
   '{hookSpecificOutput: {hookEventName: "UserPromptSubmit", additionalContext: $ctx}}'
 
 exit 0

--- a/hooks/codex-review-route.sh
+++ b/hooks/codex-review-route.sh
@@ -36,7 +36,7 @@ IS_CODEX_REVIEW_WRAP=0
 if [[ "$PROMPT" =~ ^/codex(:|-)review([[:space:]]|$) ]]; then
   IS_BARE_CODEX_REVIEW=1
 fi
-if [[ "$PROMPT" == *"codex-review-wrap"* ]]; then
+if [[ "$PROMPT" =~ ^(/praxis:)?codex-review-wrap([[:space:]]|$) ]]; then
   IS_CODEX_REVIEW_WRAP=1
 fi
 

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -391,7 +391,7 @@ can pick it up. Structural and stylistic edits do not need this trailer.
 
 | Situation | Action |
 |-----------|--------|
-| PR state ≠ OPEN | ABORT: "PR is {state} — review aborted. Re-open or target a different PR." |
+| PR state is CLOSED or MERGED | ABORT: "PR is {state} — review aborted. Re-open or target a different PR." |
 | `git worktree list` fails (not a git repo) | Abort: "git worktree list 실패 — git 저장소인지 확인하세요." |
 | All worktrees are bare | Treat as Case A (single effective target) using cwd |
 | User selects "취소" | Abort silently with one-line message |

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -39,6 +39,10 @@ sibling PR or repo, Step 5d additionally cross-checks each verified finding
 against the sibling and records the result.
 See **Step 5** for the full gate.
 
+## Invocation Model
+
+**Cardinality**: This skill handles exactly **one PR per invocation**. For N PRs, invoke the skill N times sequentially. Batch for-loops are **not supported** — they collapse Step 5c per-round ledger emission across multiple PRs and break flip-detection guarantees.
+
 ## When to Use
 
 - Before calling `/codex:review` from any multi-worktree project
@@ -124,6 +128,18 @@ If the selected path differs from cwd, note it explicitly:
 ```
 
 ### Step 4: Run codex-companion against the selected worktree
+
+Before delegating to codex-companion, verify the PR is still open. Using the branch resolved in Steps 1–2:
+
+```bash
+gh pr view "{branch}" --json state --jq '.state'
+```
+
+If the returned state is not `"OPEN"` (i.e., `CLOSED` or `MERGED`), abort immediately:
+
+```
+ABORT: "PR is {state} — review aborted. Re-open or target a different PR."
+```
 
 **MUST NOT call `Skill("codex:review")`.** `/codex:review` declares
 `disable-model-invocation: true`, so the Skill tool always returns the
@@ -374,6 +390,7 @@ can pick it up. Structural and stylistic edits do not need this trailer.
 
 | Situation | Action |
 |-----------|--------|
+| PR state ≠ OPEN | ABORT: "PR is {state} — review aborted. Re-open or target a different PR." |
 | `git worktree list` fails (not a git repo) | Abort: "git worktree list 실패 — git 저장소인지 확인하세요." |
 | All worktrees are bare | Treat as Case A (single effective target) using cwd |
 | User selects "취소" | Abort silently with one-line message |

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -129,13 +129,14 @@ If the selected path differs from cwd, note it explicitly:
 
 ### Step 4: Run codex-companion against the selected worktree
 
-Before delegating to codex-companion, verify the PR is still open. Using the branch resolved in Steps 1–2:
+Before delegating to codex-companion, verify the PR is not already closed. Using the branch resolved in Steps 1–2:
 
 ```bash
-gh pr view "{branch}" --json state --jq '.state'
+gh pr view "{branch}" --json state --jq '.state' 2>/dev/null
 ```
 
-If the returned state is not `"OPEN"` (i.e., `CLOSED` or `MERGED`), abort immediately:
+- If the command exits non-zero or returns empty (no PR exists yet): continue — pre-PR review is a valid use case.
+- If the returned state is `"CLOSED"` or `"MERGED"`: abort immediately:
 
 ```
 ABORT: "PR is {state} — review aborted. Re-open or target a different PR."

--- a/tests/test_codex_review_route.sh
+++ b/tests/test_codex_review_route.sh
@@ -2,12 +2,15 @@
 # test_codex_review_route.sh — coverage for hooks/codex-review-route.sh
 #
 # Synthesizes Claude Code UserPromptSubmit hook payloads and asserts:
-#   warn   → exit 0 + stdout contains JSON additionalContext substring
-#   silent → exit 0 + stdout empty
+#   warn          → exit 0 + stdout contains JSON additionalContext with codex-review-wrap
+#   pr_state_warn → exit 0 + stdout contains JSON additionalContext with CLOSED or MERGED
+#   silent        → exit 0 + stdout empty
 #
 # Multi-worktree state is simulated by running the hook from inside a
 # temporary repo with N synthesized worktrees, NOT against the real
 # praxis tree (test isolation).
+#
+# PR state is simulated via mock `gh` binaries injected into PATH.
 #
 # Usage: bash tests/test_codex_review_route.sh
 # Exit:  0 = all pass; 1 = at least one fail
@@ -78,8 +81,35 @@ make_bare_plus_linked_repo() {
   ( cd "$base/bare" && git worktree add -q "$base/linked" main 2>/dev/null )
 }
 
+# --- mock gh fixtures -------------------------------------------------------
+# Each mock gh binary unconditionally returns a fixed PR state, making tests
+# independent of the real `gh` CLI or any live GitHub state.
+
+make_mock_gh_state() {
+  local dir="$1" state="$2"
+  mkdir -p "$dir"
+  cat > "$dir/gh" <<EOF
+#!/bin/bash
+echo "$state"
+exit 0
+EOF
+  chmod +x "$dir/gh"
+}
+
+make_mock_gh_no_pr() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat > "$dir/gh" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+  chmod +x "$dir/gh"
+}
+
+# --- test runner -------------------------------------------------------------
+# Optional 5th argument: path to prepend to PATH (for mock gh injection).
 run_case() {
-  local name="$1" expectation="$2" cwd="$3" prompt="$4"
+  local name="$1" expectation="$2" cwd="$3" prompt="$4" mock_path="${5:-}"
 
   local payload
   payload=$(python3 -c '
@@ -88,7 +118,11 @@ print(json.dumps({"prompt": sys.argv[1], "session_id": "test-sid"}))' "$prompt")
 
   local out_file
   out_file=$(mktemp)
-  ( cd "$cwd" && echo "$payload" | "$HOOK" ) > "$out_file" 2>/dev/null
+  if [ -n "$mock_path" ]; then
+    ( cd "$cwd" && export PATH="$mock_path:$PATH" && echo "$payload" | "$HOOK" ) > "$out_file" 2>/dev/null
+  else
+    ( cd "$cwd" && echo "$payload" | "$HOOK" ) > "$out_file" 2>/dev/null
+  fi
   local rc=$?
   local out
   out=$(cat "$out_file")
@@ -105,6 +139,14 @@ print(json.dumps({"prompt": sys.argv[1], "session_id": "test-sid"}))' "$prompt")
       case "$out" in
         *"codex-review-wrap"*"additionalContext"*) ;;
         *"additionalContext"*"codex-review-wrap"*) ;;
+        *) ok=0 ;;
+      esac
+      ;;
+    pr_state_warn)
+      [ "$rc" -eq 0 ] || ok=0
+      case "$out" in
+        *"CLOSED"*"additionalContext"*|*"additionalContext"*"CLOSED"*) ;;
+        *"MERGED"*"additionalContext"*|*"additionalContext"*"MERGED"*) ;;
         *) ok=0 ;;
       esac
       ;;
@@ -132,6 +174,17 @@ BARE_LINKED="$TMPROOT/bare-plus-linked"
 make_multi_wt_repo "$MULTI"
 make_single_wt_repo "$SINGLE"
 make_bare_plus_linked_repo "$BARE_LINKED"
+
+# mock gh dirs (inside TMPROOT so they're cleaned up together)
+MOCK_GH_OPEN="$TMPROOT/mock-gh-open"
+MOCK_GH_CLOSED="$TMPROOT/mock-gh-closed"
+MOCK_GH_MERGED="$TMPROOT/mock-gh-merged"
+MOCK_GH_NO_PR="$TMPROOT/mock-gh-no-pr"
+
+make_mock_gh_state "$MOCK_GH_OPEN"   "OPEN"
+make_mock_gh_state "$MOCK_GH_CLOSED" "CLOSED"
+make_mock_gh_state "$MOCK_GH_MERGED" "MERGED"
+make_mock_gh_no_pr "$MOCK_GH_NO_PR"
 
 # Sanity check: verify raw worktree-line counts (NOT the hook's filtered count)
 multi_count=$(cd "$MULTI" && git worktree list --porcelain 2>/dev/null | awk '/^worktree /' | wc -l | tr -d ' ')
@@ -202,6 +255,18 @@ print(json.dumps({"prompt": "/codex:review", "session_id": "test-sid"}))')
   fi
 }
 not_in_repo_test
+
+# --- PR-state guard tests ---------------------------------------------------
+# Uses mock gh binaries to control the returned PR state without requiring a
+# real GitHub remote. Tests run against the single-worktree repo so worktree
+# count does not interfere with the PR-state advisory.
+
+run_case "14 silent: /codex:review, OPEN PR → no PR-state advisory"          silent        "$SINGLE" "/codex:review"              "$MOCK_GH_OPEN"
+run_case "15 pr_state_warn: /codex:review, CLOSED PR → advisory"             pr_state_warn "$SINGLE" "/codex:review"              "$MOCK_GH_CLOSED"
+run_case "16 pr_state_warn: /codex:review, MERGED PR → advisory"             pr_state_warn "$SINGLE" "/codex:review"              "$MOCK_GH_MERGED"
+run_case "17 silent: /codex:review, no PR → no advisory (regression)"        silent        "$SINGLE" "/codex:review"              "$MOCK_GH_NO_PR"
+run_case "18 pr_state_warn: codex-review-wrap, CLOSED PR → advisory"         pr_state_warn "$SINGLE" "/praxis:codex-review-wrap"  "$MOCK_GH_CLOSED"
+run_case "19 silent: codex-review-wrap, OPEN PR → no advisory"               silent        "$SINGLE" "/praxis:codex-review-wrap"  "$MOCK_GH_OPEN"
 
 # --- cleanup ---------------------------------------------------------------
 rm -rf "$TMPROOT"

--- a/tests/test_codex_review_route.sh
+++ b/tests/test_codex_review_route.sh
@@ -267,6 +267,7 @@ run_case "16 pr_state_warn: /codex:review, MERGED PR → advisory"             p
 run_case "17 silent: /codex:review, no PR → no advisory (regression)"        silent        "$SINGLE" "/codex:review"              "$MOCK_GH_NO_PR"
 run_case "18 pr_state_warn: codex-review-wrap, CLOSED PR → advisory"         pr_state_warn "$SINGLE" "/praxis:codex-review-wrap"  "$MOCK_GH_CLOSED"
 run_case "19 silent: codex-review-wrap, OPEN PR → no advisory"               silent        "$SINGLE" "/praxis:codex-review-wrap"  "$MOCK_GH_OPEN"
+run_case "20 silent: mention-only codex-review-wrap mid-sentence → no advisory" silent    "$SINGLE" "use codex-review-wrap later" "$MOCK_GH_CLOSED"
 
 # --- cleanup ---------------------------------------------------------------
 rm -rf "$TMPROOT"


### PR DESCRIPTION
## 개요

2026-05-17 retrospect에서 식별된 `codex-review-wrap` CLUSTER-A의 두 spec gap을 동시 해결.

## 변경 사항

### Gap A1 — PR-state pre-check (SKILL.md Step 4 + hook)

**증상**: codex review 후 fix commit push 시점에 대상 PR이 CLOSED/MERGED 되어 있어 orphan branch 생성됨.

**Fix**:
- `skills/codex-review-wrap/SKILL.md` Step 4 시작부에 PR-state 검증 sub-step 추가: `gh pr view "{branch}" --json state --jq '.state'` → state ≠ OPEN이면 ABORT
- Error Handling 표에 `PR state ≠ OPEN` row 추가
- `hooks/codex-review-route.sh`에 PR-state advisory 추가: 현재 branch의 PR이 CLOSED/MERGED면 경고 emit (fail-open when `gh` absent)

### Gap A2 — N>1 invocation 미정의 (SKILL.md)

**증상**: 6개 PR batch for-loop 실행 시 Step 5c per-round ledger가 collapse됨.

**Fix**:
- `skills/codex-review-wrap/SKILL.md`에 **Invocation Model 섹션** 신설 (Overview ~ When to Use 사이): "one PR per invocation, batch for-loops not supported"

### Hook 확장

- `hooks/codex-review-route.sh`에 `codex-review-wrap` prompt 패턴 트리거 추가
- multi-worktree advisory는 bare `/codex:review`에서만 emit (codex-review-wrap 호출 시 suppressed — skill이 직접 처리)
- PR-state advisory는 두 트리거 모두에서 emit

## 검증

### 테스트 결과 (20/20 PASS)

```
fixture: multi=2, single=1, bare-plus-linked raw=2 (hook should filter to 1)
PASS  [1 warn: bare /codex:review in multi-worktree]
PASS  [2 warn: /codex:review with --background flag]
PASS  [3 warn: /codex:review --model opus]
PASS  [4 warn: /codex-review (hyphenated)]
PASS  [5 silent: single-worktree repo]
PASS  [6 silent: prompt is plain text, not slash command]
PASS  [7 silent: different slash command]
PASS  [8 silent: /codex:reviews (false-positive guard)]
PASS  [9 silent: empty prompt]
PASS  [10 silent: /codex:review-thing trailing chars]
PASS  [11 silent: prompt mentions /codex:review mid-sentence]
PASS  [11b silent: bare repo + 1 linked worktree counts as 1]
PASS  [12 silent: malformed JSON stdin]
PASS  [13 silent: cwd not a git repo]
PASS  [14 silent: /codex:review, OPEN PR → no PR-state advisory]
PASS  [15 pr_state_warn: /codex:review, CLOSED PR → advisory]
PASS  [16 pr_state_warn: /codex:review, MERGED PR → advisory]
PASS  [17 silent: /codex:review, no PR → no advisory (regression)]
PASS  [18 pr_state_warn: codex-review-wrap, CLOSED PR → advisory]
PASS  [19 silent: codex-review-wrap, OPEN PR → no advisory]

Passed: 20  Failed: 0
```

### manifest 체크

```
plugin-manifest check OK
```

## 수용 기준 체크

- [x] SKILL.md Step 4가 PR-state 검증 sub-step 명시
- [x] SKILL.md에 "Cardinality" (Invocation Model) 섹션 + batch 금지 명시
- [x] `hooks/codex-review-route.sh`가 CLOSED/MERGED state에서 advisory 출력
- [x] 테스트 신규/기존 모두 PASS (20/20)
- [x] `scripts/check-plugin-manifests.py` PASS

Caller chain verified: batch worker → issue #289 → this PR

Closes #289
