### PR TITLE
feat(skill): add using-praxis meta entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Development workflow skills for Claude Code — disciplined, fast, resilient.
 > returns `Agent type not found` — Agent and Skill resolve disjoint namespaces.
 > See [RUNTIME_CONSTRAINTS.md §3](RUNTIME_CONSTRAINTS.md) for the mapping table.
 
+### Discovery
+
+| Skill | Description |
+|-------|-------------|
+| `using-praxis` | First-time orientation — skill categories, common scenarios, hook system overview |
+
 ### Development
 
 | Skill | Description |

--- a/skills/using-praxis/SKILL.md
+++ b/skills/using-praxis/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: using-praxis
+description: >
+  Onboarding entry point for new praxis users — introduces the 4 skill
+  categories, maps common scenarios to the right skill, and explains the
+  hook system. Triggers on "praxis 처음", "praxis 사용법", "어떤 skill 부터",
+  "praxis intro", "praxis getting started".
+---
+
+# Using Praxis
+
+Welcome to praxis — a set of Claude Code skills for disciplined, fast,
+resilient development workflow.
+
+## Skill Categories
+
+### Development
+Tools for code quality and review workflow.
+
+| Skill | When to call |
+|-------|-------------|
+| `retrospect` | End of session — find friction root causes and create lasting fixes |
+| `codex-review-wrap` | Before running `/codex:review` in a multi-worktree repo |
+
+### Discipline
+Session-scoped rule-violation tracking.
+
+| Skill | When to call |
+|-------|-------------|
+| `strike` | Record a rule violation (`/praxis:strike <reason>`) |
+| `strikes` | Check current strike count and recorded violations |
+| `reset-strikes` | Reset after a 3rd-strike block |
+
+### Session Management
+Recover, save, and orchestrate Claude Code sessions.
+
+| Skill | When to call |
+|-------|-------------|
+| `cmux-recover-sessions` | Sessions crashed / power loss (cmux backend) |
+| `recover-sessions` | Sessions crashed / power loss (tmux backend) |
+| `cmux-save-sessions` | Save current session layout as a JSON snapshot |
+| `cmux-resume-sessions` | Restore a previously saved snapshot |
+| `cmux-session-manager` | Daily status dashboard, cleanup, reorganize |
+| `cmux-delegate` | Delegate a task to an independent session with full context |
+| `cmux-browser` | Browser automation E2E testing via `cmux browser` CLI |
+
+### Discovery (this skill)
+| Skill | When to call |
+|-------|-------------|
+| `using-praxis` | First-time orientation — you are here |
+
+## Common Scenarios
+
+| Situation | Skill to call |
+|-----------|--------------|
+| "Claude Code sessions died after a crash or power-off" | `cmux-recover-sessions` (cmux) or `recover-sessions` (tmux) |
+| "I want to record that a CLAUDE.md rule was broken" | `strike` |
+| "There are too many Codex review comments — where to start?" | `codex-review-wrap` |
+
+## Hook System
+
+Praxis ships hooks that enforce CLAUDE.md rules structurally at the tool
+level (PreToolUse / PostToolUse / Stop / UserPromptSubmit). They fail-open
+on infrastructure errors — Claude Code never breaks, but violating patterns
+are blocked or warned before they land.
+
+Full hook index and per-hook specs: [`docs/hook/`](../../docs/hook/)
+
+## Prerequisites
+
+| Tier | Skills available | Dependencies |
+|------|-----------------|--------------|
+| **Standalone** | `recover-sessions`, `strike`, `strikes`, `reset-strikes` | `gh` CLI, `jq` |
+| **Enhanced** | + `retrospect`, `codex-review-wrap` | + oh-my-claudecode |
+| **Full** | + all `cmux-*` skills | + cmux |
+
+Install cmux: `npm i -g @anthropic/cmux`


### PR DESCRIPTION
## 개요

신규 사용자용 메타 skill `using-praxis`를 추가합니다.
`obra/superpowers`의 `using-superpowers` 패턴을 mirror했습니다.

## 변경 내용

### 신규: `skills/using-praxis/SKILL.md`

4개 카테고리(Development / Discipline / Session Management / Discovery)별 대표 skill 소개, 흔한 시나리오 3개에 대한 skill 매핑, hook 시스템 한 줄 소개 및 `docs/hook/` 진입점 링크, prerequisite 티어 표를 포함합니다.

Trigger 키워드: "praxis 처음", "praxis 사용법", "어떤 skill 부터", "praxis intro", "praxis getting started"

### 수정: `README.md`

Skills 표 최상단에 Discovery 카테고리 섹션을 추가하고 `using-praxis`를 첫 행으로 등록했습니다.

## 검증

```
$ python3 ./scripts/check-plugin-manifests.py
plugin-manifest check OK
```

코드 변경 없음 — 문서(SKILL.md)와 README만 수정.

Closes #266

## Caller chain verified: local worktree commit only, no cross-repo dependency
