### PR TITLE
docs: disambiguate CLAUDE.md refs in docs/hook, skills

### DIFF
--- a/docs/hook/advisory-wrapper-signature-verify.md
+++ b/docs/hook/advisory-wrapper-signature-verify.md
@@ -25,7 +25,7 @@ Documented occurrences:
    return types).
 
 Root cause: no enforcement gate fires before writing wrapper code to prompt
-reading the wrapped function signatures first. Memory entries and CLAUDE.md
+reading the wrapped function signatures first. Memory entries and global `~/.claude/CLAUDE.md`
 rules exist for this pattern but are not retrieved at execution time.
 
 Reference: issue [#235](https://github.com/devseunggwan/praxis/issues/235).

--- a/docs/hook/block-ask-end-option.md
+++ b/docs/hook/block-ask-end-option.md
@@ -23,7 +23,7 @@ Indirect phrasing ("take a break / prioritize other work", "pause for now",
 the option-label level. This hook detects both pattern classes so that the
 spirit of the rule survives phrasing variation.
 
-Text rules in CLAUDE.md or skill bodies alone cannot enforce this — the
+Text rules in global `~/.claude/CLAUDE.md` or skill bodies alone cannot enforce this — the
 `loaded != retrieved` limit. This hook enforces the rule at the tool
 boundary, where the check runs mechanically regardless of retrieval state.
 

--- a/docs/hook/block-manufactured-action-menu.md
+++ b/docs/hook/block-manufactured-action-menu.md
@@ -98,7 +98,7 @@ Legitimate cases that survive the hook even with a command signal:
 When ANY option label contains a destructive / irreversible action token,
 the hook passes regardless of mode. The user's prior generic command does
 not absorb per-action approval for shared-state mutations — surfacing a
-confirmation menu is required by the project CLAUDE.md
+confirmation menu is required by the global `~/.claude/CLAUDE.md`
 "Pre-Merge Reporting" + "Executing actions with care" rules.
 
 Detected destructive tokens in option labels:

--- a/docs/hook/commit-title-length-check.md
+++ b/docs/hook/commit-title-length-check.md
@@ -5,7 +5,7 @@ Supported hosts: all
 `hooks/commit-title-length-check.py` intercepts every AI-authored `git commit`
 Bash call and emits `permissionDecision: "ask"` when the first line of the
 commit message exceeds the configured maximum (default 50, matching the global
-CLAUDE.md "Git Commit & Title Rules — Title: max 50 characters" rule).
+global `~/.claude/CLAUDE.md` "Git Commit & Title Rules — Title: max 50 characters" rule).
 
 ### Why a PreToolUse hook instead of a git commit-msg hook
 

--- a/docs/hook/completion-verify.md
+++ b/docs/hook/completion-verify.md
@@ -62,7 +62,7 @@ The hook exits 0 (passes) when any of:
 
 Cross-turn carry-over (verifying in turn N, claiming in turn N+1) is the
 exact pattern this hook is designed to prevent — it lets stale evidence
-silently age out. Strict same-turn enforcement matches the global CLAUDE.md
+silently age out. Strict same-turn enforcement matches the global `~/.claude/CLAUDE.md`
 "Verification Before Completion" rule that requires verification commands in
 the *immediately preceding* turn.
 

--- a/docs/hook/count-assertion-verify.md
+++ b/docs/hook/count-assertion-verify.md
@@ -21,7 +21,7 @@ verifying each arm individually.
   to 28 — the `\|^run_test` arm introduced one extra match. Rerunning with
   `grep -c '^run_case '` confirmed 28.
 
-CLAUDE.md "Information Accuracy → Layer 2" already requires:
+Global `~/.claude/CLAUDE.md` "Information Accuracy → Layer 2" already requires:
 
 > **Data-driven claims** → show the query/command output first. Verify test
 > inputs actually reproduce the intended case before accepting results.

--- a/docs/hook/external-api-literal-trigger.md
+++ b/docs/hook/external-api-literal-trigger.md
@@ -10,7 +10,7 @@ source before proceeding.
 
 ### Why this exists
 
-The global CLAUDE.md rule `Loaded ≠ Retrieved` instructs:
+The global `~/.claude/CLAUDE.md` rule `Loaded ≠ Retrieved` instructs:
 > Before using an external API enum / literal / catalog name / configuration
 > constant, retrieve a verified source (vendor docs, `SHOW CATALOGS`,
 > `--help` output) — never write a value that "looks right" based on naming

--- a/docs/hook/external-write-falsify-check.md
+++ b/docs/hook/external-write-falsify-check.md
@@ -5,7 +5,7 @@ Supported hosts: all
 `hooks/external-write-falsify-check.py` is an **opt-in** PreToolUse advisory
 that warns before posting hypothesis-stage text to external surfaces (PR
 comments, issue bodies, Slack messages, Notion pages). It enforces the
-global CLAUDE.md rule `External-Surface Write Requires Falsification`
+global `~/.claude/CLAUDE.md` rule `External-Surface Write Requires Falsification`
 (retraction-cost / downstream-reader-training framing).
 
 ### Why this exists — and why opt-in
@@ -99,7 +99,7 @@ Restart Claude Code after adding the entry.
 The marker check is purely lexical. It cannot tell internal-team-DM
 Slack from a customer-facing channel, nor can it tell a verified-fact
 "could break" (an evidenced consequence) from a hypothesis "could break"
-(an unverified guess). The CLAUDE.md rule's `Applies to` / `Does NOT
+(an unverified guess). The global `~/.claude/CLAUDE.md` rule's `Applies to` / `Does NOT
 apply to` carveouts are NOT replicable in marker detection — the user
 remains responsible for interpreting the reminder in context.
 
@@ -200,7 +200,7 @@ A third advisory fires when:
 2. **Transcript signal**: cluster-approval language appears in any of the
    last 5 user messages in the transcript.
 
-This catches the CLAUDE.md `No Approval Transfer Across Companion PRs`
+This catches the global `~/.claude/CLAUDE.md` `No Approval Transfer Across Companion PRs`
 violation pattern: a user approves multiple tasks in bulk ("all 4 together",
 "1+3 같이"), and the agent begins writing per-child staging files without
 per-action AskUserQuestion surfacing.

--- a/docs/hook/output-block-falsify-advisory.md
+++ b/docs/hook/output-block-falsify-advisory.md
@@ -9,7 +9,7 @@ check and either asks for confirmation or emits an advisory reminder.
 
 ### Why this exists
 
-The global CLAUDE.md rule **"Output-Block-Level Falsification Gate"** instructs:
+The global `~/.claude/CLAUDE.md` rule **"Output-Block-Level Falsification Gate"** instructs:
 
 > Before surfacing a self-authored proposal as a complete output block, run
 > an explicit falsification test on its premise. If a concrete invalidating
@@ -83,7 +83,7 @@ matched; read-only commands (`git log --all`, `gh pr list`) do not fire.
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "permissionDecision": "ask",
-    "permissionDecisionReason": "(Recommended) 라벨이 있으나 question body 에 'Falsified: <disconfirming test 결과>' 가 없음. CLAUDE.md Self-Falsify Before Recommendation Lock 룰. 추가 후 재시도."
+    "permissionDecisionReason": "(Recommended) 라벨이 있으나 question body 에 'Falsified: <disconfirming test 결과>' 가 없음. global `~/.claude/CLAUDE.md` Self-Falsify Before Recommendation Lock 룰. 추가 후 재시도."
   }
 }
 ```

--- a/docs/hook/pre-edit-protected-branch-guard.md
+++ b/docs/hook/pre-edit-protected-branch-guard.md
@@ -14,7 +14,7 @@ paths on protected branches:
 
 ### Why this exists
 
-The global `CLAUDE.md` rule "Issue-Driven Worktree Workflow (MANDATORY)"
+The global `~/.claude/CLAUDE.md` rule "Issue-Driven Worktree Workflow (MANDATORY)"
 requires every code change to live in a dedicated issue + branch + worktree.
 Existing hooks (e.g. `block-pr-without-caller-evidence`) catch violations at
 PR creation time — but the window between "first file edit" and "PR creation"

--- a/docs/hook/pre-merge-approval-gate.md
+++ b/docs/hook/pre-merge-approval-gate.md
@@ -19,7 +19,7 @@ that mistakenly apply the same exemption. This hook removes the exemption
 ambiguity by making the environment variable (`CMUX_DELEGATE=1`) the sole
 signal for the background-agent path.
 
-The per-PR approval rule is already codified in the global `CLAUDE.md` (`No
+The per-PR approval rule is already codified in the global `~/.claude/CLAUDE.md` (`No
 Approval Transfer Across Companion PRs` and `Pre-Merge Reporting`). This hook
 adds structural enforcement so the rule fires even when memory-based feedback
 is not retrieved.

--- a/docs/hook/strike-counter.md
+++ b/docs/hook/strike-counter.md
@@ -21,10 +21,10 @@ slash commands (via skills/{strike,strikes,reset-strikes})
 
 ### Why this exists
 
-CLAUDE.md rule violations are the load-bearing signal that the agent has
+Global `~/.claude/CLAUDE.md` rule violations are the load-bearing signal that the agent has
 drifted off-spec. Counting them per session — with escalating
 consequences — converts a soft norm into a structural pressure: at 1 the
-agent receives a warning, at 2 a forced re-read of the relevant CLAUDE.md
+agent receives a warning, at 2 a forced re-read of the relevant global `~/.claude/CLAUDE.md`
 section, at 3 the Stop hook hard-blocks the response until the operator
 reviews and resets the counter. The reset is itself gated by a reflection
 file at count=3 so the trust restoration is a deliberate two-step act,
@@ -35,7 +35,7 @@ not a free retry.
 | Mode | Trigger | Behavior |
 |------|---------|----------|
 | `session-start` | SessionStart hook | Reads `session_id` from stdin JSON. Writes `CLAUDE_SESSION_ID=<sid>` to `$CLAUDE_ENV_FILE` (primary) and `<STATE_DIR>/.current-session` latch (backstop). If a prior strike count > 0 exists for this session, emits `additionalContext` so Claude sees the carried state. |
-| `preprompt` | UserPromptSubmit hook | Loads count. At count=1 emits a strike-1 warning context; at count=2 emits a strike-2 review-required context with cumulative reason list and forced CLAUDE.md re-read directive; at count≥3 stays silent (Stop hook handles the block). |
+| `preprompt` | UserPromptSubmit hook | Loads count. At count=1 emits a strike-1 warning context; at count=2 emits a strike-2 review-required context with cumulative reason list and forced global `~/.claude/CLAUDE.md` re-read directive; at count≥3 stays silent (Stop hook handles the block). |
 | `stop` | Stop hook | Honors `stop_hook_active=true` to avoid infinite loop. If count≥3, appends to `<STATE_DIR>/last-block.log` and emits `{"decision":"block","reason":"…"}` with the reflection requirement. |
 | `strike <reason>` | `/praxis:strike` skill | Increments count, appends reason, prints level-appropriate message (warning / review-required / blocked). Detects unexpected count values (0, non-numeric) as state corruption and surfaces a recovery message rather than mis-announcing the level. |
 | `status` | `/praxis:strikes` skill | Prints `Strikes: N/3` and the cumulative reason list. |

--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -37,7 +37,7 @@ description: Delegate a task to an independent Claude Code session in a new cmux
 | Argument | Default | Description |
 |----------|---------|-------------|
 | `<task>` | (required) | 위임할 작업 설명 |
-| `--model` | `sonnet` | Provider:model notation. `opus`/`sonnet`/`haiku` = claude. Also supports `claude`, `claude:opus`, `codex`, `codex:o3`, `gemini`, `gemini:flash`. See CLAUDE.md Provider Routing. |
+| `--model` | `sonnet` | Provider:model notation. `opus`/`sonnet`/`haiku` = claude. Also supports `claude`, `claude:opus`, `codex`, `codex:o3`, `gemini`, `gemini:flash`. See project `ARCHITECTURE.md` Provider Routing. |
 | `--cwd` | current dir | 새 세션의 작업 디렉토리 |
 | `--max-budget-usd` | (none) | 최대 예산 한도 |
 | `--account` | (기본 계정) | Claude 계정 프로필 (예: `claude-2` → `CLAUDE_CONFIG_DIR=~/.claude-2`) |
@@ -64,7 +64,7 @@ task = args.task (remaining text after flags)
 short_task = task[:30], sanitized to [a-zA-Z0-9가-힣 -] only (for cmux workspace name)
 timestamp = epoch seconds + PID (e.g., 1744163800-12345) to avoid collision
 
-# Provider resolution (from CLAUDE.md Provider Resolution Logic)
+# Provider resolution (from project ARCHITECTURE.md Provider Resolution Logic)
 if model matches /^(codex|gemini)(?::(.+))?$/:
   provider = match[1]           # "codex" or "gemini"
   sub_model = match[2] || ""    # "" or "o3" or "flash" (colon stripped)
@@ -191,7 +191,7 @@ Report results in Korean.
 1. 프롬프트를 섹션별로 분리 → 각각 개별 .md 파일 생성
 2. Context 섹션은 모든 분할 파일에 공통 포함
 3. 각 파일에 대해 개별 래퍼 .sh 생성
-4. Routing: If `--model` is explicit, apply uniformly. Otherwise, auto-assign by task type (see CLAUDE.md Task-Type Routing):
+4. Routing: If `--model` is explicit, apply uniformly. Otherwise, auto-assign by task type (see project `ARCHITECTURE.md` Task-Type Routing):
    - Code implementation/fix → `codex` (if CLI available) or `claude:sonnet`
    - Search/analysis/large context → `gemini` (if CLI available) or `claude:sonnet`
    - Design/security/review → `claude:opus`
@@ -209,7 +209,7 @@ SCRIPT_FILE="/tmp/cmux-delegate-{timestamp}.sh"
 # Cleanup: .sh만 삭제. .md는 보존 (다른 워크스페이스가 참조할 수 있음)
 trap 'rm -f "$SCRIPT_FILE"' EXIT
 
-# Provider-specific invocation (from CLAUDE.md Provider CLI Spec)
+# Provider-specific invocation (from project ARCHITECTURE.md Provider CLI Spec)
 case "{provider}" in
   claude)
     cat "$PROMPT_FILE" | {claude_env} claude \

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -268,7 +268,7 @@ verification SQL `SELECT col_a FROM t WHERE join_key = ?` assumes
 `join_key` exists; run `DESCRIBE t` once before running the SELECT.
 Do not recurse further (don't verify that DESCRIBE itself works) —
 once is enough. Premise-falsification before public claim — see
-global CLAUDE.md "External-Surface Write Requires Falsification".
+global `~/.claude/CLAUDE.md` "External-Surface Write Requires Falsification".
 
 #### 5c. Flip detection — halt A→B→A oscillation
 

--- a/skills/reset-strikes/SKILL.md
+++ b/skills/reset-strikes/SKILL.md
@@ -19,7 +19,7 @@ Clear the session strike counter so the discipline signals restart from 0.
 
 When the session is blocked at 3/3, reset is **conditional on a written reflection + an explicit user trust decision**.
 
-The strike/stop-hook output names an exact file path (`$STATE_DIR/${SID}.reflection.md`) and the required content structure (violations summary, root cause per violation mapped to a CLAUDE.md rule/section, preventive checklist). Recovery is a two-step process:
+The strike/stop-hook output names an exact file path (`$STATE_DIR/${SID}.reflection.md`) and the required content structure (violations summary, root cause per violation mapped to a global `~/.claude/CLAUDE.md` rule/section, preventive checklist). Recovery is a two-step process:
 
 1. **Reflection file** — written by Claude, gates the file check. If missing or empty when reset is called, the script prints `❌ Reset refused — reflection missing or empty.` and re-states the path and required contents. The counter is not cleared.
 2. **Persuasion turn** — before the user invokes this skill, Claude must present the reflection in-chat (quote or summarize, do not just point at the path), acknowledge each violation's harm, state concrete behavioral commitments, and explicitly ask the user to run `/praxis:reset-strikes`. This is a trust decision, not a mechanical unlock — the user may decline and require more.

--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: retrospect
 description: >
-  Session retrospect — analyze current Claude Code session against CLAUDE.md rules,
+  Session retrospect — analyze current Claude Code session against global `~/.claude/CLAUDE.md` rules,
   identify friction patterns and root causes, propose context-appropriate improvement
   actions, then execute after user approval.
   Triggers on "retrospect", "what went wrong", "session review",
@@ -46,7 +46,7 @@ Use at the END of a working session to extract learnings:
 **Use this ESPECIALLY when:**
 - The same mistake happened more than once in the session
 - You feel "I should have done that differently"
-- A rule in CLAUDE.md was violated — even once
+- A rule in global `~/.claude/CLAUDE.md` was violated — even once
 - A new workflow pattern emerged that isn't captured anywhere
 
 ## The Four Stages
@@ -57,9 +57,9 @@ You MUST complete each stage before proceeding to the next.
 
 **Before scanning the conversation:**
 
-1. **Read CLAUDE.md** — load all rules, behavioral guidelines, and workflow requirements
-   - Global: `$CLAUDE_CONFIG_DIR/CLAUDE.md`
-   - Project: `CLAUDE.md` in cwd (if exists)
+1. **Read global and project rule files** — load all rules, behavioral guidelines, and workflow requirements
+   - Global: `$CLAUDE_CONFIG_DIR/CLAUDE.md` (i.e., `~/.claude/CLAUDE.md`)
+   - Project: `AGENTS.md` in cwd (if exists; in praxis, `AGENTS.md` is canonical — the project symlink in cwd points to it)
    - Key sections: Mandatory Rules, Behavioral Rules, Workflow rules
 
 2. **Identify rule categories** to scan against:
@@ -91,7 +91,7 @@ You MUST complete each stage before proceeding to the next.
 | `behavioral` | "Claude가 확인 없이 결론 도출" / "한 PR에 여러 concern bundle" / "user가 동일 지적 반복" | none (Tool Layer = `—`) |
 | `tool` | "gh CLI `--state all` 부재" / "MCP 응답 지연" / "Read 출력 truncation" / "kubectl flag 부재" | **mandatory**: one of `mcp` / `cli` / `builtin` / `skill` |
 | `workflow` | "test 안 돌리고 PR" / "verify 단계 건너뜀" / "issue 안 만들고 브랜치" / "code review 생략" | optional: `skill` (when defect originates inside a skill's stage flow) |
-| `spec-gap` | "이 상황을 다루는 규칙 부재" / "SKILL.md trigger 모호" / "CLAUDE.md에 명시되지 않은 행동" | optional: `skill` (when rule gap is in a SKILL.md) |
+| `spec-gap` | "이 상황을 다루는 규칙 부재" / "SKILL.md trigger 모호" / "global `~/.claude/CLAUDE.md`에 명시되지 않은 행동" | optional: `skill` (when rule gap is in a SKILL.md) |
 
 **Layer E ↔ step 4b composition matrix** (normative — referenced by step 4b and Stage 3 unified table):
 
@@ -127,7 +127,7 @@ You MUST complete each stage before proceeding to the next.
    - Drop false positives that agents ruled out
    - Final list: up to 5 distinct friction events with causal chains attached
 
-4. **Map each event to a CLAUDE.md rule** (or gap):
+4. **Map each event to a global `~/.claude/CLAUDE.md` rule** (or gap):
    - Read the event's `category[]` from pre-scan and feed it into rule-mapping
    - Which rule was applicable?
    - Was it followed, violated, or simply absent?
@@ -221,14 +221,14 @@ You MUST complete each stage before proceeding to the next.
    | New pattern (structural root cause, likely to recur) | memory | First occurrence — capture for future reference |
    | Repeat (in MEMORY.md, 1-2x) | GitHub issue | Memory alone failed — need systemic fix |
    | Repeat (3x+) | hook or skill | Multiple memory entries = enforcement gap |
-   | Missing rule (new) | CLAUDE.md draft | No rule exists for this pattern |
-   | Missing rule + Repeat | CLAUDE.md draft + GitHub issue | Missing rule caused repeat — add rule + compliance issue |
+   | Missing rule (new) | global `~/.claude/CLAUDE.md` draft | No rule exists for this pattern |
+   | Missing rule + Repeat | global `~/.claude/CLAUDE.md` draft + GitHub issue | Missing rule caused repeat — add rule + compliance issue |
    | Tool friction (step 4b finding) | upstream feedback | Tool improvement needed — issue in the tool's **backing repo** (resolve via Stage 4 Action 4 routing table; not always praxis) |
    | One-off mistake (situational cause, unlikely to recur) | note only | No persistent action needed |
    | **Category default — `tool`** | upstream feedback (compound with memory only when behavioral co-label exists) | step 4b backing-repo resolution; tool defect is not a Claude behavior issue, memory alone insufficient |
    | **Category default — `workflow`** | hook code OR skill idea (memory-alone NOT allowed even on first occurrence) | enforcement gap detected — workflow steps that get skipped need structural enforcement, not memo |
-   | **Category default — `spec-gap`** | CLAUDE.md draft OR skill idea (memory-alone NOT allowed) | rule absent — gaps are filled with rules, not memos |
-   | **Category default — `behavioral`** | memory (default; compound with skill_idea or CLAUDE.md draft when structural) | only category where memory-alone is acceptable; still subject to Gate-2 rationale schema in Stage 2.5 |
+   | **Category default — `spec-gap`** | global `~/.claude/CLAUDE.md` draft OR skill idea (memory-alone NOT allowed) | rule absent — gaps are filled with rules, not memos |
+   | **Category default — `behavioral`** | memory (default; compound with skill_idea or global `~/.claude/CLAUDE.md` draft when structural) | only category where memory-alone is acceptable; still subject to Gate-2 rationale schema in Stage 2.5 |
 
    **Distinguishing "New pattern" vs "One-off mistake":**
    - **New pattern**: root cause is structural (missing rule, absent skill, unclear workflow) → likely to recur in future sessions
@@ -241,7 +241,7 @@ You MUST complete each stage before proceeding to the next.
 
    ⚠️ **MUST — backing_repo declaration for upstream_feedback rows**: When `Proposed Actions` contains `upstream_feedback` (single or compound), the row's `Rationale` cell MUST include a `backing_repo: <owner/repo>` line resolved per Stage 4 Action 4's resolution table. The declaration is **load-bearing** — Stage 4 re-reads it as the routing decision and aborts on divergence.
 
-   - Resolution source-of-truth (in priority order): plugin manifest `repository` field → MCP server git remote → dotfiles backing repo via symlink chain → project CLAUDE.md feature-to-repo mapping.
+   - Resolution source-of-truth (in priority order): plugin manifest `repository` field → MCP server git remote → dotfiles backing repo via symlink chain → project `AGENTS.md` feature-to-repo mapping.
    - Format: literal line `backing_repo: <owner>/<repo>` embedded in the Rationale cell via `<br>` separators. Example: `Rationale: tool defect in praxis distribution<br>backing_repo: <resolved-praxis-repo>`.
    - Unresolvable layer (`builtin`, or no upstream reachable per the Action 4 resolution table's `builtin` row): **remove `upstream_feedback` from the row's `Proposed Actions` set entirely**. If the row had compound actions (e.g., `memory, upstream_feedback`), retain the remaining ones (e.g., keep `memory` alone). If `upstream_feedback` was the sole action, re-derive the action via Stage 2 step 8's category-default rows (typically `skill_idea` for `tool` category, or `memory` if behavioral co-label exists). The escape-hatch state `note only` (from `repeat=true AND resolved=true`) is a separate construct and is NOT used here. Do NOT emit a placeholder `backing_repo`.
    - Ambiguous layer (resolution table's `Other / ambiguous` row): keep `upstream_feedback` but surface to user immediately at Stage 2; the user-supplied repo becomes the declared `backing_repo`. Stage 4 step 0 then re-resolves and may still divergence-prompt if the live re-resolution differs.
@@ -262,7 +262,7 @@ If `memory` is the *only* action for such a finding → return that finding to S
 
 If absent or incomplete → return that finding to Stage 2 step 8 (re-evaluate with explicit per-action rationale enforcement).
 
-**Gate-3 (Evidence Robustness)** — for each finding with `Proposed Actions` count = 2 (compound), verify three sub-conditions. Gate-1 and Gate-2 check whether the *form* of action assignment is correct; Gate-3 checks whether the *evidence* underneath each action is robust enough to justify it. Without this gate, category-default form-filling can produce a second action whose only purpose is to ask a question the first action already answered — pure structural redundancy that costs an upstream issue or a CLAUDE.md draft.
+**Gate-3 (Evidence Robustness)** — for each finding with `Proposed Actions` count = 2 (compound), verify three sub-conditions. Gate-1 and Gate-2 check whether the *form* of action assignment is correct; Gate-3 checks whether the *evidence* underneath each action is robust enough to justify it. Without this gate, category-default form-filling can produce a second action whose only purpose is to ask a question the first action already answered — pure structural redundancy that costs an upstream issue or a global `~/.claude/CLAUDE.md` draft.
 
 Sub-conditions (all three must hold):
 
@@ -290,7 +290,7 @@ If sub-condition (c) fires → apply the downgrade; if the resulting action set 
 | Condition on the finding | (a) per-action evidence | (b) decision-coupling | (c) single-observation downgrade |
 |--------------------------|:-----------------------:|:---------------------:|:--------------------------------:|
 | `Proposed Actions` count = 1 (single-action; includes behavioral-only defaults and `note only` rows) | SKIP (gate inapplicable — no sibling) | SKIP | SKIP |
-| Two actions affect different artifacts on different surfaces (e.g., `claude_md_draft` for project CLAUDE.md + `skill_idea` for tool-side enhancement) | apply | SKIP — not decision-coupled by construction | apply |
+| Two actions affect different artifacts on different surfaces (e.g., `claude_md_draft` for global `~/.claude/CLAUDE.md` + `skill_idea` for tool-side enhancement) | apply | SKIP — not decision-coupled by construction | apply |
 | `repeat=true` finding | apply (per-action evidence still required) | apply (coupling can still occur even with repeat history) | SKIP — repeat history is multi-observation evidence |
 
 The previous all-or-nothing "Gate-3 does NOT fire" framing produced a bypass: a `claude_md_draft + skill_idea` pair backed by a single non-repeat observation would silently skip (a) and (c) along with (b), defeating the core evidence-robustness intent. This table restores sub-condition granularity.
@@ -441,7 +441,7 @@ when <observation predicate>$`.
 
 If no Gate-3 (b) demotions occurred, omit this section entirely (do not emit "None.").
 
-No patterns found: emit the distribution card with all counts = 0 and verdicts = NA, plus literal "This session followed all CLAUDE.md rules. ✅"
+No patterns found: emit the distribution card with all counts = 0 and verdicts = NA, plus literal "This session followed all global `~/.claude/CLAUDE.md` rules. ✅"
 
 ### Reinforced Patterns (this session)
 
@@ -465,7 +465,7 @@ The unified table folds the previous dual-table layout (Pattern + Tool/Feature F
 |-------------|---------------|---------|
 | **MEMORY.md feedback** | New pattern (1st occurrence, repeat_count=0), individual learning | repeat=true (memory is BLOCKED) |
 | **GitHub issue** | Systemic fix needed (tool/skill implementation), repeat pattern (1–2×) | One-off mistake, purely local insight |
-| **CLAUDE.md draft** | Explicit rule gap exists, cross-project scope needed | Existing rule already covers this pattern |
+| **Global `~/.claude/CLAUDE.md` draft** | Explicit rule gap exists, cross-project scope needed | Existing rule already covers this pattern |
 | **Skill idea note** | Repeat pattern needs enforcement mechanism, manual recall is insufficient | Single memo is sufficient, no recurring trigger |
 | **Hook code** | Repeat (3x+) requiring automated enforcement; manual recall has repeatedly failed | Fewer than 3 repeats; skill idea or rule is sufficient |
 | **Upstream feedback** | Tool/feature-level defect identified in step 4b; improvement needed in the tool itself, not in Claude's behavior | Finding is purely a rule violation with no tool-level root cause |
@@ -475,8 +475,8 @@ The unified table folds the previous dual-table layout (Pattern + Tool/Feature F
 | Axis | Signal → Action |
 |------|----------------|
 | **Repeat count** | 0× → `memory` (first occurrence); 1–2× → `issue` (memory blocked — repeat=true); 3×+ → `skill` or `hook` (enforcement gap) |
-| **Scope** | Cross-project impact → `CLAUDE.md draft`; single-project → `MEMORY.md` |
-| **Gap type** | Rule violated → `memory` (reinforce); rule absent → `CLAUDE.md draft` (fill gap); no enforcement → `skill idea` |
+| **Scope** | Cross-project impact → global `~/.claude/CLAUDE.md` draft; single-project → `MEMORY.md` |
+| **Gap type** | Rule violated → `memory` (reinforce); rule absent → global `~/.claude/CLAUDE.md` draft (fill gap); no enforcement → `skill idea` |
 
 > **Axis precedence: Repeat-count is the highest-priority axis.** When `repeat=true`, the Scope and Gap type axes cannot override to `memory` — the repeat-count constraint (issue / skill / hook) always wins. Apply Scope and Gap type only to determine additional actions alongside the repeat-count result.
 
@@ -485,7 +485,7 @@ The unified table folds the previous dual-table layout (Pattern + Tool/Feature F
 **Before approval, explain each action's concrete plan:**
 
 For each finding, present:
-1. **What will be created** (file path, issue title, hook name, or CLAUDE.md rule text)
+1. **What will be created** (file path, issue title, hook name, or global `~/.claude/CLAUDE.md` rule text)
 2. **Why this action type** (escalation rationale — e.g., "Already recorded 3x in MEMORY.md")
 3. **How it will be verified** (what check confirms it works)
 4. **Stage 2 caveats carried forward** (MANDATORY when any of the following hold) — emit a literal `Stage 2 caveats:` line listing each item that applies to this finding. Omit the entire line only when none of the items apply.
@@ -553,14 +553,14 @@ Example (single action — repeat pattern):
 
 Example (compound action — rule gap + repeat):
 > Finding #1 (HIGH): Hasty interpretation without verification (ambiguous signal → worst-case conclusion, 3 occurrences)
-> - **Proposed Actions**: `CLAUDE.md draft` + `GitHub issue`
-> - **Rationale**: Rule absent + 3× repeat → fill the rule gap (CLAUDE.md draft) and track enforcement compliance (GitHub issue); matches Stage 2 ladder: "Missing rule + Repeat"
+> - **Proposed Actions**: global `~/.claude/CLAUDE.md` draft + `GitHub issue`
+> - **Rationale**: Rule absent + 3× repeat → fill the rule gap (global `~/.claude/CLAUDE.md` draft) and track enforcement compliance (GitHub issue); matches Stage 2 ladder: "Missing rule + Repeat"
 > - **What will be created**:
->   - CLAUDE.md draft: new rule requiring a disconfirmation check before concluding from ambiguous signals
+>   - global `~/.claude/CLAUDE.md` draft: new rule requiring a disconfirmation check before concluding from ambiguous signals
 >   - issue — `feat(retrospect): enforce falsify-first check on ambiguous signal interpretation`
-> - **Verify**: CLAUDE.md draft shown to user for approval + issue URL returned
+> - **Verify**: global `~/.claude/CLAUDE.md` draft shown to user for approval + issue URL returned
 > - **Stage 2 caveats**: analyst clustered with Finding #4 (same root cause family); evaluate combined fix scope before executing
-> - **Falsification**: premise survived for `CLAUDE.md draft` — if the rule already existed in another section, the 3× repeat would show citations to that rule rather than rule-absent rationale; Stage 2 step 4 confirmed no applicable rule (category=spec-gap)
+> - **Falsification**: premise survived for `global ~/.claude/CLAUDE.md draft` — if the rule already existed in another section, the 3× repeat would show citations to that rule rather than rule-absent rationale; Stage 2 step 4 confirmed no applicable rule (category=spec-gap)
 
 Example (gate-suppressed `(Recommended)`):
 > Finding #3 (MED): MCP timeout caused 3 retries (single occurrence in this session)
@@ -604,7 +604,7 @@ For each approved action:
 
    **⚠️ MANDATORY: Duplicate check before creating any memory file:**
 
-   **Precondition:** This check applies ONLY when the finding's action type is `memory` (new pattern). If Stage 2 already marked `repeat=true` and escalated to issue/hook/CLAUDE.md, skip this check — the escalation ladder takes precedence over merge.
+   **Precondition:** This check applies ONLY when the finding's action type is `memory` (new pattern). If Stage 2 already marked `repeat=true` and escalated to issue/hook/global `~/.claude/CLAUDE.md` draft, skip this check — the escalation ladder takes precedence over merge.
 
    a. Reuse Stage 2 Step 7's repeat scan results — if a finding matched an existing memory but was NOT escalated (i.e., it's a genuinely new sub-pattern), that file is the merge target
    b. If no Stage 2 match: scan MEMORY.md index for entries with overlapping root cause or topic (concept-level, not keyword)
@@ -618,16 +618,16 @@ For each approved action:
    - Title: Conventional Commits format (per project convention)
    - Body: per project convention, with background + task list
 
-3. **CLAUDE.md draft** → Write proposed rule addition as a markdown block, routed by target
+3. **Global `~/.claude/CLAUDE.md` draft** → Write proposed rule addition as a markdown block, routed by target
 
    **Step 0 — Target detection (MUST run first):**
    Resolve the target path via `realpath` and classify:
 
    | Target | Detection | Execution path |
    |--------|-----------|---------------|
-   | **Project CLAUDE.md** | `realpath <path>` does NOT match `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md` AND resolves inside cwd | Direct Edit (see Project path below) |
+   | **Project `AGENTS.md`** | `realpath <path>` does NOT match `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md` AND resolves inside cwd | Direct Edit (see Project path below) |
    | **Global `~/.claude/CLAUDE.md`** | `realpath <path>` matches `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md` | Staging → AskUserQuestion → apply only on explicit approval (see Global path below) |
-   | **External-repo CLAUDE.md** | `realpath <path>` resolves outside cwd AND outside `~/.claude/` | Same as external-repo gate — do NOT edit; surface to user with resolved path |
+   | **External-repo rule file** | `realpath <path>` resolves outside cwd AND outside `~/.claude/` | Same as external-repo gate — do NOT edit; surface to user with resolved path |
 
    **Project path** (`realpath` does NOT match global):
    - Present the draft diff to the user inline
@@ -649,7 +649,7 @@ For each approved action:
         Cap: 최대 3 라운드. 3 라운드 초과 시: "3회 재작성을 초과했습니다. 수동 편집을 권장합니다: `{staging_path}`" 후 보류 처리.
       - `보류` 선택 시: Edit 호출 없이 staging 파일 경로를 completion report에 기록하고 종료.
 
-   c. **`apply` 선택 시**: Edit on `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md` to insert the approved rule at the indicated position. Show the resulting diff as verification.
+   c. **`apply` 선택 시**: Edit on global `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md` to insert the approved rule at the indicated position. Show the resulting diff as verification.
 
 4. **Upstream feedback** → Resolve the tool's **backing repo first** (do NOT hardcode any specific repo), then create a labeled issue there. Hardcoding misroutes plugin defects, custom MCP defects, dotfiles defects across user environments.
 
@@ -705,12 +705,12 @@ For each approved action:
    | `mcp__<plugin>__*` from a Claude Code plugin | Read `repository` field from that plugin's `.claude-plugin/plugin.json` (or equivalent manifest) |
    | `mcp__<service>-*` from a custom/team MCP server | The MCP server's source repo — `git remote -v` of the server's directory, or read its package manifest |
    | Skill within the praxis distribution itself | The praxis source repo this skill was installed from — read `repository` field in praxis's own plugin manifest |
-   | Hook in `~/.claude/hooks/` or a globally symlinked CLAUDE.md/AGENTS.md | The user's dotfiles backing repo — resolve via `ls -la` symlink chain, then `git remote -v` of the target dir |
+   | Hook in `~/.claude/hooks/` or a globally symlinked `~/.claude/CLAUDE.md`/`AGENTS.md` | The user's dotfiles backing repo — resolve via `ls -la` symlink chain, then `git remote -v` of the target dir |
    | CLI tool (e.g., `gh`, `kubectl`) | The CLI's open-source upstream if accessible; otherwise `note only` |
    | Builtin tool (Read/Edit/Bash/Grep) | Typically not actionable — `note only` |
    | Other / ambiguous | Ask the user; do NOT fall back to a hardcoded repo |
 
-   If the active project's CLAUDE.md provides a feature-to-repo mapping, consult it before deciding a repo.
+   If the active project's `AGENTS.md` provides a feature-to-repo mapping, consult it before deciding a repo.
 
    ### Step 0a — External-repo authorization gate (MUST run before `gh issue create` for external findings)
 
@@ -727,7 +727,7 @@ For each approved action:
    Title: {proposed_issue_title}
    Evidence: {one-line friction event summary}
 
-   Per CLAUDE.md "External / third-party repo content isolation (MUST)", this requires
+   Per global `~/.claude/CLAUDE.md` "External / third-party repo content isolation (MUST)", this requires
    explicit per-action approval. Stage 3 "Execute now" does not satisfy this gate.
    Auto-mode override, batch approval, and "prior selection ratifies this" inferences
    are all invalid — only an explicit [a] pick here allows proceeding.
@@ -771,7 +771,7 @@ For each approved action:
    | GitHub issue | `gh issue view {url}` returns valid data |
    | Upstream feedback | `gh issue view {url}` returns valid data + URL repo matches `verified_backing_repo` from step 0 + label convention is correct for the verified repo (`tool-friction:{layer}` ONLY when verified repo is the praxis distribution; otherwise the repo's own convention label per Action 4's label rule) |
    | Hook code | Script file exists + settings.json registration confirmed (dry-run varies by hook type — no generic check) |
-   | CLAUDE.md draft | **Project target**: Diff shown + explicit approval received + Edit applied. **Global target**: Staging file created at `/tmp/claude-md-draft-{slug}.md` → AskUserQuestion 3-option presented → `apply`: Edit applied + diff shown; `보류`: staging file path logged in completion report. |
+   | Global `~/.claude/CLAUDE.md` draft | **Project target (`AGENTS.md`)**: Diff shown + explicit approval received + Edit applied. **Global target (`~/.claude/CLAUDE.md`)**: Staging file created at `/tmp/claude-md-draft-{slug}.md` → AskUserQuestion 3-option presented → `apply`: Edit applied + diff shown; `보류`: staging file path logged in completion report. |
    | Skill idea note | File exists in `.omc/plans/` |
 
    Report verification results in the completion table.
@@ -812,16 +812,16 @@ If you catch yourself:
 
 - Proposing actions before completing Stage 2 analysis
 - Writing "root cause: Claude forgot to X" without tracing WHY the forgetting happened
-- Adding a MEMORY.md entry that just repeats the CLAUDE.md rule verbatim (no new insight)
+- Adding a MEMORY.md entry that just repeats the global `~/.claude/CLAUDE.md` rule verbatim (no new insight)
 - Creating a GitHub issue for every minor friction (low-ROI noise)
 - Skipping the approval step and executing actions directly
-- Editing `$CLAUDE_CONFIG_DIR/CLAUDE.md` directly (without the staging → AskUserQuestion 3-option path) — global CLAUDE.md requires staging + explicit `apply` approval; direct Edit/Write is blocked by the self-modification classifier and skips user review. Use the Global path flow in Action 3 above.
+- Editing `$CLAUDE_CONFIG_DIR/CLAUDE.md` directly (without the staging → AskUserQuestion 3-option path) — global `~/.claude/CLAUDE.md` requires staging + explicit `apply` approval; direct Edit/Write is blocked by the self-modification classifier and skips user review. Use the Global path flow in Action 3 above.
 - Proposing `memory` for a pattern that already exists in MEMORY.md (MUST escalate instead)
 - Skipping tracer/analyst agent calls ("I can analyze this myself")
 - Generating artifacts without verification ("issue created" without showing URL)
 - Creating a new memory file without checking existing entries for overlap (MUST merge into existing when root cause matches)
 - **Proposing MEMORY.md feedback as the only action when the same rule was violated 3+ times** — this ignores memo's proven limits; enforcement mechanisms (skill, hook, rule) MUST be evaluated alongside memory
-- **Proposing MEMORY.md feedback as the only action when the finding is a rule gap (rule absent)** — gaps are not filled by memos; CLAUDE.md draft or skill idea MUST be considered
+- **Proposing MEMORY.md feedback as the only action when the finding is a rule gap (rule absent)** — gaps are not filled by memos; global `~/.claude/CLAUDE.md` draft or skill idea MUST be considered
 - **Forcing tool friction into only a rule-violation frame** — tool-layer defects from step 4b MUST be carried in the unified findings table with `Tool Layer` set to a non-`—` value and evaluated for `upstream feedback`, not collapsed into rule-violation-only findings
 - **Skipping step 4b entirely** ("no tool issues this session") — step 4b is mandatory. If no tool friction is found, the distribution card MUST emit `upstream_feedback: 0` and the report MUST state "No tool/feature friction detected. ✅" explicitly
 - **Pre-scan에서 friction event에 `category[]` 라벨링을 누락한 채 Stage 2 step 3 이상 진행** — Layer E 강제. 누락은 Stage 2 진입 전 차단되어야 한다.
@@ -836,7 +836,7 @@ If you catch yourself:
 - **Emitting `AskUserQuestion` with a `(Recommended)` label or confidence-anchoring framing (`safer` / `natural fit` / `안전한` / `자연스러운`) without an accompanying `Falsification:` trace line in the per-finding plan** — Stage 3 Pre-Output Falsification Gate violation. The label asserts ranking confidence that wasn't earned; downstream readers (user, hooks, retrospect parsers) cannot tell whether the premise was tested. If the gate didn't run, drop the label and surface the option unranked.
 - **Stage 3 ranking that contradicts Stage 2 caveats** — e.g., `(Recommended)` applied to an action whose Stage 2 row carries `tracer confidence: LOW`, `single observation` alone, or `alternative root cause not ruled out`. Stage 2's caveat is the leading signal; Stage 3 must carry it forward (`Stage 2 caveats:` line) and either discharge it via falsification or suppress the recommendation.
 - **`upstream_feedback` 행의 `backing_repo` owner가 own-org 밖인데 Stage 2.5 Gate-4 마킹(`⚠ EXTERNAL: per-action approval required at Stage 4` prefix) 없이 Stage 3 진입** — Gate-4 가 실행되지 않은 것. Stage 2.5로 돌아가 Gate-4 재실행.
-- **external-marked finding 의 Stage 4 `upstream_feedback` 실행에서 AskUserQuestion per-action 승인(step 0a) 없이 `gh issue create` 직행** — CLAUDE.md zero-exception 룰 위반. STOP, step 0a AskUserQuestion 실행 먼저.
+- **external-marked finding 의 Stage 4 `upstream_feedback` 실행에서 AskUserQuestion per-action 승인(step 0a) 없이 `gh issue create` 직행** — global `~/.claude/CLAUDE.md` zero-exception 룰 위반. STOP, step 0a AskUserQuestion 실행 먼저.
 - **Stage 3 "Execute now" 선택을 external-repo write 의 per-action 승인으로 ratify** — Stage 3 승인은 action 카테고리 선택이지, 외부 repo 개별 write 승인이 아님. Stage 4 step 0a 게이트를 반드시 별도로 실행.
 - **Omitting the `Stage 2 caveats:` line on a finding that has any of: tracer confidence below HIGH, single observation, alternative root cause not ruled out, Gate-3 downgrade, analyst cluster overlap, escape-hatch state** — carry-forward is mandatory whenever ANY of these holds. Silent omission lets Stage 3 rank as if Stage 2 returned clean HIGH-confidence evidence.
 - **조사 도구 결과를 completeness 검증 없이 결론에 사용 (premise unverified)** — 다음 두 패턴 모두 "premise falsified" (반증 테스트를 설계한 뒤 통과 → 진행 가능)가 아니라 "premise unverified" (도구 출력 자체의 한계를 검증하지 않은 채 결론에 사용 → STOP) 에 해당한다: (a) `find ... | head -N` 결과로 "파일/모듈 없음" 단정 — **`head` 를 제거한 원 명령 `find ... | wc -l` 을 별도로 실행**해 총 라인 수를 확인하고, cap 초과 시 cap 제거 또는 `grep -rn <token>` narrowing 필요 (`head -N` 파이프 뒤에 `| wc -l` 을 붙이면 cap 으로 잘린 뒤의 라인 수만 세므로 정확히 N개와 cap 초과를 구분할 수 없어 검증이 실패한다); (b) `find <path>` 빈 결과로 "경로/모듈 없음" 단정 — `ls <parent>` 로 path coverage 를 확인하거나 상위 경로로 재시도, 또는 `grep -rn <token>` cross-check 필요.
@@ -847,7 +847,7 @@ If you catch yourself:
 
 | Stage | Key Activity | Success Criteria |
 |-------|-------------|-----------------|
-| **1. Load** | Read CLAUDE.md, form scan questions | Rule categories identified |
+| **1. Load** | Read global `~/.claude/CLAUDE.md`, form scan questions | Rule categories identified |
 | **2. Analyze** | Scan conversation, map to rules, find root cause | Root cause (not symptom) for each pattern; every event has `category[]` |
 | **2.5 Audit** | Run Gate-1 (categorical) + Gate-2 (Schema A 5-line or Schema B dimension-tag rationale) + Gate-3 (evidence robustness for 2-action findings) + Gate-4 (external-repo authorization pre-check for upstream_feedback) | All applicable gates PASS/WARN or per-finding cap reached and surfaced to user |
 | **3. Report** | Present unified table + distribution card, carry Stage 2 caveats forward, run Pre-Output Falsification Gate before each `AskUserQuestion`, collect approval per item | User approved at least 1 item (or confirmed 0 findings); every `(Recommended)` label has a `Falsification:` trace |
@@ -857,7 +857,7 @@ If you catch yourself:
 
 | Stage | Failure | Action |
 |-------|---------|--------|
-| Stage 1 (load) | CLAUDE.md not found (project or global) | Proceed with global defaults; flag the missing file in the report |
+| Stage 1 (load) | `~/.claude/CLAUDE.md` not found (global) or `AGENTS.md` not found (project) | Proceed with global defaults; flag the missing file in the report |
 | Stage 2 (analyze) | Session history not accessible | Fall back to the user's verbal summary as input to steps 3–8 |
 | Stage 2 (analyze) | No friction events found | Exit with "No patterns found. ✅" — do not fabricate findings |
 | Stage 2 (analyze) | MEMORY.md scan failed (file not accessible) | Treat all findings as new patterns (repeat=false). Flag scan failure in report |

--- a/skills/strike/SKILL.md
+++ b/skills/strike/SKILL.md
@@ -19,9 +19,9 @@ Record a single rule violation against the current session's strike counter.
 ## Reinforcement after the call
 
 - If the script output starts with `⚠️ Strike 1`, internalize the recorded reason and commit to stricter rule adherence for the rest of the session.
-- If the script output starts with `🔶 Strike 2`, **stop any in-flight work**, list the cumulative violations, identify the matching CLAUDE.md section, re-read it, and state explicitly how you will avoid another strike before resuming.
+- If the script output starts with `🔶 Strike 2`, **stop any in-flight work**, list the cumulative violations, identify the matching global `~/.claude/CLAUDE.md` section, re-read it, and state explicitly how you will avoid another strike before resuming.
 - If the script output starts with `🔴 Strike 3`, recovery is a **two-step trust process**:
-  1. **Write the reflection** at the path the script printed — violations summary, root cause per violation tied to a specific CLAUDE.md rule/section, and a concrete preventive checklist. The file must be non-empty or `/praxis:reset-strikes` will be refused.
+  1. **Write the reflection** at the path the script printed — violations summary, root cause per violation tied to a specific global `~/.claude/CLAUDE.md` rule/section, and a concrete preventive checklist. The file must be non-empty or `/praxis:reset-strikes` will be refused.
   2. **Persuade the user** before asking for reset: quote or summarize the reflection in-chat (do not just point at the file path), acknowledge the specific harm each violation caused, commit to the preventive checklist in concrete terms, then explicitly ask the user to run `/praxis:reset-strikes` as a trust decision. Do not treat the user's approval as mechanical — it is a judgment call based on your appeal.
 
 ## Non-goals

--- a/skills/using-praxis/SKILL.md
+++ b/skills/using-praxis/SKILL.md
@@ -54,12 +54,12 @@ Recover, save, and orchestrate Claude Code sessions.
 | Situation | Skill to call |
 |-----------|--------------|
 | "Claude Code sessions died after a crash or power-off" | `cmux-recover-sessions` (cmux) or `recover-sessions` (tmux) |
-| "I want to record that a CLAUDE.md rule was broken" | `strike` |
+| "I want to record that a global `~/.claude/CLAUDE.md` rule was broken" | `strike` |
 | "There are too many Codex review comments — where to start?" | `codex-review-wrap` |
 
 ## Hook System
 
-Praxis ships hooks that enforce CLAUDE.md rules structurally at the tool
+Praxis ships hooks that enforce global `~/.claude/CLAUDE.md` rules structurally at the tool
 level (PreToolUse / PostToolUse / Stop / UserPromptSubmit). They fail-open
 on infrastructure errors — Claude Code never breaks, but violating patterns
 are blocked or warned before they land.

--- a/skills/writing-praxis-skill/SKILL.md
+++ b/skills/writing-praxis-skill/SKILL.md
@@ -53,7 +53,7 @@ description: >
 - `name` must exactly match the directory name under `skills/`.
 - `description` should be concise — keep it short enough to scan at a glance.
 - Always end `description` with a `Triggers on "..."` clause so the routing
-  table in CLAUDE.md can reference exact keywords.
+  table in global `~/.claude/CLAUDE.md` can reference exact keywords.
 - Use multi-line `>` block for descriptions that include trigger keywords; use
   inline text for short single-line descriptions (see `strike/SKILL.md`).
 
@@ -70,7 +70,7 @@ runtime-verified-note: "<cli-name> <version> — one-line observed behavior"
 ### Step 3: Design Trigger Keywords
 
 Trigger keywords are the phrases users type (or say) that route to this skill.
-The CLAUDE.md `Skill & Agent Routing` table maps them.
+The global `~/.claude/CLAUDE.md` `Skill & Agent Routing` table maps them.
 
 **Principles:**
 - **Specific over generic.** "recover cmux" beats "recover" — the generic form
@@ -156,7 +156,7 @@ have a reviewer read-through.
 ### Step 8: Register the Skill
 
 1. Add the skill's trigger keywords to the routing table in the project's
-   `CLAUDE.md` (or the root `CLAUDE.md` for global skills).
+   `AGENTS.md` (or global `~/.claude/CLAUDE.md` for global skills).
 2. Run `./scripts/check-plugin-manifests.py` — new skill directories are
    picked up automatically by the build script, but the check confirms no
    packaging drift.
@@ -172,7 +172,7 @@ Follow the standard praxis PR workflow:
 
 | Failure | Cause | Fix |
 |---------|-------|-----|
-| Skill not invoked by routing | Trigger keywords missing from CLAUDE.md routing table | Add keywords to the routing table |
+| Skill not invoked by routing | Trigger keywords missing from global `~/.claude/CLAUDE.md` routing table | Add keywords to the routing table |
 | `Skill(...)` call fails silently | Target skill uses `disable-model-invocation: true` (both hosts) | Call the underlying binary directly |
 | `AskUserQuestion` call rejected before tool runs | Options array > 4 items — JSON schema rejects the call | Truncate to 3 + "취소" |
 | Codex worker produces empty `git diff` | Sandbox write restriction | Add `git status` check + claude fallback re-dispatch |


### PR DESCRIPTION
Closes #334

## 개요

`docs/` 및 `skills/` 디렉토리에서 모호한 `CLAUDE.md` 참조를 전수 정비했습니다. PR #330이 최상위 `*.md` 파일을 처리한 것의 연장입니다.

## 변경 내용

### Enumerate 결과

- **Before**: 72개 bare `CLAUDE.md` 참조
- **After**: 0개 bare 참조 (모두 `global ~/.claude/CLAUDE.md` 또는 `$CLAUDE_CONFIG_DIR/CLAUDE.md` 형태로 명시)

canonical enumerate 커맨드 재실행 결과: 남은 모든 참조가 fully-qualified 형태로만 존재 확인

### 파일별 변경 수

| 파일 | 변경 refs |
|------|----------|
| `docs/hook/pre-edit-protected-branch-guard.md` | 1 |
| `docs/hook/external-api-literal-trigger.md` | 1 |
| `docs/hook/block-ask-end-option.md` | 1 |
| `docs/hook/output-block-falsify-advisory.md` | 2 |
| `docs/hook/count-assertion-verify.md` | 1 |
| `docs/hook/completion-verify.md` | 1 |
| `docs/hook/advisory-wrapper-signature-verify.md` | 1 |
| `docs/hook/external-write-falsify-check.md` | 3 |
| `docs/hook/commit-title-length-check.md` | 1 |
| `docs/hook/strike-counter.md` | 3 |
| `docs/hook/block-manufactured-action-menu.md` | 1 |
| `docs/hook/pre-merge-approval-gate.md` | 1 |
| `skills/codex-review-wrap/SKILL.md` | 1 |
| `skills/reset-strikes/SKILL.md` | 1 |
| `skills/retrospect/SKILL.md` | 38+ |
| `skills/strike/SKILL.md` | 2 |
| `skills/using-praxis/SKILL.md` | 2 |
| `skills/cmux-delegate/SKILL.md` | 4 (→ `ARCHITECTURE.md`로 재라우팅) |
| `skills/writing-praxis-skill/SKILL.md` | 4 |

**총 19개 파일, 72개 refs 정비**

### 분류 기준

- **Global** (`global ~/.claude/CLAUDE.md`): 모든 프로세스 규칙 (Pre-Merge Reporting, No Approval Transfer, Information Accuracy, Loaded ≠ Retrieved, External-Surface Write, Git Commit & Title Rules 등) → `~/.claude/CLAUDE.md`에 위치
- **Project** (`project AGENTS.md`): praxis 자체 설명 (Skills 목록, Hooks 인덱스, Multi-Platform Packaging) → `AGENTS.md`에 위치
- **cmux-delegate 특수 케이스**: Provider Routing / Provider CLI Spec / Task-Type Routing / Provider Resolution Logic → `CLAUDE.md`가 아닌 `ARCHITECTURE.md`에 위치하므로 `project ARCHITECTURE.md`로 교정

Caller chain verified: N/A -- docs-only change

## 검증

- `python3 scripts/check-plugin-manifests.py` → `plugin-manifest check OK`
- enumerate 재실행 후 bare `CLAUDE.md` 0건 확인 (fully-qualified path 참조만 남음)
- 대용량 파일 (`skills/retrospect/SKILL.md` 38+ refs) spot-check 완료

## 동시 수정 알림

- `skills/retrospect/SKILL.md`: #317 (Gate-4 wording), #325 (new Gate) 작업과 동시 수정
- `docs/hook/retrospect-mix-check.md`: #317과 동시 수정 (본 PR에서는 해당 파일에 변경 없음)
- 본 PR의 변경은 **순수 ref 정비만** (의미 내용 변경 없음) — merge 시 rebase가 필요할 수 있습니다
