### PR TITLE
feat(retrospect): wire reinforce_action=memory

### DIFF
--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -82,7 +82,7 @@ You MUST complete each stage before proceeding to the next.
 - **successful_patterns**: up to 3 patterns that worked well this session. Each entry MUST include:
   - `pattern`: one line (e.g., "deep-dive 3-lane trace identified cross-lane contradiction via direct grep")
   - `evidence`: specific turn or artifact citation (mandatory — abstract reinforcement like "was helpful" or "responded fast" is FORBIDDEN)
-  - `reinforce_action`: `memory` (capture as feedback entry) or `visualize_only` (display in Stage 3 report, no persistent action)
+  - `reinforce_action`: `memory` (capture as MEMORY.md entry; counted in Stage 2.5 distribution card `memory` total — see Stage 4 Action 1 for the origin-prefix convention) or `visualize_only` (display in Stage 3 Reinforced Patterns section, no persistent action)
 
 **Pre-scan Categorization (Mandatory)** — every friction event identified in pre-scan MUST be tagged with `category[]: string[]` containing ≥1 of these enumerated values. Stage 2 progression to step 3 is BLOCKED until every event has at least one category label.
 
@@ -349,6 +349,8 @@ User confirmation required to proceed; if user confirms, log the keyword set fou
 <!-- retrospect:distribution end -->
 ```
 
+`memory` count = (friction-event findings with Proposed Actions = `memory`, single or compound) + (successful_patterns where `reinforce_action = memory`). Stage 4 Action 1 reads the same total but routes per-entry by origin tag.
+
 `NA` = no findings of the relevant type. Per-gate `NA` semantics:
 - `gate_1_verdict: NA` — zero `tool`/`workflow`/`spec-gap` labeled findings exist
 - `gate_2_verdict: NA` — zero memory-only findings exist
@@ -443,7 +445,7 @@ No patterns found: emit the distribution card with all counts = 0 and verdicts =
 
 ### Reinforced Patterns (this session)
 
-(Emitted only when pre-scan found ≥1 successful_patterns. Omit this section entirely if none — do not emit "None.")
+(Emitted only when pre-scan found ≥1 successful_patterns with `reinforce_action: visualize_only`. Omit this section entirely if none — do not emit "None." Rows with `reinforce_action: memory` are NOT listed here — they appear in Stage 4 Actions Executed report alongside friction-origin memory entries, distinguishable by the `Reinforced — ` description prefix.)
 
 - {pattern_1} (evidence: {turn or artifact})
 - {pattern_2} ...
@@ -584,10 +586,21 @@ Do NOT execute any action until user approves.
 
 For each approved action:
 
-1. **MEMORY.md feedback** → Write to `$CLAUDE_CONFIG_DIR/projects/.../memory/` with proper frontmatter
+1. **MEMORY.md feedback** → Write to `$CLAUDE_CONFIG_DIR/projects/.../memory/` with proper frontmatter. This action processes two input streams:
+
+   **Friction-event origin** (existing behavior): finding row with `memory` in Proposed Actions. Write MEMORY.md entry per existing convention (Type: `feedback`, include: rule, why, how to apply). Description uses the standard feedback format.
+
+   **Success-pattern origin** (new): `successful_patterns` row where `reinforce_action: memory`. Write MEMORY.md entry with:
    - Type: `feedback`
-   - Include: rule, why, how to apply
-   - Update `MEMORY.md` index
+   - Description MUST start with `Reinforced — <pattern>` (the `Reinforced — ` prefix distinguishes positive reinforcement entries from friction entries in future retrospect scans)
+   - Evidence: from the `successful_patterns.evidence` field
+   - How to apply: describe how to intentionally replicate the successful pattern
+
+   Per-entry workflow:
+   1. For each finding with `memory` action → write MEMORY.md entry per existing convention.
+   2. For each `successful_patterns` row with `reinforce_action: memory` → write MEMORY.md entry with description starting `Reinforced — <pattern>`, evidence link from the `successful_patterns.evidence` field.
+
+   - Update `MEMORY.md` index (for both origins)
 
    **⚠️ MANDATORY: Duplicate check before creating any memory file:**
 


### PR DESCRIPTION
Closes #307

## 변경 요약

Stage 2의 `successful_patterns` 에서 `reinforce_action: memory` 로 지정된 항목이 Stage 4 memory handler 에 연결되지 않아 silent no-op 이 발생하는 문제를 수정합니다.

### 4가지 편집 내용

**Edit A — Stage 2 `successful_patterns` 스키마 명세 업데이트**
- `reinforce_action: memory` 설명에 Stage 2.5 distribution card `memory` 카운트에 포함됨을 명시
- Stage 4 Action 1 의 origin-prefix convention 참조 추가

**Edit B — Stage 2.5 distribution card `memory` 카운트 정의 확장**
- `memory` 카운트 = (friction-event findings with `memory` action) + (successful_patterns where `reinforce_action = memory`)
- Stage 4 Action 1 이 동일한 총합을 읽지만 origin tag 별로 라우팅함을 명시

**Edit C — Stage 4 Action 1 (memory handler) origin-aware 처리 추가**
- Friction-event origin (기존 동작): 표준 feedback 형식 유지
- Success-pattern origin (신규): `reinforce_action: memory` 인 `successful_patterns` 행에서 MEMORY.md 항목 생성. description 은 반드시 `Reinforced — <pattern>` 접두어로 시작 (friction 항목과 구분)
- per-entry 워크플로 2단계 명세 추가

**Edit D — Stage 3 Reinforced Patterns 섹션 명세 업데이트**
- `reinforce_action: visualize_only` 항목만 이 섹션에 표시됨을 명시
- `reinforce_action: memory` 항목은 이 섹션에 표시되지 않고 Stage 4 Actions Executed 보고서에 `Reinforced — ` prefix 로 표시됨을 명시

## 검증 결과

```
# test_retrospect_mix_check.sh
Cases:    31 passed, 0 failed
Fixtures: 6 passed, 0 failed

# test_retrospect_routing.sh — pre-existing PASS 8/FAIL 2 baseline (issue #308), NO new failures

# test_retrospect_falsify_recommended.sh
PASS: 28 / FAIL: 0

# check-plugin-manifests.py
plugin-manifest check OK
```

Stop hook `retrospect-mix-check.sh` 는 distribution card 의 `memory: N` 라인에서 숫자만 파싱하므로 origin 구분 없이 동일하게 동작합니다. hook 코드 변경 없음.

Caller chain verified: test_retrospect_mix_check.sh 35/7 PASS, hook parser unchanged (numeric memory count)
