### PR TITLE
feat(retrospect): add reinforced-patterns lane

### DIFF
--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -76,7 +76,13 @@ You MUST complete each stage before proceeding to the next.
 
 ### Stage 2: Analyze Conversation
 
-**Pre-scan: Quick friction event identification** — scan the conversation for up to 5 friction events (user corrections, retries, skipped steps, stalls) BEFORE calling agents. This provides the input for agent calls.
+**Pre-scan: Symmetric scan (friction + successful patterns)** — scan the conversation BEFORE calling agents. Produces two lanes:
+
+- **friction_events**: up to 5 friction events (user corrections, retries, skipped steps, stalls). This provides the input for agent calls.
+- **successful_patterns**: up to 3 patterns that worked well this session. Each entry MUST include:
+  - `pattern`: one line (e.g., "deep-dive 3-lane trace identified cross-lane contradiction via direct grep")
+  - `evidence`: specific turn or artifact citation (mandatory — abstract reinforcement like "was helpful" or "responded fast" is FORBIDDEN)
+  - `reinforce_action`: `memory` (capture as feedback entry) or `visualize_only` (display in Stage 3 report, no persistent action)
 
 **Pre-scan Categorization (Mandatory)** — every friction event identified in pre-scan MUST be tagged with `category[]: string[]` containing ≥1 of these enumerated values. Stage 2 progression to step 3 is BLOCKED until every event has at least one category label.
 
@@ -385,6 +391,13 @@ when <observation predicate>$`.
 If no Gate-3 (b) demotions occurred, omit this section entirely (do not emit "None.").
 
 No patterns found: emit the distribution card with all counts = 0 and verdicts = NA, plus literal "This session followed all CLAUDE.md rules. ✅"
+
+### Reinforced Patterns (this session)
+
+(Emitted only when pre-scan found ≥1 successful_patterns. Omit this section entirely if none — do not emit "None.")
+
+- {pattern_1} (evidence: {turn or artifact})
+- {pattern_2} ...
 ```
 
 The unified table folds the previous dual-table layout (Pattern + Tool/Feature Findings) into one. Tool-layer information that previously lived in a separate "Tool/Feature Findings" table is now carried in the `Tool Layer` column of every row tagged with `tool` in `Category`. Reviewers see all findings in priority order without cross-referencing two tables.


### PR DESCRIPTION
## 변경 요약

Stage 2 pre-scan 과 Stage 3 Report 두 곳에만 변경.

### Stage 2 pre-scan
기존 "Quick friction event identification" 단일 lane → **Symmetric scan (friction + successful patterns)** 이중 lane으로 전환:
- `friction_events`: 기존 로직 (cap ≤5, 변경 없음)
- `successful_patterns`: 신규 lane (cap ≤3)
  - `pattern`: 한 줄 필수
  - `evidence`: 구체적 turn/artifact 인용 필수 (추상 reinforcement 금지)
  - `reinforce_action`: `memory` 또는 `visualize_only`

### Stage 3 Report 끝
`### Reinforced Patterns (this session)` 섹션 신규 추가:
- pre-scan successful_patterns ≥1 개일 때만 emit (없으면 섹션 전체 omit)
- action 없음, 가시화 only
- Stop hook 파싱 범위 외 (distribution card / gate verdict 무관)

## 수용 기준 체크

- [x] SKILL.md Stage 2 pre-scan에 successful_patterns lane 추가
- [x] Stage 3 Report에 `### Reinforced Patterns` 섹션 추가 (optional emit)
- [x] 각 successful pattern의 evidence-citation 강제 명세
- [x] action 타입 매핑 없음 — 가시화 only
- [x] `hooks/retrospect-mix-check.sh` 영향 없음 (distribution card 무관)

## 변경 범위 self-check

diff가 Stage 2 pre-scan (line 79 영역) + Stage 3 Report 끝 (No patterns found 이후) 두 군데에만 한정됨을 `git diff`로 확인 완료.

Closes #286