### PR TITLE
fix(hook): remove hosts array for all-host hooks

### DIFF
--- a/.cursor-plugin/hooks/hooks.json
+++ b/.cursor-plugin/hooks/hooks.json
@@ -29,6 +29,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-pr-without-caller-evidence.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/gh-flag-verify.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/count-assertion-verify.sh",
             "timeout": 5
           },

--- a/.opencode/hooks/hooks.json
+++ b/.opencode/hooks/hooks.json
@@ -29,6 +29,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-pr-without-caller-evidence.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/gh-flag-verify.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/count-assertion-verify.sh",
             "timeout": 5
           },

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -60,8 +60,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-pr-without-caller-evidence.sh",
-            "timeout": 5,
-            "hosts": ["claude", "codex"]
+            "timeout": 5
           },
           {
             "type": "command",
@@ -84,8 +83,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/gh-flag-verify.sh",
-            "timeout": 5,
-            "hosts": ["claude", "codex"]
+            "timeout": 5
           },
           {
             "type": "command",


### PR DESCRIPTION
## 변경 내용

`hooks/hooks.json` 에서 `Supported hosts: all` 을 선언한 2개 hook 항목의 `hosts` 배열 제거.

### 대상 항목

| Hook | doc 선언 | 수정 전 | 수정 후 |
|------|---------|---------|---------|
| `gh-flag-verify.sh` | `Supported hosts: all` | `hosts: ["claude", "codex"]` | 필드 없음 (기본값 all) |
| `block-pr-without-caller-evidence.sh` | `Supported hosts: all` | `hosts: ["claude", "codex"]` | 필드 없음 (기본값 all) |

### 배경

`docs/hook/gh-flag-verify.md` 와 `docs/hook/block-pr-without-caller-evidence.md` 모두 3번째 줄에 `Supported hosts: all` 을 명시하고 있음. 그러나 `hooks/hooks.json` 에는 각각 `hosts: ["claude", "codex"]` 배열이 남아 있어, doc 과 실제 설정이 불일치했음.

`hosts` 필드를 제거하면 build script 가 default(all) 로 해석하여 doc 의 의도와 일치하게 됨.

### 재생성

`python3 scripts/build-plugin-manifests.py` 로 platform manifest 재생성 후 `python3 scripts/check-plugin-manifests.py` → `OK` 확인.

### Caller chain

Caller chain verified: hooks.json edit affects all 2 hooks; no code callers — Claude Code runtime auto-invokes via hook event matching.

Closes #401