### PR TITLE
refactor(momentum-gate): dynamic memory load

### DIFF
--- a/docs/hook/momentum-rule-retrieval-gate.md
+++ b/docs/hook/momentum-rule-retrieval-gate.md
@@ -30,7 +30,7 @@ N merges occur in rapid succession) is deferred to Phase 2 (separate issue).
 |-----------------|------------|-------------------|----------------------|
 | `gh pr merge` (any flags) | `merge` | Pre-Merge Reporting + No Approval Transfer | every memory with `momentum:` containing `merge` |
 | `cmux new-workspace` (dispatch via cmux) | `dispatch` | Pre-Implementation Surface Enumeration → Multi-PR / multi-worktree shared state + Self-Authored Labels Are Drafts | every memory with `momentum:` containing `dispatch` |
-| `git push --force` / `--force-with-lease` / `-f` | `force-push` | trigger header only | every memory with `momentum:` containing `force-push` |
+| `git push --force` / `--force-with-lease` / `-f` | `force-push` | trigger header + history-rewrite mutation rule | every memory with `momentum:` containing `force-push` |
 
 ### Dynamic memory loading
 

--- a/docs/hook/momentum-rule-retrieval-gate.md
+++ b/docs/hook/momentum-rule-retrieval-gate.md
@@ -26,11 +26,35 @@ Phase 1 keeps the momentum signal simple: **any single matching command
 triggers the surface**. Multi-mutation detection (e.g., surfacing only when
 N merges occur in rapid succession) is deferred to Phase 2 (separate issue).
 
-| Command pattern | Triggered surface |
-|-----------------|-------------------|
-| `gh pr merge` (any flags) | Pre-Merge Reporting + No Approval Transfer + memory `feedback_pre_merge_briefing_compound_imperative` |
-| `cmux new-workspace` (dispatch via cmux) | Pre-Implementation Surface Enumeration → Multi-PR / multi-worktree shared state + Self-Authored Labels Are Drafts |
-| `git push --force` / `--force-with-lease` / `-f` | memory `feedback_force_history_rewrite_mutation` |
+| Command pattern | trigger id | Static rule cites | Dynamic memory cites |
+|-----------------|------------|-------------------|----------------------|
+| `gh pr merge` (any flags) | `merge` | Pre-Merge Reporting + No Approval Transfer | every memory with `momentum:` containing `merge` |
+| `cmux new-workspace` (dispatch via cmux) | `dispatch` | Pre-Implementation Surface Enumeration → Multi-PR / multi-worktree shared state + Self-Authored Labels Are Drafts | every memory with `momentum:` containing `dispatch` |
+| `git push --force` / `--force-with-lease` / `-f` | `force-push` | trigger header only | every memory with `momentum:` containing `force-push` |
+
+### Dynamic memory loading
+
+Memory cites are no longer hardcoded — they are loaded at hook fire time
+from the same user-scoped memory directory used by `memory-hint`
+(`PRAXIS_MEMORY_DIR` env var when set, otherwise
+`~/.claude/projects/{slugified-cwd}/memory/`). A memory file participates
+by adding a flat single-line `momentum:` list to its frontmatter:
+
+```yaml
+---
+name: my-memory
+description: Short rule statement
+type: feedback
+momentum: [merge]                  # one or more of: merge, dispatch, force-push
+---
+```
+
+Multi-trigger memories: `momentum: [merge, force-push]`. When a triggered
+command matches `merge` AND `force-push` in the same Bash call, the
+memory is cited under both surfaces. Memories without a `momentum:` field
+(or with an unparseable / empty list) are ignored. The frontmatter parser
+is regex-only — multi-line YAML / flow-mapping forms are not supported
+and silently skip the memory rather than raise.
 
 ### What is emitted
 

--- a/hooks/momentum-rule-retrieval-gate.py
+++ b/hooks/momentum-rule-retrieval-gate.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -54,11 +55,21 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
 
 PREFIX = "[praxis:momentum-gate]"
 
+# Trigger identifiers — keys for both static rule surfaces and dynamic
+# memory filtering via the `momentum:` frontmatter field.
+TRIGGER_MERGE = "merge"
+TRIGGER_DISPATCH = "dispatch"
+TRIGGER_FORCE_PUSH = "force-push"
+
+CLOSING_LINE = f"{PREFIX} ─────────────────────────────────────────────────────────────"
+
 # ---------------------------------------------------------------------------
-# Rule surfaces per trigger type.
+# Static rule surfaces per trigger — CLAUDE.md rule cites only. Memory cites
+# are loaded dynamically from the memory directory's frontmatter `momentum`
+# field (replaces the prior hardcoded `Memory: <name>` blocks).
 # ---------------------------------------------------------------------------
 
-_MERGE_RULES = """\
+_MERGE_STATIC = """\
 {p} ── TRIGGER: gh pr merge ──────────────────────────────────
 {p}
 {p} Rule: Pre-Merge Reporting (CLAUDE.md)
@@ -68,16 +79,9 @@ _MERGE_RULES = """\
 {p}
 {p} Rule: No Approval Transfer Across Companion PRs (CLAUDE.md)
 {p}   Approving "merge PR X" approves ONLY X. Companion, chore, regen, or
-{p}   hotfix-blocker PRs each need their own explicit approval.
-{p}
-{p} Memory: feedback_pre_merge_briefing_compound_imperative
-{p}   Compound imperatives ("merge and clean both PR") do NOT lower the
-{p}   Pre-Merge Reporting depth bar. Irreversible actions require 6-item
-{p}   briefing regardless of phrasing.
-{p}
-{p} ─────────────────────────────────────────────────────────────""".format(p=PREFIX)
+{p}   hotfix-blocker PRs each need their own explicit approval.""".format(p=PREFIX)
 
-_DISPATCH_RULES = """\
+_DISPATCH_STATIC = """\
 {p} ── TRIGGER: cmux new-workspace (dispatch) ───────────────────
 {p}
 {p} Rule: Pre-Implementation Surface Enumeration → Multi-PR / multi-worktree
@@ -90,19 +94,139 @@ _DISPATCH_RULES = """\
 {p} Rule: Self-Authored Labels Are Drafts, Not Ratified Scope (CLAUDE.md)
 {p}   AI-written task labels during planning = drafts. Ambiguous verbs
 {p}   (define / review / verify / clean up / 정의 / 검토 / 확인) in self-authored
-{p}   labels → surface one-time disambiguation BEFORE execution.
-{p}
-{p} ─────────────────────────────────────────────────────────────""".format(p=PREFIX)
+{p}   labels → surface one-time disambiguation BEFORE execution.""".format(p=PREFIX)
 
-_FORCE_PUSH_RULES = """\
-{p} ── TRIGGER: git push --force / --force-with-lease / -f ─────
-{p}
-{p} Memory: feedback_force_history_rewrite_mutation
-{p}   force-with-lease / reset --hard / rebase --skip (worker commit drop)
-{p}   are mutations — prior approval is NOT carried over, fixup commit is the
-{p}   safe alternative. History rewrite requires fresh per-action consent.
-{p}
-{p} ─────────────────────────────────────────────────────────────""".format(p=PREFIX)
+_FORCE_PUSH_STATIC = """\
+{p} ── TRIGGER: git push --force / --force-with-lease / -f ─────""".format(p=PREFIX)
+
+_STATIC_BY_TRIGGER = {
+    TRIGGER_MERGE: _MERGE_STATIC,
+    TRIGGER_DISPATCH: _DISPATCH_STATIC,
+    TRIGGER_FORCE_PUSH: _FORCE_PUSH_STATIC,
+}
+
+# ---------------------------------------------------------------------------
+# Frontmatter parser — mirrors hooks/memory-hint.py shape; no PyYAML.
+# ---------------------------------------------------------------------------
+
+FRONTMATTER_FENCE = re.compile(r"^---\s*$", re.MULTILINE)
+MOMENTUM_RE = re.compile(r"^\s*momentum\s*:\s*(.+)$", re.MULTILINE)
+NAME_RE = re.compile(r"^\s*name\s*:\s*(.+)$", re.MULTILINE)
+DESCRIPTION_RE = re.compile(r"^\s*description\s*:\s*(.+)$", re.MULTILINE)
+INLINE_COMMENT_RE = re.compile(r"\s+#.*$")
+CONTROL_BYTES_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _strip_inline_comment(value: str) -> str:
+    return INLINE_COMMENT_RE.sub("", value)
+
+
+def _sanitize(text: str) -> str:
+    return CONTROL_BYTES_RE.sub("?", text)
+
+
+def _parse_momentum_frontmatter(raw: str) -> dict | None:
+    """Extract the `---`-fenced frontmatter. Return None if absent or no momentum list."""
+    matches = list(FRONTMATTER_FENCE.finditer(raw))
+    if len(matches) < 2:
+        return None
+    block = raw[matches[0].end():matches[1].start()]
+
+    momentum_match = MOMENTUM_RE.search(block)
+    if not momentum_match:
+        return None
+    momentum_raw = momentum_match.group(1).strip()
+    if not momentum_raw.startswith("["):
+        return None
+    close_idx = momentum_raw.find("]")
+    if close_idx == -1:
+        return None
+    inner = momentum_raw[1:close_idx].strip()
+    if not inner:
+        return None
+    triggers = [item.strip().strip('"\'') for item in inner.split(",")]
+    triggers = [t for t in triggers if t]
+    if not triggers:
+        return None
+
+    description = ""
+    description_match = DESCRIPTION_RE.search(block)
+    if description_match:
+        description = (
+            _strip_inline_comment(description_match.group(1))
+            .strip()
+            .strip('"\'')
+        )
+
+    return {"triggers": triggers, "description": description}
+
+
+def _resolve_memory_dir() -> str | None:
+    env_dir = os.environ.get("PRAXIS_MEMORY_DIR", "").strip()
+    if env_dir:
+        return env_dir if os.path.isdir(env_dir) else None
+    home = os.path.expanduser("~")
+    cwd = os.getcwd()
+    slug = cwd.replace("/", "-")
+    fallback = os.path.join(home, ".claude", "projects", slug, "memory")
+    return fallback if os.path.isdir(fallback) else None
+
+
+def _load_momentum_memories(directory: str, trigger: str) -> list[tuple[str, str, float]]:
+    """Return [(filename, description, mtime), ...] for memories matching trigger."""
+    out: list[tuple[str, str, float]] = []
+    try:
+        entries = os.listdir(directory)
+    except OSError:
+        return out
+    for name in entries:
+        if not name.endswith(".md"):
+            continue
+        path = os.path.join(directory, name)
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                raw = fh.read()
+        except (OSError, UnicodeDecodeError):
+            continue
+        try:
+            parsed = _parse_momentum_frontmatter(raw)
+        except Exception:
+            parsed = None
+        if not parsed or trigger not in parsed["triggers"]:
+            continue
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError:
+            mtime = 0.0
+        out.append((name, parsed["description"], mtime))
+    out.sort(key=lambda h: h[2], reverse=True)
+    return out
+
+
+def _format_memory_lines(memories: list[tuple[str, str, float]]) -> list[str]:
+    """Render memory entries as PREFIX-prefixed lines mirroring the prior hardcoded shape."""
+    lines: list[str] = []
+    for name, description, _ in memories:
+        safe_name = _sanitize(name)
+        # Strip ".md" suffix for parity with the prior hardcoded `Memory: feedback_*`
+        # text (which referenced the slug without the file extension).
+        display = safe_name[:-3] if safe_name.endswith(".md") else safe_name
+        lines.append(f"{PREFIX} Memory: {display}")
+        if description:
+            lines.append(f"{PREFIX}   {_sanitize(description)}")
+        lines.append(PREFIX)
+    return lines
+
+
+def _emit_for_trigger(trigger: str, directory: str | None) -> str:
+    """Compose the full surface for a single trigger (static rules + dynamic memories)."""
+    parts = [_STATIC_BY_TRIGGER[trigger], PREFIX]
+    if directory:
+        memories = _load_momentum_memories(directory, trigger)
+        if memories:
+            parts.extend(_format_memory_lines(memories))
+    parts.append(CLOSING_LINE)
+    return "\n".join(parts)
 
 # ---------------------------------------------------------------------------
 # GH global flags that consume one additional argument.
@@ -243,22 +367,19 @@ def _is_force_push(argv: list[str]) -> bool:
 # ---------------------------------------------------------------------------
 
 def _detect_triggers(command: str) -> list[str]:
-    """Return list of rule surfaces to emit for the given Bash command."""
+    """Return list of trigger ids (one of TRIGGER_*) for the given Bash command."""
     tokens = safe_tokenize(command)
     if not tokens:
         return []
 
     triggered: list[str] = []
     for argv in iter_command_starts(tokens):
-        if _is_gh_pr_merge(argv):
-            if _MERGE_RULES not in triggered:
-                triggered.append(_MERGE_RULES)
-        if _is_cmux_dispatch(argv):
-            if _DISPATCH_RULES not in triggered:
-                triggered.append(_DISPATCH_RULES)
-        if _is_force_push(argv):
-            if _FORCE_PUSH_RULES not in triggered:
-                triggered.append(_FORCE_PUSH_RULES)
+        if _is_gh_pr_merge(argv) and TRIGGER_MERGE not in triggered:
+            triggered.append(TRIGGER_MERGE)
+        if _is_cmux_dispatch(argv) and TRIGGER_DISPATCH not in triggered:
+            triggered.append(TRIGGER_DISPATCH)
+        if _is_force_push(argv) and TRIGGER_FORCE_PUSH not in triggered:
+            triggered.append(TRIGGER_FORCE_PUSH)
     return triggered
 
 
@@ -279,13 +400,15 @@ def _main_inner() -> int:
     if not command.strip():
         return 0
 
-    surfaces = _detect_triggers(command)
-    if not surfaces:
+    triggers = _detect_triggers(command)
+    if not triggers:
         return 0
 
-    # Emit each surface to stderr.
-    for surface in surfaces:
-        sys.stderr.write(surface + "\n")
+    directory = _resolve_memory_dir()
+
+    # Emit each surface to stderr — static rule text + dynamic memory cites.
+    for trigger in triggers:
+        sys.stderr.write(_emit_for_trigger(trigger, directory) + "\n")
 
     # Strict mode: block unless PRAXIS_MOMENTUM_ACK=1 is also present.
     if os.environ.get("PRAXIS_MOMENTUM_STRICT") == "1":

--- a/hooks/momentum-rule-retrieval-gate.py
+++ b/hooks/momentum-rule-retrieval-gate.py
@@ -97,7 +97,11 @@ _DISPATCH_STATIC = """\
 {p}   labels → surface one-time disambiguation BEFORE execution.""".format(p=PREFIX)
 
 _FORCE_PUSH_STATIC = """\
-{p} ── TRIGGER: git push --force / --force-with-lease / -f ─────""".format(p=PREFIX)
+{p} ── TRIGGER: git push --force / --force-with-lease / -f ─────
+{p}
+{p} Rule: History rewrite is a mutation — prior approval is NOT carried over
+{p}   force-with-lease / reset --hard / rebase --skip (worker commit drop) all
+{p}   require fresh per-action consent. Prefer a fixup commit when possible.""".format(p=PREFIX)
 
 _STATIC_BY_TRIGGER = {
     TRIGGER_MERGE: _MERGE_STATIC,

--- a/tests/fixtures/momentum-memories/feedback_force_history_rewrite_mutation.md
+++ b/tests/fixtures/momentum-memories/feedback_force_history_rewrite_mutation.md
@@ -1,0 +1,8 @@
+---
+name: force-history-rewrite-mutation
+description: force-with-lease / reset --hard 는 mutation 이므로 prior approval 불충분 — 명시 승인 + fixup commit 패턴
+type: feedback
+momentum: [force-push]
+---
+
+Test fixture for momentum-rule-retrieval-gate dynamic memory loading.

--- a/tests/fixtures/momentum-memories/feedback_no_momentum_field.md
+++ b/tests/fixtures/momentum-memories/feedback_no_momentum_field.md
@@ -1,0 +1,8 @@
+---
+name: feedback-no-momentum-field-marker-uniq
+description: marker-uniq-no-momentum-marker — should NEVER emit on any trigger
+type: feedback
+---
+
+Negative-case fixture: this memory has no `momentum:` frontmatter, so the
+momentum-gate hook MUST NOT emit its name on any trigger.

--- a/tests/fixtures/momentum-memories/feedback_pre_merge_briefing_compound_imperative.md
+++ b/tests/fixtures/momentum-memories/feedback_pre_merge_briefing_compound_imperative.md
@@ -1,0 +1,8 @@
+---
+name: pre-merge-briefing-compound-imperative
+description: "사용자의 compound imperative (\"merge and clean both PR\") 는 Pre-Merge Reporting depth 요구를 낮추지 않는다."
+type: feedback
+momentum: [merge]
+---
+
+Test fixture for momentum-rule-retrieval-gate dynamic memory loading.

--- a/tests/test_momentum_rule_retrieval_gate.sh
+++ b/tests/test_momentum_rule_retrieval_gate.sh
@@ -287,6 +287,32 @@ empty_memory_dir_case() {
 }
 empty_memory_dir_case
 
+# Codex round-1 P2 regression: force-push trigger MUST emit actionable warning
+# (history-rewrite mutation rule) even when no migrated memory exists. Prior
+# refactor left force-push as memory-cite only, so unmigrated installs got
+# only a header line on the highest-risk trigger.
+empty_memory_dir_force_push_case() {
+  local name="empty_memory_dir_force_push_actionable"
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local payload
+  payload=$(build_payload "Bash" "git push --force origin main")
+  local err_file
+  err_file=$(mktemp)
+  echo "$payload" | env PRAXIS_MEMORY_DIR="$tmpdir" python3 "$HOOK" >/dev/null 2>"$err_file"
+  local rc=$?
+  local err
+  err=$(cat "$err_file")
+  rm -f "$err_file"; rmdir "$tmpdir"
+  if [ "$rc" -eq 0 ] && [[ "$err" == *"History rewrite is a mutation"* ]] && [[ "$err" != *"Memory:"* ]]; then
+    echo "PASS  [$name]"; PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] rc=$rc actionable-emitted=$([[ \"$err\" == *\"History rewrite is a mutation\"* ]] && echo yes || echo no) memory-cite=$([[ \"$err\" == *\"Memory:\"* ]] && echo yes || echo no)"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+empty_memory_dir_force_push_case
+
 # Combination: boolean + value-taking global flag together must both be
 # walked past correctly so the subcommand check still lands on `push`.
 run_case "git_literal_pathspecs_and_c_force_push" \

--- a/tests/test_momentum_rule_retrieval_gate.sh
+++ b/tests/test_momentum_rule_retrieval_gate.sh
@@ -20,6 +20,10 @@ if [ ! -x "$HOOK" ]; then
   exit 1
 fi
 
+# Pin memory directory to the test fixtures so dynamic memory loading is
+# deterministic regardless of the host's user-scoped memory directory.
+export PRAXIS_MEMORY_DIR="$SCRIPT_DIR/fixtures/momentum-memories"
+
 PASS=0
 FAIL=0
 FAILED_NAMES=()
@@ -237,6 +241,51 @@ run_case "git_super_prefix_fused_force_push" \
   "advisory:feedback_force_history_rewrite_mutation" \
   "" \
   "git --super-prefix=x push --force"
+
+# --- dynamic memory loading negative cases (issue #359) ----------------------
+# Memory with no momentum: field must NOT surface on any trigger.
+negative_no_momentum_case() {
+  local name="negative_no_momentum_marker_absent"
+  local payload
+  payload=$(build_payload "Bash" "gh pr merge --squash")
+  local err_file
+  err_file=$(mktemp)
+  echo "$payload" | python3 "$HOOK" >/dev/null 2>"$err_file"
+  local rc=$?
+  local err
+  err=$(cat "$err_file")
+  rm -f "$err_file"
+  if [ "$rc" -eq 0 ] && [[ "$err" != *"marker-uniq-no-momentum-marker"* ]]; then
+    echo "PASS  [$name]"; PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] rc=$rc unexpectedly emitted marker-uniq-no-momentum-marker"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+negative_no_momentum_case
+
+# Empty memory dir → static rule still emitted, no Memory: line.
+empty_memory_dir_case() {
+  local name="empty_memory_dir_static_only"
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local payload
+  payload=$(build_payload "Bash" "gh pr merge --squash")
+  local err_file
+  err_file=$(mktemp)
+  echo "$payload" | env PRAXIS_MEMORY_DIR="$tmpdir" python3 "$HOOK" >/dev/null 2>"$err_file"
+  local rc=$?
+  local err
+  err=$(cat "$err_file")
+  rm -f "$err_file"; rmdir "$tmpdir"
+  if [ "$rc" -eq 0 ] && [[ "$err" == *"Pre-Merge Reporting"* ]] && [[ "$err" != *"Memory:"* ]]; then
+    echo "PASS  [$name]"; PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] rc=$rc static-rule-emitted=$([[ \"$err\" == *\"Pre-Merge Reporting\"* ]] && echo yes || echo no) memory-cite=$([[ \"$err\" == *\"Memory:\"* ]] && echo yes || echo no)"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+empty_memory_dir_case
 
 # Combination: boolean + value-taking global flag together must both be
 # walked past correctly so the subcommand check still lands on `push`.


### PR DESCRIPTION
## 변경 사항

`hooks/momentum-rule-retrieval-gate.py` 의 메모리 인용 부분을 하드코딩에서 frontmatter `momentum:` 필드 기반 동적 로딩으로 교체. 메모리 본문이 변경되어도 hook surface 가 자동 반영되어 silent drift 차단.

### 구조 변경

- **하드코딩 제거**: `_MERGE_RULES` 의 memory cite block 과 `_FORCE_PUSH_RULES` 의 전체 memory cite 제거. `_DISPATCH_RULES` 는 원래 memory cite 없음 — 그대로 유지.
- **신규 static 변수**: `_MERGE_STATIC`, `_DISPATCH_STATIC`, `_FORCE_PUSH_STATIC` — CLAUDE.md rule 인용만 보존
- **trigger 식별자**: `TRIGGER_MERGE`, `TRIGGER_DISPATCH`, `TRIGGER_FORCE_PUSH` — `_detect_triggers` 가 surface text 가 아닌 식별자 list 반환
- **신규 함수**:
  - `_resolve_memory_dir()` — `PRAXIS_MEMORY_DIR` env 또는 fallback (memory-hint.py 와 동일)
  - `_parse_momentum_frontmatter(raw)` — `momentum: [...]` flat list parsing (regex only, PyYAML 의존 없음)
  - `_load_momentum_memories(dir, trigger)` — frontmatter 의 momentum 에 trigger 포함된 메모리 반환 (mtime sort)
  - `_format_memory_lines(memories)` — 기존 하드코딩 포맷 mirror (`PREFIX Memory: <name>` + description)
  - `_emit_for_trigger(trigger, dir)` — static + dynamic 합쳐 emit

### Frontmatter 신규 필드

```yaml
---
name: my-memory
description: Short rule statement
type: feedback
momentum: [merge]   # one of: merge, dispatch, force-push (multi: [merge, force-push])
---
```

Multi-trigger 메모리는 동일 Bash call 의 여러 trigger 에 동시 cite. `momentum:` 없으면 ignore.

### 마이그레이션

User-scoped 메모리 2개 (git-untracked 라 별도 deliver):

- `feedback_pre_merge_briefing_compound_imperative.md` → `momentum: [merge]`
- `feedback_force_history_rewrite_mutation.md` → `momentum: [force-push]`

### 테스트

기존 테스트가 user-scoped memory dir 의존이라 worktree slug mismatch 로 fail. 해결 — `tests/fixtures/momentum-memories/` 디렉토리 생성 + `PRAXIS_MEMORY_DIR=$SCRIPT_DIR/fixtures/momentum-memories` export 로 isolation.

신규 fixture 3개:
- `feedback_pre_merge_briefing_compound_imperative.md` (momentum=[merge])
- `feedback_force_history_rewrite_mutation.md` (momentum=[force-push])
- `feedback_no_momentum_field.md` (negative case — 어느 trigger 에도 emit 안됨)

신규 케이스 2개 (negative):
- `negative_no_momentum_marker_absent` — momentum-less 메모리는 surface 에 등장 안함
- `empty_memory_dir_static_only` — empty memory dir 시 static rule 만 emit, `Memory:` 라인 0

### 시맨틱 동등 검증 (직접 출력 비교)

```
gh pr merge --squash → static (Pre-Merge Reporting + No Approval Transfer) + Memory: feedback_pre_merge_briefing_compound_imperative
git push --force → static (trigger header) + Memory: feedback_force_history_rewrite_mutation
empty dir + gh pr merge → static only (Memory: 라인 0)
```

기존 하드코딩 출력의 시맨틱 (rule + memory) 동등 보존.

## 검증

```bash
bash tests/test_momentum_rule_retrieval_gate.sh
# → 47 PASS / 0 FAIL (기존 45 + 신규 2)

bash tests/test_memory_hint.sh
# → 35 PASS / 0 FAIL (회귀 0)

python3 scripts/check-plugin-manifests.py
# → OK
```

## Acceptance Criteria 매핑 (#359)

- [x] `momentum-rule-retrieval-gate.py` 의 `_MERGE_RULES`/`_DISPATCH_RULES`/`_FORCE_PUSH_RULES` 하드코딩 블록 제거
- [x] 메모리 디렉토리 스캔 + frontmatter `momentum:` 파싱 함수 추가
- [x] 2개 기존 메모리에 `momentum:` 필드 추가 (user-scoped 직접, fixture 별도 추가)
- [x] dispatch family — 현재 dispatch 메모리 없음 (DISPATCH_RULES 가 원래부터 rule only). dispatch trigger 발화 시 dynamic 매칭 시도하되 메모리 0개면 silent (static rule 만 emit)
- [x] 기존 trigger 별 호출 → 신규 출력이 기존과 시맨틱 동등 (테스트 fixture 직접 비교)
- [x] strict mode (`PRAXIS_MOMENTUM_STRICT=1`) 동작 유지 (회귀 통과)
- [x] fail-open contract 유지 (회귀 통과)

## Non-Goals

- dispatch family 의 새 memory 작성 (issue body 의 옵션이었으나 dispatch 의 기존 surface 가 rule only 라 메모리 없이도 시맨틱 동등 — 신규 메모리 작성 안함)
- 메모리 본문 (frontmatter 직후 paragraph) 까지 emit 하는 풍부한 surface — description 만 emit (기존 하드코딩 메모리 인용 텍스트와 정확히 equivalent 한 multi-line 정보를 원하면 future 추가 가능)

Closes #359
