### PR TITLE
feat(hook): pretooluse gh --json validator

### DIFF
--- a/.claude-plugin/hooks/hooks.json
+++ b/.claude-plugin/hooks/hooks.json
@@ -84,6 +84,11 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/gh-json-validator.sh",
+            "timeout": 15
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/cli-flag-incompat-advisory.sh",
             "timeout": 5
           },

--- a/docs/hook/gh-json-validator.md
+++ b/docs/hook/gh-json-validator.md
@@ -1,0 +1,129 @@
+# PreToolUse gh --json Field Validator
+
+Supported hosts: claude, codex
+
+`hooks/gh-json-validator.sh` intercepts every Bash tool call of the form
+`gh <subcommand> ... --json <fields>` and hard-blocks invocations whose
+requested field names are not present in the subcommand's valid JSON
+projection. The valid field set is probed at runtime via
+`gh <subcommand> --json help 2>&1` and cached per subcommand within the
+session.
+
+### Why this exists
+
+`gh CLI` accepts `--json <fields>` whose valid field set differs from the
+GitHub REST API. A recurring failure mode (6+ sessions) is requesting a
+field that exists in the REST API but not in gh's JSON projection — for
+example `gh pr view --json merged` fails because `merged` is not a valid
+gh pr field (use `state`, `mergedAt`, or `mergeCommit` instead). The
+3-generation memory-rule threshold was already exceeded; hook-layer
+enforcement is the remaining escalation path.
+
+### What is blocked
+
+The hook uses `safe_tokenize` → `iter_command_starts` → `strip_prefix`
+from `_hook_utils.py` (same tokenization pipeline as all sibling hooks),
+so chained segments and env-prefixed invocations are covered uniformly.
+
+| Command | Action |
+|---------|--------|
+| `gh pr view 1 --json merged` | **BLOCKED** (`merged` not in gh pr fields; suggests `mergedAt`) |
+| `gh pr view 1 --json state,title,url` | **PASS** |
+| `gh pr view 1 --json state,merged` | **BLOCKED** (one invalid field) |
+| `gh issue view 5 --json merged` | **BLOCKED** (`merged` not in gh issue fields) |
+| `gh issue view 5 --json state,number,title` | **PASS** |
+| `gh pr list --json state && gh pr view 1 --json merged` | **BLOCKED** (chained segment scanned) |
+| `gh issue list --json number,title,state` | **PASS** |
+| `gh search issues --json number,title,state` | **PASS** |
+| `gh api repos/owner/repo --json name` | **PASS** (gh api excluded — REST schema) |
+| `gh release list` (no `--json`) | **PASS** (no --json flag) |
+| `gh <unknown-subcmd> --json foo` | **PASS** (fail-open; unknown subcommand) |
+| `gh pr view 1 --json state # CLAUDE_HOOK_BYPASS=gh-json-validator` | **PASS** (inline bypass) |
+| Non-Bash tool | **PASS** |
+| Malformed JSON stdin | **PASS** (fail-open) |
+
+### Field discovery
+
+The hook calls `gh <subcmd> --json help 2>&1` to enumerate valid fields.
+For subcommands that require a positional argument (`gh pr view`, `gh
+issue view`, `gh release view`), a dummy positional `0` is injected on
+retry when the arg-count error is detected in the output.
+
+Parsed field list format:
+```
+Unknown JSON field: "help"
+Available fields:
+  fieldOne
+  fieldTwo
+  ...
+```
+
+### Caching
+
+Field sets are cached per subcommand under
+`/tmp/praxis-gh-json-<session_id>/` as JSON files (one per subcommand
+shape). Cache is session-scoped — a new session starts with a fresh
+cache. `PPID` is used as the session_id fallback for direct CLI / test
+invocation.
+
+Override `PRAXIS_GH_JSON_CACHE_DIR` is not required; the `/tmp/` path is
+sufficient for session-scoped state.
+
+### Closest-match suggestion
+
+When a field is invalid, the hook tries to suggest the closest valid
+field name by:
+1. Case-insensitive exact match.
+2. Valid field contains the requested field as a substring.
+3. Requested field contains a valid field as a substring.
+
+Example: `merged` → suggests `mergedAt`.
+
+### Bypass
+
+Two opt-out mechanisms:
+
+1. **Inline comment** (per-command): append
+   `# CLAUDE_HOOK_BYPASS=gh-json-validator` anywhere on the command line.
+2. **Env var** (per-session): set `CLAUDE_HOOK_BYPASS_GH_JSON=1`.
+
+### Fail-open paths
+
+The hook never breaks a session on infrastructure failure:
+
+- `gh` not installed
+- Network / auth failure on `gh --json help`
+- Unknown subcommand (not in gh's help output format)
+- Malformed stdin JSON
+- Cache file unreadable or unwritable
+
+In every case the hook exits 0 silently; the gh command proceeds and may
+fail at execution time with the original error.
+
+### Response
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "BLOCKED: gh pr view --json has invalid field(s): 'merged' (did you mean 'mergedAt'?). Run 'gh pr view --json help' to see all valid fields. Sample valid fields: ..."
+  }
+}
+```
+
+### Relationship to gh-flag-verify and gh-label-verify
+
+- `gh-flag-verify` validates flag *names* accepted by a subcommand.
+- `gh-label-verify` validates label *values* passed to `--label`.
+- This hook validates the *field names* passed to `--json`.
+
+All three hooks co-fire under the same PreToolUse Bash matcher. Deny
+precedence means the user sees the first denial reason; double-blocking
+the same command is harmless.
+
+### Tests
+
+```bash
+bash tests/test_gh_json_validator.sh
+```

--- a/hooks/gh-json-validator.py
+++ b/hooks/gh-json-validator.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""PreToolUse(Bash) guard: validate gh --json <fields> against the subcommand's schema.
+
+Intercepts every Bash tool call containing a `gh <subcmd> ... --json <fields>`
+invocation and blocks it when any requested field is not in the subcommand's
+valid JSON field set, which is probed via `gh <subcmd> --json help 2>&1`.
+
+Motivation: gh CLI accepts `--json <fields>` whose valid field set differs from
+the GitHub REST API. A recurring failure mode is requesting a field that exists
+in the REST API but not in gh's JSON projection — e.g. `gh pr view --json
+merged` fails because `merged` is not a valid gh pr field (use `state`,
+`mergedAt`, or `mergeCommit` instead). This has recurred across 6+ sessions;
+the hook layer is the remaining enforcement escalation path after memory-rule
+addition was blocked by the 3-generation threshold rule.
+
+Design notes:
+- Field sets are fetched at runtime via `gh <subcmd> --json help 2>&1` so they
+  are always accurate for the installed gh version. Results are cached per
+  subcommand per session (session_id-keyed file under /tmp/) to amortize cost.
+- Tokenization uses `safe_tokenize` → `iter_command_starts` → `strip_prefix`
+  from `_hook_utils.py`, consistent with all sibling hooks.
+- Bypass: `# CLAUDE_HOOK_BYPASS=gh-json-validator` comment in the command
+  text causes immediate pass-through, consistent with the bypass convention
+  used by block-sciomc-finding-commit and related hooks. Also supported:
+  env var CLAUDE_HOOK_BYPASS_GH_JSON=1.
+- `gh api` subcommand is explicitly excluded (follows REST schema, different
+  concern). Unknown subcommands pass through silently (fail-open).
+- On any infrastructure error (gh missing, network fail, parse error) the hook
+  exits 0 so the session is never broken.
+- Exits 2 (deny) with a structured JSON block when an invalid field is found.
+- Closest-match suggestion: substring match against valid fields; falls back
+  to listing a sample of known valid fields for the subcommand.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Resolve sibling `_hook_utils.py` regardless of cwd at invocation time.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    iter_command_starts,
+    safe_tokenize,
+    strip_prefix,
+)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_GH_HELP_TIMEOUT_SEC = 10
+_BYPASS_COMMENT_RE = re.compile(r"#\s*CLAUDE_HOOK_BYPASS\s*=\s*gh-json-validator")
+
+# Fast prefilter: must contain `gh` and `--json` before doing full parse.
+_GH_JSON_RE = re.compile(r"\bgh\b.+--json\b")
+
+# Subcommands excluded from validation (gh api uses REST schema, not gh --json schema).
+_EXCLUDED_FIRST_TOKENS: frozenset[str] = frozenset({"api"})
+
+
+# ---------------------------------------------------------------------------
+# Cache helpers (session_id-keyed per DESIGN.md convention)
+# ---------------------------------------------------------------------------
+
+def _session_cache_dir(session_id: str) -> Path:
+    """Return per-session cache directory for gh JSON field sets."""
+    return Path(f"/tmp/praxis-gh-json-{session_id}")
+
+
+def _cache_key(subcommand_tokens: tuple[str, ...]) -> str:
+    return "_".join(subcommand_tokens)
+
+
+def _load_cached_fields(
+    cache_dir: Path, subcommand_tokens: tuple[str, ...]
+) -> frozenset[str] | None:
+    path = cache_dir / f"{_cache_key(subcommand_tokens)}.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, list):
+            return frozenset(str(f) for f in data)
+    except (OSError, json.JSONDecodeError, ValueError):
+        pass
+    return None
+
+
+def _save_cached_fields(
+    cache_dir: Path, subcommand_tokens: tuple[str, ...], fields: frozenset[str]
+) -> None:
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        path = cache_dir / f"{_cache_key(subcommand_tokens)}.json"
+        path.write_text(json.dumps(sorted(fields)), encoding="utf-8")
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Field discovery via `gh <subcmd> --json help`
+# ---------------------------------------------------------------------------
+
+def _fetch_valid_fields(subcommand_tokens: tuple[str, ...]) -> frozenset[str] | None:
+    """Run `gh <subcmd> --json help` and parse the valid field list.
+
+    Returns None on any failure (gh missing, network, parse error) — caller
+    treats this as fail-open.
+
+    The help output format (on stderr, exit code != 0):
+      Unknown JSON field: "help"
+      Available fields:
+        fieldOne
+        fieldTwo
+        ...
+
+    Some subcommands (e.g. `gh pr view`, `gh issue view`, `gh release view`)
+    require a positional argument. When an arg-count error appears in the
+    output, a dummy positional "0" is injected and the call is retried.
+    """
+    cmd = ["gh"] + list(subcommand_tokens) + ["--json", "help"]
+    try:
+        r = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=_GH_HELP_TIMEOUT_SEC,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    output = r.stdout + r.stderr
+
+    # Retry with a dummy positional when the subcommand requires an argument.
+    if "accepts" in output and "arg" in output and "received 0" in output:
+        cmd_with_dummy = ["gh"] + list(subcommand_tokens) + ["0", "--json", "help"]
+        try:
+            r2 = subprocess.run(
+                cmd_with_dummy,
+                capture_output=True,
+                text=True,
+                timeout=_GH_HELP_TIMEOUT_SEC,
+            )
+            output = r2.stdout + r2.stderr
+        except (OSError, subprocess.SubprocessError):
+            return None
+
+    if "Available fields:" not in output:
+        return None
+
+    fields: set[str] = set()
+    in_fields = False
+    for line in output.splitlines():
+        if "Available fields:" in line:
+            in_fields = True
+            continue
+        if in_fields:
+            stripped = line.strip()
+            if stripped and re.match(r"^\w+$", stripped):
+                fields.add(stripped)
+            elif stripped:
+                break  # non-word content ends the field list section
+    return frozenset(fields) if fields else None
+
+
+def _get_valid_fields(
+    subcommand_tokens: tuple[str, ...],
+    cache_dir: Path,
+) -> frozenset[str] | None:
+    """Return valid JSON fields for a subcommand, with per-session caching."""
+    cached = _load_cached_fields(cache_dir, subcommand_tokens)
+    if cached is not None:
+        return cached
+    fetched = _fetch_valid_fields(subcommand_tokens)
+    if fetched is not None:
+        _save_cached_fields(cache_dir, subcommand_tokens, fetched)
+    return fetched
+
+
+# ---------------------------------------------------------------------------
+# Argument extraction (from flat argv list)
+# ---------------------------------------------------------------------------
+
+def _extract_json_fields(argv: list[str]) -> list[str] | None:
+    """Extract --json field names from a flat argv list.
+
+    Returns None if --json is absent. Returns comma-separated fields as
+    individual stripped strings.
+
+    Handles both `--json fields` (separate token) and `--json=fields` forms.
+    """
+    for i, tok in enumerate(argv):
+        if tok == "--json" and i + 1 < len(argv):
+            return [f.strip() for f in argv[i + 1].split(",") if f.strip()]
+        if tok.startswith("--json="):
+            val = tok[len("--json="):]
+            return [f.strip() for f in val.split(",") if f.strip()]
+    return None
+
+
+def _resolve_subcommand_tokens(argv: list[str]) -> tuple[str, ...] | None:
+    """Extract (sub, sub-sub) command tokens from an argv starting with 'gh'.
+
+    Collects up to 2 non-flag positional tokens after `gh`:
+      ['gh', 'pr', 'view', ...]     → ('pr', 'view')
+      ['gh', 'issue', 'list', ...]  → ('issue', 'list')
+      ['gh', 'search', 'issues', …] → ('search', 'issues')
+      ['gh', 'release', 'view', …]  → ('release', 'view')
+
+    Flags and their values are skipped with a simple heuristic (next token
+    not starting with '-' is consumed as the flag value). This is sufficient
+    for subcommand detection; full flag parsing is not needed here.
+
+    Returns None if argv[0] != 'gh' or no subcommand token found.
+    """
+    if not argv or argv[0] != "gh":
+        return None
+
+    positionals: list[str] = []
+    i = 1
+    n = len(argv)
+    while i < n and len(positionals) < 2:
+        tok = argv[i]
+        if tok == "--":
+            break
+        if tok.startswith("-"):
+            # Skip value-taking flags heuristically.
+            if "=" not in tok and i + 1 < n and not argv[i + 1].startswith("-"):
+                i += 2
+            else:
+                i += 1
+            continue
+        positionals.append(tok)
+        i += 1
+
+    return tuple(positionals) if positionals else None
+
+
+# ---------------------------------------------------------------------------
+# Closest-match suggestion (substring heuristic)
+# ---------------------------------------------------------------------------
+
+def _suggest_field(bad_field: str, valid_fields: frozenset[str]) -> str | None:
+    """Return the closest valid field name for bad_field, or None.
+
+    Priority:
+    1. Case-insensitive exact match.
+    2. A valid field contains bad_field as a substring (case-insensitive).
+    3. bad_field contains a valid field as a substring.
+    """
+    bl = bad_field.lower()
+    for f in valid_fields:
+        if f.lower() == bl:
+            return f
+    for f in sorted(valid_fields):
+        if bl in f.lower():
+            return f
+    for f in sorted(valid_fields):
+        if f.lower() in bl:
+            return f
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+def _emit_deny(reason: str) -> None:
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason,
+            }
+        },
+        sys.stdout,
+    )
+    sys.stdout.write("\n")
+
+
+# ---------------------------------------------------------------------------
+# Per-segment check
+# ---------------------------------------------------------------------------
+
+def _check_segment(
+    raw_argv: list[str],
+    cache_dir: Path,
+) -> tuple[bool, str]:
+    """Check one command segment for gh --json field validity.
+
+    Returns (is_invalid, reason). is_invalid=True triggers deny.
+    """
+    argv = strip_prefix(raw_argv)
+    if not argv or argv[0] != "gh":
+        return False, ""
+
+    subcommand_tokens = _resolve_subcommand_tokens(argv)
+    if subcommand_tokens is None:
+        return False, ""
+
+    # Exclude gh api — REST schema, different concern.
+    if subcommand_tokens[0] in _EXCLUDED_FIRST_TOKENS:
+        return False, ""
+
+    json_fields = _extract_json_fields(argv)
+    if json_fields is None:
+        return False, ""
+
+    valid_fields = _get_valid_fields(subcommand_tokens, cache_dir)
+    if valid_fields is None:
+        return False, ""  # fail-open on gh/network errors
+
+    invalid = [f for f in json_fields if f not in valid_fields]
+    if not invalid:
+        return False, ""
+
+    subcmd_display = "gh " + " ".join(subcommand_tokens)
+    parts = []
+    for bad in invalid:
+        suggestion = _suggest_field(bad, valid_fields)
+        if suggestion:
+            parts.append(f"'{bad}' (did you mean '{suggestion}'?)")
+        else:
+            parts.append(f"'{bad}'")
+
+    sample = sorted(valid_fields)[:15]
+    suffix = f" (+ {len(valid_fields) - 15} more)" if len(valid_fields) > 15 else ""
+    reason = (
+        f"BLOCKED: {subcmd_display} --json has invalid field(s): "
+        + ", ".join(parts)
+        + f". Run '{subcmd_display} --json help' to see all valid fields."
+        + f" Sample valid fields: {', '.join(sample)}{suffix}."
+    )
+    return True, reason
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0  # fail-open on malformed stdin
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    command = payload.get("tool_input", {}).get("command", "") or ""
+    if not command.strip():
+        return 0
+
+    # Bypass via env var.
+    if os.environ.get("CLAUDE_HOOK_BYPASS_GH_JSON") == "1":
+        return 0
+
+    # Bypass via inline comment marker.
+    if _BYPASS_COMMENT_RE.search(command):
+        return 0
+
+    # Fast prefilter: must contain `gh` and `--json` before full parse.
+    if not _GH_JSON_RE.search(command):
+        return 0
+
+    # Collapse backslash line continuations (same pre-processing as siblings).
+    command = command.replace("\\\n", " ")
+
+    # Session-id keyed cache per DESIGN.md convention; PPID as back-compat
+    # fallback for direct CLI / test invocation.
+    session_id = payload.get("session_id") or str(os.getppid())
+    cache_dir = _session_cache_dir(session_id)
+
+    # Use shared tokenization pipeline (safe_tokenize → iter_command_starts
+    # → strip_prefix) consistent with all sibling hooks.
+    tokens = safe_tokenize(command)
+    if not tokens:
+        return 0
+
+    for raw_argv in iter_command_starts(tokens):
+        is_invalid, reason = _check_segment(list(raw_argv), cache_dir)
+        if is_invalid:
+            _emit_deny(reason)
+            return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/gh-json-validator.py
+++ b/hooks/gh-json-validator.py
@@ -364,12 +364,14 @@ def main() -> int:
     if _BYPASS_COMMENT_RE.search(command):
         return 0
 
+    # Collapse backslash line continuations before any regex matching so that
+    # multiline `gh --json` invocations (e.g. `gh pr view 1 \<newline>  --json
+    # merged`) are not silently bypassed by the prefilter.
+    command = command.replace("\\\n", " ")
+
     # Fast prefilter: must contain `gh` and `--json` before full parse.
     if not _GH_JSON_RE.search(command):
         return 0
-
-    # Collapse backslash line continuations (same pre-processing as siblings).
-    command = command.replace("\\\n", " ")
 
     # Session-id keyed cache per DESIGN.md convention; PPID as back-compat
     # fallback for direct CLI / test invocation.

--- a/hooks/gh-json-validator.sh
+++ b/hooks/gh-json-validator.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# PreToolUse(Bash) hook entry — delegates to the Python implementation.
+#
+# Fail-safe: if python3 is unavailable, exit 0 (pass) rather than break the
+# Claude Code session.
+
+set +e
+
+if ! command -v python3 >/dev/null 2>&1; then
+  exit 0
+fi
+
+exec python3 "$(dirname "$0")/gh-json-validator.py"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -95,6 +95,12 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/gh-json-validator.sh",
+            "timeout": 15,
+            "hosts": ["claude", "codex"]
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/cli-flag-incompat-advisory.sh",
             "timeout": 5,
             "hosts": ["claude", "codex"]

--- a/plugins/praxis/.codex-plugin/hooks/hooks.json
+++ b/plugins/praxis/.codex-plugin/hooks/hooks.json
@@ -79,6 +79,11 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/gh-json-validator.sh",
+            "timeout": 15
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/cli-flag-incompat-advisory.sh",
             "timeout": 5
           },


### PR DESCRIPTION
## 변경 사항

`gh CLI` 의 `--json <fields>` 플래그 호출 시 GitHub REST API 필드와 gh CLI JSON projection 의 필드 불일치를 PreToolUse Bash hook 에서 사전 차단합니다.

대표 실패 사례: `gh pr view <N> --json merged` — `merged` 는 REST API 에는 있지만 gh CLI 의 PR JSON projection 에는 없는 필드 (대신 `state`, `mergedAt`, `mergeCommit` 사용). 동일 family 실패가 6+ 세션에 걸쳐 재발했고 메모리 추가 한계점에 도달 → hook layer enforcement 로 escalate.

## 구현

- `hooks/gh-json-validator.py` (395줄) — 핵심 검증 로직
  - `gh <subcmd> --json help` 출력을 세션별로 캐시 (`/tmp/` 의 `session_id` 키)
  - 요청 필드 ↔ 유효 필드 비교, 불일치 시 closest-match 제안과 함께 deny
  - `gh api` 는 REST 스키마 별도 관심사 → 명시적 제외
  - 모든 infrastructure error (gh 부재, 네트워크 실패, 파싱 오류) 에 대해 fail-open (exit 0)
  - 구조적 토크나이저 (`safe_tokenize`, `iter_command_starts`, `strip_prefix`) 는 sibling hook 의 `_hook_utils.py` 패턴 재사용
- `hooks/gh-json-validator.sh` (13줄) — bash entry wrapper, python3 부재 시 fail-open
- `hooks/hooks.json` — PreToolUse `Bash` matcher 에 등록 (`gh-label-verify.sh` 직후)
- `docs/hook/gh-json-validator.md` — 129줄 spec (Supported hosts, design notes, bypass, examples)
- `.claude-plugin/hooks/hooks.json` / `plugins/praxis/.codex-plugin/hooks/hooks.json` — manifest 재생성

## 검증

```
$ python3 -m py_compile hooks/gh-json-validator.py
py_compile OK

$ shellcheck hooks/gh-json-validator.sh
shellcheck OK

$ python3 scripts/check-plugin-manifests.py
plugin-manifest check OK

# Invalid field — block 확인
$ echo '{"tool_name":"Bash","tool_input":{"command":"gh pr view 1 --json merged"}}' \
    | python3 hooks/gh-json-validator.py
{"hookSpecificOutput": {"hookEventName": "PreToolUse",
  "permissionDecision": "deny",
  "permissionDecisionReason": "BLOCKED: gh pr view --json has invalid field(s):
    'merged' (did you mean 'mergedAt'?). Run 'gh pr view --json help' to see
    all valid fields. ..."}}
exit=2

# Valid field — pass 확인
$ echo '{"tool_name":"Bash","tool_input":{"command":"gh pr view 1 --json state"}}' \
    | python3 hooks/gh-json-validator.py
exit=0
```

## Bypass

- 인라인 코멘트: `# CLAUDE_HOOK_BYPASS=gh-json-validator`
- 환경 변수: `CLAUDE_HOOK_BYPASS_GH_JSON=1`

## 동시 진행 PR

본 PR 외에 sibling 3 개 PR 이 `hooks/hooks.json` 을 함께 건드립니다:
- #386 (path-probe-gate, Write matcher) — 진행 중
- #392 (completion-signal-gate, Stop hook) — 진행 중
- #395 (codex-review-wrap SoT audit) — hooks.json 무변경, PR #396 머지 가능

본 PR 의 wave-2 머지 순서 = 1순위 (가장 자족적). 본 PR 머지 후 #386 / #392 는 rebase 로 자기 entry 흡수.

Caller chain verified: new hook (PreToolUse Bash matcher) — Claude Code runtime는 hooks.json 항목을 자동 invoke 하므로 코드 호출자 없음.

Closes #391
