### PR TITLE
feat(hook): upgrade Recommended marker tier ask->deny

### DIFF
--- a/hooks/output-block-falsify-advisory.py
+++ b/hooks/output-block-falsify-advisory.py
@@ -10,12 +10,18 @@ proposal block is authored.
 
 This hook adds a structural enforcement point at two surfaces:
 
-  1. AskUserQuestion — escalates `permissionDecision: ask` in two tiers
-     when the question body lacks a `Falsified:` line (exact prefix at
-     line start):
+  1. AskUserQuestion — escalates the question by tier when the body
+     lacks a `Falsified:` line (exact prefix at line start):
 
      T1. Label contains exact `(Recommended)` or `(추천)` (case-sensitive)
-         — original literal-marker path.
+         — original literal-marker path. **Emits `permissionDecision: deny`
+         (hard block)** — issue #393 upgrade. Rationale: the explicit
+         marker is a high-confidence false-positive-free signal; soft
+         `ask` permitted acknowledge-and-proceed and within-session
+         recurrence was observed (retrospect 2026-05-23, 3 calls in
+         a single codex-review-wrap chain). False-positive rate of
+         a literal `(Recommended)` label without `Falsified:` is low
+         enough to justify hard block.
 
      T2. Label OR description contains a confidence-anchoring framing
          token (issue #369). EN tokens (case-insensitive, ASCII word
@@ -23,6 +29,9 @@ This hook adds a structural enforcement point at two surfaces:
          `natural fit/choice`, `default to/choice`, `prefer this`,
          bare `recommend(ed|s)?`. KO substrings: `안전한`, `가장 안전`,
          `자연스러운`, `당연히`, `분명히`, `추천`, `기본값`.
+         **Emits `permissionDecision: ask` (soft gate)** — kept at ask
+         for ergonomics: framing-token detection is broader and carries
+         higher false-positive risk than the literal T1 marker.
 
      When `Falsified:` is present in the question body, both tiers
      silent-pass.
@@ -210,19 +219,33 @@ def _collect_option_texts(options: list) -> list[str]:
     return texts
 
 
-def _emit_ask(message: str) -> None:
-    """Output permissionDecision: ask JSON to stdout."""
+def _emit_decision(decision: str, message: str) -> None:
+    """Output permissionDecision JSON to stdout.
+
+    decision must be "ask" or "deny" (the two tiers used by this hook).
+    "allow" is not used — silent-pass is signaled by no JSON output.
+    """
     json.dump(
         {
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",
-                "permissionDecision": "ask",
+                "permissionDecision": decision,
                 "permissionDecisionReason": message,
             }
         },
         sys.stdout,
     )
     sys.stdout.write("\n")
+
+
+def _emit_ask(message: str) -> None:
+    """T2 path: soft gate."""
+    _emit_decision("ask", message)
+
+
+def _emit_deny(message: str) -> None:
+    """T1 path: hard block (issue #393 upgrade)."""
+    _emit_decision("deny", message)
 
 
 # ---------------------------------------------------------------------------
@@ -297,8 +320,9 @@ def _main_inner() -> int:
         questions = tool_input.get("questions") or []
         if not isinstance(questions, list):
             questions = []
-        ask_needed = False
-        ask_msg_to_emit = ASK_MSG  # T1 default; T2 overrides
+        # tier_decision: None | "deny" (T1) | "ask" (T2)
+        tier_decision: str | None = None
+        msg_to_emit: str = ASK_MSG
         advisory_needed = False
         for q in questions:
             if not isinstance(q, dict):
@@ -319,23 +343,27 @@ def _main_inner() -> int:
 
             if _has_exact_recommended_marker(q_labels):
                 # T1: literal (Recommended) / (추천) marker in label.
+                # Issue #393: upgraded from ask to deny (hard block).
                 if not falsified_present:
-                    ask_needed = True
-                    ask_msg_to_emit = ASK_MSG
+                    tier_decision = "deny"
+                    msg_to_emit = ASK_MSG
                     break  # one missing question is enough to escalate
             elif _has_confidence_anchoring(_collect_option_texts(options)):
                 # T2 (issue #369): confidence-anchoring framing token in
-                # label OR description. Same Falsified: satisfaction.
+                # label OR description. Soft gate — false-positive risk
+                # higher than T1's literal marker.
                 if not falsified_present:
-                    ask_needed = True
-                    ask_msg_to_emit = ANCHORING_ASK_MSG
+                    tier_decision = "ask"
+                    msg_to_emit = ANCHORING_ASK_MSG
                     break
             elif _has_recommended_marker(q_labels):
                 # T3 (dead under new precedence — kept for clarity).
                 advisory_needed = True
 
-        if ask_needed:
-            _emit_ask(ask_msg_to_emit)
+        if tier_decision == "deny":
+            _emit_deny(msg_to_emit)
+        elif tier_decision == "ask":
+            _emit_ask(msg_to_emit)
         elif advisory_needed:
             sys.stderr.write(ADVISORY_MSG + "\n")
 

--- a/hooks/output-block-falsify-advisory.py
+++ b/hooks/output-block-falsify-advisory.py
@@ -347,15 +347,15 @@ def _main_inner() -> int:
                 if not falsified_present:
                     tier_decision = "deny"
                     msg_to_emit = ASK_MSG
-                    break  # one missing question is enough to escalate
+                    break  # T1 deny is final — overrides any prior T2 ask
             elif _has_confidence_anchoring(_collect_option_texts(options)):
                 # T2 (issue #369): confidence-anchoring framing token in
                 # label OR description. Soft gate — false-positive risk
-                # higher than T1's literal marker.
-                if not falsified_present:
+                # higher than T1's literal marker. Record but keep scanning
+                # so a later T1 violation can upgrade the decision to deny.
+                if not falsified_present and tier_decision is None:
                     tier_decision = "ask"
                     msg_to_emit = ANCHORING_ASK_MSG
-                    break
             elif _has_recommended_marker(q_labels):
                 # T3 (dead under new precedence — kept for clarity).
                 advisory_needed = True

--- a/tests/test_output_block_falsify_advisory.sh
+++ b/tests/test_output_block_falsify_advisory.sh
@@ -32,6 +32,7 @@ FAILED_NAMES=()
 #   expectation:
 #     "advisory:<substring>" — exit 0 + stderr contains <substring>
 #     "ask:<substring>"       — exit 0 + stdout JSON has permissionDecision:ask + substring
+#     "deny:<substring>"      — exit 0 + stdout JSON has permissionDecision:deny + substring  (issue #393)
 #     "pass"                  — exit 0 + stderr empty
 run_case() {
   local name="$1" expectation="$2" payload="$3"
@@ -56,8 +57,9 @@ run_case() {
         *) ok=0 ;;
       esac
       ;;
-    ask:*)
-      local needle="${expectation#ask:}"
+    ask:*|deny:*)
+      local expected_decision="${expectation%%:*}"
+      local needle="${expectation#*:}"
       [ "$rc" -eq 0 ] || ok=0
       local decision
       decision=$(python3 -c "
@@ -69,7 +71,7 @@ try:
 except Exception:
     print('')
 " "$out" 2>/dev/null)
-      [ "$decision" = "ask" ] || ok=0
+      [ "$decision" = "$expected_decision" ] || ok=0
       case "$out" in
         *"$needle"*) ;;
         *) ok=0 ;;
@@ -245,12 +247,12 @@ print(json.dumps(payload))
 # AskUserQuestion positive cases
 # ---------------------------------------------------------------------------
 
-run_case "AskUserQuestion: (Recommended) English — no Falsified: — escalates to ask" \
-  "ask:Falsified:" \
+run_case "AskUserQuestion: (Recommended) English — no Falsified: — T1 blocks (issue #393)" \
+  "deny:Falsified:" \
   "$(make_ask_payload '["Option A (Recommended)", "Option B"]')"
 
-run_case "AskUserQuestion: (추천) Korean — no Falsified: — escalates to ask" \
-  "ask:Falsified:" \
+run_case "AskUserQuestion: (추천) Korean — no Falsified: — T1 blocks (issue #393)" \
+  "deny:Falsified:" \
   "$(make_ask_payload '["옵션 A (추천)", "옵션 B"]')"
 
 run_case "AskUserQuestion: (recommended) lowercase — T2 escalates to ask (issue #369)" \
@@ -361,9 +363,9 @@ run_case "AskUserQuestion: (Recommended) + Falsified: line in question body → 
       "Falsified: checked no existing PR for this — none found.
 What should we do?")"
 
-# Case 2: (Recommended) label + no Falsified: → ASK
-run_case "AskUserQuestion: (Recommended) + no Falsified: → ask" \
-  "ask:Falsified:" \
+# Case 2 (updated by issue #393): (Recommended) label + no Falsified: → DENY (block)
+run_case "AskUserQuestion: (Recommended) + no Falsified: → T1 deny (issue #393)" \
+  "deny:Falsified:" \
   "$(make_ask_payload '["Best option (Recommended)", "Alternative"]')"
 
 # Case 3 (updated by issue #369): (Recommended) in description-only is now
@@ -374,9 +376,9 @@ run_case "AskUserQuestion: (Recommended) in description only — T2 escalates to
   "ask:Falsified:" \
   "$(make_ask_payload_description_only)"
 
-# Case 4: (추천) Korean label + no Falsified: → ASK
-run_case "AskUserQuestion: (추천) Korean label + no Falsified: → ask" \
-  "ask:Falsified:" \
+# Case 4 (updated by issue #393): (추천) Korean label + no Falsified: → DENY (block)
+run_case "AskUserQuestion: (추천) Korean label + no Falsified: → T1 deny (issue #393)" \
+  "deny:Falsified:" \
   "$(make_ask_payload '["권장 방법 (추천)", "대안"]')"
 
 # Case 5: Non-recommended option — no (Recommended) label — silent pass (no advisory)
@@ -384,10 +386,11 @@ run_case "AskUserQuestion: non-recommended option labels — silent pass" \
   pass \
   "$(make_ask_payload '["Option A", "Option B", "Option C"]')"
 
-# Case 6 (regression for P2 fix): multi-question payload where Q1 has (Recommended)
-# but no Falsified:, and Q2 has Falsified: in its own question text — must still ask.
-run_case "AskUserQuestion: multi-question — Falsified: in Q2 does not cover Q1 (Recommended) → ask" \
-  "ask:Falsified:" \
+# Case 6 (regression for P2 fix; updated by issue #393): multi-question payload
+# where Q1 has (Recommended) but no Falsified:, and Q2 has Falsified: in its own
+# question text — Q1 still fires T1 → DENY (block).
+run_case "AskUserQuestion: multi-question — Falsified: in Q2 does not cover Q1 (Recommended) → T1 deny" \
+  "deny:Falsified:" \
   "$(make_ask_payload_multi_question_bypass)"
 
 # ---------------------------------------------------------------------------
@@ -471,10 +474,12 @@ run_case "T2: KO '안전한' triggers ANCHORING_ASK_MSG (not ASK_MSG)" \
   "$(make_ask_payload '["가장 안전한 옵션", "alt"]')"
 
 # T1 precedence over T2 — when label has literal (Recommended) AND
-# description has confidence-anchoring, T1 (ASK_MSG, not ANCHORING_ASK_MSG)
-# fires first. Verify by checking T1's message marker.
-run_case "T1>T2 precedence: literal (Recommended) + anchoring desc → ASK_MSG" \
-  "ask:Self-Falsify" \
+# description has confidence-anchoring, T1 fires first.
+# Updated by issue #393: T1 now emits deny (not ask). The T1 message
+# (ASK_MSG content, "Self-Falfify" marker) is still emitted, but the
+# decision is deny instead of ask.
+run_case "T1>T2 precedence: literal (Recommended) + anchoring desc → T1 deny (issue #393)" \
+  "deny:Self-Falsify" \
   "$(make_ask_payload_with_descriptions \
       '["X (Recommended)", "Y"]' \
       '["가장 안전한 path", "alt"]' \

--- a/tests/test_output_block_falsify_advisory.sh
+++ b/tests/test_output_block_falsify_advisory.sh
@@ -485,6 +485,43 @@ run_case "T1>T2 precedence: literal (Recommended) + anchoring desc → T1 deny (
       '["가장 안전한 path", "alt"]' \
       'Which?')"
 
+# Multi-question T2-then-T1 precedence — Q1 fires T2 (confidence-anchoring),
+# Q2 fires T1 (literal Recommended). Pre-fix bug: loop broke on Q1's T2 and
+# emitted ask, allowing user to bypass the T1 hard block. Post-fix: T2 records
+# but keeps scanning; Q2's T1 upgrades the decision to deny.
+make_ask_payload_t2_then_t1() {
+  python3 - <<'PYEOF'
+import json
+payload = {
+    "session_id": "test-session",
+    "tool_name": "AskUserQuestion",
+    "tool_input": {
+        "questions": [
+            {
+                "question": "Q1: which approach?",
+                "options": [
+                    {"label": "Option A (safer)", "description": "natural choice"},
+                    {"label": "Option B", "description": "alt"},
+                ],
+            },
+            {
+                "question": "Q2: which path?",
+                "options": [
+                    {"label": "Path X (Recommended)", "description": "T1 marker"},
+                    {"label": "Path Y", "description": "alt"},
+                ],
+            },
+        ]
+    },
+    "cwd": "/tmp",
+}
+print(json.dumps(payload))
+PYEOF
+}
+run_case "T2→T1 multi-question: Q1 anchoring, Q2 literal (Recommended) → deny (issue #393 fix)" \
+  "deny:Self-Falsify" \
+  "$(make_ask_payload_t2_then_t1)"
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 요약

`hooks/output-block-falsify-advisory.py` 의 T1 티어 (literal `(Recommended)` / `(추천)` 라벨 + question body 의 `Falsified:` 부재) 를 `permissionDecision: ask` 에서 `deny` 로 승격.

## 배경

retrospect 2026-05-23 세션에서 within-session 재발 확인:
- praxis:codex-review-wrap 1회 체인 안에서 3개 AskUserQuestion 콜이 모두 `(Recommended)` 라벨 + `Falsified:` 부재 상태로 emit
- 기존 hook 은 fire 했으나 `ask` → acknowledge-and-proceed 경로로 흘러감
- analyst (oh-my-claudecode:analyst) 판정: post-hook recurrence → tier 강화 정당

## 변경 내용

### Hook (`hooks/output-block-falsify-advisory.py`)

| 티어 | 트리거 | 변경 전 | 변경 후 |
|------|--------|---------|---------|
| **T1** | label 에 literal `(Recommended)` / `(추천)` + `Falsified:` 부재 | `ask` | **`deny` (block)** |
| T2 | label/desc 에 confidence-anchoring framing 토큰 (safer/safest/안전한 등) + `Falsified:` 부재 | `ask` | `ask` (유지) |
| Bash bulk-action | "close all" / "merge all" / "모두 삭제" 등 | stderr advisory | 유지 |

T2 는 framing-token 감지가 광범위해 false-positive 위험이 크므로 유지. T1 의 literal 마커는 false-positive 확률 매우 낮아 hard block 정당.

### Test (`tests/test_output_block_falsify_advisory.sh`)

- `deny:<substring>` expectation 패턴을 `ask:<substring>` 와 동일 구조로 추가
- T1 케이스 6건: `ask:Falsified:` → `deny:Falsified:` / `deny:Self-Falsify`
  - `(Recommended) English`, `(추천) Korean`, single+multi-question, T1>T2 precedence
- T2 케이스 전부 `ask:` 유지 (회귀 없음)

## 검증

```
$ bash tests/test_output_block_falsify_advisory.sh
... (생략) ...
Results: 40 passed, 0 failed
```

Caller chain verified: hook entrypoint registered via `.claude-plugin/hooks/hooks.json` (PreToolUse matcher AskUserQuestion + Bash); `_emit_ask`/`_emit_deny` are file-local helpers (no external callers).

Closes #393
