### PR TITLE
refactor(hook): external-api-literal-trigger use safe_tokenize

### DIFF
--- a/hooks/external-api-literal-trigger.py
+++ b/hooks/external-api-literal-trigger.py
@@ -34,8 +34,14 @@ are excluded to avoid noise on internal source-code literals.
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
+
+# Resolve sibling `_hook_utils.py` regardless of cwd at invocation time.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _hook_utils import safe_tokenize  # type: ignore[import-not-found]  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Pattern definitions
@@ -230,6 +236,12 @@ def extract_scan_target(tool_name: str, tool_input: dict) -> str | None:
     value = tool_input.get(field)
     if not isinstance(value, str):
         return None
+    # Bash commands are shell syntax: tokenize first so that quoted argument
+    # values are unquoted and shell operators (;|&) are stripped as separators.
+    # Rejoin preserves the sequential ordering that SQL context detection needs.
+    if tool_name == "Bash":
+        tokens = safe_tokenize(value)
+        return " ".join(tokens) if tokens else value
     return value
 
 

--- a/tests/test_external_api_literal_trigger.sh
+++ b/tests/test_external_api_literal_trigger.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# test_external_api_literal_trigger.sh — coverage for external-api-literal-trigger hook
+#
+# Synthesizes Claude Code PreToolUse payloads and asserts:
+#   advisory:<needle> → exit 0 + stderr contains <needle>
+#   pass              → exit 0 + stderr empty
+#
+# Usage: bash tests/test_external_api_literal_trigger.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$ROOT_DIR/hooks/external-api-literal-trigger.py"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable: $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+# run_case name expectation payload
+#   expectation:
+#     "advisory:<needle>" — exit 0 + stderr contains <needle>
+#     "pass"              — exit 0 + stderr empty
+run_case() {
+  local name="$1" expectation="$2" payload="$3"
+
+  local err_file
+  err_file=$(mktemp)
+  printf '%s' "$payload" | python3 "$HOOK" >/dev/null 2>"$err_file"
+  local rc=$?
+  local err
+  err=$(cat "$err_file")
+  rm -f "$err_file"
+
+  local ok=1
+  case "$expectation" in
+    advisory:*)
+      local needle="${expectation#advisory:}"
+      [ "$rc" -eq 0 ] || ok=0
+      case "$err" in
+        *"$needle"*) ;;
+        *) ok=0 ;;
+      esac
+      ;;
+    pass)
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$err" ]   || ok=0
+      ;;
+    *)
+      echo "FAIL  [$name] unknown expectation: $expectation"
+      FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name"); return
+      ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expectation=$expectation rc=$rc stderr=${err:0:200}"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Payload helpers
+# ---------------------------------------------------------------------------
+
+bash_payload() {
+  python3 -c "import json,sys; print(json.dumps({'tool_name':'Bash','tool_input':{'command':sys.argv[1]}}))" "$1"
+}
+
+write_payload() {
+  python3 -c "import json,sys; print(json.dumps({'tool_name':'Write','tool_input':{'file_path':'x.py','content':sys.argv[1]}}))" "$1"
+}
+
+edit_payload() {
+  python3 -c "import json,sys; print(json.dumps({'tool_name':'Edit','tool_input':{'file_path':'x.py','old_string':'x','new_string':sys.argv[1]}}))" "$1"
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+echo "test_external_api_literal_trigger"
+
+# --- Pass cases ---
+
+run_case "clean_bash_git_status" "pass" \
+  "$(bash_payload 'git status')"
+
+run_case "clean_bash_echo_plain" "pass" \
+  "$(bash_payload 'echo hello world')"
+
+run_case "stop_word_README" "pass" \
+  "$(bash_payload 'cat README.md')"
+
+run_case "stop_word_LICENSE" "pass" \
+  "$(write_payload 'MIT LICENSE')"
+
+run_case "unknown_tool" "pass" \
+  '{"tool_name":"Read","tool_input":{"file_path":"x.py"}}'
+
+run_case "malformed_stdin" "pass" \
+  'not-json-at-all'
+
+run_case "short_allcaps_under_min" "pass" \
+  "$(bash_payload 'echo ABORT')"
+
+# --- Advisory cases: Bash with safe_tokenize path ---
+
+run_case "bash_allcaps_unquoted" "advisory:LAST_365_DAYS" \
+  "$(bash_payload 'trino -e "SELECT LAST_365_DAYS FROM t"')"
+
+run_case "bash_allcaps_quoted_arg" "advisory:SHOPBY_AUTH_TOKEN" \
+  "$(bash_payload 'curl -H "Authorization: Bearer SHOPBY_AUTH_TOKEN"')"
+
+run_case "bash_compound_allcaps" "advisory:VENDOR_TOKEN_TYPE" \
+  "$(bash_payload 'echo ok && gh issue create --body VENDOR_TOKEN_TYPE')"
+
+run_case "bash_sql_3part_from" "advisory:catalog.schema.table" \
+  "$(bash_payload 'trino -e "SELECT * FROM catalog.schema.table WHERE id=1"')"
+
+# --- Advisory cases: Write / Edit (raw content path) ---
+
+run_case "write_allcaps" "advisory:TOKEN_TYPE_BEARER" \
+  "$(write_payload 'TOKEN_TYPE_BEARER value')"
+
+run_case "edit_allcaps" "advisory:AUTH_TOKEN_SCOPE" \
+  "$(edit_payload 'AUTH_TOKEN_SCOPE')"
+
+run_case "write_sql_3part" "advisory:prod.analytics.events" \
+  "$(write_payload 'SELECT * FROM prod.analytics.events WHERE dt > now()')"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+if [ "$FAIL" -eq 0 ]; then
+  echo "ALL $PASS PASSED"
+  exit 0
+else
+  echo "$FAIL FAILED / $PASS PASSED — ${FAILED_NAMES[*]}"
+  exit 1
+fi


### PR DESCRIPTION
## 변경 요약

`hooks/external-api-literal-trigger.py` 의 Bash 명령어 처리에 `_hook_utils.safe_tokenize` 를 도입합니다.

### 문제

이 hook 은 AGENTS.md hook design contract ("Structural tokenization, not regex. `safe_tokenize` → `iter_command_starts` → `strip_prefix` is the shared primitive") 를 따르지 않고 있었습니다. Bash `command` 필드를 raw 문자열로 직접 regex 스캔하여 쉘 메타문자(따옴표, `&&`, `||`, `;`)가 스캔 입력에 그대로 포함됐습니다.

### 변경 사항

- `hooks/external-api-literal-trigger.py`
  - `import os` 추가
  - `sys.path.insert(0, os.path.dirname(__file__))` + `from _hook_utils import safe_tokenize` 추가
  - `extract_scan_target()` 내 Bash 분기: `safe_tokenize(command)` 로 토크나이징 후 join → 스캔. Write/Edit 경로는 기존 raw 스캔 유지
  - `chmod +x` (다른 hook 파일과 일관된 실행 권한)

- `tests/test_external_api_literal_trigger.sh` 신규 추가 (14개 케이스)
  - pass 케이스: clean bash, stop-word, unknown tool, malformed stdin, 짧은 ALLCAPS
  - advisory 케이스: Bash 따옴표 안 ALLCAPS, 복합 명령어 ALLCAPS, SQL 3-part FROM; Write/Edit ALLCAPS + SQL

### 검증

```
bash tests/test_external_api_literal_trigger.sh
# ALL 14 PASSED
```

### Phase 2

9개 미import hook 분리 검토는 이슈 #256 Phase 2 로 follow-up.

Closes #256 (Phase 1)
