### PR TITLE
feat(retrospect): integrate hookable contract

### DIFF
--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -664,14 +664,13 @@ For each approved action:
 
    **Frontmatter contract — `memory-hint` opt-in (mandatory consideration)**
 
-   In addition to standard fields (`name`, `description`, `metadata.type`), every new memory MUST evaluate whether to include the `memory-hint` opt-in fields — `hookable` and `hookKeywords`. The full field spec (parser semantics, matching rules, fail-open contract) lives in `docs/hook/memory-hint.md`; this section defines the authoring-time decision.
+   In addition to standard fields (`name`, `description`, `type`), every new memory MUST evaluate whether to include the `memory-hint` opt-in fields — `hookable` and `hookKeywords`. The full field spec (parser semantics, matching rules, fail-open contract) lives in `docs/hook/memory-hint.md`; this section defines the authoring-time decision. Use top-level `type:` (consistent with `docs/hook/memory-hint.md` example and existing on-disk memory files); do **not** nest under `metadata:`.
 
    ```yaml
    ---
    name: my-memory
    description: Short rule statement
-   metadata:
-     type: feedback
+   type: feedback
    hookable: true                           # opt into PreToolUse surface
    hookKeywords: [keyword1, keyword2]       # whole-token match (case-sensitive)
    ---
@@ -860,7 +859,7 @@ For each approved action:
    | Artifact | Verification |
    |----------|-------------|
    | MEMORY.md feedback (new) | File exists + MEMORY.md index updated + `hookable`/`hookKeywords` frontmatter decision recorded (true with keywords, OR false with rationale in Actions Executed report) |
-   | MEMORY.md feedback (merged) | Existing file updated (diff shown) + MEMORY.md index description updated if needed + if existing entry had `hookable: false` but merged context now meets the retrieval-critical default, re-evaluate and update frontmatter |
+   | MEMORY.md feedback (merged) | Existing file updated (diff shown) + MEMORY.md index description updated if needed + if existing entry had `hookable: false` **or the field is missing entirely** and merged context now meets the retrieval-critical default, re-evaluate and add/update frontmatter (most pre-existing memories lack `hookable` — missing field is the dominant case, not false) |
    | GitHub issue | `gh issue view {url}` returns valid data |
    | Upstream feedback | `gh issue view {url}` returns valid data + URL repo matches `verified_backing_repo` from step 0 + label convention is correct for the verified repo (`tool-friction:{layer}` ONLY when verified repo is the praxis distribution; otherwise the repo's own convention label per Action 4's label rule) |
    | Hook code | Script file exists + settings.json registration confirmed (dry-run varies by hook type — no generic check) |

--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -662,6 +662,39 @@ For each approved action:
 
    - Update `MEMORY.md` index (for both origins)
 
+   **Frontmatter contract — `memory-hint` opt-in (mandatory consideration)**
+
+   In addition to standard fields (`name`, `description`, `metadata.type`), every new memory MUST evaluate whether to include the `memory-hint` opt-in fields — `hookable` and `hookKeywords`. The full field spec (parser semantics, matching rules, fail-open contract) lives in `docs/hook/memory-hint.md`; this section defines the authoring-time decision.
+
+   ```yaml
+   ---
+   name: my-memory
+   description: Short rule statement
+   metadata:
+     type: feedback
+   hookable: true                           # opt into PreToolUse surface
+   hookKeywords: [keyword1, keyword2]       # whole-token match (case-sensitive)
+   ---
+   ```
+
+   **Category-based default (apply unless rationale documented):**
+
+   | Category | `hookable` default | Rationale |
+   |---|---|---|
+   | behavioral retrieval-critical (silent-recurrence likely; failure mode is "Loaded ≠ Retrieved") | `true` | hook is the only structural enforcement; skill/memory alone fails retrieval at action time |
+   | success-pattern reinforcement (`Reinforced — ` prefix) where intentional replication needs same retrieval surface | `true` | same "retrieve at action time" need applies in reverse |
+   | abstract / meta / cross-cutting principle (no concrete action signal) | `false` | keyword match would be noisy across unrelated commands |
+   | author-generated rule (belongs in `~/.claude/CLAUDE.md` draft) or upstream-feedback note | `false` | not action-gateable; memory is a holding pen, not the enforcement surface |
+
+   When uncertain → default `hookable: false` (safer to omit than to add noise) AND record the uncertainty in the Actions Executed report so a future retrospect can re-evaluate.
+
+   **`hookKeywords` selection rules:**
+   - Choose tokens that appear in the *action* the memory is meant to gate — CLI subcommand (`merge`, `close`), tool name (`Edit`, `cmux-delegate`), distinctive flag (`--force`), or domain identifier (`Closes`, `Recommended`).
+   - Whole-token, case-sensitive matching only (per `docs/hook/memory-hint.md`). List multiple casings explicitly if needed (`[Edit, edit]`).
+   - 1–4 keywords typical; >5 raises false-positive risk linearly.
+   - **Avoid generic English words** (`add`, `run`, `test`, `update`) — they fire on unrelated commands and erode the hint signal.
+   - When the memory targets a non-Bash event (Edit, Write, AskUserQuestion, etc.), the current `memory-hint.py` only fires on Bash — record the intent in the description so a future event-coverage expansion can surface it.
+
    **⚠️ MANDATORY: Duplicate check before creating any memory file:**
 
    **Precondition:** This check applies ONLY when the finding's action type is `memory` (new pattern). If Stage 2 already marked `repeat=true` and escalated to issue/hook/global `~/.claude/CLAUDE.md` draft, skip this check — the escalation ladder takes precedence over merge.
@@ -826,8 +859,8 @@ For each approved action:
 
    | Artifact | Verification |
    |----------|-------------|
-   | MEMORY.md feedback (new) | File exists + MEMORY.md index updated |
-   | MEMORY.md feedback (merged) | Existing file updated (diff shown) + MEMORY.md index description updated if needed |
+   | MEMORY.md feedback (new) | File exists + MEMORY.md index updated + `hookable`/`hookKeywords` frontmatter decision recorded (true with keywords, OR false with rationale in Actions Executed report) |
+   | MEMORY.md feedback (merged) | Existing file updated (diff shown) + MEMORY.md index description updated if needed + if existing entry had `hookable: false` but merged context now meets the retrieval-critical default, re-evaluate and update frontmatter |
    | GitHub issue | `gh issue view {url}` returns valid data |
    | Upstream feedback | `gh issue view {url}` returns valid data + URL repo matches `verified_backing_repo` from step 0 + label convention is correct for the verified repo (`tool-friction:{layer}` ONLY when verified repo is the praxis distribution; otherwise the repo's own convention label per Action 4's label rule) |
    | Hook code | Script file exists + settings.json registration confirmed (dry-run varies by hook type — no generic check) |


### PR DESCRIPTION
## 변경 사항

`skills/retrospect/SKILL.md` 의 Stage 4 Action 1 (MEMORY.md feedback write) 에 `memory-hint` opt-in frontmatter contract 를 통합합니다.

### 추가된 섹션 (Per-entry workflow 직후)

- **Frontmatter contract — `memory-hint` opt-in (mandatory consideration)**: 모든 새 메모리는 `hookable`/`hookKeywords` 포함 여부를 평가해야 함
- **Category-based default matrix**: behavioral retrieval-critical → `true`, abstract/meta → `false` 등 4개 카테고리
- **`hookKeywords` selection rules**: whole-token case-sensitive, 1-4개 적정, 일반 영단어 회피
- `docs/hook/memory-hint.md` 와 cross-link (parser 의미, 매칭 규칙 등 detail 은 거기 위임)

### Verification table 업데이트

- `MEMORY.md feedback (new)` 행에 hookable 결정 기록 요건 추가
- `MEMORY.md feedback (merged)` 행에 기존 frontmatter 재평가 요건 추가

## 동기

deep-dive 분석 결과:
- 22개 메모리 중 2개만 `hookable: true` (9.1%)
- 최근 5개 중 0개 채택
- 근본 원인: retrospect 의 자동 메모리 작성 경로가 `memory-hint` contract 를 모름

이 PR 은 4-Phase 계획의 Phase 1 (authoring lever) 입니다.

## 검증

```bash
# (1) AC: ≥3 hit on hookable/hookKeywords in retrospect SKILL.md
grep -cE "hookable|hookKeywords" skills/retrospect/SKILL.md
# → 8 hits

# (2) Regression: 모든 retrospect 테스트 통과
bash tests/test_retrospect_falsify_recommended.sh  # → 28 PASS, 0 FAIL
bash tests/test_retrospect_routing.sh              # → 10 PASS, 0 FAIL
bash tests/test_retrospect_mix_check.sh            # → 38 cases, 11 fixtures PASS
```

## Non-Goals (이 PR 에서 다루지 않음)

- 기존 22개 메모리 backfill (#357 — Phase 2)
- `memory-hint.py` 이벤트 확장 (#358 — Phase 3)
- `momentum-rule-retrieval-gate.py` 동적 로드 (#359 — Phase 4)
- `~/.claude/CLAUDE.md` "auto memory" 섹션 동기화 (별도 PR — 백킹 repo 다름)

## Refs

Refs #356 (전체 issue scope 의 일부만 다룸 — Phase 1 only. dry-run evidence 항목은 retrospect 의 실제 실행 검증이 필요한 spec-level skill 특성상 unit test + grep 으로 대체).
