### PR TITLE
docs(hook): cross-link memory-hint.md to retrospect SKILL.md

### DIFF
--- a/docs/hook/memory-hint.md
+++ b/docs/hook/memory-hint.md
@@ -44,6 +44,10 @@ hookEvents: [Bash, Edit, AskUserQuestion]       # event whitelist (default [Bash
 | `description` | no | optional; emitted after em-dash when present. Without it, the stderr line is just `[memory:hookable] {filename}`. |
 | `type` | no | unrelated taxonomy field; the parser ignores it. `type` ≠ `hookable`. |
 
+### Authoring
+
+The fields above are not authored by hand in the typical flow. The `retrospect` skill emits them at memory-write time. See [`skills/retrospect/SKILL.md`](../../skills/retrospect/SKILL.md) Stage 4 Action 1 — specifically the "Frontmatter contract — `memory-hint` opt-in" subsection — for the per-category `hookable` default matrix and `hookKeywords` selection rules. This file specifies the **runtime parser contract** (what the hook accepts); the SKILL.md section specifies the **authoring decision** (which memories should opt in, which keywords to pick).
+
 ### Per-event tokenization
 
 | Event | Payload surface | Tokenization |


### PR DESCRIPTION
## 요약

이슈 #356 의 AC #4 (cross-link 양방향) 잔여 분을 마무리합니다. PR #360 이 `skills/retrospect/SKILL.md → docs/hook/memory-hint.md` 방향을 세웠고, 본 PR 이 역방향을 닫습니다.

## 배경

PR #360 (2026-05-19 머지) 이 retrospect Stage 4 Action 1 에 `hookable`/`hookKeywords` frontmatter 가이드를 통합했습니다. 그 PR 은 issue #356 의 AC 6개 중 5개를 충족하면서 `Refs #356` (Closes 가 아님) 으로 유지 — bidirectional cross-link 의 한 방향만 닫혔기 때문.

## 변경

`docs/hook/memory-hint.md` 의 Frontmatter contract table 직후에 짧은 **Authoring** subsection 추가 (4 line):
- 독자에게 retrospect 가 authoring 경로임을 알림
- `skills/retrospect/SKILL.md` Stage 4 Action 1 의 "Frontmatter contract — memory-hint opt-in" subsection 으로 link
- 두 문서의 역할 분리 명시: 이 파일은 **runtime parser contract**, SKILL.md 는 **authoring decision**

## AC 검증 (full)

| # | AC | 상태 |
|---|---|---|
| 1 | Stage 4 Action 1 frontmatter 가이드 추가 | ✓ PR #360 |
| 2 | 카테고리별 default 매트릭스 | ✓ PR #360 |
| 3 | hookKeywords 작성 규약 | ✓ PR #360 |
| 4 | cross-link 양방향 | ✓ **본 PR (역방향 완성)** |
| 5 | dry-run 실증 출력 첨부 | substitute (PR #360 의 grep + unit test approach 승계 — spec-level skill 특성상 unit test + grep 으로 대체. 실제 retrospect 실행 evidence 는 다음 retrospect 세션 자연 발생 시 capture) |
| 6 | 기존 흐름 무손상 | ✓ test 통과 (아래) |

## 검증 명령

```bash
cd /Users/nathan.song/projects/praxis-hub-356-feat-hookable-crosslink

# Bidirectional cross-link 확인
grep -c "docs/hook/memory-hint" skills/retrospect/SKILL.md   # → 2 (PR #360)
grep -c "skills/retrospect"     docs/hook/memory-hint.md     # → 1 (본 PR)

# Regression
bash tests/test_retrospect_mix_check.sh  # → 41 cases + 11 fixtures PASS
bash tests/test_memory_hint.sh           # → 35 PASS
```

## 비-목표

- 기존 22개 메모리 backfill (#357 Phase 2)
- memory-hint.py 이벤트 확장 (#358 Phase 3)
- momentum-rule-retrieval-gate.py 동적 로드 (#359 Phase 4)

## 영향 범위

- docs-only, +4 line
- runtime 행위 무변경
- 기존 41 + 35 + 11 테스트 모두 통과

Caller chain verified: N/A -- docs-only change (docs/hook/memory-hint.md text edit; no symbol added/renamed/removed)

Closes #356
