### PR TITLE
fix(hook): external-write-path-existence-check P1

### DIFF
--- a/docs/hook/external-write-path-existence-check.md
+++ b/docs/hook/external-write-path-existence-check.md
@@ -16,17 +16,23 @@ in issue text that downstream readers and review tools (BugBot, Codex) used
 as ground truth.  Lexical scanning of body files before posting catches this
 class of error at the last checkpoint before shared-state mutation.
 
-### What is warned (Phase 1 scope)
+### What is warned
 
 | Trigger | Condition | Advisory |
 |---------|-----------|----------|
 | `gh (issue\|pr) (create\|edit\|comment) ... --body-file <path>` | Body contains markdown link `](./target)` or `](docs/...)` etc. where target is absent under repo root | Phantom-path list to stderr |
+| Same trigger | Body contains inline code span `` `hooks/foo.sh` `` with a repo-relative prefix where target is absent | Phantom-path list to stderr |
 
-Phase 1 covers **markdown link targets** (`](path)`) only.  Inline-code path
-tokens (`` `hooks/foo.sh` ``) are Phase 2 (deferred).
+Path extraction covers two sources:
+- **Markdown link targets** (`](path)`) — Phase 1
+- **Inline code spans** (`` `hooks/foo.sh` ``) — Phase 2, repo-relative prefix only
 
-Recognized repo-relative prefixes (Phase 1):
+Recognized repo-relative prefixes:
 `./`, `docs/`, `hooks/`, `skills/`, `tests/`, `scripts/`, `manifests/`
+
+Leading `./` is stripped to produce a root-relative path using `target[2:]`
+(not `lstrip("./")`) so paths like `./../escape.md` are not mangled —
+they become `../escape.md` and are correctly flagged as out-of-tree.
 
 ### What is NOT warned
 
@@ -35,7 +41,8 @@ Recognized repo-relative prefixes (Phase 1):
 | `--body "text"` / `--body-file -` (stdin) | Body content inaccessible at PreToolUse time; fail-open |
 | Absolute paths (`/usr/...`) | Out-of-scope — not repo-relative |
 | HTTP/HTTPS/mailto/anchor links | Scheme-prefixed or anchor targets |
-| Paths outside recognized prefixes | Phase 2 |
+| Paths outside recognized prefixes | Not in scope |
+| Binary files (NUL byte in first 512 bytes) | Sniffed as binary; skipped to prevent false-positive matches inside binary blobs |
 | Same session_id + body content SHA-256 already reported | Dedup prevents spam |
 
 ### Response
@@ -109,7 +116,7 @@ Restart Claude Code after adding the entry.
 bash tests/test_external_write_path_existence_check.sh
 ```
 
-Covers 6 cases (Phase 1 scope + M1/M2/M3 regression):
+Covers 9 cases (Phase 1 scope + M1/M2/M3 regression + P1 refinements):
 
 | Case | Input | Expected |
 |------|-------|----------|
@@ -119,3 +126,6 @@ Covers 6 cases (Phase 1 scope + M1/M2/M3 regression):
 | Anchor fragment (M1) | Body links to `docs/hook/INDEX.md#preflight-gate` | Pass — fragment stripped, file exists |
 | Dedup re-emit (M2) | Same body content submitted twice in same session | Advisory fires once; second suppressed |
 | Binary body file (M3) | Body file contains non-UTF-8 bytes | Fail-open — exit 0, no advisory |
+| Inline code span (P1-Phase2) | `` `hooks/pre-tool-use/nonexistent.sh` `` phantom + `` `docs/hook/INDEX.md` `` real | Advisory for phantom only |
+| lstrip quirk (P1-lstrip) | Link target `./../escape.md` | Advisory shows `../escape.md`, not `escape.md` |
+| Binary NUL sniff (P1-binary) | Body file with NUL bytes (and embedded phantom path string) | Fail-open — NUL sniff skips file, exit 0, no advisory |

--- a/hooks/external-write-path-existence-check.py
+++ b/hooks/external-write-path-existence-check.py
@@ -211,8 +211,13 @@ def _extract_candidate_paths(body: str) -> list[str]:
     body_no_fences = _FENCED_BLOCK_RE.sub("", body)
     for m in _INLINE_CODE_RE.finditer(body_no_fences):
         token = m.group(1).strip()
-        if any(token.startswith(pfx) for pfx in REPO_RELATIVE_PREFIXES):
-            candidates.append(token[2:] if token.startswith("./") else token)
+        # Take only the path component — stop at the first whitespace so that
+        # inline command examples like `hooks/foo.py --help` do not produce a
+        # phantom-path advisory for "hooks/foo.py --help" (which includes args
+        # and would never match a real filesystem path).
+        path_token = token.split()[0] if token else token
+        if any(path_token.startswith(pfx) for pfx in REPO_RELATIVE_PREFIXES):
+            candidates.append(path_token[2:] if path_token.startswith("./") else path_token)
 
     # Dedupe while preserving order.
     seen: set[str] = set()

--- a/hooks/external-write-path-existence-check.py
+++ b/hooks/external-write-path-existence-check.py
@@ -216,6 +216,12 @@ def _extract_candidate_paths(body: str) -> list[str]:
         # phantom-path advisory for "hooks/foo.py --help" (which includes args
         # and would never match a real filesystem path).
         path_token = token.split()[0] if token else token
+        # Strip anchor fragment and query string — mirrors Phase 1 markdown-link
+        # handling so `docs/foo.md#section` and `hooks/bar.py?v=2` do not
+        # produce a phantom hit on an otherwise-existing file.
+        path_token = path_token.split("#", 1)[0].split("?", 1)[0]
+        if not path_token:
+            continue
         if any(path_token.startswith(pfx) for pfx in REPO_RELATIVE_PREFIXES):
             candidates.append(path_token[2:] if path_token.startswith("./") else path_token)
 

--- a/hooks/external-write-path-existence-check.py
+++ b/hooks/external-write-path-existence-check.py
@@ -70,6 +70,11 @@ _MD_LINK_RE = re.compile(r"\]\(([^)\s]+)\)")
 # blocks.  The backtick cannot appear inside the span content.
 _INLINE_CODE_RE = re.compile(r"`([^`]+)`")
 
+# Fenced code block (triple-backtick): strip before inline-code search to
+# avoid false-positive phantom-path hits on sample snippets in PR bodies.
+# Matches both labelled (```bash ... ```) and unlabelled (``` ... ```) fences.
+_FENCED_BLOCK_RE = re.compile(r"```[^\n]*\n.*?```", re.DOTALL)
+
 # gh subcommand pairs that accept --body-file and write to external surfaces.
 _GH_BODY_FILE_SUBCOMMANDS = frozenset({
     ("issue", "create"),
@@ -199,9 +204,12 @@ def _extract_candidate_paths(body: str) -> list[str]:
             candidates.append(target[2:] if target.startswith("./") else target)
 
     # Phase 2: inline code spans — `hooks/foo.sh` style references.
+    # Strip fenced blocks first so unlabelled triple-backtick fences
+    # (``` hooks/nonexistent.sh ```) don't produce phantom-path false positives.
     # Only repo-relative prefixes are in scope; `./` prefix is also accepted
     # and stripped consistently with the markdown-link handling above.
-    for m in _INLINE_CODE_RE.finditer(body):
+    body_no_fences = _FENCED_BLOCK_RE.sub("", body)
+    for m in _INLINE_CODE_RE.finditer(body_no_fences):
         token = m.group(1).strip()
         if any(token.startswith(pfx) for pfx in REPO_RELATIVE_PREFIXES):
             candidates.append(token[2:] if token.startswith("./") else token)
@@ -320,11 +328,29 @@ def main() -> int:
             continue
 
         repo_root = _resolve_repo_root(body_file, cwd)
+        real_repo_root = os.path.realpath(repo_root)
 
-        phantom: list[str] = [
-            p for p in candidates
-            if not os.path.exists(os.path.join(repo_root, p))
-        ]
+        def _is_phantom(p: str) -> bool:
+            """Return True if path p should be treated as a phantom reference.
+
+            A path is phantom when it does not exist inside the repo root.
+            Paths that escape the repo root via `../` traversal are always
+            phantom even when they happen to exist on the filesystem (e.g. a
+            sibling worktree directory), because they reference content outside
+            the repository boundary.
+            """
+            full = os.path.join(repo_root, p)
+            if not os.path.exists(full):
+                return True
+            # Resolve symlinks/`../` so a path like `../sibling-worktree` that
+            # physically exists outside the repo tree is still flagged.
+            # Use separator-aware prefix comparison to avoid false negatives
+            # when a sibling directory shares the repo root name as a prefix
+            # (e.g. /tmp/praxis-wt-copy startswith /tmp/praxis-wt → True).
+            resolved = os.path.realpath(full)
+            return not (resolved == real_repo_root or resolved.startswith(real_repo_root + os.sep))
+
+        phantom: list[str] = [p for p in candidates if _is_phantom(p)]
 
         if phantom:
             _mark_reported(dk)

--- a/hooks/external-write-path-existence-check.py
+++ b/hooks/external-write-path-existence-check.py
@@ -23,7 +23,8 @@ Phase 1 scope (issue #324):
   - Fail-open on any infrastructure error (malformed stdin, missing git,
     unreadable file, etc.).
 
-Phase 2 (deferred): inline-code path tokens (`` `hooks/foo.sh` ``).
+Phase 2: inline-code path tokens (`` `hooks/foo.sh` ``) with repo-relative
+prefix — extends extraction alongside Phase 1 markdown links.
 """
 from __future__ import annotations
 
@@ -63,6 +64,11 @@ REPO_RELATIVE_PREFIXES = (
 # Markdown link target: `](path)` — capture the path portion.
 # Non-greedy so `](a.md) and ](b.md)` yields two separate matches.
 _MD_LINK_RE = re.compile(r"\]\(([^)\s]+)\)")
+
+# Inline code span: `hooks/foo.sh` — capture the content between backticks.
+# Only matches single-backtick spans to avoid multi-backtick fenced code
+# blocks.  The backtick cannot appear inside the span content.
+_INLINE_CODE_RE = re.compile(r"`([^`]+)`")
 
 # gh subcommand pairs that accept --body-file and write to external surfaces.
 _GH_BODY_FILE_SUBCOMMANDS = frozenset({
@@ -166,8 +172,14 @@ def _resolve_repo_root(body_file_path: str, cwd: str) -> str:
 # ---------------------------------------------------------------------------
 
 def _extract_candidate_paths(body: str) -> list[str]:
-    """Extract markdown link targets that look like repo-relative paths."""
+    """Extract repo-relative paths from markdown links and inline code spans.
+
+    Sources:
+    - Markdown link targets: ``](path)``
+    - Inline code spans: `` `hooks/foo.sh` `` (Phase 2 — repo-relative prefix only)
+    """
     candidates: list[str] = []
+
     for m in _MD_LINK_RE.finditer(body):
         target = m.group(1)
         # Ignore http/https/mailto/anchor-only links.
@@ -181,7 +193,19 @@ def _extract_candidate_paths(body: str) -> list[str]:
             continue
         if any(target.startswith(pfx) for pfx in REPO_RELATIVE_PREFIXES):
             # Strip leading `./` so the path is always relative-to-root.
-            candidates.append(target.lstrip("./") if target.startswith("./") else target)
+            # Use target[2:] rather than lstrip("./") to avoid mangling paths
+            # like `./../escape.md` into `escape.md` (lstrip is greedy on
+            # individual characters, not the literal prefix).
+            candidates.append(target[2:] if target.startswith("./") else target)
+
+    # Phase 2: inline code spans — `hooks/foo.sh` style references.
+    # Only repo-relative prefixes are in scope; `./` prefix is also accepted
+    # and stripped consistently with the markdown-link handling above.
+    for m in _INLINE_CODE_RE.finditer(body):
+        token = m.group(1).strip()
+        if any(token.startswith(pfx) for pfx in REPO_RELATIVE_PREFIXES):
+            candidates.append(token[2:] if token.startswith("./") else token)
+
     # Dedupe while preserving order.
     seen: set[str] = set()
     result: list[str] = []
@@ -267,11 +291,22 @@ def main() -> int:
         if not os.path.isfile(body_file):
             continue
 
+        # Sniff head bytes for NUL (\x00) to detect binary files.  Binary
+        # content is not valid markdown; skip to avoid false-positive matches
+        # inside binary blobs (e.g. an accidentally passed ELF or image file).
+        try:
+            with open(body_file, "rb") as fh_bin:
+                head = fh_bin.read(512)
+            if b"\x00" in head:
+                continue  # binary file — skip silently (fail-open)
+        except OSError:
+            continue  # fail-open — unreadable file
+
         try:
             with open(body_file, encoding="utf-8", errors="replace") as fh:
                 body = fh.read()
         except (OSError, UnicodeDecodeError):
-            continue  # fail-open — binary or unreadable file
+            continue  # fail-open — unreadable file
 
         # Session-scoped dedup keyed on body content so that the same body
         # in a different temp path fires only once, and an edited body with

--- a/tests/test_external_write_path_existence_check.sh
+++ b/tests/test_external_write_path_existence_check.sh
@@ -335,8 +335,11 @@ bin9_body_file=$(mktemp /tmp/test-phantom-bin9-XXXXXX)
 # with detection the file should be skipped silently.
 python3 -c "
 import sys
-# Embed a phantom-looking path string around NUL bytes
-content = b'hooks/pre-tool-use/phantom.sh\x00binary\x00data'
+# Embed a phantom path in an inline-code span around NUL bytes so that
+# _extract_candidate_paths() would find it if NUL-sniffing were absent.
+# Without NUL detection the backtick span would trigger a phantom advisory;
+# with detection the file is skipped before link extraction fires.
+content = b'\`hooks/pre-tool-use/phantom.sh\`\x00binary\x00data'
 sys.stdout.buffer.write(content)
 " > "$bin9_body_file"
 

--- a/tests/test_external_write_path_existence_check.sh
+++ b/tests/test_external_write_path_existence_check.sh
@@ -271,6 +271,111 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Case 7 (P1-Phase2): inline code span — `hooks/foo.sh` style phantom path
+# triggers advisory; `docs/hook/INDEX.md` real path does not.
+# ---------------------------------------------------------------------------
+case7_body='# Inline code span test
+
+The file `hooks/pre-tool-use/nonexistent.sh` should be implemented.
+See `docs/hook/INDEX.md` for examples.
+'
+run_with_body "$case7_body" 'gh issue create --title "Inline"' "session-inline-$$" c7_err c7_rc
+
+c7_ok=1
+[ "$c7_rc" -eq 0 ] || c7_ok=0
+echo "$c7_err" | grep -q "\[phantom-path\]" || c7_ok=0
+echo "$c7_err" | grep -q "pre-tool-use/nonexistent.sh" || c7_ok=0
+# Real path in inline code must NOT appear as phantom
+echo "$c7_err" | grep -q "INDEX.md" && c7_ok=0
+if [ "$c7_ok" -eq 1 ]; then
+  echo "PASS: inline code span — phantom detected, real path not flagged"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: inline code span (rc=$c7_rc, stderr='${c7_err:0:200}')"
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("inline code span — phantom detected, real path not flagged")
+fi
+
+# ---------------------------------------------------------------------------
+# Case 8 (P1-lstrip): lstrip("./") quirk — `./../escape.md` must NOT be
+# mangled to `escape.md`.  The path starts with `./` so it is a recognized
+# prefix; after stripping the `./` prefix it becomes `../escape.md` which
+# does not exist under repo root and must trigger an advisory.
+# ---------------------------------------------------------------------------
+case8_body='# lstrip quirk test
+
+See [escape](./../escape.md) for details.
+'
+run_with_body "$case8_body" 'gh issue create --title "Lstrip"' "session-lstrip-$$" c8_err c8_rc
+
+c8_ok=1
+[ "$c8_rc" -eq 0 ] || c8_ok=0
+# The advisory must mention the path (not silently pass because `escape.md`
+# happened to not exist — we verify the correct path appears in the message).
+echo "$c8_err" | grep -q "\[phantom-path\]" || c8_ok=0
+# The stripped path should be `../escape.md`, not `escape.md`
+echo "$c8_err" | grep -q "\.\./escape\.md" || c8_ok=0
+if [ "$c8_ok" -eq 1 ]; then
+  echo "PASS: lstrip quirk — ./../escape.md -> ../escape.md (not mangled to escape.md)"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: lstrip quirk (rc=$c8_rc, stderr='${c8_err:0:200}')"
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("lstrip quirk — ./../escape.md -> ../escape.md (not mangled to escape.md)")
+fi
+
+# ---------------------------------------------------------------------------
+# Case 9 (P1-binary): binary file with NUL bytes — hook must exit 0 with no
+# advisory (NUL sniff causes early skip before link extraction).
+# Distinct from Case 6 (M3) which tests non-UTF-8 bytes without NUL.
+# ---------------------------------------------------------------------------
+bin9_body_file=$(mktemp /tmp/test-phantom-bin9-XXXXXX)
+# Write content that includes NUL bytes AND a phantom path string.
+# Without NUL detection the phantom string would trigger an advisory;
+# with detection the file should be skipped silently.
+python3 -c "
+import sys
+# Embed a phantom-looking path string around NUL bytes
+content = b'hooks/pre-tool-use/phantom.sh\x00binary\x00data'
+sys.stdout.buffer.write(content)
+" > "$bin9_body_file"
+
+bin9_err_file=$(mktemp /tmp/test-phantom-err9-XXXXXX)
+bin9_payload=$(python3 -c "
+import json, sys
+body_file = sys.argv[1]
+session_id = sys.argv[2]
+repo_root = sys.argv[3]
+payload = {
+    'session_id': session_id,
+    'tool_name': 'Bash',
+    'tool_input': {
+        'command': 'gh issue create --title \"Binary9\" --body-file ' + body_file,
+    },
+    'cwd': repo_root,
+}
+print(json.dumps(payload))
+" "$bin9_body_file" "session-binary9-$$" "$ROOT_DIR")
+
+env -u PRAXIS_PHANTOM_PATH_STRICT \
+  python3 "$HOOK" >/dev/null 2>"$bin9_err_file" <<< "$bin9_payload"
+bin9_rc=$?
+bin9_err=$(cat "$bin9_err_file")
+rm -f "$bin9_body_file" "$bin9_err_file"
+
+c9_ok=1
+[ "$bin9_rc" -eq 0 ] || c9_ok=0
+[ -z "$bin9_err" ] || c9_ok=0
+if [ "$c9_ok" -eq 1 ]; then
+  echo "PASS: binary NUL sniff — NUL-containing file skipped, no false-positive advisory"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: binary NUL sniff (rc=$bin9_rc, stderr='${bin9_err:0:120}')"
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("binary NUL sniff — NUL-containing file skipped, no false-positive advisory")
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 개요

`hooks/external-write-path-existence-check.py` Phase 1 이후 미뤄졌던 3가지 P1 정제 항목을 구현합니다.

Closes #335

---

## 변경 사항

### 1. Phase 2 — 인라인 코드 span 토큰 추출
`` `hooks/foo.sh` `` 형태의 인라인 코드 span에서도 repo-relative 경로를 추출합니다.
기존 마크다운 링크(`](path)`) 추출과 동일한 prefix 필터를 적용합니다.

### 2. lstrip quirk 수정
`target.lstrip("./")` → `target[2:] if target.startswith("./") else target` 로 교체.
기존 코드는 `./../escape.md`를 `escape.md`로 망가뜨렸으나, 수정 후 `../escape.md`로 올바르게 처리됩니다.

### 3. 바이너리 파일 감지
파일을 텍스트로 읽기 전 첫 512바이트를 바이너리 모드로 읽어 NUL(`\x00`) 바이트를 검사합니다.
NUL 감지 시 파일을 조용히 건너뛰어(fail-open) 바이너리 블롭 내 경로 유사 문자열에 대한 false-positive를 방지합니다.

---

## 검증

| 항목 | 결과 |
|------|------|
| 기존 6개 테스트 | 모두 통과 |
| Case 7 — 인라인 코드 span | PASS |
| Case 8 — lstrip quirk | PASS |
| Case 9 — 바이너리 NUL sniff | PASS |
| **합계** | **9/9 PASS** |

```
PASS: existing path — docs/hook/INDEX.md is real
PASS: missing path — hooks/pre-tool-use/... phantom
PASS: mixed paths — only phantom listed
PASS: anchor fragment — stripped, no false-positive advisory
PASS: dedup — same body content suppresses duplicate advisory
PASS: binary body file — fail-open, exit 0, no advisory
PASS: inline code span — phantom detected, real path not flagged
PASS: lstrip quirk — ./../escape.md -> ../escape.md (not mangled to escape.md)
PASS: binary NUL sniff — NUL-containing file skipped, no false-positive advisory

Results: 9 passed, 0 failed
```

---

## 검증하지 않은 항목

- 실제 Claude Code 세션에서 PreToolUse 훅으로 통합 실행 (로컬 단위 테스트로 검증)
- `PRAXIS_PHANTOM_PATH_STRICT=1` strict 모드와 P1 항목의 조합 (기존 동작 유지)

---

## 영향 범위

- `hooks/external-write-path-existence-check.py` — 경로 추출·바이너리 감지 로직
- `docs/hook/external-write-path-existence-check.md` — 스펙 업데이트
- `tests/test_external_write_path_existence_check.sh` — 회귀 케이스 3개 추가
- 다른 훅, `hooks/hooks.json`, `_hook_utils.py` 무수정
