### PR TITLE
chore(docs): index 3 missing hooks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -94,6 +94,8 @@ else:
 |------|-------|---------|------|
 | `block-gh-state-all` | PreToolUse | Hard-block invalid `gh search ... --state all` flag combo | [docs/hook/block-gh-state-all.md](docs/hook/block-gh-state-all.md) |
 | `gh-flag-verify` | PreToolUse | Block `gh <subcmd>` calls with flags not in the subcommand's accepted set | [docs/hook/gh-flag-verify.md](docs/hook/gh-flag-verify.md) |
+| `gh-json-validator` | PreToolUse | Block `gh <subcmd> --json <fields>` calls whose field names are not in the subcommand's valid JSON projection (issue #391) | [docs/hook/gh-json-validator.md](docs/hook/gh-json-validator.md) |
+| `gh-label-verify` | PreToolUse | Block `gh (issue\|pr) (create\|edit)` calls whose `--label` values are absent from the target repo's label set (issue #385) | [docs/hook/gh-label-verify.md](docs/hook/gh-label-verify.md) |
 | `cli-flag-incompat-advisory` | PreToolUse | Advisory nudge for known mode-incompatible flag combos in other CLIs (`git merge-tree --name-only` 3-arg form, `kubectl --use-protocol-buffers`) — issue #248 | [docs/hook/cli-flag-incompat-advisory.md](docs/hook/cli-flag-incompat-advisory.md) |
 | `block-ask-end-option` | PreToolUse | Block `AskUserQuestion` options carrying end-option markers when the most recent user message has no stop signal (strict default; advisory opt-out via `PRAXIS_ASK_END_ADVISORY=1`) | [docs/hook/block-ask-end-option.md](docs/hook/block-ask-end-option.md) |
 | `side-effect-scan` | PreToolUse | Ask before commands with collateral side effects (`git commit/push`, `gh pr merge/create`, `kubectl apply`) | [docs/hook/side-effect-scan.md](docs/hook/side-effect-scan.md) |

--- a/docs/hook/INDEX.md
+++ b/docs/hook/INDEX.md
@@ -16,6 +16,8 @@ confirmation-prompt layer.
 |------|---------|---------|
 | [block-gh-state-all](block-gh-state-all.md) | PreToolUse | Hard-block invalid `gh search ... --state all` flag combo |
 | [gh-flag-verify](gh-flag-verify.md) | PreToolUse | Block `gh <subcmd>` calls with flags not in the subcommand's accepted set |
+| [gh-json-validator](gh-json-validator.md) | PreToolUse | Block `gh <subcmd> --json <fields>` calls whose field names are not in the subcommand's valid JSON projection — issue #391 |
+| [gh-label-verify](gh-label-verify.md) | PreToolUse | Block `gh (issue\|pr) (create\|edit)` calls whose `--label` values are absent from the target repo's label set — issue #385 |
 | [block-ask-end-option](block-ask-end-option.md) | PreToolUse | Block `AskUserQuestion` options carrying end-option markers when no stop signal present |
 | [block-manufactured-action-menu](block-manufactured-action-menu.md) | PreToolUse | Warn or block when `AskUserQuestion` surfaces a "shall we proceed?" menu after user already issued a command-intent signal |
 | [block-pr-without-caller-evidence](block-pr-without-caller-evidence.md) | PreToolUse | Block `gh pr create` unless the PR body contains a `Caller chain verified:` line |
@@ -52,6 +54,7 @@ so the agent can self-correct. Fail-open on infrastructure errors by design.
 | [external-write-path-existence-check](external-write-path-existence-check.md) | PreToolUse | Advisory nudge when a `gh issue/pr` body file contains markdown links to repo paths that do not exist |
 | [path-probe-gate](path-probe-gate.md) | PreToolUse | Advisory nudge (opt-in strict: deny) when Write/Edit/NotebookEdit targets a nested worktree path whose parent has not been enumerated this session |
 | [version-bump-evidence-check](version-bump-evidence-check.md) | PreToolUse | Advisory nudge (opt-in strict) when `gh issue/pr` body describes an external version bump with no changelog URL, Fetched: line, or cross-reference matrix |
+| [count-assertion-verify](count-assertion-verify.md) | PreToolUse | Advisory nudge when `grep -c` with alternation (`\|` BRE or `\|` ERE/PCRE) runs without per-arm verification; prevents citing inflated alternation counts — issue #277 |
 
 ---
 


### PR DESCRIPTION
## 변경 사항

hooks.json 및 spec 파일에는 등록됐으나 index 에서 누락된 3개 hook 행을 추가합니다.

| Hook | hooks.json | spec | INDEX.md (전) | ARCHITECTURE.md (전) |
|---|:---:|:---:|:---:|:---:|
| `gh-json-validator` | ✓ | ✓ | ✗ | ✗ |
| `gh-label-verify` | ✓ | ✓ | ✗ | ✗ |
| `count-assertion-verify` | ✓ | ✓ | ✗ | ✓ |

### docs/hook/INDEX.md

- **preflight-gate** 섹션: `gh-json-validator` (issue #391), `gh-label-verify` (issue #385) 행 추가
- **advisory-nudge** 섹션: `count-assertion-verify` (issue #277) 행 추가

### ARCHITECTURE.md Hook index

- `gh-json-validator` 행 추가 (issue #391)
- `gh-label-verify` 행 추가 (issue #385)
- `count-assertion-verify` 는 이미 line 116 에 존재 → 미변경

## 검증

```
grep -c "gh-json-validator" docs/hook/INDEX.md ARCHITECTURE.md
docs/hook/INDEX.md:1
ARCHITECTURE.md:1

grep -c "gh-label-verify" docs/hook/INDEX.md ARCHITECTURE.md
docs/hook/INDEX.md:1
ARCHITECTURE.md:1

grep -c "count-assertion-verify" docs/hook/INDEX.md
docs/hook/INDEX.md:1

python3 scripts/check-plugin-manifests.py
plugin-manifest check OK
```

Caller chain verified: N/A -- docs-only change

Closes #400