### PR TITLE
refactor(hook): align gh-json-validator bypass naming

### DIFF
--- a/docs/hook/gh-json-validator.md
+++ b/docs/hook/gh-json-validator.md
@@ -38,7 +38,7 @@ so chained segments and env-prefixed invocations are covered uniformly.
 | `gh api repos/owner/repo --json name` | **PASS** (gh api excluded — REST schema) |
 | `gh release list` (no `--json`) | **PASS** (no --json flag) |
 | `gh <unknown-subcmd> --json foo` | **PASS** (fail-open; unknown subcommand) |
-| `gh pr view 1 --json state # CLAUDE_HOOK_BYPASS=gh-json-validator` | **PASS** (inline bypass) |
+| `gh pr view 1 --json state # PRAXIS_GH_JSON_BYPASS=skip` | **PASS** (inline bypass) |
 | Non-Bash tool | **PASS** |
 | Malformed JSON stdin | **PASS** (fail-open) |
 
@@ -84,8 +84,8 @@ Example: `merged` → suggests `mergedAt`.
 Two opt-out mechanisms:
 
 1. **Inline comment** (per-command): append
-   `# CLAUDE_HOOK_BYPASS=gh-json-validator` anywhere on the command line.
-2. **Env var** (per-session): set `CLAUDE_HOOK_BYPASS_GH_JSON=1`.
+   `# PRAXIS_GH_JSON_BYPASS=skip` anywhere on the command line.
+2. **Env var** (per-session): set `PRAXIS_GH_JSON_BYPASS=1`.
 
 ### Fail-open paths
 

--- a/hooks/gh-json-validator.py
+++ b/hooks/gh-json-validator.py
@@ -19,10 +19,8 @@ Design notes:
   subcommand per session (session_id-keyed file under /tmp/) to amortize cost.
 - Tokenization uses `safe_tokenize` → `iter_command_starts` → `strip_prefix`
   from `_hook_utils.py`, consistent with all sibling hooks.
-- Bypass: `# CLAUDE_HOOK_BYPASS=gh-json-validator` comment in the command
-  text causes immediate pass-through, consistent with the bypass convention
-  used by block-sciomc-finding-commit and related hooks. Also supported:
-  env var CLAUDE_HOOK_BYPASS_GH_JSON=1.
+- Bypass: `# PRAXIS_GH_JSON_BYPASS=skip` comment in the command text causes
+  immediate pass-through. Also supported: env var PRAXIS_GH_JSON_BYPASS=1.
 - `gh api` subcommand is explicitly excluded (follows REST schema, different
   concern). Unknown subcommands pass through silently (fail-open).
 - On any infrastructure error (gh missing, network fail, parse error) the hook
@@ -55,7 +53,7 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
 # ---------------------------------------------------------------------------
 
 _GH_HELP_TIMEOUT_SEC = 10
-_BYPASS_COMMENT_RE = re.compile(r"#\s*CLAUDE_HOOK_BYPASS\s*=\s*gh-json-validator")
+_BYPASS_COMMENT_RE = re.compile(r"#\s*PRAXIS_GH_JSON_BYPASS\s*=\s*skip")
 
 # Fast prefilter: must contain `gh` and `--json` before doing full parse.
 _GH_JSON_RE = re.compile(r"\bgh\b.+--json\b")
@@ -357,7 +355,7 @@ def main() -> int:
         return 0
 
     # Bypass via env var.
-    if os.environ.get("CLAUDE_HOOK_BYPASS_GH_JSON") == "1":
+    if os.environ.get("PRAXIS_GH_JSON_BYPASS") == "1":
         return 0
 
     # Bypass via inline comment marker.

--- a/tests/test_gh_json_validator.sh
+++ b/tests/test_gh_json_validator.sh
@@ -123,21 +123,21 @@ run_case "block: mixed valid+invalid --json state,merged" \
 
 # ---------------------------------------------------------------------------
 # Case 5: Bypass — inline comment marker
-# Command contains `# CLAUDE_HOOK_BYPASS=gh-json-validator`; must pass even
+# Command contains `# PRAXIS_GH_JSON_BYPASS=skip`; must pass even
 # with an invalid field.
 # ---------------------------------------------------------------------------
 run_case "bypass: inline comment marker" \
   "pass" \
-  "gh pr view 1 --json merged  # CLAUDE_HOOK_BYPASS=gh-json-validator"
+  "gh pr view 1 --json merged  # PRAXIS_GH_JSON_BYPASS=skip"
 
 # ---------------------------------------------------------------------------
-# Case 6: Bypass — env var CLAUDE_HOOK_BYPASS_GH_JSON=1
+# Case 6: Bypass — env var PRAXIS_GH_JSON_BYPASS=1
 # Must pass even with an invalid field when env var is set.
 # ---------------------------------------------------------------------------
-run_case "bypass: env var CLAUDE_HOOK_BYPASS_GH_JSON=1" \
+run_case "bypass: env var PRAXIS_GH_JSON_BYPASS=1" \
   "pass" \
   "gh api repos/owner/repo/pulls/1 --json merged" \
-  "CLAUDE_HOOK_BYPASS_GH_JSON=1"
+  "PRAXIS_GH_JSON_BYPASS=1"
 
 # ---------------------------------------------------------------------------
 # Case 7: Skip — `gh api` subcommand is out of scope


### PR DESCRIPTION
## 변경 요약

`hooks/gh-json-validator.py` 의 bypass mechanism 을 11개 sibling hook 컨벤션(`PRAXIS_*`)에 맞게 정렬.

### 변경 내역

| 항목 | 이전 | 이후 |
|------|------|------|
| 환경 변수 | `CLAUDE_HOOK_BYPASS_GH_JSON=1` | `PRAXIS_GH_JSON_BYPASS=1` |
| 인라인 마커 | `# CLAUDE_HOOK_BYPASS=gh-json-validator` | `# PRAXIS_GH_JSON_BYPASS=skip` |

### Sibling convention survey 결과

- `momentum-rule-retrieval-gate.py`: `PRAXIS_MOMENTUM_BYPASS=1` (env var only)
- `version-bump-evidence-check.py`: `PRAXIS_VERSION_BUMP_BYPASS=1` (env var only)

두 sibling 모두 인라인 마커 없음. `gh-json-validator` 는 명령줄 주석 bypass 패턴을 이미 지원하므로 인라인 마커는 유지하되 형태만 `PRAXIS_` prefix + `=skip` suffix 로 통일 (Issue #404 명시).

### 미완료 항목

`tests/test_gh_json_validator.sh` — Issue #403 (테스트 파일 신규 생성) 미머지로 현재 부재. #403 머지 후 bypass 케이스(case 5: 인라인 마커, case 6: env var) 를 `PRAXIS_GH_JSON_BYPASS` 로 업데이트하는 후속 커밋 예정.

### Caller chain 검증

Caller chain verified: env-var consumed inside gh-json-validator.py only; inline marker matched via regex within the same hook; no external caller.

### 검증 결과

```
$ grep -c "CLAUDE_HOOK_BYPASS" hooks/gh-json-validator.py docs/hook/gh-json-validator.md
hooks/gh-json-validator.py:0
docs/hook/gh-json-validator.md:0

$ grep -c "PRAXIS_GH_JSON" hooks/gh-json-validator.py docs/hook/gh-json-validator.md
hooks/gh-json-validator.py:4
docs/hook/gh-json-validator.md:4

$ python3 -m py_compile hooks/gh-json-validator.py && echo OK
OK

$ python3 scripts/check-plugin-manifests.py
plugin-manifest check OK
```

Closes #404
