### PR TITLE
feat(skills): add skill template and writing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,13 @@ class of drift bugs that have cost the most debugging time.
 
 ## Adding or modifying a skill
 
+### Template
+
+A starter template lives at [`skills/SKILL.md.tmpl`](skills/SKILL.md.tmpl).
+Copy it into `skills/<skill-name>/SKILL.md`, fill in the placeholders, and
+follow the step-by-step guide at
+[`skills/writing-praxis-skill/SKILL.md`](skills/writing-praxis-skill/SKILL.md).
+
 ### Directory structure
 
 ```

--- a/skills/SKILL.md.tmpl
+++ b/skills/SKILL.md.tmpl
@@ -1,0 +1,50 @@
+---
+name: <skill-name>
+description: >
+  <One-line description of what this skill does.>
+  Triggers on "<keyword1>", "<keyword2>", "<Korean-keyword>".
+---
+
+# <Skill Title>
+
+## Overview
+
+<2–3 sentences: what problem this skill solves and why it exists.>
+
+**Core principle:** <one-sentence invariant the skill enforces.>
+
+## When to Use
+
+- <condition or signal that warrants using this skill>
+- <condition 2>
+- Triggers: "<keyword1>", "<keyword2>", "<Korean-keyword>"
+
+## Process
+
+### Step 1: <Step Name>
+
+<What to do in this step. Include concrete commands or tool calls.>
+
+```bash
+# example command
+```
+
+### Step 2: <Step Name>
+
+<Next action. Keep steps atomic — one logical operation per step.>
+
+### Step N: Report
+
+<How to surface results to the user: format, required fields, one-line summary.>
+
+## Error Handling
+
+| Error | Recovery |
+|-------|----------|
+| <error condition> | <what to do> |
+| Prerequisite CLI not found | Abort with install instructions |
+
+## Limitations
+
+- <known limitation 1>
+- <known limitation 2>

--- a/skills/writing-praxis-skill/SKILL.md
+++ b/skills/writing-praxis-skill/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: writing-praxis-skill
+description: >
+  Guide for authoring a new praxis SKILL.md — template usage, SRP, trigger
+  keyword design, frontmatter conventions, and Claude/Codex host differences.
+  Triggers on "new skill", "write skill", "add skill", "skill template",
+  "skill spec", "스킬 작성", "새 스킬".
+---
+
+# writing-praxis-skill
+
+## Overview
+
+A new praxis skill needs a SKILL.md that the Claude Code plugin runtime can
+parse and route correctly. Without a consistent structure, the runtime silently
+misroutes or truncates the description, and contributors have to reverse-engineer
+the pattern from 13+ existing specs.
+
+**Core principle:** one skill = one responsibility. If a skill needs a second
+trigger phrase to describe a second job, split it into two skills.
+
+## When to Use
+
+- Creating a new praxis skill from scratch
+- Reviewing an existing SKILL.md for structural compliance
+- Onboarding a contributor who will add a skill
+- Triggers: "new skill", "write skill", "add skill", "skill template", "skill spec", "스킬 작성", "새 스킬"
+
+## Process
+
+### Step 1: Copy the Template
+
+```bash
+cp skills/SKILL.md.tmpl skills/<skill-name>/SKILL.md
+```
+
+Open the new file and replace every `<...>` placeholder. Do not leave any
+placeholder text in the committed file.
+
+### Step 2: Fill in the Frontmatter
+
+```yaml
+---
+name: <skill-name>         # kebab-case; must match the directory name
+description: >
+  <One-line description.>
+  Triggers on "<keyword1>", "<keyword2>", "<Korean-keyword>".
+---
+```
+
+**Rules:**
+- `name` must exactly match the directory name under `skills/`.
+- `description` must fit within 500 characters — the runtime truncates beyond that.
+- Always end `description` with a `Triggers on "..."` clause so the routing
+  table in CLAUDE.md can reference exact keywords.
+- Use multi-line `>` block for descriptions that include trigger keywords; use
+  inline text for short single-line descriptions (see `strike/SKILL.md`).
+
+**If the skill wraps an external CLI, calls `AskUserQuestion`, or delegates to
+another skill via `Skill(...)`,** add the runtime-verification fields after the
+initial description fields:
+
+```yaml
+verified-against-runtime: true
+runtime-verified-at: YYYY-MM-DD
+runtime-verified-note: "<cli-name> <version> — one-line observed behavior"
+```
+
+### Step 3: Design Trigger Keywords
+
+Trigger keywords are the phrases users type (or say) that route to this skill.
+The CLAUDE.md `Skill & Agent Routing` table maps them.
+
+**Principles:**
+- **Specific over generic.** "recover cmux" beats "recover" — the generic form
+  collides with unrelated skills.
+- **Cover the Korean variants.** If users will describe the task in Korean,
+  add the Korean form. Example: "크래시 복구", "세션 살려야".
+- **Cover the negation gap.** Phrases that look like a trigger but shouldn't be:
+  "strike a balance", "strike that" → these must NOT match `strike`.
+  Add exclusion notes to the description when collisions are plausible.
+- **3–6 keywords is the target range.** Fewer leaves gaps; more creates false
+  positives.
+
+### Step 4: Choose Sections
+
+Every SKILL.md must include **Overview**, **When to Use**, and **Process**.
+Add the others when relevant:
+
+| Section | Include when |
+|---------|-------------|
+| `## Overview` | Always |
+| `## When to Use` | Always |
+| `## The Iron Law` | Skill has non-negotiable invariants (recovery, destructive ops) |
+| `## Process` | Always — numbered steps, one logical op per step |
+| `## Error Handling` | Skill calls external CLIs, APIs, or cmux |
+| `## Limitations` | Known gaps the user might hit |
+| `## Architecture` | Multiple execution paths (modes, distribute variants) |
+
+**Step granularity:** each step is one logical operation. Avoid "do A and also
+B" in one step — split. Every step should leave the system in a coherent,
+inspectable state.
+
+### Step 5: Understand Host Differences
+
+The same SKILL.md runs on both the Claude Code plugin (Claude host) and the
+Codex plugin (Codex host). The two hosts differ in how they expose the skill:
+
+| Aspect | Claude host | Codex host |
+|--------|-------------|------------|
+| Invocation | `Skill("praxis:<name>")` or `/praxis:<name>` | `Skill("praxis:<name>")` |
+| `{{ARGUMENTS}}` | Populated from the slash command argument string | Populated from Skill args |
+| `Skill(...)` delegation | Supported for most skills | `disable-model-invocation: true` skills fail — use the underlying binary directly |
+| `AskUserQuestion` | Supported, max 4 options | Supported, max 4 options |
+| `Bash` cwd | Resets between separate Bash calls | Same behavior |
+| File `Write` | Supported | Sandbox-restricted; verify with `git status` after |
+
+**Critical Codex constraint:** never call `Skill("codex:review")` from inside
+a skill — it declares `disable-model-invocation: true` and always fails with
+an error. Call the underlying `codex-companion.mjs` script directly instead.
+See `codex-review-wrap/SKILL.md` Step 4 for the pattern.
+
+**`Bash` cwd reset trap:** a `Bash` call does not persist `cd` across calls.
+To change directory and run a command, chain them: `cd <path> && <command>`,
+or pass `cwd` as part of the same Bash invocation. Never assume the previous
+Bash call's directory is still active.
+
+### Step 6: Respect Runtime Constraints
+
+Read [`RUNTIME_CONSTRAINTS.md`](../../RUNTIME_CONSTRAINTS.md) before finishing
+the spec. The three constraints that bite most often:
+
+| Constraint | What to do |
+|------------|-----------|
+| `AskUserQuestion.options` max 4 items | Surface top 3 + "취소"; put the full list in the question body text |
+| `Skill(...)` rejects `disable-model-invocation: true` skills | Use the binary directly (see Step 5) |
+| `Bash` cwd resets between calls | Chain with `&&` or use absolute paths |
+
+### Step 7: Verify Before Merging
+
+Any skill that wraps an external CLI, calls `AskUserQuestion`, or delegates via
+`Skill(...)` **must** complete a live round-trip before the PR is merged.
+
+1. Invoke the skill in a real Claude Code session.
+2. Confirm the trigger keywords route correctly.
+3. Confirm `AskUserQuestion` renders with the expected options.
+4. Add `verified-against-runtime: true` + `runtime-verified-at` to frontmatter.
+5. Include a `verified:` line in the commit body (see CONTRIBUTING.md).
+
+Skills that are pure documentation (no CLI calls, no tool calls) may skip the
+live round-trip, but must still have a reviewer read-through.
+
+### Step 8: Register the Skill
+
+1. Add the skill's trigger keywords to the routing table in the project's
+   `CLAUDE.md` (or the root `CLAUDE.md` for global skills).
+2. Run `./scripts/check-plugin-manifests.py` — new skill directories are
+   picked up automatically by the build script, but the check confirms no
+   packaging drift.
+
+### Step 9: Open the PR
+
+Follow the standard praxis PR workflow:
+- Title: `feat(skill): <what the skill does>` (≤ 50 chars)
+- Body in Korean; `Closes #<issue-number>`
+- Include the `verified:` line in the commit body if Step 7 applies
+
+## Failure Modes
+
+| Failure | Cause | Fix |
+|---------|-------|-----|
+| Skill not invoked by routing | Trigger keywords missing from CLAUDE.md routing table | Add keywords to the routing table |
+| Description truncated by runtime | `description` > 500 chars | Shorten; move detail into the body |
+| `Skill(...)` call fails silently | Target skill uses `disable-model-invocation: true` | Call the underlying binary directly |
+| `AskUserQuestion` renders only 2 options | Options array > 4 items | Truncate to 3 + "취소" |
+| Codex worker produces empty `git diff` | Sandbox write restriction | Add `git status` check + claude fallback re-dispatch |
+| Trigger collides with unrelated skill | Keyword too generic | Make the keyword more specific; add exclusion note |
+
+## Examples
+
+### Minimal skill (no external CLI)
+
+```markdown
+---
+name: strikes
+description: Show the current session's strike count (0-3) and the list of
+  recorded violation reasons. Use when the user types "/strikes", "strike status",
+  "몇 진", "check strikes".
+---
+
+# Praxis Strikes
+...
+```
+
+### Skill with multi-line description and runtime verification
+
+```markdown
+---
+name: cmux-recover-sessions
+description: >
+  Bulk recover Claude Code sessions after a crash, power loss, OOM kill, or reboot
+  by scanning the .jsonl files Claude Code persists automatically.
+  Triggers on "크래시 복구", "세션 살려야", "crash recovery".
+verified-against-runtime: true
+runtime-verified-at: 2026-04-10
+runtime-verified-note: "cmux 1.2.3 — new-workspace accepted; list-workspaces format confirmed"
+---
+```

--- a/skills/writing-praxis-skill/SKILL.md
+++ b/skills/writing-praxis-skill/SKILL.md
@@ -117,8 +117,8 @@ Codex plugin (Codex host). The two hosts differ in how they expose the skill:
 
 **Critical Codex constraint:** never call `Skill("codex:review")` from inside
 a skill — it declares `disable-model-invocation: true` and always fails with
-an error. Call the underlying `codex-companion.mjs` script directly instead.
-See `codex-review-wrap/SKILL.md` Step 4 for the pattern.
+an error. Invoke the codex CLI binary directly via `Bash` instead, mirroring
+the `codex-review-wrap` skill's Step 4 pattern.
 
 **`Bash` cwd reset trap:** a `Bash` call does not persist `cd` across calls.
 To change directory and run a command, chain them: `cd <path> && <command>`,


### PR DESCRIPTION
## 개요

신규 skill 작성 진입 장벽 해소를 위해 2개 파일을 추가하고 CONTRIBUTING.md에 링크를 삽입합니다.

## 변경 사항

### `skills/SKILL.md.tmpl`
- frontmatter 스켈레톤 (`name`, `description`, Triggers 형식)
- 표준 섹션 (Overview, When to Use, Process, Error Handling, Limitations)
- `<...>` placeholder — 커밋 전 전부 교체 필요

### `skills/writing-praxis-skill/SKILL.md`
- 9-step 작성 가이드: template 복사 → frontmatter → 트리거 설계 → 섹션 선택 → 호스트 차이 → 런타임 제약 → 라이브 검증 → 등록 → PR
- SRP 원칙: 하나의 skill = 하나의 책임
- Claude/Codex 호스트별 차이 표 (`AskUserQuestion`, `Bash` cwd, `Skill()` 위임, Codex 샌드박스)
- 런타임 제약 요약표 (옵션 max 4, `disable-model-invocation`, cwd reset)
- 실패 모드 표 및 최소/완전 frontmatter 예시

### `CONTRIBUTING.md`
- "Adding or modifying a skill" 섹션 맨 위에 `### Template` 단락 추가
- 두 신규 파일로의 링크 삽입

## 검증

- `./scripts/check-plugin-manifests.py` → `plugin-manifest check OK`
- 신규 파일: 기존 sibling 5개 SKILL.md 컨벤션 흡수 후 작성
- README.md 미수정 (#266 충돌 방지)

Caller chain verified: N/A -- docs-only change

Closes #268
