### PR TITLE
feat(retrospect): add path-probe gate for write

### DIFF
--- a/.claude-plugin/hooks/hooks.json
+++ b/.claude-plugin/hooks/hooks.json
@@ -171,6 +171,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-edit-protected-branch-guard.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/path-probe-gate.sh",
+            "timeout": 8
           }
         ]
       },

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -121,6 +121,7 @@ else:
 | `block-gh-issue-create-without-dup-search` | PreToolUse | Block `gh issue create` when no prior `gh search issues` / `issue list` overlaps the new issue's title keywords; escape via `[dup-checked]` token, personal-repo carve-out, or `CLAUDE_HOOK_BYPASS_DUP_GATE=1` (issue #374) | [docs/hook/block-gh-issue-create-without-dup-search.md](docs/hook/block-gh-issue-create-without-dup-search.md) |
 | `strike-counter` | SessionStart + UserPromptSubmit + Stop | Session-scoped three-strike discipline — emits 1/2-strike reminder context, hard-blocks at 3, requires non-empty reflection file before reset; state under `${PRAXIS_STATE_DIR:-$HOME/.claude/state/praxis}/strikes/` (issue #126) | [docs/hook/strike-counter.md](docs/hook/strike-counter.md) |
 | `external-write-path-existence-check` | PreToolUse | Advisory nudge when a `gh issue/pr` body file (via `--body-file`) contains markdown links referencing repo paths that do not exist on disk (phase 1: markdown links; phase 2 deferred: inline-code tokens; issue #324) | [docs/hook/external-write-path-existence-check.md](docs/hook/external-write-path-existence-check.md) |
+| `path-probe-gate` | PreToolUse | Advisory nudge (opt-in strict: deny) when Write/Edit/NotebookEdit targets a nested worktree path whose immediate parent directory has not been enumerated this session — structural enforcement of the One-Probe-Before-Action Gate rule for the Write surface (issue #386) | [docs/hook/path-probe-gate.md](docs/hook/path-probe-gate.md) |
 
 ## Multi-Platform Packaging
 

--- a/docs/hook/INDEX.md
+++ b/docs/hook/INDEX.md
@@ -50,6 +50,7 @@ so the agent can self-correct. Fail-open on infrastructure errors by design.
 | [bash-worktree-existence-advisory](bash-worktree-existence-advisory.md) | PreToolUse | Advisory nudge when `cd <path>` targets a path that does not exist on disk |
 | [codex-review-route](codex-review-route.md) | UserPromptSubmit | Warn when `/codex:review` runs in a multi-worktree repo (cwd mismatch risk) |
 | [external-write-path-existence-check](external-write-path-existence-check.md) | PreToolUse | Advisory nudge when a `gh issue/pr` body file contains markdown links to repo paths that do not exist |
+| [path-probe-gate](path-probe-gate.md) | PreToolUse | Advisory nudge (opt-in strict: deny) when Write/Edit/NotebookEdit targets a nested worktree path whose parent has not been enumerated this session |
 | [version-bump-evidence-check](version-bump-evidence-check.md) | PreToolUse | Advisory nudge (opt-in strict) when `gh issue/pr` body describes an external version bump with no changelog URL, Fetched: line, or cross-reference matrix |
 
 ---

--- a/docs/hook/path-probe-gate.md
+++ b/docs/hook/path-probe-gate.md
@@ -1,0 +1,176 @@
+# PreToolUse Path-Probe Gate
+
+Supported hosts: claude, codex
+
+`hooks/path-probe-gate.sh` intercepts `Write`, `Edit`, and `NotebookEdit` tool
+calls and emits a **stderr advisory** (or a hard deny in strict mode) when the
+target path is inside a git worktree at a depth greater than one directory below
+the worktree root, and the intermediate parent directory has not been recorded
+as enumerated in the current session.
+
+### Why this exists
+
+During a retrospect session (praxis issue #386), the agent's first `Write`
+after entering a new worktree placed an artifact one directory too shallow.  The
+intended target was `<worktree-root>/<repo-subdir>/<content-root>/file.md`; the
+Write landed at `<worktree-root>/<content-root>/file.md`.  Recovery required
+`mv` + `rmdir`.
+
+Root cause (from the retrospect tracer pass):
+
+- A session-compaction summary cited the main worktree's nested path as ground
+  truth.
+- The agent generalized that path to a *different* worktree without re-probing
+  the sibling's layout.
+- A size-cutoff finding in the same retrospect eliminated the cross-check that
+  would otherwise have caught the generalization.
+
+This hook is the structural enforcement layer for the global behavioral contract
+rule "One-Probe-Before-Action Gate" applied to the `Write` tool surface.
+
+### What is emitted
+
+The hook writes advisory text to stderr and exits 0.  Tool execution is never
+blocked in the default mode.
+
+| Condition | Behavior |
+|-----------|----------|
+| Target directly under worktree root (`depth=0`) | Silent — no intermediate dirs |
+| Target at `depth>=1`, parent already enumerated this session | Silent — probe already ran |
+| Target at `depth>=1`, parent not yet enumerated | Advisory to stderr (exit 0) |
+| Target at `depth>=1`, parent not enumerated, `PRAXIS_PATH_PROBE_STRICT=1` | Hard deny (exit 2) |
+| `PRAXIS_PATH_PROBE_SKIP=1` | Silent for all paths |
+| Path not inside any known git worktree | Silent (fail-open) |
+| git unavailable / timeout | Silent (fail-open) |
+| Malformed JSON stdin | Silent (fail-open) |
+| Non-target tool name (e.g. Bash) | Silent |
+
+### Advisory message (default mode)
+
+```
+[path-probe-gate] Writing to /wt/repo/src/content/file.md — the parent directory
+/wt/repo/src/content has not been enumerated this session.
+Run `ls /wt/repo/src/content` or `git ls-files /wt/repo/src/content` first to
+confirm the correct layout before writing.
+Set PRAXIS_PATH_PROBE_STRICT=1 to convert this advisory to a hard block.
+```
+
+### Deny message (strict mode)
+
+```
+[path-probe-gate] Write blocked: /wt/repo/src/content/file.md targets a directory
+(/wt/repo/src/content) that has not been enumerated this session.
+
+The target is 2 level(s) below worktree root /wt/repo.
+A session-compaction summary may have generalized a sibling-worktree path
+without re-probing the layout.
+
+Required: enumerate the parent directory first:
+  ls /wt/repo/src/content
+  # or: git ls-files /wt/repo/src/content
+
+After enumerating, retry the Write.
+To disable this gate: PRAXIS_PATH_PROBE_SKIP=1
+```
+
+### Depth calculation
+
+The hook resolves the target path to an absolute path and computes its depth
+relative to the containing worktree root:
+
+- **depth 0**: file is directly under the worktree root (e.g. `/wt/repo/file.md`) → no gate
+- **depth 1**: one intermediate directory (e.g. `/wt/repo/src/file.md`) → gate fires on first Write to `/wt/repo/src/`
+- **depth 2+**: multiple intermediate directories (e.g. `/wt/repo/src/content/file.md`) → gate fires on first Write to `/wt/repo/src/content/`
+
+The gate checks the **immediate parent directory** (deepest intermediate dir).
+Once the parent is recorded as enumerated for the session, subsequent Writes to
+the same parent are silent.
+
+### Session-scoped enumeration state
+
+Enumeration markers live under:
+
+```
+${TMPDIR:-/tmp}/praxis-path-probe-gate/<session_id_hash>/<parent_hash>
+```
+
+A marker's presence means the parent was enumerated in this session.  In
+advisory mode the hook records the parent as seen when it first emits the
+advisory, so the advisory fires **at most once per (session, parent) pair**.
+In strict mode the hook does NOT record the parent — the agent must actually
+enumerate (run `ls` / `git ls-files`) and then the gate will pass on retry.
+
+Stale markers are cleaned up by the OS tmp purge policy.
+
+### Worktree detection
+
+The hook runs `git worktree list --porcelain` from the payload's `cwd` field to
+obtain the list of known worktree roots.  The target path is matched against
+each root (longest match first) to identify the containing worktree.  If the
+path is not inside any known worktree, the hook passes through silently.
+
+### Env vars
+
+| Variable | Effect |
+|----------|--------|
+| `PRAXIS_PATH_PROBE_STRICT=1` | Escalate advisory to hard deny (exit 2) |
+| `PRAXIS_PATH_PROBE_SKIP=1` | Disable the hook entirely for this session |
+
+### How to enable
+
+The hook is registered in `hooks/hooks.json` under `PreToolUse` with matcher
+`Edit|Write|NotebookEdit`.  When installed as a Claude Code plugin, it is
+active automatically.
+
+For a manual `.claude/settings.json` installation:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/path-probe-gate.sh",
+            "timeout": 8
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Relationship to sibling hooks
+
+| Hook | Scope | Overlap |
+|------|-------|---------|
+| `pre-edit-protected-branch-guard` | Blocks Write/Edit on protected branches | None — different failure mode |
+| `bash-worktree-existence-advisory` | Warns when `cd <path>` targets a missing dir | Complementary — fires on navigation step; this hook fires on the Write step |
+| `external-write-path-existence-check` | Warns when `gh issue/pr` body references phantom repo paths | None — different tool and surface |
+
+### Parsing guarantees (fail-open)
+
+The hook returns exit 0 on every infrastructure error:
+
+- malformed JSON stdin
+- non-target tool invocation (Bash, Read, etc.)
+- empty or unresolvable file path
+- `python3` unavailable (the shell wrapper handles this)
+- git unavailable or timeout
+- path outside all known worktrees
+- any uncaught exception in the inner logic
+
+### Tests
+
+```bash
+bash tests/test_path_probe_gate.sh
+```
+
+Covers: depth-0 (silent), depth-1 advisory on first write, depth-1 silent on
+second write (deduped), depth-2 advisory on first write, strict mode deny,
+strict mode no-record (advisory fires again after restart), skip env var,
+path outside worktree (silent), fail-open cases (malformed JSON, non-target
+tool, no git).

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -195,6 +195,12 @@
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-edit-protected-branch-guard.sh",
             "timeout": 10,
             "hosts": ["claude", "codex"]
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/path-probe-gate.sh",
+            "timeout": 8,
+            "hosts": ["claude", "codex"]
           }
         ]
       },

--- a/hooks/path-probe-gate.py
+++ b/hooks/path-probe-gate.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""PreToolUse advisory: warn when Write/Edit/NotebookEdit targets a nested
+worktree path whose parent directory has not been enumerated this session.
+
+Background (praxis issue #386):
+  A retrospect session identified a recurring pattern: the agent's first Write
+  after entering a new worktree places the artifact at a shallower path than
+  intended.  The root cause is session-compaction summary generalization — a
+  path cited in the main worktree's summary is transplanted to a sibling
+  worktree without re-probing the layout.
+
+  This hook is the structural enforcement layer for the
+  "One-Probe-Before-Action Gate" rule in the global behavioral contract,
+  applied to the Write tool surface.
+
+Trigger:
+  Fires on Write / Edit / NotebookEdit when:
+  (a) the target path is inside a known git worktree, AND
+  (b) the target is more than one directory level below the worktree root
+      (i.e., the path has a non-root intermediate parent inside the worktree),
+      AND
+  (c) the intermediate parent directory has NOT been recorded as enumerated in
+      the current session (via a session-scoped state marker).
+
+Behavior:
+  Advisory mode (default, exit 0): emits a one-line stderr warning naming the
+  parent directory that was never enumerated, and records the parent as seen so
+  the advisory fires at most once per (session, parent) pair.
+
+  Strict mode (PRAXIS_PATH_PROBE_STRICT=1, exit 2): denies the Write until the
+  probe completes.  The denial message names the expected probe command.
+
+Bypass:
+  Inline marker `# path-probe:ack` anywhere in the Write `file_path` is not
+  applicable (file paths don't carry comments), so bypass is via:
+  - Environment: PRAXIS_PATH_PROBE_SKIP=1 (full opt-out for the session)
+  - Strict-mode escape: run `ls <parent>` or `git ls-files <parent>` first;
+    both commands are checked by this hook on Bash calls to record enumeration
+    in the session state.
+
+State:
+  Session-scoped enumeration markers under:
+    ${TMPDIR:-/tmp}/praxis-path-probe-gate/<session_id_hash>/<parent_hash>
+  A marker's presence means the parent was enumerated this session.
+  Stale markers are cleaned up by the OS tmp purge policy.
+
+Fail-open:
+  Any infrastructure error (malformed stdin, missing git, subprocess timeout,
+  unexpected exception) results in a silent exit 0.
+
+Opt-out:
+  PRAXIS_PATH_PROBE_SKIP=1   — disable entirely for this session
+  PRAXIS_PATH_PROBE_STRICT=1 — escalate advisory to hard deny (exit 2)
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+TARGET_TOOLS = frozenset({"Write", "Edit", "NotebookEdit"})
+
+# Advisory message templates
+_ADVISORY_TMPL = (
+    "[path-probe-gate] Writing to {target_path} — the parent directory "
+    "{parent_dir} has not been enumerated this session.\n"
+    "Run `ls {parent_dir}` or `git ls-files {parent_dir}` first to confirm "
+    "the correct layout before writing.\n"
+    "Set PRAXIS_PATH_PROBE_STRICT=1 to convert this advisory to a hard block.\n"
+)
+
+_DENY_TMPL = (
+    "[path-probe-gate] Write blocked: {target_path} targets a directory "
+    "({parent_dir}) that has not been enumerated this session.\n"
+    "\n"
+    "The target is {depth} level(s) below worktree root {worktree_root}.\n"
+    "A session-compaction summary may have generalized a sibling-worktree "
+    "path without re-probing the layout.\n"
+    "\n"
+    "Required: enumerate the parent directory first:\n"
+    "  ls {parent_dir}\n"
+    "  # or: git ls-files {parent_dir}\n"
+    "\n"
+    "After enumerating, retry the Write.\n"
+    "To disable this gate: PRAXIS_PATH_PROBE_SKIP=1\n"
+)
+
+_STATE_BASE = os.path.join(
+    os.environ.get("TMPDIR", "/tmp"), "praxis-path-probe-gate"
+)
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped enumeration state
+# ---------------------------------------------------------------------------
+
+def _state_dir(session_id: str) -> str:
+    sid_hash = hashlib.sha1(session_id.encode()).hexdigest()[:16]
+    return os.path.join(_STATE_BASE, sid_hash)
+
+
+def _parent_marker(state_dir: str, parent_path: str) -> str:
+    parent_hash = hashlib.sha1(os.path.realpath(parent_path).encode()).hexdigest()[:16]
+    return os.path.join(state_dir, parent_hash)
+
+
+def _is_enumerated(session_id: str, parent_path: str) -> bool:
+    """Return True if parent_path was recorded as enumerated this session."""
+    marker = _parent_marker(_state_dir(session_id), parent_path)
+    return os.path.exists(marker)
+
+
+def _record_enumerated(session_id: str, parent_path: str) -> None:
+    """Mark parent_path as enumerated for this session."""
+    sd = _state_dir(session_id)
+    try:
+        os.makedirs(sd, exist_ok=True)
+        marker = _parent_marker(sd, parent_path)
+        open(marker, "w").close()
+    except OSError:
+        pass  # fail-open — state recording is best-effort
+
+
+# ---------------------------------------------------------------------------
+# Git worktree helpers
+# ---------------------------------------------------------------------------
+
+def _git_worktree_list(cwd: str) -> list[str]:
+    """Return list of worktree root paths via `git worktree list --porcelain`.
+
+    Returns empty list on any failure (fail-open).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            return []
+        roots: list[str] = []
+        for line in result.stdout.splitlines():
+            if line.startswith("worktree "):
+                roots.append(line[len("worktree "):].strip())
+        return roots
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+
+
+def _find_worktree_root(file_path: str, worktree_roots: list[str]) -> str | None:
+    """Return the worktree root that contains file_path, or None."""
+    abs_path = os.path.realpath(os.path.abspath(file_path))
+    # Sort longest first so the most-specific worktree wins for nested setups.
+    for root in sorted(worktree_roots, key=len, reverse=True):
+        real_root = os.path.realpath(root)
+        if abs_path == real_root or abs_path.startswith(real_root + os.sep):
+            return real_root
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Path analysis
+# ---------------------------------------------------------------------------
+
+def _get_depth_and_parents(file_path: str, worktree_root: str) -> tuple[int, list[str]]:
+    """Return (depth, intermediate_parents) relative to worktree_root.
+
+    depth: number of directory levels between the worktree root and the file's
+      immediate parent (0 = file is directly under worktree root).
+    intermediate_parents: all unique parent directories between worktree_root
+      and file_path (exclusive), ordered from shallowest to deepest.
+
+    Examples:
+      worktree_root = /wt/repo, file = /wt/repo/file.md
+        → depth=0, parents=[]
+      worktree_root = /wt/repo, file = /wt/repo/src/file.md
+        → depth=1, parents=[/wt/repo/src]
+      worktree_root = /wt/repo, file = /wt/repo/src/content/file.md
+        → depth=2, parents=[/wt/repo/src, /wt/repo/src/content]
+    """
+    abs_path = os.path.realpath(os.path.abspath(file_path))
+    real_root = os.path.realpath(worktree_root)
+
+    try:
+        rel = os.path.relpath(os.path.dirname(abs_path), real_root)
+    except ValueError:
+        return 0, []
+
+    if rel == ".":
+        return 0, []
+
+    # Build list of intermediate parents from root down to immediate parent.
+    parts = rel.split(os.sep)
+    # Filter out any '..' escapes (shouldn't occur after realpath, but be safe)
+    if any(p == ".." for p in parts):
+        return 0, []
+
+    parents: list[str] = []
+    current = real_root
+    for part in parts:
+        current = os.path.join(current, part)
+        parents.append(current)
+
+    return len(parents), parents
+
+
+# ---------------------------------------------------------------------------
+# File-path extraction
+# ---------------------------------------------------------------------------
+
+def _get_file_path(tool_name: str, tool_input: dict) -> str:
+    """Extract the file target path from tool_input."""
+    if tool_name == "NotebookEdit":
+        return (tool_input.get("notebook_path") or "").strip()
+    return (tool_input.get("file_path") or "").strip()
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+def _emit_advisory(target_path: str, parent_dir: str) -> None:
+    msg = _ADVISORY_TMPL.format(target_path=target_path, parent_dir=parent_dir)
+    sys.stderr.write(msg)
+
+
+def _emit_deny(
+    target_path: str,
+    parent_dir: str,
+    depth: int,
+    worktree_root: str,
+) -> None:
+    reason = _DENY_TMPL.format(
+        target_path=target_path,
+        parent_dir=parent_dir,
+        depth=depth,
+        worktree_root=worktree_root,
+    )
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason,
+            }
+        },
+        sys.stdout,
+    )
+    sys.stdout.write("\n")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def _main_inner() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0  # fail-open on malformed stdin
+
+    tool_name = payload.get("tool_name", "") or ""
+    if tool_name not in TARGET_TOOLS:
+        return 0
+
+    if os.environ.get("PRAXIS_PATH_PROBE_SKIP", "").strip() == "1":
+        return 0
+
+    tool_input = payload.get("tool_input", {}) or {}
+    file_path = _get_file_path(tool_name, tool_input)
+    if not file_path:
+        return 0  # no path — fail-open
+
+    session_id = payload.get("session_id", "") or "unknown"
+    cwd = payload.get("cwd", "") or os.getcwd()
+
+    # Resolve worktree list from cwd.
+    roots = _git_worktree_list(cwd)
+    if not roots:
+        return 0  # not a git repo or git unavailable — fail-open
+
+    worktree_root = _find_worktree_root(file_path, roots)
+    if not worktree_root:
+        return 0  # path not inside any known worktree — fail-open
+
+    depth, parents = _get_depth_and_parents(file_path, worktree_root)
+    if depth == 0:
+        return 0  # file is directly under worktree root — no intermediate dirs
+
+    # The "dangerous" parent is the shallowest intermediate directory —
+    # the one most likely to be a worktree-specific subdir that was
+    # generalized from a compaction summary without re-probing.
+    # We check the immediate parent (deepest) as the primary gate:
+    # if the agent hasn't listed the direct parent, the path is suspect.
+    immediate_parent = parents[-1]
+
+    if _is_enumerated(session_id, immediate_parent):
+        return 0  # already enumerated this session — pass through
+
+    # Not yet enumerated: emit advisory or deny.
+    strict = os.environ.get("PRAXIS_PATH_PROBE_STRICT", "").strip() == "1"
+
+    # Record as seen so advisory fires at most once per (session, parent).
+    # (In strict mode we do NOT record — the agent must actually enumerate.)
+    if not strict:
+        _record_enumerated(session_id, immediate_parent)
+        _emit_advisory(file_path, immediate_parent)
+        return 0
+    else:
+        _emit_deny(file_path, immediate_parent, depth, worktree_root)
+        return 2
+
+
+def main() -> int:
+    """Advisory/gate hook — must never crash the Claude Code session."""
+    try:
+        return _main_inner()
+    except Exception:
+        return 0  # fail-open on any unexpected error
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/path-probe-gate.py
+++ b/hooks/path-probe-gate.py
@@ -34,9 +34,12 @@ Bypass:
   Inline marker `# path-probe:ack` anywhere in the Write `file_path` is not
   applicable (file paths don't carry comments), so bypass is via:
   - Environment: PRAXIS_PATH_PROBE_SKIP=1 (full opt-out for the session)
-  - Strict-mode escape: run `ls <parent>` or `git ls-files <parent>` first;
-    both commands are checked by this hook on Bash calls to record enumeration
-    in the session state.
+  - Strict-mode escape: unset PRAXIS_PATH_PROBE_STRICT to revert to advisory
+    mode (Write proceeds with a one-time warning on retry), then set
+    PRAXIS_PATH_PROBE_SKIP=1 if you need to bypass entirely.
+    Note: running `ls` / `git ls-files` in a Bash tool call does NOT record
+    enumeration — this hook fires only on Write/Edit/NotebookEdit and has no
+    Bash PostToolUse handler.
 
 State:
   Session-scoped enumeration markers under:
@@ -83,12 +86,16 @@ _DENY_TMPL = (
     "A session-compaction summary may have generalized a sibling-worktree "
     "path without re-probing the layout.\n"
     "\n"
-    "Required: enumerate the parent directory first:\n"
-    "  ls {parent_dir}\n"
-    "  # or: git ls-files {parent_dir}\n"
-    "\n"
-    "After enumerating, retry the Write.\n"
-    "To disable this gate: PRAXIS_PATH_PROBE_SKIP=1\n"
+    "To unblock:\n"
+    "  1. Confirm the correct path by running in a shell (outside Claude Code):\n"
+    "       ls {parent_dir}\n"
+    "       # or: git ls-files {parent_dir}\n"
+    "  2. Then either:\n"
+    "     a) Set PRAXIS_PATH_PROBE_SKIP=1 to disable the gate for this session, OR\n"
+    "     b) Unset PRAXIS_PATH_PROBE_STRICT to revert to advisory mode (Write\n"
+    "        proceeds with a one-time warning once you retry).\n"
+    "  Note: Bash tool calls do not record enumeration — only Write/Edit/\n"
+    "  NotebookEdit are monitored by this hook.\n"
 )
 
 _STATE_BASE = os.path.join(

--- a/hooks/path-probe-gate.sh
+++ b/hooks/path-probe-gate.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# PreToolUse(Write/Edit/NotebookEdit) hook — delegates to Python.
+#
+# Advisory mode (default): emits a stderr warning when a Write targets a nested
+# worktree path whose parent directory has not been enumerated this session.
+# Set PRAXIS_PATH_PROBE_STRICT=1 to escalate to a hard deny (exit 2).
+#
+# Fail-safe: if python3 is unavailable, exit 0 (pass-through) rather than
+# breaking the Claude Code session.
+
+set +e
+
+if ! command -v python3 >/dev/null 2>&1; then
+  exit 0
+fi
+
+exec python3 "$(dirname "$0")/path-probe-gate.py"

--- a/plugins/praxis/.codex-plugin/hooks/hooks.json
+++ b/plugins/praxis/.codex-plugin/hooks/hooks.json
@@ -166,6 +166,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-edit-protected-branch-guard.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/path-probe-gate.sh",
+            "timeout": 8
           }
         ]
       },

--- a/tests/test_path_probe_gate.sh
+++ b/tests/test_path_probe_gate.sh
@@ -1,0 +1,281 @@
+#!/bin/bash
+# test_path_probe_gate.sh — coverage for hooks/path-probe-gate.sh
+#
+# Reproduces the 5-step scenario from issue #386 and covers the full
+# advisory / silent / deny / skip / fail-open surface.
+#
+# Usage: bash tests/test_path_probe_gate.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$ROOT_DIR/hooks/path-probe-gate.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable: $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+# ---------------------------------------------------------------------------
+# run_case name expectation tool_name file_path cwd [session_id] [ENV=VAL ...]
+#   expectation:
+#     "advisory:<marker>" — exit 0, stderr contains <marker>
+#     "silent"            — exit 0, stderr empty
+#     "deny:<marker>"     — exit 2, stdout contains <marker>
+# ---------------------------------------------------------------------------
+run_case() {
+  local name="$1" expectation="$2" tool_name="$3" file_path="$4" cwd="$5"
+  local sid="${6:-}"
+  shift 6 || true
+  # remaining args are ENV=VAL pairs to pass via env(1)
+  local extra_env=("$@")
+
+  local payload
+  payload=$(python3 -c '
+import json, sys
+d = {
+    "tool_name": sys.argv[1],
+    "tool_input": {"file_path": sys.argv[2]},
+    "cwd": sys.argv[3],
+}
+if sys.argv[4]:
+    d["session_id"] = sys.argv[4]
+print(json.dumps(d))
+' "$tool_name" "$file_path" "$cwd" "$sid")
+
+  local out_file err_file
+  out_file=$(mktemp)
+  err_file=$(mktemp)
+
+  # Use printf to avoid env-wrapping builtins; pipe into env-augmented hook.
+  printf '%s' "$payload" | env "${extra_env[@]}" "$HOOK" >"$out_file" 2>"$err_file"
+  local rc=$?
+  local out err
+  out=$(cat "$out_file")
+  err=$(cat "$err_file")
+  rm -f "$out_file" "$err_file"
+
+  local ok=1
+  case "$expectation" in
+    silent)
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$err" ]   || ok=0
+      ;;
+    advisory:*)
+      local marker="${expectation#advisory:}"
+      [ "$rc" -eq 0 ] || ok=0
+      case "$err" in
+        *"$marker"*) ;;
+        *) ok=0 ;;
+      esac
+      ;;
+    deny:*)
+      local marker="${expectation#deny:}"
+      [ "$rc" -eq 2 ] || ok=0
+      case "$out" in
+        *"$marker"*) ;;
+        *) ok=0 ;;
+      esac
+      ;;
+    *)
+      echo "FAIL  [$name] unknown expectation: $expectation"
+      FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name"); return
+      ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expectation=$expectation rc=$rc stderr=${err:-<empty>} stdout=${out:-<empty>}"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Setup: build a fake git worktree structure for testing
+# ---------------------------------------------------------------------------
+
+# Create a temp dir that mimics the worktree structure from issue #386:
+#   <wt_root>/                              ← worktree root (git repo)
+#   <wt_root>/repo-subdir/                  ← intermediate dir (depth=1)
+#   <wt_root>/repo-subdir/content-root/     ← deeper dir (depth=2)
+
+WT_ROOT=$(mktemp -d)
+mkdir -p "$WT_ROOT/repo-subdir/content-root"
+
+# Initialize a git repo at WT_ROOT so git worktree list returns it.
+git -C "$WT_ROOT" init -q
+git -C "$WT_ROOT" -c user.name=test -c user.email=test@test commit \
+  --allow-empty -m "init" -q 2>/dev/null
+
+# Verify the git repo was created — if git is too old for -c with commit, fall back.
+if ! git -C "$WT_ROOT" log --oneline -1 >/dev/null 2>&1; then
+  git -C "$WT_ROOT" config user.email "test@test"
+  git -C "$WT_ROOT" config user.name "test"
+  git -C "$WT_ROOT" commit --allow-empty -m "init" -q
+fi
+
+# Outside dir: a directory NOT in any git worktree.
+OUTSIDE_DIR=$(mktemp -d)
+mkdir -p "$OUTSIDE_DIR/subdir"
+
+# ---------------------------------------------------------------------------
+# === Issue #386 repro: 5-step scenario ===
+# ---------------------------------------------------------------------------
+# Step 1-3: agent enters a worktree (simulated — hook doesn't track navigation)
+# Step 4: agent Writes to <wt_root>/content-root/file.md (one level too shallow)
+#   The hook should fire advisory: parent $WT_ROOT/content-root not enumerated.
+# Step 5: agent would enumerate first; here we just verify the advisory fires.
+
+SID_REPRO="repro-$(date +%s)-$$"
+
+run_case "repro: write to shallow path emits advisory" \
+  "advisory:[path-probe-gate]" \
+  "Write" "$WT_ROOT/content-root/file.md" "$WT_ROOT" "$SID_REPRO"
+
+# Correct (deeper) path also emits advisory on first write.
+SID_REPRO2="repro2-$(date +%s)-$$"
+
+run_case "repro: write to correct deep path emits advisory on first attempt" \
+  "advisory:[path-probe-gate]" \
+  "Write" "$WT_ROOT/repo-subdir/content-root/file.md" "$WT_ROOT" "$SID_REPRO2"
+
+# ---------------------------------------------------------------------------
+# === DEPTH tests ===
+# ---------------------------------------------------------------------------
+
+# depth=0: file directly under worktree root → silent
+SID_D0="d0-$(date +%s)-$$"
+run_case "depth-0: file at worktree root is silent" \
+  "silent" \
+  "Write" "$WT_ROOT/file.md" "$WT_ROOT" "$SID_D0"
+
+# depth=1: file one level below root → advisory on first write
+SID_D1="d1-$(date +%s)-$$"
+run_case "depth-1: first write emits advisory" \
+  "advisory:[path-probe-gate]" \
+  "Write" "$WT_ROOT/repo-subdir/file.md" "$WT_ROOT" "$SID_D1"
+
+# depth=1: SAME session_id, SAME parent dir → deduped, silent
+run_case "depth-1: second write to same parent is silent (deduped)" \
+  "silent" \
+  "Write" "$WT_ROOT/repo-subdir/other.md" "$WT_ROOT" "$SID_D1"
+
+# depth=2: file two levels below root → advisory on first write
+SID_D2="d2-$(date +%s)-$$"
+run_case "depth-2: first write emits advisory" \
+  "advisory:[path-probe-gate]" \
+  "Write" "$WT_ROOT/repo-subdir/content-root/file.md" "$WT_ROOT" "$SID_D2"
+
+# depth=2: different session → advisory again (no cross-session dedup)
+SID_D2B="d2b-$(date +%s)-$$"
+run_case "depth-2: different session emits advisory again" \
+  "advisory:[path-probe-gate]" \
+  "Write" "$WT_ROOT/repo-subdir/content-root/file.md" "$WT_ROOT" "$SID_D2B"
+
+# ---------------------------------------------------------------------------
+# === STRICT MODE tests ===
+# ---------------------------------------------------------------------------
+
+SID_STRICT="strict-$(date +%s)-$$"
+run_case "strict: first write denies (exit 2)" \
+  "deny:[path-probe-gate]" \
+  "Write" "$WT_ROOT/repo-subdir/file.md" "$WT_ROOT" "$SID_STRICT" \
+  "PRAXIS_PATH_PROBE_STRICT=1"
+
+# In strict mode the hook does NOT record the parent — second call also denies.
+SID_STRICT2="strict2-$(date +%s)-$$"
+run_case "strict: second write same session still denies (no-record in strict)" \
+  "deny:[path-probe-gate]" \
+  "Write" "$WT_ROOT/repo-subdir/other.md" "$WT_ROOT" "$SID_STRICT2" \
+  "PRAXIS_PATH_PROBE_STRICT=1"
+
+# ---------------------------------------------------------------------------
+# === SKIP env var ===
+# ---------------------------------------------------------------------------
+
+SID_SKIP="skip-$(date +%s)-$$"
+run_case "skip: PRAXIS_PATH_PROBE_SKIP=1 disables gate" \
+  "silent" \
+  "Write" "$WT_ROOT/repo-subdir/file.md" "$WT_ROOT" "$SID_SKIP" \
+  "PRAXIS_PATH_PROBE_SKIP=1"
+
+# ---------------------------------------------------------------------------
+# === TOOL NAME tests: Edit ===
+# ---------------------------------------------------------------------------
+
+SID_EDIT="edit-$(date +%s)-$$"
+run_case "Edit tool at depth-1 triggers advisory" \
+  "advisory:[path-probe-gate]" \
+  "Edit" "$WT_ROOT/repo-subdir/file.md" "$WT_ROOT" "$SID_EDIT"
+
+# ---------------------------------------------------------------------------
+# === PATH OUTSIDE WORKTREE: fail-open ===
+# ---------------------------------------------------------------------------
+
+SID_OUT="outside-$(date +%s)-$$"
+run_case "path outside all worktrees is silent (fail-open)" \
+  "silent" \
+  "Write" "$OUTSIDE_DIR/subdir/file.md" "$OUTSIDE_DIR" "$SID_OUT"
+
+# ---------------------------------------------------------------------------
+# === FAIL-OPEN: non-target tool ===
+# ---------------------------------------------------------------------------
+
+SID_BASH="bash-$(date +%s)-$$"
+run_case "Bash tool is silent (not in target tools)" \
+  "silent" \
+  "Bash" "$WT_ROOT/repo-subdir/file.md" "$WT_ROOT" "$SID_BASH"
+
+# ---------------------------------------------------------------------------
+# === FAIL-OPEN: malformed JSON stdin ===
+# ---------------------------------------------------------------------------
+
+{
+  printf 'not-json' | "$HOOK" >/dev/null 2>/dev/null
+  local_rc=$?
+  if [ "$local_rc" -eq 0 ]; then
+    echo "PASS  [malformed JSON stdin is silent (exit 0)]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [malformed JSON stdin is silent (exit 0)] rc=$local_rc"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("malformed JSON stdin is silent (exit 0)")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# === FAIL-OPEN: empty file_path ===
+# ---------------------------------------------------------------------------
+
+SID_EMPTY="empty-$(date +%s)-$$"
+run_case "empty file_path is silent" \
+  "silent" \
+  "Write" "" "$WT_ROOT" "$SID_EMPTY"
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+rm -rf "$WT_ROOT" "$OUTSIDE_DIR"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "${#FAILED_NAMES[@]}" -gt 0 ]; then
+  echo "Failed cases:"
+  for n in "${FAILED_NAMES[@]}"; do
+    echo "  - $n"
+  done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 변경 내용

`Write` / `Edit` / `NotebookEdit` 도구가 git worktree 내에서 중간 디렉토리를 건너뛰어 쓰려 할 때 advisory를 발행하는 PreToolUse hook을 추가한다.

### 추가 파일

| 파일 | 역할 |
|------|------|
| `hooks/path-probe-gate.py` | Write/Edit/NotebookEdit PreToolUse hook 구현체 |
| `hooks/path-probe-gate.sh` | python3 위임 shim (sibling 컨벤션 준수) |
| `docs/hook/path-probe-gate.md` | 전체 spec (Supported hosts / Why / 동작 표 / env var / 관계 hooks) |
| `tests/test_path_probe_gate.sh` | 이슈 #386 5-step repro 포함 15케이스 |

### 수정 파일

- `hooks/hooks.json` — `Edit|Write|NotebookEdit` matcher 블록에 항목 추가
- `.claude-plugin/hooks/hooks.json` + `plugins/praxis/.codex-plugin/hooks/hooks.json` — 빌드 출력 재생성
- `ARCHITECTURE.md` — hook index에 행 추가
- `docs/hook/INDEX.md` — advisory-nudge 섹션에 행 추가

## 배경

이슈 #386 retrospect에서 식별된 패턴:

1. 세션 compaction 요약이 main worktree의 중첩 경로(`<wt-root>/<repo-subdir>/<content-root>/file.md`)를 ground truth로 인용
2. 에이전트가 sibling worktree에 `ls` 없이 그 경로를 적용 → Write가 `<wt-root>/<content-root>/file.md`에 착지 (한 단계 너무 얕음)
3. 다음 `Read`가 "File does not exist"로 실패하고 `mv` + `rmdir`로 복구

이 hook은 글로벌 behavioral contract "One-Probe-Before-Action Gate" 규칙의 Write 도구 surface 구조적 enforcement 레이어다.

## 동작

| 조건 | 동작 |
|------|------|
| depth=0 (worktree root 직하) | silent |
| depth≥1, 세션 내 parent 이미 enumerate됨 | silent |
| depth≥1, parent 미 enumerate | stderr advisory (exit 0), marker 기록 |
| depth≥1, 미 enumerate + `PRAXIS_PATH_PROBE_STRICT=1` | deny (exit 2), marker 미기록 |
| `PRAXIS_PATH_PROBE_SKIP=1` | 전체 비활성화 |
| 알 수 없는 worktree / git 불가 / 기타 오류 | fail-open (exit 0) |

## 검증 결과

### 테스트 (15 케이스)
```
bash tests/test_path_probe_gate.sh
PASS  [repro: write to shallow path emits advisory]
PASS  [repro: write to correct deep path emits advisory on first attempt]
PASS  [depth-0: file at worktree root is silent]
PASS  [depth-1: first write emits advisory]
PASS  [depth-1: second write to same parent is silent (deduped)]
PASS  [depth-2: first write emits advisory]
PASS  [depth-2: different session emits advisory again]
PASS  [strict: first write denies (exit 2)]
PASS  [strict: second write same session still denies (no-record in strict)]
PASS  [skip: PRAXIS_PATH_PROBE_SKIP=1 disables gate]
PASS  [Edit tool at depth-1 triggers advisory]
PASS  [path outside all worktrees is silent (fail-open)]
PASS  [Bash tool is silent (not in target tools)]
PASS  [malformed JSON stdin is silent (exit 0)]
PASS  [empty file_path is silent]

Results: 15 passed, 0 failed
```

### shellcheck
```
shellcheck hooks/path-probe-gate.sh
(zero issues)
```

### Advisory 출력 (기본 모드)
```
[path-probe-gate] Writing to /wt/repo-subdir/content-root/file.md — the parent directory
/wt/repo-subdir/content-root has not been enumerated this session.
Run `ls /wt/repo-subdir/content-root` or `git ls-files /wt/repo-subdir/content-root` first to
confirm the correct layout before writing.
Set PRAXIS_PATH_PROBE_STRICT=1 to convert this advisory to a hard block.
```

### Deny 출력 (strict mode, exit 2)
```json
{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny",
"permissionDecisionReason": "[path-probe-gate] Write blocked: .../file.md targets a directory
(...) that has not been enumerated this session.\n\nThe target is 2 level(s) below worktree root...\n
Required: enumerate the parent directory first:\n  ls ...\n  # or: git ls-files ..."}}
```

### 매니페스트 일관성
```
python3 scripts/check-plugin-manifests.py
plugin-manifest check OK
```

Closes #386
