### PR TITLE
feat(hook): trino-catalog-gate refinements

### DIFF
--- a/docs/hook/trino-catalog-gate.md
+++ b/docs/hook/trino-catalog-gate.md
@@ -70,13 +70,33 @@ of these SQL context keywords:
 |-------------|--------|
 | `FROM` | `SELECT ... FROM`, `DELETE FROM` |
 | `JOIN` | all JOIN variants |
-| `INTO` | `INSERT INTO`, `MERGE INTO` |
+| `INTO` | `INSERT INTO`, `MERGE INTO` — **not** bare `SELECT col INTO dest` (SELECT-INTO is not valid Trino SQL; see "Known limitations" below) |
 | `UPDATE` | `UPDATE <ref> SET ...` |
 | `TABLE` | `CREATE TABLE`, `CREATE OR REPLACE TABLE`, `ALTER TABLE` |
 | `VIEW` | `CREATE VIEW`, `CREATE OR REPLACE VIEW` |
+| `USING` | `MERGE INTO t USING <catalog>.<schema>.<table>` — source table in MERGE statements (#336 item 7) |
+| `LIKE` | `CREATE TABLE x (LIKE <catalog>.<schema>.<table>)` — LIKE clause reference (#336 item 8) |
 
 The context keyword gate avoids false positives on Python attribute chains like
 `os.path.sep`.
+
+**`INTO` arm — SELECT-INTO exclusion**: The `INTO` arm is restricted to
+`INSERT INTO` and `MERGE INTO` contexts. `SELECT col INTO cat.s.t FROM src`
+(PostgreSQL/SQL-Server SELECT-INTO syntax) does NOT trigger the gate because
+Trino does not support SELECT-INTO; blocking it would produce a misleading
+deny message pointing to a catalog-enumeration problem rather than an
+unsupported-syntax error. A separate `MERGE_INSERT_INTO_RE` pattern captures
+only the `(INSERT|MERGE) INTO` form (#336 item 6).
+
+**`SHOW SCHEMAS FROM <catalog>` and catalog-existence verification**: A
+`SHOW SCHEMAS FROM iceberg` query does NOT count as catalog-existence
+verification for the gate. Rationale: `SHOW SCHEMAS FROM <catalog>` itself
+references the catalog name inline; if the catalog does not exist, Trino
+returns `Catalog '<name>' not found`. The gate marker is created only by
+`SHOW CATALOGS` (the query that *enumerates available catalogs*), not by
+commands that *assume* a catalog exists. Use `SHOW CATALOGS` first, then
+`SHOW SCHEMAS FROM <catalog>` to list schemas in a verified catalog (#336
+item 2).
 
 String literals are masked before comment and catalog-reference detection so
 that `--` or `/* */` sequences embedded inside string values are not treated
@@ -127,9 +147,6 @@ subsequent queries in the same session once the marker file exists.
 The following SQL shapes may produce `CATALOG_NOT_FOUND` but are not yet
 detected by this hook (will silently pass through):
 
-- **MERGE source `USING <catalog>.<schema>.<table>`** — the USING clause target
-  does not follow a FROM/INTO keyword and is not currently detected (tracked in #336).
-- **`CREATE TABLE x (LIKE catalog.schema.t)`** — LIKE clause references not detected (tracked in #336).
 - **Double-quoted / backtick bypass** — marker text inside a double-quoted
   (`"-- catalog-enumerated: verified"`) or backtick
   (`` `-- catalog-enumerated: verified` ``) identifier is NOT masked, so the
@@ -139,6 +156,11 @@ detected by this hook (will silently pass through):
   but the outer query does not.
 - Dynamic SQL via `EXECUTE PREPARE <name> USING ...` (prepared statement
   reference, not the underlying SQL text).
+
+> **Resolved in #336**: `MERGE ... USING <catalog>.<schema>.<table>` (#336 item 7)
+> and `CREATE TABLE x (LIKE <catalog>.<schema>.<table>)` (#336 item 8) are now
+> detected. `SELECT col INTO <catalog>.<schema>.<table>` (SELECT-INTO) now passes
+> correctly with a non-misleading path (#336 item 6).
 
 ### Known limitations — false positives (gate blocks, should pass)
 
@@ -160,8 +182,8 @@ all the above delimiter-interaction limitations. See #336 P-redesign.
 bash tests/test_trino_catalog_gate.sh
 ```
 
-Covers 27 cases across M1 (bypass comment-only), M2 (DML/DDL keyword set),
-M3 (multi-statement isolation), and C1 (string-literal masking):
+Covers cases across M1 (bypass comment-only), M2 (DML/DDL keyword set),
+M3 (multi-statement isolation), C1 (string-literal masking), and #336 items:
 
 - (a) `SHOW CATALOGS` passes + creates marker; subsequent 3-part query passes
 - (b) 3-part `FROM`/`JOIN` reference without marker → deny
@@ -172,3 +194,9 @@ M3 (multi-statement isolation), and C1 (string-literal masking):
 - M2: `INSERT INTO`, `MERGE INTO`, `UPDATE`, `CREATE TABLE`, `CREATE VIEW`, `DELETE FROM` → deny
 - M3: `SHOW CATALOGS; SELECT ... FROM 3-part` in one payload → deny (no prior marker)
 - C1: string literal containing `-- marker text` → deny (literal masking prevents bypass)
+- Item 1: PostToolUse `isError=true` → deletes optimistic marker; `isError=false` / missing field → preserves marker
+- Item 3: marker file created with `0o600` permissions
+- Item 6: `SELECT col INTO cat.s.t` → pass (not INSERT/MERGE INTO); INSERT/MERGE INTO regression guards
+- Item 7: `MERGE INTO t USING iceberg.foo.src` → deny; 2-part USING → pass
+- Item 8: `CREATE TABLE x (LIKE iceberg.foo.src)` → deny; 2-part LIKE → pass
+- Item 9: doc-contract test — keyword arm set in code equals keyword arm table in spec (drift = test failure)

--- a/hooks/trino-catalog-gate-post.sh
+++ b/hooks/trino-catalog-gate-post.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# trino-catalog-gate-post.sh — PostToolUse shim (praxis #336)
+# Deletes the session marker when SHOW CATALOGS returns an error so the
+# optimistic PreToolUse marker does not persist after a failed enumeration.
+# Logic in trino-catalog-gate.py (run_post subcommand).
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="$SCRIPT_DIR/trino-catalog-gate.py"
+command -v python3 >/dev/null 2>&1 || exit 0
+[ -f "$PY" ] || exit 0
+exec python3 "$PY" post

--- a/hooks/trino-catalog-gate.py
+++ b/hooks/trino-catalog-gate.py
@@ -174,15 +174,42 @@ def strip_sql_comments(sql: str) -> str:
 _IDENT_SEG = r'(?:"[^"]+"|`[^`]+`|[A-Za-z_][\w$]*)'
 
 # 3-part reference: <catalog>.<schema>.<table>, optionally quoted.
+# Capturing variant used by CATALOG_REF_RE group(1).
 _CATALOG_REF = rf"({_IDENT_SEG}\.{_IDENT_SEG}\.{_IDENT_SEG})"
+# Non-capturing variant used where the caller supplies its own outer group.
+_CATALOG_REF_NC = rf"(?:{_IDENT_SEG}\.{_IDENT_SEG}\.{_IDENT_SEG})"
 
 # Context gate: SQL keywords that can be followed by a 3-part catalog.schema.table
-# reference. `INTO` covers both INSERT INTO and MERGE INTO. `TABLE` covers
-# CREATE TABLE / CREATE OR REPLACE TABLE. `VIEW` covers CREATE VIEW.
-# DELETE FROM is handled by the bare `FROM` arm (DELETE FROM <ref> matches).
-# UPDATE without FROM is also covered by `UPDATE` arm.
+# reference.
+#
+# Keyword arm decisions:
+#   FROM       — SELECT...FROM, DELETE FROM (covers both).
+#   JOIN       — all JOIN variants.
+#   INTO       — restricted to INSERT/MERGE context (see MERGE_INSERT_INTO_RE
+#                below) to avoid false positives on `SELECT col INTO dest`
+#                (PostgreSQL/SQL-Server SELECT-INTO syntax). Trino does not
+#                support SELECT-INTO but a user might paste such a query; the
+#                deny message would be misleading.
+#   UPDATE     — UPDATE <ref> SET ...
+#   TABLE      — CREATE TABLE / CREATE OR REPLACE TABLE / ALTER TABLE.
+#   VIEW       — CREATE VIEW / CREATE OR REPLACE VIEW.
+#   USING      — MERGE ... USING <catalog>.<schema>.<table> (source table in
+#                MERGE statements). Previously undetected (#336 item 7).
+#   LIKE       — CREATE TABLE x (LIKE catalog.schema.t) LIKE clause reference.
+#                Previously undetected (#336 item 8).
+#
+# DELETE FROM is handled by the FROM arm (DELETE FROM <ref> matches FROM arm).
 CATALOG_REF_RE = re.compile(
-    rf"\b(?:FROM|JOIN|INTO|UPDATE|TABLE|VIEW)\s+{_CATALOG_REF}",
+    rf"\b(?:FROM|JOIN|UPDATE|TABLE|VIEW|USING|LIKE)\s+{_CATALOG_REF}",
+    re.IGNORECASE,
+)
+
+# Separate pattern for INSERT/MERGE INTO to avoid false-positive on SELECT INTO.
+# `SELECT col INTO cat.s.t FROM src` must NOT block — Trino does not support
+# SELECT-INTO, so the deny message would be incorrect and confusing (#336 item 6).
+# This pattern requires INSERT or MERGE immediately before INTO.
+MERGE_INSERT_INTO_RE = re.compile(
+    rf"\b(?:INSERT|MERGE)\s+INTO\s+{_CATALOG_REF}",
     re.IGNORECASE,
 )
 
@@ -190,21 +217,31 @@ CATALOG_REF_RE = re.compile(
 SHOW_CATALOGS_RE = re.compile(r"\bSHOW\s+CATALOGS\b", re.IGNORECASE)
 
 
+def _add_catalog_from_match(m: re.Match, found: set) -> None:
+    """Extract the catalog (first dotted segment) from a regex match and add to found."""
+    ref = m.group(1)
+    first_part = ref.split(".")[0].strip('"').strip("`").lower()
+    if first_part:
+        found.add(first_part)
+
+
 def extract_catalogs(sql: str) -> list[str]:
     """Return distinct catalog names from 3-part DML/DDL references in sql.
 
-    Detects catalog.schema.table references in FROM, JOIN, INTO (INSERT/MERGE),
-    UPDATE, TABLE (CREATE TABLE), and VIEW (CREATE VIEW) contexts.
+    Detects catalog.schema.table references in:
+      - FROM, JOIN, UPDATE, TABLE, VIEW, USING, LIKE keyword contexts
+        (CATALOG_REF_RE).
+      - INSERT INTO, MERGE INTO contexts (MERGE_INSERT_INTO_RE — separate from
+        the generic INTO arm to avoid false positives on SELECT-INTO syntax).
+
     SQL comments are stripped before matching. Returns lowercase catalog names.
     """
     cleaned = strip_sql_comments(sql)
     found: set[str] = set()
     for m in CATALOG_REF_RE.finditer(cleaned):
-        ref = m.group(1)
-        # Extract the catalog (first segment) from catalog.schema.table.
-        first_part = ref.split(".")[0].strip('"').strip("`").lower()
-        if first_part:
-            found.add(first_part)
+        _add_catalog_from_match(m, found)
+    for m in MERGE_INSERT_INTO_RE.finditer(cleaned):
+        _add_catalog_from_match(m, found)
     return sorted(found)
 
 
@@ -328,11 +365,20 @@ def marker_exists(path: str) -> bool:
 
 
 def create_marker(path: str) -> None:
-    """Create (or touch) the marker file. Silently fails on OS errors."""
+    """Create (or touch) the marker file with 0o600 permissions. Silently fails on OS errors."""
     try:
         os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
         with open(path, "w", encoding="utf-8") as fh:
             fh.write("")
+        os.chmod(path, 0o600)
+    except OSError:
+        pass  # fail-open; never raise from a hook
+
+
+def delete_marker(path: str) -> None:
+    """Delete the marker file if it exists. Silently fails on OS errors."""
+    try:
+        os.unlink(path)
     except OSError:
         pass  # fail-open; never raise from a hook
 
@@ -431,5 +477,67 @@ def run() -> int:
     return 0
 
 
+def _tool_response_indicates_error(tool_response: object) -> bool:
+    """Return True iff tool_response clearly signals a failed MCP call.
+
+    Mirrors the same helper in trino-describe-first.py:
+      - dict with isError: True → error.
+      - any other shape (including None / missing field) → not an error (fail-open).
+    """
+    if isinstance(tool_response, dict):
+        if tool_response.get("isError") is True:
+            return True
+    return False
+
+
+def run_post() -> int:
+    """PostToolUse path: delete the session marker if SHOW CATALOGS failed.
+
+    When the PreToolUse path optimistically created the marker for a SHOW
+    CATALOGS query, but the actual Trino call returned an error, the marker
+    must be removed so the gate correctly blocks subsequent queries.
+
+    Mirrors the isError check in trino-describe-first.py run_post().
+    """
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0  # fail-open on malformed input
+
+    tool_name = payload.get("tool_name", "") or ""
+    if not tool_matches(tool_name):
+        return 0
+
+    tool_input = payload.get("tool_input", {}) or {}
+    query = tool_input.get(get_query_arg(), "") or ""
+    if not isinstance(query, str) or not query.strip():
+        return 0
+
+    # Only act on SHOW CATALOGS queries.
+    try:
+        if not is_show_catalogs_standalone(query):
+            return 0
+    except Exception:
+        return 0  # fail-open
+
+    # If no tool_response field at all → fail-open (preserve back-compat with
+    # older event shapes that omit the response).
+    if "tool_response" not in payload:
+        return 0
+
+    if _tool_response_indicates_error(payload.get("tool_response")):
+        session_id = _extract_session_id(payload)
+        marker_path = resolve_marker_path(session_id)
+        delete_marker(marker_path)
+
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) >= 2 and argv[1] == "post":
+        return run_post()
+    return run()
+
+
 if __name__ == "__main__":
-    sys.exit(run())
+    sys.exit(main(sys.argv))

--- a/hooks/trino-catalog-gate.py
+++ b/hooks/trino-catalog-gate.py
@@ -174,10 +174,8 @@ def strip_sql_comments(sql: str) -> str:
 _IDENT_SEG = r'(?:"[^"]+"|`[^`]+`|[A-Za-z_][\w$]*)'
 
 # 3-part reference: <catalog>.<schema>.<table>, optionally quoted.
-# Capturing variant used by CATALOG_REF_RE group(1).
+# Capturing variant — group(1) used by CATALOG_REF_RE and MERGE_INSERT_INTO_RE.
 _CATALOG_REF = rf"({_IDENT_SEG}\.{_IDENT_SEG}\.{_IDENT_SEG})"
-# Non-capturing variant used where the caller supplies its own outer group.
-_CATALOG_REF_NC = rf"(?:{_IDENT_SEG}\.{_IDENT_SEG}\.{_IDENT_SEG})"
 
 # Context gate: SQL keywords that can be followed by a 3-part catalog.schema.table
 # reference.

--- a/tests/test_trino_catalog_gate.sh
+++ b/tests/test_trino_catalog_gate.sh
@@ -444,6 +444,297 @@ run_case \
   "$(make_trino_payload "SELECT * FROM iceberg.foo.bar -- 'catalog-enumerated: verified'")"
 
 # ---------------------------------------------------------------------------
+# Item 1: PostToolUse — SHOW CATALOGS 실패 시 마커 삭제
+# ---------------------------------------------------------------------------
+echo ""
+echo "Item 1: PostToolUse isError → marker deleted after failed SHOW CATALOGS"
+
+# 헬퍼: PostToolUse 페이로드 생성 (run_post 경로)
+make_post_payload_show_catalogs_error() {
+  python3 -c "
+import json, sys
+payload = {
+    'session_id': 'test-session-336-post',
+    'tool_name': 'mcp__laplace-trino__trino_query',
+    'tool_input': {'query': 'SHOW CATALOGS'},
+    'tool_response': {'isError': True, 'content': [{'text': 'Connection refused'}]},
+    'cwd': '/tmp',
+}
+print(json.dumps(payload))
+"
+}
+
+make_post_payload_show_catalogs_ok() {
+  python3 -c "
+import json, sys
+payload = {
+    'session_id': 'test-session-336-post',
+    'tool_name': 'mcp__laplace-trino__trino_query',
+    'tool_input': {'query': 'SHOW CATALOGS'},
+    'tool_response': {'isError': False, 'content': [{'text': 'catalog1\ncatalog2'}]},
+    'cwd': '/tmp',
+}
+print(json.dumps(payload))
+"
+}
+
+# 케이스: PreToolUse가 마커를 만든 뒤 PostToolUse(error)가 삭제 → 다음 3-part 쿼리 deny
+_item1_marker=$(new_marker_file)
+rm -f "$_item1_marker"
+# Step 1: PreToolUse SHOW CATALOGS → 마커 생성
+make_trino_payload 'SHOW CATALOGS' | env -i PATH="$PATH" HOME="$HOME" TMPDIR="${TMPDIR:-/tmp}" \
+  PRAXIS_TRINO_CATALOG_GATE_FILE="$_item1_marker" \
+  python3 "$HOOK" >/dev/null 2>&1
+# 마커가 생성됐는지 확인
+if [ ! -f "$_item1_marker" ]; then
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("Item1: marker not created by PreToolUse SHOW CATALOGS")
+  echo "  FAIL  Item1: PreToolUse SHOW CATALOGS should create marker"
+else
+  # Step 2: PostToolUse(error) → 마커 삭제
+  make_post_payload_show_catalogs_error | env -i PATH="$PATH" HOME="$HOME" TMPDIR="${TMPDIR:-/tmp}" \
+    PRAXIS_TRINO_CATALOG_GATE_FILE="$_item1_marker" \
+    python3 "$HOOK" post >/dev/null 2>&1
+  if [ -f "$_item1_marker" ]; then
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("Item1: PostToolUse(error) should delete marker")
+    echo "  FAIL  Item1: PostToolUse(isError=true) should delete marker but it still exists"
+  else
+    PASS=$((PASS + 1))
+    echo "  PASS  Item1: PostToolUse(isError=true) deletes marker after failed SHOW CATALOGS"
+  fi
+fi
+rm -f "$_item1_marker" 2>/dev/null
+
+# 케이스: PostToolUse(success) → 마커 유지
+_item1_marker2=$(new_marker_file)
+rm -f "$_item1_marker2"
+make_trino_payload 'SHOW CATALOGS' | env -i PATH="$PATH" HOME="$HOME" TMPDIR="${TMPDIR:-/tmp}" \
+  PRAXIS_TRINO_CATALOG_GATE_FILE="$_item1_marker2" \
+  python3 "$HOOK" >/dev/null 2>&1
+make_post_payload_show_catalogs_ok | env -i PATH="$PATH" HOME="$HOME" TMPDIR="${TMPDIR:-/tmp}" \
+  PRAXIS_TRINO_CATALOG_GATE_FILE="$_item1_marker2" \
+  python3 "$HOOK" post >/dev/null 2>&1
+if [ -f "$_item1_marker2" ]; then
+  PASS=$((PASS + 1))
+  echo "  PASS  Item1: PostToolUse(isError=false) preserves marker after successful SHOW CATALOGS"
+else
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("Item1: PostToolUse(success) should preserve marker")
+  echo "  FAIL  Item1: PostToolUse(isError=false) should keep marker"
+fi
+rm -f "$_item1_marker2" 2>/dev/null
+
+# 케이스: PostToolUse payload에 tool_response 없을 때 마커 유지 (fail-open back-compat)
+_item1_marker3=$(new_marker_file)
+rm -f "$_item1_marker3"
+make_trino_payload 'SHOW CATALOGS' | env -i PATH="$PATH" HOME="$HOME" TMPDIR="${TMPDIR:-/tmp}" \
+  PRAXIS_TRINO_CATALOG_GATE_FILE="$_item1_marker3" \
+  python3 "$HOOK" >/dev/null 2>&1
+# PostToolUse payload without tool_response field
+python3 -c "
+import json
+payload = {
+    'session_id': 'test-session-336-post',
+    'tool_name': 'mcp__laplace-trino__trino_query',
+    'tool_input': {'query': 'SHOW CATALOGS'},
+    'cwd': '/tmp',
+}
+print(json.dumps(payload))
+" | env -i PATH="$PATH" HOME="$HOME" TMPDIR="${TMPDIR:-/tmp}" \
+  PRAXIS_TRINO_CATALOG_GATE_FILE="$_item1_marker3" \
+  python3 "$HOOK" post >/dev/null 2>&1
+if [ -f "$_item1_marker3" ]; then
+  PASS=$((PASS + 1))
+  echo "  PASS  Item1: PostToolUse(no tool_response) preserves marker (fail-open)"
+else
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("Item1: PostToolUse(no tool_response) should preserve marker")
+  echo "  FAIL  Item1: missing tool_response should not delete marker"
+fi
+rm -f "$_item1_marker3" 2>/dev/null
+
+# ---------------------------------------------------------------------------
+# Item 3: 마커 파일 권한 0o600
+# ---------------------------------------------------------------------------
+echo ""
+echo "Item 3: marker file created with 0o600 permissions"
+
+_item3_marker=$(new_marker_file)
+rm -f "$_item3_marker"
+make_trino_payload 'SHOW CATALOGS' | env -i PATH="$PATH" HOME="$HOME" TMPDIR="${TMPDIR:-/tmp}" \
+  PRAXIS_TRINO_CATALOG_GATE_FILE="$_item3_marker" \
+  python3 "$HOOK" >/dev/null 2>&1
+if [ -f "$_item3_marker" ]; then
+  _perm=$(python3 -c "import os, stat; st=os.stat('$_item3_marker'); print(oct(stat.S_IMODE(st.st_mode)))")
+  if [ "$_perm" = "0o600" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS  Item3: marker file permission is 0o600"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("Item3: marker file permission should be 0o600")
+    echo "  FAIL  Item3: marker file permission is $_perm (expected 0o600)"
+  fi
+else
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("Item3: marker file not created")
+  echo "  FAIL  Item3: marker file not created by SHOW CATALOGS"
+fi
+rm -f "$_item3_marker" 2>/dev/null
+
+# ---------------------------------------------------------------------------
+# Item 6: SELECT INTO — false-positive 억제 (INTO arm 분리)
+# ---------------------------------------------------------------------------
+echo ""
+echo "Item 6: SELECT...INTO cat.s.t → pass (not Trino syntax, avoid misleading deny)"
+
+# SELECT col INTO cat.s.t FROM src (PostgreSQL/SQL-Server SELECT-INTO 구문)
+# Trino에서 지원되지 않으므로 gate가 block하면 misleading → pass해야 함
+run_case \
+  "Item6: SELECT col INTO cat.s.t → pass (not INSERT/MERGE INTO)" \
+  "pass" \
+  "" \
+  "$(make_trino_payload 'SELECT col INTO iceberg.foo.dest FROM src WHERE id = 1')"
+
+# INSERT INTO는 여전히 deny
+run_case \
+  "Item6: INSERT INTO cat.s.t → deny (regression guard)" \
+  "deny" \
+  "" \
+  "$(make_trino_payload 'INSERT INTO iceberg.foo.bar VALUES (1)')"
+
+# MERGE INTO는 여전히 deny
+run_case \
+  "Item6: MERGE INTO cat.s.t → deny (regression guard)" \
+  "deny" \
+  "" \
+  "$(make_trino_payload 'MERGE INTO iceberg.foo.bar t USING src s ON t.id = s.id WHEN MATCHED THEN UPDATE SET t.v = s.v')"
+
+# ---------------------------------------------------------------------------
+# Item 7: MERGE ... USING <catalog>.<schema>.<table> 감지
+# ---------------------------------------------------------------------------
+echo ""
+echo "Item 7: MERGE USING catalog.schema.table → deny"
+
+run_case \
+  "Item7: MERGE INTO t USING iceberg.foo.src → deny" \
+  "deny" \
+  "" \
+  "$(make_trino_payload 'MERGE INTO local_tbl t USING iceberg.foo.src s ON t.id = s.id WHEN MATCHED THEN UPDATE SET t.v = s.v')"
+
+run_case \
+  "Item7: MERGE USING without catalog in target → deny (source ref caught)" \
+  "deny" \
+  "" \
+  "$(make_trino_payload 'MERGE INTO local_tbl t USING hive.warehouse.orders s ON t.id = s.id WHEN NOT MATCHED THEN INSERT VALUES (s.id, s.v)')"
+
+# USING with 2-part ref (not 3-part) → pass
+run_case \
+  "Item7: MERGE USING schema.table (2-part) → pass" \
+  "pass" \
+  "" \
+  "$(make_trino_payload 'MERGE INTO tgt t USING src_schema.src_table s ON t.id = s.id WHEN MATCHED THEN UPDATE SET t.v = s.v')"
+
+# ---------------------------------------------------------------------------
+# Item 8: CREATE TABLE x (LIKE catalog.schema.t) LIKE 절 감지
+# ---------------------------------------------------------------------------
+echo ""
+echo "Item 8: CREATE TABLE ... (LIKE catalog.schema.t) → deny"
+
+run_case \
+  "Item8: CREATE TABLE x (LIKE iceberg.foo.src) → deny" \
+  "deny" \
+  "" \
+  "$(make_trino_payload 'CREATE TABLE local_tbl (LIKE iceberg.foo.src INCLUDING ALL)')"
+
+run_case \
+  "Item8: CREATE TABLE x (LIKE iceberg.foo.src EXCLUDING PROPERTIES) → deny" \
+  "deny" \
+  "" \
+  "$(make_trino_payload 'CREATE TABLE new_tbl (LIKE iceberg.sch.src EXCLUDING PROPERTIES)')"
+
+# LIKE with 2-part ref → pass
+run_case \
+  "Item8: CREATE TABLE x (LIKE schema.t) (2-part) → pass" \
+  "pass" \
+  "" \
+  "$(make_trino_payload 'CREATE TABLE new_tbl (LIKE myschema.src_table)')"
+
+# ---------------------------------------------------------------------------
+# Item 9: 문서-계약 테스트 — CATALOG_REF_RE keyword set ↔ spec 표 일치 확인
+# ---------------------------------------------------------------------------
+echo ""
+echo "Item 9: doc-contract test — keyword arm set matches spec table"
+
+_contract_result=$(python3 -c "
+import sys, re, ast, pathlib
+
+hook_path = '$ROOT_DIR/hooks/trino-catalog-gate.py'
+spec_path = '$ROOT_DIR/docs/hook/trino-catalog-gate.md'
+
+# 1. spec 테이블에서 keyword arm 추출
+spec_text = pathlib.Path(spec_path).read_text()
+# 표 행: '| keyword |' 형태에서 keyword arm 추출 (헤더/구분선 제외)
+spec_keywords = set()
+for line in spec_text.splitlines():
+    line = line.strip()
+    if not line.startswith('|'):
+        continue
+    parts = [p.strip() for p in line.split('|') if p.strip()]
+    if not parts or parts[0].startswith('-') or parts[0].lower() in ('keyword arm', 'keyword'):
+        continue
+    # keyword arm 컬럼은 첫 번째 셀; 코드 span (\`...\`) 제거
+    kw = parts[0].strip('\`').upper()
+    # 복합 arm (INSERT INTO → INTO) 은 실제 regex keyword
+    # spec 표에서 인식하는 arm keyword들
+    if kw in ('FROM', 'JOIN', 'INTO', 'UPDATE', 'TABLE', 'VIEW', 'USING', 'LIKE'):
+        spec_keywords.add(kw)
+
+# 2. 코드에서 CATALOG_REF_RE + MERGE_INSERT_INTO_RE 패턴 파싱
+code_text = pathlib.Path(hook_path).read_text()
+
+# CATALOG_REF_RE: \b(?:...) 에서 keyword 추출
+m1 = re.search(r'CATALOG_REF_RE\s*=\s*re\.compile\(\s*rf?\"([^\"]+)\"', code_text)
+code_kws_main = set()
+if m1:
+    # (?:FROM|JOIN|...) 패턴에서 추출
+    kw_match = re.search(r'\(\?:([A-Z|]+)\)', m1.group(1).upper())
+    if kw_match:
+        code_kws_main = set(kw_match.group(1).split('|'))
+
+# MERGE_INSERT_INTO_RE: INSERT|MERGE → 변환 INTO
+m2 = re.search(r'MERGE_INSERT_INTO_RE\s*=\s*re\.compile\(\s*rf?\"([^\"]+)\"', code_text)
+code_kws_insert = set()
+if m2:
+    pat = m2.group(1).upper()
+    if 'INSERT' in pat or 'MERGE' in pat:
+        code_kws_insert.add('INTO')
+
+code_keywords = code_kws_main | code_kws_insert
+
+if spec_keywords == code_keywords:
+    print('PASS: spec={} code={}'.format(sorted(spec_keywords), sorted(code_keywords)))
+    sys.exit(0)
+else:
+    only_spec = spec_keywords - code_keywords
+    only_code = code_keywords - spec_keywords
+    print('FAIL: spec={} code={} only_spec={} only_code={}'.format(
+        sorted(spec_keywords), sorted(code_keywords), sorted(only_spec), sorted(only_code)))
+    sys.exit(1)
+" 2>&1)
+
+if echo "$_contract_result" | grep -q "^PASS:"; then
+  PASS=$((PASS + 1))
+  echo "  PASS  Item9: doc-contract test — keyword sets match"
+  echo "        $_contract_result"
+else
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("Item9: doc-contract — keyword arm mismatch between spec and code")
+  echo "  FAIL  Item9: doc-contract test"
+  echo "        $_contract_result"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
Closes #336 (items 1-3, 6-9 — P-redesign 제외)

## 변경 요약

### 구현 항목
| 항목 | 내용 |
|------|------|
| **item 1** | PostToolUse 경로(`run_post`) 추가 — SHOW CATALOGS가 `isError=true`를 반환하면 PreToolUse에서 낙관적으로 생성한 마커를 삭제. `trino-describe-first.py`의 `isError` 패턴 미러링. `trino-catalog-gate-post.sh` shim 추가. |
| **item 2** | `SHOW SCHEMAS FROM <catalog>`은 카탈로그 존재 검증으로 **인정하지 않음** — spec에 명시 및 rationale 추가. `SHOW CATALOGS`가 사용 가능한 카탈로그를 열거하는 유일한 경로. |
| **item 3** | `create_marker()`에서 `os.chmod(path, 0o600)` 추가 — 마커 파일 권한 제한. |
| **item 6** | `INTO` arm을 `MERGE_INSERT_INTO_RE`로 분리 (`INSERT\|MERGE` 앞에 오는 경우만 매칭). `SELECT col INTO cat.s.t FROM src` (PostgreSQL SELECT-INTO) false-positive deny 억제 — Trino에서 지원하지 않는 구문이므로 misleading 메시지 방지. |
| **item 7** | `CATALOG_REF_RE`에 `USING` 추가 — `MERGE INTO t USING iceberg.foo.src` 소스 테이블 감지. |
| **item 8** | `CATALOG_REF_RE`에 `LIKE` 추가 — `CREATE TABLE x (LIKE iceberg.foo.src)` LIKE 절 감지. |
| **item 9** | doc-contract 테스트 추가 — spec 키워드 arm 표와 코드 regex keyword set 동등성 검증. drift 발생 시 테스트 실패. |

### 변경 파일
- `hooks/trino-catalog-gate.py` — 핵심 로직 변경 (항목 1, 3, 6, 7, 8)
- `hooks/trino-catalog-gate-post.sh` — PostToolUse shim 추가 (항목 1)
- `docs/hook/trino-catalog-gate.md` — 키워드 arm 표, SELECT-INTO 제외 rationale, SHOW SCHEMAS 명시, 해결된 제약 사항 업데이트 (항목 2, 6, 7, 8, 9)
- `tests/test_trino_catalog_gate.sh` — 항목 1, 3, 6, 7, 8, 9 회귀 테스트 추가

## 검증 결과

```
bash tests/test_trino_catalog_gate.sh
Results: 43 passed, 0 failed
```

기존 29개 케이스 모두 통과 + 신규 14개 케이스 추가 (항목별 회귀 테스트).

## 검증하지 않은 항목
- hooks.json PostToolUse 등록 — `trino-catalog-gate-post.sh` shim은 추가했으나 hooks.json 수정은 이 PR 스코프 밖 (concurrent file conflict 회피)
- prod Trino 환경 실행 — 로컬 단위 테스트만 실행

## 미구현 항목 (scope 외)
- **P-redesign** (SQL lexer 재작성, C2/C3 double-quoted identifier / paired apostrophe 수정) — 별도 이슈/PR로 defer
- **hooks.json PostToolUse 엔트리** — concurrent file conflict 회피를 위해 이 PR에서 제외