### PR TITLE
feat(hook): T2 confidence-anchoring framing detection

### DIFF
--- a/docs/hook/output-block-falsify-advisory.md
+++ b/docs/hook/output-block-falsify-advisory.md
@@ -31,20 +31,23 @@ Text rules and MEMORY.md entries alone have proven insufficient to prevent
 recurrence. A structural hook moves the gate to the tool-call use-site.
 
 References: issue [#221](https://github.com/devseunggwan/praxis/issues/221) (advisory),
-[#290](https://github.com/devseunggwan/praxis/issues/290) (ask escalation).
+[#290](https://github.com/devseunggwan/praxis/issues/290) (T1 ask escalation),
+[#369](https://github.com/devseunggwan/praxis/issues/369) (T2 confidence-anchoring extension).
 
 ### What is detected
 
 | Tool | Trigger condition | Decision |
 |------|-----------------|----------|
-| `AskUserQuestion` | Option `label` contains exact `(Recommended)` or `(추천)` AND question body has no `Falsified:` line | `permissionDecision: ask` |
-| `AskUserQuestion` | Option `label` contains exact `(Recommended)` or `(추천)` AND question body has `Falsified:` line | Silent pass |
-| `AskUserQuestion` | Option `label` contains `(recommended)` (case-insensitive, not exact) | Advisory stderr |
+| `AskUserQuestion` (T1) | Option `label` contains exact `(Recommended)` or `(추천)` AND question body has no `Falsified:` line | `permissionDecision: ask` (ASK_MSG) |
+| `AskUserQuestion` (T1) | Option `label` contains exact `(Recommended)` or `(추천)` AND question body has `Falsified:` line | Silent pass |
+| `AskUserQuestion` (T2, issue #369) | Option `label` OR `description` contains a confidence-anchoring framing token AND question body has no `Falsified:` line | `permissionDecision: ask` (ANCHORING_ASK_MSG) |
+| `AskUserQuestion` (T2) | Same as above + `Falsified:` present | Silent pass |
+| `AskUserQuestion` (T3) | Option `label` contains case-insensitive `(recommended)` only | Dead under new precedence — T2's bare `recommend(ed\|s)?` token catches it first as ask |
 | `Bash` | Command matches a bulk-action mutation keyword (see table below) | Advisory stderr |
 | Any other tool | — | Silent pass-through |
 | Malformed payload / missing field | — | Silent fail-open |
 
-#### AskUserQuestion: (Recommended) marker and Falsified: gate
+#### AskUserQuestion T1: (Recommended) marker and Falsified: gate
 
 `(Recommended)` and `(추천)` in option labels are the canonical signal for a
 self-authored proposal block about to be surfaced. When these exact tokens
@@ -54,11 +57,43 @@ self-authored proposal block about to be surfaced. When these exact tokens
 
 - **`Falsified:` present** → silent pass. The model has provided verifiable
   evidence of a disconfirming test.
-- **`Falsified:` absent** → `permissionDecision: ask`. The model must add the
-  falsification line and retry.
+- **`Falsified:` absent** → `permissionDecision: ask` with ASK_MSG. The model
+  must add the falsification line and retry.
 
-Only `options[].label` is scanned for the marker — `options[].description` text
-that incidentally contains `(Recommended)` does not trigger the gate.
+T1 scans `options[].label` ONLY — description is scanned by T2 (below).
+
+#### AskUserQuestion T2: confidence-anchoring framing (issue #369)
+
+T1's literal-marker scope leaves two bypass paths exploited in the
+2026-05-21 devseunggwan/ai-dotfiles PR #84 session:
+
+1. **Confidence-anchoring framing without `(Recommended)` marker** — option
+   labels/descriptions using `가장 안전한` / `safer` / `자연스러운` / `prefer this`
+   etc. carry the same ranking signal but bypass T1.
+2. **Description-field placement** — anchoring framing placed in
+   `options[].description` (not label) bypasses T1's label-only scan.
+
+T2 closes both: it scans `label` AND `description` for these tokens.
+
+**EN token set** (case-insensitive, ASCII word-boundary lookarounds —
+Python's `\b` is Unicode-aware and would misfire on Hangul-adjacent ASCII):
+
+- Single-word: `safer`, `safest`, `clearly`
+- Multi-word: `natural fit`, `natural choice`, `obvious choice`, `default to`,
+  `default choice`, `prefer this`
+- Bare marker: `recommend(?:ed|s)?`
+
+**KO substring set** (plain substring — Hangul has no ASCII boundary issue):
+
+`안전한`, `가장 안전`, `자연스러운`, `당연히`, `분명히`, `추천`, `기본값`
+
+**Satisfaction**: identical to T1 — a `Falsified:` line in question body
+silent-passes T2. The model can either remove the anchoring framing or add
+the falsification line.
+
+**Precedence**: T1 fires first when both could trigger (literal marker in
+label + anchoring in description). T2's `ANCHORING_ASK_MSG` differs from
+T1's `ASK_MSG` so downstream parsers can distinguish which tier escalated.
 
 #### Bash: bulk-action mutation keywords
 
@@ -74,23 +109,42 @@ matched; read-only commands (`git log --all`, `gh pr list`) do not fire.
 
 ### Response shape
 
-#### Ask-escalation (AskUserQuestion with exact `(Recommended)` / `(추천)`, no `Falsified:`)
+#### T1 Ask-escalation (AskUserQuestion with exact `(Recommended)` / `(추천)`, no `Falsified:`)
 
-**JSON to stdout:**
+**JSON to stdout** (message constant: `ASK_MSG`):
 
 ```json
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "permissionDecision": "ask",
-    "permissionDecisionReason": "(Recommended) 라벨이 있으나 question body 에 'Falsified: <disconfirming test 결과>' 가 없음. global `~/.claude/CLAUDE.md` Self-Falsify Before Recommendation Lock 룰. 추가 후 재시도."
+    "permissionDecisionReason": "(Recommended) 라벨이 있으나 question body 에 'Falsified: <disconfirming test 결과>' 가 없음. CLAUDE.md Self-Falsify Before Recommendation Lock 룰. 추가 후 재시도."
+  }
+}
+```
+
+#### T2 Ask-escalation (issue #369 — confidence-anchoring framing, no `Falsified:`)
+
+**JSON to stdout** (message constant: `ANCHORING_ASK_MSG`):
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": "옵션 라벨/설명에 confidence-anchoring framing 토큰 (safer/safest/natural/obvious/clearly/default/prefer/recommend/안전한/자연스러운/당연히/분명히/추천/기본값) 이 있으나 question body 에 'Falsified: <disconfirming test 결과>' 가 없음. CLAUDE.md Output-Block-Level Falsification Gate. 추가 후 재시도."
   }
 }
 ```
 
 **Exit code:** `0`.
 
-#### Advisory (Bash bulk-action, or case-insensitive `(recommended)` only)
+#### Advisory (Bash bulk-action only)
+
+Note: case-insensitive `(recommended)` alone previously emitted advisory
+stderr; under issue #369 it is now caught by T2 (ask) before the
+case-insensitive fallback fires. The advisory path remains for Bash
+bulk-action keywords only.
 
 **Advisory message** (emitted to stderr, never stdout):
 
@@ -124,17 +178,27 @@ All parsing is done with the Python standard library only.
 bash tests/test_output_block_falsify_advisory.sh
 ```
 
-Covers 26 cases:
+Covers 40 cases:
 
-**Ask-escalation (AskUserQuestion, issue #290):**
-- Option label `(Recommended)` + no `Falsified:` in question body → `permissionDecision: ask`
+**T1 ask-escalation (AskUserQuestion, issue #290):**
+- Option label `(Recommended)` + no `Falsified:` in question body → `permissionDecision: ask` (ASK_MSG)
 - Option label `(추천)` + no `Falsified:` → `permissionDecision: ask`
 - Option label `(Recommended)` + `Falsified:` line present → silent pass
-- `(Recommended)` appears in `options[].description` only (not label) → silent pass (false positive guard)
 - Non-recommended option labels → silent pass
 
-**Advisory (AskUserQuestion, case-insensitive fallback):**
-- Option label `(recommended)` lowercase only → advisory emitted
+**T2 ask-escalation (AskUserQuestion, issue #369):**
+- KO `가장 안전한` in `options[].description` + no `Falsified:` → `ask` (ANCHORING_ASK_MSG) — in-vivo regression for the ai-dotfiles PR #84 session
+- EN `safer` / `safest` / `prefer this` / `obvious choice` in label or description → `ask`
+- KO `자연스러운` / `안전한` / `당연히` in description → `ask`
+- Mixed Hangul/ASCII (`prefer this 옵션`) → `ask` — word-boundary regression
+- `(Recommended)` in description-only (no marker in label) → `ask` (replaces former false-positive-guard pass)
+- T2 anchoring + `Falsified:` line → silent pass
+- T1 precedence: literal `(Recommended)` + anchoring description → ASK_MSG (T1 wins)
+
+**T2 negative cases (must not fire):**
+- `preferential treatment` (no token in set) → pass
+- Bare `safe` (only `safer`/`safest` in set) → pass
+- `unsafer` (word-boundary regression) → pass
 
 **Pass (AskUserQuestion):**
 - Option labels without any marker → silent pass

--- a/hooks/output-block-falsify-advisory.py
+++ b/hooks/output-block-falsify-advisory.py
@@ -1,21 +1,31 @@
 #!/usr/bin/env python3
 """PreToolUse advisory + ask-escalation: output-block falsification gate.
 
-Issue #221 (advisory), #290 (ask escalation). Recurring failure mode: the
-"Output-Block-Level Falsification Gate" rule in CLAUDE.md (4+ memory entries
-accumulated 2026-05-03 through 2026-05-13) fails to fire at output time because
-rule retrieval is not structural — the rule is loaded but not re-triggered at
-the moment the proposal block is authored.
+Issue #221 (advisory), #290 (ask escalation), #369 (confidence-anchoring
+extension). Recurring failure mode: the "Output-Block-Level Falsification
+Gate" rule in CLAUDE.md (4+ memory entries accumulated 2026-05-03 through
+2026-05-21) fails to fire at output time because rule retrieval is not
+structural — the rule is loaded but not re-triggered at the moment the
+proposal block is authored.
 
 This hook adds a structural enforcement point at two surfaces:
 
-  1. AskUserQuestion — option labels containing "(Recommended)" or "(추천)":
-     - Exact case-sensitive match ("(Recommended)" / "(추천)"):
-       Escalate to `permissionDecision: ask` if the question body lacks a
-       `Falsified:` line (exact prefix at line start). If `Falsified:` IS
-       present, silent pass.
-     - Case-insensitive match only (e.g. "(recommended)" lowercase):
-       Advisory stderr reminder (original behavior).
+  1. AskUserQuestion — escalates `permissionDecision: ask` in two tiers
+     when the question body lacks a `Falsified:` line (exact prefix at
+     line start):
+
+     T1. Label contains exact `(Recommended)` or `(추천)` (case-sensitive)
+         — original literal-marker path.
+
+     T2. Label OR description contains a confidence-anchoring framing
+         token (issue #369). EN tokens (case-insensitive, ASCII word
+         boundary): `safer`, `safest`, `clearly`, `obvious choice`,
+         `natural fit/choice`, `default to/choice`, `prefer this`,
+         bare `recommend(ed|s)?`. KO substrings: `안전한`, `가장 안전`,
+         `자연스러운`, `당연히`, `분명히`, `추천`, `기본값`.
+
+     When `Falsified:` is present in the question body, both tiers
+     silent-pass.
 
   2. Bash — bulk-action commands containing patterns like "close all",
      "delete all", "merge all" (+ Korean equivalents). Advisory only.
@@ -50,6 +60,14 @@ ASK_MSG = (
     "CLAUDE.md Self-Falsify Before Recommendation Lock 룰. 추가 후 재시도."
 )
 
+ANCHORING_ASK_MSG = (
+    "옵션 라벨/설명에 confidence-anchoring framing 토큰 (safer/safest/"
+    "natural/obvious/clearly/default/prefer/recommend/안전한/자연스러운/"
+    "당연히/분명히/추천/기본값) 이 있으나 question body 에 "
+    "'Falsified: <disconfirming test 결과>' 가 없음. "
+    "CLAUDE.md Output-Block-Level Falsification Gate. 추가 후 재시도."
+)
+
 # ---------------------------------------------------------------------------
 # AskUserQuestion: (Recommended) / (추천) marker detection
 # ---------------------------------------------------------------------------
@@ -61,6 +79,51 @@ RECOMMENDED_MARKERS_EXACT_KO = ("(추천)",)
 # Substrings for fallback advisory (case-insensitive for English form).
 RECOMMENDED_MARKERS_EN = ("(Recommended)",)
 RECOMMENDED_MARKERS_KO = ("(추천)",)
+
+# Confidence-anchoring framing tokens (issue #369). Scanned on BOTH option
+# label and description, not just label, because in-vivo evidence
+# (devseunggwan/ai-dotfiles PR #84 session) showed anchoring framing
+# placed in description ("가장 안전한 1회 변경") bypassed the literal
+# marker check. Same Falsified: satisfaction as the marker tier.
+#
+# EN: ASCII lookaround instead of `\b`. Python's `\b` is Unicode-aware
+# and would misfire when Korean text sits adjacent to ASCII (no
+# boundary between Hangul and ASCII word chars). Mirrors the
+# _BULK_PATTERN_EN strategy below.
+#
+# `recommend(?:ed|s)?` is intentionally bare (no parens) to catch
+# label/description usage without literal "(Recommended)" markers.
+# When `(Recommended)` IS present in a label, T1 (exact marker) fires
+# first and short-circuits before this pattern is consulted.
+_ANCHORING_EN_PATTERN = re.compile(
+    r"(?<![A-Za-z])"
+    r"(?:"
+    r"safer|safest|clearly|"
+    r"natural\s+(?:fit|choice)|"
+    r"obvious\s+choice|"
+    r"default\s+(?:to|choice)|"
+    r"prefer\s+this|"
+    r"recommend(?:ed|s)?"
+    r")"
+    r"(?![A-Za-z])",
+    re.IGNORECASE,
+)
+
+# KO substrings. Hangul has no ASCII word-boundary issue — these tokens
+# don't appear as substrings of unrelated words in option-label / desc
+# context. "가장 안전" is listed separately from bare "안전한" to keep
+# the recall for the in-vivo "가장 안전한 1회 변경" phrasing explicit,
+# even though "안전한" alone is sufficient — second entry is a no-op
+# under substring match but documents the canonical trigger phrase.
+_ANCHORING_KO_SUBSTRINGS = (
+    "안전한",
+    "가장 안전",
+    "자연스러운",
+    "당연히",
+    "분명히",
+    "추천",
+    "기본값",
+)
 
 
 def _has_exact_recommended_marker(labels: list[str]) -> bool:
@@ -87,7 +150,16 @@ def _has_falsified_line(texts: list[str]) -> bool:
 
 
 def _has_recommended_marker(labels: list[str]) -> bool:
-    """True if any option label contains a (Recommended) / (추천) marker."""
+    """True if any option label contains a (Recommended) / (추천) marker.
+
+    Reachable only when T1 (exact marker) and T2 (confidence-anchoring,
+    including bare ``recommend``) both miss. Since T2 matches any
+    case-insensitive `recommend(ed|s)?` form, an option whose label
+    contains `(recommended)` (lowercase) is now caught by T2 (ask)
+    before this fallback advisory runs — keep this function for
+    behavior continuity and clarity of the original three-tier intent,
+    but it is effectively dead under the new precedence.
+    """
     if not labels:
         return False
     for label in labels:
@@ -99,6 +171,44 @@ def _has_recommended_marker(labels: list[str]) -> bool:
             if marker in label:
                 return True
     return False
+
+
+def _has_confidence_anchoring(texts: list[str]) -> bool:
+    """True if any text contains a confidence-anchoring framing token.
+
+    Scans both EN regex (ASCII word-boundary lookarounds) and KO
+    substring patterns. See module docstring for token sets.
+    """
+    if not texts:
+        return False
+    for text in texts:
+        if not isinstance(text, str):
+            continue
+        if _ANCHORING_EN_PATTERN.search(text):
+            return True
+        for kw in _ANCHORING_KO_SUBSTRINGS:
+            if kw in text:
+                return True
+    return False
+
+
+def _collect_option_texts(options: list) -> list[str]:
+    """Collect option.label + option.description into a single text list.
+
+    Used by T2 (confidence-anchoring) detection only — T1 (exact marker)
+    still scans labels only via _has_exact_recommended_marker().
+    """
+    texts: list[str] = []
+    for o in options:
+        if not isinstance(o, dict):
+            continue
+        label = o.get("label")
+        if isinstance(label, str):
+            texts.append(label)
+        desc = o.get("description")
+        if isinstance(desc, str):
+            texts.append(desc)
+    return texts
 
 
 def _emit_ask(message: str) -> None:
@@ -189,6 +299,7 @@ def _main_inner() -> int:
         if not isinstance(questions, list):
             questions = []
         ask_needed = False
+        ask_msg_to_emit = ASK_MSG  # T1 default; T2 overrides
         advisory_needed = False
         for q in questions:
             if not isinstance(q, dict):
@@ -202,18 +313,30 @@ def _main_inner() -> int:
                     label = o.get("label")
                     if isinstance(label, str):
                         q_labels.append(label)
+            # Per-question check: only this question's text counts.
+            q_text = q.get("question")
+            q_texts = [q_text] if isinstance(q_text, str) else []
+            falsified_present = _has_falsified_line(q_texts)
+
             if _has_exact_recommended_marker(q_labels):
-                # Per-question check: only this question's text counts.
-                q_text = q.get("question")
-                q_texts = [q_text] if isinstance(q_text, str) else []
-                if not _has_falsified_line(q_texts):
+                # T1: literal (Recommended) / (추천) marker in label.
+                if not falsified_present:
                     ask_needed = True
+                    ask_msg_to_emit = ASK_MSG
                     break  # one missing question is enough to escalate
+            elif _has_confidence_anchoring(_collect_option_texts(options)):
+                # T2 (issue #369): confidence-anchoring framing token in
+                # label OR description. Same Falsified: satisfaction.
+                if not falsified_present:
+                    ask_needed = True
+                    ask_msg_to_emit = ANCHORING_ASK_MSG
+                    break
             elif _has_recommended_marker(q_labels):
+                # T3 (dead under new precedence — kept for clarity).
                 advisory_needed = True
 
         if ask_needed:
-            _emit_ask(ASK_MSG)
+            _emit_ask(ask_msg_to_emit)
         elif advisory_needed:
             sys.stderr.write(ADVISORY_MSG + "\n")
 

--- a/tests/test_output_block_falsify_advisory.sh
+++ b/tests/test_output_block_falsify_advisory.sh
@@ -174,6 +174,8 @@ PYEOF
 
 make_ask_payload_description_only() {
   # Payload where (Recommended) appears in options[].description, NOT in label.
+  # Issue #369: T2 (confidence-anchoring) now scans description too, so this
+  # payload triggers an ask via the bare `recommended` token in description.
   python3 -c "
 import json
 payload = {
@@ -194,6 +196,33 @@ payload = {
 }
 print(json.dumps(payload))
 "
+}
+
+make_ask_payload_with_descriptions() {
+  # $1 = JSON array of option label strings
+  # $2 = JSON array of option description strings (same length as labels)
+  # $3 = question text
+  python3 -c "
+import json, sys
+labels = json.loads(sys.argv[1])
+descs = json.loads(sys.argv[2])
+question_text = sys.argv[3]
+options = [{'label': l, 'description': d} for l, d in zip(labels, descs)]
+payload = {
+    'session_id': 'test-session',
+    'tool_name': 'AskUserQuestion',
+    'tool_input': {
+        'questions': [
+            {
+                'question': question_text,
+                'options': options,
+            }
+        ]
+    },
+    'cwd': '/tmp',
+}
+print(json.dumps(payload))
+" "$1" "$2" "$3"
 }
 
 make_bash_payload() {
@@ -224,8 +253,8 @@ run_case "AskUserQuestion: (추천) Korean — no Falsified: — escalates to as
   "ask:Falsified:" \
   "$(make_ask_payload '["옵션 A (추천)", "옵션 B"]')"
 
-run_case "AskUserQuestion: (recommended) lowercase also fires" \
-  "advisory:output-block-falsify-advisory" \
+run_case "AskUserQuestion: (recommended) lowercase — T2 escalates to ask (issue #369)" \
+  "ask:Falsified:" \
   "$(make_ask_payload '["use existing approach (recommended)"]')"
 
 # ---------------------------------------------------------------------------
@@ -337,9 +366,12 @@ run_case "AskUserQuestion: (Recommended) + no Falsified: → ask" \
   "ask:Falsified:" \
   "$(make_ask_payload '["Best option (Recommended)", "Alternative"]')"
 
-# Case 3: (Recommended) appears only in options[].description, not in label → PASS
-run_case "AskUserQuestion: (Recommended) in description only — false positive — silent pass" \
-  pass \
+# Case 3 (updated by issue #369): (Recommended) in description-only is now
+# scanned by T2 (bare `recommended` token, label OR description). Original
+# expectation `pass` upgraded to `ask` — false-positive guard was over-
+# conservative and let confidence-anchoring framing bypass the gate.
+run_case "AskUserQuestion: (Recommended) in description only — T2 escalates to ask (issue #369)" \
+  "ask:Falsified:" \
   "$(make_ask_payload_description_only)"
 
 # Case 4: (추천) Korean label + no Falsified: → ASK
@@ -357,6 +389,96 @@ run_case "AskUserQuestion: non-recommended option labels — silent pass" \
 run_case "AskUserQuestion: multi-question — Falsified: in Q2 does not cover Q1 (Recommended) → ask" \
   "ask:Falsified:" \
   "$(make_ask_payload_multi_question_bypass)"
+
+# ---------------------------------------------------------------------------
+# T2 confidence-anchoring framing cases — issue #369
+# ---------------------------------------------------------------------------
+
+# In-vivo regression: description has "가장 안전한" (the exact framing that
+# bypassed T1 in the devseunggwan/ai-dotfiles PR #84 session).
+run_case "T2: KO '가장 안전한' in description — no Falsified → ask" \
+  "ask:Falsified:" \
+  "$(make_ask_payload_with_descriptions \
+      '["S1 only", "S1+S2"]' \
+      '["가장 안전한 1회 변경", "Faster but more scope"]' \
+      'Phase 1?')"
+
+# EN single-word anchoring in label.
+run_case "T2: EN 'safer' in label — no Falsified → ask" \
+  "ask:Falsified:" \
+  "$(make_ask_payload '["A safer rollout", "B aggressive"]')"
+
+# EN single-word anchoring in label.
+run_case "T2: EN 'safest' in label — no Falsified → ask" \
+  "ask:Falsified:" \
+  "$(make_ask_payload '["Option A — safest", "Option B"]')"
+
+# KO single-word anchoring in description.
+run_case "T2: KO '자연스러운' in description → ask" \
+  "ask:Falsified:" \
+  "$(make_ask_payload_with_descriptions \
+      '["Approach A", "Approach B"]' \
+      '["자연스러운 진행", "주류 패턴"]' \
+      'Pick one?')"
+
+# EN multi-word anchoring in label.
+run_case "T2: EN 'prefer this' in label — no Falsified → ask" \
+  "ask:Falsified:" \
+  "$(make_ask_payload '["X (prefer this)", "Y"]')"
+
+# EN 'obvious choice' multi-word anchoring.
+run_case "T2: EN 'obvious choice' in description → ask" \
+  "ask:Falsified:" \
+  "$(make_ask_payload_with_descriptions \
+      '["A", "B"]' \
+      '["the obvious choice for new repos", "alt"]' \
+      'Setup?')"
+
+# Mixed Hangul/ASCII — ASCII lookaround must not match across boundary.
+run_case "T2: mixed Hangul/ASCII 'prefer this 옵션' → ask" \
+  "ask:Falsified:" \
+  "$(make_ask_payload '["prefer this 옵션을 사용", "대안"]')"
+
+# T2 satisfaction by Falsified: line — silent pass.
+run_case "T2: KO '가장 안전한' + Falsified: line → pass" \
+  pass \
+  "$(make_ask_payload_with_descriptions \
+      '["S1 only", "S1+S2"]' \
+      '["가장 안전한 1회 변경", "Faster"]' \
+      'Falsified: critic spawn check confirmed — no anchoring bypass.
+Phase 1?')"
+
+# T2 negative — token-like substring inside an unrelated word must not fire.
+# `disclosure` contains 'closur' but no anchoring tokens; ensure no spurious
+# match on words that happen to share letters with anchoring tokens.
+run_case "T2: negative — 'preferential treatment' not in token list — pass" \
+  pass \
+  "$(make_ask_payload '["preferential treatment of edge cases", "alternative"]')"
+
+# T2 negative — `safe` alone is not in the token set (only `safer`/`safest`).
+run_case "T2: negative — bare 'safe' not in token set — pass" \
+  pass \
+  "$(make_ask_payload '["safe path verified", "untested"]')"
+
+# T2 word-boundary regression — `unsafer` must not match `safer`.
+run_case "T2: word-boundary — 'unsafer' is not safer — pass" \
+  pass \
+  "$(make_ask_payload '["an unsafer path", "the other"]')"
+
+# T2 ANCHORING_ASK_MSG content (verify the new message variant is emitted).
+run_case "T2: KO '안전한' triggers ANCHORING_ASK_MSG (not ASK_MSG)" \
+  "ask:confidence-anchoring" \
+  "$(make_ask_payload '["가장 안전한 옵션", "alt"]')"
+
+# T1 precedence over T2 — when label has literal (Recommended) AND
+# description has confidence-anchoring, T1 (ASK_MSG, not ANCHORING_ASK_MSG)
+# fires first. Verify by checking T1's message marker.
+run_case "T1>T2 precedence: literal (Recommended) + anchoring desc → ASK_MSG" \
+  "ask:Self-Falsify" \
+  "$(make_ask_payload_with_descriptions \
+      '["X (Recommended)", "Y"]' \
+      '["가장 안전한 path", "alt"]' \
+      'Which?')"
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
Closes #369

## 변경 요약

`hooks/output-block-falsify-advisory.py` 에 **T2 (confidence-anchoring framing)** detector 추가.

### Tier 디자인

| Tier | 트리거 | 메시지 | 비고 |
|---|---|---|---|
| **T1** | 라벨 exact `(Recommended)` / `(추천)` + no Falsified | `ASK_MSG` | 기존 #290 |
| **T2 (신규)** | 라벨 OR 설명 의 anchoring 토큰 + no Falsified | `ANCHORING_ASK_MSG` | 본 PR |
| T3 | case-insensitive `(recommended)` | (dead — T2 흡수) | 기존 #221 |
| Bash | bulk-action keyword | advisory | 기존 |

T2 가 satisfied 되는 조건은 T1 과 동일: `Falsified: <evidence>` 줄 question body 에 존재.

### T2 토큰 셋

**EN** (case-insensitive, ASCII word-boundary lookarounds — Python `\b` 의 Unicode 함정 회피):
- single-word: `safer`, `safest`, `clearly`
- multi-word: `natural fit/choice`, `obvious choice`, `default to/choice`, `prefer this`
- bare marker: `recommend(?:ed|s)?` (paren 없이)

**KO** (substring — Hangul 은 ASCII boundary 무관):
- `안전한`, `가장 안전`, `자연스러운`, `당연히`, `분명히`, `추천`, `기본값`

### In-vivo 증거

devseunggwan/ai-dotfiles PR #84 머지 직전 (2026-05-21 세션) AskUserQuestion:

```json
{"options": [
  {"label": "S1 only", "description": "가장 안전한 1회 변경"},
  ...
]}
```

literal `(Recommended)` 마커 없음 → T1 bypass. 같은 turn 에 Externalization 룰 (critic spawn) 을 author 했음에도 retrieval 실패. repeat_count=3 (`feedback_authoring_is_not_retrieval` + `feedback_recommended_label_inline_falsification` + `feedback_externalize_falsification_to_critic`).

신규 fixture `T2: KO '가장 안전한' in description — no Falsified → ask` 가 본 payload 의 정확한 형태로 regression 보호.

## 행동 변경 (의도된 upgrade)

| 케이스 | 이전 | 신규 |
|---|---|---|
| description 에 `(Recommended)` 있음 (label 에는 없음) | pass | **ask** (T2) |
| label 에 `(recommended)` lowercase | advisory | **ask** (T2) |

원래 "description false-positive guard" 는 너무 보수적이어서 conf-anchoring framing 의 우회 경로를 만들었음. T2 가 closure.

## 검증

```
$ bash tests/test_output_block_falsify_advisory.sh
...
Results: 40 passed, 0 failed
```

- 신규 13 T2 케이스: 8 positive (in-vivo + EN/KO 단어 + multi-word + mixed Hangul/ASCII + T1>T2 precedence) + 4 negative (token 부재 / 단어 boundary regression) + 1 메시지 변종 확인 (ANCHORING_ASK_MSG vs ASK_MSG)
- 기존 27 케이스 전부 유지 (2개 expectation 만 upgrade 와 일치하도록 변경)
- `python3 scripts/build-plugin-manifests.py`: clean (hooks.json 변경 없음 — hook script 내부만 수정)
- `python3 scripts/check-plugin-manifests.py`: OK

## 비-목표

- Bash bulk-action 분기 변경 없음
- 신규 hook 추가 없음 (기존 hook 확장 — hooks.json 추가 등록 불필요)
- Stop hook / PostToolUse 추가 없음

## 커밋 트레일러 dogfood

ai-dotfiles #85/PR #86 (Commit Trailers subsection) 도입한 형식 사용:
- `Confidence: high`
- `Scope-risk: narrow`
- `Rejected: separate hook for T2 | ...` / `Rejected: scan description for T1 too | ...`
- `Not-tested: live AskUserQuestion turn`
