### PR TITLE
docs: disambiguate CLAUDE.md global vs project refs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ current gate.
 
 1. Survey ≥ 2 sibling implementations under `hooks/` for established conventions
    (state-key naming, payload field access, exit-code semantics) before writing
-   your spec. See the **Convention Survey Before Design** rule in `CLAUDE.md`.
+   your spec. See the **Convention Survey Before Design** rule in global `~/.claude/CLAUDE.md`.
 2. Write the hook + tests, register in `hooks/hooks.json`.
 3. Create `docs/hook/<name>.md` (use an existing spec as a template).
 4. Add a row to the hook index table in [`ARCHITECTURE.md`](ARCHITECTURE.md#hook-index).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -49,7 +49,7 @@ Design mechanisms shared by all hooks:
 
 1. Survey ≥2 sibling implementations under `hooks/` for the convention
    (state-key naming, payload field access, exit-code semantics). See the
-   `Sibling Convention Survey` rule in CLAUDE.md.
+   `Sibling Convention Survey` rule in global `~/.claude/CLAUDE.md`.
 2. Write the hook + tests under `hooks/`, register in `hooks/hooks.json`.
 3. Create `docs/hook/<name>.md` using an existing spec as the template
    (`Why this exists` / `What is blocked` / `Response` / `Parsing guarantees`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -49,7 +49,7 @@ Design mechanisms shared by all hooks:
 
 1. Survey ≥2 sibling implementations under `hooks/` for the convention
    (state-key naming, payload field access, exit-code semantics). See the
-   `Sibling Convention Survey` rule in global `~/.claude/CLAUDE.md`.
+   `Convention Survey Before Design` rule in global `~/.claude/CLAUDE.md`.
 2. Write the hook + tests under `hooks/`, register in `hooks/hooks.json`.
 3. Create `docs/hook/<name>.md` using an existing spec as the template
    (`Why this exists` / `What is blocked` / `Response` / `Parsing guarantees`


### PR DESCRIPTION
Closes #318

Caller chain verified: issue #318 (two ambiguous refs → one-line disambig per option a) → this PR.

## 변경

`DESIGN.md:52`와 `CONTRIBUTING.md:102`에서 두 CLAUDE.md 룰 참조를 명확히 했습니다.

### 변경 대상

- **DESIGN.md:52** — 룰 이름이 `Sibling Convention Survey` 로 잘못 표기됨 (해당 이름은 praxis memory file 이름). 글로벌 CLAUDE.md 의 canonical 이름인 `Convention Survey Before Design` 으로 정정 후 "global `~/.claude/CLAUDE.md`" 명시.
- **CONTRIBUTING.md:102** — `Convention Survey Before Design` 룰 참조를 "global `~/.claude/CLAUDE.md`" 명시.

### Evidence — 룰 이름 검증

```
grep -c "Sibling Convention Survey" ~/.claude/CLAUDE.md
→ 0   (존재하지 않음)

grep -c "Convention Survey Before Design" ~/.claude/CLAUDE.md
→ 1   (line 131 에 canonical name 존재)
```

## 스캔 범위 및 follow-up

**Scope**: top-level `*.md` (DESIGN / CONTRIBUTING / ETHOS / ARCHITECTURE / README / RUNTIME_CONSTRAINTS) 6개 파일만 스캔.

`docs/hook/*.md` 와 `skills/*/SKILL.md` 내 CLAUDE.md 참조는 별도 이슈로 tracking:
→ **follow-up 이슈 #334**: `docs: scan CLAUDE.md ambiguity in docs/hook and skills/`

최종 grep 결과 (변경 후):

```
DESIGN.md:52:   `Convention Survey Before Design` rule in global `~/.claude/CLAUDE.md`.
CONTRIBUTING.md:102:   your spec. See the **Convention Survey Before Design** rule in global `~/.claude/CLAUDE.md`.
RUNTIME_CONSTRAINTS.md:122: `CLAUDE.md` rule ... (이미 "global" 명시됨, 수정 불필요)
ETHOS.md (9, 15줄) — project CLAUDE.md 맥락, 수정 불필요
README.md (51줄) — project 규칙 enforcement 맥락, 수정 불필요
```

## 검증

```
grep -n "CLAUDE\.md" DESIGN.md CONTRIBUTING.md

DESIGN.md:52:   `Convention Survey Before Design` rule in global `~/.claude/CLAUDE.md`.
CONTRIBUTING.md:102:   your spec. See the **Convention Survey Before Design** rule in global `~/.claude/CLAUDE.md`.
```

## 위험

낮음. 문서 clarification만 변경하므로 런타임 영향 없음.

squash merge 시 title 단축 권장 (현재 PR title 51자 → `docs: clarify CLAUDE.md global vs project refs` = 47자).

## 검토 포인트

- [x] DESIGN.md 룰 이름을 global CLAUDE.md canonical 이름으로 정정
- [x] 두 파일의 참조 모두 global `~/.claude/CLAUDE.md` 명시
- [x] 스캔 범위 명시 (top-level 6 파일), 나머지는 follow-up #334 로 defer
- [x] 글로벌 `~/.claude/CLAUDE.md` 자체는 수정하지 않음
