### PR TITLE
feat(hooks): standardize block message format

### DIFF
--- a/docs/hook/block-message-format.md
+++ b/docs/hook/block-message-format.md
@@ -1,0 +1,72 @@
+# Standard block-message format (issue #439)
+
+Every praxis preflight-gate hook that rejects a command emits a block message
+in one shared five-field format. Before #439 each hook hand-rolled its own
+stderr text, so the wording, field order, and "how do I get past this" guidance
+drifted hook-to-hook. The standard format pins the shape so the agent — and the
+human reading the transcript — sees the same structure every time.
+
+## The format
+
+```
+⚠️ <RULE_NAME> blocked
+
+Why: <one line — which convention is violated>
+Correct path: <specific next action — skill name, command, or pattern>
+Bypass (if truly needed): <env var name>=1 <reason-comment requirement>
+Reference: <CLAUDE.md section, docs/ path, or wiki link>
+```
+
+## The helper
+
+- Python hooks: `hooks/_lib/block_message.py`
+  - `format_block(rule_name, why, correct_path, bypass_env, reference)` → string
+    (no I/O). Use when the message is carried in a JSON `permissionDecisionReason`.
+  - `emit_block(...)` → writes the formatted string to stderr (+ newline). Use on
+    the stderr / `exit 2` block path.
+- Shell hooks: `hooks/_lib/block_message.sh`
+  - source it, then `praxis_format_block` (stdout) / `praxis_emit_block` (stderr).
+  - Output is byte-identical to the Python helper.
+
+Neither helper exits the process or prints the compound-cascade hint — the
+caller keeps control of the exit code and may append
+`compound_cascade_hint(command)` after the block text.
+
+## Field semantics: mandatory vs informational
+
+| Field | Status | Notes |
+|-------|--------|-------|
+| `rule_name` | **Mandatory** | Short rule label; rendered uppercased in the header. |
+| `Why` | **Mandatory** | One line naming the violated convention. Not the symptom — the rule. |
+| `Correct path` | **Mandatory** | The concrete next action: a skill name, an exact command, or a pattern. Avoid "fix it" — say *how*. |
+| `Reference` | **Mandatory** | Where to read more: a `CLAUDE.md` section, a `docs/hook/<name>.md` path, or a wiki link. Gives the reader the authoritative source. |
+| `Bypass` | **Informational / conditional** | Rendered only when the gate has an authoritative bypass env var. Pass `bypass_env=None` (Python) or `""` (shell) to omit the line entirely. |
+
+### When to omit the Bypass line (`bypass_env=None`)
+
+Some gates have **no** authoritative self-bypass, and surfacing a bypass would
+defeat the gate. Omit the line in those cases:
+
+- **`pre-merge-approval-gate`** — a merge approval must come from the user, not
+  from a marker the agent can attach to its own command. The only authoritative
+  signal is `CMUX_DELEGATE=1` set in the *session's* shell env at startup, which
+  is not an inline bypass the agent can self-grant.
+- **`block-gh-state-all`** — `--state all` is simply invalid for `gh search`;
+  there is nothing to bypass, only a correct alternative.
+
+### When to include the Bypass line
+
+When a one-off escape hatch genuinely exists and is acceptable to use with a
+stated reason — e.g. **`block-gh-issue-create-without-dup-search`** exposes
+`CLAUDE_HOOK_BYPASS_DUP_GATE=1` for the case where the duplicate check was done
+outside the current session. The Bypass line's trailing text reminds the agent
+to record *why* it is bypassing.
+
+## Enforcement
+
+`tests/test_block_message.py` lints every preflight-gate `impl.py`: any hook
+that emits a block/ask message must build it via `block_message.py`, unless it
+is explicitly listed in the test's `LEGACY_UNMIGRATED` allowlist (hooks not yet
+ported). A new hand-rolled block hook — or a migrated hook that drops the
+helper — fails the lint. Migrating a legacy hook later means removing it from
+that allowlist.

--- a/hooks/_lib/block_message.py
+++ b/hooks/_lib/block_message.py
@@ -1,0 +1,101 @@
+"""Standard block-message format for praxis preflight-gate hooks (issue #439).
+
+Every preflight-gate hook that rejects a command used to hand-roll its own
+stderr/reason text, so the wording, field order, and "how do I bypass this"
+guidance drifted hook-to-hook. This module pins a single five-field format so
+the agent (and the user reading the transcript) sees the same shape every time:
+
+    ⚠️ <RULE_NAME> blocked
+
+    Why: <one line — which convention is violated>
+    Correct path: <specific next action — skill name, command, or pattern>
+    Bypass (if truly needed): <env var name> + <reason comment requirement>
+    Reference: <CLAUDE.md section, docs/ path, or wiki link>
+
+Field semantics (which fields are mandatory vs informational) are documented in
+`docs/hook/block-message-format.md`. In short:
+
+  - rule_name, why, correct_path, reference  → MANDATORY (always rendered)
+  - bypass_env                               → informational; omit the Bypass
+                                               line entirely when a hook has no
+                                               authoritative bypass (e.g. the
+                                               pre-merge approval gate, where a
+                                               self-bypass would defeat the
+                                               gate). Pass `bypass_env=None`.
+
+Two entry points:
+
+  format_block(...)  → returns the formatted string (no I/O). Use this when the
+                       hook emits via a JSON `permissionDecisionReason` (the
+                       `ask` decision path) rather than raw stderr.
+  emit_block(...)    → writes the formatted string to stderr (+ trailing
+                       newline). Use this on the stderr/exit-2 block path.
+
+Neither function exits the process or prints the cascade hint — the caller
+keeps control of the exit code and may append `compound_cascade_hint(command)`
+after the block text, exactly as before.
+"""
+from __future__ import annotations
+
+import sys
+from typing import Optional, TextIO
+
+
+def format_block(
+    rule_name: str,
+    why: str,
+    correct_path: str,
+    bypass_env: Optional[str],
+    reference: str,
+    bypass_reason_hint: str = "with a one-line reason comment explaining why",
+) -> str:
+    """Render the standard five-field block message and return it as a string.
+
+    Args:
+      rule_name: the hook / rule identifier, e.g. "gh search --state all".
+        Rendered uppercased in the header so it reads as a label.
+      why: one line naming the violated convention.
+      correct_path: the specific next action — a skill name, exact command,
+        or pattern the agent should run instead.
+      bypass_env: the environment variable that bypasses this gate, e.g.
+        "CLAUDE_HOOK_BYPASS_DUP_GATE". Pass None when the gate has no
+        authoritative bypass — the Bypass line is then omitted entirely.
+      reference: a CLAUDE.md section, docs/ path, or wiki link to read.
+      bypass_reason_hint: trailing guidance on the Bypass line describing the
+        reason-comment requirement. Ignored when bypass_env is None.
+
+    Returns:
+      The multi-line block message WITHOUT a trailing newline (callers that
+      write to stderr add their own newline; the cascade hint, if any, is
+      appended by the caller).
+    """
+    lines = [
+        f"⚠️ {rule_name.upper()} blocked",
+        "",
+        f"Why: {why}",
+        f"Correct path: {correct_path}",
+    ]
+    if bypass_env:
+        lines.append(f"Bypass (if truly needed): {bypass_env}=1 {bypass_reason_hint}")
+    lines.append(f"Reference: {reference}")
+    return "\n".join(lines)
+
+
+def emit_block(
+    rule_name: str,
+    why: str,
+    correct_path: str,
+    bypass_env: Optional[str],
+    reference: str,
+    bypass_reason_hint: str = "with a one-line reason comment explaining why",
+    stream: Optional[TextIO] = None,
+) -> None:
+    """Write the standard block message to stderr (+ trailing newline).
+
+    Same args as `format_block`. `stream` is injectable for testing; defaults
+    to sys.stderr. Does NOT exit — the caller owns the exit code (2 for a
+    PreToolUse block).
+    """
+    out = stream if stream is not None else sys.stderr
+    out.write(format_block(rule_name, why, correct_path, bypass_env, reference, bypass_reason_hint))
+    out.write("\n")

--- a/hooks/_lib/block_message.sh
+++ b/hooks/_lib/block_message.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Standard block-message format for praxis preflight-gate hooks (issue #439).
+#
+# Shell equivalent of hooks/_lib/block_message.py for any pure-shell hook.
+# Source this file, then call praxis_emit_block. The five-field format is
+# byte-identical to the Python helper so a hook ported between languages
+# renders the same text. Field semantics live in
+# docs/hook/block-message-format.md.
+#
+#   . "$(dirname "$0")/_lib/block_message.sh"
+#   praxis_emit_block \
+#     "gh search --state all" \
+#     "gh search subcommands only accept --state {open|closed}, not 'all'" \
+#     "omit --state, or run two calls (--state open then --state closed)" \
+#     "" \
+#     "CLAUDE.md → GitHub CLI usage; docs/hook/block-gh-state-all.md"
+#
+# Args (positional):
+#   1 rule_name     — rendered uppercased in the header label
+#   2 why           — one line naming the violated convention
+#   3 correct_path  — specific next action (skill / command / pattern)
+#   4 bypass_env    — env var that bypasses the gate; empty string ("") to
+#                     omit the Bypass line entirely (gate has no bypass)
+#   5 reference     — CLAUDE.md section, docs/ path, or wiki link
+#   6 bypass_hint   — optional; reason-comment guidance on the Bypass line
+#
+# praxis_format_block writes the message to stdout (for capture); the message
+# carries NO trailing newline beyond the last field line. praxis_emit_block
+# writes it to stderr. Neither exits — the caller owns the exit code.
+
+praxis_format_block() {
+  _bm_rule="$1"
+  _bm_why="$2"
+  _bm_correct="$3"
+  _bm_bypass="$4"
+  _bm_reference="$5"
+  _bm_hint="${6:-with a one-line reason comment explaining why}"
+
+  # Uppercase the rule name for the header label (POSIX tr).
+  _bm_rule_upper=$(printf '%s' "$_bm_rule" | tr '[:lower:]' '[:upper:]')
+
+  printf '⚠️ %s blocked\n' "$_bm_rule_upper"
+  printf '\n'
+  printf 'Why: %s\n' "$_bm_why"
+  printf 'Correct path: %s\n' "$_bm_correct"
+  if [ -n "$_bm_bypass" ]; then
+    printf 'Bypass (if truly needed): %s=1 %s\n' "$_bm_bypass" "$_bm_hint"
+  fi
+  printf 'Reference: %s' "$_bm_reference"
+}
+
+praxis_emit_block() {
+  praxis_format_block "$@" >&2
+  printf '\n' >&2
+}

--- a/hooks/preflight-gate/block-gh-issue-create-without-dup-search/impl.py
+++ b/hooks/preflight-gate/block-gh-issue-create-without-dup-search/impl.py
@@ -42,6 +42,9 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "_lib"))
+from block_message import emit_block  # type: ignore[import-not-found]  # noqa: E402
+
 
 def main() -> int:
     try:
@@ -264,58 +267,45 @@ def _read_transcript_tail(path: str, max_lines: int, max_bytes: int) -> str | No
 
 
 def _emit_no_search_block(keywords: list[str]) -> None:
-    sys.stderr.write(
-        "\n".join(
-            [
-                "BLOCKED: `gh issue create` without any prior `gh search issues` / `gh issue list`.",
-                "",
-                f"Title keywords: {', '.join(keywords[:6])}",
-                "",
-                "Rule: CLAUDE.md → GitHub Issue Hygiene",
-                "  Before creating any issue: gh search issues '<keywords>' --repo <repo>",
-                "  (open AND closed). Ask user if ambiguous. Never create duplicates.",
-                "",
-                "Pattern (praxis issue #374):",
-                "  AI spawns a new issue from a fresh analysis finding without searching;",
-                "  an existing open issue covers the same root cause → /cancel cycle.",
-                "",
-                "Resolve by one of:",
-                "  1. Run a search FIRST:",
-                "       gh search issues '<keyword>' --repo <repo>",
-                "       gh issue list --repo <repo> --search '<keyword>'",
-                "  2. If duplicate verified outside this session, add token [dup-checked]",
-                "     to --title (e.g. 'feat(x): foo bar [dup-checked]').",
-                "  3. One-off bypass: prefix with CLAUDE_HOOK_BYPASS_DUP_GATE=1",
-            ]
-        )
-        + "\n"
+    emit_block(
+        rule_name="gh issue create dup-search",
+        why="no prior `gh search issues` / `gh issue list` in this session — "
+            "creating an issue without a duplicate check risks /cancel cycles",
+        correct_path=(
+            f"run a search FIRST: gh search issues '{' '.join(keywords[:2])}' "
+            "--repo <repo> (open AND closed); or add [dup-checked] to --title "
+            "if verified outside this session"
+        ),
+        bypass_env="CLAUDE_HOOK_BYPASS_DUP_GATE",
+        reference="CLAUDE.md → GitHub Issue Hygiene; docs/hook/"
+            "block-gh-issue-create-without-dup-search.md",
     )
+    sys.stderr.write(f"\nTitle keywords: {', '.join(keywords[:6])}\n")
 
 
 def _emit_no_overlap_block(keywords: list[str], recent_searches: list[str]) -> None:
-    sys.stderr.write(
-        "\n".join(
-            [
-                "BLOCKED: `gh issue create` — prior searches exist but none overlap with title keywords.",
-                "",
-                f"Title keywords: {', '.join(keywords[:6])}",
-                "Recent search commands found in transcript (no keyword overlap):",
-                *[f"  - {s[:120]}" for s in recent_searches],
-                "",
-                "Rule: CLAUDE.md → GitHub Issue Hygiene",
-                "  Searching for unrelated keywords does not satisfy the duplicate-check",
-                "  requirement. The search must use keywords semantically overlapping with",
-                "  the new issue's scope.",
-                "",
-                "Resolve by one of:",
-                "  1. Run a targeted search using your title's keywords:",
-                f"       gh search issues '{' '.join(keywords[:2])}' --repo <repo>",
-                "  2. Add [dup-checked] to --title if duplicate verified outside session.",
-                "  3. One-off bypass: prefix with CLAUDE_HOOK_BYPASS_DUP_GATE=1",
-            ]
-        )
-        + "\n"
+    emit_block(
+        rule_name="gh issue create dup-search",
+        why="prior searches exist but none of their keywords overlap with the "
+            "new issue's title — an unrelated search does not satisfy the "
+            "duplicate-check requirement",
+        correct_path=(
+            f"run a targeted search using your title's keywords: gh search "
+            f"issues '{' '.join(keywords[:2])}' --repo <repo>; or add "
+            "[dup-checked] to --title if verified outside this session"
+        ),
+        bypass_env="CLAUDE_HOOK_BYPASS_DUP_GATE",
+        reference="CLAUDE.md → GitHub Issue Hygiene; docs/hook/"
+            "block-gh-issue-create-without-dup-search.md",
     )
+    extra = [
+        "",
+        f"Title keywords: {', '.join(keywords[:6])}",
+        "Recent search commands found in transcript (no keyword overlap):",
+        *[f"  - {s[:120]}" for s in recent_searches],
+        "",
+    ]
+    sys.stderr.write("\n".join(extra) + "\n")
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/block-gh-state-all/impl.py
+++ b/hooks/preflight-gate/block-gh-state-all/impl.py
@@ -30,6 +30,7 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     filter_argv,
     tokenize_with_roles,
 )
+from block_message import format_block  # type: ignore[import-not-found]  # noqa: E402
 
 # flag_value_spec for the role-aware tokenizer.
 #   gh global flags: -R / --repo take a separate-token value
@@ -99,12 +100,14 @@ def is_blocked_gh_search(seg: list[Token]) -> bool:
     return False
 
 
-STDERR_MESSAGE = (
-    "BLOCKED: `gh search <subcmd> ... --state all` is invalid.\n"
-    "`gh search` subcommands only accept --state {open|closed}, not 'all'.\n"
-    "Workarounds:\n"
-    "  • Omit --state entirely (returns results regardless of state)\n"
-    "  • Run two calls: --state open and --state closed\n"
+STDERR_MESSAGE = format_block(
+    rule_name="gh search --state all",
+    why="`gh search` subcommands only accept --state {open|closed}, not 'all' "
+        "(unlike `gh issue/pr list`)",
+    correct_path="omit --state entirely (returns all states), or run two calls: "
+        "--state open and --state closed",
+    bypass_env=None,  # no bypass — the flag is simply invalid for gh search
+    reference="docs/hook/block-gh-state-all.md; CLAUDE.md → GitHub CLI usage",
 )
 
 
@@ -130,7 +133,7 @@ def main() -> int:
 
     for seg in segments:
         if is_blocked_gh_search(seg):
-            sys.stderr.write(STDERR_MESSAGE + compound_cascade_hint(command))
+            sys.stderr.write(STDERR_MESSAGE + "\n" + compound_cascade_hint(command))
             return 2
 
     return 0

--- a/hooks/preflight-gate/pre-merge-approval-gate/impl.py
+++ b/hooks/preflight-gate/pre-merge-approval-gate/impl.py
@@ -44,6 +44,7 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     safe_tokenize,
     strip_prefix,
 )
+from block_message import format_block  # type: ignore[import-not-found]  # noqa: E402
 
 # gh global flags that consume one additional argument (value).
 # When these appear between `gh` and the subcommand object, they must be
@@ -55,12 +56,18 @@ GH_GLOBAL_FLAGS_WITH_ARG = frozenset({
     "--color",
 })
 
-REASON = (
-    "gh pr merge detected in a direct interactive session. "
-    "Merge is shared-state and irreversible — direct sessions require "
-    "explicit per-PR merge approval. "
-    "If you are running as a cmux-delegate background agent, set "
-    "CMUX_DELEGATE=1 in the session environment at startup."
+REASON = format_block(
+    rule_name="gh pr merge approval",
+    why="merge is shared-state and irreversible — direct interactive sessions "
+        "require explicit per-PR merge approval",
+    correct_path="confirm this merge when the dialog surfaces; approval is "
+        "per-PR and does not transfer to sibling/companion PRs",
+    # No agent-attachable bypass by design — a self-bypass would defeat the
+    # gate. The only authoritative signal is CMUX_DELEGATE=1 set in the
+    # session's shell env at startup (background cmux-delegate agents).
+    bypass_env=None,
+    reference="CLAUDE.md → Pre-Merge Reporting / No Approval Transfer Across "
+        "Companion PRs; docs/hook/pre-merge-approval-gate.md",
 )
 
 

--- a/tests/hooks/preflight-gate/test_block_gh_issue_create_without_dup_search.sh
+++ b/tests/hooks/preflight-gate/test_block_gh_issue_create_without_dup_search.sh
@@ -84,15 +84,16 @@ run_case() {
       ;;
     block)
       [ "$rc" -eq 2 ] || ok=0
-      echo "$err" | grep -q "^BLOCKED:" || ok=0
+      # Standard block format (issue #439): header line "⚠️ <RULE> blocked".
+      echo "$err" | grep -q " blocked$" || ok=0
       ;;
     block:no-search)
       [ "$rc" -eq 2 ] || ok=0
-      echo "$err" | grep -q "without any prior \`gh search issues\`" || ok=0
+      echo "$err" | grep -q "no prior \`gh search issues\`" || ok=0
       ;;
     block:no-overlap)
       [ "$rc" -eq 2 ] || ok=0
-      echo "$err" | grep -q "prior searches exist but none overlap" || ok=0
+      echo "$err" | grep -q "none of their keywords overlap" || ok=0
       ;;
     *)
       echo "  internal: unknown expectation '$expectation'" >&2

--- a/tests/test_block_message.py
+++ b/tests/test_block_message.py
@@ -1,0 +1,189 @@
+"""Tests + lint for the standard block-message helper (issue #439).
+
+Two concerns:
+
+  1. Helper format contract — `format_block` / `emit_block` render the exact
+     five-field standard format, and `bypass_env=None` omits the Bypass line.
+
+  2. Adoption lint — every preflight-gate hook that emits a block/ask message
+     must build that message via `hooks/_lib/block_message.py` rather than
+     hand-rolling stderr text. A `LEGACY_UNMIGRATED` allowlist carves out the
+     hooks not yet ported; the three hooks migrated in issue #439 are
+     deliberately NOT on it, so dropping the helper from them — or adding a
+     NEW hand-rolled block hook — fails this test.
+
+Run: python3 -m pytest tests/test_block_message.py -q
+"""
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LIB_DIR = REPO_ROOT / "hooks" / "_lib"
+PREFLIGHT_DIR = REPO_ROOT / "hooks" / "preflight-gate"
+
+sys.path.insert(0, str(LIB_DIR))
+
+_spec = importlib.util.spec_from_file_location(
+    "block_message", LIB_DIR / "block_message.py"
+)
+assert _spec is not None and _spec.loader is not None
+bm = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bm)  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# 1. Helper format contract
+# ---------------------------------------------------------------------------
+
+def test_format_block_full_five_fields() -> None:
+    out = bm.format_block(
+        rule_name="gh issue create dup-search",
+        why="no prior search this session",
+        correct_path="run gh search issues '<kw>' --repo <repo>",
+        bypass_env="CLAUDE_HOOK_BYPASS_DUP_GATE",
+        reference="CLAUDE.md → GitHub Issue Hygiene",
+    )
+    lines = out.split("\n")
+    # Header is uppercased rule name + " blocked", then a blank line.
+    assert lines[0] == "⚠️ GH ISSUE CREATE DUP-SEARCH blocked"
+    assert lines[1] == ""
+    assert lines[2].startswith("Why: ")
+    assert lines[3].startswith("Correct path: ")
+    assert lines[4].startswith("Bypass (if truly needed): CLAUDE_HOOK_BYPASS_DUP_GATE=1")
+    assert lines[5].startswith("Reference: ")
+    # No trailing newline — caller owns it.
+    assert not out.endswith("\n")
+
+
+def test_format_block_omits_bypass_line_when_none() -> None:
+    out = bm.format_block(
+        rule_name="gh pr merge approval",
+        why="merge is irreversible",
+        correct_path="confirm in the dialog",
+        bypass_env=None,
+        reference="CLAUDE.md → Pre-Merge Reporting",
+    )
+    assert "Bypass" not in out
+    lines = out.split("\n")
+    # Header, blank, Why, Correct path, Reference — exactly 5 lines.
+    assert len(lines) == 5
+    assert lines[-1].startswith("Reference: ")
+
+
+def test_emit_block_writes_to_stream_with_trailing_newline() -> None:
+    import io
+
+    buf = io.StringIO()
+    bm.emit_block(
+        rule_name="x rule",
+        why="y",
+        correct_path="z",
+        bypass_env=None,
+        reference="r",
+        stream=buf,
+    )
+    text = buf.getvalue()
+    assert text.startswith("⚠️ X RULE blocked")
+    assert text.endswith("\n")
+
+
+# ---------------------------------------------------------------------------
+# 2. Adoption lint
+# ---------------------------------------------------------------------------
+
+# Preflight-gate hooks not yet migrated to the helper. The three hooks
+# migrated in issue #439 are intentionally absent. Reserved-for-other-issue
+# hooks (block-sciomc-finding-commit / commit-title-length-check) stay listed.
+# Migrating any of these later = removing it from this set.
+LEGACY_UNMIGRATED = {
+    "block-ask-end-option",
+    "block-commit-without-codex-review",
+    "block-manufactured-action-menu",
+    "block-pr-without-caller-evidence",
+    "block-pr-without-precommit-evidence",
+    "block-sciomc-finding-commit",
+    "commit-title-length-check",
+    "cross-boundary-preflight",
+    "gh-flag-verify",
+    "gh-json-validator",
+    "gh-label-verify",
+    "pre-edit-protected-branch-guard",
+    "pre-gh-pr-create-dedup-gate",
+    "session-intent",
+    "side-effect-scan",
+    "verify-commit-flag-override",
+}
+
+# Hooks that emit a block message and so must use the helper (post-migration).
+EXPECTED_MIGRATED = {
+    "block-gh-state-all",
+    "pre-merge-approval-gate",
+    "block-gh-issue-create-without-dup-search",
+}
+
+# A hook "emits a block message" if it writes to stderr with a block marker,
+# returns the PreToolUse blocking exit code, or surfaces an ask/deny decision.
+_EMITS_BLOCK_RE = re.compile(
+    r"stderr\.write|permissionDecision|return 2\b|emit_ask|emit_block",
+)
+_USES_HELPER_RE = re.compile(r"from block_message import|import block_message")
+
+
+def _hook_impls() -> list[Path]:
+    return sorted(PREFLIGHT_DIR.glob("*/impl.py"))
+
+
+def test_migrated_hooks_use_helper() -> None:
+    """The 3 issue-#439 hooks must import the standard block helper."""
+    for name in sorted(EXPECTED_MIGRATED):
+        impl = PREFLIGHT_DIR / name / "impl.py"
+        assert impl.is_file(), f"missing {impl}"
+        src = impl.read_text(encoding="utf-8")
+        assert _USES_HELPER_RE.search(src), (
+            f"{name} must build its block message via hooks/_lib/block_message.py"
+        )
+        assert name not in LEGACY_UNMIGRATED, (
+            f"{name} is migrated — remove it from LEGACY_UNMIGRATED"
+        )
+
+
+def test_no_unaccounted_handrolled_block_hook() -> None:
+    """Any preflight hook that emits a block must either use the helper or be
+    explicitly listed as legacy. A NEW hand-rolled block hook fails here."""
+    offenders: list[str] = []
+    for impl in _hook_impls():
+        name = impl.parent.name
+        src = impl.read_text(encoding="utf-8")
+        if not _EMITS_BLOCK_RE.search(src):
+            continue  # not a blocking hook (e.g. pure advisory/ask-only)
+        if _USES_HELPER_RE.search(src):
+            continue  # compliant
+        if name in LEGACY_UNMIGRATED:
+            continue  # known not-yet-migrated
+        offenders.append(name)
+    assert not offenders, (
+        "preflight-gate hook(s) emit a block message without using "
+        "hooks/_lib/block_message.py and are not on the LEGACY_UNMIGRATED "
+        f"allowlist: {offenders}. Use emit_block/format_block (see "
+        "docs/hook/block-message-format.md), or — if intentionally legacy — "
+        "add to LEGACY_UNMIGRATED."
+    )
+
+
+def test_legacy_allowlist_has_no_phantom_entries() -> None:
+    """Every LEGACY_UNMIGRATED entry must name a real hook dir — prevents the
+    allowlist from silently rotting as hooks are renamed/removed."""
+    existing = {p.parent.name for p in _hook_impls()}
+    phantom = sorted(LEGACY_UNMIGRATED - existing)
+    assert not phantom, f"LEGACY_UNMIGRATED names non-existent hooks: {phantom}"
+
+
+def test_legacy_and_migrated_are_disjoint() -> None:
+    overlap = EXPECTED_MIGRATED & LEGACY_UNMIGRATED
+    assert not overlap, f"hook listed as both migrated and legacy: {overlap}"


### PR DESCRIPTION
## 요약
praxis hook block 메시지의 단일 표준 포맷 도입.

- `hooks/_lib/block_message.{py,sh}` 헬퍼 신규 — `emit_block/format_block` 5-field(Why/Correct path/Bypass/Reference)
- 기존 hook 3개(block-gh-state-all, pre-merge-approval-gate, block-gh-issue-create-without-dup-search) 메시지를 헬퍼로 리팩터 (로직 불변)
- 채택 lint(`tests/test_block_message.py`) + 문서(`docs/hook/block-message-format.md`)

## 검증
- pytest 58 passed, 리팩터 hook 셸 테스트 29/25/15 pass, `check-plugin-manifests` OK
- py·sh 출력 byte-identical, falsification(import 제거→lint fail) 확인
- codex review 1 round → clean

Caller chain verified: new helper, 3 callers added in this PR (block-gh-state-all, pre-merge-approval-gate, block-gh-issue-create-without-dup-search impl.py)
Pre-commit verified: python3 -m pytest tests/ -q → 58 passed; check-plugin-manifests OK (worktree)

Closes #439
