### PR TITLE
feat(platforms): add cursor, gemini, opencode manifests

### DIFF
--- a/.cursor-plugin/hooks/hooks.json
+++ b/.cursor-plugin/hooks/hooks.json
@@ -1,0 +1,53 @@
+{
+  "description": "praxis hooks: Stop gate for completion-without-evidence, retrospect memory-bias gate, session-scoped three-strike discipline, PreToolUse(Bash) side-effect scan / gh search --state all block / memory-hint / caller-chain evidence gate on gh pr create / pre-merge approval gate / cross-boundary pre-flight (heredoc block + cross-repo ask), PreToolUse(AskUserQuestion) end-option mechanical-transcribe advisory + manufactured action-menu continuation guard, PostToolUse correction for built-in task management tools, UserPromptSubmit codex-review worktree disambiguation",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/strike-counter.sh session-start",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/strike-counter.sh preprompt",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/codex-review-route.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/completion-verify.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/retrospect-mix-check.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/strike-counter.sh stop",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.cursor-plugin/hooks/hooks.json
+++ b/.cursor-plugin/hooks/hooks.json
@@ -28,6 +28,18 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/count-assertion-verify.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "praxis",
+  "description": "Development workflow skills for Claude Code — disciplined, fast, resilient",
+  "version": "3.17.0",
+  "author": {
+    "name": "devseunggwan"
+  },
+  "repository": "https://github.com/devseunggwan/praxis",
+  "keywords": [
+    "workflow",
+    "discipline",
+    "verification",
+    "debugging",
+    "session-management",
+    "cleanup"
+  ],
+  "skills": "./skills/",
+  "hooks": "./hooks/"
+}

--- a/.opencode/hooks/hooks.json
+++ b/.opencode/hooks/hooks.json
@@ -1,0 +1,53 @@
+{
+  "description": "praxis hooks: Stop gate for completion-without-evidence, retrospect memory-bias gate, session-scoped three-strike discipline, PreToolUse(Bash) side-effect scan / gh search --state all block / memory-hint / caller-chain evidence gate on gh pr create / pre-merge approval gate / cross-boundary pre-flight (heredoc block + cross-repo ask), PreToolUse(AskUserQuestion) end-option mechanical-transcribe advisory + manufactured action-menu continuation guard, PostToolUse correction for built-in task management tools, UserPromptSubmit codex-review worktree disambiguation",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/strike-counter.sh session-start",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/strike-counter.sh preprompt",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/codex-review-route.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/completion-verify.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/retrospect-mix-check.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/strike-counter.sh stop",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.opencode/hooks/hooks.json
+++ b/.opencode/hooks/hooks.json
@@ -28,6 +28,18 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/count-assertion-verify.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/.opencode/plugin.json
+++ b/.opencode/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "praxis",
+  "description": "Development workflow skills for Claude Code — disciplined, fast, resilient",
+  "version": "3.17.0",
+  "author": {
+    "name": "devseunggwan"
+  },
+  "repository": "https://github.com/devseunggwan/praxis",
+  "keywords": [
+    "workflow",
+    "discipline",
+    "verification",
+    "debugging",
+    "session-management",
+    "cleanup"
+  ],
+  "skills": "./skills/",
+  "hooks": "./hooks/"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,8 @@ resolution algorithm.
 ## Multi-Platform Packaging
 
 Runtime source (`skills/`, `hooks/`, `scripts/`) is shared; per-platform
-manifests (Claude, Codex) are generated from canonical metadata. See
+manifests (Claude, Codex, Cursor, Gemini, OpenCode) are generated from
+canonical metadata. See
 [`ARCHITECTURE.md → Multi-Platform Packaging`](ARCHITECTURE.md#multi-platform-packaging)
 for the source files, generated outputs, and add-a-new-platform flow.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -129,11 +129,16 @@ packaging is *generated* from canonical metadata, not hand-edited:
 - `manifests/plugin.base.json` — shared metadata (name, description, author,
   repository, homepage, category, keywords). `VERSION` is the authoritative
   version string.
-- `manifests/platforms/{claude,codex}.json` — per-platform output list.
+- `manifests/platforms/{claude,codex,cursor,gemini,opencode}.json` — per-platform output list.
 - `scripts/build-plugin-manifests.py` — regenerate every artifact. Idempotent.
 - `scripts/check-plugin-manifests.py` — CI drift gate. Verifies generated
   files match the source and that the Codex adapter shell's symlinks
   (`plugins/praxis/{skills,hooks,scripts}`) point at the repo root.
+
+Platform manifests support two optional top-level fields:
+- `excluded_hooks` — hook script names (without `.sh`) to omit when generating
+  `filtered-hooks` outputs. Also serves as compatibility documentation.
+- `excluded_skills` — reserved for future per-platform skill filtering.
 
 Generated (committed) outputs:
 
@@ -144,6 +149,11 @@ Generated (committed) outputs:
 | `.agents/plugins/marketplace.json` | Codex marketplace root |
 | `plugins/praxis/.codex-plugin/plugin.json` | Codex plugin root |
 | `plugins/praxis/{skills,hooks,scripts}` | Symlinks into repo-root runtime |
+| `.cursor-plugin/plugin.json` | Cursor IDE plugin root |
+| `.cursor-plugin/hooks/hooks.json` | Cursor-compatible hooks (filtered) |
+| `gemini-extension.json` | Gemini CLI extension catalog |
+| `.opencode/plugin.json` | OpenCode plugin root |
+| `.opencode/hooks/hooks.json` | OpenCode-compatible hooks (filtered) |
 
 **Do not edit generated files directly.** Change `manifests/*.json` (or
 `VERSION`) and re-run the build script. Run `./scripts/check-plugin-manifests.py`

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,15 @@
+{
+  "name": "praxis",
+  "description": "Development workflow skills for Claude Code — disciplined, fast, resilient",
+  "version": "3.17.0",
+  "author": "devseunggwan",
+  "repository": "https://github.com/devseunggwan/praxis",
+  "keywords": [
+    "workflow",
+    "discipline",
+    "verification",
+    "debugging",
+    "session-management",
+    "cleanup"
+  ]
+}

--- a/manifests/platforms/cursor.json
+++ b/manifests/platforms/cursor.json
@@ -1,0 +1,43 @@
+{
+  "platform": "cursor",
+  "excluded_hooks": [
+    "side-effect-scan",
+    "block-gh-state-all",
+    "memory-hint",
+    "cross-boundary-preflight",
+    "cross-repo-worktree-preflight",
+    "block-pr-without-caller-evidence",
+    "pre-gh-pr-create-dedup-gate",
+    "commit-title-length-check",
+    "pre-merge-approval-gate",
+    "gh-flag-verify",
+    "cli-flag-incompat-advisory",
+    "verify-commit-flag-override",
+    "session-intent",
+    "output-block-falsify-advisory",
+    "external-api-literal-trigger",
+    "pre-edit-protected-branch-guard",
+    "pre-edit-md-escape-advisory-pre",
+    "advisory-wrapper-signature-verify",
+    "block-ask-end-option",
+    "block-manufactured-action-menu",
+    "trino-describe-first-pre",
+    "builtin-task-postuse",
+    "pre-edit-md-escape-advisory-post",
+    "trino-describe-first-post"
+  ],
+  "outputs": [
+    {
+      "kind": "plugin",
+      "path": ".cursor-plugin/plugin.json",
+      "plugin_overrides": {
+        "skills": "./skills/",
+        "hooks": "./hooks/"
+      }
+    },
+    {
+      "kind": "filtered-hooks",
+      "path": ".cursor-plugin/hooks/hooks.json"
+    }
+  ]
+}

--- a/manifests/platforms/gemini.json
+++ b/manifests/platforms/gemini.json
@@ -1,0 +1,39 @@
+{
+  "platform": "gemini",
+  "excluded_hooks": [
+    "strike-counter",
+    "codex-review-route",
+    "session-intent",
+    "side-effect-scan",
+    "block-gh-state-all",
+    "memory-hint",
+    "cross-boundary-preflight",
+    "cross-repo-worktree-preflight",
+    "block-pr-without-caller-evidence",
+    "pre-gh-pr-create-dedup-gate",
+    "commit-title-length-check",
+    "pre-merge-approval-gate",
+    "gh-flag-verify",
+    "cli-flag-incompat-advisory",
+    "verify-commit-flag-override",
+    "output-block-falsify-advisory",
+    "external-api-literal-trigger",
+    "pre-edit-protected-branch-guard",
+    "pre-edit-md-escape-advisory-pre",
+    "advisory-wrapper-signature-verify",
+    "block-ask-end-option",
+    "block-manufactured-action-menu",
+    "trino-describe-first-pre",
+    "builtin-task-postuse",
+    "pre-edit-md-escape-advisory-post",
+    "trino-describe-first-post",
+    "completion-verify",
+    "retrospect-mix-check"
+  ],
+  "outputs": [
+    {
+      "kind": "gemini-extension",
+      "path": "gemini-extension.json"
+    }
+  ]
+}

--- a/manifests/platforms/opencode.json
+++ b/manifests/platforms/opencode.json
@@ -1,0 +1,43 @@
+{
+  "platform": "opencode",
+  "excluded_hooks": [
+    "side-effect-scan",
+    "block-gh-state-all",
+    "memory-hint",
+    "cross-boundary-preflight",
+    "cross-repo-worktree-preflight",
+    "block-pr-without-caller-evidence",
+    "pre-gh-pr-create-dedup-gate",
+    "commit-title-length-check",
+    "pre-merge-approval-gate",
+    "gh-flag-verify",
+    "cli-flag-incompat-advisory",
+    "verify-commit-flag-override",
+    "session-intent",
+    "output-block-falsify-advisory",
+    "external-api-literal-trigger",
+    "pre-edit-protected-branch-guard",
+    "pre-edit-md-escape-advisory-pre",
+    "advisory-wrapper-signature-verify",
+    "block-ask-end-option",
+    "block-manufactured-action-menu",
+    "trino-describe-first-pre",
+    "builtin-task-postuse",
+    "pre-edit-md-escape-advisory-post",
+    "trino-describe-first-post"
+  ],
+  "outputs": [
+    {
+      "kind": "plugin",
+      "path": ".opencode/plugin.json",
+      "plugin_overrides": {
+        "skills": "./skills/",
+        "hooks": "./hooks/"
+      }
+    },
+    {
+      "kind": "filtered-hooks",
+      "path": ".opencode/hooks/hooks.json"
+    }
+  ]
+}

--- a/scripts/build-plugin-manifests.py
+++ b/scripts/build-plugin-manifests.py
@@ -7,12 +7,19 @@ Reads:
                                    keywords)
   manifests/platforms/*.json     — per-platform output declarations
   VERSION                        — authoritative version string
+  hooks/hooks.json               — canonical hook registry (used when
+                                   generating filtered-hooks outputs)
 
 Writes (generated artifacts, committed to the repo):
   .claude-plugin/plugin.json
   .claude-plugin/marketplace.json
   .agents/plugins/marketplace.json
   plugins/praxis/.codex-plugin/plugin.json
+  .cursor-plugin/plugin.json
+  .cursor-plugin/hooks/hooks.json
+  gemini-extension.json
+  .opencode/plugin.json
+  .opencode/hooks/hooks.json
 
 Also creates `plugins/praxis/{skills,hooks,scripts}` as symlinks into the
 repo root so the Codex adapter shell forwards to the common runtime
@@ -20,11 +27,26 @@ directories without duplicating source.
 
 Idempotent. Re-running on a clean tree produces no diff — that invariant
 is what `scripts/check-plugin-manifests.py` verifies in CI.
+
+Platform manifest schema:
+  platform          str   — platform identifier
+  excluded_hooks    list  — hook script names (without .sh) to omit from
+                            filtered-hooks outputs; documentation for
+                            gemini-extension outputs
+  excluded_skills   list  — reserved for future per-platform skill filtering
+  outputs           list  — output declarations (see output kinds below)
+
+Output kinds:
+  plugin            — plugin.json with base metadata + plugin_overrides
+  marketplace       — marketplace catalog JSON
+  filtered-hooks    — hooks/hooks.json with excluded_hooks entries removed
+  gemini-extension  — gemini-extension.json in Gemini CLI format
 """
 from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -34,12 +56,51 @@ MANIFESTS_DIR = REPO_ROOT / "manifests"
 PLATFORMS_DIR = MANIFESTS_DIR / "platforms"
 ADAPTER_SHELL = REPO_ROOT / "plugins" / "praxis"
 FORWARDED_DIRS = ("skills", "hooks", "scripts")
+HOOKS_JSON_PATH = REPO_ROOT / "hooks" / "hooks.json"
 
 
 def load_base() -> dict:
     base = json.loads((MANIFESTS_DIR / "plugin.base.json").read_text())
     base["version"] = (REPO_ROOT / "VERSION").read_text().strip()
     return base
+
+
+def load_hooks() -> dict:
+    return json.loads(HOOKS_JSON_PATH.read_text())
+
+
+def _extract_hook_name(command: str) -> str:
+    """Return the hook script basename (no .sh) from a hook command string."""
+    m = re.search(r"/hooks/([^/\s]+?)\.sh", command)
+    return m.group(1) if m else ""
+
+
+def filter_hooks(hooks_config: dict, excluded: list[str]) -> dict:
+    """Return a new hooks config with entries for excluded scripts removed.
+
+    An entry is removed when its ``command`` field references a script whose
+    basename (without .sh) appears in *excluded*.  Events and groups that
+    become empty after filtering are also removed.
+    """
+    if not excluded:
+        return hooks_config
+    excluded_set = set(excluded)
+    result: dict = {"description": hooks_config.get("description", ""), "hooks": {}}
+    for event, groups in hooks_config.get("hooks", {}).items():
+        filtered_groups = []
+        for group in groups:
+            kept = [
+                entry
+                for entry in group.get("hooks", [])
+                if _extract_hook_name(entry.get("command", "")) not in excluded_set
+            ]
+            if kept:
+                new_group = {k: v for k, v in group.items() if k != "hooks"}
+                new_group["hooks"] = kept
+                filtered_groups.append(new_group)
+        if filtered_groups:
+            result["hooks"][event] = filtered_groups
+    return result
 
 
 def render_plugin(base: dict, overrides: dict) -> dict:
@@ -80,7 +141,27 @@ def render_marketplace(base: dict, plugin_source: str, extras: dict | None) -> d
     return manifest
 
 
-def render_output(base: dict, output: dict) -> dict:
+def render_gemini_extension(base: dict) -> dict:
+    author_name = (
+        base["author"]["name"]
+        if isinstance(base["author"], dict)
+        else base["author"]
+    )
+    return {
+        "name": base["name"],
+        "description": base["description"],
+        "version": base["version"],
+        "author": author_name,
+        "repository": base["repository"],
+        "keywords": base["keywords"],
+    }
+
+
+def render_output(
+    base: dict,
+    output: dict,
+    excluded_hooks: list[str] | None = None,
+) -> dict:
     kind = output["kind"]
     if kind == "plugin":
         return render_plugin(base, output.get("plugin_overrides", {}))
@@ -90,6 +171,11 @@ def render_output(base: dict, output: dict) -> dict:
             plugin_source=output["plugin_source"],
             extras=output.get("marketplace_overrides"),
         )
+    if kind == "filtered-hooks":
+        hooks_config = load_hooks()
+        return filter_hooks(hooks_config, excluded_hooks or [])
+    if kind == "gemini-extension":
+        return render_gemini_extension(base)
     raise ValueError(f"unknown output kind: {kind}")
 
 
@@ -127,9 +213,10 @@ def main() -> int:
 
     for platform_file in sorted(PLATFORMS_DIR.glob("*.json")):
         platform = json.loads(platform_file.read_text())
+        excluded_hooks = platform.get("excluded_hooks", [])
         for output in platform["outputs"]:
             out_path = REPO_ROOT / output["path"]
-            rendered = render_output(base, output)
+            rendered = render_output(base, output, excluded_hooks)
             if write_json(out_path, rendered):
                 changed_paths.append(output["path"])
 

--- a/scripts/check-plugin-manifests.py
+++ b/scripts/check-plugin-manifests.py
@@ -35,10 +35,15 @@ def main() -> int:
 
     for platform_file in sorted(_build.PLATFORMS_DIR.glob("*.json")):
         platform = json.loads(platform_file.read_text())
+        excluded_hooks = platform.get("excluded_hooks", [])
         for output in platform["outputs"]:
             out_path = REPO_ROOT / output["path"]
             expected = (
-                json.dumps(_build.render_output(base, output), indent=2, ensure_ascii=False)
+                json.dumps(
+                    _build.render_output(base, output, excluded_hooks),
+                    indent=2,
+                    ensure_ascii=False,
+                )
                 + "\n"
             )
             actual = out_path.read_text() if out_path.exists() else ""
@@ -62,21 +67,21 @@ def main() -> int:
                 f"expected '../../{name}'"
             )
 
-    # Version consistency: every generated artifact must carry the same version.
+    # Version consistency: collect versioned plugin artifacts from platform manifests.
+    versioned_kinds = {"plugin", "gemini-extension"}
     seen: dict[str, str] = {}
-    for artifact in (
-        ".claude-plugin/plugin.json",
-        ".claude-plugin/marketplace.json",
-        ".agents/plugins/marketplace.json",
-        "plugins/praxis/.codex-plugin/plugin.json",
-    ):
-        p = REPO_ROOT / artifact
-        if not p.exists():
-            continue
-        data = json.loads(p.read_text())
-        v = data.get("version") or (data.get("plugins") or [{}])[0].get("version")
-        if v:
-            seen[artifact] = v
+    for platform_file in sorted(_build.PLATFORMS_DIR.glob("*.json")):
+        platform = json.loads(platform_file.read_text())
+        for output in platform["outputs"]:
+            if output["kind"] not in versioned_kinds:
+                continue
+            p = REPO_ROOT / output["path"]
+            if not p.exists():
+                continue
+            data = json.loads(p.read_text())
+            v = data.get("version") or (data.get("plugins") or [{}])[0].get("version")
+            if v:
+                seen[output["path"]] = v
     unique = set(seen.values())
     if len(unique) > 1:
         drifts.append(


### PR DESCRIPTION
## 개요

`manifests/platforms/` 에 cursor / gemini / opencode 3개 플랫폼 매니페스트를 추가하고,
`scripts/build-plugin-manifests.py` 에 platform-specific hook 제외 로직을 구현합니다.

## 변경 내용

### 신규 플랫폼 매니페스트

| 플랫폼 | 파일 | 특징 |
|--------|------|------|
| Cursor IDE | `manifests/platforms/cursor.json` | PreToolUse/PostToolUse 24개 hook 제외 (Bash/Edit/AskUserQuestion 매처 미지원). SessionStart·UserPromptSubmit·Stop hooks 유지. |
| Gemini CLI | `manifests/platforms/gemini.json` | hook 시스템 비호환 → 전체 28개 제외. `gemini-extension.json` 생성. |
| OpenCode | `manifests/platforms/opencode.json` | Cursor와 동일 제외 세트. `.opencode/` 에 plugin.json + filtered hooks.json 생성. |

### 빌드 스크립트 (`scripts/build-plugin-manifests.py`)

- **새 output kind `filtered-hooks`**: `excluded_hooks` 목록 기반으로 플랫폼별 `hooks.json` 생성. hook 커맨드 경로 `/hooks/<name>.sh` 에서 스크립트명을 추출하여 필터링.
- **새 output kind `gemini-extension`**: Gemini CLI 확장 메타데이터 포맷.
- `render_output()` 에 `excluded_hooks` 파라미터 추가 (기본값 `None`으로 기존 호환 유지).
- `filter_hooks()` / `render_gemini_extension()` / `_extract_hook_name()` 헬퍼 추가.

### 체크 스크립트 (`scripts/check-plugin-manifests.py`)

- `render_output()` 호출 시 `excluded_hooks` 전달 → `filtered-hooks` kind 검증 가능.
- 버전 일관성 검사를 플랫폼 매니페스트 동적 수집으로 전환 (하드코딩 제거).

### AGENTS.md

- 플랫폼 목록, 생성 파일 테이블, `excluded_hooks` / `excluded_skills` 필드 문서 추가.

## 생성된 파일

```
.cursor-plugin/plugin.json
.cursor-plugin/hooks/hooks.json   ← SessionStart + UserPromptSubmit + Stop 만 포함
gemini-extension.json
.opencode/plugin.json
.opencode/hooks/hooks.json        ← SessionStart + UserPromptSubmit + Stop 만 포함
```

## 검증

```
$ python3 scripts/build-plugin-manifests.py
wrote:
  .cursor-plugin/plugin.json
  .cursor-plugin/hooks/hooks.json
  gemini-extension.json
  .opencode/plugin.json
  .opencode/hooks/hooks.json

$ python3 scripts/check-plugin-manifests.py
plugin-manifest check OK

$ python3 scripts/build-plugin-manifests.py  # 재실행 멱등성
clean — no changes
```

Closes #270
