### PR TITLE
fix(hook): narrow rule 2 namespaced to praxis cwd

### DIFF
--- a/hooks/completion-signal-gate.py
+++ b/hooks/completion-signal-gate.py
@@ -199,8 +199,8 @@ def _detect_foreign_slash_commands(text: str, cwd_plugin: str | None) -> list[st
             prefix = cmd.split(":")[0]
             # If the prefix is explicitly foreign
             if prefix in _FOREIGN_PREFIXES:
-                # If cwd is praxis and the command is from a different plugin
-                if cwd_plugin and cwd_plugin != prefix:
+                # Only fire when cwd is praxis (mirrors bare-form scope)
+                if cwd_plugin == "praxis" and cwd_plugin != prefix:
                     foreign.append(f"/{cmd}")
             continue
         # Bare /command — flag only if it is in the known-foreign skill set.

--- a/tests/hooks/test_completion_signal_gate.py
+++ b/tests/hooks/test_completion_signal_gate.py
@@ -405,6 +405,47 @@ def test_rule2_bare_unknown_command_silent(tmp_path: Path) -> None:
     )
 
 
+def test_rule2_namespaced_foreign_silent_in_non_praxis_cwd(tmp_path: Path) -> None:
+    """Namespaced foreign command in laplace-dev-hub cwd → no advisory.
+
+    Rule 2 namespaced branch fires only when cwd_plugin == 'praxis'.
+    When working inside another plugin (e.g. laplace-dev-hub), the hook
+    must remain silent even if a foreign-namespaced command appears in output.
+    """
+    # Simulate laplace-dev-hub cwd by creating a .claude-plugin/marketplace.json
+    plugin_dir = tmp_path / ".claude-plugin"
+    plugin_dir.mkdir()
+    (plugin_dir / "marketplace.json").write_text(
+        json.dumps({"name": "laplace-dev-hub"})
+    )
+    events = [
+        mk_user("다음 단계는 뭔가요?"),
+        mk_assistant(
+            "/oh-my-claudecode:ralph 스킬로 루프를 돌려보세요."
+        ),
+    ]
+    tp = write_jsonl(events, tmp_path)
+    payload = json.dumps(
+        {
+            "transcript_path": tp,
+            "stop_hook_active": False,
+            "session_id": "test-rule2-non-praxis",
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        cwd=str(tmp_path),  # laplace-dev-hub cwd, NOT praxis
+    )
+    assert result.returncode == 0
+    assert "[praxis:completion-signal-gate]" not in result.stderr, (
+        f"Rule 2 must NOT fire in non-praxis cwd; stderr={result.stderr!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Fail-safe paths
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 변경 개요

Rule 2 namespaced branch의 `cwd_plugin` 조건을 praxis-only로 좁힘.

- **기존**: `if cwd_plugin and cwd_plugin != prefix:`  → ANY non-matching cwd에서 발화
- **변경**: `if cwd_plugin == "praxis" and cwd_plugin != prefix:`  → praxis cwd에서만 발화

bare-form branch (line 209)는 이미 `cwd_plugin == "praxis"` 조건이었으나 namespaced branch는 비대칭 구조였음. 이번 변경으로 `docs/hook/completion-signal-gate.md:82`의 "praxis cwd에서만" 기술과 정합.

## Caller chain verified

hook called by Claude Code Stop event; behavior change scope is internal _detect_foreign_slash_commands branch.

## 검증

```
$ grep -A2 "if prefix in _FOREIGN_PREFIXES" hooks/completion-signal-gate.py
            if prefix in _FOREIGN_PREFIXES:
                # Only fire when cwd is praxis (mirrors bare-form scope)
                if cwd_plugin == "praxis" and cwd_plugin != prefix:
```

```
$ python3 -m pytest tests/hooks/test_completion_signal_gate.py -v 2>&1 | tail -5
tests/hooks/test_completion_signal_gate.py::test_has_evidence_block[done-False-False-False] PASSED [100%]

============================== 51 passed in 1.29s ==============================
```

신규 테스트: `test_rule2_namespaced_foreign_silent_in_non_praxis_cwd`
- laplace-dev-hub cwd에서 `/oh-my-claudecode:ralph` 출력 → advisory 미발화 검증
- 기존 50개 테스트 모두 통과 유지

```
$ python3 scripts/check-plugin-manifests.py
plugin-manifest check OK
```

Closes #402