### PR TITLE
fix(hooks): token-based parsing for sciomc gate

### DIFF
--- a/hooks/block-sciomc-finding-commit.py
+++ b/hooks/block-sciomc-finding-commit.py
@@ -30,7 +30,13 @@ Concrete retrospect pattern (praxis issue #374):
      analysis-as-directive pipeline
 
 Block conditions (ALL must hold):
-  (a) Tool is Bash with `git commit` (not amend/merge/revert/cherry-pick)
+  (a) Tool is Bash with a content `git commit` (not amend/merge/rebase/
+      cherry-pick/revert). Classification is shlex token-based with
+      `punctuation_chars` so shell operators split reliably, so `git commit`
+      inside a quoted arg (`echo "git commit"`) and the `commit-tree` plumbing
+      subcommand do not match. EVERY `git commit` in a compound command is
+      checked, so a later content commit cannot hide behind an earlier
+      exempt/ratified one (`git commit --amend && git commit -m x`).
   (b) Recent transcript tail (last ~200 lines) contains a sciomc/finding
       marker: "sibling-deviant", "Stage N finding/analysis/complete",
       "sciomc", "[FINDING:", "[STAGE_COMPLETE:", "scientist-agent",
@@ -40,16 +46,31 @@ Block conditions (ALL must hold):
       marker in the transcript tail
 
 Allow conditions (escape hatches):
-  - Commit message contains [user-approved] or [ratified-by-user] token
+  - Commit -m/--message message contains a [user-approved] / [ratified-by-user]
+    / [user-ratified] token (a -F file / heredoc body is not argv-visible —
+    use the env bypass there)
   - CLAUDE_HOOK_BYPASS_SCIOMC_GATE=1 env var
-  - git commit --amend / git merge / git revert / git cherry-pick
-  - --allow-empty
+  - git commit --amend / git merge / git rebase / git cherry-pick / git revert
+  - Unparseable command (unbalanced quotes) → fail-open
+
+NOT exempt: --allow-empty / --allow-empty-message. They permit an empty commit
+or message but do not prevent staged content from being committed, so a content
+commit using them is still gated (use the env bypass for an intentional empty
+commit).
+
+Known limitation: a `git commit` whose subcommand is produced via command
+substitution / eval (`git $(echo commit)`, `bash -c '...'`) is not detected.
+Defeating arbitrary shell metaprogramming is out of the threat model (the
+threat is an inadvertent auto-flip after a finding — issue #374 — not a
+deliberately obfuscated dodge of one's own guardrail). Use the env bypass for
+any legitimate edge case.
 """
 from __future__ import annotations
 
 import json
 import os
 import re
+import shlex
 import sys
 from pathlib import Path
 
@@ -67,11 +88,17 @@ def main() -> int:
         return 0
 
     command = (payload.get("tool_input") or {}).get("command", "")
-    if not _is_content_git_commit(command):
-        return 0
-
-    if _has_ratification_token(command):
-        return 0
+    invocations = _commit_invocations(command)
+    # Block if ANY invocation is a gated content commit — not exempt via --amend
+    # and not ratified via a message token. Checking every invocation (not just
+    # the first) closes compound-command bypasses such as
+    # `git commit --amend --no-edit && git commit -m "feat: x"`, where the first
+    # invocation is exempt but the second is an unapproved content commit.
+    if not any(
+        not _is_exempt(args) and not _has_ratification_token(args)
+        for args in (invocations or [])
+    ):
+        return 0  # no git commit, unparseable, or every commit exempt/ratified
 
     transcript_path = payload.get("transcript_path")
     if not transcript_path:
@@ -100,15 +127,25 @@ def main() -> int:
 # Helpers
 # ---------------------------------------------------------------------------
 
-_GIT_COMMIT_RE = re.compile(r"\bgit\s+commit\b")
-_GIT_NON_CONTENT_RE = re.compile(r"\bgit\s+(merge|rebase|cherry-pick|revert)\b")
-_AMEND_RE = re.compile(r"--amend\b")
-_ALLOW_EMPTY_RE = re.compile(r"--allow-empty\b")
+# Command classification operates on shlex tokens, not the raw command string.
+# Raw-string matching is unsound for a commit gate: `--amend` inside a -m
+# message would falsely exempt a content commit, `git commit-tree` would falsely
+# match `commit` via a `\b` boundary, and `echo "git commit"` would falsely trip
+# the gate on a non-commit command.
+_SHELL_SEPARATORS = {";", "&", "&&", "|", "||", "(", ")", "<", ">", "\n"}
+# git's separate-value global options (every other value-opt uses --opt=value,
+# handled generically by the startswith("-") skip). Keep in sync with git.
+_GLOBAL_OPTS_WITH_VALUE = {"-c", "-C", "--git-dir", "--work-tree", "--namespace"}
+# Only `--amend` is exempt. `--allow-empty` / `--allow-empty-message` are NOT:
+# they permit an empty commit/message but do not prevent staged content from
+# riding along, so exempting them would let `git commit --allow-empty -m x`
+# (with staged changes) bypass the gate.
+_EXEMPT_FLAGS = {"--amend"}
+_MESSAGE_FLAGS = {"-m", "--message"}
 _RATIFICATION_TOKEN_RE = re.compile(
     r"\[(?:user-approved|ratified-by-user|user-ratified)\]",
     re.IGNORECASE,
 )
-_COMMIT_MSG_RE = re.compile(r"""-m\s+(?:"((?:[^"\\]|\\.)*)"|'([^']*)')""")
 
 _FINDING_MARKERS = (
     re.compile(r"\bsibling[- ]deviant\b", re.IGNORECASE),
@@ -135,24 +172,105 @@ _CONSENSUS_REFETCH_MARKERS = (
 )
 
 
-def _is_content_git_commit(command: str) -> bool:
-    if not _GIT_COMMIT_RE.search(command):
-        return False
-    if _AMEND_RE.search(command):
-        return False
-    if _GIT_NON_CONTENT_RE.search(command):
-        return False
-    if _ALLOW_EMPTY_RE.search(command):
-        return False
-    return True
+def _tokenize(command: str) -> list[str] | None:
+    # `punctuation_chars=True` makes shlex emit shell operators (`;`, `&&`,
+    # `||`, `|`, `&`, `(`, `)`, `<`, `>`) as standalone tokens even when glued
+    # to an adjacent word (`-m "x"; echo` → `… "x" ; echo`). Plain
+    # `shlex.split` absorbs the operator into the neighbouring token (`x;`),
+    # which would let a later command's `-m` value be misread as this commit's
+    # message and bypass the gate.
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+        lexer.whitespace_split = True
+        return list(lexer)
+    except ValueError:
+        return None  # unbalanced quotes → unparseable → caller fail-opens
 
 
-def _has_ratification_token(command: str) -> bool:
-    msg_match = _COMMIT_MSG_RE.search(command)
-    if not msg_match:
-        return False
-    msg = msg_match.group(1) or msg_match.group(2) or ""
-    return bool(_RATIFICATION_TOKEN_RE.search(msg))
+def _commit_invocations(command: str) -> list[list[str]] | None:
+    """Return the argument tokens of EVERY real `git commit` invocation in the
+    command — each from its `commit` subcommand token up to the next shell
+    separator or the next `git` invocation — or None if the command is
+    unparseable. An empty list means there is no `git commit`.
+
+    Every invocation is returned (not just the first) so a compound command
+    cannot hide an unapproved content commit behind an earlier exempt/ratified
+    one. `git commit` inside a quoted argument is not a `git`+`commit` token
+    adjacency and is ignored; `git commit-tree` tokenizes as `commit-tree`
+    (≠ `commit`); non-content subcommands (`merge`, `rebase`, `cherry-pick`,
+    `revert`) are not `commit` and contribute no invocation.
+    """
+    tokens = _tokenize(command)
+    if tokens is None:
+        return None
+    invocations: list[list[str]] = []
+    n = len(tokens)
+    i = 0
+    while i < n:
+        tok = tokens[i]
+        if tok == "git" or tok.endswith("/git"):
+            j = i + 1
+            while j < n:
+                t = tokens[j]
+                if t in _GLOBAL_OPTS_WITH_VALUE:
+                    j += 2  # skip option + its value
+                    continue
+                if t.startswith("-"):
+                    j += 1
+                    continue
+                break
+            if j < n and tokens[j] == "commit":
+                args: list[str] = []
+                k = j
+                while k < n:
+                    t = tokens[k]
+                    if t in _SHELL_SEPARATORS:
+                        break
+                    if k > j and (t == "git" or t.endswith("/git")):
+                        break
+                    args.append(t)
+                    k += 1
+                invocations.append(args)
+                i = k  # resume scanning after this invocation
+                continue
+            i = j
+            continue
+        i += 1
+    return invocations
+
+
+def _is_exempt(commit_args: list[str]) -> bool:
+    # Exempt flags must be standalone tokens — `--amend` inside a -m message is
+    # part of the message value token, not a flag, so it does not match here.
+    return any(arg in _EXEMPT_FLAGS for arg in commit_args)
+
+
+def _message_values(commit_args: list[str]) -> list[str]:
+    """Extract -m / --message values (separate, joined `-mMSG`, and
+    `--message=MSG` forms). -F/--file values are file paths, not message text."""
+    values: list[str] = []
+    i = 0
+    n = len(commit_args)
+    while i < n:
+        arg = commit_args[i]
+        if arg in _MESSAGE_FLAGS:
+            if i + 1 < n:
+                values.append(commit_args[i + 1])
+            i += 2
+            continue
+        if arg.startswith("--message="):
+            values.append(arg[len("--message="):])
+        elif arg.startswith("-m") and len(arg) > 2:
+            values.append(arg[2:])
+        i += 1
+    return values
+
+
+def _has_ratification_token(commit_args: list[str]) -> bool:
+    # Scope the token check to -m/--message values so a token elsewhere in a
+    # compound command (`git commit -m x; echo '[user-approved]'`) does not
+    # falsely satisfy the ratification escape hatch.
+    return any(_RATIFICATION_TOKEN_RE.search(value) for value in _message_values(commit_args))
 
 
 def _read_transcript_tail(path: str, max_lines: int, max_bytes: int) -> str | None:

--- a/tests/hooks/test_block_sciomc_finding_commit.sh
+++ b/tests/hooks/test_block_sciomc_finding_commit.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# test_block_sciomc_finding_commit.sh — coverage for the sciomc finding gate
+#
+# Synthesizes Claude Code PreToolUse(Bash) payloads (with a transcript fixture)
+# and asserts:
+#   block → exit 2 + stderr non-empty
+#   pass  → exit 0 + stderr empty
+#
+# This suite covers the #427 command-classification layer (shlex token parsing,
+# --allow-empty no longer exempt). The gate fires only when a finding marker is
+# present AND no consensus re-fetch follows it, so the command-classification
+# cases use a transcript that already satisfies those finding conditions.
+#
+# Usage: bash tests/hooks/test_block_sciomc_finding_commit.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK="$ROOT_DIR/hooks/block-sciomc-finding-commit.sh"
+
+if [ ! -x "$HOOK" ]; then
+  echo "FAIL: hook not executable: $HOOK" >&2
+  exit 1
+fi
+
+# Transcript fixtures -------------------------------------------------------
+# A finding marker present, no consensus re-fetch → gate conditions (b)+(c) hold.
+TX_FINDING=$(mktemp)
+printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"[FINDING:f1] the user value looks sibling-deviant"}]}}' >"$TX_FINDING"
+
+# Finding present, but a consensus re-fetch follows → gate must NOT fire.
+TX_FINDING_THEN_REFETCH=$(mktemp)
+printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"[FINDING:f1] the user value looks off"}]}}' >"$TX_FINDING_THEN_REFETCH"
+printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"running gh pr view 12 --json body --jq .body to re-confirm"}]}}' >>"$TX_FINDING_THEN_REFETCH"
+
+# No finding marker at all → gate must NOT fire regardless of command.
+TX_NO_FINDING=$(mktemp)
+printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"just an ordinary edit, nothing analytical here"}]}}' >"$TX_NO_FINDING"
+
+NONEXISTENT_TX="/tmp/does-not-exist-praxis-427-$$.jsonl"
+
+PASS=0; FAIL=0; FAILED_NAMES=()
+
+# run_case <name> <block|pass> <tool_name> <command> [transcript_path|"NONE"] [env]
+run_case() {
+  local name="$1" expected="$2" tool_name="$3" command="$4" tx="${5:-NONE}" env_kv="${6:-}"
+  local payload err_file rc err_content
+  payload=$(python3 -c '
+import json, sys
+p = {"tool_name": sys.argv[1], "tool_input": {"command": sys.argv[2]}}
+if sys.argv[3] != "NONE":
+    p["transcript_path"] = sys.argv[3]
+print(json.dumps(p))' "$tool_name" "$command" "$tx")
+  err_file=$(mktemp)
+  if [ -n "$env_kv" ]; then
+    echo "$payload" | env "$env_kv" "$HOOK" >/dev/null 2>"$err_file"
+  else
+    echo "$payload" | "$HOOK" >/dev/null 2>"$err_file"
+  fi
+  rc=$?
+  err_content=$(cat "$err_file"); rm -f "$err_file"
+
+  local ok=1
+  if [ "$expected" = "block" ]; then
+    [ "$rc" -eq 2 ] && [ -n "$err_content" ] || ok=0
+  else
+    [ "$rc" -eq 0 ] && [ -z "$err_content" ] || ok=0
+  fi
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS [$expected] $name"; ((PASS++))
+  else
+    echo "FAIL [$expected→rc=$rc,stderr=$([ -n "$err_content" ] && echo non-empty || echo empty)] $name"
+    ((FAIL++)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# BLOCK — content commit, finding present, no re-fetch
+# ---------------------------------------------------------------------------
+
+run_case "content commit blocks" block Bash \
+  'git commit -m "feat: x"' "$TX_FINDING"
+
+run_case "commit -F file blocks" block Bash \
+  'git commit -F /tmp/msg.txt' "$TX_FINDING"
+
+# --allow-empty / --allow-empty-message no longer exempt (#427): staged content
+# can ride along, so a content commit using them is still gated.
+run_case "allow-empty not exempt blocks" block Bash \
+  'git commit --allow-empty -m "ci: trigger"' "$TX_FINDING"
+
+run_case "allow-empty-message not exempt blocks" block Bash \
+  'git commit --allow-empty-message -m ""' "$TX_FINDING"
+
+# --amend inside the message is part of the message value, not the flag.
+run_case "amend word inside message still blocks" block Bash \
+  'git commit -m "docs: explain the --amend flag"' "$TX_FINDING"
+
+# ratification token OUTSIDE the commit message must not bypass.
+run_case "ratification token outside message blocks" block Bash \
+  "git commit -m \"feat: x\"; echo '[user-approved]'" "$TX_FINDING"
+
+run_case "commit after && still gated" block Bash \
+  'cd /repo && git commit -m "feat: y"' "$TX_FINDING"
+
+# Compound bypass (Codex #427 round-1 P2-A): a second content commit must not
+# hide behind an earlier exempt --amend.
+run_case "amend then content commit — second still gated" block Bash \
+  'git commit --amend --no-edit && git commit -m "feat: x"' "$TX_FINDING"
+
+# Compound bypass (Codex #427 round-1 P2-B): a later command's -m value glued
+# after `;` must not be read as this commit's message.
+run_case "trailing echo -m token does not ratify" block Bash \
+  'git commit -m "feat: x"; echo -m "[user-approved]"' "$TX_FINDING"
+
+# ---------------------------------------------------------------------------
+# PASS — exemptions (non-content subcommands / --amend)
+# ---------------------------------------------------------------------------
+
+run_case "amend exempt" pass Bash \
+  'git commit --amend --no-edit' "$TX_FINDING"
+
+run_case "git merge exempt" pass Bash \
+  'git merge --no-ff feature' "$TX_FINDING"
+
+run_case "git rebase exempt" pass Bash \
+  'git rebase origin/main' "$TX_FINDING"
+
+run_case "git revert exempt" pass Bash \
+  'git revert abc123' "$TX_FINDING"
+
+run_case "git cherry-pick exempt" pass Bash \
+  'git cherry-pick abc123' "$TX_FINDING"
+
+# ---------------------------------------------------------------------------
+# PASS — ratification token in the commit message (escape hatch)
+# ---------------------------------------------------------------------------
+
+run_case "user-approved token in -m" pass Bash \
+  'git commit -m "feat: x [user-approved]"' "$TX_FINDING"
+
+run_case "ratified-by-user token in -m" pass Bash \
+  'git commit -m "feat: x [ratified-by-user]"' "$TX_FINDING"
+
+run_case "joined -m ratification token" pass Bash \
+  'git commit -m"feat: x [user-approved]"' "$TX_FINDING"
+
+run_case "message= ratification token" pass Bash \
+  'git commit --message="feat: x [user-ratified]"' "$TX_FINDING"
+
+run_case "env bypass" pass Bash \
+  'git commit -m "x"' "$TX_FINDING" "CLAUDE_HOOK_BYPASS_SCIOMC_GATE=1"
+
+# Compound where every invocation is exempt or ratified → no gated commit.
+run_case "amend then ratified commit passes" pass Bash \
+  'git commit --amend --no-edit && git commit -m "feat: x [user-approved]"' "$TX_FINDING"
+
+# ---------------------------------------------------------------------------
+# PASS — token-level classification edge cases
+# ---------------------------------------------------------------------------
+
+run_case "git commit-tree plumbing exempt" pass Bash \
+  'git commit-tree abc123 -m "tree"' "$TX_FINDING"
+
+run_case "echo git commit string not a commit" pass Bash \
+  'echo "remember to git commit later"' "$TX_FINDING"
+
+run_case "git log grep git commit not a commit" pass Bash \
+  'git log --grep="git commit" --oneline' "$TX_FINDING"
+
+# ---------------------------------------------------------------------------
+# PASS — out of scope
+# ---------------------------------------------------------------------------
+
+run_case "non-Bash tool" pass Edit \
+  'git commit -m "x"' "$TX_FINDING"
+
+run_case "git push not commit" pass Bash \
+  'git push origin main' "$TX_FINDING"
+
+run_case "git status not commit" pass Bash \
+  'git status' "$TX_FINDING"
+
+# ---------------------------------------------------------------------------
+# PASS — finding-context gating (unchanged Layer-2 behavior, sanity)
+# ---------------------------------------------------------------------------
+
+run_case "no finding marker → content commit passes" pass Bash \
+  'git commit -m "feat: x"' "$TX_NO_FINDING"
+
+run_case "consensus re-fetch after finding → passes" pass Bash \
+  'git commit -m "feat: x"' "$TX_FINDING_THEN_REFETCH"
+
+# ---------------------------------------------------------------------------
+# PASS — fail-open
+# ---------------------------------------------------------------------------
+
+run_case "unparseable command fail-open" pass Bash \
+  'git commit -m "unterminated' "$TX_FINDING"
+
+run_case "no transcript_path fail-open" pass Bash \
+  'git commit -m "x"' "NONE"
+
+run_case "nonexistent transcript path fail-open" pass Bash \
+  'git commit -m "x"' "$NONEXISTENT_TX"
+
+# Malformed stdin → fail-open (exit 0, no stderr)
+_malformed_err=$(mktemp)
+printf 'not json' | "$HOOK" >/dev/null 2>"$_malformed_err"; _mrc=$?
+if [ "$_mrc" -eq 0 ] && [ ! -s "$_malformed_err" ]; then
+  echo "PASS [pass] malformed stdin fail-open"; ((PASS++))
+else
+  echo "FAIL [pass→rc=$_mrc] malformed stdin fail-open"; ((FAIL++)); FAILED_NAMES+=("malformed stdin fail-open")
+fi
+rm -f "$_malformed_err"
+
+# ---------------------------------------------------------------------------
+# Cleanup + summary
+# ---------------------------------------------------------------------------
+
+rm -f "$TX_FINDING" "$TX_FINDING_THEN_REFETCH" "$TX_NO_FINDING"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "${#FAILED_NAMES[@]}" -gt 0 ]; then
+  echo "Failed cases:"
+  for n in "${FAILED_NAMES[@]}"; do echo "  - $n"; done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 배경

`block-sciomc-finding-commit.py` 의 명령 분류가 raw-string regex 기반이라 content commit 을 오분류했습니다. PR #426 의 codex 리뷰에서 동일 결함 클래스가 형제 훅에 잠재함이 5d cross-check 로 확인되어, #426 의 shlex 토큰 파서를 이 훅에 포팅합니다.

## 변경 (Layer 1 — 명령 파싱만)

- raw-string `--amend` 매칭이 `-m "... --amend ..."` 메시지를 false-exempt 하던 것 해소
- `git commit` 정규식이 `git commit-tree` plumbing 과 `echo "git commit"` 을 오탐하던 것 해소
- **`--allow-empty` / `--allow-empty-message` 면제 제거** — 이 플래그들은 빈 커밋/메시지를 허용할 뿐 staged content 커밋을 막지 않음 (functional test 로 검증). `--amend` 만 면제 유지
- 파서가 `shlex.shlex(punctuation_chars=True)` 사용 → shell 연산자(`;` `&&` 등) 신뢰성 있게 분리
- compound 명령의 **모든** `git commit` invocation 검사 → content commit 이 앞선 exempt/ratified commit 뒤에 숨지 못함
- ratification 토큰 검사를 `-m`/`--message` 값으로 scope

## 테스트

이 훅의 **첫 테스트 스위트** (커버리지 0 → 32 케이스): 분류 edge, 면제, ratification 형태, compound-command 우회, fail-open 전부.

## 리뷰

- Codex round 1 → 2개 compound 우회 발견 (P2-A first-commit-only, P2-B glued separator) → 수정 → round 2 clean
- omc:code-reviewer → APPROVE (CRITICAL/HIGH/MEDIUM 0, LOW 2 문서-only 반영)

## 검증

Pre-commit verified: `bash tests/hooks/test_block_sciomc_finding_commit.sh` → 32 passed; `python3 -m pytest tests/` → 51 passed; `./scripts/check-plugin-manifests.py` → OK

## 관련

- Layer 2 (finding 탐지 구조화 토큰 마이그레이션) 는 #429 에서 별도 처리
- ⚠️ 동일 파서가 `block-commit-without-codex-review.py` (PR #426, 이미 머지) 에도 있어 같은 compound-command 버그 보유 → follow-up 필요

Closes #427
