### PR TITLE
refactor(hooks): migrate 4 callers to role-aware token API

### DIFF
--- a/hooks/block-gh-state-all.py
+++ b/hooks/block-gh-state-all.py
@@ -6,9 +6,11 @@
 Conflating these causes `invalid argument "all" for "--state" flag` — a
 recurring mistake caught by structural enforcement rather than a memo.
 
-Uses shlex tokenization (same approach as side-effect-scan.py) so that
-pattern references inside quoted strings, echo arguments, or comments are not
-mistakenly blocked.
+Uses the role-aware token API (issue #263) so flag-value attribution is
+handled centrally. The check reduces to: COMMAND is `gh`, subcommand
+positional is `search`, an object positional follows, and somewhere after
+that a FLAG `--state` is followed by FLAG_VALUE `all` (or a single FLAG
+token `--state=all`).
 
 Exits 2 (PreToolUse blocking code) when the command is a live `gh search`
 call with `--state all`. Exits 0 otherwise (transparent pass-through).
@@ -23,61 +25,76 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    Token,
+    TokenRole,
     compound_cascade_hint,
-    iter_command_starts,
-    safe_tokenize,
-    strip_prefix,
+    filter_argv,
+    tokenize_with_roles,
 )
 
-# gh global flags that take a separate-token argument
-GH_GLOBAL_FLAGS_WITH_ARG = frozenset({
-    "-R", "--repo",
-    "--hostname",
-    "--color",
-})
+# flag_value_spec for the role-aware tokenizer.
+#   gh global flags: -R / --repo take a separate-token value
+#   gh search subcommand: --state takes a value (so `all` lands as FLAG_VALUE)
+_FLAG_VALUE_SPEC: dict[str, set[str]] = {
+    "gh": {"-R", "--repo"},
+    "gh search": {"--state"},
+}
 
 
 # ---------------------------------------------------------------------------
 # Detection
 # ---------------------------------------------------------------------------
 
-def is_blocked_gh_search(argv: list[str]) -> bool:
-    """Return True iff argv is a live `gh search <subcmd> ... --state all` call."""
-    argv = strip_prefix(argv)
-    if not argv or argv[0] != "gh":
+def is_blocked_gh_search(seg: list[Token]) -> bool:
+    """Return True iff seg is a live `gh search <subcmd> ... --state all` call.
+
+    Walks the typed Token list:
+      1. argv[0] must be COMMAND "gh".
+      2. Skip leading FLAG / FLAG_VALUE tokens (gh-level globals like
+         `--no-pager`, `-R owner/repo`).
+      3. The next POSITIONAL must be exactly `search`.
+      4. Skip more FLAG / FLAG_VALUE tokens.
+      5. The next POSITIONAL is the search object word (issues / prs /
+         repos / commits / code — gh itself validates the name).
+      6. After the object word, scan for `--state all` (FLAG + FLAG_VALUE)
+         or `--state=all` (single FLAG token).
+    """
+    argv = filter_argv(seg)
+    if not argv or argv[0].text != "gh":
         return False
 
-    # Skip gh global flags to reach the subcommand.
-    # For flags that take a separate value (e.g. -R owner/repo), consume both.
     i = 1
-    while i < len(argv):
-        tok = argv[i]
-        if tok == "--":
-            i += 1
-            break
-        if not tok.startswith("-"):
-            break  # reached the subcommand
+    n = len(argv)
+
+    # Skip pre-search FLAG / FLAG_VALUE tokens.
+    while i < n and argv[i].role in (TokenRole.FLAG, TokenRole.FLAG_VALUE):
         i += 1
-        if "=" not in tok and tok in GH_GLOBAL_FLAGS_WITH_ARG and i < len(argv):
-            i += 1  # consume separate value token
 
-    if i >= len(argv) or argv[i] != "search":
+    if i >= n or argv[i].role != TokenRole.POSITIONAL or argv[i].text != "search":
         return False
-    i += 1  # skip "search"
-
-    # Skip the search object (issues, prs, repos, commits, code)
-    if i >= len(argv) or argv[i].startswith("-"):
-        return False  # no object word present — not a valid gh search invocation
     i += 1
 
-    # Scan remaining tokens for --state all or --state=all
-    while i < len(argv):
+    # Skip FLAG / FLAG_VALUE tokens between `search` and the object word.
+    while i < n and argv[i].role in (TokenRole.FLAG, TokenRole.FLAG_VALUE):
+        i += 1
+
+    if i >= n or argv[i].role != TokenRole.POSITIONAL:
+        return False  # no object word — not a valid gh search invocation
+    i += 1
+
+    # Scan remaining tokens for --state all. SEPARATOR_DD / POST_DD end the
+    # flag region — `gh` does not accept POSIX `--` but we honor it defensively.
+    while i < n:
         tok = argv[i]
-        if tok.startswith("--state="):
-            if tok.split("=", 1)[1] == "all":
+        if tok.role in (TokenRole.SEPARATOR_DD, TokenRole.POST_DD):
+            break
+        if tok.role == TokenRole.FLAG:
+            if tok.text == "--state=all":
                 return True
-        elif tok == "--state" and i + 1 < len(argv) and argv[i + 1] == "all":
-            return True
+            if tok.text == "--state" and i + 1 < n:
+                nxt = argv[i + 1]
+                if nxt.role == TokenRole.FLAG_VALUE and nxt.text == "all":
+                    return True
         i += 1
 
     return False
@@ -108,12 +125,12 @@ def main() -> int:
     # Backslash line continuation → single space so tokenizer sees one line
     command = command.replace("\\\n", " ")
 
-    tokens = safe_tokenize(command)
-    if not tokens:
+    segments = tokenize_with_roles(command, _FLAG_VALUE_SPEC)
+    if not segments:
         return 0
 
-    for argv in iter_command_starts(tokens):
-        if is_blocked_gh_search(argv):
+    for seg in segments:
+        if is_blocked_gh_search(seg):
             sys.stderr.write(STDERR_MESSAGE + compound_cascade_hint(command))
             return 2
 

--- a/hooks/cross-boundary-preflight.py
+++ b/hooks/cross-boundary-preflight.py
@@ -15,6 +15,13 @@ Related hooks that cover adjacent scenarios:
   block-pr-without-caller-evidence → gh pr create without Caller chain verified:
   pre-merge-approval-gate.sh       → gh pr merge without per-PR approval
 
+Role-aware tokenization (issue #263): subcommand detection and --repo
+value extraction use the typed `Token` API from `_hook_utils`. Heredoc
+detection still inspects raw token text for `<<` since the role API does
+not classify the redirect operator itself — but the quoted-string guard
+(tokens with internal whitespace cannot be unquoted shell words) keeps
+literal `<<` inside `--body` values from triggering a false block.
+
 Opt-out: embed `# cross-boundary:ack` in the shell command portion of the
 invocation (e.g., as a trailing comment on the `gh` line or after the heredoc
 terminator), NOT inside the heredoc body. The heredoc body becomes the
@@ -32,17 +39,53 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    Token,
+    TokenRole,
     compound_cascade_hint,
-    iter_command_starts,
-    safe_tokenize,
-    strip_prefix,
+    filter_argv,
+    tokenize_with_roles,
 )
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 
-GH_GLOBAL_FLAGS_WITH_ARG = frozenset({"-R", "--repo", "--hostname", "--color"})
+# Role-aware tokenizer spec. Globals consume separate-token values; per-object
+# entries list the value-taking flags that appear after the subcommand verb
+# (`--title VALUE`, `--body-file PATH`, etc.) so the role API attributes
+# them as FLAG_VALUE rather than POSITIONAL.
+#
+# `gh issue` and `gh pr` aggregate value flags across `create / new / edit /
+# comment` since `_resolve_subcommand` is single-level — the verb after
+# `gh issue` is a POSITIONAL in the segment. Whitelist breadth here only
+# affects role attribution; the checklist gate cares about (object, verb)
+# membership, not which flags appeared.
+_FLAG_VALUE_SPEC: dict[str, set[str]] = {
+    "gh": {"-R", "--repo"},
+    "gh issue": {
+        "-R", "--repo",
+        "-t", "--title",
+        "-b", "--body",
+        "-F", "--body-file",
+        "-a", "--assignee",
+        "-l", "--label",
+        "-m", "--milestone",
+        "-p", "--project",
+    },
+    "gh pr": {
+        "-R", "--repo",
+        "-t", "--title",
+        "-b", "--body",
+        "-F", "--body-file",
+        "-a", "--assignee",
+        "-B", "--base",
+        "-H", "--head",
+        "-l", "--label",
+        "-m", "--milestone",
+        "-p", "--project",
+        "-r", "--reviewer",
+    },
+}
 
 # gh subcommand pairs that write to a repo
 GH_WRITE_SUBCOMMANDS = frozenset({
@@ -104,58 +147,77 @@ Correct pattern:
 # Detection helpers
 # ---------------------------------------------------------------------------
 
-def _skip_flags(argv: list[str], i: int) -> int:
-    """Advance i past any flags (and their values) in argv, return new i."""
-    while i < len(argv):
-        tok = argv[i]
-        if tok == "--":
-            return i + 1
-        if not tok.startswith("-"):
-            break
-        i += 1
-        if "=" not in tok and tok in GH_GLOBAL_FLAGS_WITH_ARG and i < len(argv):
-            i += 1  # consume value token for known flag-with-arg
-    return i
+def _gh_write_subcommand(seg: list[Token]) -> tuple[str, str] | None:
+    """Return (object, verb) if seg is a gh write subcommand, else None.
 
-
-def _gh_write_subcommand(argv: list[str]) -> tuple[str, str] | None:
-    """Return (object, verb) if argv is a gh write subcommand, else None.
-
-    Handles flags between object and verb, e.g.:
-      gh issue --repo owner/repo create   → ('issue', 'create')
-      gh --repo X issue --flag create     → ('issue', 'create')
+    Walks the typed Token list after the COMMAND token, skipping FLAG and
+    FLAG_VALUE tokens between the object and verb POSITIONALs. Handles
+    `gh issue --repo X create` (flags between object and verb) and the
+    common `gh --repo X issue create` (flags before object).
     """
-    argv = strip_prefix(argv)
-    if not argv or argv[0] != "gh":
+    argv = filter_argv(seg)
+    if not argv or argv[0].text != "gh":
         return None
-    # Skip gh-level global flags to find the object word (e.g., 'issue', 'pr').
-    i = _skip_flags(argv, 1)
-    if i >= len(argv):
+
+    n = len(argv)
+    i = 1
+
+    # Skip pre-object FLAG / FLAG_VALUE tokens to find the object word.
+    while i < n:
+        tok = argv[i]
+        if tok.role == TokenRole.POSITIONAL:
+            break
+        if tok.role in (TokenRole.SEPARATOR_DD, TokenRole.POST_DD):
+            return None
+        i += 1
+
+    if i >= n or argv[i].role != TokenRole.POSITIONAL:
         return None
-    obj = argv[i]
-    # Skip flags between object and verb (e.g., `gh issue --repo X create`).
-    i = _skip_flags(argv, i + 1)
-    if i >= len(argv):
+    obj = argv[i].text
+    i += 1
+
+    # Skip FLAG / FLAG_VALUE tokens between object and verb.
+    while i < n:
+        tok = argv[i]
+        if tok.role == TokenRole.POSITIONAL:
+            break
+        if tok.role in (TokenRole.SEPARATOR_DD, TokenRole.POST_DD):
+            return None
+        i += 1
+
+    if i >= n or argv[i].role != TokenRole.POSITIONAL:
         return None
-    verb = argv[i]
+    verb = argv[i].text
+
     pair = (obj, verb)
     return pair if pair in GH_WRITE_SUBCOMMANDS else None
 
 
-def _has_repo_flag(argv: list[str]) -> tuple[bool, str]:
-    """Return (True, repo_value) if --repo/-R flag is present, else (False, '')."""
+def _has_repo_flag(seg: list[Token]) -> tuple[bool, str]:
+    """Return (True, repo_value) if --repo / -R flag is present, else (False, '').
+
+    The role API has already attributed the value as FLAG_VALUE for the
+    space form. The equals form (`--repo=value`) appears as a single FLAG
+    token with the value embedded; the `-Rvalue` shorthand likewise stays
+    as a single FLAG token whose text starts with `-R`.
+    """
+    argv = filter_argv(seg)
+    n = len(argv)
     for i, tok in enumerate(argv):
-        if tok in ("-R", "--repo") and i + 1 < len(argv):
-            return True, argv[i + 1]
-        if tok.startswith("--repo="):
-            return True, tok.split("=", 1)[1]
-        if tok.startswith("-R") and len(tok) > 2:
-            return True, tok[2:]
+        if tok.role != TokenRole.FLAG:
+            continue
+        text = tok.text
+        if text in ("-R", "--repo") and i + 1 < n and argv[i + 1].role == TokenRole.FLAG_VALUE:
+            return True, argv[i + 1].text
+        if text.startswith("--repo="):
+            return True, text.split("=", 1)[1]
+        if text.startswith("-R") and len(text) > 2:
+            return True, text[2:]
     return False, ""
 
 
-def _has_heredoc(argv: list[str]) -> bool:
-    """Return True if argv contains a << heredoc redirect operator.
+def _has_heredoc(seg: list[Token]) -> bool:
+    """Return True if seg contains a `<<` heredoc redirect operator.
 
     Two tokenization forms handled (both invalid in gh write commands):
 
@@ -175,21 +237,21 @@ def _has_heredoc(argv: list[str]) -> bool:
     has the heredoc on a different newline, which safe_tokenize separates
     into a different segment with a synthetic ';'. The heredoc token does
     NOT appear in the gh write argv slice.
+
+    Role agnostic — we iterate every typed Token's text since `<<` does
+    not survive the role API's `-` prefix check and may appear in FLAG /
+    FLAG_VALUE / POSITIONAL / SUBST_RUN texts depending on attachment.
     """
-    for tok in argv:
-        if "<<" not in tok:
+    for tok in seg:
+        text = tok.text
+        if "<<" not in text:
             continue
         # Quoted-string guard: shlex strips quotes but preserves internal
         # spaces. A token containing a space cannot be an unquoted shell
         # word, so `<<` inside it is a literal (e.g. `--body "code: a<<b"`
         # tokenizes as `code: a<<b`). Skip such tokens entirely.
-        if " " in tok:
+        if " " in text or "\t" in text:
             continue
-        # Case 1: token starts with '<<' (space-separated redirect)
-        if tok.startswith("<<"):
-            return True
-        # Case 2: '<<' embedded in token without surrounding spaces
-        # (attached redirect like 'foo<<EOF').
         return True
     return False
 
@@ -270,18 +332,17 @@ def main() -> int:
     # (marker-in-shell-portion) and (no-marker) the same way for heredocs.
     opt_out_present = OPT_OUT_MARKER in _strip_heredoc_bodies(command)
 
-    tokens = safe_tokenize(command.replace("\\\n", " "))
-    if not tokens:
+    segments = tokenize_with_roles(command.replace("\\\n", " "), _FLAG_VALUE_SPEC)
+    if not segments:
         return 0
 
-    for argv in iter_command_starts(tokens):
-        argv = list(argv)
-        subcommand = _gh_write_subcommand(argv)
+    for seg in segments:
+        subcommand = _gh_write_subcommand(seg)
         if subcommand is None:
             continue
 
         # Check 1: heredoc in same segment → hard block (marker-independent)
-        if _has_heredoc(argv):
+        if _has_heredoc(seg):
             sys.stderr.write(HEREDOC_BLOCK_MSG + compound_cascade_hint(command))
             return 2
 
@@ -289,7 +350,7 @@ def main() -> int:
         # (opt-out marker, if any, skips the checklist here only)
         if opt_out_present:
             return 0
-        has_repo, repo_val = _has_repo_flag(argv)
+        has_repo, repo_val = _has_repo_flag(seg)
         if has_repo:
             _emit_ask(_build_checklist(subcommand, repo_val) + compound_cascade_hint(command))
             return 0

--- a/hooks/cross-repo-worktree-preflight.py
+++ b/hooks/cross-repo-worktree-preflight.py
@@ -40,6 +40,12 @@ the worktree-list comparison so that `cd somewhere && git worktree
 remove ../sibling-wt` is correctly classified by where it actually
 lands on disk.
 
+Role-aware tokenization (issue #263): the local `_coalesce_subst_runs`
+mirror was removed; `tokenize_with_roles` now handles `$()` coalesce,
+flag-value attribution (`-c $(echo k=v)`), and the `--` argv boundary
+centrally. The caller iterates typed Token segments and only needs to
+recognize `worktree remove` structure and `-C` / `--git-dir` overrides.
+
 Opt-out: embed `# worktree-chain:ack` anywhere in the shell command portion
 after manually confirming the target path. Marker placement inside heredoc
 bodies is irrelevant here — `git worktree remove` does not accept heredoc
@@ -55,10 +61,11 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    Token,
+    TokenRole,
     compound_cascade_hint,
-    iter_command_starts,
-    safe_tokenize,
-    strip_prefix,
+    filter_argv,
+    tokenize_with_roles,
 )
 
 # ---------------------------------------------------------------------------
@@ -79,51 +86,54 @@ OPT_OUT_MARKER = "# worktree-chain:ack"
 # scenario this hook is built to surface.
 GIT_REPO_OVERRIDE_FLAGS_WITH_ARG = frozenset({"-C", "--git-dir"})
 
-# Every git global flag that consumes a separate-token argument. Used when
-# walking past the global-flag block to reach the subcommand — we must skip
-# the value token even for flags that do NOT bind git to a specific repo
-# (e.g. `-c name=value`). Otherwise the value token (`name=value`) is read
-# as a non-flag and we mis-conclude the subcommand is missing.
+# Role-aware tokenizer spec. Every git-level value-taking global flag is
+# included so the role API attributes their value tokens as FLAG_VALUE
+# (otherwise the next token slips into the subcommand slot and the walker
+# bails). Subcommand level for `git worktree` has no separate-value flags
+# we care about — `-f` / `--force` are valueless and fall through generically.
 # Source: `git --help`. `--exec-path`, `--namespace`, `--super-prefix`,
-# `--config-env` all use the `--flag=value` equals form which strip_prefix
-# handles via the `"=" in tok` branch; only `-c` and `-C` actually accept
-# a separate value token.
-GIT_GLOBAL_FLAGS_WITH_ARG = frozenset({
-    "-C", "-c",
-    "--git-dir", "--work-tree",
-})
-
-# `git worktree remove` flags that take no argument. Any flag we don't know
-# about is consumed generically (single token) — we only need to skip them
-# until we hit the path positional.
-WORKTREE_REMOVE_FLAGS = frozenset({"-f", "--force"})
+# `--config-env` all use the `--flag=value` equals form which is a single
+# token; only `-c` / `-C` / `--git-dir` / `--work-tree` / `--namespace`
+# accept a separate value token.
+_FLAG_VALUE_SPEC: dict[str, set[str]] = {
+    "git": {"-C", "-c", "--git-dir", "--work-tree", "--namespace"},
+    "git worktree": set(),
+}
 
 
 # ---------------------------------------------------------------------------
 # Detection helpers
 # ---------------------------------------------------------------------------
 
-def _has_repo_override(argv: list[str]) -> bool:
-    """Return True if argv contains a git-level `-C` / `--git-dir` / `--work-tree`.
+def _has_repo_override(seg: list[Token]) -> bool:
+    """Return True if seg contains a git-level `-C` / `--git-dir` override.
 
     Three forms covered:
       • separated:  `git -C /other worktree remove X`
       • equals:     `git --git-dir=/other/.git worktree remove X`
       • shorthand:  `git -C/other worktree remove X` (rare but legal)
+
+    `--work-tree` alone does NOT qualify (see GIT_REPO_OVERRIDE_FLAGS_WITH_ARG
+    docstring). The role API has already split FLAG / FLAG_VALUE for the
+    separated form; we iterate FLAG tokens and inspect their text.
     """
+    argv = filter_argv(seg)
     for tok in argv:
-        if tok in GIT_REPO_OVERRIDE_FLAGS_WITH_ARG:
+        if tok.role != TokenRole.FLAG:
+            continue
+        text = tok.text
+        if text in GIT_REPO_OVERRIDE_FLAGS_WITH_ARG:
             return True
         for prefix in GIT_REPO_OVERRIDE_FLAGS_WITH_ARG:
-            if tok.startswith(prefix + "="):
+            if text.startswith(prefix + "="):
                 return True
         # `-C/other` shorthand (only -C supports this; --long= form handled above)
-        if tok.startswith("-C") and len(tok) > 2:
+        if text.startswith("-C") and len(text) > 2:
             return True
     return False
 
 
-def _interpret_cd(argv: list[str], current_cwd: str) -> str | None:
+def _interpret_cd(seg: list[Token], current_cwd: str) -> str | None:
     """Return the new cwd after `cd <path>` in this segment, else None.
 
     Used to thread an `effective_cwd` across compound segments so that
@@ -134,20 +144,26 @@ def _interpret_cd(argv: list[str], current_cwd: str) -> str | None:
     list of the *original* process cwd.
 
     Resolution rules:
-      • argv is not a bare `cd` (after strip_prefix) → None
-      • argv is `cd` with no argument → None (cd-to-home; we do not try
+      • COMMAND is not `cd` → None
+      • no positional argument → None (cd-to-home; we do not try
         to resolve `$HOME` so we leave effective_cwd as the caller had it)
       • target is `-` or starts with `$` → None (cd-to-prev / variable
         expansion is unresolvable statically — caller retains current cwd)
       • absolute target → normalized path
       • relative target → normalized join against `current_cwd`
     """
-    argv = strip_prefix(argv)
-    if not argv or argv[0] != "cd":
+    argv = filter_argv(seg)
+    if not argv or argv[0].text != "cd":
         return None
-    if len(argv) < 2:
+    # Find the first positional / subst_run / post-DD token after COMMAND.
+    target: str | None = None
+    for tok in argv[1:]:
+        if tok.role in (TokenRole.FLAG, TokenRole.FLAG_VALUE, TokenRole.SEPARATOR_DD):
+            continue
+        target = tok.text
+        break
+    if not target:
         return None
-    target = argv[1]
     if target == "-" or target.startswith("$"):
         return None
     if target.startswith("/"):
@@ -155,95 +171,70 @@ def _interpret_cd(argv: list[str], current_cwd: str) -> str | None:
     return os.path.normpath(os.path.join(current_cwd, target))
 
 
-def _coalesce_subst_runs(tokens: list[str]) -> list[str]:
-    """Collapse unquoted `$(...)` command-substitution runs into single tokens.
-
-    `safe_tokenize` uses shlex with whitespace_split=True, which is unaware
-    of POSIX command substitution. An unquoted `$(echo k=v)` therefore
-    splits into `['$(echo', 'k=v)']`, and any flag-value-skip logic only
-    consumes the first token. The remaining token (`k=v)`) then sits where
-    a subcommand or positional is expected and breaks parsing.
-
-    This helper walks the token list and merges any run that starts with a
-    token containing `$(` and ends with a token containing the matching `)`
-    into a single logical token. Quoted substitutions (e.g. `"$(...)"`)
-    are already a single token at this layer and need no special handling.
-
-    Mirror of `_coalesce_subst_runs` in `cli-flag-incompat-advisory.py`
-    (codex review round 2 sibling fix). The helper will move into
-    `_hook_utils.py` at the third consumer per the project DRY-3 rule.
-    """
-    out: list[str] = []
-    i = 0
-    n = len(tokens)
-    while i < n:
-        tok = tokens[i]
-        if "$(" in tok and ")" not in tok[tok.index("$(") + 2:]:
-            j = i + 1
-            parts = [tok]
-            while j < n:
-                parts.append(tokens[j])
-                if ")" in tokens[j]:
-                    break
-                j += 1
-            out.append(" ".join(parts))
-            i = j + 1
-        else:
-            out.append(tok)
-            i += 1
-    return out
-
-
-def _extract_worktree_remove_path(argv: list[str]) -> str | None:
+def _extract_worktree_remove_path(seg: list[Token]) -> str | None:
     """Return the path argument of `git worktree remove <path>`, else None.
 
-    Walks past git global flags, locates the `worktree` `remove` subcommand
-    pair, skips any `-f` / `--force` style flags, and returns the first
-    positional argument (the path). Returns None when the command is not a
-    `git worktree remove` call or the path is missing. Unquoted `$(...)`
-    runs are coalesced before walking so a flag-with-arg value that
-    contains a multi-token substitution is counted as exactly one token.
+    Walks the typed Token list:
+      1. argv[0] must be COMMAND `git`.
+      2. Skip FLAG / FLAG_VALUE tokens (git globals — value tokens have
+         already been attributed via _FLAG_VALUE_SPEC).
+      3. The next POSITIONAL must be `worktree`.
+      4. Skip more FLAG / FLAG_VALUE tokens.
+      5. The next POSITIONAL must be `remove`.
+      6. Skip remove-level FLAG / FLAG_VALUE tokens (`-f`, `--force`).
+      7. The next POSITIONAL / SUBST_RUN / POST_DD text is the path.
+
+    Returns None for any other shape (non-git, non-worktree-remove).
     """
-    argv = _coalesce_subst_runs(strip_prefix(argv))
-    if not argv or argv[0] != "git":
+    argv = filter_argv(seg)
+    if not argv or argv[0].text != "git":
         return None
 
-    # Skip git-level global flags to find the subcommand. Consume value
-    # tokens for every known separated-arg global flag (not just repo-override
-    # flags), otherwise a benign `git -c name=value worktree remove <path>`
-    # bypasses detection because `name=value` is parsed as the subcommand.
+    n = len(argv)
     i = 1
-    while i < len(argv):
+
+    # Step 2-3: find `worktree`.
+    while i < n:
         tok = argv[i]
-        if tok == "--":
-            i += 1
-            break
-        if not tok.startswith("-"):
-            break
+        if tok.role == TokenRole.POSITIONAL:
+            if tok.text == "worktree":
+                break
+            return None  # different git subcommand
+        if tok.role in (TokenRole.SEPARATOR_DD, TokenRole.POST_DD, TokenRole.SUBST_RUN):
+            return None
+        # FLAG / FLAG_VALUE — skip
         i += 1
-        if "=" not in tok and tok in GIT_GLOBAL_FLAGS_WITH_ARG and i < len(argv):
-            i += 1  # consume value token for known flag-with-arg
-
-    # Expect: argv[i] == "worktree", argv[i+1] == "remove"
-    if i + 1 >= len(argv):
+    if i >= n:
         return None
-    if argv[i] != "worktree" or argv[i + 1] != "remove":
-        return None
-    i += 2
+    i += 1  # past 'worktree'
 
-    # Skip remove-level flags to reach the path positional.
-    while i < len(argv):
+    # Step 4-5: find `remove`.
+    while i < n:
         tok = argv[i]
-        if tok == "--":
-            i += 1
-            break
-        if not tok.startswith("-"):
-            break
+        if tok.role == TokenRole.POSITIONAL:
+            if tok.text == "remove":
+                break
+            return None  # different worktree subcommand
+        if tok.role in (TokenRole.SEPARATOR_DD, TokenRole.POST_DD, TokenRole.SUBST_RUN):
+            return None
         i += 1
-
-    if i >= len(argv):
+    if i >= n:
         return None
-    return argv[i]
+    i += 1  # past 'remove'
+
+    # Step 6-7: find the path positional.
+    while i < n:
+        tok = argv[i]
+        if tok.role == TokenRole.SEPARATOR_DD:
+            i += 1
+            continue
+        if tok.role in (TokenRole.FLAG, TokenRole.FLAG_VALUE):
+            i += 1
+            continue
+        if tok.role in (TokenRole.POSITIONAL, TokenRole.SUBST_RUN, TokenRole.POST_DD):
+            return tok.text
+        i += 1
+    return None
 
 
 def _normalize_path(path: str) -> str:
@@ -347,8 +338,8 @@ def main() -> int:
     if OPT_OUT_MARKER in command:
         return 0
 
-    tokens = safe_tokenize(command.replace("\\\n", " "))
-    if not tokens:
+    segments = tokenize_with_roles(command.replace("\\\n", " "), _FLAG_VALUE_SPEC)
+    if not segments:
         return 0
 
     # `effective_cwd` is updated by each preceding `cd <path>` segment so
@@ -362,20 +353,18 @@ def main() -> int:
     known: list[str] | None = None
     known_for_cwd: str | None = None
 
-    for argv in iter_command_starts(tokens):
-        argv = list(argv)
-
-        new_cwd = _interpret_cd(argv, effective_cwd)
+    for seg in segments:
+        new_cwd = _interpret_cd(seg, effective_cwd)
         if new_cwd is not None:
             effective_cwd = new_cwd
             continue
 
-        target = _extract_worktree_remove_path(argv)
+        target = _extract_worktree_remove_path(seg)
         if target is None:
             continue
 
         # Skip when the operator already pinned a repo via `-C` / `--git-dir`.
-        if _has_repo_override(argv):
+        if _has_repo_override(seg):
             continue
 
         # Resolve relative remove targets against effective_cwd. git

--- a/hooks/gh-flag-verify.py
+++ b/hooks/gh-flag-verify.py
@@ -30,6 +30,11 @@ Design notes:
   Value tokens after value-taking flags are consumed and never re-interpreted
   as flag identifiers. This correctly handles positional query strings that
   start with '-' (e.g. `gh search issues "-label:bug"`).
+- Role-aware tokenization (issue #263): `tokenize_with_roles` does the
+  value-skip centrally based on the derived `_FLAG_VALUE_SPEC`. Each FLAG
+  identifier the caller sees is already separated from its value, and the
+  `--` argv separator is honored automatically via SEPARATOR_DD / POST_DD
+  roles. The caller's only job is whitelist-match against COMPAT.
 """
 from __future__ import annotations
 
@@ -41,9 +46,10 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
-    iter_command_starts,
-    safe_tokenize,
-    strip_prefix,
+    Token,
+    TokenRole,
+    filter_argv,
+    tokenize_with_roles,
 )
 
 # ---------------------------------------------------------------------------
@@ -327,167 +333,161 @@ COMPAT: dict[tuple[str, str], dict[str, bool]] = {
     },
 }
 
+
+# ---------------------------------------------------------------------------
+# Role-aware flag-value spec derivation (issue #263).
+#
+# The role-aware tokenizer needs to know which flags consume a separate-token
+# value so that the value lands as FLAG_VALUE (not POSITIONAL). Since
+# `_resolve_subcommand` is single-level, we derive the per-(command,verb)
+# spec from COMPAT and aggregate at the "<command> <verb>" key. Globals
+# include every value-taking flag that appears anywhere in COMPAT, so a
+# misplaced subcommand flag at the global position (e.g. `gh --base main
+# issue list`) still consumes its value cleanly — and the caller then denies
+# on the flag name itself (it is not in GH_GLOBAL_FLAGS).
+# ---------------------------------------------------------------------------
+
+
+def _build_flag_value_spec() -> dict[str, set[str]]:
+    """Derive `tokenize_with_roles` spec from COMPAT + GH_GLOBAL_FLAGS_WITH_ARG."""
+    spec: dict[str, set[str]] = {"gh": set(GH_GLOBAL_FLAGS_WITH_ARG)}
+    for (obj, _), flags in COMPAT.items():
+        sub_key = f"gh {obj}"
+        spec.setdefault(sub_key, set())
+        for flag_name, takes_value in flags.items():
+            if takes_value:
+                spec[sub_key].add(flag_name)
+                # Also accept the same flag at the gh-level position so that
+                # erroneous placements before the subcommand still consume
+                # their value — the caller denies on the name.
+                spec["gh"].add(flag_name)
+    return spec
+
+
+_FLAG_VALUE_SPEC: dict[str, set[str]] = _build_flag_value_spec()
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def _skip_gh_global_flags(argv: list[str], start: int) -> tuple[int, str | None]:
-    """Walk past gh global flags from index `start` to find the subcommand.
-
-    Consumes tokens for flags that take a separate argument value
-    (e.g. `-R owner/repo`). Returns (index, bad_flag) where:
-    - index is the position of the first non-flag token (the subcommand).
-    - bad_flag is None when all pre-subcommand flags are in GH_GLOBAL_FLAGS;
-      when a `-*` token is NOT a recognized global flag, bad_flag is set to
-      that token and the caller should deny.
-    """
-    i = start
-    while i < len(argv):
-        tok = argv[i]
-        if tok == "--":
-            i += 1
-            break
-        if not tok.startswith("-"):
-            break
-        # Strip `=value` suffix to get the bare flag name for lookup.
-        bare = tok.split("=", 1)[0]
-        if bare not in GH_GLOBAL_FLAGS:
-            return i, tok  # unknown pre-subcommand flag — signal denial
-        i += 1
-        if "=" not in tok and tok in GH_GLOBAL_FLAGS_WITH_ARG and i < len(argv):
-            i += 1  # consume the value token
-    return i, None
-
-
-def _collect_flags(
-    argv: list[str],
-    flags_start: int,
-    subcommand_flags: dict[str, bool],
-) -> list[str]:
-    """Collect flag identifiers from argv[flags_start:], skipping value tokens.
-
-    Only collects tokens that have valid flag form:
-      - Long flags: start with '--' (e.g. --label, --state)
-      - Short flags: '-' followed by exactly one character (e.g. -R, -L, -w)
+def _is_valid_flag_form(text: str) -> bool:
+    """True iff text has the form of a real CLI flag (--long or -x).
 
     Tokens like '-label:bug' (single dash + multiple chars) are GitHub
-    advanced-search exclusion qualifiers used as positional arguments — they
-    are NOT flag identifiers and are silently ignored. This handles cases such
-    as `gh search issues "-label:bug"` where shlex strips the quotes and
-    delivers '-label:bug' as a plain token.
-
-    For value-taking flags (subcommand_flags[flag] is True or flag is in
-    GH_GLOBAL_FLAGS_WITH_ARG), advances past the following token so that
-    values starting with '-' are never re-interpreted as flag identifiers.
-    Handles both `--flag value` and `--flag=value` forms; the latter yields
-    `--flag` as the identifier (the `=value` part is stripped).
+    advanced-search exclusion qualifiers used as positional arguments.
+    They tokenize with a leading '-' and are tagged FLAG by the role API,
+    but they are NOT real flag identifiers and should be skipped.
     """
-    flags: list[str] = []
-    i = flags_start
-    while i < len(argv):
-        tok = argv[i]
-        if tok == "--":
-            break  # end of options
-        if tok.startswith("-"):
-            # Determine whether this token has valid flag form.
-            # Long flag: starts with '--'
-            # Short flag: '-' + exactly one character
-            # Anything else (e.g. '-label:bug') is a positional — skip it.
-            is_long_flag = tok.startswith("--")
-            is_short_flag = len(tok) == 2 and tok[0] == "-" and tok[1] != "-"
-            if not is_long_flag and not is_short_flag:
-                i += 1  # positional that looks like a search qualifier — ignore
-                continue
-            if "=" in tok:
-                # --flag=value form — value is embedded; no next-token skip needed
-                flag_name = tok.split("=", 1)[0]
-                flags.append(flag_name)
-                i += 1
-            else:
-                flags.append(tok)
-                i += 1
-                # Consume the value token when this is a value-taking flag
-                # so it is never interpreted as a flag identifier.
-                takes_value = subcommand_flags.get(tok) or tok in GH_GLOBAL_FLAGS_WITH_ARG
-                if takes_value and i < len(argv) and argv[i] != "--":
-                    i += 1  # skip the value token
-        else:
-            i += 1  # positional argument — skip
-    return flags
+    if text.startswith("--"):
+        return True
+    if len(text) == 2 and text[0] == "-" and text[1] != "-":
+        return True
+    return False
 
 
-def check_gh_flags(argv: list[str]) -> tuple[bool, str]:
+def check_gh_flags(seg: list[Token]) -> tuple[bool, str]:
     """Check a single command segment for gh flag compatibility.
 
-    Returns (is_invalid, reason_message).
-    is_invalid=True means the command should be blocked.
+    Returns (is_invalid, reason_message). is_invalid=True means deny.
+
+    Walk strategy (typed Token):
+      1. argv[0] must be COMMAND `gh`.
+      2. Pre-subcommand pass: every FLAG before the first POSITIONAL must
+         be in GH_GLOBAL_FLAGS (whitelist). FLAG_VALUE tokens are skipped
+         (already consumed by the role API).
+      3. First POSITIONAL → subcommand verb. Skip subsequent FLAG / FLAG_VALUE
+         tokens to find the second POSITIONAL → sub-subcommand verb.
+      4. Lookup `(subcommand, sub_subcommand)` in COMPAT — fail-open (silent
+         pass-through) if not present.
+      5. Post-subcommand pass: every FLAG after the sub-subcommand must be
+         in COMPAT[key] ∪ GH_GLOBAL_FLAGS. SEPARATOR_DD / POST_DD ends the
+         flag region.
     """
-    argv = strip_prefix(argv)
-    if not argv or argv[0] != "gh":
+    argv = filter_argv(seg)
+    if not argv or argv[0].text != "gh":
         return False, ""
 
-    # Walk past any gh global flags to find the subcommand word.
-    sub_start, bad_global = _skip_gh_global_flags(argv, 1)
-    if bad_global is not None:
-        bare_bad = bad_global.split("=", 1)[0]
-        allowed_list = ", ".join(sorted(GH_GLOBAL_FLAGS))
-        reason = (
-            f"Global flag '{bare_bad}' is not a recognized gh inherited flag. "
-            f"Allowed: {allowed_list}. "
-            f"Note: --hostname and --color are not accepted by gh subcommands."
-        )
-        return True, reason
-    if sub_start >= len(argv):
+    n = len(argv)
+    i = 1
+
+    # Step 2: Validate pre-subcommand flags against GH_GLOBAL_FLAGS.
+    while i < n:
+        tok = argv[i]
+        if tok.role == TokenRole.POSITIONAL:
+            break  # found subcommand verb
+        if tok.role == TokenRole.FLAG:
+            if not _is_valid_flag_form(tok.text.split("=", 1)[0]):
+                i += 1
+                continue
+            bare = tok.text.split("=", 1)[0]
+            if bare not in GH_GLOBAL_FLAGS:
+                allowed_list = ", ".join(sorted(GH_GLOBAL_FLAGS))
+                reason = (
+                    f"Global flag '{bare}' is not a recognized gh inherited flag. "
+                    f"Allowed: {allowed_list}. "
+                    f"Note: --hostname and --color are not accepted by gh subcommands."
+                )
+                return True, reason
+        # FLAG_VALUE / SUBST_RUN / etc. — skip.
+        i += 1
+
+    if i >= n:
         return False, ""  # no subcommand present
 
-    subcommand = argv[sub_start]
-    if subcommand.startswith("-"):
-        return False, ""  # flag where subcommand expected — malformed, skip
+    subcommand = argv[i].text
+    i += 1
 
-    # Determine whether this subcommand has a sub-subcommand (e.g. "search issues").
-    subsubcommand = ""
-    flags_start = sub_start + 1
-    key: tuple[str, str]
+    # Step 3: find sub-subcommand POSITIONAL. Skip intervening flag tokens.
+    sub_subcommand = ""
+    sub_idx: int | None = None
+    j = i
+    while j < n:
+        tok = argv[j]
+        if tok.role in (TokenRole.SEPARATOR_DD, TokenRole.POST_DD):
+            break
+        if tok.role == TokenRole.POSITIONAL:
+            sub_subcommand = tok.text
+            sub_idx = j
+            break
+        j += 1
 
-    # Check two-word form first (e.g. search issues, search prs).
-    if flags_start < len(argv) and not argv[flags_start].startswith("-"):
-        candidate_subsub = argv[flags_start]
-        two_word_key = (subcommand, candidate_subsub)
-        if two_word_key in COMPAT:
-            subsubcommand = candidate_subsub
-            flags_start += 1
-            key = two_word_key
-        else:
-            # Try single-word key (e.g. issue list, pr create).
-            one_word_key = (subcommand, argv[flags_start])
-            if one_word_key in COMPAT:
-                subsubcommand = argv[flags_start]
-                flags_start += 1
-                key = one_word_key
-            else:
-                return False, ""  # unknown subcommand — pass through
-    else:
-        key = (subcommand, "")
-        if key not in COMPAT:
-            return False, ""  # unknown subcommand — pass through
+    if sub_idx is None:
+        return False, ""  # unknown subcommand shape — pass through
 
-    subcommand_flags: dict[str, bool] = COMPAT[key]
-    # Build the allowed set: subcommand flag names + global flag names.
+    key = (subcommand, sub_subcommand)
+    if key not in COMPAT:
+        return False, ""  # unknown subcommand — pass through
+
+    subcommand_flags = COMPAT[key]
     allowed: frozenset[str] = frozenset(subcommand_flags) | GH_GLOBAL_FLAGS
 
-    flags_in_command = _collect_flags(argv, flags_start, subcommand_flags)
-    for flag in flags_in_command:
-        if flag not in allowed:
+    # Step 5: validate every FLAG after the sub-subcommand against allowed set.
+    # Also re-check any FLAGs that appeared BETWEEN the subcommand and the
+    # sub-subcommand — those belong to the same allowed set (cf. test T08
+    # and `gh issue --repo X create` form).
+    for k in range(i, n):
+        if k == sub_idx:
+            continue  # the sub-sub POSITIONAL itself
+        tok = argv[k]
+        if tok.role in (TokenRole.SEPARATOR_DD, TokenRole.POST_DD):
+            break
+        if tok.role != TokenRole.FLAG:
+            continue
+        bare = tok.text.split("=", 1)[0]
+        if not _is_valid_flag_form(bare):
+            continue  # positional that looks like a search qualifier — ignore
+        if bare not in allowed:
             subcmd_display = (
-                f"gh {subcommand} {subsubcommand}".strip()
-                if subsubcommand
+                f"gh {subcommand} {sub_subcommand}".strip()
+                if sub_subcommand
                 else f"gh {subcommand}"
             )
             reason = (
-                f"Flag '{flag}' is not valid for '{subcmd_display}'. "
+                f"Flag '{bare}' is not valid for '{subcmd_display}'. "
                 f"Run 'gh {subcommand}"
-                + (f" {subsubcommand}" if subsubcommand else "")
+                + (f" {sub_subcommand}" if sub_subcommand else "")
                 + " --help' to see accepted flags."
             )
             return True, reason
@@ -536,12 +536,12 @@ def main() -> int:
     # as a single command segment (same pre-processing as sibling hooks).
     command = command.replace("\\\n", " ")
 
-    tokens = safe_tokenize(command)
-    if not tokens:
+    segments = tokenize_with_roles(command, _FLAG_VALUE_SPEC)
+    if not segments:
         return 0
 
-    for argv in iter_command_starts(tokens):
-        is_invalid, reason = check_gh_flags(argv)
+    for seg in segments:
+        is_invalid, reason = check_gh_flags(seg)
         if is_invalid:
             _emit_deny(reason)
             return 2  # deny exit code


### PR DESCRIPTION
Closes #263 — Phase 2 (caller migration + dead helper 제거).

## 배경

Phase 1 (PR #284, 머지됨) 에서 `tokenize_with_roles` / `Token` / `TokenRole` API 가 `_hook_utils.py` 에 도입되고 `cli-flag-incompat-advisory.py` 1 개 caller 가 proof migration 으로 마이그레이션됨. 본 PR 은 issue #263 의 남은 작업 — 나머지 4 개 caller 마이그레이션 + 중복된 `_coalesce_subst_runs` mirror 제거 — 을 수행하여 issue 를 closes 한다.

## 변경 사항

### 1. 마이그레이션 4 개 caller

| 파일 | Phase 1 이전 ad-hoc 로직 | role-aware API 활용 |
|---|---|---|
| `block-gh-state-all.py` | `safe_tokenize` + 자체 flag-value 스킵 + 수동 `gh search <obj>` 구조 파싱 | `tokenize_with_roles` + COMMAND/POSITIONAL/FLAG/FLAG_VALUE iterate. `--state` 가 `gh search` spec 에 있어 `all` 이 자동 FLAG_VALUE 분류 |
| `gh-flag-verify.py` | `_skip_gh_global_flags` + `_collect_flags` 자체 walker, value-skip 로직 caller 가 관리 | `_FLAG_VALUE_SPEC` 을 COMPAT 으로부터 자동 도출. caller 는 typed token iterate + `_is_valid_flag_form` 만 |
| `cross-boundary-preflight.py` | `_skip_flags` + `_gh_write_subcommand` + `_has_repo_flag` 모두 자체 구현 | role API 가 subcommand 구조 + `--repo` FLAG_VALUE attribution 자동 처리. heredoc 검출만 raw token text 기반 유지 (`<<` 는 role 으로 분류 불가) |
| `cross-repo-worktree-preflight.py` | `_coalesce_subst_runs` mirror, 자체 `GIT_GLOBAL_FLAGS_WITH_ARG` value-skip, `_interpret_cd` / `_has_repo_override` / `_extract_worktree_remove_path` ad-hoc 파싱 | `$()` coalesce + `-c name=value` value-skip 모두 role API 가 처리. caller 는 `worktree`/`remove` POSITIONAL 매칭 + `-C`/`--git-dir` FLAG 검사만 |

### 2. Dead helper 제거

- `cross-repo-worktree-preflight.py:158-194` 의 `_coalesce_subst_runs` mirror 함수 삭제. Canonical 버전은 `_hook_utils.py:347-388` (PR #284 에서 도입). 마이그레이션 후 caller 가 직접 호출하지 않아도 됨.

`_count_merge_tree_positionals` 는 `cli-flag-incompat-advisory.py` 에서 활성 사용 중이므로 유지.

## 검증

각 caller 의 기존 테스트 그대로 전부 통과:

```
$ bash hooks/test-block-gh-state-all.sh
Passed: 29  Failed: 0

$ bash tests/test_gh_flag_verify.sh
Result: 35 passed, 0 failed

$ bash tests/test_cross_boundary_preflight.sh
  PASS: 43  FAIL: 0

$ bash hooks/test-cross-repo-worktree-preflight.sh
Passed: 28  Failed: 0

$ bash hooks/test-cli-flag-incompat-advisory.sh
Passed: 26  Failed: 0

$ bash tests/test_hook_utils.sh
  PASS: 69  FAIL: 0
```

합 230 개. 전체 hook test suite 중 `test_retrospect_routing.sh` (SKILL.md placeholder) + `test-pre-edit-md-escape-advisory.sh` (stale tmp 파일) 2 개는 본 PR 영향 무관 pre-existing 실패 — git stash 로 변경 제거 후 baseline 에서도 동일하게 재현 확인.

## Backward compat

기존 `safe_tokenize` / `iter_command_starts` / `strip_prefix` API 는 변경 없음. 본 PR 은 caller 내부 마이그레이션만 수행.

## Caller chain verification

Caller chain verified: grep found following _hook_utils consumers in hooks/.

```
$ grep -rln "from _hook_utils import" hooks/
hooks/advisory-wrapper-signature-verify.py
hooks/block-ask-end-option.py
hooks/block-gh-state-all.py             ← 본 PR 마이그레이션
hooks/block-manufactured-action-menu.py
hooks/block-pr-without-caller-evidence.py
hooks/builtin-task-postuse.py
hooks/cli-flag-incompat-advisory.py     ← Phase 1 (PR #284) 마이그레이션
hooks/commit-title-length-check.py
hooks/cross-boundary-preflight.py       ← 본 PR 마이그레이션
hooks/cross-repo-worktree-preflight.py  ← 본 PR 마이그레이션
hooks/external-api-literal-trigger.py
hooks/external-write-falsify-check.py
hooks/gh-flag-verify.py                 ← 본 PR 마이그레이션
hooks/memory-hint.py
hooks/output-block-falsify-advisory.py
hooks/pre-edit-md-escape-advisory.py
hooks/pre-edit-protected-branch-guard.py
hooks/pre-gh-pr-create-dedup-gate.py
hooks/pre-merge-approval-gate.py
hooks/session-intent.py
hooks/side-effect-scan.py
hooks/trino-describe-first.py
hooks/verify-commit-flag-override.py
hooks/external-api-literal-trigger.py
```

issue #263 의 「caller 마이그레이션」체크리스트 4 개 + dead helper 제거 항목 모두 본 PR 에서 완료. role-aware API 미사용 hook (위 grep 결과 중 본 PR 마이그레이션 4 곳 + Phase 1 의 cli-flag-incompat-advisory 외 나머지) 들은 `safe_tokenize` / `iter_command_starts` / `strip_prefix` legacy API 만 사용하여 본 변경의 영향 없음.
