### PR TITLE
docs: remove wrong cmux npm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Most skills delegate to external agents or session managers. Install the depende
 | **gh CLI** | Standalone (`recover-sessions`), strike skills, PR/issue ops | `brew install gh` |
 | **jq** | Strike skills (session-scoped counter parsing) | `brew install jq` |
 | **oh-my-claudecode** | Agent delegation (tracer, analyst, ultraqa, code-reviewer) | `omc install` |
-| **cmux** | Session management skills (cmux-*) | `npm i -g @anthropic/cmux` |
+| **cmux** | Session management skills (cmux-*) | Mac app installer |
 | **codex-cli, gemini-cli** | Multi-provider routing in `cmux-delegate` | per upstream docs |
 
 ### Compatibility Tiers

--- a/skills/using-praxis/SKILL.md
+++ b/skills/using-praxis/SKILL.md
@@ -74,4 +74,3 @@ Full hook index and per-hook specs: [`docs/hook/`](../../docs/hook/)
 | **Enhanced** | + `retrospect`, `codex-review-wrap` | + oh-my-claudecode |
 | **Full** | + all `cmux-*` skills | + cmux |
 
-Install cmux: `npm i -g @anthropic/cmux`


### PR DESCRIPTION
## 변경 요약

`README.md`와 `skills/using-praxis/SKILL.md`에 존재하던 잘못된 cmux npm 설치 명령을 제거합니다.

### 문제

두 파일 모두 cmux 설치 방법으로 `npm i -g @anthropic/cmux`를 안내하고 있었으나, 해당 npm 패키지는 존재하지 않습니다.

```
npm error 404 Not Found - GET https://registry.npmjs.org/@anthropic%2fcmux
```

실제 cmux는 Mac 앱으로 배포됩니다 (`/Applications/cmux.app`, v0.64.6 로컬 확인).  
npm registry의 `cmux` (by austinywang)는 무관한 별개 도구이므로 대체 불가.

### 변경 내용

| 파일 | 위치 | 변경 |
|------|------|------|
| `README.md` | L67 Dependencies 테이블 | `npm i -g @anthropic/cmux` → `Mac app installer` |
| `skills/using-praxis/SKILL.md` | L77 | `Install cmux: \`npm i -g @anthropic/cmux\`` 줄 삭제 |

### 검증 결과

```
# @anthropic/cmux 참조 없음 확인
$ grep -nE "@anthropic/cmux|npm i -g @anthropic" README.md skills/using-praxis/SKILL.md
(출력 없음 — 참조 완전 제거)

# manifest 검사
$ ./scripts/check-plugin-manifests.py
plugin-manifest check OK

# 라우팅 테스트 (baseline 동일, 회귀 없음)
$ bash tests/test_retrospect_routing.sh
PASS: 8
FAIL: 2  ← 기존 baseline (#308 에서 추적 중)
```

Caller chain verified: README.md L67 + using-praxis/SKILL.md L77 — grep confirms no remaining @anthropic/cmux references

Closes #309
