### PR TITLE
feat(hook): jq config-read empty-dict guard advisory

### DIFF
--- a/.claude-plugin/hooks/hooks.json
+++ b/.claude-plugin/hooks/hooks.json
@@ -94,6 +94,11 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/jq-config-empty-dict-advisory.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/verify-commit-flag-override.sh",
             "timeout": 5
           },

--- a/docs/hook/INDEX.md
+++ b/docs/hook/INDEX.md
@@ -45,6 +45,7 @@ so the agent can self-correct. Fail-open on infrastructure errors by design.
 | [external-api-literal-trigger](external-api-literal-trigger.md) | PreToolUse | Advisory nudge when ALL_CAPS enum candidates or 3-part SQL identifiers are written without prior retrieval verification |
 | [output-block-falsify-advisory](output-block-falsify-advisory.md) | PreToolUse | Advisory nudge to run output-block falsification gate before surfacing `(Recommended)` options or bulk-action commands |
 | [advisory-wrapper-signature-verify](advisory-wrapper-signature-verify.md) | PreToolUse | Advisory nudge to verify wrapped function signatures before writing wrapper/client code |
+| [jq-config-empty-dict-advisory](jq-config-empty-dict-advisory.md) | PreToolUse | Advisory nudge when `jq` reads a config file (settings.json, hooks.json, ~/.claude/*.json, ~/.codex/*.json) that is empty or invalid JSON |
 | [codex-review-route](codex-review-route.md) | UserPromptSubmit | Warn when `/codex:review` runs in a multi-worktree repo (cwd mismatch risk) |
 
 ---

--- a/docs/hook/jq-config-empty-dict-advisory.md
+++ b/docs/hook/jq-config-empty-dict-advisory.md
@@ -19,14 +19,23 @@ This hook surfaces the problem *before* the command executes (issue #323).
 
 ### What is detected
 
-Detection surface — a Bash segment is scanned when it contains `jq` followed
-by at least one positional argument matching a known config path:
+Detection surface — config paths matched:
 
 - `~/.claude/*.json`
 - `~/.codex/*.json`
 - Repo-root `settings.json` or `hooks.json` (bare filename)
 - Any `.json` file under a `.claude/` or `.codex/` directory component
   (absolute or relative)
+
+Four invocation patterns are recognized:
+
+| Pattern | Example |
+|---------|---------|
+| Direct | `jq '.' ~/.claude/settings.json` |
+| Boolean flag | `jq -e '.theme' ~/.claude/settings.json` |
+| Stdin redirect | `jq '.' < ~/.claude/settings.json` |
+| Pipe from prior segment | `cat ~/.claude/settings.json \| jq '.'` |
+| Command substitution | `threshold=$(jq -r '.foo' ~/.claude/settings.json)` |
 
 File-level outcomes:
 
@@ -41,14 +50,28 @@ Command-level examples:
 
 | Command | Action |
 |---------|--------|
-| `jq '.' ~/.claude/settings.json` (file empty) | **ADVISORY** `[config-empty]` |
-| `jq '.hooks' hooks.json` (file invalid JSON) | **ADVISORY** `[config-invalid]` |
-| `jq -r '.foo' .claude/settings.json` (file valid) | **SILENT** |
-| `jq '.' ~/.codex/config.json` (file valid) | **SILENT** |
-| `jq '.' /tmp/unrelated.json` (non-config path) | **SILENT** — path not in scope |
-| `jq '.' settings.json` (file missing) | **SILENT** — existence not in scope |
+| `jq '.' ~/.claude/settings.json` (empty) | **ADVISORY** `[config-empty]` |
+| `jq -e '.theme' ~/.claude/settings.json` (empty) | **ADVISORY** `[config-empty]` — `-e` is boolean |
+| `jq --sort-keys '.foo' ~/.claude/settings.json` (empty) | **ADVISORY** `[config-empty]` — `--sort-keys` is boolean |
+| `jq '.hooks' hooks.json` (invalid JSON) | **ADVISORY** `[config-invalid]` |
+| `cat ~/.claude/settings.json \| jq '.'` (empty) | **ADVISORY** `[config-empty]` — pipe correlation |
+| `jq '.' < ~/.claude/settings.json` (empty) | **ADVISORY** `[config-empty]` — stdin redirect |
+| `threshold=$(jq -r '.foo' ~/.claude/settings.json)` (empty) | **ADVISORY** `[config-empty]` — substitution |
+| `jq -r '.foo' .claude/settings.json` (valid) | **SILENT** |
+| `jq '.' ~/.codex/config.json` (valid) | **SILENT** |
+| `jq '.' /tmp/unrelated.json` (any state) | **SILENT** — path not in scope |
+| `jq '.' settings.json` (missing) | **SILENT** — existence not in scope |
+| `jq -n 'null'` | **SILENT** — no file argument |
 | Non-Bash tool | **SILENT** |
 | Malformed JSON stdin | **SILENT** (fail-open) |
+
+Not detected (by design):
+
+| Pattern | Reason |
+|---------|--------|
+| `jq '.' /tmp/other.json` | Non-config path, out of scope |
+| `jq -n '{}'` | Null input (`-n`), no file read |
+| Multi-hop pipe `cmd1 \| cmd2 \| jq`  | Only immediate prior segment correlated |
 
 ### Response format
 
@@ -63,9 +86,10 @@ user sees the stderr text and can inspect / repair the file before rerunning.
 
 ### Deduplication
 
-Advisories are deduplicated per `session_id` + canonical path. A given file
-triggers at most one advisory per session regardless of how many `jq` calls
-target it. State file:
+Advisories are deduplicated per `session_id` + canonical path. Only
+advisory-emitting checks are recorded — a file that is valid on first access
+and later becomes empty will re-trigger the advisory on the next call. State
+file:
 
 ```
 ${TMPDIR:-/tmp}/praxis-jq-config-advisory-<session_id>.json
@@ -98,5 +122,7 @@ test invocations).
 bash hooks/test-jq-config-empty-dict-advisory.sh
 ```
 
-3 cases: empty file (`[config-empty]` advisory), invalid JSON file
-(`[config-invalid]` advisory), valid JSON file (silent).
+10 cases: empty file, invalid JSON file, valid JSON file (original 3),
+plus C1 command substitution, C2a `-e` boolean flag, C2b `--sort-keys`
+boolean flag, M3a/M3b dedup state transition (valid→empty), M4a pipe
+correlation, M4b stdin redirect.

--- a/docs/hook/jq-config-empty-dict-advisory.md
+++ b/docs/hook/jq-config-empty-dict-advisory.md
@@ -71,7 +71,9 @@ Not detected (by design):
 |---------|--------|
 | `jq '.' /tmp/other.json` | Non-config path, out of scope |
 | `jq -n '{}'` | Null input (`-n`), no file read |
-| Multi-hop pipe `cmd1 \| cmd2 \| jq`  | Only immediate prior segment correlated |
+| Multi-hop pipe `cmd1 \| cmd2 \| jq` | Only immediate prior segment correlated |
+| `` `jq -r '.foo' ~/.claude/settings.json` `` | Backtick substitution — `safe_tokenize` does not parse backtick blocks; follow-up #338 |
+| `$(jq -r .foo cfg.json && jq -r .bar cfg.json)` | Shell separator inside `$(…)` — `_coalesce_subst_runs` joins past `&&` boundary; follow-up #338 |
 
 ### Response format
 

--- a/docs/hook/jq-config-empty-dict-advisory.md
+++ b/docs/hook/jq-config-empty-dict-advisory.md
@@ -1,0 +1,102 @@
+# PreToolUse jq Config Empty/Invalid Advisory
+
+Supported hosts: all
+
+`hooks/jq-config-empty-dict-advisory.sh` watches Bash tool calls that invoke
+`jq` against known config file paths. When the target file is empty (size 0)
+or contains invalid JSON, it emits a stderr advisory — before `jq` silently
+returns `empty` or crashes downstream.
+
+### Why this exists
+
+`jq` applied to an empty config file returns the literal string `empty` on
+stdout rather than erroring. Downstream code that pipes or assigns this
+output may silently fall back to a wrong default, masking the root cause for
+several turns. Invalid JSON produces a jq parse error, but only at runtime
+— the agent has already composed and dispatched the full pipeline.
+
+This hook surfaces the problem *before* the command executes (issue #323).
+
+### What is detected
+
+Detection surface — a Bash segment is scanned when it contains `jq` followed
+by at least one positional argument matching a known config path:
+
+- `~/.claude/*.json`
+- `~/.codex/*.json`
+- Repo-root `settings.json` or `hooks.json` (bare filename)
+- Any `.json` file under a `.claude/` or `.codex/` directory component
+  (absolute or relative)
+
+File-level outcomes:
+
+| File state | Action |
+|------------|--------|
+| Missing / does not exist | **SILENT** — out of scope; other hooks cover existence |
+| Empty (size 0) | **ADVISORY** `[config-empty]` |
+| Present, invalid JSON (jq parse fail) | **ADVISORY** `[config-invalid]` |
+| Present, valid JSON | **SILENT** |
+
+Command-level examples:
+
+| Command | Action |
+|---------|--------|
+| `jq '.' ~/.claude/settings.json` (file empty) | **ADVISORY** `[config-empty]` |
+| `jq '.hooks' hooks.json` (file invalid JSON) | **ADVISORY** `[config-invalid]` |
+| `jq -r '.foo' .claude/settings.json` (file valid) | **SILENT** |
+| `jq '.' ~/.codex/config.json` (file valid) | **SILENT** |
+| `jq '.' /tmp/unrelated.json` (non-config path) | **SILENT** — path not in scope |
+| `jq '.' settings.json` (file missing) | **SILENT** — existence not in scope |
+| Non-Bash tool | **SILENT** |
+| Malformed JSON stdin | **SILENT** (fail-open) |
+
+### Response format
+
+```
+stderr: "[config-empty] <path> is empty — jq will return 'empty', downstream may silently fallback"
+stderr: "[config-invalid] <path> is not parseable as JSON — jq will fail"
+exit 0
+```
+
+Advisory-only: the hook **never blocks** and never emits JSON to stdout. The
+user sees the stderr text and can inspect / repair the file before rerunning.
+
+### Deduplication
+
+Advisories are deduplicated per `session_id` + canonical path. A given file
+triggers at most one advisory per session regardless of how many `jq` calls
+target it. State file:
+
+```
+${TMPDIR:-/tmp}/praxis-jq-config-advisory-<session_id>.json
+```
+
+PPID is used as a fallback key when `session_id` is absent (direct CLI /
+test invocations).
+
+### Parsing guarantees (fail-open)
+
+- malformed JSON stdin → exit 0
+- non-Bash tool → exit 0
+- empty / whitespace command → exit 0
+- `python3` unavailable → shell wrapper exits 0
+- `jq` binary absent → skip advisory, exit 0
+- jq validation timeout (>5 s) → skip advisory, exit 0
+- any uncaught exception → exit 0
+
+### Relationship to sibling hooks
+
+| Hook | Scope | Overlap |
+|------|-------|---------|
+| `cli-flag-incompat-advisory` | Advisory nudge for mode-incompatible flag combos | None — covers flag errors, not file-content errors |
+| `external-api-literal-trigger` | Advisory nudge for unverified ALL_CAPS / 3-part SQL identifiers | None — different detection surface |
+| `memory-hint` | Surface hookable memory entries | None — complementary |
+
+### Tests
+
+```bash
+bash hooks/test-jq-config-empty-dict-advisory.sh
+```
+
+3 cases: empty file (`[config-empty]` advisory), invalid JSON file
+(`[config-invalid]` advisory), valid JSON file (silent).

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -107,6 +107,12 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/jq-config-empty-dict-advisory.sh",
+            "timeout": 5,
+            "hosts": ["claude", "codex"]
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/verify-commit-flag-override.sh",
             "timeout": 5,
             "hosts": ["claude", "codex"]

--- a/hooks/jq-config-empty-dict-advisory.py
+++ b/hooks/jq-config-empty-dict-advisory.py
@@ -132,20 +132,7 @@ _JQ_DOUBLE_VALUE_FLAGS: frozenset[str] = frozenset({
 # hard stop for file-path extraction.
 _JQ_STOP_FLAGS: frozenset[str] = frozenset({"--args", "--jsonargs"})
 
-# Regex to detect jq invocations inside coalesced $(…) substitution tokens.
-# Matches: jq <optional flags> <filter> <config-path>
-# Used for C1 (command substitution) detection.
-_JQ_SUBST_RE = re.compile(
-    r"""
-    (?:^|\s|=)              # start of string, whitespace, or assignment
-    \$\(                    # start of command substitution
-    [^)]*                   # any content
-    \bjq\b                  # the jq command
-    """,
-    re.VERBOSE,
-)
-
-# Simpler pattern to extract config paths from a raw coalesced SUBST_RUN token.
+# Pattern to extract config paths from a raw coalesced SUBST_RUN token.
 # Looks for any token matching the config path shape in the substitution body.
 _CONFIG_PATH_IN_TEXT_RE = re.compile(
     r"""
@@ -275,7 +262,6 @@ def _extract_config_paths_from_non_jq_segment(argv: list[str]) -> list[str]:
     paths: list[str] = []
     if not argv:
         return paths
-    cmd = argv[0]
     # Only correlate for known pipe-source commands or redirect-style patterns.
     # cat, head, tail, less, python3, etc. — any command may pipe to jq.
     # We conservatively detect config paths in any non-jq segment and let
@@ -399,7 +385,7 @@ def _collect_config_paths(command: str) -> list[str]:
     # Track config paths seen in the previous segment (for pipe correlation).
     prev_segment_config_paths: list[str] = []
 
-    for seg_idx, seg_raw in enumerate(segments):
+    for seg_raw in segments:
         seg = list(seg_raw)
 
         # --- C1: SUBST_RUN scan ---

--- a/hooks/jq-config-empty-dict-advisory.py
+++ b/hooks/jq-config-empty-dict-advisory.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""PreToolUse(Bash) advisory: warn when jq reads an empty or invalid JSON
+config file.
+
+Issue #323. Recurring failure mode: `jq` invocations against config files
+(settings.json, hooks.json, ~/.claude/*.json, ~/.codex/*.json) silently
+return `null` or `empty` when the target file is empty (size 0), and fail
+with a parse error when the file contains invalid JSON. Downstream code
+that pipes jq output may silently fall back to incorrect defaults, masking
+the root cause.
+
+Detection surface:
+  • Bash tool calls containing `jq ... <path>.json`
+  • <path> matches known config locations:
+      - ~/.claude/*.json
+      - ~/.codex/*.json
+      - repo-root settings.json
+      - repo-root hooks.json
+      - any path ending in .json under .claude/ or .codex/ (relative or absolute)
+
+Actions:
+  • file missing → skip (out of scope; other hooks cover existence checks)
+  • file empty (size 0) → stderr advisory [config-empty]
+  • file present but invalid JSON (jq parse fail) → stderr advisory [config-invalid]
+  • file present and valid JSON → silent pass
+
+Deduplicated per session_id + path so the nudge fires at most once per
+file per session. Session-state file:
+  ${TMPDIR:-/tmp}/praxis-jq-config-advisory-<session_id>.json
+
+Fail-open contract:
+  • malformed JSON / non-Bash payload → exit 0
+  • empty command → exit 0
+  • any uncaught exception in the inner logic → swallowed, exit 0
+  • python3 unavailable → shell wrapper exits 0
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Optional
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    iter_command_starts,
+    safe_tokenize,
+    strip_prefix,
+)
+
+
+# ---------------------------------------------------------------------------
+# Config path patterns
+# ---------------------------------------------------------------------------
+#
+# A path matches if it ends with .json AND satisfies at least one of:
+#   1. Has .claude/ or .codex/ anywhere in it (absolute or relative)
+#   2. Is literally "settings.json" or "hooks.json" (repo-root files)
+#   3. Is under ~ expansion for ~/.claude/ or ~/.codex/
+#
+# We do NOT anchor on ~/.claude exactly — relative paths like
+# .claude/settings.json are also config paths.
+
+_CONFIG_PATH_RE = re.compile(
+    r"""
+    (?:
+        (?:^|/)\.claude/   # under .claude/ dir
+      | (?:^|/)\.codex/    # under .codex/ dir
+      | (?:^|/)settings\.json$   # repo-root settings.json
+      | (?:^|/)hooks\.json$      # repo-root hooks.json
+    )
+    """,
+    re.VERBOSE,
+)
+
+
+def _is_config_path(token: str) -> bool:
+    """Return True if `token` looks like a known config JSON path."""
+    # Must end with .json
+    if not token.endswith(".json"):
+        return False
+    return bool(_CONFIG_PATH_RE.search(token))
+
+
+# ---------------------------------------------------------------------------
+# Extract jq target path from a command segment argv
+# ---------------------------------------------------------------------------
+#
+# jq syntax: jq [OPTIONS] FILTER [FILE...]
+# We look for any POSITIONAL argument (non-flag, non-filter) that ends in
+# .json. The filter is the first positional; subsequent positionals are
+# input files. We skip the filter and look for file arguments.
+#
+# Heuristic: skip the first positional (the filter), then collect all
+# remaining positionals that end in .json. Handles the common patterns:
+#   jq '.' settings.json
+#   jq '.hooks' ~/.claude/settings.json
+#   cat settings.json | jq '.'   ← no file arg (piped), skip
+#   jq -r '.foo' ~/.codex/config.json
+
+def _extract_jq_config_paths(argv: list[str]) -> list[str]:
+    """Return all config-matching .json positional arguments in a jq call.
+
+    argv must already be stripped of env/wrapper prefixes. argv[0] == 'jq'.
+    Returns an empty list if this is not a jq invocation or no config paths
+    are found.
+    """
+    if not argv or argv[0] != "jq":
+        return []
+
+    # Known jq flags that take a separate-token value.
+    # Source: jq --help (jq 1.6/1.7)
+    jq_value_flags: frozenset[str] = frozenset({
+        "--arg", "--argjson", "--slurpfile", "--rawfile", "--jsonargs",
+        "--args", "-e", "--exit-status", "--indent", "--tab",
+        "--from-file", "-f", "--sort-keys", "--stream",
+        "-L", "--rawfile",
+    })
+
+    paths: list[str] = []
+    filter_seen = False
+    i = 1
+    n = len(argv)
+    while i < n:
+        tok = argv[i]
+        if tok == "--":
+            # Everything after -- is a file argument
+            for j in range(i + 1, n):
+                if _is_config_path(argv[j]):
+                    paths.append(argv[j])
+            break
+        if tok.startswith("-") and len(tok) > 1:
+            # Flag — check if it consumes a value token
+            bare = tok.split("=", 1)[0]
+            if "=" not in tok and bare in jq_value_flags and i + 1 < n:
+                i += 2
+                continue
+            i += 1
+            continue
+        # Positional
+        if not filter_seen:
+            # First positional is the filter expression
+            filter_seen = True
+        else:
+            # Subsequent positionals are input files
+            if _is_config_path(tok):
+                paths.append(tok)
+        i += 1
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped deduplication
+# ---------------------------------------------------------------------------
+
+def _extract_session_id(payload: dict) -> Optional[str]:
+    """Return the trimmed session_id, or None."""
+    sid = payload.get("session_id")
+    if isinstance(sid, str) and sid.strip():
+        return sid.strip()
+    return None
+
+
+def _resolve_dedup_path(session_id: Optional[str]) -> str:
+    tmp = os.environ.get("TMPDIR", "/tmp").rstrip("/") or "/tmp"
+    if session_id:
+        return os.path.join(tmp, f"praxis-jq-config-advisory-{session_id}.json")
+    ppid = os.getppid()
+    return os.path.join(tmp, f"praxis-jq-config-advisory-{ppid}.json")
+
+
+def _load_seen(path: str) -> set:
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, list):
+            return set(data)
+        return set()
+    except (OSError, ValueError):
+        return set()
+
+
+def _save_seen(path: str, seen: set) -> None:
+    try:
+        tmp_path = path + ".tmp"
+        with open(tmp_path, "w", encoding="utf-8") as fh:
+            json.dump(sorted(seen), fh)
+        os.replace(tmp_path, path)
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# File validation
+# ---------------------------------------------------------------------------
+
+def _check_file(path: str) -> Optional[str]:
+    """Return an advisory message if path is empty or invalid JSON, else None.
+
+    Returns None (skip) when the file does not exist.
+    """
+    expanded = os.path.expanduser(path)
+    if not os.path.exists(expanded):
+        return None  # out of scope
+    if os.path.getsize(expanded) == 0:
+        return (
+            f"[config-empty] {path} is empty — "
+            "jq will return 'empty', downstream may silently fallback"
+        )
+    # Validate JSON by invoking jq. If jq is absent or times out, skip
+    # (fail-open) — the hook's job is to warn, not to enforce.
+    try:
+        result = subprocess.run(
+            ["jq", ".", expanded],
+            capture_output=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            return (
+                f"[config-invalid] {path} is not parseable as JSON — "
+                "jq will fail"
+            )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None  # jq absent or timed out — skip advisory
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def _main_inner() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    command = payload.get("tool_input", {}).get("command", "") or ""
+    if not command.strip():
+        return 0
+
+    # Find all jq invocations with config-path arguments
+    tokens = safe_tokenize(command.replace("\\\n", " "))
+    if not tokens:
+        return 0
+
+    config_paths: list[str] = []
+    for argv_raw in iter_command_starts(tokens):
+        argv = strip_prefix(list(argv_raw))
+        paths = _extract_jq_config_paths(argv)
+        config_paths.extend(paths)
+
+    if not config_paths:
+        return 0
+
+    session_id = _extract_session_id(payload)
+    dedup_path = _resolve_dedup_path(session_id)
+    seen = _load_seen(dedup_path)
+
+    new_seen = set(seen)
+    emitted = False
+
+    for path in config_paths:
+        # Canonicalize for dedup: expand user, but keep original for display
+        key = os.path.normpath(os.path.expanduser(path))
+        if key in seen:
+            continue
+        msg = _check_file(path)
+        if msg:
+            sys.stderr.write(msg + "\n")
+            emitted = True
+        new_seen.add(key)
+
+    if new_seen != seen:
+        _save_seen(dedup_path, new_seen)
+
+    return 0
+
+
+def main() -> int:
+    """Advisory hook — must NEVER break tool execution."""
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/jq-config-empty-dict-advisory.py
+++ b/hooks/jq-config-empty-dict-advisory.py
@@ -18,6 +18,17 @@ Detection surface:
       - repo-root hooks.json
       - any path ending in .json under .claude/ or .codex/ (relative or absolute)
 
+Handled patterns:
+  • jq '.' ~/.claude/settings.json         — direct invocation
+  • jq -r '.foo' ~/.codex/config.json      — raw-output flag
+  • cat ~/.claude/settings.json | jq '.'   — piped; prior segment file
+  • jq '.' < ~/.claude/settings.json       — stdin redirect
+  • threshold=$(jq -r '.foo' settings.json) — command substitution
+
+Not detected (by design):
+  • jq invocations against non-config .json files (out of scope)
+  • jq -n (null input — no file arg by design)
+
 Actions:
   • file missing → skip (out of scope; other hooks cover existence checks)
   • file empty (size 0) → stderr advisory [config-empty]
@@ -25,7 +36,7 @@ Actions:
   • file present and valid JSON → silent pass
 
 Deduplicated per session_id + path so the nudge fires at most once per
-file per session. Session-state file:
+advisory-emitting invocation per session. Session-state file:
   ${TMPDIR:-/tmp}/praxis-jq-config-advisory-<session_id>.json
 
 Fail-open contract:
@@ -33,6 +44,7 @@ Fail-open contract:
   • empty command → exit 0
   • any uncaught exception in the inner logic → swallowed, exit 0
   • python3 unavailable → shell wrapper exits 0
+  • jq binary absent or timeout → skip advisory, exit 0
 """
 from __future__ import annotations
 
@@ -49,6 +61,7 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     iter_command_starts,
     safe_tokenize,
     strip_prefix,
+    _coalesce_subst_runs,
 )
 
 
@@ -59,7 +72,6 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
 # A path matches if it ends with .json AND satisfies at least one of:
 #   1. Has .claude/ or .codex/ anywhere in it (absolute or relative)
 #   2. Is literally "settings.json" or "hooks.json" (repo-root files)
-#   3. Is under ~ expansion for ~/.claude/ or ~/.codex/
 #
 # We do NOT anchor on ~/.claude exactly — relative paths like
 # .claude/settings.json are also config paths.
@@ -79,46 +91,122 @@ _CONFIG_PATH_RE = re.compile(
 
 def _is_config_path(token: str) -> bool:
     """Return True if `token` looks like a known config JSON path."""
-    # Must end with .json
     if not token.endswith(".json"):
         return False
     return bool(_CONFIG_PATH_RE.search(token))
 
 
 # ---------------------------------------------------------------------------
-# Extract jq target path from a command segment argv
+# jq flag classification (jq 1.7.1, verified via `jq --help`)
+# ---------------------------------------------------------------------------
+#
+# Only flags that consume exactly ONE separate next token are listed here.
+# Boolean flags (--sort-keys, --stream, --tab, -e, --exit-status, etc.) are
+# NOT listed — they do not consume a value token.
+#
+# Note: --arg, --argjson, --slurpfile, --rawfile each consume TWO tokens
+# (name + value). We model this as consuming 2 tokens when bare.
+# --from-file/-f and -L each consume ONE token.
+#
+# --args / --jsonargs: consume ALL remaining argv as positional strings —
+# once encountered, no further jq file arguments appear. We break on them.
+
+# Single-token consuming flags (name-only, one following token)
+_JQ_SINGLE_VALUE_FLAGS: frozenset[str] = frozenset({
+    "--from-file", "-f",    # load filter from file
+    "-L",                   # module search directory
+    "--indent",             # indentation spaces
+})
+
+# Two-token consuming flags (name value, two following tokens)
+_JQ_DOUBLE_VALUE_FLAGS: frozenset[str] = frozenset({
+    "--arg",        # name value  → $name = string
+    "--argjson",    # name value  → $name = JSON
+    "--slurpfile",  # name file
+    "--rawfile",    # name file
+})
+
+# Boolean flags that terminate further file argument scanning.
+# After --args or --jsonargs, all remaining tokens are positional string
+# values passed to the program, NOT file arguments. We treat them as a
+# hard stop for file-path extraction.
+_JQ_STOP_FLAGS: frozenset[str] = frozenset({"--args", "--jsonargs"})
+
+# Regex to detect jq invocations inside coalesced $(…) substitution tokens.
+# Matches: jq <optional flags> <filter> <config-path>
+# Used for C1 (command substitution) detection.
+_JQ_SUBST_RE = re.compile(
+    r"""
+    (?:^|\s|=)              # start of string, whitespace, or assignment
+    \$\(                    # start of command substitution
+    [^)]*                   # any content
+    \bjq\b                  # the jq command
+    """,
+    re.VERBOSE,
+)
+
+# Simpler pattern to extract config paths from a raw coalesced SUBST_RUN token.
+# Looks for any token matching the config path shape in the substitution body.
+_CONFIG_PATH_IN_TEXT_RE = re.compile(
+    r"""
+    (?:
+        (?:^|[\s(])                 # preceded by start/space/open-paren
+        (
+            ~?/[^\s)'"]*\.json      # absolute path (possibly tilde)
+          | \.claude/[^\s)'"]*\.json   # relative .claude/...
+          | \.codex/[^\s)'"]*\.json    # relative .codex/...
+          | settings\.json             # bare repo-root name
+          | hooks\.json                # bare repo-root name
+        )
+    )
+    """,
+    re.VERBOSE,
+)
+
+
+def _scan_subst_for_config_paths(token: str) -> list[str]:
+    """Extract config-matching paths from a coalesced SUBST_RUN token.
+
+    A coalesced token like:
+      'threshold=$(jq -r .ambiguity_threshold ~/.claude/settings.json)'
+    contains a jq invocation. We extract any config-path candidates from the
+    raw substitution text.
+
+    Returns an empty list if no jq invocation or config path is detected.
+    """
+    if "jq" not in token or "$(" not in token:
+        return []
+    # Only bother if there's a jq somewhere in the substitution.
+    if not re.search(r'\bjq\b', token):
+        return []
+    paths = []
+    for m in _CONFIG_PATH_IN_TEXT_RE.finditer(token):
+        candidate = m.group(1)
+        if _is_config_path(candidate):
+            paths.append(candidate)
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Extract jq target paths from a command segment
 # ---------------------------------------------------------------------------
 #
 # jq syntax: jq [OPTIONS] FILTER [FILE...]
-# We look for any POSITIONAL argument (non-flag, non-filter) that ends in
-# .json. The filter is the first positional; subsequent positionals are
-# input files. We skip the filter and look for file arguments.
-#
-# Heuristic: skip the first positional (the filter), then collect all
-# remaining positionals that end in .json. Handles the common patterns:
-#   jq '.' settings.json
-#   jq '.hooks' ~/.claude/settings.json
-#   cat settings.json | jq '.'   ← no file arg (piped), skip
-#   jq -r '.foo' ~/.codex/config.json
+# We skip the filter (first positional) and collect subsequent .json positionals.
+# Special handling:
+#   • `<` redirect token followed by a config path
+#   • piped segments: if prev segment had a config path via cat/< , passed
+#     via caller-level cross-segment logic
 
 def _extract_jq_config_paths(argv: list[str]) -> list[str]:
-    """Return all config-matching .json positional arguments in a jq call.
+    """Return config-matching .json paths in a jq call argv.
 
-    argv must already be stripped of env/wrapper prefixes. argv[0] == 'jq'.
-    Returns an empty list if this is not a jq invocation or no config paths
-    are found.
+    argv must already be stripped of env/wrapper prefixes (argv[0] == 'jq').
+    Returns an empty list if this is not a jq invocation or no config
+    paths are found.
     """
     if not argv or argv[0] != "jq":
         return []
-
-    # Known jq flags that take a separate-token value.
-    # Source: jq --help (jq 1.6/1.7)
-    jq_value_flags: frozenset[str] = frozenset({
-        "--arg", "--argjson", "--slurpfile", "--rawfile", "--jsonargs",
-        "--args", "-e", "--exit-status", "--indent", "--tab",
-        "--from-file", "-f", "--sort-keys", "--stream",
-        "-L", "--rawfile",
-    })
 
     paths: list[str] = []
     filter_seen = False
@@ -126,28 +214,87 @@ def _extract_jq_config_paths(argv: list[str]) -> list[str]:
     n = len(argv)
     while i < n:
         tok = argv[i]
+
+        # -- terminates options; everything after is a file path
         if tok == "--":
-            # Everything after -- is a file argument
             for j in range(i + 1, n):
                 if _is_config_path(argv[j]):
                     paths.append(argv[j])
             break
+
+        # --args / --jsonargs: remaining argv are positional strings, not files
+        if tok in _JQ_STOP_FLAGS:
+            break
+
+        # stdin redirect: `< path` — the `<` token is followed by the file
+        if tok == "<":
+            if i + 1 < n and _is_config_path(argv[i + 1]):
+                paths.append(argv[i + 1])
+            i += 2
+            continue
+
         if tok.startswith("-") and len(tok) > 1:
-            # Flag — check if it consumes a value token
             bare = tok.split("=", 1)[0]
-            if "=" not in tok and bare in jq_value_flags and i + 1 < n:
+            if "=" in tok:
+                # Value is embedded (--flag=value) — skip this token only
+                i += 1
+                continue
+            if bare in _JQ_DOUBLE_VALUE_FLAGS and i + 2 < n:
+                # name value — skip two following tokens
+                i += 3
+                continue
+            if bare in _JQ_SINGLE_VALUE_FLAGS and i + 1 < n:
+                # value — skip one following token
                 i += 2
                 continue
+            # Boolean flag — skip just this token
             i += 1
             continue
+
         # Positional
         if not filter_seen:
-            # First positional is the filter expression
+            # First positional is the jq filter expression
             filter_seen = True
         else:
             # Subsequent positionals are input files
             if _is_config_path(tok):
                 paths.append(tok)
+        i += 1
+    return paths
+
+
+def _extract_config_paths_from_non_jq_segment(argv: list[str]) -> list[str]:
+    """Return config-matching .json paths from a non-jq segment.
+
+    Used for M4: `cat ~/.claude/settings.json | jq '.'` — we need to
+    detect the config path in the `cat` segment and correlate it with the
+    subsequent `jq` segment.
+
+    Scans all positional tokens (non-flags) for config paths.
+    """
+    paths: list[str] = []
+    if not argv:
+        return paths
+    cmd = argv[0]
+    # Only correlate for known pipe-source commands or redirect-style patterns.
+    # cat, head, tail, less, python3, etc. — any command may pipe to jq.
+    # We conservatively detect config paths in any non-jq segment and let
+    # the caller decide.
+    i = 1
+    n = len(argv)
+    while i < n:
+        tok = argv[i]
+        if tok == "<":
+            # redirect: the next token is the source file
+            if i + 1 < n and _is_config_path(argv[i + 1]):
+                paths.append(argv[i + 1])
+            i += 2
+            continue
+        if tok.startswith("-") and len(tok) > 1:
+            i += 1
+            continue
+        if _is_config_path(tok):
+            paths.append(tok)
         i += 1
     return paths
 
@@ -232,6 +379,63 @@ def _check_file(path: str) -> Optional[str]:
 # Main
 # ---------------------------------------------------------------------------
 
+def _collect_config_paths(command: str) -> list[str]:
+    """Extract all config-matching jq target paths from a Bash command string.
+
+    Handles four patterns:
+      1. Direct: `jq '.' ~/.claude/settings.json`
+      2. Stdin redirect: `jq '.' < ~/.claude/settings.json`
+      3. Pipe: `cat ~/.claude/settings.json | jq '.'`
+      4. Substitution: `threshold=$(jq -r '.foo' ~/.claude/settings.json)`
+    """
+    normalized = command.replace("\\\n", " ")
+    raw_tokens = safe_tokenize(normalized)
+    if not raw_tokens:
+        return []
+
+    config_paths: list[str] = []
+    segments = list(iter_command_starts(raw_tokens))
+
+    # Track config paths seen in the previous segment (for pipe correlation).
+    prev_segment_config_paths: list[str] = []
+
+    for seg_idx, seg_raw in enumerate(segments):
+        seg = list(seg_raw)
+
+        # --- C1: SUBST_RUN scan ---
+        # Coalesce to find $(…) tokens and scan them for embedded jq calls.
+        coalesced = _coalesce_subst_runs(seg)
+        for tok in coalesced:
+            if "$(" in tok and "jq" in tok:
+                subst_paths = _scan_subst_for_config_paths(tok)
+                config_paths.extend(subst_paths)
+
+        # Standard segment analysis (stripped argv)
+        argv = strip_prefix(seg)
+        if not argv:
+            prev_segment_config_paths = []
+            continue
+
+        cmd = argv[0].rsplit("/", 1)[-1]  # basename, handle /usr/bin/jq
+
+        if cmd == "jq":
+            # Pattern 1 & 2: direct jq invocation (includes < redirect in argv)
+            direct_paths = _extract_jq_config_paths(argv)
+            config_paths.extend(direct_paths)
+
+            # Pattern 3 (M4): if previous segment contained config paths,
+            # and this is a jq segment with no file args, correlate.
+            if not direct_paths and prev_segment_config_paths:
+                config_paths.extend(prev_segment_config_paths)
+
+            prev_segment_config_paths = []
+        else:
+            # Non-jq segment: collect its config paths for pipe correlation.
+            prev_segment_config_paths = _extract_config_paths_from_non_jq_segment(argv)
+
+    return config_paths
+
+
 def _main_inner() -> int:
     try:
         payload = json.load(sys.stdin)
@@ -245,17 +449,7 @@ def _main_inner() -> int:
     if not command.strip():
         return 0
 
-    # Find all jq invocations with config-path arguments
-    tokens = safe_tokenize(command.replace("\\\n", " "))
-    if not tokens:
-        return 0
-
-    config_paths: list[str] = []
-    for argv_raw in iter_command_starts(tokens):
-        argv = strip_prefix(list(argv_raw))
-        paths = _extract_jq_config_paths(argv)
-        config_paths.extend(paths)
-
+    config_paths = _collect_config_paths(command)
     if not config_paths:
         return 0
 
@@ -264,18 +458,18 @@ def _main_inner() -> int:
     seen = _load_seen(dedup_path)
 
     new_seen = set(seen)
-    emitted = False
 
     for path in config_paths:
-        # Canonicalize for dedup: expand user, but keep original for display
+        # Canonicalize for dedup: expand user + normalize
         key = os.path.normpath(os.path.expanduser(path))
         if key in seen:
             continue
         msg = _check_file(path)
         if msg:
             sys.stderr.write(msg + "\n")
-            emitted = True
-        new_seen.add(key)
+            # M3 fix: only record in dedup state when advisory was emitted,
+            # so a file that later becomes empty is re-checked.
+            new_seen.add(key)
 
     if new_seen != seen:
         _save_seen(dedup_path, new_seen)

--- a/hooks/jq-config-empty-dict-advisory.sh
+++ b/hooks/jq-config-empty-dict-advisory.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# PreToolUse(Bash) hook — delegates to the Python implementation.
+# Advisory-only: writes to stderr, exits 0. Never blocks tool execution.
+
+set +e
+
+if ! command -v python3 >/dev/null 2>&1; then
+  exit 0
+fi
+
+exec python3 "$(dirname "$0")/jq-config-empty-dict-advisory.py"

--- a/hooks/test-jq-config-empty-dict-advisory.sh
+++ b/hooks/test-jq-config-empty-dict-advisory.sh
@@ -89,12 +89,19 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 SID_EMPTY="test-empty-$$"
 SID_INVALID="test-invalid-$$"
 SID_VALID="test-valid-$$"
+SID_C1="test-c1-subst-$$"
+SID_C2A="test-c2a-eflag-$$"
+SID_C2B="test-c2b-sortkeys-$$"
+SID_M3A="test-m3a-$$"
+SID_M3B="test-m3b-$$"
+SID_M4A="test-m4a-pipe-$$"
+SID_M4B="test-m4b-redirect-$$"
+
+mkdir -p "$TMP_DIR/.claude"
 
 # --- Case 1: empty file -------------------------------------------------------
 
 EMPTY_JSON="$TMP_DIR/.claude/settings.json"
-mkdir -p "$(dirname "$EMPTY_JSON")"
-# Create a zero-byte file
 : > "$EMPTY_JSON"
 
 run_case "empty config file" \
@@ -105,7 +112,6 @@ run_case "empty config file" \
 # --- Case 2: invalid JSON file ------------------------------------------------
 
 INVALID_JSON="$TMP_DIR/.claude/hooks.json"
-mkdir -p "$(dirname "$INVALID_JSON")"
 printf '{not valid json' > "$INVALID_JSON"
 
 run_case "invalid JSON config file" \
@@ -116,13 +122,87 @@ run_case "invalid JSON config file" \
 # --- Case 3: valid JSON file --------------------------------------------------
 
 VALID_JSON="$TMP_DIR/.claude/valid.json"
-mkdir -p "$(dirname "$VALID_JSON")"
 printf '{"key": "value"}' > "$VALID_JSON"
 
 run_case "valid JSON config file" \
   "silent" \
   "jq '.key' $VALID_JSON" \
   "$SID_VALID"
+
+# --- Case 4 (C1): command substitution — threshold=$(jq -r '...' file) --------
+# Issue body originating pattern. safe_tokenize splits threshold=$(jq into one
+# token; _coalesce_subst_runs joins the $(…) run; _scan_subst_for_config_paths
+# then extracts the path from the coalesced SUBST_RUN token.
+
+C1_JSON="$TMP_DIR/.claude/c1.json"
+: > "$C1_JSON"
+
+run_case "C1 command substitution empty file" \
+  "advisory:[config-empty]" \
+  "threshold=\$(jq -r '.ambiguity_threshold // 0.2' $C1_JSON)" \
+  "$SID_C1"
+
+# --- Case 5 (C2a): jq -e flag (boolean, must not consume filter as value) -----
+
+C2A_JSON="$TMP_DIR/.claude/c2a.json"
+: > "$C2A_JSON"
+
+run_case "C2a -e flag (boolean) empty file" \
+  "advisory:[config-empty]" \
+  "jq -e '.theme' $C2A_JSON" \
+  "$SID_C2A"
+
+# --- Case 6 (C2b): jq --sort-keys flag (boolean, must not consume value) ------
+
+C2B_JSON="$TMP_DIR/.claude/c2b.json"
+: > "$C2B_JSON"
+
+run_case "C2b --sort-keys flag (boolean) empty file" \
+  "advisory:[config-empty]" \
+  "jq --sort-keys '.foo' $C2B_JSON" \
+  "$SID_C2B"
+
+# --- Case 7 (M3): dedup — advisory-emitting keys are deduplicated, ---------
+# but a file not yet advisory-emitting is NOT blocked from future checks.
+# Sub-case A: first call on valid file → silent, key NOT stored.
+# Sub-case B: same session, same file now empty → advisory must fire.
+# We simulate by sharing a session_id across A and B.
+
+M3_JSON="$TMP_DIR/.claude/m3.json"
+printf '{"ok": true}' > "$M3_JSON"
+
+run_case "M3a valid file first call (no advisory stored)" \
+  "silent" \
+  "jq '.' $M3_JSON" \
+  "$SID_M3A"
+
+# Now make the file empty and re-check with same session_id.
+: > "$M3_JSON"
+
+run_case "M3b same file now empty — advisory must fire" \
+  "advisory:[config-empty]" \
+  "jq '.' $M3_JSON" \
+  "$SID_M3A"
+
+# --- Case 8 (M4a): cat config | jq '.' — pipe correlation --------------------
+
+M4A_JSON="$TMP_DIR/.claude/m4a.json"
+: > "$M4A_JSON"
+
+run_case "M4a piped cat config | jq empty file" \
+  "advisory:[config-empty]" \
+  "cat $M4A_JSON | jq '.'" \
+  "$SID_M4A"
+
+# --- Case 9 (M4b): jq '.' < config — stdin redirect --------------------------
+
+M4B_JSON="$TMP_DIR/.claude/m4b.json"
+: > "$M4B_JSON"
+
+run_case "M4b stdin redirect jq '.' < config empty file" \
+  "advisory:[config-empty]" \
+  "jq '.' < $M4B_JSON" \
+  "$SID_M4B"
 
 # ---------------------------------------------------------------------------
 echo

--- a/hooks/test-jq-config-empty-dict-advisory.sh
+++ b/hooks/test-jq-config-empty-dict-advisory.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# test-jq-config-empty-dict-advisory.sh — coverage for the advisory hook.
+#
+# Synthesizes Claude Code PreToolUse(Bash) payloads against real temporary
+# files and asserts:
+#   advisory:<marker>  → exit 0 + stderr contains the marker string
+#   silent             → exit 0 + stderr empty
+#
+# Usage: bash hooks/test-jq-config-empty-dict-advisory.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/jq-config-empty-dict-advisory.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable: $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+# run_case name expected command [session_id]
+#   expected: "advisory:<marker>"  (exit 0, stderr contains <marker>)
+#             "silent"             (exit 0, stderr empty)
+run_case() {
+  local name="$1" expected="$2" command="$3" session_id="${4:-test-session-$$}"
+
+  local payload
+  payload=$(python3 -c '
+import json, sys
+d = {
+    "tool_name": "Bash",
+    "tool_input": {"command": sys.argv[1]},
+    "session_id": sys.argv[2],
+}
+print(json.dumps(d))' "$command" "$session_id")
+
+  local out_file err_file
+  out_file=$(mktemp)
+  err_file=$(mktemp)
+  echo "$payload" | "$HOOK" >"$out_file" 2>"$err_file"
+  local rc=$?
+  local out err
+  out=$(cat "$out_file")
+  err=$(cat "$err_file")
+  rm -f "$out_file" "$err_file"
+
+  local ok=1
+  case "$expected" in
+    advisory:*)
+      local marker="${expected#advisory:}"
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$out" ]   || ok=0
+      echo "$err" | grep -qF "$marker" || ok=0
+      ;;
+    silent)
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$out" ]   || ok=0
+      [ -z "$err" ]   || ok=0
+      ;;
+    *)
+      echo "FAIL  [$name] unknown expected: $expected"
+      FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name"); return
+      ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  [$name]"; PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expected=$expected rc=$rc"
+    [ -n "$out" ] && echo "        stdout: $out"
+    [ -n "$err" ] && echo "        stderr: $err"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Shared tmp dir — unique per test run so dedup state doesn't bleed between
+# cases (each case uses a distinct session_id derived from the tmp dir name).
+# ---------------------------------------------------------------------------
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# Unique session IDs per case to avoid dedup state interference.
+SID_EMPTY="test-empty-$$"
+SID_INVALID="test-invalid-$$"
+SID_VALID="test-valid-$$"
+
+# --- Case 1: empty file -------------------------------------------------------
+
+EMPTY_JSON="$TMP_DIR/.claude/settings.json"
+mkdir -p "$(dirname "$EMPTY_JSON")"
+# Create a zero-byte file
+: > "$EMPTY_JSON"
+
+run_case "empty config file" \
+  "advisory:[config-empty]" \
+  "jq '.' $EMPTY_JSON" \
+  "$SID_EMPTY"
+
+# --- Case 2: invalid JSON file ------------------------------------------------
+
+INVALID_JSON="$TMP_DIR/.claude/hooks.json"
+mkdir -p "$(dirname "$INVALID_JSON")"
+printf '{not valid json' > "$INVALID_JSON"
+
+run_case "invalid JSON config file" \
+  "advisory:[config-invalid]" \
+  "jq '.hooks' $INVALID_JSON" \
+  "$SID_INVALID"
+
+# --- Case 3: valid JSON file --------------------------------------------------
+
+VALID_JSON="$TMP_DIR/.claude/valid.json"
+mkdir -p "$(dirname "$VALID_JSON")"
+printf '{"key": "value"}' > "$VALID_JSON"
+
+run_case "valid JSON config file" \
+  "silent" \
+  "jq '.key' $VALID_JSON" \
+  "$SID_VALID"
+
+# ---------------------------------------------------------------------------
+echo
+echo "----"
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed cases:"
+  for n in "${FAILED_NAMES[@]}"; do echo "  - $n"; done
+  exit 1
+fi
+exit 0

--- a/plugins/praxis/.codex-plugin/hooks/hooks.json
+++ b/plugins/praxis/.codex-plugin/hooks/hooks.json
@@ -89,6 +89,11 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/jq-config-empty-dict-advisory.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/verify-commit-flag-override.sh",
             "timeout": 5
           },


### PR DESCRIPTION
Closes #323

## 변경 사항

`hooks/jq-config-empty-dict-advisory.sh` (+ `.py`) 신규 추가.

PreToolUse(Bash) advisory 훅으로, `jq` 명령이 알려진 config 파일 경로(`.claude/*.json`, `.codex/*.json`, 루트 `settings.json`/`hooks.json`)를 대상으로 할 때 파일 상태를 사전 검사한다.

- **파일 없음** → skip
- **빈 파일 (size 0)** → `[config-empty]` advisory to stderr
- **유효하지 않은 JSON** → `[config-invalid]` advisory to stderr
- **유효한 JSON** → silent pass

항상 `exit 0` (advisory-only, 절대 block 없음).

**Phantom-path 수정**: 이슈 본문의 `hooks/pre-tool-use/` 서브디렉토리 → 실제 flat 구조 `hooks/` 에 배치.

## CRITICAL/MAJOR 수정 (round 2 fixup)

**C1** — command substitution 패턴 미감지: `_coalesce_subst_runs` + `_scan_subst_for_config_paths` 로 SUBST_RUN 내부 config path 추출.

**C2** — boolean flag 잘못 분류: `-e`, `--exit-status`, `--sort-keys`, `-S`, `--stream`, `--tab`, `--args`, `--jsonargs`, `--rawfile`(중복) 제거. Flag를 `_JQ_SINGLE_VALUE_FLAGS` / `_JQ_DOUBLE_VALUE_FLAGS` / `_JQ_STOP_FLAGS` 3분류.

**M3** — dedup state가 advisory 무관하게 항상 저장: `new_seen.add(key)` 를 `if msg:` 블록 안으로 이동.

**M4** — pipe/redirect 패턴 미감지: cross-segment pipe correlation + `<` stdin redirect 처리.

## Lint 수정 (round 3 fixup)

**`_JQ_SUBST_RE`** (미사용 정규식 정의) 블록 삭제 — C1 실제 구현은 `re.search(r'\bjq\b', token)` + `_CONFIG_PATH_IN_TEXT_RE` 가 처리.

**`cmd = argv[0]`** (`_extract_config_paths_from_non_jq_segment` 내 F841) 삭제.

**`seg_idx`** (`_collect_config_paths` 내 B007) — `enumerate(segments)` → `for seg_raw in segments:`.

```
ruff check --select F,B hooks/jq-config-empty-dict-advisory.py
→ All checks passed!

grep -c _JQ_SUBST_RE hooks/jq-config-empty-dict-advisory.py
→ 0
```

## 설계

- `_hook_utils.py` `safe_tokenize` / `iter_command_starts` / `strip_prefix` / `_coalesce_subst_runs` 사용
- jq flag를 boolean / 1-token-value / 2-token-value / stop-flag 4분류 (`jq --help` 1.7.1 검증)
- advisory 발화시에만 dedup key 저장 (valid→empty 상태 변화 재검사 보장)

## 검증

Caller chain verified: `bash hooks/test-jq-config-empty-dict-advisory.sh` 10/10 PASS

```
PASS  [empty config file]
PASS  [invalid JSON config file]
PASS  [valid JSON config file]
PASS  [C1 command substitution empty file]
PASS  [C2a -e flag (boolean) empty file]
PASS  [C2b --sort-keys flag (boolean) empty file]
PASS  [M3a valid file first call (no advisory stored)]
PASS  [M3b same file now empty — advisory must fire]
PASS  [M4a piped cat config | jq empty file]
PASS  [M4b stdin redirect jq '.' < config empty file]

----
Passed: 10
Failed: 0
```

매니페스트: `plugin-manifest check OK`

## 위험

Advisory-only: `exit 0` 고정. jq / python3 없는 환경 fail-open.

## Follow-up

추가 개선 사항(backtick substitution, `$(...)` internal separator, 2-token flag 검증, relative path dedup 등)은 #338에서 추적. spec "Not detected" 표에 현재 미감지 패턴 명시 완료.
