### PR TITLE
fix(hooks): harden sciomc finding detection

### DIFF
--- a/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
+++ b/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
@@ -3,9 +3,9 @@
 without user-design consensus re-fetch.
 
 Backs the rule: user-stated design (PR body / issue body / direct utterance)
-is RATIFIED — AI analysis findings (sciomc Stage N, deep-dive, review finds,
-scientist agent output) are DRAFTS. Surface findings to the user, never
-auto-flip the design via direct commit.
+is RATIFIED — AI analysis findings (sciomc structured output, reviewer
+analysis) are DRAFTS. Surface findings to the user, never auto-flip the
+design via direct commit.
 
 Background:
   Four converging memory rules encode the same root cause family
@@ -32,10 +32,9 @@ Concrete retrospect pattern (praxis issue #374):
 Block conditions (ALL must hold):
   (a) Tool is Bash with a content `git commit` (not amend/merge/rebase/
       cherry-pick/revert)
-  (b) Recent transcript tail (last ~200 lines) contains a sciomc/finding
-      marker: "sibling-deviant", "Stage N finding/analysis/complete",
-      "sciomc", "[FINDING:", "[STAGE_COMPLETE:", "scientist-agent",
-      "deep-dive", "cross-validation", "의미 mismatch"
+  (b) Recent transcript tail (last ~200 lines) contains a sciomc structured
+      output marker: "[FINDING:", "[STAGE_COMPLETE:", "[CONFLICTS:",
+      "sibling-deviant", "의미 mismatch", "의미 충돌"
   (c) No `gh pr view ... --json body` OR `gh issue view ... --json body` OR
       explicit ratification token was emitted AFTER the most recent finding
       marker in the transcript tail
@@ -147,17 +146,22 @@ _RATIFICATION_TOKEN_RE = re.compile(
 )
 
 _FINDING_MARKERS = (
-    re.compile(r"\bsibling[- ]deviant\b", re.IGNORECASE),
-    re.compile(r"\bStage\s*\d\s*(?:분석|finding|analysis|결과|complete)", re.IGNORECASE),
-    re.compile(r"\bsciomc\b", re.IGNORECASE),
+    # Structured strong tokens — sciomc emits these in its output schema.
+    # `[FINDING:` / `[STAGE_COMPLETE:` / `[CONFLICTS:` are bracket-delimited
+    # tokens with a colon; only sciomc output contains them, so false-positive
+    # risk is minimal and no word-boundary guard is needed.
     re.compile(r"\[FINDING:"),
-    re.compile(r"\[STAGE_COMPLETE:"),
-    re.compile(r"\bscientist[- ]agent\b", re.IGNORECASE),
-    re.compile(r"\breview[- ]finds?\b", re.IGNORECASE),
-    re.compile(r"\bdeep[- ]dive\b", re.IGNORECASE),
-    re.compile(r"\bcross[- ]validation\b", re.IGNORECASE),
-    re.compile(r"\b의미\s*mismatch\b", re.IGNORECASE),
-    re.compile(r"\b의미\s*충돌\b"),
+    re.compile(r"\[STAGE_COMPLETE:\d"),
+    re.compile(r"\[CONFLICTS:"),
+    # Praxis-unique prose markers — these phrases appear only in sciomc
+    # sibling-convention analysis or its Korean equivalents; low FP risk.
+    re.compile(r"\bsibling[- ]deviant\b", re.IGNORECASE),
+    # Trailing \b omitted for Korean-particle attachment: Python's Unicode-aware \b
+    # does not place a boundary between a Hangul word char and a following Hangul
+    # particle (e.g. "의미 충돌이" has no \b after 충돌).  The leading \b still
+    # guards against substring matches like "무의미 충돌".
+    re.compile(r"\b의미\s*mismatch", re.IGNORECASE),
+    re.compile(r"\b의미\s*충돌"),
 )
 
 _CONSENSUS_REFETCH_MARKERS = (
@@ -165,7 +169,10 @@ _CONSENSUS_REFETCH_MARKERS = (
     re.compile(r"\bgh\s+issue\s+view\s+[^\n]*--json\s+[^\n]*body", re.IGNORECASE),
     re.compile(r"\bconsensus\s+re[- ]?fetch", re.IGNORECASE),
     re.compile(r"\bre[- ]?read\s+(?:PR|issue)\s+body", re.IGNORECASE),
-    re.compile(r"\buser-stated\s+design\b", re.IGNORECASE),
+    # "user-stated design" removed: it appears verbatim inside [CONFLICTS:] marker
+    # payloads (e.g. "[CONFLICTS: user-stated design vs sibling convention]"), which
+    # would self-satisfy the re-fetch check and silently pass the gate.  The
+    # remaining gh-view and consensus-refetch patterns cover all real re-fetch paths.
     re.compile(r"\[ratified-by-user\]", re.IGNORECASE),
     re.compile(r"\[user-approved\]", re.IGNORECASE),
 )
@@ -441,13 +448,14 @@ def _emit_block_message(matched_markers: list[str]) -> None:
     sys.stderr.write(
         "\n".join(
             [
-                "BLOCKED: `git commit` after sciomc/reviewer finding without user-design consensus re-fetch.",
+                "BLOCKED: `git commit` after sciomc finding without user-design consensus re-fetch.",
                 "",
                 f"Detected finding markers in recent transcript: {', '.join(matched_markers) or '(none)'}",
                 "",
                 "Rule: User-stated design (PR body / issue body) is RATIFIED.",
-                "AI analysis findings (sciomc Stage N, deep-dive, review finds, scientist agent)",
-                "are DRAFTS — surface to user, never auto-flip the design via direct commit.",
+                "AI analysis findings ([FINDING:...], [STAGE_COMPLETE:N], [CONFLICTS:...],",
+                "sibling-deviant, 의미 mismatch/충돌) are DRAFTS — surface to user, never",
+                "auto-flip the design via direct commit.",
                 "",
                 "Pattern (praxis issue #374):",
                 "  AI flips a user-stated literal/design based on a sciomc/reviewer finding,",

--- a/hooks/preflight-gate/block-sciomc-finding-commit/spec.md
+++ b/hooks/preflight-gate/block-sciomc-finding-commit/spec.md
@@ -40,10 +40,12 @@ All three conditions must hold for a block (exit 2):
    slip through behind them. Commits wrapped in a subshell/group (`(git …)`),
    command substitution (`$(git …)` / `` `git …` ``), or chained behind a
    space-less separator (`true;git commit …`) are detected too.
-2. The recent transcript tail (last ~200 lines) contains a finding marker:
-   `sibling-deviant`, `Stage N 분석/finding/analysis/결과/complete`, `sciomc`,
-   `[FINDING:`, `[STAGE_COMPLETE:`, `scientist-agent`, `review finds`,
-   `deep-dive`, `cross-validation`, `의미 mismatch`, `의미 충돌`.
+2. The recent transcript tail (last ~200 lines) contains a sciomc structured
+   output marker: `[FINDING:`, `[STAGE_COMPLETE:<digit>]`, `[CONFLICTS:`,
+   `sibling-deviant`, `의미 mismatch`, `의미 충돌`. Loose prose terms
+   (`sciomc`, `scientist-agent`, `deep-dive`, `cross-validation`, bare
+   `Stage N analysis`) are **not** markers — they generated false-positives
+   on normal workflow discussion.
 3. No consensus re-fetch appears AFTER the most recent finding marker —
    re-fetch is `gh pr view ... --json ... body`, `gh issue view ... --json
    ... body`, `consensus re-fetch`, `re-read PR/issue body`, `user-stated
@@ -52,12 +54,18 @@ All three conditions must hold for a block (exit 2):
 | Situation | Action |
 |-----------|--------|
 | `git commit -m "..."` after a `[FINDING:` line, no re-fetch | **BLOCKED** (exit 2) |
-| `git commit` after sciomc Stage 5, then `gh pr view N --json body` | **PASS** (re-fetch after finding) |
+| `git commit -m "..."` after a `[CONFLICTS: ...]` line, no re-fetch | **BLOCKED** (exit 2) |
+| `git commit -m "..."` after a `[STAGE_COMPLETE:2]` line, no re-fetch | **BLOCKED** (exit 2) |
+| `git commit -m "..."` after `sibling-deviant` prose, no re-fetch | **BLOCKED** (exit 2) |
+| `git commit -m "..."` after `의미 mismatch` / `의미 충돌`, no re-fetch | **BLOCKED** (exit 2) |
+| `git commit` after a marker, then `gh pr view N --json body` | **PASS** (re-fetch after finding) |
 | `git commit --amend` after a finding | **PASS** (amend exempt) |
 | `git commit --allow-empty -m x` (staged content) after a finding | **BLOCKED** (allow-empty not exempt) |
 | `git revert <sha>` after a finding | **PASS** (non-content op) |
 | `git commit -m "fix [user-approved]"` after a finding | **PASS** (ratification token) |
 | `git commit` with no finding marker in transcript | **PASS** (no finding context) |
+| `git commit` after bare `sciomc` / `deep-dive` / `cross-validation` prose | **PASS** (not a marker — FP prevention) |
+| `git commit` after bare `scientist-agent` / `Stage N analysis` prose | **PASS** (not a marker — FP prevention) |
 
 ### Limitations (threat model: accidental, not adversarial)
 
@@ -86,13 +94,23 @@ scope.
 ### Tests
 
 ```bash
-bash tests/test_block_sciomc_finding_commit.sh
+bash tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
 ```
 
-Covers 40 cases: block paths (finding + no re-fetch, `--allow-empty*` with
-staged content, grouped / command-substitution / nested / separator-chained
-commits, `-m --amend` value), silent paths (each escape hatch, amend / revert
-exemption, `commit-tree` plumbing, quoted-literal `git commit`, single-quoted
-substitution, `git --help/--version commit` terminal options, re-fetch after
-finding, no finding context), non-Bash tool passthrough, missing
-`transcript_path`, and malformed JSON fail-open.
+Covers 53 cases:
+- **Block paths** (22): finding + no re-fetch, `--allow-empty*` with staged
+  content, grouped / command-substitution / nested / separator-chained commits,
+  `-m --amend` value; new in #429: `[CONFLICTS:]`, `[STAGE_COMPLETE:2]`,
+  `sibling-deviant`, `의미 mismatch`, `의미 충돌` markers each individually;
+  also `의미 충돌이` / `의미 mismatch가` (Hangul particle attachment forms),
+  and `[CONFLICTS: user-stated design ...]` (marker payload must not
+  self-satisfy the consensus re-fetch check).
+- **Silent paths** (24): each escape hatch, amend / revert exemption,
+  `commit-tree` plumbing, quoted-literal `git commit`, single-quoted
+  substitution, `git --help/--version commit` terminal options, re-fetch after
+  finding, no finding context.
+- **FP-regression paths** (6, new in #429): bare `sciomc`, `scientist-agent`,
+  `deep-dive`, `cross-validation`, `Stage N analysis` prose, and
+  `[STAGE_COMPLETE:` without digit — none of these should block.
+- **Non-Bash tool passthrough**, missing `transcript_path`, malformed JSON
+  fail-open (1 each).

--- a/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
+++ b/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
@@ -26,26 +26,88 @@ FAILED_NAMES=()
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-# Fixture: transcript with sciomc finding markers
+# Fixture: transcript with sciomc structured finding markers
 TX_FINDING="$TMPDIR/tx-finding.jsonl"
 cat > "$TX_FINDING" <<'EOF'
-{"type":"assistant","message":"Running sciomc Stage 5 analysis"}
+{"type":"assistant","message":"Running sciomc analysis"}
 {"type":"tool_use","content":"[FINDING:F1] sibling-deviant pattern detected"}
+{"type":"assistant","message":"about to commit"}
+EOF
+
+# Fixture: transcript with [CONFLICTS:] marker
+TX_CONFLICTS="$TMPDIR/tx-conflicts.jsonl"
+cat > "$TX_CONFLICTS" <<'EOF'
+{"type":"assistant","message":"sciomc output:"}
+{"type":"tool_use","content":"[CONFLICTS: design choice in PR body vs sibling convention]"}
+{"type":"assistant","message":"about to commit"}
+EOF
+
+# Fixture: [CONFLICTS:] payload that includes "user-stated design" text — must still block
+TX_CONFLICTS_USD="$TMPDIR/tx-conflicts-usd.jsonl"
+cat > "$TX_CONFLICTS_USD" <<'EOF'
+{"type":"assistant","message":"sciomc output:"}
+{"type":"tool_use","content":"[CONFLICTS: user-stated design vs sibling convention]"}
+{"type":"assistant","message":"about to commit"}
+EOF
+
+# Fixture: transcript with [STAGE_COMPLETE:N] marker
+TX_STAGE_COMPLETE="$TMPDIR/tx-stage-complete.jsonl"
+cat > "$TX_STAGE_COMPLETE" <<'EOF'
+{"type":"assistant","message":"sciomc output:"}
+{"type":"tool_use","content":"[STAGE_COMPLETE:2] stage 2 done"}
+{"type":"assistant","message":"about to commit"}
+EOF
+
+# Fixture: transcript with 의미 mismatch marker
+TX_UIMI_MISMATCH="$TMPDIR/tx-uimi-mismatch.jsonl"
+cat > "$TX_UIMI_MISMATCH" <<'EOF'
+{"type":"assistant","message":"의미 mismatch detected in sibling convention analysis"}
+{"type":"assistant","message":"about to commit"}
+EOF
+
+# Fixture: transcript with 의미 충돌 marker
+TX_UIMI_CONFLICT="$TMPDIR/tx-uimi-conflict.jsonl"
+cat > "$TX_UIMI_CONFLICT" <<'EOF'
+{"type":"assistant","message":"의미 충돌: 두 sibling 간 설계 불일치"}
+{"type":"assistant","message":"about to commit"}
+EOF
+
+# Fixture: transcript with 의미 충돌 + Hangul particle attachment (조사 결합)
+TX_UIMI_CONFLICT_PARTICLE="$TMPDIR/tx-uimi-conflict-particle.jsonl"
+cat > "$TX_UIMI_CONFLICT_PARTICLE" <<'EOF'
+{"type":"assistant","message":"의미 충돌이 감지됩니다 — sibling 간 설계 충돌"}
+{"type":"assistant","message":"about to commit"}
+EOF
+
+# Fixture: transcript with 의미 mismatch + Hangul particle attachment (조사 결합)
+TX_UIMI_MISMATCH_PARTICLE="$TMPDIR/tx-uimi-mismatch-particle.jsonl"
+cat > "$TX_UIMI_MISMATCH_PARTICLE" <<'EOF'
+{"type":"assistant","message":"의미 mismatch가 있습니다 — 정렬 필요"}
 {"type":"assistant","message":"about to commit"}
 EOF
 
 # Fixture: transcript with sciomc finding AND consensus re-fetch after
 TX_FINDING_REFETCH="$TMPDIR/tx-finding-refetch.jsonl"
 cat > "$TX_FINDING_REFETCH" <<'EOF'
-{"type":"assistant","message":"sciomc Stage 5 sibling-deviant"}
+{"type":"assistant","message":"sibling-deviant pattern detected"}
 {"type":"tool_use","content":"gh pr view 8299 --json body --jq .body"}
 {"type":"assistant","message":"compared with user design"}
 EOF
 
-# Fixture: transcript with no finding markers
+# Fixture: transcript with no finding markers (prose-only, no structured tokens)
 TX_NORMAL="$TMPDIR/tx-normal.jsonl"
 cat > "$TX_NORMAL" <<'EOF'
 {"type":"assistant","message":"normal fix work"}
+EOF
+
+# Fixture: transcript with removed-prose-only markers (FP regression)
+TX_FP_PROSE="$TMPDIR/tx-fp-prose.jsonl"
+cat > "$TX_FP_PROSE" <<'EOF'
+{"type":"assistant","message":"deep-dive 하자"}
+{"type":"assistant","message":"cross-validation 결과를 확인했다"}
+{"type":"assistant","message":"sciomc 라는 도구가 있음"}
+{"type":"assistant","message":"scientist-agent 가 실행됨"}
+{"type":"assistant","message":"Stage 2 analysis 시작"}
 EOF
 
 # run_case name expectation payload_json [env_vars...]
@@ -197,6 +259,40 @@ run_case "semicolon inside message value still blocks (no token)" \
   "block" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'fix: a;b'\"},\"transcript_path\":\"$TX_FINDING\"}"
 
+# NEW: [CONFLICTS:] marker (Layer 2 addition — sciomc emits this for design conflicts)
+run_case "[CONFLICTS:] marker blocks commit" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'fix: use sibling pattern'\"},\"transcript_path\":\"$TX_CONFLICTS\"}"
+
+# [CONFLICTS:] payload containing "user-stated design" must not self-satisfy re-fetch check
+run_case "[CONFLICTS: user-stated design] does not self-satisfy re-fetch (block)" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'fix: apply finding'\"},\"transcript_path\":\"$TX_CONFLICTS_USD\"}"
+
+# NEW: [STAGE_COMPLETE:N] marker with digit
+run_case "[STAGE_COMPLETE:2] marker blocks commit" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'fix: stage 2 result'\"},\"transcript_path\":\"$TX_STAGE_COMPLETE\"}"
+
+# NEW: 의미 mismatch Korean praxis-unique marker
+run_case "의미 mismatch marker blocks commit" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'fix: align'\"},\"transcript_path\":\"$TX_UIMI_MISMATCH\"}"
+
+# NEW: 의미 충돌 Korean praxis-unique marker
+run_case "의미 충돌 marker blocks commit" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'fix: resolve'\"},\"transcript_path\":\"$TX_UIMI_CONFLICT\"}"
+
+# Korean particle attachment: 의미 충돌이 / 의미 mismatch가 must also block
+run_case "의미 충돌이 (particle attachment) blocks commit" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'fix: resolve'\"},\"transcript_path\":\"$TX_UIMI_CONFLICT_PARTICLE\"}"
+
+run_case "의미 mismatch가 (particle attachment) blocks commit" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'fix: align'\"},\"transcript_path\":\"$TX_UIMI_MISMATCH_PARTICLE\"}"
+
 # ---------------------------------------------------------------------------
 # SILENT cases — should not block
 # ---------------------------------------------------------------------------
@@ -293,6 +389,46 @@ run_case "missing transcript_path (silent — cannot enforce)" \
 run_case "malformed JSON (silent — fail-open)" \
   "silent" \
   "not-json"
+
+# ---------------------------------------------------------------------------
+# FP-regression cases — removed loose-prose markers must NOT block
+# ---------------------------------------------------------------------------
+
+# bare 'sciomc' prose mention — no longer a marker (was FP source)
+run_case "bare sciomc prose mention (silent — FP regression)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'chore: doc'\"},\"transcript_path\":\"$TX_FP_PROSE\"}"
+
+# 'scientist-agent' prose — no longer a marker
+run_case "scientist-agent prose (silent — FP regression)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'chore: doc'\"},\"transcript_path\":\"$TX_FP_PROSE\"}"
+
+# 'deep-dive' prose — no longer a marker
+run_case "deep-dive prose (silent — FP regression)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'chore: doc'\"},\"transcript_path\":\"$TX_FP_PROSE\"}"
+
+# 'cross-validation' prose — no longer a marker
+run_case "cross-validation prose (silent — FP regression)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'chore: doc'\"},\"transcript_path\":\"$TX_FP_PROSE\"}"
+
+# loose 'Stage 2 analysis' prose — no longer a marker
+run_case "loose Stage N analysis prose (silent — FP regression)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'chore: doc'\"},\"transcript_path\":\"$TX_FP_PROSE\"}"
+
+# [STAGE_COMPLETE: without digit (malformed/bare token) must NOT match — only
+# [STAGE_COMPLETE:<digit> is a valid sciomc output token
+TX_STAGE_COMPLETE_NO_DIGIT="$TMPDIR/tx-stage-complete-nodigit.jsonl"
+cat > "$TX_STAGE_COMPLETE_NO_DIGIT" <<'EOF'
+{"type":"assistant","message":"[STAGE_COMPLETE: some text without digit after colon]"}
+{"type":"assistant","message":"about to commit"}
+EOF
+run_case "[STAGE_COMPLETE: without digit does not block (silent)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'chore: doc'\"},\"transcript_path\":\"$TX_STAGE_COMPLETE_NO_DIGIT\"}"
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## 요약
`block-sciomc-finding-commit` 의 Layer 2(finding 탐지) 마커 세트를 정밀화 — 느슨한 prose 마커를 제거해 false-positive 를 줄이고 구조화 토큰 + praxis 고유 마커로 재구성 (이슈 #429).

- **구조화 강 토큰**: `[FINDING:`, `[STAGE_COMPLETE:<digit>`, `[CONFLICTS:`(신규)
- **praxis 고유 유지**: sibling-deviant / 의미 mismatch / 의미 충돌
- **제거(FP 소스)**: bare sciomc, scientist-agent, deep-dive, cross-validation, 느슨한 Stage-N regex
- Layer 2(탐지)만 — Layer 1(명령 파싱)은 #427 에서 처리됨

## codex 리뷰 (3 라운드)
- R1: 한글 조사 경계 버그(`의미 충돌이` 미매칭) → trailing `\b` 제거
- R2: `[CONFLICTS: user-stated design]` 마커가 consensus re-fetch 패턴에 self-match 하여 gate 우회 → 해당 패턴 제거
- R3: clean

## 검증
- shell 53/53 passed, `plugin-manifest check OK`, pytest 58 passed

Caller chain verified: 기존 hook 수정 — 호출 경로(manifest 등록 → 빌드 생성 shim/hooks.json) 불변, 마커 매칭 로직만 변경
Pre-commit verified: 53 shell cases + plugin-manifest check OK + pytest 58 passed (worktree)

Closes #429
