### PR TITLE
fix(hooks): extract search topic before overlap match in dup-search gate

### DIFF
--- a/hooks/block-gh-issue-create-without-dup-search.py
+++ b/hooks/block-gh-issue-create-without-dup-search.py
@@ -27,9 +27,12 @@ Allow conditions (escape hatches):
 Keyword extraction:
   Strip Conventional Commits prefix (`feat(scope):`, `fix:`), lowercase,
   split on word boundaries, drop stop words and tokens <4 chars. Match if
-  ANY remaining keyword appears literally in a prior search/list command.
-  (Single overlap is a weak gate but catches the most damaging case —
-  completely cold issue creation.)
+  the title-keyword set has non-empty intersection with the prior search
+  command's topic-token set (positionals + `--search` value), where
+  flag-arg tokens (`--repo VAL`, `--limit N`, ...) are skipped. Substring
+  match against the full command line is INCORRECT because flag values
+  (e.g. `--repo acme/widget`) leak keyword fragments into the topic
+  corpus — see issue #384.
 """
 from __future__ import annotations
 
@@ -83,10 +86,8 @@ def main() -> int:
         _emit_no_search_block(keywords)
         return 2
 
-    overlap = any(
-        any(tok in cmd for tok in keywords)
-        for cmd in search_cmds
-    )
+    kw_set = set(keywords)
+    overlap = any(kw_set & _extract_search_topic(cmd) for cmd in search_cmds)
     if overlap:
         return 0
 
@@ -126,6 +127,52 @@ _SEARCH_CMD_RE = re.compile(
     r"\bgh\s+(?:search\s+issues|issue\s+list|issue\s+view)\b[^\n]*",
 )
 
+# Value-taking flags relevant to gh search issues / gh issue list / gh issue
+# view. Each consumes the next whitespace-separated token (or `=VALUE`
+# inline). Lowercased — _SEARCH_CMD_RE input is `tail.lower()`. Lowercase
+# short-flag collisions (-l for both --limit and --label, -a for both
+# --assignee and --author, -s for both --state and --search) are all
+# value-taking for the relevant subcommands, so collision is harmless.
+_VALUE_FLAG_NAMES: frozenset[str] = frozenset({
+    "--repo", "-r",
+    "--limit", "-l",
+    "--state", "-s",
+    "--search",
+    "--label",
+    "--owner",
+    "--author", "-a",
+    "--assignee",
+    "--milestone", "-m",
+    "--mention",
+    "--language",
+    "--app",
+    "--match",
+    "--sort",
+    "--order",
+    "--visibility",
+    "--commenter",
+    "--comments",
+    "--created",
+    "--updated",
+    "--closed",
+    "--interactions",
+    "--involves",
+    "--jq", "-q",
+    "--json",
+    "--template", "-t",
+    "--project", "-p",
+    "--reactions",
+    "--team-mentions",
+})
+
+# Flags whose value is itself topic text (not metadata). Currently only the
+# `--search` family on `gh issue list` / `gh pr list`.
+_TOPIC_VALUE_FLAGS: frozenset[str] = frozenset({"--search", "-s"})
+
+# Trailing chars to strip from a token. Raw transcript text often glues JSON
+# closure chars to the last argv token (e.g. `acme/repo"}`).
+_TRAILING_STRIP = '"}],'
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -143,6 +190,65 @@ def _extract_keywords(title: str) -> list[str]:
     body = _CC_PREFIX_RE.sub("", title).lower()
     tokens = [t for t in _TOKEN_SPLIT_RE.split(body) if t]
     return [t for t in tokens if len(t) >= 4 and t not in _STOP_WORDS]
+
+
+def _topic_tokens_from(s: str) -> set[str]:
+    """Split a topic string into ≥4-char tokens minus stop words.
+
+    Mirrors `_extract_keywords` so the title-keyword and prior-search-topic
+    token domains are symmetric for set intersection.
+    """
+    tokens = [t for t in _TOKEN_SPLIT_RE.split(s.lower()) if t]
+    return {t for t in tokens if len(t) >= 4 and t not in _STOP_WORDS}
+
+
+def _extract_search_topic(cmd: str) -> set[str]:
+    """Extract the topic-token set from a prior `gh search issues|issue
+    list|issue view` command line.
+
+    Whitespace-splits the command, strips JSON-closure chars glued to the
+    last token by raw-transcript matching (`acme/repo"}`), and walks argv
+    as a small state machine:
+
+      - `--flag=value` inline: keep `value` only when flag ∈ _TOPIC_VALUE_FLAGS.
+      - `--flag value`: consume both tokens; keep `value` only when flag ∈
+        _TOPIC_VALUE_FLAGS.
+      - Bare `--bool` or `-x` (not value-taking): skip self.
+      - Positional: emit its tokens.
+
+    Returns the set of ≥4-char non-stop-word tokens — same domain as
+    `_extract_keywords`, so set intersection with title keywords is a
+    valid overlap test.
+    """
+    tokens = cmd.strip().split()
+    if len(tokens) < 3 or tokens[0] != "gh":
+        return set()
+    args = tokens[3:]
+    topic: set[str] = set()
+    i, n = 0, len(args)
+    while i < n:
+        tok = args[i].rstrip(_TRAILING_STRIP)
+        if not tok:
+            i += 1
+            continue
+        if tok.startswith("--") and "=" in tok:
+            flag, _, val = tok.partition("=")
+            if flag in _TOPIC_VALUE_FLAGS:
+                topic.update(_topic_tokens_from(val))
+            i += 1
+            continue
+        if tok in _VALUE_FLAG_NAMES:
+            if tok in _TOPIC_VALUE_FLAGS and i + 1 < n:
+                next_val = args[i + 1].rstrip(_TRAILING_STRIP)
+                topic.update(_topic_tokens_from(next_val))
+            i += 2
+            continue
+        if tok.startswith("-"):
+            i += 1
+            continue
+        topic.update(_topic_tokens_from(tok))
+        i += 1
+    return topic
 
 
 def _read_transcript_tail(path: str, max_lines: int, max_bytes: int) -> str | None:

--- a/tests/test_block_gh_issue_create_without_dup_search.sh
+++ b/tests/test_block_gh_issue_create_without_dup_search.sh
@@ -42,6 +42,16 @@ cat > "$TX_NO_OVERLAP" <<'EOF'
 {"type":"tool_use","content":"gh search issues authentication --repo acme/repo"}
 EOF
 
+# Regression fixture for issue #384: the prior `--repo` value contains a
+# substring that matches one of the title keywords (`widget`). Under the
+# old substring-overlap check, `widget` ⊂ `--repo acme/widget` flipped
+# overlap=true and silently passed. With set-intersection on extracted
+# topic tokens (flag values skipped), this case must BLOCK.
+TX_NO_OVERLAP_FLAG_LEAK="$TMPDIR/tx-no-overlap-flag-leak.jsonl"
+cat > "$TX_NO_OVERLAP_FLAG_LEAK" <<'EOF'
+{"type":"tool_use","content":"gh search issues authentication --repo acme/widget"}
+EOF
+
 TX_ISSUE_LIST="$TMPDIR/tx-issue-list.jsonl"
 cat > "$TX_ISSUE_LIST" <<'EOF'
 {"type":"tool_use","content":"gh issue list --repo acme/repo --search brands"}
@@ -76,6 +86,14 @@ run_case() {
       [ "$rc" -eq 2 ] || ok=0
       echo "$err" | grep -q "^BLOCKED:" || ok=0
       ;;
+    block:no-search)
+      [ "$rc" -eq 2 ] || ok=0
+      echo "$err" | grep -q "without any prior \`gh search issues\`" || ok=0
+      ;;
+    block:no-overlap)
+      [ "$rc" -eq 2 ] || ok=0
+      echo "$err" | grep -q "prior searches exist but none overlap" || ok=0
+      ;;
     *)
       echo "  internal: unknown expectation '$expectation'" >&2
       ok=0
@@ -100,12 +118,20 @@ echo "test_block_gh_issue_create_without_dup_search"
 # ---------------------------------------------------------------------------
 
 run_case "gh issue create + no prior search (block)" \
-  "block" \
+  "block:no-search" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh issue create --repo acme/repo --title 'feat(provider): add zeta brands lookup pattern'\"},\"transcript_path\":\"$TX_EMPTY\"}"
 
 run_case "gh issue create + prior search but no keyword overlap (block)" \
-  "block" \
+  "block:no-overlap" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh issue create --repo acme/repo --title 'feat(provider): add zeta brands lookup pattern'\"},\"transcript_path\":\"$TX_NO_OVERLAP\"}"
+
+# Regression for issue #384: title keyword `widget` collides with the value
+# of a prior `--repo acme/widget` flag. With the buggy substring overlap
+# check, this silently passed; with set-intersection on extracted topic
+# tokens (flag values skipped), it must BLOCK with the no-overlap reason.
+run_case "gh issue create + prior search w/ keyword leaking from --repo value (regression #384)" \
+  "block:no-overlap" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh issue create --repo acme/repo --title 'feat(provider): add widget brands lookup pattern'\"},\"transcript_path\":\"$TX_NO_OVERLAP_FLAG_LEAK\"}"
 
 # ---------------------------------------------------------------------------
 # SILENT cases


### PR DESCRIPTION
The dup-search hook's overlap check used substring match against the
full prior `gh search issues` command line, including flag values. A
title keyword that happened to appear inside a flag value (e.g. `widget`
keyword vs `--repo acme/widget`) flipped overlap=true and silently
skipped the BLOCK that the no-overlap path was designed to fire.

Replace the substring check with set-intersection on extracted topic
tokens:

- New `_extract_search_topic()` walks argv as a small state machine,
  consuming known value-taking flags (`--repo`, `--limit`, `--state`,
  ...) and their values, and treating positionals and `--search` values
  as topic source. Trailing JSON-closure chars glued by raw-transcript
  matching (`acme/repo"}`) are stripped per token.
- `_topic_tokens_from()` mirrors `_extract_keywords()` (≥4-char,
  stop-word filtered) so both sides of the intersection share the same
  token domain.
- main() switches overlap test to `kw_set & _extract_search_topic(cmd)`.

The shlex route was rejected because the regex-matched search command
lines include glued JSON closures from the raw JSONL transcript, which
break `shlex.split` on unclosed-quote. A simple `str.split` +
per-token rstrip is JSON-safe and sufficient for whitespace-separated
shell argv.

Tests:

- Restore the PR #383 regression fixture (`--repo acme/widget` + title
  keyword `widget`) — previously masked by fixture rename, now exercised
  as a `block:no-overlap` assertion that fails without the fix.
- Strengthen assertions: `block:no-search` / `block:no-overlap`
  expectations check the BLOCK reason in stderr, not just the rc=2 +
  `^BLOCKED:` prefix that any block path satisfies.

15/15 tests pass.

Refs #384

---
_Generated by [Claude Code](https://claude.ai/code/session_014sAEJozMdtHdKJ6sJx1PBM)_