### PR TITLE
feat(docs): autonomy vs convention template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 
 | File | Purpose |
 |------|---------|
-| [`ETHOS.md`](ETHOS.md) | Why praxis exists — values and principles that gate every skill, hook, and manifest |
+| [`ETHOS.md`](ETHOS.md) | Why praxis exists — values and principles that gate every skill, hook, and manifest; includes [Autonomy vs Convention](ETHOS.md#autonomy-vs-convention) boundary table |
 | [`DESIGN.md`](DESIGN.md) | How hooks are built — structural-tokenization, session_id keying, compound-bash-cascade, ordering, and add-a-new-hook flow |
 | [`ARCHITECTURE.md`](ARCHITECTURE.md) | Skill ↔ hook ↔ manifest dependency graph — provider routing, hook index, multi-platform packaging |
 | [`RUNTIME_CONSTRAINTS.md`](RUNTIME_CONSTRAINTS.md) | Fixed Claude Code runtime limits every skill must respect |

--- a/ETHOS.md
+++ b/ETHOS.md
@@ -10,6 +10,19 @@ graph (`ARCHITECTURE.md`) descend from these — they do not override them.
 - **SRP per skill**: each skill has one responsibility
 - **Discipline over convenience**: Iron Laws gate each phase, no skipping
 
+## Autonomy vs Convention
+
+| Domain | AI authority | Example |
+|---|---|---|
+| **Problem exploration** | Active judgment expected | Hypothesis choice, debug direction, falsification strategy, tool selection |
+| **Convention** | Follow as defined; no autonomous override | Issue creation path, branch/worktree workflow, external-mutation tool layer, code patterns |
+
+### Key principles
+1. **Convention authority is not delegated.** Rules represent trade-offs already made by the team; the agent does NOT re-evaluate them at runtime.
+2. **Scale is not an exemption.** "Too small to follow the workflow" == "too big to follow it" — both claim authority over the rule's scope.
+3. **Disclosure is not compliance.** Telling the user about a bypass before doing it does not authorize it. Explicit per-action approval required.
+4. **Hook blocks are signals, not failures.** Follow the suggested fallback, do not invent a workaround.
+
 ## Hook Ethos
 
 Hooks exist because text rules in CLAUDE.md or memory entries alone have

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -2,6 +2,8 @@
 
 Supported hosts: claude, codex
 
+Reference: [Autonomy vs Convention — ETHOS.md](../../../ETHOS.md#autonomy-vs-convention)
+
 `hooks/momentum-rule-retrieval-gate.sh` intercepts `Bash` tool calls at
 high-momentum action points and emits a **stderr advisory** (never a block
 in default mode) surfacing the relevant CLAUDE.md rules and memory entries

--- a/hooks/preflight-gate/cross-boundary-preflight/spec.md
+++ b/hooks/preflight-gate/cross-boundary-preflight/spec.md
@@ -2,6 +2,8 @@
 
 Supported hosts: all
 
+Reference: [Autonomy vs Convention — ETHOS.md](../../../ETHOS.md#autonomy-vs-convention)
+
 `hooks/cross-boundary-preflight.sh` intercepts every Bash tool call and
 fires on two cross-boundary patterns before the command executes.
 


### PR DESCRIPTION
## 요약
"Autonomy vs Convention" canonical 경계 섹션 추가 — 에이전트가 의사결정 시점에 권한 경계를 retrieve (이슈 #440).

- `ETHOS.md`: 신규 섹션(도메인 표 + 4 key principles: convention authority not delegated / scale is not an exemption / disclosure is not compliance / hook blocks are signals)
- `AGENTS.md`: doc-map 행에서 섹션 링크
- `momentum-rule-retrieval-gate` + `cross-boundary-preflight` spec.md: 섹션 Reference 링크(각 block이 경계를 reinforce하는 피드백 루프)

## 검증
- `check-plugin-manifests` OK, pytest 51
- codex review 2 rounds → Reference 링크 깊이 수정 후 clean

Caller chain verified: N/A — docs-only change (ETHOS.md, AGENTS.md, 2 spec.md)
Pre-commit verified: check-plugin-manifests OK; pytest 51 passed (worktree)

Closes #440
