### PR TITLE
feat(hook): wire gate-4 verdict into retrospect-mix-check

### DIFF
--- a/docs/hook/retrospect-mix-check.md
+++ b/docs/hook/retrospect-mix-check.md
@@ -40,6 +40,8 @@ of the following hold:
 | `gate_1_verdict: FAIL` in the distribution card | Stage 2.5 Gate-1 (categorical) was violated |
 | `gate_2_verdict: FAIL` in the distribution card | Stage 2.5 Gate-2 (procedural rationale) was violated |
 | `gate_3_verdict: FAIL` in the distribution card | Stage 2.5 Gate-3 (evidence robustness) was violated — a 2-action compound finding lacked independent evidence per action, or had decision-coupled actions |
+| `gate_4_verdict: FAIL` in the distribution card | Stage 2.5 Gate-4 (external-repo authorization) emitted FAIL |
+| `gate_4_verdict` absent AND Rationale contains `⚠ EXTERNAL:` prefix | Gate-4 ran and marked findings external, but `gate_4_verdict` was not written to the distribution card — Stage 2.5 was partially skipped |
 | `gate_1_verdict` or `gate_2_verdict` key missing | Distribution card is malformed or Stage 2.5 was skipped |
 | Any row with `Category` ∈ {tool, workflow, spec-gap} AND `Proposed Actions = memory` (single) | Gate-1 violation detected via independent table parse |
 | Any row with `Proposed Actions = memory` (single) whose `Rationale` lacks exactly 5 lines `^not (issue\|claude_md_draft\|skill_idea\|hook_code\|upstream_feedback): .+$` | Gate-2 violation detected via independent table parse |
@@ -52,6 +54,8 @@ of the following hold:
 - `behavioral`-only findings with valid 5-line rationales — legitimately memory-only
 - Compound actions like `memory, skill_idea` — Gate-2 only checks single `memory`
 - Rows whose `Proposed Actions` contain neither `upstream_feedback` nor `issue` — Gate-3 does not apply
+- `gate_4_verdict: PASS` or `gate_4_verdict: WARN` in the distribution card — WARN means external findings exist but per-action approval is the enforcement at Stage 4 (not here)
+- `gate_4_verdict: NA` — no `upstream_feedback` findings exist; Gate-4 did not apply
 
 ### Trigger condition summary
 
@@ -106,7 +110,7 @@ git -C ~/.claude/plugins/.../praxis apply --reverse <patch>
 
 ### Tests
 
-`tests/test_retrospect_mix_check.sh` covers 31 cases plus 5 synthetic
+`tests/test_retrospect_mix_check.sh` covers 38 cases plus 8 synthetic
 regression fixtures:
 
 - 4 pass scenarios (behavior-only with rationale, escalated tool, escalated
@@ -126,6 +130,9 @@ regression fixtures:
   backing_repo needed → pass)
 - 2 Gate-3 verdict (T30 gate_3_verdict: FAIL in card → block, T31
   gate_3_verdict: PASS in card → pass)
+- 3 Gate-4 verdict (T36 gate_4_verdict: PASS → pass, T37 external marker +
+  absent gate_4_verdict → block, T38 gate_4_verdict: NA + no upstream_feedback
+  → pass)
 
 Fixtures live in `tests/fixtures/retrospect-synth-{tool,workflow,behavior,
 mixed,gate3-fail}.jsonl` with `.expected.json` sidecars (`{expected_decision,

--- a/hooks/retrospect-mix-check.sh
+++ b/hooks/retrospect-mix-check.sh
@@ -101,9 +101,11 @@ DIST_CARD=$(printf '%s\n' "$MOST_RECENT_BLOCK" | awk '
 GATE_1=$(printf '%s\n' "$DIST_CARD" | awk -F': *' '/^- gate_1_verdict:/ {v=$2} END{print v}')
 GATE_2=$(printf '%s\n' "$DIST_CARD" | awk -F': *' '/^- gate_2_verdict:/ {v=$2} END{print v}')
 GATE_3=$(printf '%s\n' "$DIST_CARD" | awk -F': *' '/^- gate_3_verdict:/ {v=$2} END{print v}')
+GATE_4=$(printf '%s\n' "$DIST_CARD" | awk -F': *' '/^- gate_4_verdict:/ {v=$2} END{print v}')
 [ -z "$GATE_1" ] && GATE_1="MISSING"
 [ -z "$GATE_2" ] && GATE_2="MISSING"
 # Gate-3 MISSING is not blocked (newly added enforcement; old cards legitimately omit this key).
+# Gate-4 MISSING is not blocked (old cards legitimately omit this key).
 
 # Independent table parse (defense-in-depth: don't trust the card alone).
 # Find the unified findings table header row and walk subsequent rows until a
@@ -244,6 +246,22 @@ if [ "$GATE_3" = "FAIL" ]; then
   should_block=true
   reason_parts+=("Gate-3 verdict in distribution card = FAIL")
 fi
+# Gate-4 (External-Repo Authorization): FAIL or missing + ⚠ EXTERNAL: prefix in Rationale → block.
+# PASS or WARN → pass (WARN means external=true but per-action approval is procedural at Stage 4).
+# NA → pass (no upstream_feedback findings).
+if [ "$GATE_4" = "FAIL" ]; then
+  should_block=true
+  reason_parts+=("Gate-4 verdict in distribution card = FAIL")
+fi
+# If gate_4_verdict is absent but the Rationale contains the ⚠ EXTERNAL: marker, block:
+# Stage 2.5 should have written gate_4_verdict: WARN for external findings; its absence
+# with an EXTERNAL marker indicates Stage 2.5 was skipped or incomplete.
+if [ -z "$GATE_4" ]; then
+  if printf '%s\n' "$MOST_RECENT_BLOCK" | grep -qF '⚠ EXTERNAL:'; then
+    should_block=true
+    reason_parts+=("gate_4_verdict key absent but ⚠ EXTERNAL: marker found in Rationale — Stage 2.5 Gate-4 may have been skipped")
+  fi
+fi
 if [ "$GATE_1" = "MISSING" ] || [ "$GATE_2" = "MISSING" ]; then
   should_block=true
   reason_parts+=("distribution card missing gate_1_verdict or gate_2_verdict key")
@@ -287,7 +305,7 @@ if [ "$should_block" = "true" ]; then
     fi
   done
 
-  full_reason="Retrospect mix-check gate triggered. ${reason}. Fix guide: Gate-1 → relabel finding category; Gate-2 → supply either (a) 5-line 'not <action>: <reason>' rationale (Schema A) or (b) 1-2 'not-others: <dim-tags>' lines (Schema B, issue #285) in Stage 2.5; Gate-3 verdict → return to Stage 2.5 and re-evaluate evidence robustness for 2-action findings; Gate-3 backing_repo → return to Stage 2 step 8 and add 'backing_repo: <owner/repo>' to Rationale cell. See skills/retrospect/SKILL.md."
+  full_reason="Retrospect mix-check gate triggered. ${reason}. Fix guide: Gate-1 → relabel finding category; Gate-2 → supply either (a) 5-line 'not <action>: <reason>' rationale (Schema A) or (b) 1-2 'not-others: <dim-tags>' lines (Schema B, issue #285) in Stage 2.5; Gate-3 verdict → return to Stage 2.5 and re-evaluate evidence robustness for 2-action findings; Gate-3 backing_repo → return to Stage 2 step 8 and add 'backing_repo: <owner/repo>' to Rationale cell; Gate-4 → return to Stage 2.5 Gate-4 and re-run external-repo classification; ensure gate_4_verdict is emitted in the distribution card. See skills/retrospect/SKILL.md."
   jq -n --arg r "$full_reason" '{decision: "block", reason: $r}'
   exit 0
 fi

--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -357,7 +357,7 @@ User confirmation required to proceed; if user confirms, log the keyword set fou
 - `gate_3_verdict: NA` — zero findings have `Proposed Actions` count = 2 (every finding is single-action)
 - `gate_4_verdict: NA` — zero `upstream_feedback` findings exist
 
-The Stop hook `retrospect-mix-check.sh` currently parses `gate_1_verdict` and `gate_2_verdict`; `gate_3_verdict` is emitted for visibility and audit-trail purposes (the hook silently ignores unknown keys). Gate-3 is enforced procedurally inside Stage 2.5; structural Stop-hook enforcement is reserved for a follow-up tightening if procedural compliance proves insufficient. `gate_4_verdict` is similarly informational — emitted for audit-trail purposes; the hook silently ignores it. Gate-4 enforcement is procedural inside Stage 4 Action 4 step 0a.
+The Stop hook `retrospect-mix-check.sh` parses `gate_1_verdict`, `gate_2_verdict`, and `gate_4_verdict`; `gate_3_verdict` is emitted for visibility and audit-trail purposes (the hook silently ignores unknown keys). Gate-3 is enforced procedurally inside Stage 2.5; structural Stop-hook enforcement is reserved for a follow-up tightening if procedural compliance proves insufficient. Gate-4 is enforced both procedurally (Stage 4 Action 4 step 0a per-action approval) and structurally by the Stop hook: a `gate_4_verdict: FAIL` in the card blocks Stage 3 output, and an absent `gate_4_verdict` combined with a `⚠ EXTERNAL:` Rationale prefix also blocks (indicating Stage 2.5 Gate-4 was partially skipped).
 
 This card and verdict block become Stage 3's input header.
 
@@ -373,7 +373,7 @@ Stage 3 output MUST emit, in this order:
    ```markdown
    <!-- AUTHORITATIVE_SCHEMA — Stop hook depends on this. Co-update hooks/retrospect-mix-check.sh + tests/test_retrospect_mix_check.sh + tests/fixtures/retrospect-synth-*.expected.json on any change to: (1) the fence markers themselves, (2) the action key set (memory/issue/claude_md_draft/skill_idea/hook_code/upstream_feedback), or (3) gate_1_verdict / gate_2_verdict keys.
         Gate-3 carve-out: gate_3_verdict is informational-only and INTENTIONALLY EXCLUDED from this co-update contract. The hook's awk parser keys on gate_1_verdict/gate_2_verdict literals only and silently ignores all other lines (regression-tested by tests T8–T17 + the 4 fixture files which still pass without gate_3_verdict). Adding/removing/renaming gate_3_verdict alone does NOT require hook or test changes.
-        Gate-4 carve-out: gate_4_verdict is informational-only and INTENTIONALLY EXCLUDED from this co-update contract (parallel to gate_3_verdict). The hook silently ignores gate_4_verdict. Adding/removing/renaming gate_4_verdict alone does NOT require hook or test changes. -->
+        Gate-4 enforcement note: gate_4_verdict IS structurally enforced by the Stop hook (unlike gate_3_verdict which remains informational-only). Changes to gate_4_verdict semantics or its FAIL/WARN/NA/PASS values REQUIRE synchronized edits to hooks/retrospect-mix-check.sh and tests/test_retrospect_mix_check.sh (T36/T37/T38). Adding/removing gate_4_verdict from the card alone does NOT require fence-marker or action-key changes. -->
    <!-- retrospect:distribution begin -->
    - memory: 1
    - issue: 0

--- a/tests/test_retrospect_mix_check.sh
+++ b/tests/test_retrospect_mix_check.sh
@@ -733,6 +733,68 @@ T35_ROW="| 1 | behavioral | — | misjudged action | structural | rule absent | 
 run_case "T35_block_schema_a_and_b_mixed" "block" \
   "$(mk_assistant "$(mk_retrospect_stage3 "$T35_CARD" "$T35_ROW")")"
 
+# Gate-4 (External-Repo Authorization) cases ----------------------------------
+
+# T36: pass — external=true + gate_4_verdict: PASS in card.
+# Scenario: all upstream_feedback rows are own-org; Gate-4 classified them as
+# internal and emitted PASS. Stop hook must pass.
+T36_CARD=$(cat <<EOF
+- memory: 0
+- issue: 0
+- claude_md_draft: 0
+- skill_idea: 0
+- hook_code: 0
+- upstream_feedback: 1
+- gate_1_verdict: PASS
+- gate_2_verdict: NA
+- gate_3_verdict: NA
+- gate_4_verdict: PASS
+EOF
+)
+T36_ROW="| 1 | tool | cli | gh flag missing | tool defect | gap | No | upstream_feedback | tool defect confirmed<br>backing_repo: devseunggwan/praxis | HIGH |"
+run_case "T36_pass_gate4_verdict_pass" "pass" \
+  "$(mk_assistant "$(mk_retrospect_stage3 "$T36_CARD" "$T36_ROW")")"
+
+# T37: block — external=true + gate_4_verdict absent but ⚠ EXTERNAL: prefix present.
+# Scenario: Stage 2.5 emitted the EXTERNAL marker in the Rationale cell but did
+# NOT emit gate_4_verdict in the distribution card (Stage 2.5 was partially skipped
+# or the card was hand-edited). Stop hook must block.
+T37_CARD=$(cat <<EOF
+- memory: 0
+- issue: 0
+- claude_md_draft: 0
+- skill_idea: 0
+- hook_code: 0
+- upstream_feedback: 1
+- gate_1_verdict: PASS
+- gate_2_verdict: NA
+- gate_3_verdict: NA
+EOF
+)
+T37_ROW="| 1 | tool | cli | gh flag missing | tool defect | gap | No | upstream_feedback | ⚠ EXTERNAL: per-action approval required at Stage 4<br>tool defect in third-party CLI<br>backing_repo: third-party/tool | HIGH |"
+run_case "T37_block_external_marker_no_gate4_verdict" "block" \
+  "$(mk_assistant "$(mk_retrospect_stage3 "$T37_CARD" "$T37_ROW")")"
+
+# T38: pass — external=false (no upstream_feedback) + gate_4_verdict: NA.
+# Scenario: session had no upstream_feedback findings; Gate-4 emitted NA.
+# Stop hook must pass.
+T38_CARD=$(cat <<EOF
+- memory: 1
+- issue: 0
+- claude_md_draft: 0
+- skill_idea: 0
+- hook_code: 0
+- upstream_feedback: 0
+- gate_1_verdict: NA
+- gate_2_verdict: PASS
+- gate_3_verdict: NA
+- gate_4_verdict: NA
+EOF
+)
+T38_ROW="| 1 | behavioral | — | hasty conclusion | did not verify | rule absent | No | memory | ${RATIONALE_5LINE} | MED |"
+run_case "T38_pass_gate4_verdict_na_no_upstream_feedback" "pass" \
+  "$(mk_assistant "$(mk_retrospect_stage3 "$T38_CARD" "$T38_ROW")")"
+
 # Synthetic regression fixtures (AC-R1~R4) ----------------------------------
 # Each fixture pairs a .jsonl transcript with a .expected.json sidecar:
 #   {expected_decision: "pass"|"block", must_contain: [...], must_not_contain: [...]}


### PR DESCRIPTION
## 개요

`hooks/retrospect-mix-check.sh` Stop 훅에 Gate-4 (External-Repo Authorization) 판정 처리를 추가합니다.

기존에는 `gate_4_verdict`가 배포 카드에 기록되어도 훅이 해당 키를 무시했습니다 (Gate-3 초기 상태와 동일한 구조적 공백 — #291에서 Gate-3는 수정됨). 이번 PR로 Gate-4도 구조적으로 집행됩니다.

Closes #317

---

## 변경 사항

### `hooks/retrospect-mix-check.sh`
- `gate_4_verdict` 파싱 추가 (`GATE_4` 변수)
- 블록 조건 두 가지 추가:
  1. `gate_4_verdict: FAIL` → 즉시 block
  2. `gate_4_verdict` 키 부재 + Rationale에 `⚠ EXTERNAL:` prefix 존재 → block (Stage 2.5 Gate-4 부분 스킵 감지)
- `gate_4_verdict: PASS` / `WARN` / `NA` → 통과 (WARN은 Stage 4 Action 4 step 0a의 절차적 집행에 위임)
- 수정 가이드 메시지에 Gate-4 안내 추가

### `tests/test_retrospect_mix_check.sh`
새 케이스 3개 추가 (T36~T38):
- **T36** (`pass`): `external=true` + `gate_4_verdict: PASS` → 통과
- **T37** (`block`): `gate_4_verdict` 미존재 + Rationale에 `⚠ EXTERNAL:` prefix → block
- **T38** (`pass`): `upstream_feedback` 없음 + `gate_4_verdict: NA` → 통과

### `docs/hook/retrospect-mix-check.md`
- 블록 트리거 테이블에 Gate-4 행 2개 추가
- "통과 케이스" 섹션에 Gate-4 PASS/WARN/NA 추가
- 테스트 케이스 수 업데이트: 31 → 38 케이스, 5 → 8 fixture

### `skills/retrospect/SKILL.md`
- Stage 2.5 Output Schema Contract 주석: "Gate-4 carve-out — hook silently ignores" 문구 제거, 구조적 집행 확인 문구로 교체
- Stage 2.5 문단: `gate_4_verdict`가 이제 훅에서 파싱됨을 명시, 이전의 "silently ignores" 표현 제거
- **변경 범위 최소화**: Gate-4 wording 관련 2개 구간만 수정 (동시 진행 중인 #325 rebase 영향 최소화)

---

## 검증 결과

```
Cases:    38 passed, 0 failed
Fixtures: 8 passed, 0 failed
```

`python3 scripts/check-plugin-manifests.py` → `plugin-manifest check OK`

Caller chain verified: `retrospect-mix-check.sh`가 Stop 이벤트 수신 → 배포 카드의 `gate_4_verdict` 파싱 → FAIL 또는 EXTERNAL-marker-without-verdict 조건 시 `{"decision":"block"}` 반환 → Stage 3 출력 차단.

---

## 주의 사항

`skills/retrospect/SKILL.md`는 동시 진행 중인 #325 에이전트도 수정 중입니다. 본 PR의 변경은 Gate-4 wording 2개 구간에만 한정되어 있어 충돌 범위가 최소입니다. #325가 먼저 merge될 경우 rebase 필요합니다.
