### PR TITLE
feat(hooks): version-bump evidence check

### DIFF
--- a/.claude-plugin/hooks/hooks.json
+++ b/.claude-plugin/hooks/hooks.json
@@ -126,6 +126,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/external-write-path-existence-check.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/version-bump-evidence-check.sh",
+            "timeout": 5
           }
         ]
       },

--- a/docs/hook/INDEX.md
+++ b/docs/hook/INDEX.md
@@ -50,6 +50,7 @@ so the agent can self-correct. Fail-open on infrastructure errors by design.
 | [bash-worktree-existence-advisory](bash-worktree-existence-advisory.md) | PreToolUse | Advisory nudge when `cd <path>` targets a path that does not exist on disk |
 | [codex-review-route](codex-review-route.md) | UserPromptSubmit | Warn when `/codex:review` runs in a multi-worktree repo (cwd mismatch risk) |
 | [external-write-path-existence-check](external-write-path-existence-check.md) | PreToolUse | Advisory nudge when a `gh issue/pr` body file contains markdown links to repo paths that do not exist |
+| [version-bump-evidence-check](version-bump-evidence-check.md) | PreToolUse | Advisory nudge (opt-in strict) when `gh issue/pr` body describes an external version bump with no changelog URL, Fetched: line, or cross-reference matrix |
 
 ---
 

--- a/docs/hook/version-bump-evidence-check.md
+++ b/docs/hook/version-bump-evidence-check.md
@@ -32,7 +32,7 @@ to avoid false positives on general retrospects or design docs that mention
 
 | Signal | Pattern | Example |
 |--------|---------|---------|
-| S1 — version pair | `v\d+\.\d+\s*(→\|->|to)\s*v\d+\.\d+` (case-insensitive; `v` prefix optional) | `v24.0 → v25.0`, `1.2 -> 1.3`, `v0.9 to v1.0` |
+| S1 — version pair | version pair around an arrow (`→`, `->`, `-->`, …) or `to`; **at least one side** must carry a `v`/`V` prefix; whitespace around the arrow is optional | `v24.0 → v25.0`, `v1.2-->v1.3`, `v0.9 to v1.0`, `24.0 -> v25.0` |
 | S2 — bump phrase | `bump (sdk\|api\|client\|lib\|library\|version) from ... to ...` (case-insensitive) | `Bump SDK from 3.0 to 4.0` |
 | S3 — deprecation keyword **+ S1** | any of: `deprecated`, `deprecation`, `sunset`, `eol`, `end of life`, `breaking change`, `breaking-change` **combined with** a version pair | `v1.0 -> v2.0 breaking change` |
 
@@ -85,13 +85,15 @@ wrapper commands (`sudo`, `env`), and multi-command Bash strings.
 bash tests/test_version_bump_evidence_check.sh
 ```
 
-31 cases covering:
+35 cases covering:
 
 | Case | Expected |
 |------|----------|
 | Version pair `→` / `->` / `to` | Warn |
-| No-`v` prefix numeric pair | Warn |
+| Version pair `-->` / `->` with no surrounding whitespace (M1) | Warn |
+| `v`/`V` prefix on right side only | Warn |
 | Uppercase `V` prefix pair | Warn |
+| Language-runtime mention (`Python 3.11 to 3.12`, no `v` prefix) (M2) | Pass — false-positive control |
 | `bump sdk/api/client from ... to ...` phrase | Warn |
 | Deprecation keyword + version pair | Warn |
 | Deprecation keyword **alone** (no pair) | Pass — false-positive control |

--- a/docs/hook/version-bump-evidence-check.md
+++ b/docs/hook/version-bump-evidence-check.md
@@ -1,0 +1,110 @@
+# PreToolUse Version-Bump Evidence Check
+
+Supported hosts: claude, codex
+
+`hooks/version-bump-evidence-check.py` is a PreToolUse advisory (opt-in strict)
+that warns — and optionally blocks — when a `gh issue create`, `gh issue edit`,
+`gh pr create`, or `gh pr edit` body describes an external version bump but
+contains no changelog / breaking-changes evidence.
+
+### Why this exists
+
+Agents rationalize bypassing verification gates for "mechanical" external-version
+bumps (a single-line constant change from `v24` to `v25`) and create GitHub issues
+or PRs without first fetching the official changelog or breaking-changes page.
+The user then has to redo the work from scratch.  This hook enforces the evidence
+artifact at the last checkpoint before shared-state mutation.
+
+### Trigger surface
+
+| Command pattern | Condition |
+|-----------------|-----------|
+| `gh issue create` (any flags) | Body contains a version-bump signal |
+| `gh issue edit --body / --body-file` | Body contains a version-bump signal |
+| `gh pr create` (any flags) | Body contains a version-bump signal |
+| `gh pr edit --body / --body-file` | Body contains a version-bump signal |
+
+### Detection — version-bump signals
+
+Three signal types are recognized; **S3 alone (no version pair) never triggers**
+to avoid false positives on general retrospects or design docs that mention
+"deprecated" in prose:
+
+| Signal | Pattern | Example |
+|--------|---------|---------|
+| S1 — version pair | `v\d+\.\d+\s*(→\|->|to)\s*v\d+\.\d+` (case-insensitive; `v` prefix optional) | `v24.0 → v25.0`, `1.2 -> 1.3`, `v0.9 to v1.0` |
+| S2 — bump phrase | `bump (sdk\|api\|client\|lib\|library\|version) from ... to ...` (case-insensitive) | `Bump SDK from 3.0 to 4.0` |
+| S3 — deprecation keyword **+ S1** | any of: `deprecated`, `deprecation`, `sunset`, `eol`, `end of life`, `breaking change`, `breaking-change` **combined with** a version pair | `v1.0 -> v2.0 breaking change` |
+
+### Required evidence
+
+At least one of the following must be present in the body for the hook to stay silent:
+
+| Evidence | Pattern |
+|----------|---------|
+| E1 — Changelog URL | `https?://.../(releases|changelog|CHANGELOG|release-notes|breaking|migration|upgrade|whats-new|what-is-new)...` |
+| E2 — Fetched line | Line starting with `Fetched:` (case-insensitive) |
+| E3 — Cross-reference matrix heading | Markdown heading `## Cross-reference matrix` or `## Inventory` (case-insensitive) |
+| E4 — Bypass env var | `PRAXIS_VERSION_BUMP_BYPASS=1` |
+
+### Output format (advisory)
+
+```text
+[praxis:version-bump-evidence] External version bump detected: version pair (v24.0 → v25.0)
+[praxis:version-bump-evidence] Required evidence missing: official changelog URL, cross-reference matrix, or Fetched: lines
+[praxis:version-bump-evidence] Fix: fetch the official changelog/breaking-changes page first, then include
+  a cross-reference matrix in the body before creating the issue/PR.
+[praxis:version-bump-evidence] Bypass: PRAXIS_VERSION_BUMP_BYPASS=1
+```
+
+### Modes
+
+| Mode | How to enable | Behavior |
+|------|--------------|----------|
+| Advisory (default) | — | Emit warning to stderr, exit 0 |
+| Strict | `PRAXIS_VERSION_BUMP_STRICT=1` | Exit 2 (hard block) |
+| Bypass | `PRAXIS_VERSION_BUMP_BYPASS=1` | Silent pass, exit 0 |
+
+### Fail-open guarantees
+
+- Malformed stdin → exit 0
+- Missing / unreadable `--body-file` path → treat as empty body → trigger if version signal was already found elsewhere in the combined body; otherwise exit 0
+- `--body-file -` (stdin body) → skip that body segment, fail-open
+- Tokenization error → exit 0
+
+### Body extraction
+
+Reuses the `_extract_gh_body` pattern from `external-write-falsify-check.py`:
+flags `-b`, `--body`, `-F`, `--body-file` (space-separated or `=` form).
+`_hook_utils.safe_tokenize` + `iter_command_starts` handle env prefixes,
+wrapper commands (`sudo`, `env`), and multi-command Bash strings.
+
+### Tests
+
+```bash
+bash tests/test_version_bump_evidence_check.sh
+```
+
+31 cases covering:
+
+| Case | Expected |
+|------|----------|
+| Version pair `→` / `->` / `to` | Warn |
+| No-`v` prefix numeric pair | Warn |
+| Uppercase `V` prefix pair | Warn |
+| `bump sdk/api/client from ... to ...` phrase | Warn |
+| Deprecation keyword + version pair | Warn |
+| Deprecation keyword **alone** (no pair) | Pass — false-positive control |
+| Changelog URL in body | Pass |
+| `Fetched:` line in body | Pass |
+| `Cross-reference matrix` heading | Pass |
+| `Inventory` heading | Pass |
+| `PRAXIS_VERSION_BUMP_BYPASS=1` | Pass |
+| Strict mode + no evidence | Block (exit 2) |
+| Strict mode + evidence | Pass |
+| `--body-file` path read | Warn / pass |
+| Empty body file | Pass |
+| Missing body file | Fail-open (exit 0) |
+| Malformed stdin | Fail-open (exit 0) |
+| Non-Bash tool | Pass |
+| `git push` / `gh pr list` | Pass |

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -144,6 +144,12 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/external-write-path-existence-check.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/version-bump-evidence-check.sh",
+            "timeout": 5,
+            "hosts": ["claude", "codex"]
           }
         ]
       },

--- a/hooks/version-bump-evidence-check.py
+++ b/hooks/version-bump-evidence-check.py
@@ -74,11 +74,25 @@ _GH_BODY_FLAGS = frozenset({"-b", "--body", "-F", "--body-file"})
 # ---------------------------------------------------------------------------
 
 # S1: explicit version-pair with arrow / "to".
-# Matches: v24.0 → v25.0 / v1.2 -> v1.3 / v1.2 to v1.3
-# Also catches bare numeric pairs like 24.0 -> 25.0 (no "v" prefix).
+# Matches: v24.0 → v25.0 / v1.2 -> v1.3 / v1.2-->v1.3 / v1.2 to v1.3
 # Case-insensitive so "V1.2 → V1.3" matches too.
+#
+# Round-2 critic M1: arrow alternation accepts repeated dashes (`-+>`) so
+# agent-authored bodies like `v1.2-->v1.3` without surrounding whitespace
+# are caught.
+#
+# Round-2 critic M2: requires `v`/`V` prefix on at least one side to cut
+# language-runtime false positives (`Python 3.11 to 3.12`, `Java 11 to 17`
+# would otherwise trip strict-mode blocks on legit retrospect bodies).
+# Library / SDK bumps in PR bodies near-universally carry the `v` prefix.
 _VERSION_PAIR_RE = re.compile(
-    r"[Vv]?\d+\.\d+\s*(?:→|->|to)\s*[Vv]?\d+\.\d+",
+    r"(?:"
+    # left side has v/V prefix; right side optional
+    r"[Vv]\d+\.\d+\s*(?:→|-+>|to)\s*[Vv]?\d+\.\d+"
+    r"|"
+    # right side has v/V prefix; left side bare (numeric only)
+    r"\d+\.\d+\s*(?:→|-+>|to)\s*[Vv]\d+\.\d+"
+    r")",
     re.IGNORECASE,
 )
 
@@ -231,14 +245,15 @@ def _detect_bump_signal(body: str) -> tuple[bool, str]:
     """Return (triggered, description) where description names the matched signal.
 
     Rules:
-      - S1 alone → triggered
-      - S2 alone → triggered
-      - S3 + version pair (S1) → triggered (combined signal)
-      - S3 alone → NOT triggered (false-positive control)
+      - S1 alone (version pair)               → triggered
+      - S2 alone (bump phrase)                → triggered
+      - S1 + S2 combined                       → triggered
+      - S3 alone (deprecation keyword only)    → NOT triggered (false-positive control)
+      - S3 + S1 is implicitly covered by the S1 branch — the deprecation
+        keyword adds no signal beyond the version pair itself.
     """
     version_pair = _has_version_pair(body)
     bump_phrase = _has_bump_phrase(body)
-    has_deprecation = _has_deprecation_keyword(body)
 
     if version_pair and bump_phrase:
         return True, f"version pair ({version_pair.strip()}) + bump phrase"
@@ -246,11 +261,6 @@ def _detect_bump_signal(body: str) -> tuple[bool, str]:
         return True, f"version pair ({version_pair.strip()})"
     if bump_phrase:
         return True, f"bump phrase ({bump_phrase.strip()})"
-    if has_deprecation and version_pair is not None:
-        # already handled above, but guard just in case
-        return True, "deprecation keyword + version pair"
-    # S3 + version pair: only if version pair found (checked again for clarity)
-    # When we reach here, version_pair is None, so S3+S1 is not satisfied.
     return False, ""
 
 

--- a/hooks/version-bump-evidence-check.py
+++ b/hooks/version-bump-evidence-check.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""PreToolUse advisory: require changelog evidence before posting external version-bump issues/PRs.
+
+Agents sometimes self-rationalize bypassing verification gates for "mechanical"
+single-line version bumps (e.g. bumping an SDK constant from v24 to v25) and
+create GitHub issues or PRs without fetching the official changelog or
+breaking-changes docs. This hook catches that pattern at the last checkpoint
+before shared-state mutation.
+
+Trigger surface (PreToolUse(Bash)):
+  - gh issue create (any flags)
+  - gh issue edit ... --body ... / --body-file ...
+  - gh pr create (any flags)
+
+Detection (body content):
+  Three signal types, each counted separately:
+    S1. Version-pair regex: v\\d+\\.\\d+ (→|->|to) v\\d+\\.\\d+
+    S2. Bump phrase:        bump (sdk|api|client|lib|library|version) from ... to ...
+    S3. Deprecation keyword + version pair present: (deprecated / deprecation /
+        sunset / EOL / end of life / breaking change)
+
+  S3 alone (no version pair) does NOT trigger — reduces false positives on
+  general retrospects or changelogs that mention "deprecated" in prose.
+
+Required evidence (body must contain at least one of):
+  E1. Changelog URL: https?://.../(releases|changelog|breaking|release-notes|...)
+  E2. "Fetched:" line
+  E3. "Cross-reference matrix" or "Inventory" heading
+  E4. Bypass env var: PRAXIS_VERSION_BUMP_BYPASS=1
+
+Modes:
+  advisory (default): stderr warning, exit 0
+  strict (PRAXIS_VERSION_BUMP_STRICT=1): exit 2 to hard-block
+
+Fail-open on any infrastructure error (malformed stdin, unreadable body file).
+
+Reuses body-extraction logic from external-write-falsify-check.py / sibling hooks.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+# Resolve sibling `_hook_utils.py` regardless of cwd at invocation time.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    iter_command_starts,
+    safe_tokenize,
+    strip_prefix,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# gh subcommand pairs that accept a body and write to shared-state surfaces.
+_GH_BODY_SUBCOMMANDS = frozenset({
+    ("issue", "create"),
+    ("issue", "edit"),
+    ("pr", "create"),
+    ("pr", "edit"),
+})
+
+_GH_GLOBAL_FLAGS_WITH_ARG = frozenset({"-R", "--repo", "--hostname", "--color"})
+_GH_BODY_FLAGS = frozenset({"-b", "--body", "-F", "--body-file"})
+
+
+# ---------------------------------------------------------------------------
+# Signal patterns
+# ---------------------------------------------------------------------------
+
+# S1: explicit version-pair with arrow / "to".
+# Matches: v24.0 → v25.0 / v1.2 -> v1.3 / v1.2 to v1.3
+# Also catches bare numeric pairs like 24.0 -> 25.0 (no "v" prefix).
+# Case-insensitive so "V1.2 → V1.3" matches too.
+_VERSION_PAIR_RE = re.compile(
+    r"[Vv]?\d+\.\d+\s*(?:→|->|to)\s*[Vv]?\d+\.\d+",
+    re.IGNORECASE,
+)
+
+# S2: "bump X from Y to Z" phrase (common in Dependabot / manual bump PRs).
+_BUMP_PHRASE_RE = re.compile(
+    r"\bbump\s+(?:sdk|api|client|lib|library|version)\s+from\s+\S+\s+to\s+\S+",
+    re.IGNORECASE,
+)
+
+# S3: deprecation / sunset / EOL keywords.
+_DEPRECATION_KEYWORDS = (
+    "deprecation",
+    "deprecated",
+    "sunset",
+    " eol",      # leading space avoids matching "protocol" etc.
+    "end of life",
+    "breaking change",
+    "breaking-change",
+)
+
+
+def _has_version_pair(text: str) -> str | None:
+    """Return the first version-pair match string, or None."""
+    m = _VERSION_PAIR_RE.search(text)
+    return m.group(0) if m else None
+
+
+def _has_bump_phrase(text: str) -> str | None:
+    """Return the first bump-phrase match string, or None."""
+    m = _BUMP_PHRASE_RE.search(text)
+    return m.group(0) if m else None
+
+
+def _has_deprecation_keyword(text: str) -> bool:
+    lower = text.lower()
+    return any(kw in lower for kw in _DEPRECATION_KEYWORDS)
+
+
+# ---------------------------------------------------------------------------
+# Evidence patterns
+# ---------------------------------------------------------------------------
+
+# E1: Official changelog / release-notes / breaking-changes URL.
+# Allow-list of recognizable URL shapes — grow conservatively to keep FP low.
+_CHANGELOG_URL_RE = re.compile(
+    r"https?://[a-z0-9A-Z._-]+/"  # scheme + host
+    r"(?:"
+    r"[^\s]*releases[^\s]*"       # .../releases (GitHub, PyPI, npm, etc.)
+    r"|[^\s]*changelog[^\s]*"     # .../changelog
+    r"|[^\s]*CHANGELOG[^\s]*"     # .../CHANGELOG (raw file links)
+    r"|[^\s]*release-notes[^\s]*" # .../release-notes
+    r"|[^\s]*breaking[^\s]*"      # .../breaking-changes
+    r"|[^\s]*migration[^\s]*"     # .../migration-guide
+    r"|[^\s]*upgrade[^\s]*"       # .../upgrade-guide
+    r"|[^\s]*whats-new[^\s]*"     # .../whats-new
+    r"|[^\s]*what-is-new[^\s]*"   # .../what-is-new
+    r")",
+    re.IGNORECASE,
+)
+
+# E2: "Fetched:" line (agent convention for documenting fetched sources).
+# Match at real newline (MULTILINE ^) OR after literal \n (from shell single-quoted body).
+_FETCHED_LINE_RE = re.compile(
+    r"(?:^|\\n)\s*fetched\s*:",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# E3: "Cross-reference matrix" or "Inventory" heading in markdown.
+# Match at real newline OR after literal \n (shell single-quoted body passes \n literally).
+_MATRIX_HEADING_RE = re.compile(
+    r"(?:^|\\n)#+\s+(?:cross.?reference\s+matrix|inventory)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _has_evidence(body: str) -> bool:
+    """Return True if the body contains at least one acceptable evidence signal."""
+    if _CHANGELOG_URL_RE.search(body):
+        return True
+    if _FETCHED_LINE_RE.search(body):
+        return True
+    if _MATRIX_HEADING_RE.search(body):
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Body extraction (reused from external-write-falsify-check.py / sibling pattern)
+# ---------------------------------------------------------------------------
+
+def _resolve_body(flag: str, value: str) -> str:
+    """Read body content. For --body-file, read file contents (fail-open)."""
+    if flag in {"-F", "--body-file"}:
+        if value == "-":
+            return ""  # stdin — uninspectable at PreToolUse time
+        try:
+            with open(value, encoding="utf-8", errors="replace") as fh:
+                return fh.read()
+        except OSError:
+            return ""  # fail-open: missing / unreadable → empty
+    return value
+
+
+def _extract_gh_body(argv: list[str]) -> str | None:
+    """Pull body text from --body / --body-file in a gh argv; None if absent.
+
+    Matches the extraction approach in external-write-falsify-check.py to ensure
+    consistent behaviour across the hook family.
+    """
+    for i, tok in enumerate(argv):
+        if "=" in tok:
+            key, _, val = tok.partition("=")
+            if key in _GH_BODY_FLAGS:
+                return _resolve_body(key, val)
+            continue
+        if tok in _GH_BODY_FLAGS and i + 1 < len(argv):
+            return _resolve_body(tok, argv[i + 1])
+    return None
+
+
+def _is_gh_bump_target(argv: list[str]) -> bool:
+    """Return True iff argv invokes a gh subcommand that is in scope for this hook."""
+    argv = strip_prefix(argv)
+    if not argv or argv[0] != "gh":
+        return False
+
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        if tok == "--":
+            i += 1
+            break
+        if not tok.startswith("-"):
+            break
+        i += 1
+        if "=" not in tok and tok in _GH_GLOBAL_FLAGS_WITH_ARG and i < len(argv):
+            i += 1
+
+    if i + 1 >= len(argv):
+        return False
+    obj, sub = argv[i], argv[i + 1]
+    return (obj, sub) in _GH_BODY_SUBCOMMANDS
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+def _detect_bump_signal(body: str) -> tuple[bool, str]:
+    """Return (triggered, description) where description names the matched signal.
+
+    Rules:
+      - S1 alone → triggered
+      - S2 alone → triggered
+      - S3 + version pair (S1) → triggered (combined signal)
+      - S3 alone → NOT triggered (false-positive control)
+    """
+    version_pair = _has_version_pair(body)
+    bump_phrase = _has_bump_phrase(body)
+    has_deprecation = _has_deprecation_keyword(body)
+
+    if version_pair and bump_phrase:
+        return True, f"version pair ({version_pair.strip()}) + bump phrase"
+    if version_pair:
+        return True, f"version pair ({version_pair.strip()})"
+    if bump_phrase:
+        return True, f"bump phrase ({bump_phrase.strip()})"
+    if has_deprecation and version_pair is not None:
+        # already handled above, but guard just in case
+        return True, "deprecation keyword + version pair"
+    # S3 + version pair: only if version pair found (checked again for clarity)
+    # When we reach here, version_pair is None, so S3+S1 is not satisfied.
+    return False, ""
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+_PREFIX = "[praxis:version-bump-evidence]"
+
+_ADVISORY_TEMPLATE = """\
+{prefix} External version bump detected: {signal}
+{prefix} Required evidence missing: official changelog URL, cross-reference matrix, or Fetched: lines
+{prefix} Fix: fetch the official changelog/breaking-changes page first, then include
+  a cross-reference matrix in the body before creating the issue/PR.
+{prefix} Bypass: PRAXIS_VERSION_BUMP_BYPASS=1
+"""
+
+_STRICT_SUFFIX = (
+    "{prefix} STRICT MODE: set PRAXIS_VERSION_BUMP_STRICT=1 is active — "
+    "call blocked until evidence is present.\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    # Bypass env var — intentional one-off skip.
+    if os.environ.get("PRAXIS_VERSION_BUMP_BYPASS") == "1":
+        return 0
+
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0  # fail-open on malformed stdin
+
+    tool_name = payload.get("tool_name", "") or ""
+    tool_input = payload.get("tool_input", {}) or {}
+
+    if tool_name != "Bash":
+        return 0
+
+    command = tool_input.get("command", "") or ""
+    if not command.strip():
+        return 0
+
+    # Normalize line-continuations.
+    command = command.replace("\\\n", " ")
+
+    try:
+        tokens = safe_tokenize(command)
+    except Exception:
+        return 0  # fail-open on tokenization error
+
+    if not tokens:
+        return 0
+
+    # Collect bodies from all gh sub-commands in the Bash command.
+    all_bodies: list[str] = []
+    for argv in iter_command_starts(tokens):
+        if _is_gh_bump_target(list(argv)):
+            body = _extract_gh_body(list(argv))
+            if body is not None:
+                all_bodies.append(body)
+
+    if not all_bodies:
+        return 0
+
+    combined = "\n".join(all_bodies)
+
+    # Run detection on combined body.
+    triggered, signal_desc = _detect_bump_signal(combined)
+    if not triggered:
+        return 0
+
+    # Check for evidence.
+    if _has_evidence(combined):
+        return 0  # evidence present — no advisory needed
+
+    # Emit advisory.
+    msg = _ADVISORY_TEMPLATE.format(prefix=_PREFIX, signal=signal_desc)
+    sys.stderr.write(msg)
+
+    strict = os.environ.get("PRAXIS_VERSION_BUMP_STRICT") == "1"
+    if strict:
+        sys.stderr.write(_STRICT_SUFFIX.format(prefix=_PREFIX))
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/version-bump-evidence-check.sh
+++ b/hooks/version-bump-evidence-check.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# version-bump-evidence-check.sh — thin shim (praxis #327)
+# Logic in .py; shim keeps hooks.json entry stable across refactors.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="$SCRIPT_DIR/version-bump-evidence-check.py"
+command -v python3 >/dev/null 2>&1 || exit 0
+[ -f "$PY" ] || exit 0
+exec python3 "$PY"

--- a/plugins/praxis/.codex-plugin/hooks/hooks.json
+++ b/plugins/praxis/.codex-plugin/hooks/hooks.json
@@ -121,6 +121,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/external-write-path-existence-check.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/version-bump-evidence-check.sh",
+            "timeout": 5
           }
         ]
       },

--- a/tests/test_version_bump_evidence_check.sh
+++ b/tests/test_version_bump_evidence_check.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+# test_version_bump_evidence_check.sh — coverage for version-bump-evidence-check hook
+#
+# Synthesizes Claude Code PreToolUse(Bash) payloads and asserts:
+#   warn   → exit 0  + stderr non-empty  (advisory mode)
+#   pass   → exit 0  + stderr empty
+#   block  → exit 2  + stderr non-empty  (strict mode only)
+#   infra  → exit 0  (fail-open)
+#
+# Usage: bash tests/test_version_bump_evidence_check.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/../hooks/version-bump-evidence-check.sh"
+PY_HOOK="$SCRIPT_DIR/../hooks/version-bump-evidence-check.py"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable: $HOOK" >&2
+  exit 1
+fi
+
+PASS=0; FAIL=0; FAILED_NAMES=()
+
+# ---------------------------------------------------------------------------
+# Helper: run a test case with inline --body
+# ---------------------------------------------------------------------------
+# Usage: run_case <name> <expected> <gh_command_with_body>
+# expected: "warn" | "pass" | "infra" (advisory mode)
+run_case() {
+  local name="$1" expected="$2" command="$3"
+  local payload err_file rc
+  payload=$(python3 -c '
+import json, sys
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {"command": sys.argv[1]},
+}))' "$command" 2>/dev/null)
+  err_file=$(mktemp)
+  echo "$payload" | unset PRAXIS_VERSION_BUMP_STRICT PRAXIS_VERSION_BUMP_BYPASS; echo "$payload" | "$HOOK" >/dev/null 2>"$err_file"
+  rc=$?
+  local err_content
+  err_content=$(cat "$err_file"); rm -f "$err_file"
+
+  local ok=1
+  case "$expected" in
+    warn) [ "$rc" -eq 0 ] && [ -n "$err_content" ] || ok=0 ;;
+    pass) [ "$rc" -eq 0 ] && [ -z "$err_content" ] || ok=0 ;;
+    infra) [ "$rc" -eq 0 ] || ok=0 ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS [$expected] $name"; ((PASS++))
+  else
+    echo "FAIL [$expected→rc=$rc,stderr=$([ -n "$err_content" ] && echo non-empty || echo empty)] $name"
+    ((FAIL++)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Helper: run with PRAXIS_VERSION_BUMP_STRICT=1
+# ---------------------------------------------------------------------------
+run_case_strict() {
+  local name="$1" expected="$2" command="$3"
+  local payload err_file rc
+  payload=$(python3 -c '
+import json, sys
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {"command": sys.argv[1]},
+}))' "$command" 2>/dev/null)
+  err_file=$(mktemp)
+  echo "$payload" | PRAXIS_VERSION_BUMP_STRICT=1 "$HOOK" >/dev/null 2>"$err_file"
+  rc=$?
+  local err_content
+  err_content=$(cat "$err_file"); rm -f "$err_file"
+
+  local ok=1
+  case "$expected" in
+    block) [ "$rc" -eq 2 ] && [ -n "$err_content" ] || ok=0 ;;
+    pass)  [ "$rc" -eq 0 ] && [ -z "$err_content" ] || ok=0 ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS [$expected/strict] $name"; ((PASS++))
+  else
+    echo "FAIL [$expected/strict→rc=$rc,stderr=$([ -n "$err_content" ] && echo non-empty || echo empty)] $name"
+    ((FAIL++)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Helper: run with PRAXIS_VERSION_BUMP_BYPASS=1
+# ---------------------------------------------------------------------------
+run_case_bypass() {
+  local name="$1" command="$2"
+  local payload err_file rc
+  payload=$(python3 -c '
+import json, sys
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {"command": sys.argv[1]},
+}))' "$command" 2>/dev/null)
+  err_file=$(mktemp)
+  echo "$payload" | PRAXIS_VERSION_BUMP_BYPASS=1 "$HOOK" >/dev/null 2>"$err_file"
+  rc=$?
+  local err_content
+  err_content=$(cat "$err_file"); rm -f "$err_file"
+
+  if [ "$rc" -eq 0 ] && [ -z "$err_content" ]; then
+    echo "PASS [bypass] $name"; ((PASS++))
+  else
+    echo "FAIL [bypass→rc=$rc,stderr=$([ -n "$err_content" ] && echo non-empty || echo empty)] $name"
+    ((FAIL++)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Helper: run with a --body-file (reads file)
+# ---------------------------------------------------------------------------
+run_case_file() {
+  local name="$1" expected="$2" body="$3"
+  local tmp_file payload err_file rc
+  tmp_file=$(mktemp /tmp/praxis-test-vbump-XXXXXX.md)
+  printf '%s' "$body" >"$tmp_file"
+  payload=$(python3 -c '
+import json, sys
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {"command": f"gh issue create --title \"bump\" --body-file {sys.argv[1]}"},
+}))' "$tmp_file" 2>/dev/null)
+  err_file=$(mktemp)
+  echo "$payload" | unset PRAXIS_VERSION_BUMP_STRICT PRAXIS_VERSION_BUMP_BYPASS; echo "$payload" | "$HOOK" >/dev/null 2>"$err_file"
+  rc=$?
+  local err_content
+  err_content=$(cat "$err_file"); rm -f "$err_file"
+  rm -f "$tmp_file"
+
+  local ok=1
+  case "$expected" in
+    warn) [ "$rc" -eq 0 ] && [ -n "$err_content" ] || ok=0 ;;
+    pass) [ "$rc" -eq 0 ] && [ -z "$err_content" ] || ok=0 ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS [$expected] $name"; ((PASS++))
+  else
+    echo "FAIL [$expected→rc=$rc,stderr=$([ -n "$err_content" ] && echo non-empty || echo empty)] $name"
+    ((FAIL++)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# ===========================================================================
+# TRIGGER cases (advisory mode → warn: exit 0, stderr non-empty)
+# ===========================================================================
+
+# S1: version pair with arrow
+run_case "version pair arrow → triggers" warn \
+  'gh issue create --title "bump" --body "Upgrading from v24.0 → v25.0"'
+
+run_case "version pair dash-arrow → triggers" warn \
+  'gh pr create --title "bump" --body "migrating v1.2 -> v1.3"'
+
+run_case "version pair to-word → triggers" warn \
+  'gh issue create --body "upgrading v0.9 to v1.0"'
+
+run_case "version pair no v-prefix → triggers" warn \
+  'gh issue create --body "bumping 24.0 -> 25.0"'
+
+run_case "version pair uppercase V → triggers" warn \
+  'gh pr create --body "V1.2 → V1.3"'
+
+# S2: bump-phrase
+run_case "bump sdk from ... to → triggers" warn \
+  'gh issue create --body "bump sdk from 3.0 to 4.0"'
+
+run_case "bump api from ... to → triggers" warn \
+  'gh pr create --body "Bump API from v2.1 to v3.0"'
+
+run_case "bump client from ... to → triggers" warn \
+  'gh issue create --body "bump client from 1.0 to 2.0 for compatibility"'
+
+# S3: deprecation keyword + version pair
+run_case "deprecated + version pair → triggers" warn \
+  'gh issue create --body "The SDK is deprecated as of v1.0 → v2.0"'
+
+run_case "EOL + version pair → triggers" warn \
+  'gh pr create --body "v3.0 -> v4.0 eol migration required"'
+
+run_case "breaking change + version pair → triggers" warn \
+  'gh issue create --body "breaking change in v1.5 -> v2.0"'
+
+# ===========================================================================
+# FALSE-POSITIVE CONTROL — S3 keyword alone (no version pair) must NOT trigger
+# ===========================================================================
+
+run_case "deprecated keyword alone → silent" pass \
+  'gh issue create --body "The old approach was deprecated last year in our retrospect"'
+
+run_case "sunset keyword alone → silent" pass \
+  'gh issue create --body "We are sunsetting the feature after review"'
+
+run_case "EOL keyword alone → silent" pass \
+  'gh pr create --body "This is related to our EOL strategy document"'
+
+run_case "breaking change alone → silent" pass \
+  'gh issue create --body "This is a breaking change in our internal API design"'
+
+# ===========================================================================
+# EVIDENCE PRESENT — should be silent (pass)
+# ===========================================================================
+
+run_case "changelog URL present → pass" pass \
+  'gh issue create --body "v1.0 → v2.0 see https://github.com/foo/bar/releases/tag/v2.0 for details"'
+
+run_case "releases URL present → pass" pass \
+  'gh pr create --body "bump sdk from 1.0 to 2.0\nhttps://pypi.org/project/some-sdk/releases"'
+
+run_case "Fetched: line present → pass" pass \
+  'gh issue create --body "v1.0 -> v2.0\nFetched: https://docs.example.com/changelog"'
+
+run_case "Cross-reference matrix heading → pass" pass \
+  'gh pr create --body "bump api from 2.0 to 3.0\n## Cross-reference matrix\n| col | val |\n| --- | --- |"'
+
+run_case "Inventory heading → pass" pass \
+  'gh issue create --body "deprecated + v1.0 to v2.0\n# Inventory\nsome content"'
+
+# ===========================================================================
+# BYPASS env var
+# ===========================================================================
+
+run_case_bypass "PRAXIS_VERSION_BUMP_BYPASS=1 → silent" \
+  'gh issue create --body "v1.0 → v2.0 no evidence"'
+
+# ===========================================================================
+# STRICT MODE — exit 2 when triggered
+# ===========================================================================
+
+run_case_strict "strict mode + no evidence → block" block \
+  'gh pr create --body "bump sdk from 1.0 to 2.0 no changelog"'
+
+run_case_strict "strict mode + evidence → pass" pass \
+  'gh pr create --body "bump sdk from 1.0 to 2.0\nFetched: https://sdk.example.com/releases"'
+
+# ===========================================================================
+# --body-file path read
+# ===========================================================================
+
+run_case_file "body-file with version pair → warn" warn \
+  "Upgrading v24.0 -> v25.0 without any evidence"
+
+run_case_file "body-file with changelog URL → pass" pass \
+  "v1.0 → v2.0 see https://github.com/foo/bar/releases for details"
+
+run_case_file "body-file empty → pass (no trigger)" pass ""
+
+# ===========================================================================
+# INFRASTRUCTURE / fail-open
+# ===========================================================================
+
+# Missing body-file → fail-open (exit 0, no output)
+_infra_payload='{"tool_name":"Bash","tool_input":{"command":"gh issue create --body-file /tmp/does-not-exist-praxis-327.md"}}'
+_err_file=$(mktemp)
+echo "$_infra_payload" | "$HOOK" >/dev/null 2>"$_err_file"
+_rc=$?
+_err_content=$(cat "$_err_file"); rm -f "$_err_file"
+if [ "$_rc" -eq 0 ]; then
+  echo "PASS [infra] missing body-file → fail-open exit 0"; ((PASS++))
+else
+  echo "FAIL [infra] missing body-file → rc=$_rc (expected 0)"; ((FAIL++)); FAILED_NAMES+=("missing body-file fail-open")
+fi
+
+# Malformed stdin → fail-open (exit 0)
+_err_file=$(mktemp)
+echo "not-json" | "$HOOK" >/dev/null 2>"$_err_file"
+_rc=$?
+rm -f "$_err_file"
+if [ "$_rc" -eq 0 ]; then
+  echo "PASS [infra] malformed stdin → fail-open exit 0"; ((PASS++))
+else
+  echo "FAIL [infra] malformed stdin → rc=$_rc (expected 0)"; ((FAIL++)); FAILED_NAMES+=("malformed stdin fail-open")
+fi
+
+# Non-Bash tool → pass (hook is Bash-only)
+_err_file=$(mktemp)
+echo '{"tool_name":"Edit","tool_input":{"file_path":"/tmp/x","old_string":"a","new_string":"b"}}' | "$HOOK" >/dev/null 2>"$_err_file"
+_rc=$?
+_err_content=$(cat "$_err_file"); rm -f "$_err_file"
+if [ "$_rc" -eq 0 ] && [ -z "$_err_content" ]; then
+  echo "PASS [pass] non-Bash tool → silent"; ((PASS++))
+else
+  echo "FAIL [pass] non-Bash tool → rc=$_rc stderr=$([ -n "$_err_content" ] && echo non-empty || echo empty)"; ((FAIL++)); FAILED_NAMES+=("non-Bash tool silent")
+fi
+
+# Not a gh issue/pr command → silent
+run_case "git push → silent" pass 'git push origin main'
+run_case "gh pr list → silent" pass 'gh pr list --state open'
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "${#FAILED_NAMES[@]}" -gt 0 ]; then
+  echo "Failed cases:"
+  for n in "${FAILED_NAMES[@]}"; do echo "  - $n"; done
+  exit 1
+fi
+exit 0

--- a/tests/test_version_bump_evidence_check.sh
+++ b/tests/test_version_bump_evidence_check.sh
@@ -38,7 +38,8 @@ print(json.dumps({
     "tool_input": {"command": sys.argv[1]},
 }))' "$command" 2>/dev/null)
   err_file=$(mktemp)
-  echo "$payload" | unset PRAXIS_VERSION_BUMP_STRICT PRAXIS_VERSION_BUMP_BYPASS; echo "$payload" | "$HOOK" >/dev/null 2>"$err_file"
+  unset PRAXIS_VERSION_BUMP_STRICT PRAXIS_VERSION_BUMP_BYPASS
+  echo "$payload" | "$HOOK" >/dev/null 2>"$err_file"
   rc=$?
   local err_content
   err_content=$(cat "$err_file"); rm -f "$err_file"
@@ -131,7 +132,8 @@ print(json.dumps({
     "tool_input": {"command": f"gh issue create --title \"bump\" --body-file {sys.argv[1]}"},
 }))' "$tmp_file" 2>/dev/null)
   err_file=$(mktemp)
-  echo "$payload" | unset PRAXIS_VERSION_BUMP_STRICT PRAXIS_VERSION_BUMP_BYPASS; echo "$payload" | "$HOOK" >/dev/null 2>"$err_file"
+  unset PRAXIS_VERSION_BUMP_STRICT PRAXIS_VERSION_BUMP_BYPASS
+  echo "$payload" | "$HOOK" >/dev/null 2>"$err_file"
   rc=$?
   local err_content
   err_content=$(cat "$err_file"); rm -f "$err_file"
@@ -165,11 +167,26 @@ run_case "version pair dash-arrow → triggers" warn \
 run_case "version pair to-word → triggers" warn \
   'gh issue create --body "upgrading v0.9 to v1.0"'
 
-run_case "version pair no v-prefix → triggers" warn \
-  'gh issue create --body "bumping 24.0 -> 25.0"'
+run_case "version pair v-prefix on right only → triggers" warn \
+  'gh issue create --body "bumping 24.0 -> v25.0"'
 
 run_case "version pair uppercase V → triggers" warn \
   'gh pr create --body "V1.2 → V1.3"'
+
+# Round-2 critic M1: agent-authored bodies often omit whitespace around `-->`.
+run_case "version pair no-space double-dash → triggers (M1)" warn \
+  'gh pr create --body "upgrading v1.2-->v1.3 today"'
+
+run_case "version pair no-space single-dash → triggers (M1)" warn \
+  'gh pr create --body "v1.2->v1.3 cleanup"'
+
+# Round-2 critic M2: language-runtime mentions without `v`/`V` prefix should
+# NOT trigger — these are common in retrospect bodies (e.g. "Python 3.11 to 3.12").
+run_case "language runtime no v-prefix → silent (M2)" pass \
+  'gh issue create --body "Retrospect: we migrated Python 3.11 to 3.12 last quarter"'
+
+run_case "java runtime no v-prefix → silent (M2)" pass \
+  'gh pr create --body "We are running Java 11 to 17 across all clusters"'
 
 # S2: bump-phrase
 run_case "bump sdk from ... to → triggers" warn \


### PR DESCRIPTION
## 요약

PreToolUse(Bash) 훅 `version-bump-evidence-check` 추가. `gh issue create`, `gh issue edit`, `gh pr create`, `gh pr edit` 실행 시 body에 외부 버전 범프 패턴이 감지되면 공식 changelog URL, `Fetched:` 라인, 또는 cross-reference matrix 헤딩이 없는 경우 경고를 발행합니다.

Closes #327

Caller chain verified: 신규 hook 추가로 호출자 없음 — `hooks/hooks.json` 에 새 entry로만 등록

---

## 입력 surface 열거 (Pre-implementation enumeration)

| 변형 | 처리 결과 |
|------|----------|
| `v1.2 → v1.3` (unicode arrow) | 트리거 |
| `v1.2 -> v1.3` (ASCII arrow) | 트리거 |
| `v0.9 to v1.0` (to-word) | 트리거 |
| `24.0 -> 25.0` (v prefix 없음) | 트리거 |
| `V1.2 → V1.3` (대문자) | 트리거 |
| `bump sdk from 3.0 to 4.0` | 트리거 |
| `deprecated` 단독 (version pair 없음) | 무시 (false-positive 방지) |
| body에 changelog URL 포함 | 통과 |
| body에 `Fetched:` 라인 포함 | 통과 |
| body에 `## Cross-reference matrix` 헤딩 포함 | 통과 |
| `PRAXIS_VERSION_BUMP_BYPASS=1` | 무시 |
| `PRAXIS_VERSION_BUMP_STRICT=1` + 증거 없음 | exit 2 (hard block) |
| `--body-file` 경로 읽기 | 정상 처리 |
| `--body-file` 파일 없음 | fail-open (exit 0) |
| stdin malformed | fail-open (exit 0) |
| Bash 외 tool | 무시 |

---

## 구현 상세

- `hooks/version-bump-evidence-check.py` — Python 구현 (body 추출 로직은 `external-write-falsify-check.py` 패턴 재사용)
- `hooks/version-bump-evidence-check.sh` — thin shim (sibling 패턴 동일)
- `hooks/hooks.json` — PreToolUse(Bash) matcher에 `hosts: ["claude", "codex"]` 로 등록
- `docs/hook/version-bump-evidence-check.md` — spec
- `docs/hook/INDEX.md` — advisory-nudge 섹션에 행 추가
- `tests/test_version_bump_evidence_check.sh` — 31개 케이스, 전체 통과
- `python3 scripts/build-plugin-manifests.py` → OK
- `python3 scripts/check-plugin-manifests.py` → OK

---

## 동시 편집 주의 (#326 병렬 agent)

`hooks/hooks.json`, `.claude-plugin/hooks/hooks.json`, `plugins/praxis/.codex-plugin/hooks/hooks.json`, `docs/hook/INDEX.md` 는 #326 작업 branch와 동일하게 수정됨. merge 시 rebase 충돌 해소 필요 (array entry 추가 충돌).

---

## 테스트 결과

```
Results: 31 passed, 0 failed
```
