### PR TITLE
docs(cw): clarify step5 ordering, env var, region labels

### DIFF
--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -224,6 +224,26 @@ session, not just the first. Terminology used below:
 - **round** — one invocation of Codex review (Step 4 produces one round of findings)
 - **session** — the assistant's working-memory lifetime; the Step 5c ledger lives here
 
+##### Execution order
+
+Sub-sections below are numbered for cross-reference, not execution order.
+The execution order each round is:
+
+1. **5f counter update + advisory check** — increment `rounds_per_region:`
+   ledger for each region touched; emit the diminishing-returns advisory if
+   `cumulative = N + 1`.
+2. **5d-i sibling-identification question** — `AskUserQuestion` to confirm
+   whether the PR is a port / parallel hotfix / A/B implementation.
+3. **5a classify findings** — fact-modifying vs structural vs stylistic.
+4. **5b verify premises** — falsify each fact-modifying finding's premise
+   before applying.
+5. **5c flip detection during apply** — scan ledger for `applied:` /
+   `rejected:` collisions before each edit.
+6. **5d-ii / 5d-iii sibling cross-check + propose** — only when 5d-i
+   identified a sibling.
+7. **5e commit-message trailer** — `Premise-Verified:` trailer on the
+   committed edit.
+
 #### 5a. Classify each finding
 
 | Type | Examples | Premise check required |
@@ -458,7 +478,10 @@ N=${PRAXIS_DIMINISHING_RETURNS_N:-4}
 
 In Python hook contexts, the equivalent is
 `int(os.environ.get("PRAXIS_DIMINISHING_RETURNS_N", "4"))` (consistent with
-how `PRAXIS_ASK_END_STRICT` and similar vars are read in `hooks/*.py`).
+the `os.environ.get("PRAXIS_EXTERNAL_WRITE_STRICT")` pattern at
+`hooks/external-write-falsify-check.py:579` and the
+`os.environ.get("PRAXIS_AUTHOR_EXEMPT_STRICT")` pattern at
+`hooks/external-write-falsify-check.py:592`).
 
 **Mid-session change semantics**: the env var is read fresh at each round's
 counter-update step; it is not cached at session start. If
@@ -531,11 +554,16 @@ user selects: 1
 [Step 4] cd /Users/dev/project-wt/windmill-hub-1539
          → node {install_path}/scripts/codex-companion.mjs review
 
-[Step 5 — Sibling check] AskUserQuestion fired at start of Step 5:
+[Step 5 — Round 1 — counter update (5f, first action)]:
+  ledger: rounds_per_region: query.sql:filter_clause | round=1 | cumulative=1
+  ledger: rounds_per_region: cli.sh:parse_prompt      | round=1 | cumulative=1
+  (cumulative ≤ N=4 → no advisory emitted yet)
+
+[Step 5 — Round 1 — sibling check (5d-i)]: AskUserQuestion fired:
   User: "이 PR은 praxis#199 (shell 버전)의 Python port입니다."
   → sibling identified: praxis#199 on branch issue-199-hook-shell
 
-[Step 5 — Round 1] Codex returned 3 findings:
+[Step 5 — Round 1 — classify + verify (5a → 5b)] Codex returned 3 findings:
   - F1: rename `query()` → `run_query()`           [structural — apply directly]
   - F2: change WHERE col_a = 1 → col_b = 1         [fact-modifying — verify column exists]
   - F3: drop the `--state all` flag                [fact-modifying — verify CLI accepts the value]

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -321,7 +321,9 @@ against the sibling implementation.
 
 ##### 5d-i. Identify sibling implementations
 
-At the **start of Step 5**, before classifying findings, surface:
+At the **start of Step 5** — immediately after the `rounds_per_region:` counter
+update (5f counter, which runs first) and before classifying findings (5a) —
+surface:
 
 ```
 AskUserQuestion: "이 PR이 다른 PR/레포의 port · parallel hotfix · A/B 구현체인가요?
@@ -413,7 +415,7 @@ context in the source file:
 
 | File type | Region label |
 |-----------|-------------|
-| Markdown (`.md`, `.mdx`) | Nearest enclosing `#`/`##`/`###` heading text |
+| Markdown (`.md`, `.mdx`) | Nearest enclosing heading text at any level (`#` through `######`); H4+ headings are valid region labels because this SKILL.md itself uses `####` and `#####` for sub-steps, and excluding them would leave deeply-nested findings unlabelled |
 | Code (`.py`, `.ts`, `.sh`, `.js`, …) | Enclosing function / class / method symbol name |
 | Plain text / unknown | The file path alone (no region suffix) |
 
@@ -421,10 +423,19 @@ Region label format: `{file}:{region}` — e.g.
 `skills/codex-review-wrap/SKILL.md:Step 5` or
 `hooks/codex-review-route.sh:parse_prompt`.
 
+**Same-file collision tiebreaker**: when two distinct occurrences of the same
+symbol name appear in one file (e.g., two functions both named `parse_prompt`),
+append the 1-based occurrence index: `{file}:{region}:{occurrence}` (e.g.,
+`hooks/codex-review-route.sh:parse_prompt:1` and
+`hooks/codex-review-route.sh:parse_prompt:2`). Occurrence order follows
+top-to-bottom source order. This suffix is added only when a collision exists —
+unique names keep the plain `{file}:{region}` form.
+
 ##### Counter update (every round)
 
-At the **start of Step 5**, before classifying findings, append one
-`rounds_per_region:` entry to the session ledger for each distinct
+At the **start of Step 5** — this is the **first action**, before the sibling
+identification question (5d-i) and before classifying findings (5a) — append
+one `rounds_per_region:` entry to the session ledger for each distinct
 `{file}:{region}` pair touched by this round's findings:
 
 ```
@@ -436,11 +447,25 @@ have touched `{file}:{region}` in the current session.
 
 ##### Advisory threshold
 
-Read the threshold `N` from the environment:
+Read the threshold `N` from the environment at the **start of each round**
+(during the counter-update step above). The read mechanism follows the same
+convention as other `PRAXIS_*` env vars in this codebase — a Bash
+parameter expansion with a default:
 
+```bash
+N=${PRAXIS_DIMINISHING_RETURNS_N:-4}
 ```
-PRAXIS_DIMINISHING_RETURNS_N   (integer, default: 4)
-```
+
+In Python hook contexts, the equivalent is
+`int(os.environ.get("PRAXIS_DIMINISHING_RETURNS_N", "4"))` (consistent with
+how `PRAXIS_ASK_END_STRICT` and similar vars are read in `hooks/*.py`).
+
+**Mid-session change semantics**: the env var is read fresh at each round's
+counter-update step; it is not cached at session start. If
+`PRAXIS_DIMINISHING_RETURNS_N` changes mid-session (e.g., changed from 4 to 2
+between round 3 and round 4), the new value takes effect from round 4 onward.
+Prior rounds use the value that was in effect at their own round start — there
+is no retroactive adjustment to already-recorded ledger entries.
 
 When `cumulative` reaches `N + 1` (i.e., the session is starting its
 `(N+1)`-th round on the same region), surface the following advisory


### PR DESCRIPTION
Closes #339

## 개요

`skills/codex-review-wrap/SKILL.md` 의 5가지 마이너 스펙 모호성을 해소합니다.

Caller chain verified: N/A -- docs-only change (SKILL.md spec refinement only; no code, hook, or executable changed)

## Caller chain 검증

env var 읽기 메커니즘은 아래 형제 구현체를 grep 조사하여 결정:
- `hooks/block-ask-end-option.py` → `os.environ.get("PRAXIS_ASK_END_STRICT", "")`
- `hooks/trino-describe-first.py` → `os.environ.get("PRAXIS_DESCRIBE_FIRST_MODE", "warn")`
- `hooks/external-write-falsify-check.py` → `os.environ.get("PRAXIS_EXTERNAL_WRITE_STRICT")`
- `hooks/trino-catalog-gate.py` → `os.environ.get("PRAXIS_TRINO_CATALOG_GATE", "")`

지배적 패턴: Python은 `os.environ.get("VAR", "default")`, Bash는 `${VAR:-default}`. 둘 다 명세에 추가.

## 변경 내역 (5개 항목)

### 1. Step 5d-i vs 5f 순서 명확화
- **이전**: 5d-i와 5f Counter update 모두 "At the **start of Step 5**" 라고만 기술 → 순서 불명확
- **이후**: 5f Counter update에 "this is the **first action**" 명시, 5d-i에 "immediately after the `rounds_per_region:` counter update (5f counter, which runs first) and before classifying findings (5a)" 추가
- **확정 순서**: 5f counter → 5d-i (sibling AskUserQuestion) → 5a (classify)

### 2. Markdown heading depth cap 근거 명시
- **이전**: Region label 표에 `#`/`##`/`###` 만 나열, H4+ 허용 여부 미정
- **이후**: `#` through `######` (전 레벨 허용)로 변경, "this SKILL.md itself uses `####` and `#####` for sub-steps, and excluding them would leave deeply-nested findings unlabelled" 근거 추가

### 3. Same-file region label 충돌 타이브레이커
- **이전**: 같은 파일에 `parse_prompt` 가 2개면 둘 다 `{file}:parse_prompt` → 구분 불가
- **이후**: `{file}:{region}:{occurrence}` 폴백 추가 (1-based, 소스 상단→하단 순); 충돌 없으면 기존 형식 유지

### 4. Env var 읽기 메커니즘
- **이전**: `PRAXIS_DIMINISHING_RETURNS_N (integer, default: 4)` 한 줄만 기재, 읽기 방법 미정
- **이후**: Bash 예시 `${PRAXIS_DIMINISHING_RETURNS_N:-4}` 와 Python 예시 `os.environ.get("PRAXIS_DIMINISHING_RETURNS_N", "4")` 추가; 실제 sibling hook 코드 패턴 기준

### 5. 세션 중 env var 변경 semantics
- **이전**: 변경 시 동작 미정의
- **이후**: "env var는 각 라운드 counter-update 시점에 새로 읽음; 세션 시작 시 캐시 없음. 이전 라운드에 소급 적용 없음" 명시
