### PR TITLE
feat(hook): pre-bash worktree-existence advisory

### DIFF
--- a/.claude-plugin/hooks/hooks.json
+++ b/.claude-plugin/hooks/hooks.json
@@ -99,6 +99,11 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/bash-worktree-existence-advisory.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/verify-commit-flag-override.sh",
             "timeout": 5
           },

--- a/docs/hook/INDEX.md
+++ b/docs/hook/INDEX.md
@@ -47,6 +47,7 @@ so the agent can self-correct. Fail-open on infrastructure errors by design.
 | [output-block-falsify-advisory](output-block-falsify-advisory.md) | PreToolUse | Advisory nudge to run output-block falsification gate before surfacing `(Recommended)` options or bulk-action commands |
 | [advisory-wrapper-signature-verify](advisory-wrapper-signature-verify.md) | PreToolUse | Advisory nudge to verify wrapped function signatures before writing wrapper/client code |
 | [jq-config-empty-dict-advisory](jq-config-empty-dict-advisory.md) | PreToolUse | Advisory nudge when `jq` reads a config file (settings.json, hooks.json, ~/.claude/*.json, ~/.codex/*.json) that is empty or invalid JSON |
+| [bash-worktree-existence-advisory](bash-worktree-existence-advisory.md) | PreToolUse | Advisory nudge when `cd <path>` targets a path that does not exist or is not a registered git worktree |
 | [codex-review-route](codex-review-route.md) | UserPromptSubmit | Warn when `/codex:review` runs in a multi-worktree repo (cwd mismatch risk) |
 | [external-write-path-existence-check](external-write-path-existence-check.md) | PreToolUse | Advisory nudge when a `gh issue/pr` body file contains markdown links to repo paths that do not exist |
 

--- a/docs/hook/INDEX.md
+++ b/docs/hook/INDEX.md
@@ -47,7 +47,7 @@ so the agent can self-correct. Fail-open on infrastructure errors by design.
 | [output-block-falsify-advisory](output-block-falsify-advisory.md) | PreToolUse | Advisory nudge to run output-block falsification gate before surfacing `(Recommended)` options or bulk-action commands |
 | [advisory-wrapper-signature-verify](advisory-wrapper-signature-verify.md) | PreToolUse | Advisory nudge to verify wrapped function signatures before writing wrapper/client code |
 | [jq-config-empty-dict-advisory](jq-config-empty-dict-advisory.md) | PreToolUse | Advisory nudge when `jq` reads a config file (settings.json, hooks.json, ~/.claude/*.json, ~/.codex/*.json) that is empty or invalid JSON |
-| [bash-worktree-existence-advisory](bash-worktree-existence-advisory.md) | PreToolUse | Advisory nudge when `cd <path>` targets a path that does not exist or is not a registered git worktree |
+| [bash-worktree-existence-advisory](bash-worktree-existence-advisory.md) | PreToolUse | Advisory nudge when `cd <path>` targets a path that does not exist on disk |
 | [codex-review-route](codex-review-route.md) | UserPromptSubmit | Warn when `/codex:review` runs in a multi-worktree repo (cwd mismatch risk) |
 | [external-write-path-existence-check](external-write-path-existence-check.md) | PreToolUse | Advisory nudge when a `gh issue/pr` body file contains markdown links to repo paths that do not exist |
 

--- a/docs/hook/bash-worktree-existence-advisory.md
+++ b/docs/hook/bash-worktree-existence-advisory.md
@@ -33,7 +33,8 @@ blocked.
 | `cd ~` / `cd ~/foo` / `cd ~user/foo` | silent (tilde expansion; hook process `$HOME` may differ from agent effective `$HOME`) |
 | `pushd /path` | silent (out of scope Phase 1) |
 | `(cd /path && ...)` subshell | silent (out of scope Phase 1) |
-| `cd /path` inside a heredoc body | silent (heredoc body segments are skipped — see Heredoc handling) |
+| `cd /path` inside a heredoc body — space-separated opener `cat << EOF` | silent (heredoc body segments are skipped — see Heredoc handling) |
+| `cd /path` inside a heredoc body — fused opener (`cat <<EOF`, `<<'EOF'`, `<<"EOF"`, `<<-EOF`) | known false-positive: body `cd /path` fires advisory (tracked in #337 P6) |
 | Opt-out marker `# worktree-advisory:ack` | silent (all advisories suppressed) |
 | Non-Bash tool name | silent (fail-open) |
 | Malformed JSON stdin | silent (fail-open) |
@@ -70,6 +71,18 @@ The hook detects the `<<` or `<<-` POSITIONAL token in a segment and records
 the end-marker word. All subsequent segments are skipped as heredoc body lines
 until the end-marker segment is consumed. Commands appearing after the heredoc
 close are processed normally.
+
+**Known limitation — fused heredoc openers (tracked in #337 P6):**
+shlex tokenizes fused forms as a **single** POSITIONAL token — `<<EOF`,
+`<<'EOF'`, `<<"EOF"`, `<<-EOF` — rather than two separate tokens (`<<` +
+`EOF`). The current detector looks for the literal token `<<` or `<<-` and
+therefore misses all four fused forms. The body `cd /path` in fused heredocs
+fires a false-positive `[worktree-missing]` advisory. The space-separated
+form (`cat << EOF`, which shlex splits into three tokens) is handled
+correctly.
+
+Workaround until #337 P6 is resolved: add `# worktree-advisory:ack` to the
+command, or use the space-separated `<< EOF` opener form.
 
 ### Deduplication
 
@@ -121,11 +134,12 @@ The hook returns exit 0 on every infrastructure error:
 bash tests/test_bash_worktree_existence_advisory.sh
 ```
 
-27 cases covering: missing path advisory (direct and compound command),
+29 cases covering: missing path advisory (direct and compound command),
 existing path silent (including registered worktree), tilde expansion forms
 (`~`, `~/foo`, `~user/foo`), pushd/subshell out-of-scope silent, heredoc
-body silent (body `cd` suppressed, post-heredoc `cd` fires, non-cd no-heredoc
-silent), dedupe (first fires, second deduped, different session fires
-independently, state-transition missing→exists→missing fires again),
-infrastructure fail-open (non-Bash tool name, malformed JSON, bare cd, `$VAR`,
-`cd -`, opt-out marker, empty command).
+body (space-separated opener silent, post-heredoc `cd` fires, non-cd silent),
+3 known-limitation pins (fused `<<EOF`/`<<'EOF'`/`<<-EOF` body fires
+false-positive — tracked in #337 P6), dedupe (first fires, second deduped,
+different session fires independently, state-transition missing→exists→missing
+fires again), infrastructure fail-open (non-Bash tool name, malformed JSON,
+bare cd, `$VAR`, `cd -`, opt-out marker, empty command).

--- a/docs/hook/bash-worktree-existence-advisory.md
+++ b/docs/hook/bash-worktree-existence-advisory.md
@@ -4,8 +4,7 @@ Supported hosts: all
 
 `hooks/bash-worktree-existence-advisory.sh` intercepts `Bash` tool calls
 containing a `cd <path>` command and emits a **stderr advisory** (never a
-block) when the target path does not exist on disk or is not a registered git
-worktree.
+block) when the target path does not exist on disk.
 
 ### Why this exists
 
@@ -26,15 +25,26 @@ blocked.
 
 | Condition | Message |
 |-----------|---------|
-| `cd <path>` where `<path>` does not exist | `[worktree-missing] <path> does not exist — check 'git worktree list' before retry` |
-| `cd <path>` where `<path>` exists but is not a registered worktree | `[worktree-stale] <path> exists but is not a registered worktree — verify with 'git worktree list'` |
-| `cd <path>` where `<path>` is a registered worktree | silent (no output) |
+| `cd <path>` where path does not exist | `[worktree-missing] <path> does not exist — check 'git worktree list' before retry` |
+| `cd <path>` where path exists | silent (no output) |
 | Bare `cd` (no argument) | silent |
-| `cd $VAR` (variable expansion) | silent (unresolvable statically) |
-| `cd -` (previous dir) | silent (unresolvable statically) |
-| Opt-out marker present | silent |
-| Malformed JSON / non-Bash tool | silent (fail-open) |
-| `git worktree list` unavailable or fails | silent (fail-open, missing check skipped) |
+| `cd $VAR` / `cd $(...)` | silent (variable/substitution expansion, unresolvable) |
+| `cd -` | silent (previous dir, unresolvable) |
+| `cd ~` / `cd ~/foo` / `cd ~user/foo` | silent (tilde expansion; hook process `$HOME` may differ from agent effective `$HOME`) |
+| `pushd /path` | silent (out of scope Phase 1) |
+| `(cd /path && ...)` subshell | silent (out of scope Phase 1) |
+| heredoc body containing `cd /path` | silent (heredoc body not parsed as commands) |
+| Opt-out marker `# worktree-advisory:ack` | silent (all advisories suppressed) |
+| Non-Bash tool name | silent (fail-open) |
+| Malformed JSON stdin | silent (fail-open) |
+| `git` binary unavailable / timeout | silent (fail-open) |
+
+### Scope (Phase 1)
+
+Only direct `cd <path>` commands are detected. `pushd`, subshell form
+`(cd /path && ...)`, and `cd` inside heredoc bodies are out of scope for
+this phase to avoid parser complexity. A follow-up issue tracks Phase 2
+expansion to cover these forms.
 
 ### Path detection
 
@@ -51,23 +61,27 @@ the `git worktree list --porcelain` output on macOS.
 
 ### Deduplication
 
-Per-session marker files in
-`${TMPDIR:-/tmp}/praxis-bash-worktree-advisory/<session_id>.<path-hash>`
-suppress repeat advisories for the same (session, path) pair. A single
-advisory per unique missing/stale path is emitted per session; subsequent
-commands targeting the same path are silent.
+Per-session marker files in:
+```
+${TMPDIR:-/tmp}/praxis-bash-worktree-advisory/<session_id>.<path-hash>.<state>
+```
+suppress repeat advisories for the same (session, path, state) triple.
+The `<state>` component (`missing`) ensures that if a path is later created,
+the old marker does not suppress a fresh advisory (or silence) for the new
+state. Stale marker files are cleaned up by the OS tmp purge policy; no
+explicit cleanup is performed.
 
 ### Opt-out
 
-Append `# worktree-advisory:ack` anywhere in the command to suppress the
-advisory for that invocation:
+Append `# worktree-advisory:ack` anywhere in the command to suppress all
+advisories for that invocation:
 
 ```bash
 cd /some/path  # worktree-advisory:ack
 ```
 
-Use only after confirming that the path context is intentional (e.g., creating
-a new directory that does not yet exist as a worktree).
+Use only after confirming that the path context is intentional (e.g.,
+creating a new directory that does not yet exist).
 
 ### Relationship to sibling hooks
 
@@ -75,7 +89,7 @@ a new directory that does not yet exist as a worktree).
 |------|-------|---------|
 | `cross-repo-worktree-preflight` | `git worktree remove <path>` cross-repo mismatch | Complementary — this hook fires on the `cd` step *before* any git operation; the sibling fires on the remove step |
 | `cross-boundary-preflight` | `gh` write subcommands across `--repo` boundary | None — different command family |
-| `side-effect-scan` | collateral side effects (`git commit/push`, `gh pr merge`) | Complementary — fires on the downstream mutation, not the worktree navigation |
+| `side-effect-scan` | collateral side effects (`git commit/push`, `gh pr merge`) | Complementary — fires on downstream mutation, not worktree navigation |
 
 ### Parsing guarantees (fail-open)
 
@@ -84,8 +98,6 @@ The hook returns exit 0 on every infrastructure error:
 - malformed JSON stdin
 - non-Bash tool invocation
 - empty / whitespace-only command
-- `git worktree list` failure or timeout (missing check is skipped silently)
-- `git` binary unavailable
 - `python3` unavailable (the shell wrapper handles this)
 - any uncaught exception in the inner logic
 
@@ -95,5 +107,10 @@ The hook returns exit 0 on every infrastructure error:
 bash tests/test_bash_worktree_existence_advisory.sh
 ```
 
-3 cases: missing path (worktree-missing advisory), existing non-worktree path
-(worktree-stale advisory), registered worktree (silent pass).
+21 cases covering: missing path advisory (direct and compound command),
+existing path silent (including registered worktree), tilde expansion forms
+(`~`, `~/foo`, `~user/foo`), pushd/subshell out-of-scope silent,
+heredoc body silent, dedupe state-transition (first fires, second deduped,
+different session fires independently), infrastructure fail-open (non-Bash
+tool name, malformed JSON, bare cd, `$VAR`, `cd -`, opt-out marker, empty
+command).

--- a/docs/hook/bash-worktree-existence-advisory.md
+++ b/docs/hook/bash-worktree-existence-advisory.md
@@ -1,0 +1,99 @@
+# PreToolUse Bash Worktree Existence Advisory
+
+Supported hosts: all
+
+`hooks/bash-worktree-existence-advisory.sh` intercepts `Bash` tool calls
+containing a `cd <path>` command and emits a **stderr advisory** (never a
+block) when the target path does not exist on disk or is not a registered git
+worktree.
+
+### Why this exists
+
+Claude Code sessions frequently use `cd <worktree-path> && <cmd>` chains to
+scope work to a specific git worktree. When the worktree directory was removed
+externally (e.g., `git worktree remove` in a prior session) or the path was
+mistyped, the failure happens inside the Bash tool and produces a cryptic shell
+error — not the clear "you are targeting a missing worktree" message that would
+let the agent self-correct. Memory entry `worktree_context_pre_git_op` covers
+the rule, but retrieval at command-composition time keeps failing. This hook
+fires earlier than `cross-repo-worktree-preflight` (which handles the remove
+operation) by checking the `cd` step itself (praxis issue #322).
+
+### What is emitted
+
+The hook writes advisory text to stderr and exits 0. Tool execution is never
+blocked.
+
+| Condition | Message |
+|-----------|---------|
+| `cd <path>` where `<path>` does not exist | `[worktree-missing] <path> does not exist — check 'git worktree list' before retry` |
+| `cd <path>` where `<path>` exists but is not a registered worktree | `[worktree-stale] <path> exists but is not a registered worktree — verify with 'git worktree list'` |
+| `cd <path>` where `<path>` is a registered worktree | silent (no output) |
+| Bare `cd` (no argument) | silent |
+| `cd $VAR` (variable expansion) | silent (unresolvable statically) |
+| `cd -` (previous dir) | silent (unresolvable statically) |
+| Opt-out marker present | silent |
+| Malformed JSON / non-Bash tool | silent (fail-open) |
+| `git worktree list` unavailable or fails | silent (fail-open, missing check skipped) |
+
+### Path detection
+
+The hook segments the Bash command using `tokenize_with_roles` (same pipeline
+as sibling advisory hooks) and inspects each segment for a leading `cd`
+command. For compound commands (`cd <path> && <cmd>`) the `cd` segment is
+found first; the resolved path is used as the effective cwd for subsequent
+segments.
+
+Relative paths are resolved against the hook process's cwd (or the preceding
+segment's resolved path in a compound chain). Symlinks are canonicalized via
+`os.path.realpath` so that `/tmp/foo` compares equal to `/private/tmp/foo` in
+the `git worktree list --porcelain` output on macOS.
+
+### Deduplication
+
+Per-session marker files in
+`${TMPDIR:-/tmp}/praxis-bash-worktree-advisory/<session_id>.<path-hash>`
+suppress repeat advisories for the same (session, path) pair. A single
+advisory per unique missing/stale path is emitted per session; subsequent
+commands targeting the same path are silent.
+
+### Opt-out
+
+Append `# worktree-advisory:ack` anywhere in the command to suppress the
+advisory for that invocation:
+
+```bash
+cd /some/path  # worktree-advisory:ack
+```
+
+Use only after confirming that the path context is intentional (e.g., creating
+a new directory that does not yet exist as a worktree).
+
+### Relationship to sibling hooks
+
+| Hook | Scope | Overlap |
+|------|-------|---------|
+| `cross-repo-worktree-preflight` | `git worktree remove <path>` cross-repo mismatch | Complementary — this hook fires on the `cd` step *before* any git operation; the sibling fires on the remove step |
+| `cross-boundary-preflight` | `gh` write subcommands across `--repo` boundary | None — different command family |
+| `side-effect-scan` | collateral side effects (`git commit/push`, `gh pr merge`) | Complementary — fires on the downstream mutation, not the worktree navigation |
+
+### Parsing guarantees (fail-open)
+
+The hook returns exit 0 on every infrastructure error:
+
+- malformed JSON stdin
+- non-Bash tool invocation
+- empty / whitespace-only command
+- `git worktree list` failure or timeout (missing check is skipped silently)
+- `git` binary unavailable
+- `python3` unavailable (the shell wrapper handles this)
+- any uncaught exception in the inner logic
+
+### Tests
+
+```bash
+bash tests/test_bash_worktree_existence_advisory.sh
+```
+
+3 cases: missing path (worktree-missing advisory), existing non-worktree path
+(worktree-stale advisory), registered worktree (silent pass).

--- a/docs/hook/bash-worktree-existence-advisory.md
+++ b/docs/hook/bash-worktree-existence-advisory.md
@@ -33,7 +33,7 @@ blocked.
 | `cd ~` / `cd ~/foo` / `cd ~user/foo` | silent (tilde expansion; hook process `$HOME` may differ from agent effective `$HOME`) |
 | `pushd /path` | silent (out of scope Phase 1) |
 | `(cd /path && ...)` subshell | silent (out of scope Phase 1) |
-| heredoc body containing `cd /path` | silent (heredoc body not parsed as commands) |
+| `cd /path` inside a heredoc body | silent (heredoc body segments are skipped — see Heredoc handling) |
 | Opt-out marker `# worktree-advisory:ack` | silent (all advisories suppressed) |
 | Non-Bash tool name | silent (fail-open) |
 | Malformed JSON stdin | silent (fail-open) |
@@ -41,10 +41,10 @@ blocked.
 
 ### Scope (Phase 1)
 
-Only direct `cd <path>` commands are detected. `pushd`, subshell form
-`(cd /path && ...)`, and `cd` inside heredoc bodies are out of scope for
-this phase to avoid parser complexity. A follow-up issue tracks Phase 2
-expansion to cover these forms.
+Only direct `cd <path>` commands are detected. `pushd` and subshell form
+`(cd /path && ...)` are out of scope for this phase. Heredoc bodies are
+correctly skipped (see Heredoc handling). A follow-up issue tracks Phase 2
+expansion for `pushd` and subshell forms.
 
 ### Path detection
 
@@ -59,6 +59,18 @@ segment's resolved path in a compound chain). Symlinks are canonicalized via
 `os.path.realpath` so that `/tmp/foo` compares equal to `/private/tmp/foo` in
 the `git worktree list --porcelain` output on macOS.
 
+### Heredoc handling
+
+`tokenize_with_roles` is not heredoc-aware: `cat << EOF\ncd /path\nEOF` is
+parsed as three segments — the opener (`cat`), the body line (`cd /path`),
+and the end marker (`EOF`). Without special handling the body `cd /path`
+would fire a false-positive advisory.
+
+The hook detects the `<<` or `<<-` POSITIONAL token in a segment and records
+the end-marker word. All subsequent segments are skipped as heredoc body lines
+until the end-marker segment is consumed. Commands appearing after the heredoc
+close are processed normally.
+
 ### Deduplication
 
 Per-session marker files in:
@@ -66,10 +78,12 @@ Per-session marker files in:
 ${TMPDIR:-/tmp}/praxis-bash-worktree-advisory/<session_id>.<path-hash>.<state>
 ```
 suppress repeat advisories for the same (session, path, state) triple.
-The `<state>` component (`missing`) ensures that if a path is later created,
-the old marker does not suppress a fresh advisory (or silence) for the new
-state. Stale marker files are cleaned up by the OS tmp purge policy; no
-explicit cleanup is performed.
+The `<state>` suffix is `missing`. When a path is observed to **exist**
+(the `cd` target is a valid directory), the hook deletes any stale `missing`
+marker for that path so that if the directory is later removed and `cd`'d
+again, a fresh `[worktree-missing]` advisory fires rather than being
+suppressed by the old marker. Stale marker files are cleaned up by the OS
+tmp purge policy; no explicit cleanup is performed.
 
 ### Opt-out
 
@@ -107,10 +121,11 @@ The hook returns exit 0 on every infrastructure error:
 bash tests/test_bash_worktree_existence_advisory.sh
 ```
 
-21 cases covering: missing path advisory (direct and compound command),
+27 cases covering: missing path advisory (direct and compound command),
 existing path silent (including registered worktree), tilde expansion forms
-(`~`, `~/foo`, `~user/foo`), pushd/subshell out-of-scope silent,
-heredoc body silent, dedupe state-transition (first fires, second deduped,
-different session fires independently), infrastructure fail-open (non-Bash
-tool name, malformed JSON, bare cd, `$VAR`, `cd -`, opt-out marker, empty
-command).
+(`~`, `~/foo`, `~user/foo`), pushd/subshell out-of-scope silent, heredoc
+body silent (body `cd` suppressed, post-heredoc `cd` fires, non-cd no-heredoc
+silent), dedupe (first fires, second deduped, different session fires
+independently, state-transition missing→exists→missing fires again),
+infrastructure fail-open (non-Bash tool name, malformed JSON, bare cd, `$VAR`,
+`cd -`, opt-out marker, empty command).

--- a/hooks/bash-worktree-existence-advisory.py
+++ b/hooks/bash-worktree-existence-advisory.py
@@ -25,7 +25,8 @@ Silent cases (no output emitted):
   - `cd ~user/...` — user-specific tilde, unresolvable
   - `pushd /path` — out of scope (Phase 1)
   - `(cd /path && ...)` — subshell, out of scope (Phase 1)
-  - heredoc body containing `cd /path` — not parsed as command
+  - `cd /path` inside a heredoc body — heredoc body segments are skipped
+    (see _extract_heredoc_end_marker for the detection mechanism)
   - opt-out marker `# worktree-advisory:ack` anywhere in command
   - non-Bash tool name
   - malformed JSON stdin
@@ -161,6 +162,45 @@ def _record_dedupe(session_id: str, path: str, state: str) -> None:
         pass
 
 
+def _delete_dedupe(session_id: str, path: str, state: str) -> None:
+    """Remove a dedupe marker when path state has changed.
+
+    Called when a path is observed to exist (missing → exists transition)
+    so that a subsequent `cd` to the same path after it was deleted again
+    will fire a fresh [worktree-missing] advisory rather than being suppressed
+    by the stale marker from when the path still existed as missing.
+    """
+    marker = _dedupe_marker(session_id, path, state)
+    try:
+        os.unlink(marker)
+    except OSError:
+        pass  # fail-open: marker may not exist
+
+
+def _extract_heredoc_end_marker(seg: list[Token]) -> str | None:
+    """Return the heredoc end-marker word if this segment opens a heredoc.
+
+    `tokenize_with_roles` parses `cat << EOF` as a segment with tokens
+    ['cat', '<<', 'EOF']. The `<<` is emitted as a POSITIONAL token because
+    shlex with punctuation_chars=';|&' does not treat `<` as punctuation.
+
+    Detection: find the literal `<<` or `<<-` token (POSITIONAL role) and
+    return the token immediately following it as the end-marker word.
+    Strip optional `-` from `<<-` (tab-stripping form of heredoc).
+
+    Returns None when no heredoc opener is present in the segment.
+    """
+    argv = filter_argv(seg)
+    for i, tok in enumerate(argv):
+        if tok.role == TokenRole.POSITIONAL and tok.text in ("<<", "<<-"):
+            if i + 1 < len(argv):
+                # End-marker may be quoted in the source (`<< 'EOF'`) but
+                # shlex in posix mode strips quotes, so the token text is
+                # always the bare word. Strip leading `-` from `<<-` form.
+                return argv[i + 1].text
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -191,7 +231,30 @@ def _main_inner() -> int:
     # are resolved correctly (matching the shell's sequential execution order).
     effective_cwd = os.getcwd()
 
+    # Heredoc tracking: when a segment opens a heredoc (`<< EOF`), the
+    # subsequent segments up to and including the matching end-marker segment
+    # are heredoc body lines — they must NOT be processed as shell commands.
+    # `_heredoc_end` holds the expected end-marker word while inside a body.
+    _heredoc_end: str | None = None
+
     for seg in segments:
+        # --- Heredoc body skip ---
+        if _heredoc_end is not None:
+            # Check if this segment IS the end-marker (e.g. a segment whose
+            # sole COMMAND token is `EOF`).
+            argv = filter_argv(seg)
+            if argv and argv[0].text == _heredoc_end:
+                _heredoc_end = None  # end marker consumed; resume normal scan
+            # Either way (body line or end marker), skip cd detection.
+            continue
+
+        # --- Check if this segment opens a heredoc ---
+        heredoc_end = _extract_heredoc_end_marker(seg)
+        if heredoc_end is not None:
+            _heredoc_end = heredoc_end
+            # The opener segment itself is not a `cd`; continue after setting.
+            continue
+
         target = _extract_cd_target(seg)
         if target is None:
             # Not a `cd` segment — no effective_cwd update here since we do
@@ -220,7 +283,11 @@ def _main_inner() -> int:
                 _record_dedupe(session_id, real_target, "missing")
         else:
             # Path exists — update effective_cwd for downstream segments.
+            # Also clear any stale `missing` marker so that if this path is
+            # later removed and cd'd again, a fresh advisory fires (M3 fix).
             effective_cwd = abs_target
+            if session_id:
+                _delete_dedupe(session_id, real_target, "missing")
 
     return 0
 

--- a/hooks/bash-worktree-existence-advisory.py
+++ b/hooks/bash-worktree-existence-advisory.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""PreToolUse(Bash) advisory: emit stderr warning when a `cd <path>` target
+does not exist on disk or is not a registered git worktree.
+
+Trigger pattern (issue #322):
+  `cd <path>` at the start of a Bash command, or `cd <path> && ...` in a
+  compound command. Each segment is inspected for a leading `cd <path>`.
+
+Advisory messages (stderr only — exit 0 always):
+  [worktree-missing] <path> does not exist — check 'git worktree list' before retry
+    When the resolved path does not exist on disk.
+  [worktree-stale] <path> exists but is not a registered worktree
+    When the path exists but `git worktree list --porcelain` does not include it.
+
+Deduplication:
+  Per-session marker files in
+  `${TMPDIR:-/tmp}/praxis-bash-worktree-advisory/<session_id>.<path-hash>`
+  suppress repeat advisories for the same (session, path) pair, reducing
+  noise in long-running sessions.
+
+Design:
+  - Advisory only — writes to stderr, exits 0. Never blocks tool execution.
+  - Fail-open — malformed JSON, missing session_id, git failure, timeout
+    all result in a silent exit 0.
+  - Role-aware tokenization via `tokenize_with_roles` / `filter_argv` from
+    `_hook_utils.py` — consistent with sibling advisory hooks (cli-flag-incompat-advisory,
+    cross-repo-worktree-preflight).
+
+Opt-out: embed `# worktree-advisory:ack` anywhere in the command to suppress.
+
+Relationship to sibling hooks:
+  cross-repo-worktree-preflight — fires on `git worktree remove <path>` cross-repo
+    mismatch. This hook fires earlier: on the `cd <path>` step itself before
+    any git operation, catching the case where the worktree directory was
+    already removed externally and the agent doesn't know yet.
+  cross-boundary-preflight — gh write subcommands across --repo boundary.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    Token,
+    TokenRole,
+    filter_argv,
+    tokenize_with_roles,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+OPT_OUT_MARKER = "# worktree-advisory:ack"
+
+# Dedupe dir — per-session markers suppress repeat advisories for the same path.
+_DEDUPE_BASE = os.path.join(os.environ.get("TMPDIR", "/tmp"), "praxis-bash-worktree-advisory")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _normalize_path(path: str) -> str:
+    """Resolve symlinks and strip trailing slash for comparison."""
+    return os.path.realpath(path.rstrip("/"))
+
+
+def _extract_cd_target(seg: list[Token]) -> str | None:
+    """Return the path argument of a `cd <path>` segment, else None.
+
+    Resolution:
+      - argv[0] must be COMMAND `cd`
+      - first POSITIONAL / SUBST_RUN / POST_DD argument after COMMAND
+      - if no such token → None (bare `cd`, cd to home)
+      - if target starts with `$` → None (variable expansion, unresolvable)
+      - if target is `-` → None (cd to previous dir, unresolvable)
+
+    Relative targets are returned as-is; the caller resolves them against
+    the effective cwd.
+    """
+    argv = filter_argv(seg)
+    if not argv or argv[0].text != "cd":
+        return None
+    for tok in argv[1:]:
+        if tok.role in (TokenRole.FLAG, TokenRole.FLAG_VALUE, TokenRole.SEPARATOR_DD):
+            continue
+        target = tok.text
+        if not target or target == "-" or target.startswith("$"):
+            return None
+        return target
+    return None
+
+
+def _list_registered_worktrees() -> list[str] | None:
+    """Return absolute (realpath) of every registered worktree, else None on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    paths: list[str] = []
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            paths.append(_normalize_path(line[len("worktree "):]))
+    return paths
+
+
+def _dedupe_marker(session_id: str, path: str) -> str:
+    """Return path to the per-session dedupe marker file for this path."""
+    path_hash = hashlib.sha1(path.encode()).hexdigest()[:12]
+    safe_sid = session_id.replace("/", "_").replace("\\", "_")[:64]
+    return os.path.join(_DEDUPE_BASE, f"{safe_sid}.{path_hash}")
+
+
+def _is_deduped(session_id: str, path: str) -> bool:
+    return os.path.exists(_dedupe_marker(session_id, path))
+
+
+def _record_dedupe(session_id: str, path: str) -> None:
+    os.makedirs(_DEDUPE_BASE, exist_ok=True)
+    marker = _dedupe_marker(session_id, path)
+    try:
+        open(marker, "w").close()
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def _main_inner() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    command = payload.get("tool_input", {}).get("command", "") or ""
+    if not command.strip():
+        return 0
+
+    if OPT_OUT_MARKER in command:
+        return 0
+
+    session_id = payload.get("session_id", "") or ""
+
+    segments = tokenize_with_roles(command.replace("\\\n", " "), {})
+    if not segments:
+        return 0
+
+    # Thread effective_cwd across compound segments so that relative paths
+    # are resolved correctly (matching the shell's sequential execution).
+    effective_cwd = os.getcwd()
+
+    # Lazy-load registered worktrees once per invocation.
+    registered: list[str] | None = None
+    registered_loaded = False
+
+    for seg in segments:
+        target = _extract_cd_target(seg)
+        if target is None:
+            # This segment is not a `cd` — track any effective cwd update for
+            # relative target resolution in subsequent segments.
+            # (No cwd update here since this segment doesn't cd.)
+            continue
+
+        # Resolve target to absolute path.
+        if target.startswith("/"):
+            abs_target = os.path.normpath(target)
+        else:
+            abs_target = os.path.normpath(os.path.join(effective_cwd, target))
+
+        real_target = _normalize_path(abs_target)
+
+        # Dedupe: skip if we already emitted an advisory for this (session, path).
+        if session_id and _is_deduped(session_id, real_target):
+            # Even if suppressed, update effective_cwd for downstream segments.
+            if os.path.isdir(abs_target):
+                effective_cwd = abs_target
+            continue
+
+        # Check 1: path does not exist.
+        if not os.path.isdir(abs_target):
+            sys.stderr.write(
+                f"[worktree-missing] {real_target} does not exist"
+                " — check 'git worktree list' before retry\n"
+            )
+            if session_id:
+                _record_dedupe(session_id, real_target)
+            continue
+
+        # Path exists — update effective_cwd for downstream segments.
+        effective_cwd = abs_target
+
+        # Check 2: path exists but is not a registered worktree.
+        if not registered_loaded:
+            registered = _list_registered_worktrees()
+            registered_loaded = True
+
+        if registered is None:
+            # git not available or not in a git repo — skip worktree check.
+            continue
+
+        if real_target not in registered:
+            sys.stderr.write(
+                f"[worktree-stale] {real_target} exists but is not a registered worktree"
+                " — verify with 'git worktree list'\n"
+            )
+            if session_id:
+                _record_dedupe(session_id, real_target)
+
+    return 0
+
+
+def main() -> int:
+    """Advisory hook — must NEVER break tool execution."""
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/bash-worktree-existence-advisory.py
+++ b/hooks/bash-worktree-existence-advisory.py
@@ -1,46 +1,69 @@
 #!/usr/bin/env python3
 """PreToolUse(Bash) advisory: emit stderr warning when a `cd <path>` target
-does not exist on disk or is not a registered git worktree.
+does not exist on disk.
 
 Trigger pattern (issue #322):
   `cd <path>` at the start of a Bash command, or `cd <path> && ...` in a
   compound command. Each segment is inspected for a leading `cd <path>`.
 
-Advisory messages (stderr only — exit 0 always):
+Advisory message (stderr only — exit 0 always):
   [worktree-missing] <path> does not exist — check 'git worktree list' before retry
     When the resolved path does not exist on disk.
-  [worktree-stale] <path> exists but is not a registered worktree
-    When the path exists but `git worktree list --porcelain` does not include it.
+
+Scope (Phase 1):
+  Only direct `cd <path>` command is detected. `pushd`, subshell `(cd /path
+  && ...)`, heredoc bodies containing `cd` are out of scope for this phase
+  to avoid parser complexity. See follow-up issue for Phase 2 expansion.
+
+Silent cases (no output emitted):
+  - `cd <path>` where path exists on disk
+  - bare `cd` (no argument — cd to $HOME)
+  - `cd $VAR` or `cd $(...)` — variable/substitution expansion, unresolvable
+  - `cd -` — previous dir, unresolvable
+  - `cd ~` or `cd ~/...` — tilde expansion; hook process $HOME may differ
+    from the agent's effective $HOME (e.g. sudo to different user)
+  - `cd ~user/...` — user-specific tilde, unresolvable
+  - `pushd /path` — out of scope (Phase 1)
+  - `(cd /path && ...)` — subshell, out of scope (Phase 1)
+  - heredoc body containing `cd /path` — not parsed as command
+  - opt-out marker `# worktree-advisory:ack` anywhere in command
+  - non-Bash tool name
+  - malformed JSON stdin
 
 Deduplication:
   Per-session marker files in
-  `${TMPDIR:-/tmp}/praxis-bash-worktree-advisory/<session_id>.<path-hash>`
-  suppress repeat advisories for the same (session, path) pair, reducing
-  noise in long-running sessions.
+  `${TMPDIR:-/tmp}/praxis-bash-worktree-advisory/<session_id>.<path-hash>.<state>`
+  suppress repeat advisories for the same (session, path, state) triple.
+  State is `missing`. If path state changes (e.g. directory is created),
+  the old marker does not suppress the new state's advisory.
 
 Design:
   - Advisory only — writes to stderr, exits 0. Never blocks tool execution.
   - Fail-open — malformed JSON, missing session_id, git failure, timeout
     all result in a silent exit 0.
   - Role-aware tokenization via `tokenize_with_roles` / `filter_argv` from
-    `_hook_utils.py` — consistent with sibling advisory hooks (cli-flag-incompat-advisory,
-    cross-repo-worktree-preflight).
+    `_hook_utils.py` — consistent with sibling advisory hooks.
 
-Opt-out: embed `# worktree-advisory:ack` anywhere in the command to suppress.
+Opt-out: embed `# worktree-advisory:ack` anywhere in the command to suppress
+all advisories for that invocation.
 
 Relationship to sibling hooks:
-  cross-repo-worktree-preflight — fires on `git worktree remove <path>` cross-repo
-    mismatch. This hook fires earlier: on the `cd <path>` step itself before
-    any git operation, catching the case where the worktree directory was
-    already removed externally and the agent doesn't know yet.
+  cross-repo-worktree-preflight — fires on `git worktree remove <path>` cross-
+    repo mismatch. This hook fires earlier: on the `cd <path>` step itself
+    before any git operation, catching the case where the worktree directory
+    was removed externally and the agent does not know yet.
   cross-boundary-preflight — gh write subcommands across --repo boundary.
+
+Dedupe cleanup:
+  Stale marker files are cleaned up by the OS tmp purge policy. No explicit
+  cleanup is performed by this hook. Markers accumulate at
+  ~1 file/unique-path/session, negligible footprint.
 """
 from __future__ import annotations
 
 import hashlib
 import json
 import os
-import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -59,7 +82,9 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
 
 OPT_OUT_MARKER = "# worktree-advisory:ack"
 
-# Dedupe dir — per-session markers suppress repeat advisories for the same path.
+# Dedupe dir — per-session markers suppress repeat advisories for the same
+# (path, state) pair. State is encoded in the marker filename suffix so that
+# a path transitioning from missing → exists triggers a fresh advisory.
 _DEDUPE_BASE = os.path.join(os.environ.get("TMPDIR", "/tmp"), "praxis-bash-worktree-advisory")
 
 
@@ -68,22 +93,24 @@ _DEDUPE_BASE = os.path.join(os.environ.get("TMPDIR", "/tmp"), "praxis-bash-workt
 # ---------------------------------------------------------------------------
 
 def _normalize_path(path: str) -> str:
-    """Resolve symlinks and strip trailing slash for comparison."""
+    """Resolve symlinks and strip trailing slash for display."""
     return os.path.realpath(path.rstrip("/"))
 
 
 def _extract_cd_target(seg: list[Token]) -> str | None:
     """Return the path argument of a `cd <path>` segment, else None.
 
-    Resolution:
-      - argv[0] must be COMMAND `cd`
-      - first POSITIONAL / SUBST_RUN / POST_DD argument after COMMAND
-      - if no such token → None (bare `cd`, cd to home)
-      - if target starts with `$` → None (variable expansion, unresolvable)
-      - if target is `-` → None (cd to previous dir, unresolvable)
+    Silent cases (return None):
+      - argv[0] is not `cd` (including `pushd` — out of scope Phase 1)
+      - bare `cd` (no positional argument after COMMAND)
+      - target starts with `$` (variable expansion, unresolvable)
+      - target starts with `$(` (command substitution, unresolvable)
+      - target is `-` (cd to previous dir, unresolvable)
+      - target is `~` or starts with `~/` or `~<user>` (tilde expansion;
+        hook process $HOME may differ from agent's effective $HOME)
 
     Relative targets are returned as-is; the caller resolves them against
-    the effective cwd.
+    the effective_cwd by joining with os.path.join and normpath.
     """
     argv = filter_argv(seg)
     if not argv or argv[0].text != "cd":
@@ -92,47 +119,42 @@ def _extract_cd_target(seg: list[Token]) -> str | None:
         if tok.role in (TokenRole.FLAG, TokenRole.FLAG_VALUE, TokenRole.SEPARATOR_DD):
             continue
         target = tok.text
-        if not target or target == "-" or target.startswith("$"):
+        if not target:
+            return None
+        # Unresolvable cases — silent skip.
+        if target == "-":
+            return None
+        if target.startswith("$"):
+            return None
+        if target == "~" or target.startswith("~/") or target.startswith("~"):
+            # Covers `~`, `~/foo`, `~user/foo` (any tilde prefix).
             return None
         return target
     return None
 
 
-def _list_registered_worktrees() -> list[str] | None:
-    """Return absolute (realpath) of every registered worktree, else None on failure."""
-    try:
-        result = subprocess.run(
-            ["git", "worktree", "list", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=3,
-            check=False,
-        )
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-        return None
-    if result.returncode != 0:
-        return None
-    paths: list[str] = []
-    for line in result.stdout.splitlines():
-        if line.startswith("worktree "):
-            paths.append(_normalize_path(line[len("worktree "):]))
-    return paths
+def _dedupe_marker(session_id: str, path: str, state: str) -> str:
+    """Return path to the per-session dedupe marker for (path, state).
 
+    The `state` suffix ensures that if a path transitions from `missing` to
+    exists (worktree added), the old marker does not suppress the new state's
+    advisory (or silence for an existing worktree path).
 
-def _dedupe_marker(session_id: str, path: str) -> str:
-    """Return path to the per-session dedupe marker file for this path."""
-    path_hash = hashlib.sha1(path.encode()).hexdigest()[:12]
+    sha1 truncated to 16 hex chars: 64-bit collision space is more than
+    sufficient for the ~hundreds of unique paths a single session touches.
+    """
+    path_hash = hashlib.sha1(path.encode()).hexdigest()[:16]
     safe_sid = session_id.replace("/", "_").replace("\\", "_")[:64]
-    return os.path.join(_DEDUPE_BASE, f"{safe_sid}.{path_hash}")
+    return os.path.join(_DEDUPE_BASE, f"{safe_sid}.{path_hash}.{state}")
 
 
-def _is_deduped(session_id: str, path: str) -> bool:
-    return os.path.exists(_dedupe_marker(session_id, path))
+def _is_deduped(session_id: str, path: str, state: str) -> bool:
+    return os.path.exists(_dedupe_marker(session_id, path, state))
 
 
-def _record_dedupe(session_id: str, path: str) -> None:
+def _record_dedupe(session_id: str, path: str, state: str) -> None:
     os.makedirs(_DEDUPE_BASE, exist_ok=True)
-    marker = _dedupe_marker(session_id, path)
+    marker = _dedupe_marker(session_id, path, state)
     try:
         open(marker, "w").close()
     except OSError:
@@ -166,19 +188,15 @@ def _main_inner() -> int:
         return 0
 
     # Thread effective_cwd across compound segments so that relative paths
-    # are resolved correctly (matching the shell's sequential execution).
+    # are resolved correctly (matching the shell's sequential execution order).
     effective_cwd = os.getcwd()
-
-    # Lazy-load registered worktrees once per invocation.
-    registered: list[str] | None = None
-    registered_loaded = False
 
     for seg in segments:
         target = _extract_cd_target(seg)
         if target is None:
-            # This segment is not a `cd` — track any effective cwd update for
-            # relative target resolution in subsequent segments.
-            # (No cwd update here since this segment doesn't cd.)
+            # Not a `cd` segment — no effective_cwd update here since we do
+            # not execute the segment; the next `cd` segment will still resolve
+            # relative paths against the last known effective_cwd.
             continue
 
         # Resolve target to absolute path.
@@ -189,42 +207,20 @@ def _main_inner() -> int:
 
         real_target = _normalize_path(abs_target)
 
-        # Dedupe: skip if we already emitted an advisory for this (session, path).
-        if session_id and _is_deduped(session_id, real_target):
-            # Even if suppressed, update effective_cwd for downstream segments.
-            if os.path.isdir(abs_target):
-                effective_cwd = abs_target
-            continue
-
-        # Check 1: path does not exist.
+        # Check: path does not exist on disk.
         if not os.path.isdir(abs_target):
+            # Dedupe: suppress if we already emitted [worktree-missing] this session.
+            if session_id and _is_deduped(session_id, real_target, "missing"):
+                continue
             sys.stderr.write(
                 f"[worktree-missing] {real_target} does not exist"
                 " — check 'git worktree list' before retry\n"
             )
             if session_id:
-                _record_dedupe(session_id, real_target)
-            continue
-
-        # Path exists — update effective_cwd for downstream segments.
-        effective_cwd = abs_target
-
-        # Check 2: path exists but is not a registered worktree.
-        if not registered_loaded:
-            registered = _list_registered_worktrees()
-            registered_loaded = True
-
-        if registered is None:
-            # git not available or not in a git repo — skip worktree check.
-            continue
-
-        if real_target not in registered:
-            sys.stderr.write(
-                f"[worktree-stale] {real_target} exists but is not a registered worktree"
-                " — verify with 'git worktree list'\n"
-            )
-            if session_id:
-                _record_dedupe(session_id, real_target)
+                _record_dedupe(session_id, real_target, "missing")
+        else:
+            # Path exists — update effective_cwd for downstream segments.
+            effective_cwd = abs_target
 
     return 0
 

--- a/hooks/bash-worktree-existence-advisory.py
+++ b/hooks/bash-worktree-existence-advisory.py
@@ -25,8 +25,11 @@ Silent cases (no output emitted):
   - `cd ~user/...` — user-specific tilde, unresolvable
   - `pushd /path` — out of scope (Phase 1)
   - `(cd /path && ...)` — subshell, out of scope (Phase 1)
-  - `cd /path` inside a heredoc body — heredoc body segments are skipped
-    (see _extract_heredoc_end_marker for the detection mechanism)
+  - `cd /path` inside a heredoc body — space-separated opener `<< EOF`:
+    heredoc body segments are skipped by _extract_heredoc_end_marker.
+    KNOWN LIMITATION: fused openers (`<<EOF`, `<<'EOF'`, `<<"EOF"`, `<<-EOF`)
+    are not detected — their body `cd /path` fires a false-positive advisory.
+    Tracked in follow-up #337 P6.
   - opt-out marker `# worktree-advisory:ack` anywhere in command
   - non-Bash tool name
   - malformed JSON stdin
@@ -184,11 +187,17 @@ def _extract_heredoc_end_marker(seg: list[Token]) -> str | None:
     ['cat', '<<', 'EOF']. The `<<` is emitted as a POSITIONAL token because
     shlex with punctuation_chars=';|&' does not treat `<` as punctuation.
 
-    Detection: find the literal `<<` or `<<-` token (POSITIONAL role) and
-    return the token immediately following it as the end-marker word.
-    Strip optional `-` from `<<-` (tab-stripping form of heredoc).
+    Detection: find a POSITIONAL token that is the literal `<<` or `<<-`
+    and return the next token as the end-marker word.
 
-    Returns None when no heredoc opener is present in the segment.
+    KNOWN LIMITATION: shlex with posix=True tokenizes fused heredoc openers
+    (`<<EOF`, `<<'EOF'`, `<<"EOF"`, `<<-EOF`) as a **single** POSITIONAL
+    token (`<<EOF` or `<<-EOF`), not as two separate tokens. This function
+    only matches the space-separated form (`<< EOF`) where `<<` appears as
+    an isolated token. Fused forms are NOT detected, and their body `cd`
+    lines fire false-positive advisories. Tracked in follow-up #337 P6.
+
+    Returns None when no space-separated heredoc opener is present.
     """
     argv = filter_argv(seg)
     for i, tok in enumerate(argv):
@@ -196,7 +205,7 @@ def _extract_heredoc_end_marker(seg: list[Token]) -> str | None:
             if i + 1 < len(argv):
                 # End-marker may be quoted in the source (`<< 'EOF'`) but
                 # shlex in posix mode strips quotes, so the token text is
-                # always the bare word. Strip leading `-` from `<<-` form.
+                # always the bare word.
                 return argv[i + 1].text
     return None
 

--- a/hooks/bash-worktree-existence-advisory.sh
+++ b/hooks/bash-worktree-existence-advisory.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# PreToolUse(Bash) hook — delegates to the Python implementation.
+# Advisory-only: writes to stderr, exits 0. Never blocks tool execution.
+
+set +e
+
+if ! command -v python3 >/dev/null 2>&1; then
+  exit 0
+fi
+
+exec python3 "$(dirname "$0")/bash-worktree-existence-advisory.py"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -113,6 +113,12 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/bash-worktree-existence-advisory.sh",
+            "timeout": 5,
+            "hosts": ["claude", "codex"]
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/verify-commit-flag-override.sh",
             "timeout": 5,
             "hosts": ["claude", "codex"]

--- a/plugins/praxis/.codex-plugin/hooks/hooks.json
+++ b/plugins/praxis/.codex-plugin/hooks/hooks.json
@@ -94,6 +94,11 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/bash-worktree-existence-advisory.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/verify-commit-flag-override.sh",
             "timeout": 5
           },

--- a/tests/test_bash_worktree_existence_advisory.sh
+++ b/tests/test_bash_worktree_existence_advisory.sh
@@ -185,6 +185,26 @@ run_case "non-cd command without heredoc is silent" \
   "cat /tmp/foo.txt"
 
 # ---------------------------------------------------------------------------
+# === Known limitation: fused heredoc openers fire false-positive (#337 P6) ===
+# shlex tokenizes `<<EOF`, `<<'EOF'`, `<<-EOF` as a single POSITIONAL token,
+# so _extract_heredoc_end_marker cannot detect them. Body `cd /path` fires.
+# These cases are pinned here to document current behavior. When #337 P6 is
+# resolved, all three should be changed to "silent".
+# ---------------------------------------------------------------------------
+
+run_case "KNOWN-LIMITATION: fused <<EOF body cd fires false-positive (pin)" \
+  "advisory:[worktree-missing]" \
+  "$(printf 'cat <<EOF\ncd /this/does/not/exist/anywhere\nEOF')"
+
+run_case "KNOWN-LIMITATION: fused <<'EOF' body cd fires false-positive (pin)" \
+  "advisory:[worktree-missing]" \
+  "$(printf "cat <<'EOF'\ncd /this/does/not/exist/anywhere\nEOF")"
+
+run_case "KNOWN-LIMITATION: fused <<-EOF body cd fires false-positive (pin)" \
+  "advisory:[worktree-missing]" \
+  "$(printf 'cat <<-EOF\n\tcd /this/does/not/exist/anywhere\n\tEOF')"
+
+# ---------------------------------------------------------------------------
 # === M3 fix: dedupe keyed on (session, path, state) — state-change aware ===
 # ---------------------------------------------------------------------------
 

--- a/tests/test_bash_worktree_existence_advisory.sh
+++ b/tests/test_bash_worktree_existence_advisory.sh
@@ -144,9 +144,9 @@ run_case "cd user-tilde is silent" \
   "cd ~root/foo && ls"
 
 # ---------------------------------------------------------------------------
-# === C2 fix: git -C target_dir worktree list (not hook-process cwd) ===
-# The worktree lookup now uses git -C <probe_dir>. We verify that a missing
-# path still fires correctly regardless of hook process cwd.
+# === missing path fires regardless of hook-process cwd (no git worktree lookup) ===
+# [worktree-stale] was removed (M5 option B) — the hook now only checks
+# whether the path exists on disk, not whether it is a registered worktree.
 # ---------------------------------------------------------------------------
 
 run_case "missing path advisory works regardless of cwd context" \
@@ -166,18 +166,21 @@ run_case "subshell cd non-existent is silent (out of scope Phase 1)" \
   "(cd $MISSING_PATH && ls)"
 
 # ---------------------------------------------------------------------------
-# === M2 fix: heredoc body containing cd does not fire ===
+# === M2 fix: heredoc body containing cd is skipped (no false-positive) ===
 # ---------------------------------------------------------------------------
 
-# tokenize_with_roles is heredoc-unaware so the body tokens may be parsed.
-# The hook silently skips any segment whose argv[0] is not `cd` (it would
-# be parsed as a POSITIONAL in the heredoc context). However, `cd` inside
-# a heredoc body IS parsed as a segment command — we rely on the heredoc
-# opener token `<<` being present to suppress. The current implementation
-# does NOT do heredoc-aware skip (Phase 1 scope); we confirm the existing
-# behavior: false-positive is present but out of scope. We test that the
-# OPENER command (`cat`) does not itself emit an advisory.
-run_case "heredoc opener cat does not fire advisory" \
+# `cat << EOF\ncd /missing\nEOF` — body segment `cd /missing` must be silent.
+run_case "heredoc body cd non-existent is silent" \
+  "silent" \
+  "$(printf 'cat << EOF\ncd /this/does/not/exist/anywhere\nEOF')"
+
+# cd AFTER the heredoc close still fires (not suppressed by heredoc skip).
+run_case "cd after heredoc close fires advisory" \
+  "advisory:[worktree-missing]" \
+  "$(printf 'cat << EOF\ncd /this/does/not/exist/anywhere\nEOF\ncd /also/does/not/exist')"
+
+# Non-cd opener command (cat /tmp/foo.txt) with no heredoc — still silent.
+run_case "non-cd command without heredoc is silent" \
   "silent" \
   "cat /tmp/foo.txt"
 
@@ -203,6 +206,30 @@ run_case "different session fires advisory independently" \
   "advisory:[worktree-missing]" \
   "cd $MISSING_PATH" \
   "test-dedup-other-$$"
+
+# M3 state-transition: missing → mkdir (cd existing clears marker) → rmdir → cd missing again fires.
+# Step 1: cd missing → advisory + marker written.
+TRANSITION_SID="test-transition-$$"
+TRANSITION_PATH="$NON_WT_DIR/transition-dir-$$"
+
+run_case "state-transition step1: missing fires advisory" \
+  "advisory:[worktree-missing]" \
+  "cd $TRANSITION_PATH" \
+  "$TRANSITION_SID"
+
+# Step 2: create the directory, then cd existing → marker cleared.
+mkdir -p "$TRANSITION_PATH"
+run_case "state-transition step2: existing path is silent and clears marker" \
+  "silent" \
+  "cd $TRANSITION_PATH" \
+  "$TRANSITION_SID"
+
+# Step 3: remove the directory, cd again → advisory fires (marker was cleared in step 2).
+rmdir "$TRANSITION_PATH" 2>/dev/null || true
+run_case "state-transition step3: missing again fires advisory (marker cleared)" \
+  "advisory:[worktree-missing]" \
+  "cd $TRANSITION_PATH" \
+  "$TRANSITION_SID"
 
 # ---------------------------------------------------------------------------
 # === Infrastructure / fail-open cases ===

--- a/tests/test_bash_worktree_existence_advisory.sh
+++ b/tests/test_bash_worktree_existence_advisory.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# test_bash_worktree_existence_advisory.sh — coverage for
+# hooks/bash-worktree-existence-advisory.sh
+#
+# Synthesizes Claude Code PreToolUse(Bash) payloads and asserts:
+#   advisory:<marker>  — exit 0, stderr contains <marker>
+#   silent             — exit 0, stderr empty
+#
+# Usage: bash tests/test_bash_worktree_existence_advisory.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$ROOT_DIR/hooks/bash-worktree-existence-advisory.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable: $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+# run_case name expectation command [session_id]
+#   expectation:
+#     "advisory:<marker>" — exit 0, stderr contains <marker>
+#     "silent"            — exit 0, stderr empty
+run_case() {
+  local name="$1" expectation="$2" command="$3" sid="${4:-test-session-$$}"
+
+  local payload
+  payload=$(python3 -c '
+import json, sys
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {"command": sys.argv[1]},
+    "session_id": sys.argv[2],
+}))' "$command" "$sid")
+
+  local err_file
+  err_file=$(mktemp)
+  echo "$payload" | "$HOOK" >/dev/null 2>"$err_file"
+  local rc=$?
+  local err
+  err=$(cat "$err_file")
+  rm -f "$err_file"
+
+  local ok=1
+  case "$expectation" in
+    silent)
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$err" ]   || ok=0
+      ;;
+    advisory:*)
+      local marker="${expectation#advisory:}"
+      [ "$rc" -eq 0 ] || ok=0
+      case "$err" in
+        *"$marker"*) ;;
+        *) ok=0 ;;
+      esac
+      ;;
+    *)
+      echo "FAIL  [$name] unknown expectation: $expectation"
+      FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name"); return
+      ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expectation=$expectation rc=$rc stderr=${err:-<empty>}"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Setup: scratch directories for testing
+# ---------------------------------------------------------------------------
+
+# Existing directory that is NOT a registered git worktree.
+NON_WT_DIR=$(mktemp -d)
+
+# Path that does not exist at all.
+MISSING_PATH="$NON_WT_DIR/does-not-exist-$$"
+
+# A real registered worktree: the root of the praxis repo itself.
+# `git worktree list` always includes the main worktree.
+REAL_WT_PATH="$(git -C "$ROOT_DIR" rev-parse --show-toplevel 2>/dev/null)"
+
+# ---------------------------------------------------------------------------
+# Case 1: missing path → [worktree-missing] advisory
+# ---------------------------------------------------------------------------
+
+run_case "missing path emits worktree-missing advisory" \
+  "advisory:[worktree-missing]" \
+  "cd $MISSING_PATH && ls"
+
+# ---------------------------------------------------------------------------
+# Case 2: existing path that is NOT a registered worktree → [worktree-stale]
+# ---------------------------------------------------------------------------
+
+run_case "existing non-worktree path emits worktree-stale advisory" \
+  "advisory:[worktree-stale]" \
+  "cd $NON_WT_DIR && ls"
+
+# ---------------------------------------------------------------------------
+# Case 3: registered worktree → silent (no advisory)
+# ---------------------------------------------------------------------------
+
+if [ -n "$REAL_WT_PATH" ] && [ -d "$REAL_WT_PATH" ]; then
+  run_case "registered worktree path is silent" \
+    "silent" \
+    "cd $REAL_WT_PATH && git status"
+else
+  echo "SKIP  [registered worktree path is silent] — could not determine real worktree path"
+fi
+
+# ---------------------------------------------------------------------------
+# Infrastructure / fail-open cases
+# ---------------------------------------------------------------------------
+
+run_case "non-Bash tool name is silent" \
+  "silent" \
+  "cd $MISSING_PATH"
+
+# Override tool_name to Read
+read_payload=$(python3 -c '
+import json, sys
+print(json.dumps({
+    "tool_name": "Read",
+    "tool_input": {"command": "cd /nonexistent/path && ls"},
+    "session_id": "test-infra-$$",
+}))' 2>/dev/null)
+err_file_infra=$(mktemp)
+echo "$read_payload" | "$HOOK" >/dev/null 2>"$err_file_infra"
+rc_infra=$?
+err_infra=$(cat "$err_file_infra")
+rm -f "$err_file_infra"
+if [ "$rc_infra" -eq 0 ] && [ -z "$err_infra" ]; then
+  echo "PASS  [non-Bash tool_name passthrough]"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL  [non-Bash tool_name passthrough] rc=$rc_infra stderr=${err_infra:-<empty>}"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("non-Bash tool_name passthrough")
+fi
+
+run_case "malformed command bare cd is silent" \
+  "silent" \
+  "cd"
+
+run_case "cd with variable expansion is silent" \
+  "silent" \
+  'cd $SOME_VAR && ls'
+
+run_case "opt-out marker suppresses advisory" \
+  "silent" \
+  "cd $MISSING_PATH  # worktree-advisory:ack"
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+rm -rf "$NON_WT_DIR" 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "${#FAILED_NAMES[@]}" -gt 0 ]; then
+  echo "Failed:"
+  for n in "${FAILED_NAMES[@]}"; do
+    echo "  - $n"
+  done
+fi
+
+[ "$FAIL" -eq 0 ]

--- a/tests/test_bash_worktree_existence_advisory.sh
+++ b/tests/test_bash_worktree_existence_advisory.sh
@@ -24,21 +24,26 @@ PASS=0
 FAIL=0
 FAILED_NAMES=()
 
-# run_case name expectation command [session_id]
+# run_case name expectation command session_id
 #   expectation:
 #     "advisory:<marker>" — exit 0, stderr contains <marker>
 #     "silent"            — exit 0, stderr empty
 run_case() {
-  local name="$1" expectation="$2" command="$3" sid="${4:-test-session-$$}"
+  local name="$1" expectation="$2" command="$3" sid="${4:-}"
 
+  # Build payload. Use empty string for session_id when not provided so
+  # dedupe is disabled (each test case sees a fresh state).
   local payload
   payload=$(python3 -c '
 import json, sys
-print(json.dumps({
+d = {
     "tool_name": "Bash",
     "tool_input": {"command": sys.argv[1]},
-    "session_id": sys.argv[2],
-}))' "$command" "$sid")
+}
+if sys.argv[2]:
+    d["session_id"] = sys.argv[2]
+print(json.dumps(d))
+' "$command" "$sid")
 
   local err_file
   err_file=$(mktemp)
@@ -87,78 +92,176 @@ NON_WT_DIR=$(mktemp -d)
 # Path that does not exist at all.
 MISSING_PATH="$NON_WT_DIR/does-not-exist-$$"
 
-# A real registered worktree: the root of the praxis repo itself.
-# `git worktree list` always includes the main worktree.
+# A real registered worktree: the root of the praxis clone (always registered).
 REAL_WT_PATH="$(git -C "$ROOT_DIR" rev-parse --show-toplevel 2>/dev/null)"
 
 # ---------------------------------------------------------------------------
-# Case 1: missing path → [worktree-missing] advisory
+# === CORE advisory path ===
 # ---------------------------------------------------------------------------
 
-run_case "missing path emits worktree-missing advisory" \
+# C1: missing path → [worktree-missing]
+run_case "missing path emits worktree-missing" \
   "advisory:[worktree-missing]" \
   "cd $MISSING_PATH && ls"
 
+# Compound form: missing path in the cd segment
+run_case "missing path in compound command" \
+  "advisory:[worktree-missing]" \
+  "cd $MISSING_PATH && git status && echo done"
+
 # ---------------------------------------------------------------------------
-# Case 2: existing path that is NOT a registered worktree → [worktree-stale]
+# === SILENT paths — existing dir, registered worktree ===
 # ---------------------------------------------------------------------------
 
-run_case "existing non-worktree path emits worktree-stale advisory" \
-  "advisory:[worktree-stale]" \
+# Existing non-worktree dir: [worktree-stale] removed (M5 option B) — silent.
+run_case "existing non-worktree dir is silent (M5: stale removed)" \
+  "silent" \
   "cd $NON_WT_DIR && ls"
 
-# ---------------------------------------------------------------------------
-# Case 3: registered worktree → silent (no advisory)
-# ---------------------------------------------------------------------------
-
+# Registered worktree → silent.
 if [ -n "$REAL_WT_PATH" ] && [ -d "$REAL_WT_PATH" ]; then
   run_case "registered worktree path is silent" \
     "silent" \
     "cd $REAL_WT_PATH && git status"
 else
-  echo "SKIP  [registered worktree path is silent] — could not determine real worktree path"
+  echo "SKIP  [registered worktree path is silent] — cannot determine repo root"
 fi
 
 # ---------------------------------------------------------------------------
-# Infrastructure / fail-open cases
+# === C1 fix: tilde expansion → silent ===
 # ---------------------------------------------------------------------------
 
-run_case "non-Bash tool name is silent" \
+run_case "cd tilde alone is silent" \
   "silent" \
+  "cd ~"
+
+run_case "cd tilde-slash prefix is silent" \
+  "silent" \
+  "cd ~/projects/foo && ls"
+
+run_case "cd user-tilde is silent" \
+  "silent" \
+  "cd ~root/foo && ls"
+
+# ---------------------------------------------------------------------------
+# === C2 fix: git -C target_dir worktree list (not hook-process cwd) ===
+# The worktree lookup now uses git -C <probe_dir>. We verify that a missing
+# path still fires correctly regardless of hook process cwd.
+# ---------------------------------------------------------------------------
+
+run_case "missing path advisory works regardless of cwd context" \
+  "advisory:[worktree-missing]" \
   "cd $MISSING_PATH"
 
-# Override tool_name to Read
-read_payload=$(python3 -c '
+# ---------------------------------------------------------------------------
+# === M1 spec: pushd and subshell are out of scope (silent) ===
+# ---------------------------------------------------------------------------
+
+run_case "pushd non-existent path is silent (out of scope Phase 1)" \
+  "silent" \
+  "pushd $MISSING_PATH && ls"
+
+run_case "subshell cd non-existent is silent (out of scope Phase 1)" \
+  "silent" \
+  "(cd $MISSING_PATH && ls)"
+
+# ---------------------------------------------------------------------------
+# === M2 fix: heredoc body containing cd does not fire ===
+# ---------------------------------------------------------------------------
+
+# tokenize_with_roles is heredoc-unaware so the body tokens may be parsed.
+# The hook silently skips any segment whose argv[0] is not `cd` (it would
+# be parsed as a POSITIONAL in the heredoc context). However, `cd` inside
+# a heredoc body IS parsed as a segment command — we rely on the heredoc
+# opener token `<<` being present to suppress. The current implementation
+# does NOT do heredoc-aware skip (Phase 1 scope); we confirm the existing
+# behavior: false-positive is present but out of scope. We test that the
+# OPENER command (`cat`) does not itself emit an advisory.
+run_case "heredoc opener cat does not fire advisory" \
+  "silent" \
+  "cat /tmp/foo.txt"
+
+# ---------------------------------------------------------------------------
+# === M3 fix: dedupe keyed on (session, path, state) — state-change aware ===
+# ---------------------------------------------------------------------------
+
+# Same session, same missing path → second call deduplicated.
+DEDUP_SID="test-dedup-$$"
+
+run_case "first call emits advisory" \
+  "advisory:[worktree-missing]" \
+  "cd $MISSING_PATH" \
+  "$DEDUP_SID"
+
+run_case "second call for same missing path is deduped (silent)" \
+  "silent" \
+  "cd $MISSING_PATH" \
+  "$DEDUP_SID"
+
+# Different session → advisory fires again (not deduped across sessions).
+run_case "different session fires advisory independently" \
+  "advisory:[worktree-missing]" \
+  "cd $MISSING_PATH" \
+  "test-dedup-other-$$"
+
+# ---------------------------------------------------------------------------
+# === Infrastructure / fail-open cases ===
+# ---------------------------------------------------------------------------
+
+# Non-Bash tool_name → silent.
+infra_payload=$(python3 -c '
 import json, sys
 print(json.dumps({
     "tool_name": "Read",
     "tool_input": {"command": "cd /nonexistent/path && ls"},
-    "session_id": "test-infra-$$",
+    "session_id": "test-infra-read-$$",
 }))' 2>/dev/null)
-err_file_infra=$(mktemp)
-echo "$read_payload" | "$HOOK" >/dev/null 2>"$err_file_infra"
-rc_infra=$?
-err_infra=$(cat "$err_file_infra")
-rm -f "$err_file_infra"
-if [ "$rc_infra" -eq 0 ] && [ -z "$err_infra" ]; then
+infra_err=$(mktemp)
+echo "$infra_payload" | "$HOOK" >/dev/null 2>"$infra_err"
+infra_rc=$?
+infra_err_content=$(cat "$infra_err")
+rm -f "$infra_err"
+if [ "$infra_rc" -eq 0 ] && [ -z "$infra_err_content" ]; then
   echo "PASS  [non-Bash tool_name passthrough]"
   PASS=$((PASS + 1))
 else
-  echo "FAIL  [non-Bash tool_name passthrough] rc=$rc_infra stderr=${err_infra:-<empty>}"
+  echo "FAIL  [non-Bash tool_name passthrough] rc=$infra_rc stderr=${infra_err_content:-<empty>}"
   FAIL=$((FAIL + 1)); FAILED_NAMES+=("non-Bash tool_name passthrough")
 fi
 
-run_case "malformed command bare cd is silent" \
+# Malformed JSON → silent (fail-open).
+malformed_err=$(mktemp)
+echo "not-valid-json" | "$HOOK" >/dev/null 2>"$malformed_err"
+malformed_rc=$?
+malformed_err_content=$(cat "$malformed_err")
+rm -f "$malformed_err"
+if [ "$malformed_rc" -eq 0 ] && [ -z "$malformed_err_content" ]; then
+  echo "PASS  [malformed JSON stdin is silent]"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL  [malformed JSON stdin is silent] rc=$malformed_rc stderr=${malformed_err_content:-<empty>}"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("malformed JSON stdin is silent")
+fi
+
+run_case "bare cd is silent" \
   "silent" \
   "cd"
 
-run_case "cd with variable expansion is silent" \
+run_case "cd with dollar-sign variable is silent" \
   "silent" \
   'cd $SOME_VAR && ls'
+
+run_case "cd dash is silent" \
+  "silent" \
+  "cd -"
 
 run_case "opt-out marker suppresses advisory" \
   "silent" \
   "cd $MISSING_PATH  # worktree-advisory:ack"
+
+run_case "empty command is silent" \
+  "silent" \
+  ""
 
 # ---------------------------------------------------------------------------
 # Cleanup


### PR DESCRIPTION
Closes #322

Caller chain verified: `hooks/bash-worktree-existence-advisory.sh` → `hooks/bash-worktree-existence-advisory.py` → `_hook_utils.tokenize_with_roles` / `filter_argv`

## Round 4 결정: Option B (scope honesty + redesign follow-up)

Heredoc false-positive는 단일 파서 제약에서 파생된 동일-family bug 이다. 부분 fix (round 3)
가 정직하지 못한 spec 을 만들었고, round 4 에서는 코드 재설계 대신 spec/docstring/test 정직화 + follow-up 추적을 선택했다.

### Round 4 변경 내용 (commit 4: `docs(hook): bash-worktree-existence-advisory scope honesty`)

**spec 정직화 (`docs/hook/bash-worktree-existence-advisory.md`)**:
- 단일 "silent" 행이었던 heredoc row를 두 행으로 분리:
  - space-separated opener (`cat << EOF`) → silent (처리됨)
  - fused opener (`cat <<EOF`, `<<'EOF'`, `<<"EOF"`, `<<-EOF`) → known false-positive (tracked #337 P6)
- "Heredoc handling" 섹션에 "Known limitation" 단락 추가: shlex fused-token 근본 원인 + 워크어라운드 명시

**docstring 정직화 (`hooks/bash-worktree-existence-advisory.py`)**:
- Silent cases 목록의 heredoc 항목: 처리됨/미처리 형태 구분 명시
- `_extract_heredoc_end_marker` docstring: KNOWN LIMITATION 단락 추가 (fused 토큰 미감지 이유 + #337 P6 참조)

**테스트 known-limitation pin (`tests/test_bash_worktree_existence_advisory.sh`)**:
- 3개 케이스 추가 (fused `<<EOF`, `<<'EOF'`, `<<-EOF`): 현재 false-positive 동작을 `advisory:` 로 pin
- `#337 P6` 해결 시 이 케이스들을 `silent` 로 전환

**follow-up #337 업데이트**:
- P6 추가: fused heredoc opener 처리, root cause, fix 옵션 A/B, 테스트 체크리스트
- 우선순위: P6 > P1 > P3 > P5 > P4

---

## 전체 fix 요약 (4 commits)

| Commit | 내용 |
|--------|------|
| 1: `feat(hook): pre-bash worktree-existence advisory` | 초기 구현 (8 tests) |
| 2: `fix(hook): bash-worktree-existence-advisory CRITICAL+MAJOR` | C1(tilde), M3(state suffix), M5(stale 제거) |
| 3: `fix(hook): bash-worktree-existence-advisory spec sync + M3 cleanup` | M2(heredoc space-sep fix), M3(exists→delete marker), INDEX.md |
| 4: `docs(hook): bash-worktree-existence-advisory scope honesty` | fused heredoc limitation 정직화 + pin tests |

## 위험

- **Advisory only** — 절대 tool 실행을 차단하지 않음 (exit 0 보장)
- **Heredoc limitation**: space-separated opener (`<< EOF`) 1형만 처리. 나머지 4형 (fused) 은 body `cd /path` 가 false-positive advisory 를 발화한다. 발화 빈도는 낮지만 `<<'EOF'` (bash 표준 no-expansion 패턴) 은 이 레포에서 사용 중 → 워크어라운드: `# worktree-advisory:ack` 추가 또는 `<< EOF` space-separated form 사용. #337 P6 에서 추적.
- `# worktree-advisory:ack` opt-out으로 모든 advisory 억제 가능

## 검증 (테스트 출력)

```
PASS  [missing path emits worktree-missing]
PASS  [missing path in compound command]
PASS  [existing non-worktree dir is silent (M5: stale removed)]
PASS  [registered worktree path is silent]
PASS  [cd tilde alone is silent]
PASS  [cd tilde-slash prefix is silent]
PASS  [cd user-tilde is silent]
PASS  [missing path advisory works regardless of cwd context]
PASS  [pushd non-existent path is silent (out of scope Phase 1)]
PASS  [subshell cd non-existent is silent (out of scope Phase 1)]
PASS  [heredoc body cd non-existent is silent]
PASS  [cd after heredoc close fires advisory]
PASS  [non-cd command without heredoc is silent]
PASS  [KNOWN-LIMITATION: fused <<EOF body cd fires false-positive (pin)]
PASS  [KNOWN-LIMITATION: fused <<'EOF' body cd fires false-positive (pin)]
PASS  [KNOWN-LIMITATION: fused <<-EOF body cd fires false-positive (pin)]
PASS  [first call emits advisory]
PASS  [second call for same missing path is deduped (silent)]
PASS  [different session fires advisory independently]
PASS  [state-transition step1: missing fires advisory]
PASS  [state-transition step2: existing path is silent and clears marker]
PASS  [state-transition step3: missing again fires advisory (marker cleared)]
PASS  [non-Bash tool_name passthrough]
PASS  [malformed JSON stdin is silent]
PASS  [bare cd is silent]
PASS  [cd with dollar-sign variable is silent]
PASS  [cd dash is silent]
PASS  [opt-out marker suppresses advisory]
PASS  [empty command is silent]

Results: 29 passed, 0 failed
```

매니페스트: `clean — no changes` / `plugin-manifest check OK`

## Follow-up

Phase 2 이슈: https://github.com/devseunggwan/praxis/issues/337  
(P6: fused heredoc fix [최우선], P1: pushd/subshell, P3: marker cleanup, P5: stale 재도입, P4: git worktree remove advisory)
