### PR TITLE
fix(hooks): close sciomc gate commit bypasses

### DIFF
--- a/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
+++ b/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
@@ -209,14 +209,41 @@ def _is_git_binary(token: str) -> bool:
 
 
 def _extract_substitutions(command: str) -> list[str]:
+    # Quote-aware scan. Bash runs `$(…)` / backtick substitution when unquoted
+    # or inside DOUBLE quotes, but NOT inside SINGLE quotes (`echo '$(git …)'`
+    # is a literal string, not an executed commit). We track quote state so the
+    # scanner mirrors what bash actually executes — extracting from single-quoted
+    # text would false-block, scanning raw across quotes would mis-handle an
+    # apostrophe inside double quotes (`"it's $(git …)"`). A paren-depth counter
+    # that skips backslash-escaped chars handles nested `$( $( ) )` and `\)`.
     spans: list[str] = []
     i = 0
     n = len(command)
+    in_squote = False
+    in_dquote = False
     while i < n:
         c = command[i]
-        if c == "`":  # backtick substitution — closes at the next backtick
-            j = command.find("`", i + 1)
-            if j == -1:
+        if in_squote:
+            if c == "'":
+                in_squote = False
+            i += 1
+            continue
+        if c == "\\":
+            i += 2  # escaped char is literal, never opens a substitution
+            continue
+        if c == "'" and not in_dquote:
+            in_squote = True
+            i += 1
+            continue
+        if c == '"':
+            in_dquote = not in_dquote
+            i += 1
+            continue
+        if c == "`":  # backtick substitution (active unquoted and in double quotes)
+            j = i + 1
+            while j < n and command[j] != "`":
+                j += 2 if command[j] == "\\" else 1
+            if j >= n:
                 break
             spans.append(command[i + 1:j])
             i = j + 1

--- a/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
+++ b/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
@@ -30,7 +30,8 @@ Concrete retrospect pattern (praxis issue #374):
      analysis-as-directive pipeline
 
 Block conditions (ALL must hold):
-  (a) Tool is Bash with `git commit` (not amend/merge/revert/cherry-pick)
+  (a) Tool is Bash with a content `git commit` (not amend/merge/rebase/
+      cherry-pick/revert)
   (b) Recent transcript tail (last ~200 lines) contains a sciomc/finding
       marker: "sibling-deviant", "Stage N finding/analysis/complete",
       "sciomc", "[FINDING:", "[STAGE_COMPLETE:", "scientist-agent",
@@ -40,16 +41,29 @@ Block conditions (ALL must hold):
       marker in the transcript tail
 
 Allow conditions (escape hatches):
-  - Commit message contains [user-approved] or [ratified-by-user] token
+  - Commit message (-m / --message value) contains [user-approved] or
+    [ratified-by-user] token (scoped to message value only)
   - CLAUDE_HOOK_BYPASS_SCIOMC_GATE=1 env var
-  - git commit --amend / git merge / git revert / git cherry-pick
-  - --allow-empty
+  - git commit --amend / git merge / git rebase / git revert / git cherry-pick
+
+NOT exempt: --allow-empty / --allow-empty-message. These flags do NOT prevent
+staged content from being committed — `git commit --allow-empty -m x` with a
+staged file commits that file. Exempting them would let staged changes bypass
+the gate. An intentional empty CI-trigger commit uses the [user-approved] token
+or the env bypass instead.
+
+Classification is token-level (shlex), not raw-string, so:
+  - `git commit-tree` plumbing does not match (tokenizes as one token)
+  - `echo "git commit"` does not trip the gate (no `git`+`commit` adjacency)
+  - `--amend` inside a `-m` message is a value token, not a flag
+  - `[user-approved]` outside the message value (e.g. after &&) does not bypass
 """
 from __future__ import annotations
 
 import json
 import os
 import re
+import shlex
 import sys
 from pathlib import Path
 
@@ -67,10 +81,14 @@ def main() -> int:
         return 0
 
     command = (payload.get("tool_input") or {}).get("command", "")
-    if not _is_content_git_commit(command):
-        return 0
+    commit_args = _commit_invocation_args(command)
+    if commit_args is None:
+        return 0  # no real `git commit` invocation (or unparseable) → fail-open
 
-    if _has_ratification_token(command):
+    if _is_exempt(commit_args):
+        return 0  # --amend (fix-up of an already-gated commit)
+
+    if _has_ratification_token(commit_args):
         return 0
 
     transcript_path = payload.get("transcript_path")
@@ -97,18 +115,33 @@ def main() -> int:
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Command classification
+#
+# Classification operates on shlex tokens, not the raw command string.
+# Matching a raw string is unsound for a commit gate:
+#   - `--amend` inside a -m message would falsely exempt a content commit
+#   - `git commit-tree` tokenizes as one token "commit-tree" (≠ "commit")
+#     so plumbing subcommands do not match
+#   - `echo "git commit"` has no `git`+`commit` token adjacency → no match
+#   - `[user-approved]` outside the -m value (e.g. after &&) does not bypass
+#
+# Only `--amend` is exempt: its intent is to fix up a prior (already-gated)
+# commit. `--allow-empty` / `--allow-empty-message` are deliberately NOT exempt
+# — they only *permit* an empty commit / message and do not *prevent* staged
+# content from riding along, so exempting them would let
+# `git commit --allow-empty -m x` (with staged changes) bypass the gate.
+# Verified functionally: both flags commit staged files.
 # ---------------------------------------------------------------------------
 
-_GIT_COMMIT_RE = re.compile(r"\bgit\s+commit\b")
-_GIT_NON_CONTENT_RE = re.compile(r"\bgit\s+(merge|rebase|cherry-pick|revert)\b")
-_AMEND_RE = re.compile(r"--amend\b")
-_ALLOW_EMPTY_RE = re.compile(r"--allow-empty\b")
+_SHELL_SEPARATORS = {";", "&", "&&", "|", "||", "\n"}
+_GLOBAL_OPTS_WITH_VALUE = {"-c", "-C", "--git-dir", "--work-tree", "--namespace"}
+_EXEMPT_FLAGS = {"--amend"}
+_MESSAGE_FLAGS = {"-m", "--message"}
+
 _RATIFICATION_TOKEN_RE = re.compile(
     r"\[(?:user-approved|ratified-by-user|user-ratified)\]",
     re.IGNORECASE,
 )
-_COMMIT_MSG_RE = re.compile(r"""-m\s+(?:"((?:[^"\\]|\\.)*)"|'([^']*)')""")
 
 _FINDING_MARKERS = (
     re.compile(r"\bsibling[- ]deviant\b", re.IGNORECASE),
@@ -135,24 +168,137 @@ _CONSENSUS_REFETCH_MARKERS = (
 )
 
 
-def _is_content_git_commit(command: str) -> bool:
-    if not _GIT_COMMIT_RE.search(command):
-        return False
-    if _AMEND_RE.search(command):
-        return False
-    if _GIT_NON_CONTENT_RE.search(command):
-        return False
-    if _ALLOW_EMPTY_RE.search(command):
-        return False
-    return True
+def _tokenize(command: str) -> list[str] | None:
+    # punctuation_chars=True splits shell operators (`;`, `&&`, `|`, `(`, `)`,
+    # redirects) into their own tokens even when not space-delimited, while
+    # quotes still protect their contents. Plain shlex.split folds
+    # `true;git commit` into a single `true;git` token, letting a content commit
+    # ride behind a space-less separator — a bypass the prior raw regex caught.
+    # whitespace_split=True keeps normal word splitting; commenters='' preserves
+    # the old comments=False behaviour (a bare `#` is not a comment delimiter).
+    try:
+        lex = shlex.shlex(command, posix=True, punctuation_chars=True)
+        lex.whitespace_split = True
+        lex.commenters = ""
+        return list(lex)
+    except ValueError:
+        return None  # unbalanced quotes → unparseable → caller fail-opens
 
 
-def _has_ratification_token(command: str) -> bool:
-    msg_match = _COMMIT_MSG_RE.search(command)
-    if not msg_match:
-        return False
-    msg = msg_match.group(1) or msg_match.group(2) or ""
-    return bool(_RATIFICATION_TOKEN_RE.search(msg))
+# shlex (posix) does not treat shell grouping / command-substitution syntax as
+# operators, so `(git commit …)` and `echo $(git commit …)` tokenize the binary
+# as `(git` / `$(git` / `` `git ``. Without normalizing these, the parser would
+# miss a real content commit wrapped in a subshell/group — a bypass the prior
+# raw-regex (`\bgit\s+commit\b`) happened to catch. Strip a leading run of
+# grouping/substitution chars before the binary-name check.
+_GROUP_PREFIX_CHARS = "(){}$`"
+
+
+def _is_git_binary(token: str) -> bool:
+    stripped = token.lstrip(_GROUP_PREFIX_CHARS)
+    return stripped == "git" or stripped.endswith("/git")
+
+
+def _commit_invocation_args(command: str) -> list[str] | None:
+    """Return the argument tokens of the first real `git commit` invocation —
+    from the `commit` subcommand token up to the next shell separator or the
+    next `git` invocation — or None if the command contains no `git commit`.
+
+    Token-level detection means `git commit` inside a quoted argument
+    (`echo "git commit"`, `git log --grep="git commit"`) is not a `git`+`commit`
+    adjacency and is ignored, and `git commit-tree` tokenizes as the single
+    token `commit-tree` (≠ `commit`) so plumbing subcommands do not match.
+    Non-content subcommands (`merge`, `rebase`, `cherry-pick`, `revert`) are
+    also not `commit` and return None.
+    """
+    tokens = _tokenize(command)
+    if tokens is None:
+        return None
+    n = len(tokens)
+    i = 0
+    while i < n:
+        tok = tokens[i]
+        if _is_git_binary(tok):
+            j = i + 1
+            while j < n:
+                t = tokens[j]
+                if t in _GLOBAL_OPTS_WITH_VALUE:
+                    j += 2  # skip option + its value
+                    continue
+                if t.startswith("-"):
+                    j += 1
+                    continue
+                break
+            if j < n and tokens[j] == "commit":
+                args: list[str] = []
+                k = j
+                while k < n:
+                    t = tokens[k]
+                    if t in _SHELL_SEPARATORS:
+                        break
+                    if k > j and _is_git_binary(t):
+                        break
+                    args.append(t)
+                    k += 1
+                return args
+            i = j
+            continue
+        i += 1
+    return None
+
+
+def _is_exempt(commit_args: list[str]) -> bool:
+    # Exempt flags must be standalone tokens — `--amend` inside a -m message is
+    # part of the message value token, not a flag, so it does not match here.
+    return any(arg in _EXEMPT_FLAGS for arg in commit_args)
+
+
+def _message_values(commit_args: list[str]) -> list[str]:
+    """Extract -m / --message values (separate, joined `-mMSG`, and
+    `--message=MSG` forms). -F/--file values are file paths, not the message
+    text, so they are not inspected."""
+    values: list[str] = []
+    i = 0
+    n = len(commit_args)
+    while i < n:
+        arg = commit_args[i]
+        if arg in _MESSAGE_FLAGS:
+            if i + 1 < n:
+                values.append(commit_args[i + 1])
+            i += 2
+            continue
+        # Clustered short options ending in -m, e.g. `-am 'msg'` or `-am'msg'`
+        # (-ammsg). git requires -m last in a short cluster; its value is the
+        # attached remainder or the next token. Without this, the ratification
+        # escape-hatch silently fails for the common `git commit -am` form.
+        if (
+            arg.startswith("-")
+            and not arg.startswith("--")
+            and len(arg) > 2
+            and arg[1] != "m"            # `-m`/`-mMSG` handled separately
+            and "m" in arg
+            and arg[1:arg.index("m")].isalpha()
+        ):
+            rest = arg[arg.index("m") + 1:]
+            if rest:
+                values.append(rest)
+            elif i + 1 < n:
+                values.append(commit_args[i + 1])
+                i += 1  # consume the value token
+            i += 1
+            continue
+        if arg.startswith("--message="):
+            values.append(arg[len("--message="):])
+        elif arg.startswith("-m") and len(arg) > 2:
+            values.append(arg[2:])
+        i += 1
+    return values
+
+
+def _has_ratification_token(commit_args: list[str]) -> bool:
+    # Scope the check to -m/--message values so a token elsewhere in a compound
+    # command (`git commit -m x; echo '[user-approved]'`) does not bypass the gate.
+    return any(_RATIFICATION_TOKEN_RE.search(value) for value in _message_values(commit_args))
 
 
 def _read_transcript_tail(path: str, max_lines: int, max_bytes: int) -> str | None:

--- a/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
+++ b/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
@@ -247,50 +247,70 @@ def _commit_invocation_args(command: str) -> list[str] | None:
     return None
 
 
+def _is_separate_message_flag(arg: str) -> bool:
+    """True if `arg` is a message flag whose value is the NEXT token: `-m`,
+    `--message`, or a clustered short option ending in -m with no attached
+    value (`-am`). Inline forms (`-mMSG`, `--message=MSG`, `-ammsg`) carry the
+    value in the token itself and return False (no separate value token)."""
+    if arg in _MESSAGE_FLAGS:
+        return True
+    return (
+        arg.startswith("-")
+        and not arg.startswith("--")
+        and len(arg) > 2
+        and arg[1] != "m"                     # `-m`/`-mMSG` handled separately
+        and "m" in arg
+        and arg[1:arg.index("m")].isalpha()
+        and not arg[arg.index("m") + 1:]      # no attached value → next token is value
+    )
+
+
 def _is_exempt(commit_args: list[str]) -> bool:
-    # Exempt flags must be standalone tokens — `--amend` inside a -m message is
-    # part of the message value token, not a flag, so it does not match here.
-    return any(arg in _EXEMPT_FLAGS for arg in commit_args)
+    # Exempt flags must be standalone flag tokens. A `-m`/`--message`/`-am`
+    # VALUE that happens to equal "--amend" (`git commit -m --amend`) is the
+    # message text, not the amend flag — skip the consumed value token before
+    # matching, or it would false-exempt a content commit.
+    i = 0
+    n = len(commit_args)
+    while i < n:
+        arg = commit_args[i]
+        if _is_separate_message_flag(arg):
+            i += 2  # skip the flag and its separate value token
+            continue
+        if arg in _EXEMPT_FLAGS:
+            return True
+        i += 1
+    return False
 
 
 def _message_values(commit_args: list[str]) -> list[str]:
-    """Extract -m / --message values (separate, joined `-mMSG`, and
-    `--message=MSG` forms). -F/--file values are file paths, not the message
-    text, so they are not inspected."""
+    """Extract -m / --message values (separate, joined `-mMSG`, clustered
+    `-am`/`-ammsg`, and `--message=MSG` forms). -F/--file values are file
+    paths, not the message text, so they are not inspected."""
     values: list[str] = []
     i = 0
     n = len(commit_args)
     while i < n:
         arg = commit_args[i]
-        if arg in _MESSAGE_FLAGS:
+        if _is_separate_message_flag(arg):
             if i + 1 < n:
                 values.append(commit_args[i + 1])
             i += 2
-            continue
-        # Clustered short options ending in -m, e.g. `-am 'msg'` or `-am'msg'`
-        # (-ammsg). git requires -m last in a short cluster; its value is the
-        # attached remainder or the next token. Without this, the ratification
-        # escape-hatch silently fails for the common `git commit -am` form.
-        if (
-            arg.startswith("-")
-            and not arg.startswith("--")
-            and len(arg) > 2
-            and arg[1] != "m"            # `-m`/`-mMSG` handled separately
-            and "m" in arg
-            and arg[1:arg.index("m")].isalpha()
-        ):
-            rest = arg[arg.index("m") + 1:]
-            if rest:
-                values.append(rest)
-            elif i + 1 < n:
-                values.append(commit_args[i + 1])
-                i += 1  # consume the value token
-            i += 1
             continue
         if arg.startswith("--message="):
             values.append(arg[len("--message="):])
         elif arg.startswith("-m") and len(arg) > 2:
             values.append(arg[2:])
+        elif (
+            arg.startswith("-")
+            and not arg.startswith("--")
+            and len(arg) > 2
+            and arg[1] != "m"
+            and "m" in arg
+            and arg[1:arg.index("m")].isalpha()
+        ):
+            # inline clustered value: `-ammsg` → "msg"
+            values.append(arg[arg.index("m") + 1:])
         i += 1
     return values
 

--- a/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
+++ b/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
@@ -135,6 +135,9 @@ def main() -> int:
 
 _SHELL_SEPARATORS = {";", "&", "&&", "|", "||", "\n"}
 _GLOBAL_OPTS_WITH_VALUE = {"-c", "-C", "--git-dir", "--work-tree", "--namespace"}
+# Terminal global options consume the rest as non-execution: `git --help commit`
+# and `git --version commit` print help/version, they do NOT run commit.
+_TERMINAL_GLOBAL_OPTS = {"--help", "-h", "--version"}
 _EXEMPT_FLAGS = {"--amend"}
 _MESSAGE_FLAGS = {"-m", "--message"}
 
@@ -286,6 +289,8 @@ def _scan_tokens_for_commit(tokens: list[str] | None) -> list[str] | None:
             j = i + 1
             while j < n:
                 t = tokens[j]
+                if t in _TERMINAL_GLOBAL_OPTS:
+                    break  # `git --help commit` / `git --version commit` run no commit
                 if t in _GLOBAL_OPTS_WITH_VALUE:
                     j += 2  # skip option + its value
                     continue

--- a/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
+++ b/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
@@ -199,19 +199,20 @@ def _is_git_binary(token: str) -> bool:
     return stripped == "git" or stripped.endswith("/git")
 
 
-def _commit_invocation_args(command: str) -> list[str] | None:
-    """Return the argument tokens of the first real `git commit` invocation —
-    from the `commit` subcommand token up to the next shell separator or the
-    next `git` invocation — or None if the command contains no `git commit`.
+# Command-substitution spans. Bash executes the inner command even when the
+# substitution sits inside double quotes — where shlex keeps the whole quoted
+# string as a single token — so a content commit can hide in `echo "$(git
+# commit …)"` or `x="$(git …)"`. We extract each span and re-scan it. Non-greedy
+# inner capture is sufficient for *detection* (we only need git+commit
+# adjacency, not a perfect parse), so nested `)` truncation is harmless.
+_CMD_SUBST_RE = re.compile(r"\$\((.*?)\)|`([^`]*)`", re.DOTALL)
 
-    Token-level detection means `git commit` inside a quoted argument
-    (`echo "git commit"`, `git log --grep="git commit"`) is not a `git`+`commit`
-    adjacency and is ignored, and `git commit-tree` tokenizes as the single
-    token `commit-tree` (≠ `commit`) so plumbing subcommands do not match.
-    Non-content subcommands (`merge`, `rebase`, `cherry-pick`, `revert`) are
-    also not `commit` and return None.
-    """
-    tokens = _tokenize(command)
+
+def _scan_tokens_for_commit(tokens: list[str] | None) -> list[str] | None:
+    """Walk shlex tokens and return the arg tokens of the first real
+    `git commit` invocation (from the `commit` token up to the next shell
+    separator or next `git`), or None. `git commit-tree` (single token
+    `commit-tree` ≠ `commit`) and non-content subcommands return None."""
     if tokens is None:
         return None
     n = len(tokens)
@@ -244,6 +245,29 @@ def _commit_invocation_args(command: str) -> list[str] | None:
             i = j
             continue
         i += 1
+    return None
+
+
+def _commit_invocation_args(command: str) -> list[str] | None:
+    """Return the argument tokens of the first real `git commit` invocation, or
+    None if the command runs no `git commit`.
+
+    Hybrid detection: (1) direct shlex tokenization handles plain, grouped
+    (`(git …)`), unquoted-substitution (`$(git …)`), and separator-chained
+    forms; (2) a command-substitution span scan handles QUOTED substitution
+    (`echo "$(git commit …)"`, `x="$(git …)"`) that shlex folds into one token.
+    A plain quoted literal (`echo "git commit"`, `--grep="git commit"`) has no
+    `$(…)`/backtick span and no `git`+`commit` token adjacency, so it is
+    correctly ignored — the precision the token approach was introduced for.
+    """
+    args = _scan_tokens_for_commit(_tokenize(command))
+    if args is not None:
+        return args
+    for m in _CMD_SUBST_RE.finditer(command):
+        inner = m.group(1) if m.group(1) is not None else m.group(2)
+        args = _scan_tokens_for_commit(_tokenize(inner))
+        if args is not None:
+            return args
     return None
 
 

--- a/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
+++ b/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
@@ -202,10 +202,46 @@ def _is_git_binary(token: str) -> bool:
 # Command-substitution spans. Bash executes the inner command even when the
 # substitution sits inside double quotes — where shlex keeps the whole quoted
 # string as a single token — so a content commit can hide in `echo "$(git
-# commit …)"` or `x="$(git …)"`. We extract each span and re-scan it. Non-greedy
-# inner capture is sufficient for *detection* (we only need git+commit
-# adjacency, not a perfect parse), so nested `)` truncation is harmless.
-_CMD_SUBST_RE = re.compile(r"\$\((.*?)\)|`([^`]*)`", re.DOTALL)
+# commit …)"` or `x="$(git …)"`. A regex cannot delimit `$(…)` reliably: nested
+# `$(a $(b))` and escaped `\)` (a literal paren passed to the inner command, not
+# a closer) break naive `\$\(.*?\)` matching. We scan with a paren-depth counter
+# that skips backslash-escaped chars, then re-tokenize each extracted span.
+
+
+def _extract_substitutions(command: str) -> list[str]:
+    spans: list[str] = []
+    i = 0
+    n = len(command)
+    while i < n:
+        c = command[i]
+        if c == "`":  # backtick substitution — closes at the next backtick
+            j = command.find("`", i + 1)
+            if j == -1:
+                break
+            spans.append(command[i + 1:j])
+            i = j + 1
+            continue
+        if c == "$" and i + 1 < n and command[i + 1] == "(":
+            depth = 1
+            j = i + 2
+            start = j
+            while j < n and depth:
+                ch = command[j]
+                if ch == "\\":  # escaped char (e.g. `\)`) does not close the span
+                    j += 2
+                    continue
+                if ch == "(":
+                    depth += 1
+                elif ch == ")":
+                    depth -= 1
+                    if depth == 0:
+                        break
+                j += 1
+            spans.append(command[start:j])
+            i = j + 1
+            continue
+        i += 1
+    return spans
 
 
 def _scan_tokens_for_commit(tokens: list[str] | None) -> list[str] | None:
@@ -263,8 +299,7 @@ def _commit_invocation_args(command: str) -> list[str] | None:
     args = _scan_tokens_for_commit(_tokenize(command))
     if args is not None:
         return args
-    for m in _CMD_SUBST_RE.finditer(command):
-        inner = m.group(1) if m.group(1) is not None else m.group(2)
+    for inner in _extract_substitutions(command):
         args = _scan_tokens_for_commit(_tokenize(inner))
         if args is not None:
             return args

--- a/hooks/preflight-gate/block-sciomc-finding-commit/spec.md
+++ b/hooks/preflight-gate/block-sciomc-finding-commit/spec.md
@@ -32,9 +32,14 @@ redirected back to the originally-stated design and the flip was reverted
 
 All three conditions must hold for a block (exit 2):
 
-1. The Bash command is a content `git commit` — `--amend`, `git merge`,
-   `git rebase`, `git cherry-pick`, `git revert`, and `--allow-empty` are
-   exempt.
+1. The Bash command is a content `git commit`. Only `--amend` and the
+   non-content ops (`git merge`, `git rebase`, `git cherry-pick`,
+   `git revert`) are exempt. `--allow-empty` / `--allow-empty-message` are
+   **not** exempt — they only permit an empty commit/message and do not stop
+   staged content from riding along, so a finding-gated content commit cannot
+   slip through behind them. Commits wrapped in a subshell/group (`(git …)`),
+   command substitution (`$(git …)` / `` `git …` ``), or chained behind a
+   space-less separator (`true;git commit …`) are detected too.
 2. The recent transcript tail (last ~200 lines) contains a finding marker:
    `sibling-deviant`, `Stage N 분석/finding/analysis/결과/complete`, `sciomc`,
    `[FINDING:`, `[STAGE_COMPLETE:`, `scientist-agent`, `review finds`,
@@ -49,6 +54,7 @@ All three conditions must hold for a block (exit 2):
 | `git commit -m "..."` after a `[FINDING:` line, no re-fetch | **BLOCKED** (exit 2) |
 | `git commit` after sciomc Stage 5, then `gh pr view N --json body` | **PASS** (re-fetch after finding) |
 | `git commit --amend` after a finding | **PASS** (amend exempt) |
+| `git commit --allow-empty -m x` (staged content) after a finding | **BLOCKED** (allow-empty not exempt) |
 | `git revert <sha>` after a finding | **PASS** (non-content op) |
 | `git commit -m "fix [user-approved]"` after a finding | **PASS** (ratification token) |
 | `git commit` with no finding marker in transcript | **PASS** (no finding context) |

--- a/hooks/preflight-gate/block-sciomc-finding-commit/spec.md
+++ b/hooks/preflight-gate/block-sciomc-finding-commit/spec.md
@@ -59,6 +59,22 @@ All three conditions must hold for a block (exit 2):
 | `git commit -m "fix [user-approved]"` after a finding | **PASS** (ratification token) |
 | `git commit` with no finding marker in transcript | **PASS** (no finding context) |
 
+### Limitations (threat model: accidental, not adversarial)
+
+The gate targets **accidental momentum commits** (`git commit -m x` after a
+review finding), not an adversary crafting a bypass. Command detection covers
+plain, grouped (`(git …)`), separator-chained (`true;git commit`), clustered
+(`-am`), and command-substitution forms — including quoted (`echo "$(git
+commit …)"`), nested (`$(… $(git commit) …)`), escaped-paren, and single-quote
+literals (correctly NOT flagged). It does **not** fully replicate bash's parser:
+a content commit hidden behind quote state *inside* a `$(…)` span
+(e.g. `echo "$(printf ')' ; git commit -m x)"`) can still slip through, because
+the substitution scanner does not track quoting within the span. This is an
+adversarial construction, not an accidental one — and a deliberate bypass is
+already a first-class feature (`[user-approved]` token / `CLAUDE_HOOK_BYPASS_SCIOMC_GATE=1`).
+Full shell-grammar parsing (e.g. a `bashlex` dependency) is intentionally out of
+scope.
+
 ### Escape hatches
 
 - Add `[user-approved]` or `[ratified-by-user]` to the commit message when
@@ -73,7 +89,10 @@ All three conditions must hold for a block (exit 2):
 bash tests/test_block_sciomc_finding_commit.sh
 ```
 
-Covers 15 cases: block paths (finding + no re-fetch), silent paths (each
-escape hatch, amend / revert exemption, re-fetch after finding, no finding
-context), non-Bash tool passthrough, missing `transcript_path`, and malformed
-JSON fail-open.
+Covers 40 cases: block paths (finding + no re-fetch, `--allow-empty*` with
+staged content, grouped / command-substitution / nested / separator-chained
+commits, `-m --amend` value), silent paths (each escape hatch, amend / revert
+exemption, `commit-tree` plumbing, quoted-literal `git commit`, single-quoted
+substitution, `git --help/--version commit` terminal options, re-fetch after
+finding, no finding context), non-Bash tool passthrough, missing
+`transcript_path`, and malformed JSON fail-open.

--- a/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
+++ b/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
@@ -172,6 +172,16 @@ run_case "nested command-substitution git commit (block)" \
   "block" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo \\\"\$(echo \$(git commit -m nested))\\\"\"},\"transcript_path\":\"$TX_FINDING\"}"
 
+# SINGLE-quoted substitution is a literal — bash does NOT execute it → silent
+run_case "single-quoted substitution literal (silent)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo '\$(git commit -m x)'\"},\"transcript_path\":\"$TX_FINDING\"}"
+
+# apostrophe inside double quotes is literal — substitution still executes → block
+run_case "apostrophe in double-quoted substitution (block)" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo \\\"it's \$(git commit -m x)\\\"\"},\"transcript_path\":\"$TX_FINDING\"}"
+
 # space-less shell separator: `true;git commit` must tokenize git as its own token
 run_case "no-space semicolon separator before git commit (block)" \
   "block" \

--- a/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
+++ b/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
@@ -125,6 +125,16 @@ run_case "amend word inside message still blocks" \
   "block" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'docs: explain the --amend flag'\"},\"transcript_path\":\"$TX_FINDING\"}"
 
+# `-m --amend`: the message VALUE is exactly "--amend" — must NOT be exempted
+run_case "git commit -m --amend (value is --amend, not flag) blocks" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m --amend\"},\"transcript_path\":\"$TX_FINDING\"}"
+
+# `-am --amend`: clustered flag consumes "--amend" as the message value — must block
+run_case "git commit -am --amend (clustered, value is --amend) blocks" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -am --amend\"},\"transcript_path\":\"$TX_FINDING\"}"
+
 # ratification token outside the -m value must NOT bypass
 run_case "user-approved token outside message (semicolon) still blocks" \
   "block" \

--- a/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
+++ b/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
@@ -151,6 +151,22 @@ run_case "command-substitution git commit (block)" \
   "block" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo \$(git commit -m 'fix: subst')\"},\"transcript_path\":\"$TX_FINDING\"}"
 
+# QUOTED command-substitution: bash executes the inner commit even inside double
+# quotes (shlex folds it into one token) — hybrid span scan must catch it
+run_case "quoted command-substitution echo (block)" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo \\\"\$(git commit -m subst)\\\"\"},\"transcript_path\":\"$TX_FINDING\"}"
+
+# assignment with quoted command-substitution
+run_case "assignment quoted command-substitution (block)" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"out=\\\"\$(git commit -m subst)\\\"\"},\"transcript_path\":\"$TX_FINDING\"}"
+
+# quoted command-substitution of a NON-commit must NOT match
+run_case "quoted command-substitution git status (silent)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo \\\"\$(git status)\\\"\"},\"transcript_path\":\"$TX_FINDING\"}"
+
 # space-less shell separator: `true;git commit` must tokenize git as its own token
 run_case "no-space semicolon separator before git commit (block)" \
   "block" \

--- a/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
+++ b/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
@@ -167,6 +167,11 @@ run_case "quoted command-substitution git status (silent)" \
   "silent" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo \\\"\$(git status)\\\"\"},\"transcript_path\":\"$TX_FINDING\"}"
 
+# nested command-substitution containing a commit (paren-depth scan)
+run_case "nested command-substitution git commit (block)" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo \\\"\$(echo \$(git commit -m nested))\\\"\"},\"transcript_path\":\"$TX_FINDING\"}"
+
 # space-less shell separator: `true;git commit` must tokenize git as its own token
 run_case "no-space semicolon separator before git commit (block)" \
   "block" \

--- a/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
+++ b/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
@@ -6,7 +6,7 @@
 #   block  → rc=2, stderr non-empty (BLOCKED: prefix)
 #   silent → rc=0, stderr empty
 #
-# Usage: bash tests/test_block_sciomc_finding_commit.sh
+# Usage: bash tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
 
 set +e
 
@@ -110,6 +110,52 @@ run_case "git commit -am + finding + no refetch (block)" \
   "block" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -am 'fix: stuff'\"},\"transcript_path\":\"$TX_FINDING\"}"
 
+# --allow-empty does NOT prevent staged content from being committed — must block
+run_case "git commit --allow-empty with staged content (block)" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit --allow-empty -m 'trigger ci'\"},\"transcript_path\":\"$TX_FINDING\"}"
+
+# --allow-empty-message likewise does not prevent staged content — must block
+run_case "git commit --allow-empty-message with staged content (block)" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit --allow-empty-message -m ''\"},\"transcript_path\":\"$TX_FINDING\"}"
+
+# `--amend` inside the -m message value is NOT the amend flag — must still block
+run_case "amend word inside message still blocks" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'docs: explain the --amend flag'\"},\"transcript_path\":\"$TX_FINDING\"}"
+
+# ratification token outside the -m value must NOT bypass
+run_case "user-approved token outside message (semicolon) still blocks" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'fix: x'; echo '[user-approved]'\"},\"transcript_path\":\"$TX_FINDING\"}"
+
+# subshell-grouped commit: shlex tokenizes binary as "(git" — must still block
+# (regression guard: the prior raw-regex caught this; token parser must too)
+run_case "subshell-grouped git commit (block)" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"(git commit -m 'fix: sub')\"},\"transcript_path\":\"$TX_FINDING\"}"
+
+# command-substitution wrapped commit: binary tokenizes as "\$(git" — must still block
+run_case "command-substitution git commit (block)" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo \$(git commit -m 'fix: subst')\"},\"transcript_path\":\"$TX_FINDING\"}"
+
+# space-less shell separator: `true;git commit` must tokenize git as its own token
+run_case "no-space semicolon separator before git commit (block)" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"true;git commit -m 'fix: chained'\"},\"transcript_path\":\"$TX_FINDING\"}"
+
+# space-less && separator
+run_case "no-space && separator before git commit (block)" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git status&&git commit -m 'fix: andand'\"},\"transcript_path\":\"$TX_FINDING\"}"
+
+# a literal ';' INSIDE the quoted message must NOT be treated as a separator
+run_case "semicolon inside message value still blocks (no token)" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'fix: a;b'\"},\"transcript_path\":\"$TX_FINDING\"}"
+
 # ---------------------------------------------------------------------------
 # SILENT cases — should not block
 # ---------------------------------------------------------------------------
@@ -122,15 +168,35 @@ run_case "git commit + no finding in transcript (silent)" \
   "silent" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'chore: bump'\"},\"transcript_path\":\"$TX_NORMAL\"}"
 
-run_case "git commit + finding + [user-approved] token (silent)" \
+run_case "git commit + finding + [user-approved] in message (silent)" \
   "silent" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'fix: change [user-approved]'\"},\"transcript_path\":\"$TX_FINDING\"}"
 
-run_case "git commit + finding + [ratified-by-user] token (silent)" \
+run_case "git commit + finding + [ratified-by-user] in message (silent)" \
   "silent" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'fix: change [ratified-by-user]'\"},\"transcript_path\":\"$TX_FINDING\"}"
 
-run_case "git commit --amend + finding (silent — non-content)" \
+run_case "git commit + finding + [user-ratified] in message (silent)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'fix: change [user-ratified]'\"},\"transcript_path\":\"$TX_FINDING\"}"
+
+# clustered short option `-am`: ratification token in message value must bypass
+run_case "git commit -am with [user-approved] in message (silent)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -am 'fix: change [user-approved]'\"},\"transcript_path\":\"$TX_FINDING\"}"
+
+# attached form `-am'msg'` tokenizes as -ammsg — token must still be extracted
+run_case "git commit -ammsg attached with [user-approved] (silent)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -am'done [user-approved]'\"},\"transcript_path\":\"$TX_FINDING\"}"
+
+# `-am` content commit WITHOUT a token must still block (escape-hatch is opt-in)
+run_case "git commit -am without token still blocks" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -am 'fix: real change'\"},\"transcript_path\":\"$TX_FINDING\"}"
+
+# legit --amend is still exempt (it fixes up a prior already-gated commit)
+run_case "git commit --amend + finding (silent — exempt)" \
   "silent" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit --amend --no-edit\"},\"transcript_path\":\"$TX_FINDING\"}"
 
@@ -142,9 +208,15 @@ run_case "git merge + finding (silent — non-content)" \
   "silent" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git merge origin/main\"},\"transcript_path\":\"$TX_FINDING\"}"
 
-run_case "git commit --allow-empty + finding (silent)" \
+# git commit-tree is plumbing (one token "commit-tree") — must NOT match
+run_case "git commit-tree plumbing (silent — not a git commit)" \
   "silent" \
-  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit --allow-empty -m 'trigger ci'\"},\"transcript_path\":\"$TX_FINDING\"}"
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit-tree abc123 -m 'tree'\"},\"transcript_path\":\"$TX_FINDING\"}"
+
+# echo containing "git commit" — no token-level git+commit adjacency
+run_case "echo git commit string not a commit (silent)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo 'run git commit later'\"},\"transcript_path\":\"$TX_FINDING\"}"
 
 run_case "non-Bash tool (silent)" \
   "silent" \
@@ -153,6 +225,11 @@ run_case "non-Bash tool (silent)" \
 run_case "git status (non-commit, silent)" \
   "silent" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git status\"},\"transcript_path\":\"$TX_FINDING\"}"
+
+# subshell-grouped non-commit must NOT over-match (prefix-strip is binary-only)
+run_case "subshell-grouped git status (silent — not a commit)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"(git status)\"},\"transcript_path\":\"$TX_FINDING\"}"
 
 run_case "env var bypass (silent)" \
   "silent" \

--- a/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
+++ b/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
@@ -254,6 +254,15 @@ run_case "git commit-tree plumbing (silent — not a git commit)" \
   "silent" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit-tree abc123 -m 'tree'\"},\"transcript_path\":\"$TX_FINDING\"}"
 
+# `git --help commit` / `git --version commit` are terminal — no commit runs
+run_case "git --help commit (silent — terminal option)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git --help commit\"},\"transcript_path\":\"$TX_FINDING\"}"
+
+run_case "git --version commit (silent — terminal option)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git --version commit\"},\"transcript_path\":\"$TX_FINDING\"}"
+
 # echo containing "git commit" — no token-level git+commit adjacency
 run_case "echo git commit string not a commit (silent)" \
   "silent" \


### PR DESCRIPTION
## 요약
sciomc 게이트(`block-sciomc-finding-commit`) Layer 1(명령 파싱) hardening — 형제 hook `block-commit-without-codex-review` 파서 포팅.

- `--allow-empty` / `--allow-empty-message` 면제 제거(staged content 동반 커밋 차단), `--amend`만 유지
- raw-string regex → shlex 토큰 분류
- ratification 토큰 검사를 `-m`/`--message` 값으로 한정
- `_tokenize`를 `shlex.shlex(punctuation_chars=True)`로 교체 → grouped/subshell/공백없는 separator 우회 클래스 일괄 차단

## 검증
- 셸 테스트 30/30, pytest 51, `check-plugin-manifests` OK
- shlex 13-case surface probe로 전제 검증
- codex review 4 rounds → 파서 회귀 3건 근본수정 + spec 동기화, 최종 clean

## 형제 결함 (별도 PR 예정)
`block-commit-without-codex-review/impl.py`가 동일 파서 갭 보유(포팅 원본) — 별도 이슈/PR로 처리 (5d cross-check).

Caller chain verified: internal hook functions (_commit_invocation_args/_message_values/_tokenize/_is_git_binary), invoked within impl.py main(); hook entrypoint runs via hooks/manifest.json
Pre-commit verified: bash test_block_sciomc_finding_commit.sh → 30/30; pytest 51 passed; check-plugin-manifests OK (worktree)

Closes #427
