### PR TITLE
feat(scripts): cross-check hook index and hosts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,12 @@ To regenerate after changing `manifests/*.json` or `VERSION`:
 ./scripts/check-plugin-manifests.py   # verify no drift
 ```
 
+`check-plugin-manifests.py` also verifies (a) every hook in `hooks/hooks.json`
+appears in both `docs/hook/INDEX.md` and the `ARCHITECTURE.md` hook index
+table, and (b) each hook spec's `Supported hosts:` line agrees with the
+`hosts` array in `hooks/hooks.json` (`all` = no `hosts` field; explicit list
+= exact set match).
+
 ## Commit conventions
 
 - Format: `type(scope): description` (Conventional Commits)

--- a/scripts/check-plugin-manifests.py
+++ b/scripts/check-plugin-manifests.py
@@ -132,6 +132,103 @@ def main() -> int:
             + ", ".join(f"{k}={v}" for k, v in seen.items())
         )
 
+    # Rule 1 — Hook index drift
+    # For each registered hook in hooks/hooks.json, verify it appears in both
+    # docs/hook/INDEX.md and ARCHITECTURE.md Hook index table.
+    index_md = (REPO_ROOT / "docs" / "hook" / "INDEX.md").read_text()
+    arch_md = (REPO_ROOT / "ARCHITECTURE.md").read_text()
+    seen_hook_names: set[str] = set()
+    for event_groups in hooks_source.get("hooks", {}).values():
+        for group in event_groups:
+            for hook in group.get("hooks", []):
+                cmd = hook.get("command", "")
+                hook_filename = Path(cmd.split("/")[-1]) if "/" in cmd else Path(cmd)
+                hook_name = hook_filename.stem
+                hook_name = hook_name.split()[0] if " " in hook_name else hook_name
+                for suffix in ("-pre", "-post"):
+                    if hook_name.endswith(suffix):
+                        hook_name = hook_name[: -len(suffix)]
+                        break
+                if hook_name in seen_hook_names:
+                    continue
+                seen_hook_names.add(hook_name)
+                if hook_name not in index_md:
+                    drifts.append(
+                        f"MISSING INDEX docs/hook/INDEX.md: {hook_name} "
+                        f"(registered in hooks.json but not in INDEX.md)"
+                    )
+                if hook_name not in arch_md:
+                    drifts.append(
+                        f"MISSING INDEX ARCHITECTURE.md: {hook_name} "
+                        f"(registered in hooks.json but not in ARCHITECTURE.md)"
+                    )
+
+    # Rule 2 — Supported hosts ↔ hosts array cross-check
+    # For each hook spec in docs/hook/*.md, compare the "Supported hosts:" line
+    # to the actual hosts field in hooks/hooks.json.
+    # Build a lookup: hook_name → hosts value from hooks.json (None = all hosts).
+    hooks_json_hosts: dict[str, list[str] | None] = {}
+    for event_groups in hooks_source.get("hooks", {}).values():
+        for group in event_groups:
+            for hook in group.get("hooks", []):
+                cmd = hook.get("command", "")
+                hook_filename = Path(cmd.split("/")[-1]) if "/" in cmd else Path(cmd)
+                hook_name = hook_filename.stem
+                hook_name = hook_name.split()[0] if " " in hook_name else hook_name
+                for suffix in ("-pre", "-post"):
+                    if hook_name.endswith(suffix):
+                        hook_name = hook_name[: -len(suffix)]
+                        break
+                # First registration wins (multiple groups may share same hook name)
+                if hook_name not in hooks_json_hosts:
+                    hooks_json_hosts[hook_name] = hook.get("hosts")
+
+    for spec_file in sorted(docs_dir.glob("*.md")):
+        if spec_file.name == "INDEX.md":
+            continue
+        hook_name = spec_file.stem
+        # Parse "Supported hosts:" from the spec (typically line 3, but scan first 10)
+        spec_text = spec_file.read_text()
+        hosts_value: str | None = None
+        for line in spec_text.splitlines()[:10]:
+            if line.strip().lower().startswith("supported hosts:"):
+                hosts_value = line.split(":", 1)[1].strip()
+                break
+        if hosts_value is None:
+            # No Supported hosts line — skip (spec not yet annotated)
+            continue
+
+        # Hooks not registered in hooks.json are opt-in — skip hosts cross-check
+        if hook_name not in hooks_json_hosts:
+            continue
+
+        json_hosts = hooks_json_hosts[hook_name]
+
+        if hosts_value.lower() == "all":
+            # Spec says all → hooks.json must have NO hosts field
+            if json_hosts is not None:
+                drifts.append(
+                    f"FAIL hosts mismatch {hook_name}: "
+                    f"spec='all' hooks.json={json_hosts!r} "
+                    f"(remove hosts array to mean all hosts)"
+                )
+        else:
+            # Spec lists explicit hosts — parse comma-separated, compare as sets.
+            # Strip parenthetical comments from each token (e.g. "claude (excludes …)")
+            # so only the bare host identifier is retained.
+            raw_tokens = hosts_value.split(",")
+            spec_set = {
+                t.split("(")[0].strip()
+                for t in raw_tokens
+                if t.split("(")[0].strip()
+            }
+            json_set = set(json_hosts) if json_hosts is not None else set()
+            if spec_set != json_set:
+                drifts.append(
+                    f"FAIL hosts mismatch {hook_name}: "
+                    f"spec={sorted(spec_set)!r} hooks.json={sorted(json_set)!r}"
+                )
+
     if drifts:
         print("plugin-manifest check FAILED:")
         for d in drifts:


### PR DESCRIPTION
## 변경 사항

`scripts/check-plugin-manifests.py` 에 2개 drift-detection 룰 추가:

### Rule 1 — Hook index drift

`hooks/hooks.json` 에 등록된 모든 hook 이 `docs/hook/INDEX.md` 와 `ARCHITECTURE.md` Hook index 표 양쪽에 존재하는지 검증.

예외: `(opt-in)` 명시된 spec (예: `external-write-falsify-check`) 은 hooks.json 미등록 허용.

### Rule 2 — Supported hosts ↔ hosts 배열 cross-check

각 hook spec 의 `Supported hosts:` 라인을 파싱하여:
- `all` → hooks.json entry 에 `hosts` 필드 부재 (default = 전체) 인지 확인
- 명시 list → hooks.json `hosts` 배열과 정확 일치 (set equality) 인지 확인

mismatch 시 `FAIL: <hook-name> spec='<value>' hooks.json=[<actual>]` 출력 + non-zero exit.

## CONTRIBUTING.md 갱신

`Plugin manifests` 섹션에 새 룰 동작 1단락 추가.

## 머지 의존성 (CRITICAL)

본 PR 머지 시점에 `python3 scripts/check-plugin-manifests.py` 가 **FAIL** 출력. 이는 의도된 pre-existing drift:

- **#400 (PR #407)**: 3 hook INDEX/ARCH 추가
- **#401 (PR #408)**: 2 hook hosts 배열 제거
- **#412**: 4 hook ARCH 추가 (#405 작업 중 추가 발견)
- **#413**: 22 hook hosts 배열 제거 (#405 작업 중 추가 발견)

위 4개 PR 이 모두 머지된 후 본 PR rebase 시 clean 통과 예정. **본 PR 은 위 4개 PR 머지 후 마지막에 머지.**

## 검증

```
$ python3 -c "import ast; ast.parse(open('scripts/check-plugin-manifests.py').read())"
(no error)

$ python3 scripts/check-plugin-manifests.py
# 현재 main HEAD 에서는 FAIL 출력 (예상됨 — #407/#408/#412/#413 미 머지 상태)
# #407/#408/#412/#413 모두 머지 후 본 PR rebase 시: plugin-manifest check OK
```

## 자동화 갭 해소

본 PR 머지 후 다음과 같은 drift 가 silent merge 되지 못함:
1. 새 hook 등록 시 INDEX.md / ARCHITECTURE.md 갱신 누락 → FAIL
2. hook spec 의 Supported hosts ↔ hooks.json hosts 배열 불일치 → FAIL

Caller chain verified: script invoked via `./scripts/check-plugin-manifests.py` (CI manual check / pre-merge 검증) — 코드 import 없음.

Closes #405
