### PR TITLE
feat(hooks): verify gh pr/issue label values exist in target repo

### DIFF
--- a/.claude-plugin/hooks/hooks.json
+++ b/.claude-plugin/hooks/hooks.json
@@ -79,6 +79,11 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/gh-label-verify.sh",
+            "timeout": 15
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/cli-flag-incompat-advisory.sh",
             "timeout": 5
           },

--- a/docs/hook/gh-label-verify.md
+++ b/docs/hook/gh-label-verify.md
@@ -1,0 +1,98 @@
+# PreToolUse gh PR/Issue Label Verifier
+
+Supported hosts: claude, codex
+
+`hooks/gh-label-verify.sh` intercepts every Bash tool call of the form
+`gh (issue|pr) (create|edit)` and hard-blocks invocations whose `--label`
+/ `-l` / `--add-label` values are not present in the target repository's
+label set. Probes `gh label list` with a per-repo TTL cache so the
+verification cost is amortized across a session.
+
+### Why this exists
+
+Label namespaces differ across repositories. A label name that exists in
+one repo (e.g. a prefixed `area:foo`) does not exist in another (e.g. a
+bare `foo`). When a session pattern-matches a label convention from one
+repo onto another without probing the target repo's label set first,
+`gh pr create --label <missing>` fails after the round-trip — wasted
+work that recurs across sessions.
+
+This hook fills the One-Probe-Before-Action gap for the label-namespace
+sub-variant. Memory-only enforcement was insufficient; the verification
+is mechanical, so it belongs at the hook layer.
+
+### What is blocked
+
+The hook tokenizes the command via `safe_tokenize` →
+`iter_command_starts` → `strip_prefix` (the same pipeline as
+`gh-flag-verify`), so chained segments and env-prefixed invocations are
+covered uniformly.
+
+| Command | Action |
+|---------|--------|
+| `gh pr create --label bug --repo acme/repo` (bug exists) | **PASS** |
+| `gh pr create --label nope --repo acme/repo` (nope absent) | **BLOCKED** |
+| `gh pr create --label bug,nope --repo acme/repo` (one missing) | **BLOCKED** |
+| `gh pr create --label bug --label nope --repo acme/repo` | **BLOCKED** |
+| `gh issue create -l nope --repo acme/repo` | **BLOCKED** |
+| `gh issue edit 1 --add-label nope --repo acme/repo` | **BLOCKED** |
+| `gh pr edit 1 --add-label bug --repo acme/repo` | **PASS** |
+| `gh pr create --label=nope --repo acme/repo` | **BLOCKED** (inline `=` form) |
+| `gh pr create --label bug` (no `--repo`, cwd resolves to acme/repo) | **PASS** |
+| `gh pr create --label bug` (no `--repo`, cwd not a git repo) | **PASS** (fail-open) |
+| `gh label list --repo ...` fails (network / auth) | **PASS** (fail-open) |
+| `gh pr list --label nope` (label is a filter here, not a write) | **PASS** (subcmd not in scope) |
+| `gh pr create --label nope --help` | **PASS** (help skips enforcement) |
+| Non-Bash tool | **PASS** |
+
+### Repo resolution
+
+1. `--repo <r>` / `-R <r>` / `--repo=<r>` in argv → use as-is.
+2. Otherwise parse `git -C <cwd> remote get-url origin` → `owner/repo`.
+3. Both unavailable → fail-open (cannot key the cache, cannot validate).
+
+### Caching
+
+Label sets are cached per repo at
+`${XDG_CACHE_HOME:-~/.cache}/claude-praxis/gh-label-cache.json`. Cache
+entries expire after `PRAXIS_GH_LABEL_CACHE_TTL_SEC` seconds (default
+300). Cache corruption, write failures, or read failures are all
+fail-open: enforcement still runs from a fresh fetch, just without
+persistence.
+
+Override the cache file location via `PRAXIS_GH_LABEL_CACHE_PATH` (used
+by tests; also useful for isolated sandboxes).
+
+### Fail-open paths
+
+The hook never breaks a session on infrastructure failure:
+
+- `gh` not installed
+- Network / auth failure on `gh label list`
+- `shlex` / `safe_tokenize` failure
+- Cache file unreadable or unwritable
+- `--repo` absent AND cwd not a git repo
+
+In every case the hook exits 0 silently; the gh command proceeds and may
+fail at execution time, surfacing the original error.
+
+### Configuration
+
+| Env var | Default | Purpose |
+|---------|---------|---------|
+| `PRAXIS_GH_LABEL_CACHE_TTL_SEC` | `300` | Per-repo cache TTL in seconds |
+| `PRAXIS_GH_LABEL_CACHE_PATH` | (computed) | Override cache file path |
+
+### Relationship to gh-flag-verify
+
+`gh-flag-verify` validates *which flag names* are accepted by a
+subcommand (a name-level check). This hook validates the *values*
+passed to `--label` for the subset of subcommands that write labels (a
+value-level check). The two hooks co-fire under the same PreToolUse
+matcher; deny precedence ensures the user sees the first denial reason.
+
+### Tests
+
+```bash
+bash tests/test_gh_label_verify.sh
+```

--- a/hooks/gh-label-verify.py
+++ b/hooks/gh-label-verify.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""PreToolUse(Bash) guard: block `gh (issue|pr) (create|edit)` invocations
+that pass a `--label` / `-l` / `--add-label` value not present in the
+target repository's label set.
+
+Concrete recurring case (issue #385):
+  AI pattern-matches a label naming convention from one repo (e.g. a
+  prefixed `area:foo`) onto a different repo whose label namespace lacks
+  it (e.g. only bare `foo` exists). `gh pr create --label area:foo` then
+  fails with "label not found" after the command has already been issued
+  — one wasted round-trip per occurrence, recurring across sessions.
+
+Pipeline:
+  1. Fast prefilter: command must contain `gh (issue|pr) (create|edit)`
+     AND at least one label-flag token (`--label`, `-l`, `--add-label`).
+  2. Structural tokenize (safe_tokenize → iter_command_starts →
+     strip_prefix) so chained segments and env-prefixed invocations are
+     covered uniformly.
+  3. Extract label values: `--label x`, `--label=x`, `--label x,y`,
+     repeated `--label x --label y` (gh accepts both forms).
+  4. Resolve target repo:
+       a. `--repo <r>` / `-R <r>` / `--repo=<r>` in argv → use as-is.
+       b. Else parse cwd's `git remote get-url origin` → owner/repo.
+       c. If both fail → fail-open (cannot validate without a key).
+  5. Fetch label set via `gh label list --repo <r> --limit 300 --json
+     name -q '.[].name'`, cached per-repo for PRAXIS_GH_LABEL_CACHE_TTL_SEC
+     (default 300) at <XDG_CACHE_HOME or ~/.cache>/claude-praxis/
+     gh-label-cache.json. Cache corrupt / unwritable → in-memory only.
+  6. If any extracted label is absent from the fetched set → exit 2 with
+     a stderr block listing the missing labels and a sample of valid
+     labels for the repo.
+
+Fail-open in every infrastructure-error path: gh missing, network fail,
+auth fail, shlex parse error, transcript missing, cwd not a git repo
+without `--repo`. Better silent pass than blocking the session.
+
+Skip conditions:
+  - `--help` / `-h` present (introspection, not execution)
+  - No label flag in argv (nothing to validate)
+  - `tool_name` != "Bash"
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Resolve sibling `_hook_utils.py` regardless of cwd at invocation time.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    iter_command_starts,
+    safe_tokenize,
+    strip_prefix,
+)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CACHE_TTL_SEC = 300
+_GH_LABEL_FETCH_TIMEOUT_SEC = 10
+_GIT_REMOTE_TIMEOUT_SEC = 2
+_GH_LABEL_LIMIT = 300
+
+_LABEL_FLAGS: frozenset[str] = frozenset({"--label", "-l", "--add-label"})
+_REPO_FLAGS: frozenset[str] = frozenset({"--repo", "-R"})
+_HELP_FLAGS: frozenset[str] = frozenset({"--help", "-h"})
+
+_LABELED_SUBCMDS: frozenset[tuple[str, str]] = frozenset({
+    ("issue", "create"),
+    ("issue", "edit"),
+    ("pr", "create"),
+    ("pr", "edit"),
+})
+
+_GH_LABELED_CMD_RE = re.compile(r"\bgh\s+(?:issue|pr)\s+(?:create|edit)\b")
+_LABEL_FLAG_RE = re.compile(r"(?:--label|--add-label|(?<!\S)-l)\b")
+_REPO_URL_RE = re.compile(r"[:/]([^/:\s]+)/([^/\s]+?)(?:\.git)?/?$")
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    command = (payload.get("tool_input") or {}).get("command", "")
+    if not _GH_LABELED_CMD_RE.search(command):
+        return 0
+    if not _LABEL_FLAG_RE.search(command):
+        return 0
+
+    tokens = safe_tokenize(command)
+    if not tokens:
+        return 0
+
+    cwd = payload.get("cwd") or os.getcwd()
+
+    for raw_argv in iter_command_starts(tokens):
+        argv = strip_prefix(list(raw_argv))
+        rc = _process_segment(argv, cwd)
+        if rc != 0:
+            return rc
+    return 0
+
+
+def _process_segment(argv: list[str], cwd: str) -> int:
+    if len(argv) < 3 or argv[0] != "gh":
+        return 0
+    if (argv[1], argv[2]) not in _LABELED_SUBCMDS:
+        return 0
+    sub_args = argv[3:]
+    if _HELP_FLAGS & set(sub_args):
+        return 0
+
+    labels = _extract_label_values(sub_args)
+    if not labels:
+        return 0
+
+    repo = _resolve_repo(sub_args, cwd)
+    if not repo:
+        return 0
+
+    valid = _get_labels(repo)
+    if valid is None:
+        return 0
+
+    missing = [l for l in labels if l not in valid]
+    if not missing:
+        return 0
+
+    _emit_block(missing, repo, sorted(valid)[:20])
+    return 2
+
+
+# ---------------------------------------------------------------------------
+# argv extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_label_values(args: list[str]) -> list[str]:
+    """Extract all label values from --label / -l / --add-label flags.
+
+    Supports both forms:
+      --label x
+      --label=x
+      --label x,y      (comma-separated multi-value)
+      -l x --label y   (repeated flag aggregation)
+    """
+    out: list[str] = []
+    i, n = 0, len(args)
+    while i < n:
+        tok = args[i]
+        if tok.startswith("--") and "=" in tok:
+            flag, _, val = tok.partition("=")
+            if flag in _LABEL_FLAGS:
+                out.extend(_split_csv(val))
+            i += 1
+            continue
+        if tok in _LABEL_FLAGS:
+            if i + 1 < n:
+                out.extend(_split_csv(args[i + 1]))
+            i += 2
+            continue
+        i += 1
+    return out
+
+
+def _split_csv(s: str) -> list[str]:
+    return [v.strip() for v in s.split(",") if v.strip()]
+
+
+def _resolve_repo(args: list[str], cwd: str) -> str | None:
+    i, n = 0, len(args)
+    while i < n:
+        tok = args[i]
+        if tok in _REPO_FLAGS and i + 1 < n:
+            return args[i + 1]
+        if tok.startswith("--repo="):
+            return tok[len("--repo="):]
+        i += 1
+    return _resolve_repo_from_git(cwd)
+
+
+def _resolve_repo_from_git(cwd: str) -> str | None:
+    try:
+        r = subprocess.run(
+            ["git", "-C", cwd, "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_REMOTE_TIMEOUT_SEC,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if r.returncode != 0:
+        return None
+    m = _REPO_URL_RE.search(r.stdout.strip())
+    return f"{m.group(1)}/{m.group(2)}" if m else None
+
+
+# ---------------------------------------------------------------------------
+# Label fetch + cache
+# ---------------------------------------------------------------------------
+
+
+def _cache_path() -> Path:
+    override = os.environ.get("PRAXIS_GH_LABEL_CACHE_PATH")
+    if override:
+        return Path(override)
+    base = os.environ.get("XDG_CACHE_HOME")
+    if base:
+        root = Path(base)
+    else:
+        root = Path.home() / ".cache"
+    return root / "claude-praxis" / "gh-label-cache.json"
+
+
+def _cache_ttl_sec() -> int:
+    raw = os.environ.get("PRAXIS_GH_LABEL_CACHE_TTL_SEC")
+    if raw is None:
+        return _DEFAULT_CACHE_TTL_SEC
+    try:
+        v = int(raw)
+        return v if v >= 0 else _DEFAULT_CACHE_TTL_SEC
+    except ValueError:
+        return _DEFAULT_CACHE_TTL_SEC
+
+
+def _get_labels(repo: str) -> frozenset[str] | None:
+    """Return the set of label names defined in `repo`, with caching.
+
+    Returns None when the label set cannot be determined (gh missing,
+    network failure, auth failure) — caller treats this as fail-open.
+    """
+    now = time.time()
+    cache_path = _cache_path()
+    cache = _load_cache(cache_path)
+    entry = cache.get(repo)
+    if isinstance(entry, dict):
+        fetched_at = entry.get("fetched_at", 0)
+        labels = entry.get("labels")
+        if (
+            isinstance(fetched_at, (int, float))
+            and isinstance(labels, list)
+            and (now - fetched_at) < _cache_ttl_sec()
+        ):
+            return frozenset(labels)
+
+    fetched = _fetch_labels(repo)
+    if fetched is None:
+        return None
+    cache[repo] = {"labels": sorted(fetched), "fetched_at": now}
+    _save_cache(cache_path, cache)
+    return frozenset(fetched)
+
+
+def _load_cache(path: Path) -> dict:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return {}
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save_cache(path: Path, cache: dict) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(cache, separators=(",", ":")), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _fetch_labels(repo: str) -> set[str] | None:
+    try:
+        r = subprocess.run(
+            [
+                "gh", "label", "list",
+                "--repo", repo,
+                "--limit", str(_GH_LABEL_LIMIT),
+                "--json", "name",
+                "-q", ".[].name",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=_GH_LABEL_FETCH_TIMEOUT_SEC,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if r.returncode != 0:
+        return None
+    return {ln.strip() for ln in r.stdout.splitlines() if ln.strip()}
+
+
+# ---------------------------------------------------------------------------
+# Block output
+# ---------------------------------------------------------------------------
+
+
+def _emit_block(missing: list[str], repo: str, sample: list[str]) -> None:
+    lines = [
+        f"BLOCKED: gh label(s) not found in {repo}: {', '.join(missing)}",
+        "",
+        "Rule: probe target-repo label set before applying a label convention.",
+        "Label namespaces differ across repos — a name that exists in one repo",
+        "may not exist in another. Verify before passing --label.",
+        "",
+        f"Verify the repo's label set: gh label list --repo {repo}",
+        "",
+    ]
+    if sample:
+        lines.append(f"Labels in {repo} (showing {len(sample)}):")
+        lines.extend(f"  - {l}" for l in sample)
+        lines.append("")
+    lines.extend([
+        "Resolve by one of:",
+        "  1. Use an existing label name from the list above.",
+        f"  2. Create the missing label first: gh label create '<name>' --repo {repo}",
+        "  3. Drop the --label flag if it is optional for this command.",
+    ])
+    sys.stderr.write("\n".join(lines) + "\n")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/gh-label-verify.sh
+++ b/hooks/gh-label-verify.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# PreToolUse(Bash) hook entry — delegates to the Python implementation.
+#
+# Fail-safe: if python3 is unavailable, exit 0 (pass) rather than break the
+# Claude Code session.
+
+set +e
+
+if ! command -v python3 >/dev/null 2>&1; then
+  exit 0
+fi
+
+exec python3 "$(dirname "$0")/gh-label-verify.py"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -89,6 +89,12 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/gh-label-verify.sh",
+            "timeout": 15,
+            "hosts": ["claude", "codex"]
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/cli-flag-incompat-advisory.sh",
             "timeout": 5,
             "hosts": ["claude", "codex"]

--- a/plugins/praxis/.codex-plugin/hooks/hooks.json
+++ b/plugins/praxis/.codex-plugin/hooks/hooks.json
@@ -74,6 +74,11 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/gh-label-verify.sh",
+            "timeout": 15
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/cli-flag-incompat-advisory.sh",
             "timeout": 5
           },

--- a/tests/test_gh_label_verify.sh
+++ b/tests/test_gh_label_verify.sh
@@ -240,11 +240,17 @@ run_case "shlex-breaking unmatched quote — fail-open silent" \
 #
 # The inline cases below construct PATH-restricted environments to prove
 # that cache state — not a live `gh` call — drives enforcement. They
-# include `dirname $(command -v python3)` in PATH so the testbed can
-# still launch the interpreter; only `gh` is selectively dropped from
-# the env to simulate a missing/failing CLI.
+# include the directory holding the real Python interpreter in PATH so
+# the testbed can still launch the interpreter; only `gh` is selectively
+# dropped from the env to simulate a missing/failing CLI.
+#
+# We resolve python3 via `sys.executable` rather than `command -v python3`
+# so wrapper-shim installations (pyenv, asdf) do not leak a `bash` runtime
+# dependency into the restricted PATH — those shims are bash scripts and
+# would otherwise fail with `env: bash: No such file or directory`.
 
-PY_DIR=$(dirname "$(command -v python3)")
+PY_BIN=$(python3 -c 'import sys; print(sys.executable)' 2>/dev/null) || PY_BIN=$(command -v python3)
+PY_DIR=$(dirname "$PY_BIN")
 GH_ABSENT_PATH="$PY_DIR"
 
 run_inline_case() {

--- a/tests/test_gh_label_verify.sh
+++ b/tests/test_gh_label_verify.sh
@@ -1,0 +1,336 @@
+#!/bin/bash
+# test_gh_label_verify.sh — coverage for hooks/gh-label-verify.py
+#
+# Synthesizes Claude Code PreToolUse(Bash) hook payloads and asserts:
+#   block  → rc=2, stderr starts with "BLOCKED:"
+#   silent → rc=0, stderr empty
+#
+# The hook shells out to `gh label list ...`. We stub `gh` via a temp
+# directory on PATH so cases are deterministic and offline. The cache
+# file path is also redirected to a temp file per-run.
+#
+# Usage: bash tests/test_gh_label_verify.sh
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$ROOT_DIR/hooks/gh-label-verify.py"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable: $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# ---------------------------------------------------------------------------
+# Mock gh
+# ---------------------------------------------------------------------------
+#
+# The stub recognises a handful of canned repos:
+#   acme/repo   → labels: bug, enhancement, tool-friction:cli
+#   acme/empty  → labels: (none)
+#   acme/fail   → exit 1 (simulates network/auth failure)
+#   anything else → exit 1
+#
+# Only `gh label list --repo <r> ...` is recognised — any other invocation
+# (e.g. `gh issue create`) exits 0 with empty output, so test payloads
+# that would otherwise call `gh` for real are inert.
+MOCK_BIN="$TMPDIR/mockbin"
+mkdir -p "$MOCK_BIN"
+cat > "$MOCK_BIN/gh" <<'EOF'
+#!/bin/bash
+if [ "$1" = "label" ] && [ "$2" = "list" ]; then
+  shift 2
+  repo=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --repo) repo="$2"; shift 2 ;;
+      --repo=*) repo="${1#--repo=}"; shift ;;
+      *) shift ;;
+    esac
+  done
+  case "$repo" in
+    acme/repo)
+      printf 'bug\nenhancement\ntool-friction:cli\n' ;;
+    acme/empty)
+      : ;;
+    acme/fail|"")
+      exit 1 ;;
+    *)
+      exit 1 ;;
+  esac
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$MOCK_BIN/gh"
+
+# Per-run cache file. Reset between cases via `rm -f`.
+CACHE_FILE="$TMPDIR/gh-label-cache.json"
+
+# A cwd that is NOT a git repo (no .git directory). Resolves to None.
+NON_GIT_CWD="$TMPDIR/non-git"
+mkdir -p "$NON_GIT_CWD"
+
+# run_case name expectation payload [env_kv ...]
+run_case() {
+  local name="$1" expectation="$2" payload="$3"
+  shift 3
+  local env_args=("PRAXIS_GH_LABEL_CACHE_PATH=$CACHE_FILE" "PATH=$MOCK_BIN:$PATH")
+  for kv in "$@"; do env_args+=("$kv"); done
+
+  rm -f "$CACHE_FILE"
+
+  local out_file err_file
+  out_file=$(mktemp); err_file=$(mktemp)
+
+  echo "$payload" | env "${env_args[@]}" python3 "$HOOK" >"$out_file" 2>"$err_file"
+  local rc=$?
+  local out err
+  out=$(cat "$out_file"); err=$(cat "$err_file")
+  rm -f "$out_file" "$err_file"
+
+  local ok=1
+  case "$expectation" in
+    silent)
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$err" ]   || ok=0
+      ;;
+    block)
+      [ "$rc" -eq 2 ] || ok=0
+      echo "$err" | grep -q "^BLOCKED:" || ok=0
+      ;;
+    *)
+      echo "  internal: unknown expectation '$expectation'" >&2
+      ok=0
+      ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS  $name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+    echo "  FAIL  $name (rc=$rc, expected=$expectation)"
+    [ -n "$err" ] && echo "        stderr: $(echo "$err" | head -c 400)"
+  fi
+}
+
+echo "test_gh_label_verify"
+
+# ---------------------------------------------------------------------------
+# Subcommand × label × repo matrix — PR / issue, create / edit
+# ---------------------------------------------------------------------------
+
+run_case "gh pr create --label bug (exists) — silent" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label bug --repo acme/repo --title t --body b"}}'
+
+run_case "gh pr create --label nope (missing) — block" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label nope --repo acme/repo --title t --body b"}}'
+
+run_case "gh issue create --label bug (exists) — silent" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue create --label bug --repo acme/repo --title t --body b"}}'
+
+run_case "gh issue create --label nope (missing) — block" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue create --label nope --repo acme/repo --title t --body b"}}'
+
+run_case "gh pr edit 1 --add-label bug (exists) — silent" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr edit 1 --add-label bug --repo acme/repo"}}'
+
+run_case "gh pr edit 1 --add-label nope (missing) — block" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr edit 1 --add-label nope --repo acme/repo"}}'
+
+run_case "gh issue edit 1 --add-label nope (missing) — block" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue edit 1 --add-label nope --repo acme/repo"}}'
+
+# ---------------------------------------------------------------------------
+# Multi-value forms
+# ---------------------------------------------------------------------------
+
+run_case "gh pr create --label bug,enhancement (both exist) — silent" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label bug,enhancement --repo acme/repo --title t --body b"}}'
+
+run_case "gh pr create --label bug,nope (one missing) — block" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label bug,nope --repo acme/repo --title t --body b"}}'
+
+run_case "gh pr create --label bug --label nope (repeated; one missing) — block" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label bug --label nope --repo acme/repo --title t --body b"}}'
+
+run_case "gh pr create --label=nope (inline = form; missing) — block" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label=nope --repo acme/repo --title t --body b"}}'
+
+run_case "gh pr create -l bug (short flag; exists) — silent" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create -l bug --repo acme/repo --title t --body b"}}'
+
+run_case "gh pr create -l nope (short flag; missing) — block" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create -l nope --repo acme/repo --title t --body b"}}'
+
+run_case "gh pr create --label 'tool-friction:cli' (existing namespaced label) — silent" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label tool-friction:cli --repo acme/repo --title t --body b"}}'
+
+# ---------------------------------------------------------------------------
+# Repo resolution
+# ---------------------------------------------------------------------------
+
+run_case "no --repo, cwd not a git repo — fail-open silent" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh pr create --label nope --title t --body b\"},\"cwd\":\"$NON_GIT_CWD\"}"
+
+run_case "gh label list returns failure (acme/fail) — fail-open silent" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label nope --repo acme/fail --title t --body b"}}'
+
+run_case "gh label list returns empty set, label missing — block" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label bug --repo acme/empty --title t --body b"}}'
+
+# ---------------------------------------------------------------------------
+# Help / no-op paths
+# ---------------------------------------------------------------------------
+
+run_case "gh pr create --label nope --help — silent (help bypass)" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label nope --help --repo acme/repo"}}'
+
+run_case "gh pr create with no label flag — silent (nothing to validate)" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --repo acme/repo --title t --body b"}}'
+
+run_case "gh pr list --label nope (filter, not write) — silent (subcmd out of scope)" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr list --label nope --repo acme/repo"}}'
+
+run_case "non-Bash tool — silent" \
+  "silent" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"/tmp/x"}}'
+
+run_case "malformed JSON payload — fail-open silent" \
+  "silent" \
+  "not-json"
+
+run_case "shlex-breaking unmatched quote — fail-open silent" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label \"open-quote --repo acme/repo"}}'
+
+# ---------------------------------------------------------------------------
+# Cache behavior
+# ---------------------------------------------------------------------------
+#
+# The inline cases below construct PATH-restricted environments to prove
+# that cache state — not a live `gh` call — drives enforcement. They
+# include `dirname $(command -v python3)` in PATH so the testbed can
+# still launch the interpreter; only `gh` is selectively dropped from
+# the env to simulate a missing/failing CLI.
+
+PY_DIR=$(dirname "$(command -v python3)")
+GH_ABSENT_PATH="$PY_DIR"
+
+run_inline_case() {
+  local name="$1" expectation="$2" payload="$3" path_override="$4"
+  shift 4
+  local extra_env=("$@")
+
+  local out_file err_file
+  out_file=$(mktemp); err_file=$(mktemp)
+
+  echo "$payload" \
+    | env "PRAXIS_GH_LABEL_CACHE_PATH=$CACHE_FILE" "PATH=$path_override" \
+          "${extra_env[@]}" \
+          python3 "$HOOK" >"$out_file" 2>"$err_file"
+  local rc=$?
+  local err
+  err=$(cat "$err_file")
+  rm -f "$out_file" "$err_file"
+
+  local ok=1
+  case "$expectation" in
+    silent)
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$err" ]   || ok=0
+      ;;
+    block)
+      [ "$rc" -eq 2 ] || ok=0
+      echo "$err" | grep -q "^BLOCKED:" || ok=0
+      ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS  $name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+    echo "  FAIL  $name (rc=$rc, expected=$expectation)"
+    [ -n "$err" ] && echo "        stderr: $(echo "$err" | head -c 400)"
+  fi
+}
+
+# Prime: fetch the label set under MOCK_BIN once so the cache file holds
+# {bug, enhancement, tool-friction:cli} for acme/repo. Subsequent cases
+# drop `gh` from PATH and rely on the cache.
+rm -f "$CACHE_FILE"
+echo '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label bug --repo acme/repo --title t --body b"}}' \
+  | PRAXIS_GH_LABEL_CACHE_PATH="$CACHE_FILE" PATH="$MOCK_BIN:$PATH" python3 "$HOOK" >/dev/null 2>&1
+
+run_inline_case "cache-hit blocks missing label even when gh is gone" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label nope --repo acme/repo --title t --body b"}}' \
+  "$GH_ABSENT_PATH"
+
+run_inline_case "cache-hit passes existing label when gh is gone" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label bug --repo acme/repo --title t --body b"}}' \
+  "$GH_ABSENT_PATH"
+
+# Corrupt the cache file. With gh available, a fresh fetch repopulates
+# the cache; the missing label still blocks.
+echo "not-json-garbage" > "$CACHE_FILE"
+run_inline_case "corrupt cache falls back to fresh fetch" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label nope --repo acme/repo --title t --body b"}}' \
+  "$MOCK_BIN:$PATH"
+
+# TTL=0 forces re-fetch every call. With `gh` removed AND TTL=0 (so the
+# warm cache is rejected as stale), enforcement falls open silently
+# instead of blocking a missing label.
+run_inline_case "TTL=0 expires cache; gh missing → fail-open silent" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label nope --repo acme/repo --title t --body b"}}' \
+  "$GH_ABSENT_PATH" \
+  "PRAXIS_GH_LABEL_CACHE_TTL_SEC=0"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo
+TOTAL=$((PASS + FAIL))
+echo "Result: $PASS/$TOTAL passed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed:"
+  for n in "${FAILED_NAMES[@]}"; do echo "  - $n"; done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Add a PreToolUse(Bash) hook that intercepts `gh (issue|pr) (create|edit)`
calls and blocks invocations whose `--label` / `-l` / `--add-label`
values are missing from the target repository's label set, with a
per-repo TTL cache so the verification cost is amortized.

Concrete recurring case: label namespaces differ across repos — a name
that exists in one repo (e.g. `area:foo`) does not exist in another
(e.g. only bare `foo`). Pattern-matching a label convention from one
repo onto another without probing the target's label set first wastes
a round-trip per occurrence. Memory-only enforcement was insufficient;
the verification is mechanical, so it belongs at the hook layer.

Design

- Fast prefilter: regex on `gh (issue|pr) (create|edit)` + presence of a
  label flag token. Skips the rest of the pipeline on non-write subcmds
  (e.g. `gh pr list --label`) and on writes without `--label`.
- Structural tokenize: safe_tokenize → iter_command_starts →
  strip_prefix, matching sibling hooks. Chained segments and
  env-prefixed invocations are handled uniformly.
- Label-value extraction handles `--label x`, `--label=x`,
  `--label x,y` (CSV multi-value), and repeated flag aggregation
  (`--label x --label y`), plus the `-l` short alias and `--add-label`
  on edit.
- Repo resolution: `--repo` / `-R` / `--repo=` in argv, else parse
  `git -C <cwd> remote get-url origin` → `owner/repo`. Both unavailable
  → fail-open (no cache key, no validation).
- Fetch via `gh label list --repo <r> --limit 300 --json name -q
  '.[].name'`. Results cached at
  `${XDG_CACHE_HOME:-~/.cache}/claude-praxis/gh-label-cache.json` per
  repo, TTL `PRAXIS_GH_LABEL_CACHE_TTL_SEC` (default 300). Corrupt /
  unwritable cache → in-memory fall through (still enforces, just
  without persistence).
- Fail-open on every infrastructure error: gh missing, network/auth
  failure, shlex/safe_tokenize failure, --help present, cwd not a git
  repo without --repo.

Scope chosen per issue #385: `gh pr create|edit` AND `gh issue
create|edit` — same root-cause family (repo-specific label namespace),
single hook covers both surfaces.

Registered in hooks/hooks.json with hosts ["claude", "codex"] and
timeout 15s (gh fetch defaults to 10s; 5s left for cache/IO). Manifests
regenerated for both Claude and Codex platforms.

Tests (27 cases): subcommand × label × repo matrix (PR/issue × create/
edit), multi-value forms (CSV, repeated flag, inline `=`, short `-l`),
namespaced label (`tool-friction:cli`), repo resolution edges (no
--repo + non-git cwd → fail-open), fetch-failure fail-open, empty
label set, --help bypass, no-label-flag silent, out-of-scope subcmd
(`gh pr list --label`), non-Bash silent, malformed JSON, unmatched
quote shlex error, cache-hit serves when gh is gone, cache-corrupt
falls back to fresh fetch, TTL=0 with gh missing → fail-open silent.

Refs #385