### PR TITLE
feat(memory-hint): extend events Edit Write Ask

### DIFF
--- a/.claude-plugin/hooks/hooks.json
+++ b/.claude-plugin/hooks/hooks.json
@@ -49,11 +49,6 @@
           },
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/memory-hint.sh",
-            "timeout": 5
-          },
-          {
-            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/cross-boundary-preflight.sh",
             "timeout": 5
           },
@@ -135,6 +130,16 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/momentum-rule-retrieval-gate.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Bash|Edit|Write|NotebookEdit|AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/memory-hint.sh",
             "timeout": 5
           }
         ]

--- a/docs/hook/memory-hint.md
+++ b/docs/hook/memory-hint.md
@@ -2,10 +2,12 @@
 
 Supported hosts: all
 
-`hooks/memory-hint.py` fires on every Bash tool call and emits stderr lines
+`hooks/memory-hint.py` fires on PreToolUse for `Bash`, `Edit`, `Write`,
+`NotebookEdit`, and `AskUserQuestion` tool calls and emits stderr lines
 referencing user-scoped memory files whose YAML frontmatter declares
-`hookable: true` plus a matching `hookKeywords: [...]` token. The signal is
-purely attention-shifting for the LLM's next reasoning step — the hook
+`hookable: true` plus a matching `hookKeywords: [...]` token. Memories opt
+into specific events via `hookEvents: [...]` (default `[Bash]`). The signal
+is purely attention-shifting for the LLM's next reasoning step — the hook
 **never blocks**, **never asks**, **always exits 0**.
 
 ### Why this exists
@@ -21,15 +23,16 @@ Reference: issue [#139](https://github.com/devseunggwan/praxis/issues/139).
 
 ### Frontmatter contract
 
-Memory authors opt in by adding two fields to their existing frontmatter:
+Memory authors opt in by adding fields to their existing frontmatter:
 
 ```yaml
 ---
 name: my-memory
 description: Short rule statement
 type: feedback
-hookable: true                           # NEW — opt-in switch
-hookKeywords: [kubectl, hubctl, gh]      # NEW — match tokens (whole-token)
+hookable: true                                  # opt-in switch
+hookKeywords: [kubectl, hubctl, gh]             # match tokens (whole-token)
+hookEvents: [Bash, Edit, AskUserQuestion]       # event whitelist (default [Bash])
 ---
 ```
 
@@ -37,8 +40,21 @@ hookKeywords: [kubectl, hubctl, gh]      # NEW — match tokens (whole-token)
 |-------|----------|-------|
 | `hookable` | yes | scalar; `true` / `True` / `TRUE` / `yes` / `Yes` enable. Anything else (or missing) → not indexed. |
 | `hookKeywords` | yes | flat single-line list, e.g. `[a, b, "c d"]`. Scalar form (`hookKeywords: kubectl`) is **rejected** — the memory is silently skipped. |
+| `hookEvents` | no | flat single-line list of supported tool names — any of `Bash`, `Edit`, `Write`, `NotebookEdit`, `AskUserQuestion`. Default `[Bash]`. Tool names outside that set are dropped; if every listed event is unsupported, the parser retains the default `[Bash]`. |
 | `description` | no | optional; emitted after em-dash when present. Without it, the stderr line is just `[memory:hookable] {filename}`. |
 | `type` | no | unrelated taxonomy field; the parser ignores it. `type` ≠ `hookable`. |
+
+### Per-event tokenization
+
+| Event | Payload surface | Tokenization |
+|---|---|---|
+| `Bash` | `tool_input.command` | shlex via `safe_tokenize` (quoted multi-words preserved as a single non-matching token — see AC-10) |
+| `Edit` | `file_path` + `old_string` + `new_string` | free-text regex (ASCII identifier-with-dashes OR unicode word) |
+| `Write` | `file_path` + `content` | free-text regex |
+| `NotebookEdit` | `notebook_path` + `new_source` | free-text regex |
+| `AskUserQuestion` | each question's `question` + `header` + every option's `label` + `description` | free-text regex |
+
+Whole-token equality + case-sensitive matching applies uniformly across events.
 
 ### Hook execution model
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -53,12 +53,6 @@
           },
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/memory-hint.sh",
-            "timeout": 5,
-            "hosts": ["claude", "codex"]
-          },
-          {
-            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/cross-boundary-preflight.sh",
             "timeout": 5,
             "hosts": ["claude", "codex"]
@@ -154,6 +148,17 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/momentum-rule-retrieval-gate.sh",
+            "timeout": 5,
+            "hosts": ["claude", "codex"]
+          }
+        ]
+      },
+      {
+        "matcher": "Bash|Edit|Write|NotebookEdit|AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/memory-hint.sh",
             "timeout": 5,
             "hosts": ["claude", "codex"]
           }

--- a/hooks/memory-hint.py
+++ b/hooks/memory-hint.py
@@ -1,12 +1,21 @@
 #!/usr/bin/env python3
-"""PreToolUse(Bash) memory hint: surface relevant memory file descriptions.
+"""PreToolUse memory hint: surface relevant memory file descriptions.
 
 Scans the user-scoped memory directory for `*.md` files whose YAML
 frontmatter declares `hookable: true` plus a `hookKeywords: [...]` list,
-tokenizes the inbound Bash command via the shared `safe_tokenize` /
-`strip_prefix` / `iter_command_starts` pipeline, and emits up to 3
+tokenizes the inbound tool payload, and emits up to 3
 `[memory:hookable] {filename} — {description}` lines to stderr per match
 (plus an `...and N more` summary line when truncated).
+
+Supported PreToolUse events (matched via `hooks.json` matcher) — Bash,
+Edit, Write, NotebookEdit, AskUserQuestion. Each memory opts into specific
+events via the optional `hookEvents: [...]` frontmatter field (default
+`[Bash]` for backward compatibility). Tokenization differs per event:
+
+  - Bash: shlex via `safe_tokenize` (whole-token, quoted multi-words
+          preserved as a single non-matching token — see AC-10)
+  - Other events: free-text regex tokenizer that preserves identifier
+          tokens (e.g. `cmux-delegate` stays as one token)
 
 Always exits 0. Never blocks. Never asks. The signal is purely
 attention-shifting for the LLM's next reasoning step. Co-firing with
@@ -24,6 +33,7 @@ Frontmatter parser is pure regex (no PyYAML dependency). Supported shapes:
   - `hookable: true|True|TRUE|yes|Yes` (other values silently skip the file)
   - `hookKeywords: [a, b, "c d"]` (flat single-line list only;
                                   multi-line / flow-mapping NOT supported)
+  - `hookEvents: [Bash, Edit, ...]` (flat single-line list; default `[Bash]`)
   - `description: anything` (optional; emitted after em-dash when present)
 Any parse error within a memory skips that memory only — never the hook.
 """
@@ -47,10 +57,19 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
 HIT_LIMIT = 3
 TRUTHY_VALUES = {"true", "yes"}
 
+SUPPORTED_EVENTS = ("Bash", "Edit", "Write", "NotebookEdit", "AskUserQuestion")
+DEFAULT_EVENTS = ("Bash",)
+
 FRONTMATTER_FENCE = re.compile(r"^---\s*$", re.MULTILINE)
 HOOKABLE_RE = re.compile(r"^\s*hookable\s*:\s*(.+)$", re.MULTILINE)
 KEYWORDS_RE = re.compile(r"^\s*hookKeywords\s*:\s*(.+)$", re.MULTILINE)
+EVENTS_RE = re.compile(r"^\s*hookEvents\s*:\s*(.+)$", re.MULTILINE)
 DESCRIPTION_RE = re.compile(r"^\s*description\s*:\s*(.+)$", re.MULTILINE)
+
+# Free-text payload tokenizer: ASCII identifier-with-dashes OR any unicode
+# word. Mixed ASCII/Hangul text segments still produce separable tokens
+# because the ASCII path stops at non-`[\w-]` boundaries.
+TEXT_TOKEN_RE = re.compile(r"[A-Za-z][\w-]*|\w+", re.UNICODE)
 
 # YAML inline comment: `#` preceded by whitespace (per YAML 1.2 spec). The
 # `hookKeywords` list parser additionally tolerates anything after the first
@@ -124,7 +143,31 @@ def parse_frontmatter(raw: str) -> dict | None:
             .strip('"\'')
         )
 
-    return {"keywords": keywords, "description": description}
+    events: tuple[str, ...] = DEFAULT_EVENTS
+    events_match = EVENTS_RE.search(block)
+    if events_match:
+        events_raw = events_match.group(1).strip()
+        if events_raw.startswith("["):
+            close_idx = events_raw.find("]")
+            if close_idx != -1:
+                inner = events_raw[1:close_idx].strip()
+                if inner:
+                    parsed_events = tuple(
+                        e.strip().strip('"\'')
+                        for e in inner.split(",")
+                        if e.strip()
+                    )
+                    filtered = tuple(
+                        e for e in parsed_events if e in SUPPORTED_EVENTS
+                    )
+                    if filtered:
+                        events = filtered
+
+    return {
+        "keywords": keywords,
+        "description": description,
+        "events": events,
+    }
 
 
 def resolve_memory_dir() -> str | None:
@@ -183,17 +226,86 @@ def collect_command_tokens(command: str) -> set[str]:
     return flat
 
 
+def tokenize_text_payload(text: str) -> set[str]:
+    """Whole-token split for non-Bash payloads (file paths, content, prompts)."""
+    if not text:
+        return set()
+    return set(TEXT_TOKEN_RE.findall(text))
+
+
+def extract_event_payload(payload: dict) -> tuple[str, str]:
+    """Map (tool_name, tool_input) → (event_name, free-text blob for tokenization).
+
+    Returns ('', '') when tool is unsupported or input shape unexpected.
+    """
+    tool = payload.get("tool_name", "") or ""
+    if tool not in SUPPORTED_EVENTS:
+        return "", ""
+    tool_input = payload.get("tool_input", {}) or {}
+    if not isinstance(tool_input, dict):
+        return "", ""
+
+    if tool == "Bash":
+        return "Bash", str(tool_input.get("command", "") or "")
+
+    if tool == "Edit":
+        parts = [
+            tool_input.get("file_path", ""),
+            tool_input.get("old_string", ""),
+            tool_input.get("new_string", ""),
+        ]
+        return "Edit", "\n".join(str(p) for p in parts if p)
+
+    if tool == "Write":
+        parts = [
+            tool_input.get("file_path", ""),
+            tool_input.get("content", ""),
+        ]
+        return "Write", "\n".join(str(p) for p in parts if p)
+
+    if tool == "NotebookEdit":
+        parts = [
+            tool_input.get("notebook_path", ""),
+            tool_input.get("new_source", ""),
+        ]
+        return "NotebookEdit", "\n".join(str(p) for p in parts if p)
+
+    if tool == "AskUserQuestion":
+        questions = tool_input.get("questions", []) or []
+        chunks: list[str] = []
+        if isinstance(questions, list):
+            for q in questions:
+                if not isinstance(q, dict):
+                    continue
+                chunks.append(str(q.get("question", "") or ""))
+                chunks.append(str(q.get("header", "") or ""))
+                options = q.get("options", []) or []
+                if isinstance(options, list):
+                    for opt in options:
+                        if isinstance(opt, dict):
+                            chunks.append(str(opt.get("label", "") or ""))
+                            chunks.append(str(opt.get("description", "") or ""))
+        return "AskUserQuestion", "\n".join(c for c in chunks if c)
+
+    return "", ""
+
+
 def find_hits(
     indexed: list[tuple[str, dict, float]],
     cmd_tokens: set[str],
+    event: str,
 ) -> list[tuple[str, dict, float]]:
-    """Return memories whose hookKeywords match any command token (whole-token)."""
-    # Whole-token equality (case-sensitive). Quoted multi-word strings shlex
-    # parses as a single token (e.g. `echo "use kubectl"` → `use kubectl`),
-    # so `kubectl` keyword does NOT match — see AC-10. Substring matching
-    # would create false positives across `kubectl-prod` vs `kubectl`.
+    """Return memories whose hookKeywords match any token AND hookEvents contains `event`.
+
+    Whole-token equality (case-sensitive). Quoted multi-word strings shlex
+    parses as a single token (e.g. `echo "use kubectl"` → `use kubectl`),
+    so `kubectl` keyword does NOT match — see AC-10. Substring matching
+    would create false positives across `kubectl-prod` vs `kubectl`.
+    """
     hits: list[tuple[str, dict, float]] = []
     for name, parsed, mtime in indexed:
+        if event not in parsed.get("events", DEFAULT_EVENTS):
+            continue
         if any(keyword in cmd_tokens for keyword in parsed["keywords"]):
             hits.append((name, parsed, mtime))
     return hits
@@ -220,15 +332,13 @@ def main() -> int:
     except Exception:
         return 0  # fail-open on malformed stdin
 
-    if payload.get("tool_name") != "Bash":
+    event, text = extract_event_payload(payload)
+    if not event or not text.strip():
         return 0
 
-    command = payload.get("tool_input", {}).get("command", "") or ""
-    if not command.strip():
-        return 0
-
-    # Backslash line continuation → single space so tokenizer sees one line
-    command = command.replace("\\\n", " ")
+    if event == "Bash":
+        # Backslash line continuation → single space so tokenizer sees one line
+        text = text.replace("\\\n", " ")
 
     directory = resolve_memory_dir()
     if not directory:
@@ -238,11 +348,14 @@ def main() -> int:
     if not indexed:
         return 0
 
-    cmd_tokens = collect_command_tokens(command)
+    if event == "Bash":
+        cmd_tokens = collect_command_tokens(text)
+    else:
+        cmd_tokens = tokenize_text_payload(text)
     if not cmd_tokens:
         return 0
 
-    hits = find_hits(indexed, cmd_tokens)
+    hits = find_hits(indexed, cmd_tokens, event)
     if hits:
         emit_hits(hits)
     return 0

--- a/hooks/memory-hint.py
+++ b/hooks/memory-hint.py
@@ -67,9 +67,11 @@ EVENTS_RE = re.compile(r"^\s*hookEvents\s*:\s*(.+)$", re.MULTILINE)
 DESCRIPTION_RE = re.compile(r"^\s*description\s*:\s*(.+)$", re.MULTILINE)
 
 # Free-text payload tokenizer: ASCII identifier-with-dashes OR any unicode
-# word. Mixed ASCII/Hangul text segments still produce separable tokens
-# because the ASCII path stops at non-`[\w-]` boundaries.
-TEXT_TOKEN_RE = re.compile(r"[A-Za-z][\w-]*|\w+", re.UNICODE)
+# word. The first alternative uses an ASCII-only character class so a token
+# like `push할까요` splits into `['push', '할까요']` (and not the unicode-`\w`
+# greedy match `['push할까요']`). The second alternative (`\w+`) is kept
+# unicode-aware so Korean-only text still yields word tokens.
+TEXT_TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9_-]*|\w+", re.UNICODE)
 
 # YAML inline comment: `#` preceded by whitespace (per YAML 1.2 spec). The
 # `hookKeywords` list parser additionally tolerates anything after the first

--- a/plugins/praxis/.codex-plugin/hooks/hooks.json
+++ b/plugins/praxis/.codex-plugin/hooks/hooks.json
@@ -44,11 +44,6 @@
           },
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/memory-hint.sh",
-            "timeout": 5
-          },
-          {
-            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/cross-boundary-preflight.sh",
             "timeout": 5
           },
@@ -130,6 +125,16 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/momentum-rule-retrieval-gate.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Bash|Edit|Write|NotebookEdit|AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/memory-hint.sh",
             "timeout": 5
           }
         ]

--- a/tests/fixtures/memory-hint/hook_ask_event.md
+++ b/tests/fixtures/memory-hint/hook_ask_event.md
@@ -1,0 +1,10 @@
+---
+name: hook-ask-event
+description: ask user question event handler
+type: feedback
+hookable: true
+hookKeywords: [AskEventToken]
+hookEvents: [AskUserQuestion]
+---
+
+Body irrelevant.

--- a/tests/fixtures/memory-hint/hook_edit_event.md
+++ b/tests/fixtures/memory-hint/hook_edit_event.md
@@ -1,0 +1,10 @@
+---
+name: hook-edit-event
+description: edit event handler
+type: feedback
+hookable: true
+hookKeywords: [EditEventToken]
+hookEvents: [Edit]
+---
+
+Body irrelevant.

--- a/tests/fixtures/memory-hint/hook_multi_event.md
+++ b/tests/fixtures/memory-hint/hook_multi_event.md
@@ -1,0 +1,10 @@
+---
+name: hook-multi-event
+description: multi event handler
+type: feedback
+hookable: true
+hookKeywords: [MultiEventToken]
+hookEvents: [Bash, Edit]
+---
+
+Body irrelevant.

--- a/tests/fixtures/memory-hint/hook_notebook_event.md
+++ b/tests/fixtures/memory-hint/hook_notebook_event.md
@@ -1,0 +1,10 @@
+---
+name: hook-notebook-event
+description: notebook edit event handler
+type: feedback
+hookable: true
+hookKeywords: [NotebookEditToken]
+hookEvents: [NotebookEdit]
+---
+
+Body irrelevant.

--- a/tests/fixtures/memory-hint/hook_write_event.md
+++ b/tests/fixtures/memory-hint/hook_write_event.md
@@ -1,0 +1,10 @@
+---
+name: hook-write-event
+description: write event handler
+type: feedback
+hookable: true
+hookKeywords: [WriteEventToken]
+hookEvents: [Write]
+---
+
+Body irrelevant.

--- a/tests/test_memory_hint.sh
+++ b/tests/test_memory_hint.sh
@@ -271,6 +271,11 @@ run_input_case "33 hit: multi-event memory fires on Edit" \
   "hit:hook_multi_event.md" "$FIXTURES_MAIN" Edit \
   '{"file_path": "/tmp/x.py", "old_string": "MultiEventToken in code", "new_string": "y"}'
 
+# --- AC-34: ASCII keyword adjacent to Hangul must split (mixed-text guard) ---
+run_input_case "34 hit: ASCII keyword adjacent to Hangul splits as separate token" \
+  "hit:hook_edit_event.md" "$FIXTURES_MAIN" Edit \
+  '{"file_path": "/tmp/x.py", "old_string": "EditEventToken할까요?", "new_string": "y"}'
+
 # --- summary -----------------------------------------------------------------
 echo ""
 echo "Passed: $PASS  Failed: $FAIL"

--- a/tests/test_memory_hint.sh
+++ b/tests/test_memory_hint.sh
@@ -84,6 +84,53 @@ run_case "2 hit: keyword across separator"            "hit:hook_kubectl.md"     
 run_case "3 silent: keyword inside quoted string"     silent                     "$FIXTURES_MAIN" Bash 'echo "use kubectl carefully"'
 run_case "4 silent: keyword absent"                   silent                     "$FIXTURES_MAIN" Bash 'ls -la'
 
+# run_input_case name expectation memory_dir tool_name tool_input_json
+#   Like run_case but passes raw tool_input JSON for non-Bash events.
+run_input_case() {
+  local name="$1" expectation="$2" memory_dir="$3" tool_name="$4" tool_input_json="$5"
+
+  local payload
+  payload=$(python3 -c '
+import json, sys
+print(json.dumps({"tool_name": sys.argv[1], "tool_input": json.loads(sys.argv[2])}))' "$tool_name" "$tool_input_json")
+
+  local err_file
+  err_file=$(mktemp)
+  echo "$payload" | env PRAXIS_MEMORY_DIR="$memory_dir" "$HOOK" >/dev/null 2>"$err_file"
+  local rc=$?
+  local err
+  err=$(cat "$err_file")
+  rm -f "$err_file"
+
+  local ok=1
+  case "$expectation" in
+    silent)
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$err" ]   || ok=0
+      ;;
+    hit:*)
+      local needle="${expectation#hit:}"
+      [ "$rc" -eq 0 ] || ok=0
+      case "$err" in
+        *"$needle"*) ;;
+        *) ok=0 ;;
+      esac
+      ;;
+    *)
+      echo "FAIL  [$name] unknown expectation: $expectation"
+      FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name"); return
+      ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expectation=$expectation rc=$rc stderr=${err:-<empty>}"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
 # --- frontmatter gate paths --------------------------------------------------
 run_case "5 silent: hookable false skipped"           silent                     "$FIXTURES_MAIN" Bash 'echo __hookable_false_marker__'
 run_case "6 silent: hookable missing skipped"         silent                     "$FIXTURES_MAIN" Bash 'echo no_hookable_token'
@@ -194,6 +241,35 @@ print(json.dumps({"tool_name": "Bash", "tool_input": {"command": "kubectl get po
   fi
 }
 undecodable_silent_test
+
+# --- AC-27..33: non-Bash events (Edit/Write/NotebookEdit/AskUserQuestion) ----
+run_input_case "27 hit: Edit event fires hookEvents=[Edit]" \
+  "hit:hook_edit_event.md" "$FIXTURES_MAIN" Edit \
+  '{"file_path": "/tmp/x.py", "old_string": "EditEventToken here", "new_string": "y"}'
+
+run_input_case "28 hit: Write event fires hookEvents=[Write]" \
+  "hit:hook_write_event.md" "$FIXTURES_MAIN" Write \
+  '{"file_path": "/tmp/y.txt", "content": "body with WriteEventToken inside"}'
+
+run_input_case "29 hit: NotebookEdit event fires hookEvents=[NotebookEdit]" \
+  "hit:hook_notebook_event.md" "$FIXTURES_MAIN" NotebookEdit \
+  '{"notebook_path": "/tmp/n.ipynb", "new_source": "cell source NotebookEditToken"}'
+
+run_input_case "30 hit: AskUserQuestion event fires hookEvents=[AskUserQuestion]" \
+  "hit:hook_ask_event.md" "$FIXTURES_MAIN" AskUserQuestion \
+  '{"questions": [{"question": "go?", "header": "x", "options": [{"label": "AskEventToken", "description": "y"}]}]}'
+
+run_input_case "31 silent: Edit event but memory has default hookEvents=[Bash]" \
+  silent "$FIXTURES_MAIN" Edit \
+  '{"file_path": "/tmp/x.py", "old_string": "kubectl get pods", "new_string": "y"}'
+
+run_input_case "32 hit: multi-event memory fires on Bash" \
+  "hit:hook_multi_event.md" "$FIXTURES_MAIN" Bash \
+  '{"command": "echo MultiEventToken"}'
+
+run_input_case "33 hit: multi-event memory fires on Edit" \
+  "hit:hook_multi_event.md" "$FIXTURES_MAIN" Edit \
+  '{"file_path": "/tmp/x.py", "old_string": "MultiEventToken in code", "new_string": "y"}'
 
 # --- summary -----------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## 변경 사항

`memory-hint.py` 의 이벤트 커버리지를 `PreToolUse(Bash)` 단일 → `PreToolUse(Bash|Edit|Write|NotebookEdit|AskUserQuestion)` 로 확장. 메모리는 신규 `hookEvents:` frontmatter 필드로 fire 대상 이벤트를 opt-in.

### 코드

- **`hooks/memory-hint.py`** — 핵심 변경
  - `extract_event_payload(payload)`: tool_name 별 payload → (event, free-text blob) 매핑
  - `tokenize_text_payload(text)`: 비-Bash 이벤트용 토크나이저 (`[A-Za-z][\w-]*|\w+`, unicode-aware)
  - `parse_frontmatter`: `hookEvents` 파싱 추가 (default `[Bash]`, 지원 이벤트 외 값은 drop, 전부 unsupported 면 default 유지)
  - `find_hits(indexed, tokens, event)`: 메모리의 `hookEvents` 에 현재 event 포함 시에만 매칭
  - `main`: 분기 — Bash 는 기존 shlex (backslash continuation 처리), 그 외는 free-text 토크나이저

- **`hooks/hooks.json`** — matcher 변경
  - `memory-hint.sh` 를 Bash 단일 matcher group 에서 제거
  - 새 matcher group `Bash|Edit|Write|NotebookEdit|AskUserQuestion` 에 단일 등록
  - 플랫폼 manifest 2개 (`.claude-plugin/...`, `plugins/.../codex-plugin/...`) 는 `scripts/build-plugin-manifests.py` 로 regenerate

- **`docs/hook/memory-hint.md`** — spec 업데이트
  - `hookEvents` 필드 표 행 추가
  - 이벤트별 payload surface + 토크나이저 표 추가

### 테스트

- **`tests/fixtures/memory-hint/`** — 5개 신규 fixture
  - `hook_edit_event.md`, `hook_write_event.md`, `hook_notebook_event.md`, `hook_ask_event.md` — 단일 이벤트 hookEvents
  - `hook_multi_event.md` — multi-event `[Bash, Edit]`
- **`tests/test_memory_hint.sh`** — `run_input_case` helper (raw tool_input JSON 받음) + 7개 신규 케이스 (AC-27~33)
  - 27: Edit 이벤트 fire
  - 28: Write 이벤트 fire
  - 29: NotebookEdit 이벤트 fire
  - 30: AskUserQuestion 이벤트 fire
  - 31: Edit 이벤트지만 메모리가 default `hookEvents=[Bash]` → silent
  - 32: multi-event 메모리가 Bash 에서 fire
  - 33: multi-event 메모리가 Edit 에서 fire

## 검증

```bash
bash tests/test_memory_hint.sh
# → Passed: 34  Failed: 0 (기존 27 + 신규 7)

python3 scripts/check-plugin-manifests.py
# → plugin-manifest check OK
```

## Acceptance Criteria 매핑 (#358)

- [x] `memory-hint.py` 가 5개 이벤트 처리
- [x] `hookEvents:` opt-in 필드 (default `[Bash]`)
- [x] 이벤트별 payload extraction 함수 분리 (단일 dispatch — `extract_event_payload` 가 case 별로 추출)
- [x] `hooks/hooks.json` matcher 업데이트
- [x] 테스트 fixture 가 5개 이벤트 cover (Bash 기존 + 신규 4 + multi-event 1)
- [x] fail-open contract 유지 — `parse_frontmatter` / `extract_event_payload` 모두 예외 시 silent skip
- [x] 기존 Bash 동작 회귀 없음 — 27개 기존 테스트 무수정 통과

## Non-Goals

- UserPromptSubmit 이벤트 (issue body 에서 별도 후속 이슈로 분리 권장 — surface 가 너무 넓어 noise risk 큼). 본 PR scope 밖.
- 메모리 frontmatter 의 다른 필드 (description, type, etc.) 변경 — `hookEvents` 만 신설.

## 의존되는 후속 작업

PR-2b 5개 메모리 backfill (#357 evidence comment 참고) — 본 PR 머지 후 Phase 2b 로 별도 진행:
- `feedback_recommended_label_inline_falsification` (`hookEvents: [AskUserQuestion]`)
- `feedback_read_before_mutating_tool` (`hookEvents: [Edit, Write, NotebookEdit]`)
- `feedback_sendmessage_uuid_for_resume` (Phase 3 에서 SendMessage 미포함 — UserPromptSubmit 또는 별도 후속)
- `feedback_routing_keyword_disambiguation` (UserPromptSubmit 의존 — 후속)
- `feedback_closes_vs_refs_partial_scope` (매칭 시맨틱 변경 검토 필요)

Closes #358
