### PR TITLE
feat(retrospect): hook-write worktree fallback

### DIFF
--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -1050,11 +1050,29 @@ For each approved action:
    - Include: problem, proposed skill trigger, pipeline sketch
 
 6. **Hook code** → For enforcement-level actions (repeat 3x+):
-   a. Write hook script to `.claude/hooks/` or appropriate location
+   a. **Write the hook script.** First resolve the target repo (the project's
+      `.claude/hooks/`, or a personal-config / dotfiles repo when the hook backs
+      `~/.claude/`) and check its current branch: `git -C <repo> branch --show-current`.
+      - **On a protected branch (`main` / `dev` / `prod` / `master`)**: an inline
+        `Write` here is blocked by `pre-edit-protected-branch-guard` (it guards
+        Edit/Write on protected branches — both the dirty-tree and the clean-tree
+        PR-workflow-signal paths). Create a dedicated worktree on a new branch and
+        write the hook inside it:
+        ```
+        git -C <repo> worktree add -b retrospect-hook-{slug} \
+            <repo-parent>/<repo-name>.retrospect-hook-{slug} <protected-branch>
+        ```
+        Surface the worktree path to the user for the commit / PR decision —
+        retrospect does NOT auto-commit or auto-PR the hook; its contract ends at
+        the file write.
+      - **Already on a feature branch**: write the hook directly to
+        `.claude/hooks/` or the appropriate location.
    b. Present the hook code to user for review
    c. Explain how to register in `.claude/settings.json` (show the exact JSON entry)
    d. Use AskUserQuestion: "Hook을 settings.json에 등록할까요?" (✅ 등록 / ⏭ 파일만 유지 / 🕐 나중에)
-   e. If approved: Edit `.claude/settings.json` to register the hook
+   e. If approved: Edit `.claude/settings.json` to register the hook (inside the
+      step-(a) worktree when one was created — `settings.json` shares the same
+      protected-branch repo as the hook file)
    f. If skipped/deferred: leave the hook file in place and provide manual registration instructions
 
 7. **Verification** — For each executed action, verify the artifact:
@@ -1065,7 +1083,7 @@ For each approved action:
    | MEMORY.md feedback (merged) | Existing file updated (diff shown) + MEMORY.md index description updated if needed + if existing entry had `hookable: false` **or the field is missing entirely** and merged context now meets the retrieval-critical default, re-evaluate and add/update frontmatter (most pre-existing memories lack `hookable` — missing field is the dominant case, not false) |
    | GitHub issue | `gh issue view {url}` returns valid data |
    | Upstream feedback | `gh issue view {url}` returns valid data + URL repo matches `verified_backing_repo` from step 0 + label convention is correct for the verified repo (`tool-friction:{layer}` ONLY when verified repo is the praxis distribution; otherwise the repo's own convention label per Action 4's label rule) |
-   | Hook code | Script file exists + settings.json registration confirmed (dry-run varies by hook type — no generic check) |
+   | Hook code | Script file exists + settings.json registration confirmed (dry-run varies by hook type — no generic check). If Action 6 step (a) created a worktree, report the worktree path and confirm the file exists there. |
    | Global `~/.claude/CLAUDE.md` draft | **Project target (`AGENTS.md`)**: Diff shown + explicit approval received + Edit applied. **Global target (`~/.claude/CLAUDE.md`)**: Staging file created at `/tmp/claude-md-draft-{slug}.md` → AskUserQuestion 3-option presented → `apply`: Edit applied + diff shown; `보류`: staging file path logged in completion report. |
    | Skill idea note | File exists in `.omc/plans/` |
 


### PR DESCRIPTION
## Summary

`retrospect` Stage 4 Action 6 (`hook_code`) does an inline `Write` to
`.claude/hooks/`. When the hook target is a personal-config / dotfiles repo on a
protected branch, `pre-edit-protected-branch-guard` blocks the `Write` and the
retrospect procedure stalls mid-flight.

This implements **option 3** from #375 — keep both praxis components intact,
let retrospect route the write through a worktree.

## Change

`skills/retrospect/SKILL.md` Action 6:

- **step (a)** now resolves the target repo's current branch first. On a
  protected branch (`main`/`dev`/`prod`/`master`) it creates a dedicated
  worktree (`retrospect-hook-{slug}`) and writes the hook there, surfacing the
  path for the user's commit/PR decision; on a feature branch it writes directly
  as before. retrospect does not auto-commit or auto-PR — its contract ends at
  the file write.
- **step (e)** routes the `settings.json` edit into the same worktree (it shares
  the protected-branch repo with the hook file).
- **Action 7** verification row notes the worktree path when one was created.

## Scope note

#375 framed the trigger as "dirty `main`", but `pre-edit-protected-branch-guard`
also blocks a *clean* protected branch when recent commits carry a `(#NNN)`
PR-workflow signal. The robust trigger is therefore "target repo is on a
protected branch" — not "dirty" — so the worktree path sidesteps every guard
path. Branch-name check only; no `git status` parsing needed.

## Test

`tests/test_retrospect_mix_check.sh` → 41 + 11 fixtures pass / 0 fail
`tests/test_retrospect_routing.sh` → 5 pass / 0 fail
`tests/test_retrospect_falsify_recommended.sh` → 28 pass / 0 fail
`scripts/check-plugin-manifests.py` → OK

(Prose-only SKILL.md change — the action-key set is untouched, so the
`AUTHORITATIVE_SCHEMA` / `retrospect-mix-check` contract is unaffected.)

Closes #375
