### PR TITLE
docs(claude-md): partial Closes vs Refs convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,3 +135,16 @@ are corrected. Re-run after pulls or after adding a new CLI script.
 
 Exits non-zero on drift, so it can be wired into CI or a SessionStart hook
 to catch "patch landed in the wrong clone" before it bites a future session.
+
+## Issue & PR Conventions
+
+- **Partial-scope PR**: When a PR addresses only a subset of an issue's body
+  (e.g., "items 1-3 implemented, P-redesign deferred to follow-up"), use
+  `Refs #N` (or `Addresses #N (items X, Y; Z deferred)`) in the PR body
+  **instead of** `Closes #N`. GitHub's `Closes` keyword auto-closes the issue
+  on merge regardless of deferred items inside the issue body, orphaning their
+  tracking thread.
+- **Full-scope PR**: `Closes #N` per global CLAUDE.md (Issue & PR Rules).
+- **Agent prompts that delegate PR authorship**: do not hardcode `Closes #N` —
+  instruct the agent to choose `Closes` vs `Refs` based on whether the PR
+  addresses the issue's full scope.


### PR DESCRIPTION
## 배경

2026-05-18 5 PR 병렬 dispatch 세션 retrospect 결과 식별된 workflow 결함.

5개 PR이 agent prompt 지시로 모두 `Closes #N` 포함하여 merge → 5개 원본 이슈 자동 close → 각 이슈 body에 있던 30+ deferred 항목이 추적 thread 잃음 (#336 P-redesign, #337 P3/P4/P5/Option-B, #338 6건, #346 Phase 2 등).

## 변경

`AGENTS.md` (= CLAUDE.md symlink target)에 "Issue & PR Conventions" 섹션 추가:
- Partial-scope PR: `Refs #N` 또는 `Addresses #N (items X, Y; Z deferred)` 사용
- Full-scope PR: `Closes #N` (global CLAUDE.md 규칙 유지)
- Agent prompts: hardcoded `Closes` 금지, scope 기반 판단 명시

## 검증

- Memory 동반 작성: `feedback_closes_vs_refs_partial_scope.md`
- Single-line markdown addition, build/test 영향 없음

Refs #352