### PR TITLE
docs(hook): correct Supported hosts to claude, codex for two gated hooks

### DIFF
--- a/docs/hook/block-pr-without-caller-evidence.md
+++ b/docs/hook/block-pr-without-caller-evidence.md
@@ -1,6 +1,6 @@
 # PreToolUse Block PR Without Caller-Chain Evidence
 
-Supported hosts: all
+Supported hosts: claude, codex
 
 `hooks/block-pr-without-caller-evidence.py` fires on every PreToolUse(Bash)
 event and inspects the command for `gh pr create` / `gh pr new` invocations.

--- a/docs/hook/gh-flag-verify.md
+++ b/docs/hook/gh-flag-verify.md
@@ -1,6 +1,6 @@
 # PreToolUse gh CLI Flag Validator
 
-Supported hosts: all
+Supported hosts: claude, codex
 
 `hooks/gh-flag-verify.sh` intercepts every Bash tool call and hard-blocks
 `gh <subcommand>` invocations that supply a flag not in the subcommand's


### PR DESCRIPTION
block-pr-without-caller-evidence and gh-flag-verify are intentionally
restricted to claude+codex in hooks.json, but their specs declared
"Supported hosts: all", creating a doc↔json mismatch that the
hook/host cross-check (PR #416) flags as FAIL. Align the specs with
the actual hosts arrays.

https://claude.ai/code/session_01KLRfmtZ5L4rRZMd7eqqZfG