### PR TITLE
feat(hook): bash-worktree advisory P6+P1

### DIFF
--- a/docs/hook/bash-worktree-existence-advisory.md
+++ b/docs/hook/bash-worktree-existence-advisory.md
@@ -31,21 +31,23 @@ blocked.
 | `cd $VAR` / `cd $(...)` | silent (variable/substitution expansion, unresolvable) |
 | `cd -` | silent (previous dir, unresolvable) |
 | `cd ~` / `cd ~/foo` / `cd ~user/foo` | silent (tilde expansion; hook process `$HOME` may differ from agent effective `$HOME`) |
-| `pushd /path` | silent (out of scope Phase 1) |
-| `(cd /path && ...)` subshell | silent (out of scope Phase 1) |
+| `pushd /path` where path does not exist | `[worktree-missing] <path> does not exist — check 'git worktree list' before retry` |
+| `pushd /path` where path exists | silent |
+| `(cd /path && ...)` subshell where path does not exist | `[worktree-missing] <path> does not exist — check 'git worktree list' before retry` |
+| `(cd /path && ...)` subshell where path exists | silent |
 | `cd /path` inside a heredoc body — space-separated opener `cat << EOF` | silent (heredoc body segments are skipped — see Heredoc handling) |
-| `cd /path` inside a heredoc body — fused opener (`cat <<EOF`, `<<'EOF'`, `<<"EOF"`, `<<-EOF`) | known false-positive: body `cd /path` fires advisory (tracked in #337 P6) |
+| `cd /path` inside a heredoc body — fused opener (`cat <<EOF`, `<<'EOF'`, `<<"EOF"`, `<<-EOF`) | silent (fused openers are now detected — #337 P6 fix) |
 | Opt-out marker `# worktree-advisory:ack` | silent (all advisories suppressed) |
 | Non-Bash tool name | silent (fail-open) |
 | Malformed JSON stdin | silent (fail-open) |
 | `git` binary unavailable / timeout | silent (fail-open) |
 
-### Scope (Phase 1)
+### Scope (Phase 2 — #337 P6 + P1)
 
-Only direct `cd <path>` commands are detected. `pushd` and subshell form
-`(cd /path && ...)` are out of scope for this phase. Heredoc bodies are
-correctly skipped (see Heredoc handling). A follow-up issue tracks Phase 2
-expansion for `pushd` and subshell forms.
+Direct `cd <path>` and `pushd <path>` commands are detected, as well as the
+subshell form `(cd /path && ...)`. Heredoc bodies are correctly skipped for
+both space-separated (`<< EOF`) and fused (`<<EOF`, `<<'EOF'`, `<<"EOF"`,
+`<<-EOF`) heredoc openers.
 
 ### Path detection
 
@@ -72,17 +74,14 @@ the end-marker word. All subsequent segments are skipped as heredoc body lines
 until the end-marker segment is consumed. Commands appearing after the heredoc
 close are processed normally.
 
-**Known limitation — fused heredoc openers (tracked in #337 P6):**
+**Fused heredoc openers (#337 P6 fix):**
 shlex tokenizes fused forms as a **single** POSITIONAL token — `<<EOF`,
 `<<'EOF'`, `<<"EOF"`, `<<-EOF` — rather than two separate tokens (`<<` +
-`EOF`). The current detector looks for the literal token `<<` or `<<-` and
-therefore misses all four fused forms. The body `cd /path` in fused heredocs
-fires a false-positive `[worktree-missing]` advisory. The space-separated
-form (`cat << EOF`, which shlex splits into three tokens) is handled
-correctly.
-
-Workaround until #337 P6 is resolved: add `# worktree-advisory:ack` to the
-command, or use the space-separated `<< EOF` opener form.
+`EOF`). The detector now matches these by checking for a POSITIONAL token
+that starts with `<<` and has a non-empty remainder after stripping the
+optional `-` prefix. The bare marker word is extracted from the token itself
+rather than requiring it to be a separate token. Both space-separated and
+fused forms are handled correctly.
 
 ### Deduplication
 
@@ -134,12 +133,13 @@ The hook returns exit 0 on every infrastructure error:
 bash tests/test_bash_worktree_existence_advisory.sh
 ```
 
-29 cases covering: missing path advisory (direct and compound command),
+33 cases covering: missing path advisory (direct and compound command),
 existing path silent (including registered worktree), tilde expansion forms
-(`~`, `~/foo`, `~user/foo`), pushd/subshell out-of-scope silent, heredoc
-body (space-separated opener silent, post-heredoc `cd` fires, non-cd silent),
-3 known-limitation pins (fused `<<EOF`/`<<'EOF'`/`<<-EOF` body fires
-false-positive — tracked in #337 P6), dedupe (first fires, second deduped,
+(`~`, `~/foo`, `~user/foo`), P1 pushd/subshell detection (missing fires
+advisory, existing is silent), heredoc body (space-separated opener silent,
+post-heredoc `cd` fires, non-cd silent), P6 fused heredoc regression guard
+(all four fused forms — `<<EOF`/`<<'EOF'`/`<<"EOF"`/`<<-EOF` — body is
+silent; post-fused-heredoc `cd` fires), dedupe (first fires, second deduped,
 different session fires independently, state-transition missing→exists→missing
 fires again), infrastructure fail-open (non-Bash tool name, malformed JSON,
 bare cd, `$VAR`, `cd -`, opt-out marker, empty command).

--- a/hooks/bash-worktree-existence-advisory.py
+++ b/hooks/bash-worktree-existence-advisory.py
@@ -12,14 +12,18 @@ Advisory message (stderr only — exit 0 always):
 
 Scope (Phase 2 — #337 P6 + P1):
   Direct `cd <path>` and `pushd <path>` commands are detected, as well as
-  the subshell form `(cd /path && ...)`. Heredoc bodies containing `cd` are
-  skipped for both space-separated (`<< EOF`) and fused (`<<EOF`, `<<'EOF'`,
+  both subshell forms: compact `(cd /path && ...)` and spaced `( cd /path && ... )`.
+  Subshell cd/pushd emits an advisory when the target is missing, but does NOT
+  update the hook's effective_cwd because subshell directory changes do not
+  persist after `)` in Bash. Heredoc bodies containing `cd` are skipped for
+  both space-separated (`<< EOF`) and fused (`<<EOF`, `<<'EOF'`,
   `<<"EOF"`, `<<-EOF`) heredoc openers.
 
 Silent cases (no output emitted):
   - `cd <path>` where path exists on disk
   - `pushd <path>` where path exists on disk
-  - `(cd <path> && ...)` where path exists on disk
+  - `(cd <path> && ...)` where path exists on disk (compact subshell form)
+  - `( cd <path> && ... )` where path exists on disk (spaced subshell form)
   - bare `cd` (no argument — cd to $HOME)
   - `cd $VAR` or `cd $(...)` — variable/substitution expansion, unresolvable
   - `cd -` — previous dir, unresolvable
@@ -100,14 +104,22 @@ def _normalize_path(path: str) -> str:
     return os.path.realpath(path.rstrip("/"))
 
 
-def _extract_cd_target(seg: list[Token]) -> str | None:
-    """Return the path argument of a `cd <path>` or `pushd <path>` segment,
-    else None. Also handles the subshell form `(cd <path> && ...)` where
-    tokenize_with_roles emits the fused token `(cd` as argv[0].
+def _extract_cd_target(seg: list[Token]) -> tuple[str | None, bool]:
+    """Return (path, is_subshell) for a `cd`/`pushd` segment, else (None, False).
 
-    Silent cases (return None):
-      - argv[0] is not `cd`, `pushd`, or `(cd` (i.e. not a recognized
-        directory-change command)
+    `is_subshell` is True when the cd/pushd is inside a subshell group
+    `(cd <path> && ...)` — callers must NOT update effective_cwd in that case
+    because subshell directory changes do not persist after `)` in Bash.
+
+    Two subshell forms are handled:
+      - Compact: `(cd /path && ...)` — tokenize_with_roles fuses `(cd` into a
+        single COMMAND token. Detected by cmd.startswith("(").
+      - Spaced: `( cd /path && ... )` — tokenize_with_roles emits `(` as the
+        COMMAND token and `cd` as the first POSITIONAL token. Detected by
+        cmd == "(" and argv[1].text in ("cd", "pushd").
+
+    Silent cases (return None, False):
+      - argv[0] is not `cd`, `pushd`, `(cd`, or `(` with `cd`/`pushd` next
       - bare `cd` / `pushd` (no positional argument after COMMAND)
       - target starts with `$` (variable expansion, unresolvable)
       - target starts with `$(` (command substitution, unresolvable)
@@ -120,30 +132,43 @@ def _extract_cd_target(seg: list[Token]) -> str | None:
     """
     argv = filter_argv(seg)
     if not argv:
-        return None
+        return None, False
     cmd = argv[0].text
-    # Strip leading `(` for subshell form `(cd /path && ...)`.
-    # tokenize_with_roles emits `(cd` as a single COMMAND token.
-    if cmd.startswith("("):
+    is_subshell = False
+    # Spaced subshell form: `( cd /path && ... )` — tokenize_with_roles emits
+    # `(` as the COMMAND token and `cd`/`pushd` as the first POSITIONAL token.
+    # Check exact `(` match first so that the fused-form branch below does not
+    # consume it (both `"(" == "("` and `"(".startswith("(")` are true).
+    if cmd == "(":
+        if len(argv) >= 2 and argv[1].text in ("cd", "pushd"):
+            is_subshell = True
+            cmd = argv[1].text
+            argv = [argv[1]] + argv[2:]  # shift so the loop below starts at the target
+        else:
+            return None, False
+    # Compact subshell form: `(cd /path && ...)` — tokenize_with_roles fuses
+    # the opening paren with the command into a single COMMAND token `(cd`.
+    elif cmd.startswith("("):
+        is_subshell = True
         cmd = cmd[1:]
     if cmd not in ("cd", "pushd"):
-        return None
+        return None, False
     for tok in argv[1:]:
         if tok.role in (TokenRole.FLAG, TokenRole.FLAG_VALUE, TokenRole.SEPARATOR_DD):
             continue
         target = tok.text
         if not target:
-            return None
+            return None, False
         # Unresolvable cases — silent skip.
         if target == "-":
-            return None
+            return None, False
         if target.startswith("$"):
-            return None
+            return None, False
         if target == "~" or target.startswith("~/") or target.startswith("~"):
             # Covers `~`, `~/foo`, `~user/foo` (any tilde prefix).
-            return None
-        return target
-    return None
+            return None, False
+        return target, is_subshell
+    return None, False
 
 
 def _dedupe_marker(session_id: str, path: str, state: str) -> str:
@@ -287,7 +312,7 @@ def _main_inner() -> int:
             # The opener segment itself is not a `cd`; continue after setting.
             continue
 
-        target = _extract_cd_target(seg)
+        target, is_subshell = _extract_cd_target(seg)
         if target is None:
             # Not a `cd` segment — no effective_cwd update here since we do
             # not execute the segment; the next `cd` segment will still resolve
@@ -314,10 +339,11 @@ def _main_inner() -> int:
             if session_id:
                 _record_dedupe(session_id, real_target, "missing")
         else:
-            # Path exists — update effective_cwd for downstream segments.
-            # Also clear any stale `missing` marker so that if this path is
-            # later removed and cd'd again, a fresh advisory fires (M3 fix).
-            effective_cwd = abs_target
+            # Path exists. For a subshell cd `(cd /path && ...)`, the
+            # directory change does not persist after `)` in Bash — do NOT
+            # update effective_cwd. Only update for a real parent-shell cd.
+            if not is_subshell:
+                effective_cwd = abs_target
             if session_id:
                 _delete_dedupe(session_id, real_target, "missing")
 

--- a/hooks/bash-worktree-existence-advisory.py
+++ b/hooks/bash-worktree-existence-advisory.py
@@ -105,11 +105,17 @@ def _normalize_path(path: str) -> str:
 
 
 def _extract_cd_target(seg: list[Token]) -> tuple[str | None, bool]:
-    """Return (path, is_subshell) for a `cd`/`pushd` segment, else (None, False).
+    """Return (path, skip_cwd_update) for a `cd`/`pushd` segment, else (None, False).
 
-    `is_subshell` is True when the cd/pushd is inside a subshell group
-    `(cd <path> && ...)` — callers must NOT update effective_cwd in that case
-    because subshell directory changes do not persist after `)` in Bash.
+    `skip_cwd_update` is True when the effective_cwd must NOT be updated after
+    this command:
+      - Subshell forms `(cd /path ...)` and `( cd /path ... )`: directory
+        changes inside a subshell do not persist after `)` in Bash.
+      - `pushd`: pushd manipulates a directory stack; a subsequent `popd` would
+        restore the previous directory. The hook has no stack model, so updating
+        effective_cwd on pushd would cause false positives for relative paths
+        following a `popd`. The conservative choice is to not update effective_cwd
+        for pushd at all (advisory for the missing-path case still fires).
 
     Two subshell forms are handled:
       - Compact: `(cd /path && ...)` — tokenize_with_roles fuses `(cd` into a
@@ -153,6 +159,11 @@ def _extract_cd_target(seg: list[Token]) -> tuple[str | None, bool]:
         cmd = cmd[1:]
     if cmd not in ("cd", "pushd"):
         return None, False
+    # pushd manipulates a directory stack; popd would restore the previous dir.
+    # Without a stack model, updating effective_cwd on pushd causes false
+    # positives for relative paths following a popd. Mark as skip_cwd_update.
+    if cmd == "pushd":
+        is_subshell = True  # reuse flag: skip_cwd_update
     for tok in argv[1:]:
         if tok.role in (TokenRole.FLAG, TokenRole.FLAG_VALUE, TokenRole.SEPARATOR_DD):
             continue
@@ -339,9 +350,9 @@ def _main_inner() -> int:
             if session_id:
                 _record_dedupe(session_id, real_target, "missing")
         else:
-            # Path exists. For a subshell cd `(cd /path && ...)`, the
-            # directory change does not persist after `)` in Bash — do NOT
-            # update effective_cwd. Only update for a real parent-shell cd.
+            # Path exists. skip_cwd_update (reused as is_subshell flag) is True
+            # for subshell forms and pushd — neither reliably persists the cwd
+            # change for subsequent segments. Only a bare `cd` updates it.
             if not is_subshell:
                 effective_cwd = abs_target
             if session_id:

--- a/hooks/bash-worktree-existence-advisory.py
+++ b/hooks/bash-worktree-existence-advisory.py
@@ -26,6 +26,7 @@ Silent cases (no output emitted):
   - `( cd <path> && ... )` where path exists on disk (spaced subshell form)
   - `pushd +N` or `pushd -N` — directory-stack rotation, not a path
   - `cd /path` inside a `cat<<EOF` heredoc body (command-attached fused opener)
+  - subshell cd/pushd where subshell-local cwd tracking is not yet resolved
   - bare `cd` (no argument — cd to $HOME)
   - `cd $VAR` or `cd $(...)` — variable/substitution expansion, unresolvable
   - `cd -` — previous dir, unresolvable
@@ -171,11 +172,6 @@ def _extract_cd_target(seg: list[Token]) -> tuple[str | None, bool]:
         if tok.role in (TokenRole.FLAG, TokenRole.FLAG_VALUE, TokenRole.SEPARATOR_DD):
             continue
         target = tok.text
-        # Strip trailing `)` fused by shlex when the subshell closing paren is
-        # the last character of the command: `(cd /path && cd sub)` → the
-        # last token is `sub)`.  Strip one trailing `)` only (not multiple).
-        if target.endswith(")"):
-            target = target[:-1]
         if not target:
             return None, False
         # Unresolvable cases — silent skip.
@@ -325,6 +321,28 @@ def _main_inner() -> int:
     # `_heredoc_end` holds the expected end-marker word while inside a body.
     _heredoc_end: str | None = None
 
+    # Subshell tracking: compact form `(cd /a && cd b)` — shlex fuses the
+    # opening paren with the first command (`(cd`), then emits subsequent
+    # commands as independent segments, and fuses the closing `)` into the
+    # last token of the final segment.
+    #
+    # To resolve relative paths inside a subshell correctly, we track a
+    # separate `subshell_cwd` that is updated for cd/pushd segments inside
+    # the subshell. When the subshell closes (last token ends with `)`), we
+    # discard it and resume from `effective_cwd`. The outer `effective_cwd`
+    # is never updated by subshell-internal cds (they don't persist after `)`).
+    #
+    # Detection heuristics (compact form only):
+    #   open:  first token of a segment starts with `(` (e.g. `(cd` or `(`)
+    #   close: last raw token of the same or a later segment ends with `)`
+    #   strip: trailing `)` is stripped from the path token before resolution
+    #
+    # Spaced form `( cd /path )` is handled entirely by _extract_cd_target
+    # (which detects cmd == "(") and returns is_subshell=True; the `)` is a
+    # separate POSITIONAL token so no stripping is needed here.
+    in_subshell: bool = False
+    subshell_cwd: str = effective_cwd
+
     for seg in segments:
         # --- Heredoc body skip ---
         if _heredoc_end is not None:
@@ -343,18 +361,51 @@ def _main_inner() -> int:
             # The opener segment itself is not a `cd`; continue after setting.
             continue
 
-        target, is_subshell = _extract_cd_target(seg)
+        # --- Subshell open/close detection (compact form) ---
+        # Open: first raw token starts with `(` — covers `(cd` and bare `(`.
+        first_raw = seg[0].text if seg else ""
+        seg_opens_subshell = first_raw.startswith("(")
+        # Close: last raw token ends with `)` — the closing paren is fused by
+        # shlex into the final token of the last segment inside the subshell.
+        last_raw = seg[-1].text if seg else ""
+        seg_closes_subshell = last_raw.endswith(")")
+
+        if seg_opens_subshell and not in_subshell:
+            in_subshell = True
+            subshell_cwd = effective_cwd
+
+        # Choose the cwd to resolve relative paths against.
+        resolve_cwd = subshell_cwd if in_subshell else effective_cwd
+
+        # Strip one trailing `)` from the last raw token when inside a compact
+        # subshell — shlex fuses the closing paren into the last path token.
+        # Only done here (main loop), never in _extract_cd_target, so that
+        # legitimate paths ending in `)` outside a subshell are not mutated.
+        seg_for_extract = seg
+        if in_subshell and seg_closes_subshell and seg:
+            last_tok = seg[-1]
+            if last_tok.text.endswith(")"):
+                # Rebuild the segment with the last token's text stripped.
+                stripped_text = last_tok.text[:-1]
+                new_last = Token(text=stripped_text, role=last_tok.role)
+                seg_for_extract = seg[:-1] + [new_last]
+
+        target, is_subshell_flag = _extract_cd_target(seg_for_extract)
+
+        if seg_closes_subshell and in_subshell:
+            in_subshell = False  # subshell closed; revert to outer cwd next seg
+
         if target is None:
             # Not a `cd` segment — no effective_cwd update here since we do
             # not execute the segment; the next `cd` segment will still resolve
             # relative paths against the last known effective_cwd.
             continue
 
-        # Resolve target to absolute path.
+        # Resolve target to absolute path using the appropriate cwd.
         if target.startswith("/"):
             abs_target = os.path.normpath(target)
         else:
-            abs_target = os.path.normpath(os.path.join(effective_cwd, target))
+            abs_target = os.path.normpath(os.path.join(resolve_cwd, target))
 
         real_target = _normalize_path(abs_target)
 
@@ -370,10 +421,15 @@ def _main_inner() -> int:
             if session_id:
                 _record_dedupe(session_id, real_target, "missing")
         else:
-            # Path exists. skip_cwd_update (reused as is_subshell flag) is True
-            # for subshell forms and pushd — neither reliably persists the cwd
-            # change for subsequent segments. Only a bare `cd` updates it.
-            if not is_subshell:
+            # Path exists. Update the appropriate cwd tracker:
+            # - inside a subshell: always update subshell_cwd (outer not
+            #   affected regardless of is_subshell_flag; the flag only guards
+            #   the outer effective_cwd update for pushd/subshell-opener).
+            # - pushd at parent-shell level (is_subshell_flag=True): skip.
+            # - bare cd at parent-shell level: update effective_cwd.
+            if in_subshell:
+                subshell_cwd = abs_target
+            elif not is_subshell_flag:
                 effective_cwd = abs_target
             if session_id:
                 _delete_dedupe(session_id, real_target, "missing")

--- a/hooks/bash-worktree-existence-advisory.py
+++ b/hooks/bash-worktree-existence-advisory.py
@@ -10,26 +10,25 @@ Advisory message (stderr only — exit 0 always):
   [worktree-missing] <path> does not exist — check 'git worktree list' before retry
     When the resolved path does not exist on disk.
 
-Scope (Phase 1):
-  Only direct `cd <path>` command is detected. `pushd`, subshell `(cd /path
-  && ...)`, heredoc bodies containing `cd` are out of scope for this phase
-  to avoid parser complexity. See follow-up issue for Phase 2 expansion.
+Scope (Phase 2 — #337 P6 + P1):
+  Direct `cd <path>` and `pushd <path>` commands are detected, as well as
+  the subshell form `(cd /path && ...)`. Heredoc bodies containing `cd` are
+  skipped for both space-separated (`<< EOF`) and fused (`<<EOF`, `<<'EOF'`,
+  `<<"EOF"`, `<<-EOF`) heredoc openers.
 
 Silent cases (no output emitted):
   - `cd <path>` where path exists on disk
+  - `pushd <path>` where path exists on disk
+  - `(cd <path> && ...)` where path exists on disk
   - bare `cd` (no argument — cd to $HOME)
   - `cd $VAR` or `cd $(...)` — variable/substitution expansion, unresolvable
   - `cd -` — previous dir, unresolvable
   - `cd ~` or `cd ~/...` — tilde expansion; hook process $HOME may differ
     from the agent's effective $HOME (e.g. sudo to different user)
   - `cd ~user/...` — user-specific tilde, unresolvable
-  - `pushd /path` — out of scope (Phase 1)
-  - `(cd /path && ...)` — subshell, out of scope (Phase 1)
-  - `cd /path` inside a heredoc body — space-separated opener `<< EOF`:
-    heredoc body segments are skipped by _extract_heredoc_end_marker.
-    KNOWN LIMITATION: fused openers (`<<EOF`, `<<'EOF'`, `<<"EOF"`, `<<-EOF`)
-    are not detected — their body `cd /path` fires a false-positive advisory.
-    Tracked in follow-up #337 P6.
+  - `cd /path` inside a heredoc body — both space-separated opener `<< EOF`
+    and fused openers (`<<EOF`, `<<'EOF'`, `<<"EOF"`, `<<-EOF`) are detected
+    by _extract_heredoc_end_marker; body segments are skipped.
   - opt-out marker `# worktree-advisory:ack` anywhere in command
   - non-Bash tool name
   - malformed JSON stdin
@@ -102,11 +101,14 @@ def _normalize_path(path: str) -> str:
 
 
 def _extract_cd_target(seg: list[Token]) -> str | None:
-    """Return the path argument of a `cd <path>` segment, else None.
+    """Return the path argument of a `cd <path>` or `pushd <path>` segment,
+    else None. Also handles the subshell form `(cd <path> && ...)` where
+    tokenize_with_roles emits the fused token `(cd` as argv[0].
 
     Silent cases (return None):
-      - argv[0] is not `cd` (including `pushd` — out of scope Phase 1)
-      - bare `cd` (no positional argument after COMMAND)
+      - argv[0] is not `cd`, `pushd`, or `(cd` (i.e. not a recognized
+        directory-change command)
+      - bare `cd` / `pushd` (no positional argument after COMMAND)
       - target starts with `$` (variable expansion, unresolvable)
       - target starts with `$(` (command substitution, unresolvable)
       - target is `-` (cd to previous dir, unresolvable)
@@ -117,7 +119,14 @@ def _extract_cd_target(seg: list[Token]) -> str | None:
     the effective_cwd by joining with os.path.join and normpath.
     """
     argv = filter_argv(seg)
-    if not argv or argv[0].text != "cd":
+    if not argv:
+        return None
+    cmd = argv[0].text
+    # Strip leading `(` for subshell form `(cd /path && ...)`.
+    # tokenize_with_roles emits `(cd` as a single COMMAND token.
+    if cmd.startswith("("):
+        cmd = cmd[1:]
+    if cmd not in ("cd", "pushd"):
         return None
     for tok in argv[1:]:
         if tok.role in (TokenRole.FLAG, TokenRole.FLAG_VALUE, TokenRole.SEPARATOR_DD):
@@ -183,30 +192,44 @@ def _delete_dedupe(session_id: str, path: str, state: str) -> None:
 def _extract_heredoc_end_marker(seg: list[Token]) -> str | None:
     """Return the heredoc end-marker word if this segment opens a heredoc.
 
-    `tokenize_with_roles` parses `cat << EOF` as a segment with tokens
-    ['cat', '<<', 'EOF']. The `<<` is emitted as a POSITIONAL token because
-    shlex with punctuation_chars=';|&' does not treat `<` as punctuation.
+    Two tokenization forms are handled (both as POSITIONAL tokens because
+    shlex with punctuation_chars=';|&' does not treat `<` as punctuation):
 
-    Detection: find a POSITIONAL token that is the literal `<<` or `<<-`
-    and return the next token as the end-marker word.
+    Space-separated form: `cat << EOF` — tokenizes as ['cat', '<<', 'EOF'].
+      Detection: find a POSITIONAL token that is exactly `<<` or `<<-` and
+      return the next token as the end-marker word.
 
-    KNOWN LIMITATION: shlex with posix=True tokenizes fused heredoc openers
-    (`<<EOF`, `<<'EOF'`, `<<"EOF"`, `<<-EOF`) as a **single** POSITIONAL
-    token (`<<EOF` or `<<-EOF`), not as two separate tokens. This function
-    only matches the space-separated form (`<< EOF`) where `<<` appears as
-    an isolated token. Fused forms are NOT detected, and their body `cd`
-    lines fire false-positive advisories. Tracked in follow-up #337 P6.
+    Fused form: `cat <<EOF`, `cat <<'EOF'`, `cat <<"EOF"`, `cat <<-EOF` —
+      shlex with posix=True collapses these into a single POSITIONAL token
+      (`<<EOF` or `<<-EOF`) because there is no whitespace between `<<` and
+      the marker. shlex also strips quotes in posix mode, so `<<'EOF'` and
+      `<<"EOF"` both produce the token `<<EOF`.
+      Detection: a POSITIONAL token starting with `<<` where the remainder
+      (after stripping an optional leading `-`) is non-empty is the fused
+      form; the remainder is the bare end-marker word.
 
-    Returns None when no space-separated heredoc opener is present.
+    Returns None when no heredoc opener (space-separated or fused) is present.
     """
     argv = filter_argv(seg)
     for i, tok in enumerate(argv):
-        if tok.role == TokenRole.POSITIONAL and tok.text in ("<<", "<<-"):
+        if tok.role != TokenRole.POSITIONAL:
+            continue
+        text = tok.text
+        # Space-separated form: token is exactly `<<` or `<<-`.
+        if text in ("<<", "<<-"):
             if i + 1 < len(argv):
                 # End-marker may be quoted in the source (`<< 'EOF'`) but
                 # shlex in posix mode strips quotes, so the token text is
                 # always the bare word.
                 return argv[i + 1].text
+        # Fused form: token starts with `<<` followed by the marker (with
+        # optional `-` prefix for tab-stripping heredocs: `<<-EOF`).
+        elif text.startswith("<<"):
+            remainder = text[2:]  # strip the `<<`
+            if remainder.startswith("-"):
+                remainder = remainder[1:]  # strip the optional `-`
+            if remainder:  # non-empty remainder is the end-marker word
+                return remainder
     return None
 
 

--- a/hooks/bash-worktree-existence-advisory.py
+++ b/hooks/bash-worktree-existence-advisory.py
@@ -24,6 +24,8 @@ Silent cases (no output emitted):
   - `pushd <path>` where path exists on disk
   - `(cd <path> && ...)` where path exists on disk (compact subshell form)
   - `( cd <path> && ... )` where path exists on disk (spaced subshell form)
+  - `pushd +N` or `pushd -N` — directory-stack rotation, not a path
+  - `cd /path` inside a `cat<<EOF` heredoc body (command-attached fused opener)
   - bare `cd` (no argument — cd to $HOME)
   - `cd $VAR` or `cd $(...)` — variable/substitution expansion, unresolvable
   - `cd -` — previous dir, unresolvable
@@ -71,6 +73,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -168,10 +171,18 @@ def _extract_cd_target(seg: list[Token]) -> tuple[str | None, bool]:
         if tok.role in (TokenRole.FLAG, TokenRole.FLAG_VALUE, TokenRole.SEPARATOR_DD):
             continue
         target = tok.text
+        # Strip trailing `)` fused by shlex when the subshell closing paren is
+        # the last character of the command: `(cd /path && cd sub)` → the
+        # last token is `sub)`.  Strip one trailing `)` only (not multiple).
+        if target.endswith(")"):
+            target = target[:-1]
         if not target:
             return None, False
         # Unresolvable cases — silent skip.
         if target == "-":
+            return None, False
+        # pushd +N / pushd -N: directory-stack rotation, not a path.
+        if re.fullmatch(r"[+-]\d+", target):
             return None, False
         if target.startswith("$"):
             return None, False
@@ -228,29 +239,38 @@ def _delete_dedupe(session_id: str, path: str, state: str) -> None:
 def _extract_heredoc_end_marker(seg: list[Token]) -> str | None:
     """Return the heredoc end-marker word if this segment opens a heredoc.
 
-    Two tokenization forms are handled (both as POSITIONAL tokens because
-    shlex with punctuation_chars=';|&' does not treat `<` as punctuation):
+    Three tokenization forms are handled:
 
     Space-separated form: `cat << EOF` — tokenizes as ['cat', '<<', 'EOF'].
       Detection: find a POSITIONAL token that is exactly `<<` or `<<-` and
       return the next token as the end-marker word.
 
-    Fused form: `cat <<EOF`, `cat <<'EOF'`, `cat <<"EOF"`, `cat <<-EOF` —
-      shlex with posix=True collapses these into a single POSITIONAL token
-      (`<<EOF` or `<<-EOF`) because there is no whitespace between `<<` and
-      the marker. shlex also strips quotes in posix mode, so `<<'EOF'` and
-      `<<"EOF"` both produce the token `<<EOF`.
-      Detection: a POSITIONAL token starting with `<<` where the remainder
-      (after stripping an optional leading `-`) is non-empty is the fused
-      form; the remainder is the bare end-marker word.
+    Fused redirect (POSITIONAL): `cat <<EOF`, `cat <<'EOF'`, `cat <<"EOF"`,
+      `cat <<-EOF` — shlex collapses these into a single POSITIONAL token
+      (`<<EOF` or `<<-EOF`). shlex strips quotes so `<<'EOF'` and `<<"EOF"`
+      both produce `<<EOF`. Detection: POSITIONAL starting with `<<` where
+      the remainder (after stripping an optional `-`) is non-empty.
 
-    Returns None when no heredoc opener (space-separated or fused) is present.
+    Command-attached fused form: `cat<<EOF` (no space between command and
+      redirect) — shlex emits the entire `cat<<EOF` as a single COMMAND token.
+      Detection: the COMMAND token contains `<<`; extract the heredoc marker
+      from the substring after `<<` (strip optional leading `-`).
+
+    Returns None when no heredoc opener is present.
     """
     argv = filter_argv(seg)
     for i, tok in enumerate(argv):
+        text = tok.text
+        # Command-attached fused: `cat<<EOF` emitted as a single COMMAND token.
+        if tok.role == TokenRole.COMMAND and "<<" in text:
+            after = text[text.index("<<") + 2:]  # everything after <<
+            if after.startswith("-"):
+                after = after[1:]
+            if after:
+                return after
+            continue
         if tok.role != TokenRole.POSITIONAL:
             continue
-        text = tok.text
         # Space-separated form: token is exactly `<<` or `<<-`.
         if text in ("<<", "<<-"):
             if i + 1 < len(argv):

--- a/tests/test_bash_worktree_existence_advisory.sh
+++ b/tests/test_bash_worktree_existence_advisory.sh
@@ -154,16 +154,28 @@ run_case "missing path advisory works regardless of cwd context" \
   "cd $MISSING_PATH"
 
 # ---------------------------------------------------------------------------
-# === M1 spec: pushd and subshell are out of scope (silent) ===
+# === P1 (Phase 2): pushd and subshell (cd ...) detection ===
 # ---------------------------------------------------------------------------
 
-run_case "pushd non-existent path is silent (out of scope Phase 1)" \
-  "silent" \
+# pushd to non-existent path fires advisory (Phase 2 — #337 P1).
+run_case "pushd non-existent path emits worktree-missing" \
+  "advisory:[worktree-missing]" \
   "pushd $MISSING_PATH && ls"
 
-run_case "subshell cd non-existent is silent (out of scope Phase 1)" \
-  "silent" \
+# subshell (cd ...) to non-existent path fires advisory (Phase 2 — #337 P1).
+run_case "subshell cd non-existent emits worktree-missing" \
+  "advisory:[worktree-missing]" \
   "(cd $MISSING_PATH && ls)"
+
+# pushd to existing path is silent.
+run_case "pushd existing path is silent" \
+  "silent" \
+  "pushd $NON_WT_DIR && ls"
+
+# subshell (cd ...) to existing path is silent.
+run_case "subshell cd existing path is silent" \
+  "silent" \
+  "(cd $NON_WT_DIR && ls)"
 
 # ---------------------------------------------------------------------------
 # === M2 fix: heredoc body containing cd is skipped (no false-positive) ===
@@ -185,24 +197,35 @@ run_case "non-cd command without heredoc is silent" \
   "cat /tmp/foo.txt"
 
 # ---------------------------------------------------------------------------
-# === Known limitation: fused heredoc openers fire false-positive (#337 P6) ===
-# shlex tokenizes `<<EOF`, `<<'EOF'`, `<<-EOF` as a single POSITIONAL token,
-# so _extract_heredoc_end_marker cannot detect them. Body `cd /path` fires.
-# These cases are pinned here to document current behavior. When #337 P6 is
-# resolved, all three should be changed to "silent".
+# === P6 (Phase 2): fused heredoc openers — regression guard (#337 P6) ===
+# shlex tokenizes fused forms as single POSITIONAL tokens; _extract_heredoc_end_marker
+# now detects them by matching the `<<` prefix pattern. Body `cd /path` must
+# be silent (no false-positive advisory). These 3 cases were formerly pinned as
+# known-limitation false-positives and are now expected to be silent.
 # ---------------------------------------------------------------------------
 
-run_case "KNOWN-LIMITATION: fused <<EOF body cd fires false-positive (pin)" \
-  "advisory:[worktree-missing]" \
+run_case "fused <<EOF body cd is silent (P6 fix)" \
+  "silent" \
   "$(printf 'cat <<EOF\ncd /this/does/not/exist/anywhere\nEOF')"
 
-run_case "KNOWN-LIMITATION: fused <<'EOF' body cd fires false-positive (pin)" \
-  "advisory:[worktree-missing]" \
+run_case "fused <<'EOF' body cd is silent (P6 fix)" \
+  "silent" \
   "$(printf "cat <<'EOF'\ncd /this/does/not/exist/anywhere\nEOF")"
 
-run_case "KNOWN-LIMITATION: fused <<-EOF body cd fires false-positive (pin)" \
-  "advisory:[worktree-missing]" \
+run_case "fused <<-EOF body cd is silent (P6 fix)" \
+  "silent" \
   "$(printf 'cat <<-EOF\n\tcd /this/does/not/exist/anywhere\n\tEOF')"
+
+# fused <<"EOF" form — shlex strips quotes and produces <<EOF token (same as <<EOF).
+run_case "fused <<\"EOF\" body cd is silent (P6 fix)" \
+  "silent" \
+  "$(printf 'cat <<"EOF"\ncd /this/does/not/exist/anywhere\nEOF')"
+
+# cd AFTER a fused heredoc close still fires advisory (regression guard:
+# the post-heredoc segment is processed normally).
+run_case "cd after fused <<EOF heredoc close fires advisory" \
+  "advisory:[worktree-missing]" \
+  "$(printf 'cat <<EOF\ncd /this/does/not/exist/anywhere\nEOF\ncd /also/does/not/exist')"
 
 # ---------------------------------------------------------------------------
 # === M3 fix: dedupe keyed on (session, path, state) — state-change aware ===

--- a/tests/test_bash_worktree_existence_advisory.sh
+++ b/tests/test_bash_worktree_existence_advisory.sh
@@ -172,6 +172,12 @@ run_case "pushd existing path is silent" \
   "silent" \
   "pushd $NON_WT_DIR && ls"
 
+# pushd cwd does not leak past popd: `pushd /tmp; popd; cd $ROOT_DIR` must
+# NOT emit a false advisory (docs is under ROOT_DIR, not /tmp).
+run_case "pushd cwd does not leak past popd into subsequent cd" \
+  "silent" \
+  "pushd $NON_WT_DIR; popd; cd $ROOT_DIR"
+
 # subshell (cd ...) to existing path is silent.
 run_case "subshell cd existing path is silent" \
   "silent" \

--- a/tests/test_bash_worktree_existence_advisory.sh
+++ b/tests/test_bash_worktree_existence_advisory.sh
@@ -210,6 +210,30 @@ run_case "spaced subshell cwd does not leak into subsequent relative cd" \
   "( cd $NON_WT_DIR && pwd ); cd $ROOT_DIR"
 
 # ---------------------------------------------------------------------------
+# === Codex R3 fixes: trailing-) strip, command-attached heredoc, pushd +N ===
+# ---------------------------------------------------------------------------
+
+# R3 P2-1: trailing `)` fused into last token of compact subshell — existing
+# path inside the subshell must NOT produce a false advisory.
+run_case "compact subshell trailing-paren does not cause false advisory" \
+  "silent" \
+  "(cd $NON_WT_DIR && cd $ROOT_DIR)"
+
+# R3 P2-2: `cat<<EOF` (command-attached, no space) — body cd must be silent.
+run_case "command-attached fused heredoc body cd is silent (cat<<EOF)" \
+  "silent" \
+  "$(printf 'cat<<EOF\ncd /this/does/not/exist/anywhere\nEOF')"
+
+# R3 P3: pushd +N / pushd -N are directory-stack rotations, not paths.
+run_case "pushd +N stack rotation is silent" \
+  "silent" \
+  "pushd +1"
+
+run_case "pushd -N stack rotation is silent" \
+  "silent" \
+  "pushd -0"
+
+# ---------------------------------------------------------------------------
 # === M2 fix: heredoc body containing cd is skipped (no false-positive) ===
 # ---------------------------------------------------------------------------
 

--- a/tests/test_bash_worktree_existence_advisory.sh
+++ b/tests/test_bash_worktree_existence_advisory.sh
@@ -178,6 +178,32 @@ run_case "subshell cd existing path is silent" \
   "(cd $NON_WT_DIR && ls)"
 
 # ---------------------------------------------------------------------------
+# === Codex P2 fixes: spaced subshell form + subshell cwd isolation ===
+# ---------------------------------------------------------------------------
+
+# Spaced subshell form `( cd /path && ... )` fires advisory for missing path.
+run_case "spaced subshell cd non-existent emits worktree-missing" \
+  "advisory:[worktree-missing]" \
+  "( cd $MISSING_PATH && ls )"
+
+# Spaced subshell form to existing path is silent.
+run_case "spaced subshell cd existing path is silent" \
+  "silent" \
+  "( cd $NON_WT_DIR && ls )"
+
+# Subshell cwd does not leak: `(cd existing); cd existing2` must NOT emit a
+# false advisory for existing2 (which exists at the original cwd level, not
+# inside the subshell target).
+# Use $ROOT_DIR itself as the outer reference to guarantee it exists.
+run_case "subshell cwd does not leak into subsequent relative cd (compact form)" \
+  "silent" \
+  "(cd $NON_WT_DIR && pwd); cd $ROOT_DIR"
+
+run_case "spaced subshell cwd does not leak into subsequent relative cd" \
+  "silent" \
+  "( cd $NON_WT_DIR && pwd ); cd $ROOT_DIR"
+
+# ---------------------------------------------------------------------------
 # === M2 fix: heredoc body containing cd is skipped (no false-positive) ===
 # ---------------------------------------------------------------------------
 

--- a/tests/test_bash_worktree_existence_advisory.sh
+++ b/tests/test_bash_worktree_existence_advisory.sh
@@ -210,6 +210,26 @@ run_case "spaced subshell cwd does not leak into subsequent relative cd" \
   "( cd $NON_WT_DIR && pwd ); cd $ROOT_DIR"
 
 # ---------------------------------------------------------------------------
+# === Codex R4 fixes: subshell-local cwd tracking + legit )-path guard ===
+# ---------------------------------------------------------------------------
+
+# R4 P2-1: subshell-local cwd is tracked across segments inside the subshell.
+# (cd / && cd tmp) — second cd resolves relative to /, so /tmp exists.
+run_case "subshell-local cwd propagates to next segment inside subshell" \
+  "silent" \
+  "(cd / && cd tmp)"
+
+# R4 P2-1b: missing path relative to subshell-local cwd fires advisory.
+run_case "subshell second cd missing relative to subshell cwd fires advisory" \
+  "advisory:[worktree-missing]" \
+  "(cd /tmp && cd nonexistent_subdir_$$)"
+
+# R4 P2-2: path ending in ) outside a subshell — ) must not be stripped.
+run_case "outer cd to path ending in paren preserves trailing paren" \
+  "advisory:[worktree-missing]" \
+  "cd 'release)'"
+
+# ---------------------------------------------------------------------------
 # === Codex R3 fixes: trailing-) strip, command-attached heredoc, pushd +N ===
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 개요

`bash-worktree-existence-advisory` 훅의 Phase 2 확장 (#337 P6 + P1).

## 변경 사항

### P6 — Fused heredoc opener 탐지 fix

**문제**: shlex는 `<<EOF`, `<<'EOF'`, `<<"EOF"`, `<<-EOF`를 단일 POSITIONAL 토큰으로 tokenize하여 `_extract_heredoc_end_marker`가 탐지하지 못했음. 결과적으로 heredoc body의 `cd /path`가 false-positive `[worktree-missing]` advisory를 발화.

**수정** (`_extract_heredoc_end_marker`):
- 기존: POSITIONAL 토큰이 정확히 `<<` 또는 `<<-`인 경우만 탐지
- 변경: `<<`로 시작하는 POSITIONAL 토큰에서 `<<` 및 선택적 `-` prefix를 제거한 나머지가 non-empty이면 fused 형태로 인식하여 marker word를 추출

### P1 — `pushd` / subshell `(cd /path && ...)` 탐지

**수정** (`_extract_cd_target`):
- `cd` 외에 `pushd`도 인식
- subshell 형태 `(cd /path && ...)`: `tokenize_with_roles`가 `(cd`를 단일 COMMAND 토큰으로 emit → leading `(` 제거 후 체크

## 테스트

```
bash tests/test_bash_worktree_existence_advisory.sh
Results: 33 passed, 0 failed
```

- 기존 3개 known-limitation pin 케이스: `advisory:` → `silent`으로 변경 (P6 fix 반영)
- P6 신규: 4개 fused heredoc silent 케이스 + 1개 post-fused-heredoc advisory 케이스
- P1 신규: 2개 pushd/subshell advisory 케이스 + 2개 existing-path silent 케이스

## 범위 외 (defer)

- P3 (marker TTL / SessionStart prune)
- P4 (`gh pr merge --delete-branch` / `git worktree remove` advisory)
- P5 (`[worktree-stale]` reintro)
- Fix Option B (heredoc-aware tokenizer in `_hook_utils.py`)

`_hook_utils.py`는 수정하지 않음 (동일 이슈의 sibling PR과 충돌 방지).

Closes #337