### PR TITLE
feat(hook): external-write phantom-path existence check

### DIFF
--- a/.claude-plugin/hooks/hooks.json
+++ b/.claude-plugin/hooks/hooks.json
@@ -111,6 +111,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/count-assertion-verify.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/external-write-path-existence-check.sh",
+            "timeout": 5
           }
         ]
       },

--- a/.cursor-plugin/hooks/hooks.json
+++ b/.cursor-plugin/hooks/hooks.json
@@ -31,6 +31,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/count-assertion-verify.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/external-write-path-existence-check.sh",
+            "timeout": 5
           }
         ]
       }

--- a/.opencode/hooks/hooks.json
+++ b/.opencode/hooks/hooks.json
@@ -31,6 +31,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/count-assertion-verify.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/external-write-path-existence-check.sh",
+            "timeout": 5
           }
         ]
       }

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -120,6 +120,7 @@ else:
 | `block-pr-without-caller-evidence` | PreToolUse | Block `gh pr create` / `gh pr new` unless the effective PR body contains a `Caller chain verified:` line (closes stdin / missing-file / TOCTOU bypasses; issue #158) | [docs/hook/block-pr-without-caller-evidence.md](docs/hook/block-pr-without-caller-evidence.md) |
 | `verify-commit-flag-override` | PreToolUse | Deny `git commit` invocations that override hooks / signing / hook path / template (`--no-verify`, `--no-gpg-sign`, `-S`, `-c commit.gpgsign=`, `-c core.hooksPath=`, `-c commit.template=`) without env verification; opt-out via `PRAXIS_SKIP_COMMIT_FLAG_CHECK=1` (issue #184) | [docs/hook/verify-commit-flag-override.md](docs/hook/verify-commit-flag-override.md) |
 | `strike-counter` | SessionStart + UserPromptSubmit + Stop | Session-scoped three-strike discipline — emits 1/2-strike reminder context, hard-blocks at 3, requires non-empty reflection file before reset; state under `${PRAXIS_STATE_DIR:-$HOME/.claude/state/praxis}/strikes/` (issue #126) | [docs/hook/strike-counter.md](docs/hook/strike-counter.md) |
+| `external-write-path-existence-check` | PreToolUse | Advisory nudge when a `gh issue/pr` body file (via `--body-file`) contains markdown links referencing repo paths that do not exist on disk (phase 1: markdown links; phase 2 deferred: inline-code tokens; issue #324) | [docs/hook/external-write-path-existence-check.md](docs/hook/external-write-path-existence-check.md) |
 
 ## Multi-Platform Packaging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `external-write-path-existence-check` hook: advisory for `gh issue/pr` body files referencing repo paths that do not exist on disk (#324)
+
 ## [3.17.0] - 2026-05-16
 
 ### Added

--- a/docs/hook/INDEX.md
+++ b/docs/hook/INDEX.md
@@ -46,6 +46,7 @@ so the agent can self-correct. Fail-open on infrastructure errors by design.
 | [output-block-falsify-advisory](output-block-falsify-advisory.md) | PreToolUse | Advisory nudge to run output-block falsification gate before surfacing `(Recommended)` options or bulk-action commands |
 | [advisory-wrapper-signature-verify](advisory-wrapper-signature-verify.md) | PreToolUse | Advisory nudge to verify wrapped function signatures before writing wrapper/client code |
 | [codex-review-route](codex-review-route.md) | UserPromptSubmit | Warn when `/codex:review` runs in a multi-worktree repo (cwd mismatch risk) |
+| [external-write-path-existence-check](external-write-path-existence-check.md) | PreToolUse | Advisory nudge when a `gh issue/pr` body file contains markdown links to repo paths that do not exist |
 
 ---
 

--- a/docs/hook/external-write-path-existence-check.md
+++ b/docs/hook/external-write-path-existence-check.md
@@ -36,7 +36,7 @@ Recognized repo-relative prefixes (Phase 1):
 | Absolute paths (`/usr/...`) | Out-of-scope — not repo-relative |
 | HTTP/HTTPS/mailto/anchor links | Scheme-prefixed or anchor targets |
 | Paths outside recognized prefixes | Phase 2 |
-| Same session_id + body-file already reported | Dedup prevents spam |
+| Same session_id + body content SHA-256 already reported | Dedup prevents spam |
 
 ### Response
 
@@ -62,7 +62,7 @@ outside the repo tree.
 
 ### Session-scoped dedup
 
-Advisory is emitted at most once per `(session_id, body-file-path)` pair.
+Advisory is emitted at most once per `(session_id, body content SHA-256)` pair.
 State marker written to `${PRAXIS_STATE_DIR:-~/.claude/state/praxis}/phantom-path/<hash>`.
 
 ### Parsing guarantees
@@ -109,10 +109,13 @@ Restart Claude Code after adding the entry.
 bash tests/test_external_write_path_existence_check.sh
 ```
 
-Covers 3 cases (Phase 1 scope):
+Covers 6 cases (Phase 1 scope + M1/M2/M3 regression):
 
 | Case | Input | Expected |
 |------|-------|----------|
-| Existing path | Body links to `docs/hook/` (real dir) | Pass — no advisory |
+| Existing path | Body links to `docs/hook/INDEX.md` (real file) | Pass — no advisory |
 | Missing path | Body links to `hooks/pre-tool-use/fake.sh` (phantom) | Advisory emitted |
 | Mixed paths | Body links to one real + one phantom | Advisory lists only the phantom |
+| Anchor fragment (M1) | Body links to `docs/hook/INDEX.md#preflight-gate` | Pass — fragment stripped, file exists |
+| Dedup re-emit (M2) | Same body content submitted twice in same session | Advisory fires once; second suppressed |
+| Binary body file (M3) | Body file contains non-UTF-8 bytes | Fail-open — exit 0, no advisory |

--- a/docs/hook/external-write-path-existence-check.md
+++ b/docs/hook/external-write-path-existence-check.md
@@ -1,0 +1,118 @@
+# PreToolUse External-Write Phantom-Path Existence Check
+
+Supported hosts: all
+
+`hooks/external-write-path-existence-check.py` is a PreToolUse advisory
+that warns when a `gh issue` / `gh pr` body file references repository paths
+that do not exist on disk.
+
+### Why this exists
+
+The immediate trigger for this hook (praxis issue #324) was a parent agent
+writing phantom `hooks/pre-tool-use/external-write-path-existence-check.sh`
+paths into a GitHub issue body.  The flat `hooks/` layout means
+`hooks/pre-tool-use/...` can never exist, but the fabricated path appeared
+in issue text that downstream readers and review tools (BugBot, Codex) used
+as ground truth.  Lexical scanning of body files before posting catches this
+class of error at the last checkpoint before shared-state mutation.
+
+### What is warned (Phase 1 scope)
+
+| Trigger | Condition | Advisory |
+|---------|-----------|----------|
+| `gh (issue\|pr) (create\|edit\|comment) ... --body-file <path>` | Body contains markdown link `](./target)` or `](docs/...)` etc. where target is absent under repo root | Phantom-path list to stderr |
+
+Phase 1 covers **markdown link targets** (`](path)`) only.  Inline-code path
+tokens (`` `hooks/foo.sh` ``) are Phase 2 (deferred).
+
+Recognized repo-relative prefixes (Phase 1):
+`./`, `docs/`, `hooks/`, `skills/`, `tests/`, `scripts/`, `manifests/`
+
+### What is NOT warned
+
+| Pattern | Reason |
+|---------|--------|
+| `--body "text"` / `--body-file -` (stdin) | Body content inaccessible at PreToolUse time; fail-open |
+| Absolute paths (`/usr/...`) | Out-of-scope — not repo-relative |
+| HTTP/HTTPS/mailto/anchor links | Scheme-prefixed or anchor targets |
+| Paths outside recognized prefixes | Phase 2 |
+| Same session_id + body-file already reported | Dedup prevents spam |
+
+### Response
+
+```text
+[phantom-path] 2 referenced path(s) do not exist in repo root (/Users/.../praxis):
+  • hooks/pre-tool-use/external-write-path-existence-check.sh
+  • docs/hook/nonexistent-spec.md
+Verify paths before posting — phantom links confuse readers and review tools.
+Set PRAXIS_PHANTOM_PATH_STRICT=1 to convert this advisory into a hard block (exit 2).
+```
+
+Default mode emits the advisory to stderr and **exits 0** (advisory only).
+Set `PRAXIS_PHANTOM_PATH_STRICT=1` to convert into a hard block (exit 2).
+
+### Repo root resolution
+
+1. `git -C <dir-of-body-file> rev-parse --show-toplevel`
+2. `git -C <cwd> rev-parse --show-toplevel`
+3. Fallback: `cwd` from payload (fail-open)
+
+This handles worktree layouts where the body file lives in a temp directory
+outside the repo tree.
+
+### Session-scoped dedup
+
+Advisory is emitted at most once per `(session_id, body-file-path)` pair.
+State marker written to `${PRAXIS_STATE_DIR:-~/.claude/state/praxis}/phantom-path/<hash>`.
+
+### Parsing guarantees
+
+- Inherited from `_hook_utils.safe_tokenize` (same primitive as sibling hooks):
+  quoted strings, env prefixes, wrapper commands, shell control-flow keywords
+  are handled before the hook inspects the argv.
+- Subshells (`$(...)`) are opaque to shlex — not decomposed (acknowledged
+  limitation shared with all sibling Bash hooks).
+- `--body-file -` (stdin) is not inspected — hook passes through silently.
+- Body file read failure (missing, permission denied) is fail-open: hook exits 0.
+
+### How to enable
+
+Add an entry to `~/.claude/settings.json` or `.claude/settings.json` under
+`hooks.PreToolUse`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/external-write-path-existence-check.sh" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+For strict mode (hard block on any phantom path detected):
+
+```bash
+export PRAXIS_PHANTOM_PATH_STRICT=1
+```
+
+Restart Claude Code after adding the entry.
+
+### Tests
+
+```bash
+bash tests/test_external_write_path_existence_check.sh
+```
+
+Covers 3 cases (Phase 1 scope):
+
+| Case | Input | Expected |
+|------|-------|----------|
+| Existing path | Body links to `docs/hook/` (real dir) | Pass — no advisory |
+| Missing path | Body links to `hooks/pre-tool-use/fake.sh` (phantom) | Advisory emitted |
+| Mixed paths | Body links to one real + one phantom | Advisory lists only the phantom |

--- a/hooks/external-write-path-existence-check.py
+++ b/hooks/external-write-path-existence-check.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""PreToolUse advisory: warn when gh issue/pr body references repo paths that do not exist.
+
+Inspects `gh issue create|edit` / `gh pr create|edit` / `gh issue|pr comment`
+invocations that pass a `--body-file <path>` argument.  The hook reads the body
+file and extracts markdown link targets (`[text](./target)`) that look like
+relative repository paths.  For each candidate path it checks whether the path
+exists under the repository root.  Any missing paths are reported to stderr as a
+advisory nudge — the hook never blocks (exit 0 always).
+
+Phase 1 scope (issue #324):
+  - Trigger: `gh (issue|pr) (create|edit|comment)` with `--body-file <path>`
+    or `--body-file=<path>` (and the `-F` alias).
+  - Extraction: markdown link syntax `](<path>)` where <path> starts with
+    one of the recognized repo-relative prefixes:
+      `./`  `docs/`  `hooks/`  `skills/`  `tests/`  `scripts/`  `manifests/`
+  - Existence check: `os.path.exists(repo_root / path)`.
+  - Repo root: resolved via `git rev-parse --show-toplevel` from the directory
+    containing the body file; falls back to `payload["cwd"]` if git is
+    unavailable.
+  - Dedup: per session_id + body-file path hash so repeated calls with the
+    same file do not spam the same advisory.
+  - Fail-open on any infrastructure error (malformed stdin, missing git,
+    unreadable file, etc.).
+
+Phase 2 (deferred): inline-code path tokens (`` `hooks/foo.sh` ``).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Resolve sibling `_hook_utils.py` regardless of cwd at invocation time.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    iter_command_starts,
+    safe_tokenize,
+    strip_prefix,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Repo-relative path prefixes that are in scope for Phase 1.
+REPO_RELATIVE_PREFIXES = (
+    "./",
+    "docs/",
+    "hooks/",
+    "skills/",
+    "tests/",
+    "scripts/",
+    "manifests/",
+)
+
+# Markdown link target: `](path)` — capture the path portion.
+# Non-greedy so `](a.md) and ](b.md)` yields two separate matches.
+_MD_LINK_RE = re.compile(r"\]\(([^)\s]+)\)")
+
+# gh subcommand pairs that accept --body-file and write to external surfaces.
+_GH_BODY_FILE_SUBCOMMANDS = frozenset({
+    ("issue", "create"),
+    ("issue", "edit"),
+    ("issue", "comment"),
+    ("pr", "create"),
+    ("pr", "edit"),
+    ("pr", "comment"),
+})
+
+_GH_GLOBAL_FLAGS_WITH_ARG = frozenset({"-R", "--repo", "--hostname", "--color"})
+_GH_BODY_FILE_FLAGS = frozenset({"-F", "--body-file"})
+
+# State dir for session-scoped dedup.
+_STATE_DIR = Path(
+    os.environ.get("PRAXIS_STATE_DIR", os.path.expanduser("~/.claude/state/praxis"))
+) / "phantom-path"
+
+
+# ---------------------------------------------------------------------------
+# gh command parsing
+# ---------------------------------------------------------------------------
+
+def _parse_gh_body_file(argv: list[str]) -> str | None:
+    """Return the --body-file path from a gh argv, or None if not present.
+
+    Only fires for gh (issue|pr) (create|edit|comment) subcommands.
+    """
+    argv = strip_prefix(argv)
+    if not argv or argv[0] != "gh":
+        return None
+
+    # Skip global flags to reach object/subcommand pair.
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        if tok == "--":
+            i += 1
+            break
+        if not tok.startswith("-"):
+            break
+        i += 1
+        if "=" not in tok and tok in _GH_GLOBAL_FLAGS_WITH_ARG and i < len(argv):
+            i += 1
+
+    if i + 1 >= len(argv):
+        return None
+    obj, sub = argv[i], argv[i + 1]
+    if (obj, sub) not in _GH_BODY_FILE_SUBCOMMANDS:
+        return None
+
+    # Scan remaining tokens for --body-file / -F.
+    rest = argv[i + 2:]
+    for j, tok in enumerate(rest):
+        if "=" in tok:
+            key, _, val = tok.partition("=")
+            if key in _GH_BODY_FILE_FLAGS:
+                return val
+        elif tok in _GH_BODY_FILE_FLAGS and j + 1 < len(rest):
+            return rest[j + 1]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Repo root resolution
+# ---------------------------------------------------------------------------
+
+def _git_toplevel(start_dir: str) -> str | None:
+    """Run `git rev-parse --show-toplevel` from start_dir.  Returns None on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=start_dir,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
+def _resolve_repo_root(body_file_path: str, cwd: str) -> str:
+    """Determine the repository root relative to the body file's directory.
+
+    Priority:
+    1. git -C <dir-of-body-file> rev-parse --show-toplevel
+    2. git -C <cwd> rev-parse --show-toplevel
+    3. Fallback: cwd as-is (fail-open)
+    """
+    body_dir = os.path.dirname(os.path.abspath(body_file_path))
+    root = _git_toplevel(body_dir) or _git_toplevel(cwd)
+    return root or cwd
+
+
+# ---------------------------------------------------------------------------
+# Path extraction
+# ---------------------------------------------------------------------------
+
+def _extract_candidate_paths(body: str) -> list[str]:
+    """Extract markdown link targets that look like repo-relative paths."""
+    candidates: list[str] = []
+    for m in _MD_LINK_RE.finditer(body):
+        target = m.group(1)
+        # Ignore http/https/mailto/anchor links.
+        if target.startswith(("http://", "https://", "mailto:", "#")):
+            continue
+        if any(target.startswith(pfx) for pfx in REPO_RELATIVE_PREFIXES):
+            # Strip leading `./` so the path is always relative-to-root.
+            candidates.append(target.lstrip("./") if target.startswith("./") else target)
+    # Dedupe while preserving order.
+    seen: set[str] = set()
+    result: list[str] = []
+    for p in candidates:
+        if p not in seen:
+            seen.add(p)
+            result.append(p)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped dedup
+# ---------------------------------------------------------------------------
+
+def _dedup_key(session_id: str, body_file_path: str) -> str:
+    """Return a hash key combining session_id and body file path."""
+    raw = f"{session_id}:{os.path.abspath(body_file_path)}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+def _already_reported(key: str) -> bool:
+    marker = _STATE_DIR / key
+    return marker.exists()
+
+
+def _mark_reported(key: str) -> None:
+    try:
+        _STATE_DIR.mkdir(parents=True, exist_ok=True)
+        (_STATE_DIR / key).touch()
+    except OSError:
+        pass  # fail-open — dedup is best-effort
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0  # fail-open on malformed stdin
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input", {}) or {}
+    command = tool_input.get("command", "") or ""
+    if not command.strip():
+        return 0
+
+    cwd = payload.get("cwd", "") or os.getcwd()
+    session_id = payload.get("session_id", "") or "unknown"
+
+    command = command.replace("\\\n", " ")
+    tokens = safe_tokenize(command)
+    if not tokens:
+        return 0
+
+    # Collect body files from all gh sub-commands in the Bash command.
+    body_files: list[str] = []
+    for argv in iter_command_starts(tokens):
+        bf = _parse_gh_body_file(list(argv))
+        if bf:
+            body_files.append(bf)
+
+    if not body_files:
+        return 0
+
+    for body_file in body_files:
+        # Resolve path relative to cwd if not absolute.
+        if not os.path.isabs(body_file):
+            body_file = os.path.join(cwd, body_file)
+
+        # Skip unreadable files — fail-open.
+        if not os.path.isfile(body_file):
+            continue
+
+        # Session-scoped dedup.
+        dk = _dedup_key(session_id, body_file)
+        if _already_reported(dk):
+            continue
+
+        try:
+            with open(body_file, encoding="utf-8") as fh:
+                body = fh.read()
+        except OSError:
+            continue
+
+        candidates = _extract_candidate_paths(body)
+        if not candidates:
+            continue
+
+        repo_root = _resolve_repo_root(body_file, cwd)
+
+        phantom: list[str] = [
+            p for p in candidates
+            if not os.path.exists(os.path.join(repo_root, p))
+        ]
+
+        if phantom:
+            _mark_reported(dk)
+            lines = "\n".join(f"  • {p}" for p in phantom)
+            sys.stderr.write(
+                f"[phantom-path] {len(phantom)} referenced path(s) do not exist "
+                f"in repo root ({repo_root}):\n{lines}\n"
+                "Verify paths before posting — phantom links confuse readers and "
+                "review tools.\n"
+                "Set PRAXIS_PHANTOM_PATH_STRICT=1 to convert this advisory into "
+                "a hard block (exit 2).\n"
+            )
+            if os.environ.get("PRAXIS_PHANTOM_PATH_STRICT") == "1":
+                return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/external-write-path-existence-check.py
+++ b/hooks/external-write-path-existence-check.py
@@ -33,7 +33,6 @@ import os
 import re
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 # Resolve sibling `_hook_utils.py` regardless of cwd at invocation time.
@@ -171,8 +170,14 @@ def _extract_candidate_paths(body: str) -> list[str]:
     candidates: list[str] = []
     for m in _MD_LINK_RE.finditer(body):
         target = m.group(1)
-        # Ignore http/https/mailto/anchor links.
+        # Ignore http/https/mailto/anchor-only links.
         if target.startswith(("http://", "https://", "mailto:", "#")):
+            continue
+        # Strip anchor fragment (#section) and query string (?q=1) — both are
+        # not part of the filesystem path and would produce false-positive
+        # phantom hits on otherwise-valid links like `docs/foo.md#section`.
+        target = target.split("#", 1)[0].split("?", 1)[0]
+        if not target:
             continue
         if any(target.startswith(pfx) for pfx in REPO_RELATIVE_PREFIXES):
             # Strip leading `./` so the path is always relative-to-root.
@@ -191,9 +196,16 @@ def _extract_candidate_paths(body: str) -> list[str]:
 # Session-scoped dedup
 # ---------------------------------------------------------------------------
 
-def _dedup_key(session_id: str, body_file_path: str) -> str:
-    """Return a hash key combining session_id and body file path."""
-    raw = f"{session_id}:{os.path.abspath(body_file_path)}"
+def _dedup_key(session_id: str, body_content: str) -> str:
+    """Return a hash key combining session_id and body content SHA-256.
+
+    Keyed on content rather than file path so that:
+    - the same body in different temp paths (e.g. successive `gh pr edit`)
+      only fires once, and
+    - an edited body (phantom paths removed) generates a new key so the
+      advisory fires again if new phantom paths are introduced.
+    """
+    raw = f"{session_id}:{hashlib.sha256(body_content.encode()).hexdigest()}"
     return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
 
@@ -255,15 +267,17 @@ def main() -> int:
         if not os.path.isfile(body_file):
             continue
 
-        # Session-scoped dedup.
-        dk = _dedup_key(session_id, body_file)
-        if _already_reported(dk):
-            continue
-
         try:
-            with open(body_file, encoding="utf-8") as fh:
+            with open(body_file, encoding="utf-8", errors="replace") as fh:
                 body = fh.read()
-        except OSError:
+        except (OSError, UnicodeDecodeError):
+            continue  # fail-open — binary or unreadable file
+
+        # Session-scoped dedup keyed on body content so that the same body
+        # in a different temp path fires only once, and an edited body with
+        # new phantom paths re-fires.
+        dk = _dedup_key(session_id, body)
+        if _already_reported(dk):
             continue
 
         candidates = _extract_candidate_paths(body)

--- a/hooks/external-write-path-existence-check.py
+++ b/hooks/external-write-path-existence-check.py
@@ -18,8 +18,8 @@ Phase 1 scope (issue #324):
   - Repo root: resolved via `git rev-parse --show-toplevel` from the directory
     containing the body file; falls back to `payload["cwd"]` if git is
     unavailable.
-  - Dedup: per session_id + body-file path hash so repeated calls with the
-    same file do not spam the same advisory.
+  - Dedup: per session_id + body content SHA-256 so identical body content
+    in different temp paths fires once, and an edited body re-fires.
   - Fail-open on any infrastructure error (malformed stdin, missing git,
     unreadable file, etc.).
 

--- a/hooks/external-write-path-existence-check.sh
+++ b/hooks/external-write-path-existence-check.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# external-write-path-existence-check.sh — thin shim (praxis #324)
+# Logic in .py; shim keeps hooks.json entry stable across refactors.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="$SCRIPT_DIR/external-write-path-existence-check.py"
+command -v python3 >/dev/null 2>&1 || exit 0
+[ -f "$PY" ] || exit 0
+exec python3 "$PY"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -127,6 +127,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/count-assertion-verify.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/external-write-path-existence-check.sh",
+            "timeout": 5
           }
         ]
       },

--- a/plugins/praxis/.codex-plugin/hooks/hooks.json
+++ b/plugins/praxis/.codex-plugin/hooks/hooks.json
@@ -106,6 +106,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/count-assertion-verify.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/external-write-path-existence-check.sh",
+            "timeout": 5
           }
         ]
       },

--- a/tests/test_external_write_path_existence_check.sh
+++ b/tests/test_external_write_path_existence_check.sh
@@ -178,6 +178,99 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Case 4 (M1): anchor fragment in link — should NOT produce advisory.
+# docs/hook/INDEX.md#preflight-gate references a real file; fragment must be
+# stripped before the existence check so this produces no advisory.
+# ---------------------------------------------------------------------------
+case4_body='# Anchor test
+
+See [preflight hooks](docs/hook/INDEX.md#preflight-gate) for details.
+'
+run_with_body "$case4_body" 'gh issue create --title "Anchor"' "session-anchor-$$" c4_err c4_rc
+
+c4_ok=1
+[ "$c4_rc" -eq 0 ] || c4_ok=0
+[ -z "$c4_err" ] || c4_ok=0
+if [ "$c4_ok" -eq 1 ]; then
+  echo "PASS: anchor fragment — stripped, no false-positive advisory"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: anchor fragment (rc=$c4_rc, stderr='${c4_err:0:120}')"
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("anchor fragment — stripped, no false-positive advisory")
+fi
+
+# ---------------------------------------------------------------------------
+# Case 5 (M2): same body content re-submitted — dedup suppresses second advisory.
+# ---------------------------------------------------------------------------
+dedup_body='# Phantom again
+
+See [phantom](hooks/pre-tool-use/phantom.sh) for details.
+'
+# First call — advisory expected.
+run_with_body "$dedup_body" 'gh issue create --title "Dedup1"' "session-dedup-$$" c5a_err c5a_rc
+# Second call with identical content + same session_id — dedup must suppress.
+run_with_body "$dedup_body" 'gh issue edit 1 --body-file' "session-dedup-$$" c5b_err c5b_rc
+
+c5_ok=1
+# First call: advisory fired.
+[ "$c5a_rc" -eq 0 ] || c5_ok=0
+echo "$c5a_err" | grep -q "\[phantom-path\]" || c5_ok=0
+# Second call with same content: dedup suppresses advisory.
+[ "$c5b_rc" -eq 0 ] || c5_ok=0
+[ -z "$c5b_err" ] || c5_ok=0
+if [ "$c5_ok" -eq 1 ]; then
+  echo "PASS: dedup — same body content suppresses duplicate advisory"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: dedup (c5a_rc=$c5a_rc stderr='${c5a_err:0:80}' c5b_rc=$c5b_rc stderr='${c5b_err:0:80}')"
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("dedup — same body content suppresses duplicate advisory")
+fi
+
+# ---------------------------------------------------------------------------
+# Case 6 (M3): binary body file — hook must exit 0 with no advisory.
+# ---------------------------------------------------------------------------
+bin_body_file=$(mktemp /tmp/test-phantom-bin-XXXXXX)
+# Write null bytes (binary) into the file.
+python3 -c "import sys; sys.stdout.buffer.write(b'\x00\x01\x02\xff\xfe')" > "$bin_body_file"
+
+bin_err_file=$(mktemp /tmp/test-phantom-err-XXXXXX)
+bin_payload=$(python3 -c "
+import json, sys
+body_file = sys.argv[1]
+session_id = sys.argv[2]
+repo_root = sys.argv[3]
+payload = {
+    'session_id': session_id,
+    'tool_name': 'Bash',
+    'tool_input': {
+        'command': 'gh issue create --title \"Binary\" --body-file ' + body_file,
+    },
+    'cwd': repo_root,
+}
+print(json.dumps(payload))
+" "$bin_body_file" "session-binary-$$" "$ROOT_DIR")
+
+env -u PRAXIS_PHANTOM_PATH_STRICT \
+  python3 "$HOOK" >/dev/null 2>"$bin_err_file" <<< "$bin_payload"
+bin_rc=$?
+bin_err=$(cat "$bin_err_file")
+rm -f "$bin_body_file" "$bin_err_file"
+
+c6_ok=1
+[ "$bin_rc" -eq 0 ] || c6_ok=0
+[ -z "$bin_err" ] || c6_ok=0
+if [ "$c6_ok" -eq 1 ]; then
+  echo "PASS: binary body file — fail-open, exit 0, no advisory"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: binary body file (rc=$bin_rc, stderr='${bin_err:0:120}')"
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("binary body file — fail-open, exit 0, no advisory")
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/tests/test_external_write_path_existence_check.sh
+++ b/tests/test_external_write_path_existence_check.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# test_external_write_path_existence_check.sh — coverage for hooks/external-write-path-existence-check.py
+#
+# Synthesizes Claude Code PreToolUse hook payloads and asserts:
+#   advisory → exit 0 + stderr contains "[phantom-path]"
+#   pass     → exit 0 + stderr empty
+#
+# Usage: bash tests/test_external_write_path_existence_check.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$ROOT_DIR/hooks/external-write-path-existence-check.py"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable: $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+# run_case name expectation payload_json
+#   expectation:
+#     "advisory" — stderr contains "[phantom-path]", rc=0
+#     "pass"     — stderr empty, rc=0
+run_case() {
+  local name="$1" expectation="$2" payload="$3"
+
+  local err_file
+  err_file=$(mktemp)
+  # Unset strict env so advisory vs pass tests are not affected by environment.
+  echo "$payload" | env -u PRAXIS_PHANTOM_PATH_STRICT python3 "$HOOK" >/dev/null 2>"$err_file"
+  local rc=$?
+  local err
+  err=$(cat "$err_file")
+  rm -f "$err_file"
+
+  local ok=1
+  case "$expectation" in
+    advisory)
+      [ "$rc" -eq 0 ] || ok=0
+      echo "$err" | grep -q "\[phantom-path\]" || ok=0
+      ;;
+    pass)
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$err" ] || ok=0
+      ;;
+    *)
+      echo "FAIL: unknown expectation: $expectation" >&2
+      ok=0
+      ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (rc=$rc, stderr='${err:0:120}')"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# build_payload writes $1 (body content) to a temp file, runs the hook with
+# the given gh command ($2) and session_id ($3), captures stderr into $4,
+# and stores the exit code in $5.  The temp file is deleted before returning.
+# This avoids subshell-array propagation issues and BSD mktemp suffix limits.
+run_with_body() {
+  local content="$1" gh_cmd="$2" session_id="$3"
+  local out_err_var="$4" out_rc_var="$5"
+
+  local body_file err_file payload rc err_content
+  body_file=$(mktemp /tmp/test-phantom-XXXXXX)
+  err_file=$(mktemp /tmp/test-phantom-err-XXXXXX)
+  printf '%s' "$content" > "$body_file"
+
+  payload=$(python3 -c "
+import json, sys
+body_file, session_id, repo_root, gh_cmd = sys.argv[1:]
+payload = {
+    'session_id': session_id,
+    'tool_name': 'Bash',
+    'tool_input': {
+        'command': gh_cmd + ' --body-file ' + body_file,
+    },
+    'cwd': repo_root,
+}
+print(json.dumps(payload))
+" "$body_file" "$session_id" "$ROOT_DIR" "$gh_cmd")
+
+  env -u PRAXIS_PHANTOM_PATH_STRICT \
+    python3 "$HOOK" >/dev/null 2>"$err_file" <<< "$payload"
+  rc=$?
+  err_content=$(cat "$err_file")
+  rm -f "$body_file" "$err_file"
+
+  # Return values via named variables.
+  printf -v "$out_err_var" '%s' "$err_content"
+  printf -v "$out_rc_var" '%s' "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: existing path — body links to a real path in the repo.
+# ---------------------------------------------------------------------------
+case1_body='# Test PR
+
+See [hook index](docs/hook/INDEX.md) for the full list.
+'
+run_with_body "$case1_body" 'gh issue create --title "Test"' "session-exist-$$" c1_err c1_rc
+
+c1_ok=1
+[ "$c1_rc" -eq 0 ] || c1_ok=0
+[ -z "$c1_err" ] || c1_ok=0
+if [ "$c1_ok" -eq 1 ]; then
+  echo "PASS: existing path — docs/hook/INDEX.md is real"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: existing path (rc=$c1_rc, stderr='${c1_err:0:120}')"
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("existing path — docs/hook/INDEX.md is real")
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2: missing path — body links to a phantom path.
+# ---------------------------------------------------------------------------
+# hooks/pre-tool-use/ does not exist (flat hooks/ layout has no sub-dirs).
+case2_body='# Bug report
+
+The file [phantom hook](hooks/pre-tool-use/external-write-path-existence-check.sh)
+should be implemented first.
+'
+run_with_body "$case2_body" 'gh issue create --title "Bug"' "session-miss-$$" c2_err c2_rc
+
+c2_ok=1
+[ "$c2_rc" -eq 0 ] || c2_ok=0
+echo "$c2_err" | grep -q "\[phantom-path\]" || c2_ok=0
+if [ "$c2_ok" -eq 1 ]; then
+  echo "PASS: missing path — hooks/pre-tool-use/... phantom"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: missing path (rc=$c2_rc, stderr='${c2_err:0:120}')"
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("missing path — hooks/pre-tool-use/... phantom")
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3: mixed paths — one real, one phantom.
+# Only the phantom should appear in the advisory.
+# ---------------------------------------------------------------------------
+case3_body='# Mixed links
+
+- Real: [INDEX](docs/hook/INDEX.md)
+- Phantom: [nonexistent](hooks/pre-tool-use/nonexistent.sh)
+'
+run_with_body "$case3_body" 'gh pr create --title "Mixed"' "session-mixed-$$" c3_err c3_rc
+
+c3_ok=1
+[ "$c3_rc" -eq 0 ] || c3_ok=0
+echo "$c3_err" | grep -q "\[phantom-path\]" || c3_ok=0
+echo "$c3_err" | grep -q "pre-tool-use/nonexistent.sh" || c3_ok=0
+# docs/hook/INDEX.md must NOT appear as a phantom
+echo "$c3_err" | grep -q "INDEX.md" && c3_ok=0
+if [ "$c3_ok" -eq 1 ]; then
+  echo "PASS: mixed paths — only phantom listed"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: mixed paths (rc=$c3_rc, stderr='${c3_err:0:200}')"
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("mixed paths — only phantom listed")
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:"
+  for name in "${FAILED_NAMES[@]}"; do
+    echo "  - $name"
+  done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #324

## 변경 내용

`gh issue/pr create|edit|comment`에서 `--body-file <path>`로 전달된 본문 파일을 파싱하여, 존재하지 않는 레포지토리 경로를 참조하는 마크다운 링크를 감지하는 PreToolUse advisory hook을 추가합니다.

**새로 추가된 파일:**
- `hooks/external-write-path-existence-check.py` — 핵심 로직
- `hooks/external-write-path-existence-check.sh` — thin shim (hooks.json 진입점)
- `docs/hook/external-write-path-existence-check.md` — 스펙 문서
- `tests/test_external_write_path_existence_check.sh` — 6개 테스트 케이스

**수정된 파일:**
- `hooks/hooks.json` + 4개 생성된 manifest — 새 hook 등록
- `docs/hook/INDEX.md` — advisory-nudge 섹션에 항목 추가
- `ARCHITECTURE.md` — hook index 테이블에 행 추가
- `CHANGELOG.md` — `[Unreleased]` 섹션에 항목 추가

## 설계

- **트리거**: `Bash` tool matcher. `gh (issue|pr) (create|edit|comment) ... --body-file <path>`
- **추출 대상 (Phase 1)**: 마크다운 링크 `](path)` — 인식 prefix: `./`, `docs/`, `hooks/`, `skills/`, `tests/`, `scripts/`, `manifests/`
  - anchor fragment (`#section`) 및 query string (`?q=1`) strip 후 존재 확인
- **존재 확인**: `git rev-parse --show-toplevel`로 레포 루트 결정 후 `os.path.exists` 검사
- **중복 방지**: session_id + body content SHA-256 기반 세션 스코프 dedup — 같은 내용은 한 번만 발화, 수정된 내용은 재발화
- **Fail-open**: 파일 읽기 실패 / binary 파일 / git 없음 / stdin malformed → exit 0
- **advisory-only**: 기본 exit 0; `PRAXIS_PHANTOM_PATH_STRICT=1`로 hard block(exit 2) 전환 가능

## 검증

```
PASS: existing path — docs/hook/INDEX.md is real
PASS: missing path — hooks/pre-tool-use/... phantom
PASS: mixed paths — only phantom listed
PASS: anchor fragment — stripped, no false-positive advisory
PASS: dedup — same body content suppresses duplicate advisory
PASS: binary body file — fail-open, exit 0, no advisory

Results: 6 passed, 0 failed
```

```
plugin-manifest check OK
```

Caller chain verified: new hook — no existing callers expected.

## 리뷰 라운드 요약

| 라운드 | 처리 내용 |
|--------|-----------|
| Round 1 (M1) | anchor fragment `#section` false-positive — `split("#")` strip 추가 |
| Round 1 (M2) | dedup key를 file-path → body content SHA-256 기반으로 변경 |
| Round 1 (M3) | `UnicodeDecodeError` 미처리 — `errors="replace"` + except 확장 |
| Round 1 (lint) | `import tempfile` 미사용 제거 |
| Round 2 (spec) | spec doc 3 spots stale (dedup 표현 2곳, 테스트 카운트 + 표) 동기화 |
| Round 3 (docstring) | source docstring dedup 설명이 구현과 불일치 — content SHA-256 기반으로 갱신 |
| Round 3 (CHANGELOG) | `[Unreleased]` 섹션 누락 — `### Added` 항목 추가 |

## follow-up

추가 개선 항목은 #335 에서 추적합니다 (Phase 2 inline-code path, lstrip quirk, binary detection, subprocess timeout 등).

## 위험

- Advisory-only이므로 기존 워크플로에 영향 없음

## phantom-path correction note

이슈 본문에는 `hooks/pre-tool-use/external-write-path-existence-check.{sh,py}` 경로가 명시되어 있었지만, 실제 레포는 `hooks/` 플랫 레이아웃을 사용합니다. 이 hook이 존재했다면 해당 이슈 작성 시점에 phantom-path advisory가 발동되어 잘못된 경로를 잡아냈을 것입니다.
