### PR TITLE
feat(cli): add bypass-review telemetry CLI

### DIFF
--- a/docs/bypass-telemetry.md
+++ b/docs/bypass-telemetry.md
@@ -58,9 +58,76 @@ A var is only recorded if its value is truthy (non-empty and not `"0"`).
 - `tool_response` content (stdout/stderr) is never stored — only the
   derived `"ok"` / `"error"` status.
 
-## Deferred phases
+## Phase 2 — Review CLI (`bypass-review`)
 
-- **Phase 2** — `praxis bypass-telemetry review` CLI to aggregate the local
-  JSONL log and surface top bypass patterns by session/var.
+Implemented in issue #456.  The `bypass-review` binary reads the local JSONL
+files and aggregates them for human review.
+
+### Installation
+
+```bash
+./scripts/install.sh
+```
+
+This symlinks `~/.local/bin/bypass-review` → `skills/bypass-review/bypass-review`.
+
+### Usage
+
+```
+bypass-review [OPTIONS]
+
+Options:
+  -d, --days N      Query the last N days (default: 7)
+  --dir PATH        Override the telemetry directory
+                    (default: ~/.praxis/telemetry)
+  --errors-only     Show only events where tool_result_status == "error"
+  -h, --help        Show help and exit
+```
+
+### Output
+
+The report has four sections:
+
+1. **Summary** — total events, date window, error count.
+2. **Top bypass vars** — frequency table; vars with error events are flagged
+   `⚠ bad-bypass candidate` (bypass followed by a tool failure).
+3. **Bypass by tool** — group by `tool` field.
+4. **Error events** — per-event detail for `tool_result_status == "error"`.
+
+Use `--errors-only` to print just the error-event section.
+
+### Privacy
+
+The CLI is read-only and only aggregates what is already in the JSONL.
+Bypass var **values** were never stored by the hook; they do not appear in
+any output.  `tool_input` is printed as-is (already truncated and redacted
+by the writer at ≤200 chars).
+
+### Example output
+
+```
+────────────────────────────────────────────────────────────
+bypass-review: Bypass Telemetry Report
+────────────────────────────────────────────────────────────
+  Period : 2026-05-21 → 2026-05-27 (last 7 days)
+  Source : ~/.praxis/telemetry
+  Total events : 6
+  Error events : 1
+
+────────────────────────────────────────────────────────────
+Top Bypass Vars (most bypassed rules)
+────────────────────────────────────────────────────────────
+  Var name                                            Count  Errors  Note
+  ──────────────────────────────────────────────────  ─────  ──────  ──────────────────────
+  CLAUDE_HOOK_BYPASS_SCIOMC_GATE                          4       1  ⚠ bad-bypass candidate
+  CLAUDE_HOOK_BYPASS_DUP_GATE                             1       0
+  PRAXIS_MOMENTUM_BYPASS                                  1       0
+  CLAUDE_HOOK_BYPASS_CODEX_REVIEW_GATE                    1       0
+
+  Note: high count = rule may be too strict; Errors = bypass followed by tool failure.
+```
+
+## Deferred
+
 - **Phase 3** — Optional HTTP forwarding to a central collector for
   cross-session analytics.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -51,6 +51,7 @@ CLI_SCRIPTS=(
   "skills/cmux-session-manager/cmux-session-status"
   "skills/cmux-session-manager/cmux-session-cleanup"
   "skills/cmux-browser/cmux-browser"
+  "skills/bypass-review/bypass-review"
 )
 
 mkdir -p "$BIN_DIR"

--- a/skills/bypass-review/bypass-review
+++ b/skills/bypass-review/bypass-review
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""bypass-review — Review CLI for praxis bypass-telemetry events.
+
+Reads the local JSONL logs written by the bypass-telemetry PostToolUse hook
+(~/.praxis/telemetry/bypass-events-YYYY-MM-DD.jsonl) and aggregates them for
+human review.
+
+Phase 2 of issue #456 (Phase 1 = hook that writes the log; Phase 3 = HTTP
+forwarding, deferred).
+
+Usage:
+  bypass-review [OPTIONS]
+
+Options:
+  -d, --days N           Query the last N days (default: 7)
+  --dir PATH             Override the telemetry directory
+                         (default: ~/.praxis/telemetry)
+  --errors-only          Show only events where tool_result_status = "error"
+  -h, --help             Show this message and exit
+
+Output sections:
+  1. Summary — total events + date window
+  2. Top bypass vars — frequency table (which rules are bypassed most)
+  3. Bypass by hook/tool — group by tool field
+  4. Error events — events where tool_result_status == "error"
+
+Privacy contract (read-only, never re-derives omitted fields):
+  - bypass var VALUES are not in the JSONL; this CLI never prints them
+  - tool_input is already truncated/redacted in the log; printed as-is
+  - tool_response content is not in the log; this CLI never prints it
+
+Exit codes:
+  0   success (even if zero events found)
+  1   argument error
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# JSONL field names — cited verbatim from
+# hooks/postuse-correction/bypass-telemetry/impl.py lines 250-257
+# ---------------------------------------------------------------------------
+FIELD_TIMESTAMP = "timestamp"
+FIELD_SESSION_ID = "session_id"
+FIELD_TOOL = "tool"
+FIELD_BYPASS_ENV_VARS = "bypass_env_vars"
+FIELD_TOOL_INPUT = "tool_input"
+FIELD_TOOL_RESULT_STATUS = "tool_result_status"
+
+STATUS_ERROR = "error"
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="bypass-review",
+        description=(
+            "Aggregate praxis bypass-telemetry events for human review.\n"
+            "Reads ~/.praxis/telemetry/bypass-events-YYYY-MM-DD.jsonl files."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "-d", "--days",
+        type=int,
+        default=7,
+        metavar="N",
+        help="Query the last N days (default: 7)",
+    )
+    parser.add_argument(
+        "--dir",
+        dest="telemetry_dir",
+        default=None,
+        metavar="PATH",
+        help="Override telemetry directory (default: ~/.praxis/telemetry)",
+    )
+    parser.add_argument(
+        "--errors-only",
+        action="store_true",
+        help="Show only events where tool_result_status == 'error'",
+    )
+    return parser.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# JSONL loading
+# ---------------------------------------------------------------------------
+
+def date_range(days: int) -> list[str]:
+    """Return a list of UTC date strings YYYY-MM-DD for the last N days."""
+    today = datetime.now(tz=timezone.utc).date()
+    return [(today - timedelta(days=i)).strftime("%Y-%m-%d") for i in range(days)]
+
+
+def load_events(telemetry_dir: Path, days: int) -> list[dict]:
+    """Load all valid JSONL records from the last N days of telemetry files."""
+    events: list[dict] = []
+    for date_str in date_range(days):
+        path = telemetry_dir / f"bypass-events-{date_str}.jsonl"
+        if not path.is_file():
+            continue
+        try:
+            with path.open(encoding="utf-8") as fh:
+                for lineno, raw_line in enumerate(fh, 1):
+                    line = raw_line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        # Skip malformed lines — same fail-open philosophy as the hook
+                        continue
+                    if not isinstance(record, dict):
+                        continue
+                    events.append(record)
+        except OSError:
+            # Unreadable file — skip silently (consistent with hook fail-open)
+            continue
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+def aggregate(events: list[dict]) -> dict:
+    """Return aggregated statistics over the event list."""
+    bypass_var_counts: Counter[str] = Counter()
+    tool_counts: Counter[str] = Counter()
+    error_events: list[dict] = []
+    # Per-var error count for the "signal too strict?" callout
+    bypass_var_error_counts: Counter[str] = Counter()
+
+    for ev in events:
+        bypass_vars: list[str] = ev.get(FIELD_BYPASS_ENV_VARS) or []
+        tool: str = ev.get(FIELD_TOOL) or "(unknown)"
+        status: str = ev.get(FIELD_TOOL_RESULT_STATUS) or "ok"
+
+        for var in bypass_vars:
+            bypass_var_counts[var] += 1
+            if status == STATUS_ERROR:
+                bypass_var_error_counts[var] += 1
+
+        tool_counts[tool] += 1
+
+        if status == STATUS_ERROR:
+            error_events.append(ev)
+
+    return {
+        "total": len(events),
+        "bypass_var_counts": bypass_var_counts,
+        "bypass_var_error_counts": bypass_var_error_counts,
+        "tool_counts": tool_counts,
+        "error_events": error_events,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+_DIVIDER = "─" * 60
+
+
+def _render_header(title: str) -> str:
+    return f"\n{_DIVIDER}\n{title}\n{_DIVIDER}"
+
+
+def render_report(
+    events: list[dict],
+    agg: dict,
+    days: int,
+    telemetry_dir: Path,
+    errors_only: bool,
+) -> str:
+    lines: list[str] = []
+
+    today = datetime.now(tz=timezone.utc).date()
+    since = today - timedelta(days=days - 1)
+
+    lines.append(_render_header("bypass-review: Bypass Telemetry Report"))
+    lines.append(f"  Period : {since} → {today} (last {days} day{'s' if days != 1 else ''})")
+    lines.append(f"  Source : {telemetry_dir}")
+    lines.append(f"  Total events : {agg['total']}")
+    lines.append(f"  Error events : {len(agg['error_events'])}")
+
+    if agg["total"] == 0:
+        lines.append("\n  No bypass events found in the selected period.")
+        return "\n".join(lines)
+
+    if errors_only:
+        _render_error_events(lines, agg["error_events"])
+        return "\n".join(lines)
+
+    # ── Section 2: Top bypass vars ──
+    lines.append(_render_header("Top Bypass Vars (most bypassed rules)"))
+    if agg["bypass_var_counts"]:
+        lines.append(f"  {'Var name':<50}  {'Count':>5}  {'Errors':>6}  Note")
+        lines.append(f"  {'─' * 50}  {'─' * 5}  {'─' * 6}  {'─' * 20}")
+        for var, count in agg["bypass_var_counts"].most_common():
+            err_count = agg["bypass_var_error_counts"].get(var, 0)
+            note = "⚠ bad-bypass candidate" if err_count > 0 else ""
+            lines.append(f"  {var:<50}  {count:>5}  {err_count:>6}  {note}")
+        lines.append("")
+        lines.append(
+            "  Note: high count = rule may be too strict; "
+            "Errors = bypass followed by tool failure (bad-bypass candidate)."
+        )
+    else:
+        lines.append("  (no bypass var data)")
+
+    # ── Section 3: By tool ──
+    lines.append(_render_header("Bypass Events by Tool"))
+    if agg["tool_counts"]:
+        lines.append(f"  {'Tool':<30}  {'Count':>5}")
+        lines.append(f"  {'─' * 30}  {'─' * 5}")
+        for tool, count in agg["tool_counts"].most_common():
+            lines.append(f"  {tool:<30}  {count:>5}")
+    else:
+        lines.append("  (no tool data)")
+
+    # ── Section 4: Error events detail ──
+    _render_error_events(lines, agg["error_events"])
+
+    return "\n".join(lines)
+
+
+def _render_error_events(lines: list[str], error_events: list[dict]) -> None:
+    lines.append(_render_header(
+        f"Error Events (tool_result_status == 'error')  [{len(error_events)} total]"
+    ))
+    if not error_events:
+        lines.append("  (none — all bypasses succeeded)")
+        return
+
+    lines.append(
+        "  These events had an active bypass AND the tool call failed.\n"
+        "  They are the strongest 'bad-bypass' signal: the bypass did not\n"
+        "  prevent a failure — it may have caused or obscured one."
+    )
+    for i, ev in enumerate(error_events, 1):
+        ts = ev.get(FIELD_TIMESTAMP, "(no timestamp)")
+        session = ev.get(FIELD_SESSION_ID, "") or "(no session)"
+        tool = ev.get(FIELD_TOOL, "(unknown)")
+        bypass_vars = ev.get(FIELD_BYPASS_ENV_VARS) or []
+        tool_input = ev.get(FIELD_TOOL_INPUT, "") or ""
+        lines.append(f"\n  [{i}] {ts}")
+        lines.append(f"      session : {session}")
+        lines.append(f"      tool    : {tool}")
+        lines.append(f"      bypass  : {', '.join(bypass_vars)}")
+        if tool_input:
+            lines.append(f"      input   : {tool_input}")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.days < 1:
+        print("bypass-review: --days must be >= 1", file=sys.stderr)
+        return 1
+
+    if args.telemetry_dir is not None:
+        telemetry_dir = Path(args.telemetry_dir)
+    else:
+        telemetry_dir = Path.home() / ".praxis" / "telemetry"
+
+    events = load_events(telemetry_dir, args.days)
+    agg = aggregate(events)
+    report = render_report(events, agg, args.days, telemetry_dir, args.errors_only)
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_bypass_review.sh
+++ b/tests/test_bypass_review.sh
@@ -1,0 +1,445 @@
+#!/bin/bash
+# tests/test_bypass_review.sh — bypass-review CLI coverage (Phase 2, issue #456)
+#
+# Uses SYNTHETIC JSONL fixtures only — never reads ~/.praxis real telemetry.
+# The fixture field names are copied verbatim from the writer:
+#   hooks/postuse-correction/bypass-telemetry/impl.py lines 250-257
+#
+# JSONL fields used in fixtures (verbatim from writer record dict):
+#   timestamp         (str) UTC ISO-8601
+#   session_id        (str)
+#   tool              (str)
+#   bypass_env_vars   (list[str]) — var NAMES only, values never stored
+#   tool_input        (str) ≤200 chars, values redacted
+#   tool_result_status (str) "ok" | "error"
+#
+# Tested surface variants:
+#   1. Grouping by bypass var name — frequency counts are correct
+#   2. Error event highlighting — tool_result_status=="error" events surfaced
+#   3. --errors-only flag — output restricted to error events
+#   4. Zero events — handles empty telemetry dir gracefully
+#   5. Multi-day span — events from multiple files aggregated correctly
+#   6. --days flag — events outside the window are excluded
+#   7. --dir flag — reads from override directory (not ~/.praxis)
+#   8. Malformed JSONL lines — skipped without crashing
+#   9. Missing field graceful — record with absent field doesn't crash
+#  10. Privacy: bypass var VALUES do not appear in output
+#  11. Exit code 0 on success, 1 on bad --days value
+#
+# Run:  bash tests/test_bypass_review.sh
+# Exit: 0 on success, 1 on at least one failure
+
+set +e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLI="$REPO_ROOT/skills/bypass-review/bypass-review"
+
+if [ ! -f "$CLI" ]; then
+  echo "FAIL: CLI not found: $CLI" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "SKIP: python3 not available" >&2
+  exit 0
+fi
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+assert_pass() {
+  local name="$1"
+  PASS=$((PASS + 1))
+  printf '  OK  %s\n' "$name"
+}
+
+assert_fail() {
+  local name="$1" msg="$2"
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("$name")
+  printf 'FAIL  [%s] %s\n' "$name" "$msg"
+}
+
+# make_event <bypass_vars_json_array> <status> [tool] [session]
+# Emits a single JSON line using TODAY's UTC date in the timestamp.
+make_event() {
+  local bypass_vars_json="$1"
+  local status="$2"
+  local tool="${3:-Bash}"
+  local session="${4:-test-session-42}"
+  python3 -c "
+import json, sys
+from datetime import datetime, timezone
+bypass_vars = json.loads(sys.argv[1])
+status, tool, session = sys.argv[2], sys.argv[3], sys.argv[4]
+print(json.dumps({
+    'timestamp': datetime.now(tz=timezone.utc).isoformat(),
+    'session_id': session,
+    'tool': tool,
+    'bypass_env_vars': bypass_vars,
+    'tool_input': 'CLAUDE_HOOK_BYPASS_X=<redacted> git commit',
+    'tool_result_status': status,
+}))" "$bypass_vars_json" "$status" "$tool" "$session"
+}
+
+# write_fixture_file <path> <list of json lines>
+write_fixture() {
+  local path="$1"; shift
+  for line in "$@"; do
+    echo "$line" >> "$path"
+  done
+}
+
+# today and yesterday for multi-day tests
+TODAY=$(python3 -c "from datetime import datetime, timezone; print(datetime.now(tz=timezone.utc).strftime('%Y-%m-%d'))")
+YESTERDAY=$(python3 -c "from datetime import datetime, timedelta, timezone; print((datetime.now(tz=timezone.utc) - timedelta(days=1)).strftime('%Y-%m-%d'))")
+
+# ---------------------------------------------------------------------------
+# Test 1: Grouping by bypass var — frequency counts
+# ---------------------------------------------------------------------------
+echo "=== bypass-review: grouping by bypass var ==="
+
+DIR1="$TMP_DIR/t1"
+mkdir -p "$DIR1"
+ev_sciomc=$(make_event '["CLAUDE_HOOK_BYPASS_SCIOMC_GATE"]' "ok")
+ev_sciomc2=$(make_event '["CLAUDE_HOOK_BYPASS_SCIOMC_GATE"]' "ok")
+ev_dup=$(make_event '["CLAUDE_HOOK_BYPASS_DUP_GATE"]' "ok")
+write_fixture "$DIR1/bypass-events-$TODAY.jsonl" "$ev_sciomc" "$ev_sciomc2" "$ev_dup"
+
+out1=$(python3 "$CLI" --dir "$DIR1" --days 7 2>&1)
+
+# CLAUDE_HOOK_BYPASS_SCIOMC_GATE should appear with count 2
+if echo "$out1" | grep -q "CLAUDE_HOOK_BYPASS_SCIOMC_GATE"; then
+  assert_pass "SCIOMC_GATE var name appears in output"
+else
+  assert_fail "SCIOMC_GATE var name appears in output" "var name missing from report"
+fi
+
+# DUP_GATE should appear with count 1
+if echo "$out1" | grep -q "CLAUDE_HOOK_BYPASS_DUP_GATE"; then
+  assert_pass "DUP_GATE var name appears in output"
+else
+  assert_fail "DUP_GATE var name appears in output" "var name missing from report"
+fi
+
+# Total events should be 3
+if echo "$out1" | grep -q "Total events.*3\|3.*total"; then
+  assert_pass "total events = 3"
+else
+  assert_fail "total events = 3" "could not find '3' in total events line; output: $out1"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: Error event highlighting
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== bypass-review: error event highlighting ==="
+
+DIR2="$TMP_DIR/t2"
+mkdir -p "$DIR2"
+ev_ok=$(make_event '["CLAUDE_HOOK_BYPASS_SCIOMC_GATE"]' "ok")
+ev_err=$(make_event '["PRAXIS_MOMENTUM_BYPASS"]' "error")
+write_fixture "$DIR2/bypass-events-$TODAY.jsonl" "$ev_ok" "$ev_err"
+
+out2=$(python3 "$CLI" --dir "$DIR2" --days 7 2>&1)
+
+# Error section should mention the error event
+if echo "$out2" | grep -q "error\|Error"; then
+  assert_pass "error events section present"
+else
+  assert_fail "error events section present" "no error mention in output"
+fi
+
+# PRAXIS_MOMENTUM_BYPASS should appear in error section
+if echo "$out2" | grep -q "PRAXIS_MOMENTUM_BYPASS"; then
+  assert_pass "error event bypass var name in output"
+else
+  assert_fail "error event bypass var name in output" "PRAXIS_MOMENTUM_BYPASS missing"
+fi
+
+# Error count should be 1
+if echo "$out2" | grep -q "Error events.*1\|1.*error"; then
+  assert_pass "error event count = 1"
+else
+  assert_fail "error event count = 1" "could not confirm error count; output: $out2"
+fi
+
+# "bad-bypass candidate" marker should appear for PRAXIS_MOMENTUM_BYPASS (it has errors)
+if echo "$out2" | grep -q "bad-bypass"; then
+  assert_pass "bad-bypass candidate marker shown"
+else
+  assert_fail "bad-bypass candidate marker shown" "marker absent; output: $out2"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: --errors-only flag
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== bypass-review: --errors-only flag ==="
+
+DIR3="$TMP_DIR/t3"
+mkdir -p "$DIR3"
+ev_ok3=$(make_event '["CLAUDE_HOOK_BYPASS_SCIOMC_GATE"]' "ok")
+ev_err3=$(make_event '["PRAXIS_GH_JSON_BYPASS"]' "error")
+write_fixture "$DIR3/bypass-events-$TODAY.jsonl" "$ev_ok3" "$ev_err3"
+
+out3=$(python3 "$CLI" --dir "$DIR3" --days 7 --errors-only 2>&1)
+
+# Should include the error bypass var
+if echo "$out3" | grep -q "PRAXIS_GH_JSON_BYPASS"; then
+  assert_pass "--errors-only: error event bypass var present"
+else
+  assert_fail "--errors-only: error event bypass var present" "PRAXIS_GH_JSON_BYPASS missing"
+fi
+
+# The "Top Bypass Vars" frequency table section should NOT appear in errors-only mode
+if echo "$out3" | grep -q "Top Bypass Vars"; then
+  assert_fail "--errors-only: no Top Bypass Vars section" "Top Bypass Vars section appeared in --errors-only output"
+else
+  assert_pass "--errors-only: Top Bypass Vars section suppressed"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: Zero events — empty dir
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== bypass-review: zero events — empty telemetry dir ==="
+
+DIR4="$TMP_DIR/t4-empty"
+mkdir -p "$DIR4"
+
+out4=$(python3 "$CLI" --dir "$DIR4" --days 7 2>&1)
+rc4=$?
+
+if [ "$rc4" -ne 0 ]; then
+  assert_fail "zero events: exit code 0" "exited with code $rc4"
+else
+  assert_pass "zero events: exit code 0"
+fi
+
+if echo "$out4" | grep -q "No bypass events\|0"; then
+  assert_pass "zero events: zero-count message present"
+else
+  assert_fail "zero events: zero-count message present" "output: $out4"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: Multi-day aggregation
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== bypass-review: multi-day aggregation ==="
+
+DIR5="$TMP_DIR/t5"
+mkdir -p "$DIR5"
+ev_today=$(make_event '["CLAUDE_HOOK_BYPASS_SCIOMC_GATE"]' "ok")
+ev_yesterday=$(make_event '["CLAUDE_HOOK_BYPASS_DUP_GATE"]' "ok")
+write_fixture "$DIR5/bypass-events-$TODAY.jsonl" "$ev_today"
+write_fixture "$DIR5/bypass-events-$YESTERDAY.jsonl" "$ev_yesterday"
+
+out5=$(python3 "$CLI" --dir "$DIR5" --days 7 2>&1)
+
+# Both vars from both days should appear
+if echo "$out5" | grep -q "CLAUDE_HOOK_BYPASS_SCIOMC_GATE"; then
+  assert_pass "multi-day: today's event aggregated"
+else
+  assert_fail "multi-day: today's event aggregated" "SCIOMC_GATE missing"
+fi
+
+if echo "$out5" | grep -q "CLAUDE_HOOK_BYPASS_DUP_GATE"; then
+  assert_pass "multi-day: yesterday's event aggregated"
+else
+  assert_fail "multi-day: yesterday's event aggregated" "DUP_GATE missing"
+fi
+
+# Total should be 2
+if echo "$out5" | grep -q "Total events.*2"; then
+  assert_pass "multi-day: total events = 2"
+else
+  assert_fail "multi-day: total events = 2" "output: $out5"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: --days flag — old events outside window excluded
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== bypass-review: --days=1 excludes yesterday ==="
+
+DIR6="$TMP_DIR/t6"
+mkdir -p "$DIR6"
+ev_today6=$(make_event '["CLAUDE_HOOK_BYPASS_SCIOMC_GATE"]' "ok")
+ev_yesterday6=$(make_event '["CLAUDE_HOOK_BYPASS_DUP_GATE"]' "ok")
+write_fixture "$DIR6/bypass-events-$TODAY.jsonl" "$ev_today6"
+write_fixture "$DIR6/bypass-events-$YESTERDAY.jsonl" "$ev_yesterday6"
+
+out6=$(python3 "$CLI" --dir "$DIR6" --days 1 2>&1)
+
+# Only today's event (SCIOMC_GATE) should appear; yesterday (DUP_GATE) excluded
+if echo "$out6" | grep -q "CLAUDE_HOOK_BYPASS_SCIOMC_GATE"; then
+  assert_pass "--days=1: today's event present"
+else
+  assert_fail "--days=1: today's event present" "SCIOMC_GATE missing; output: $out6"
+fi
+
+if echo "$out6" | grep -q "CLAUDE_HOOK_BYPASS_DUP_GATE"; then
+  assert_fail "--days=1: yesterday excluded" "DUP_GATE appeared despite --days=1"
+else
+  assert_pass "--days=1: yesterday excluded"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: --dir flag
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== bypass-review: --dir override ==="
+
+DIR7="$TMP_DIR/t7-override"
+mkdir -p "$DIR7"
+ev7=$(make_event '["PRAXIS_VERSION_BUMP_BYPASS"]' "ok")
+write_fixture "$DIR7/bypass-events-$TODAY.jsonl" "$ev7"
+
+out7=$(python3 "$CLI" --dir "$DIR7" 2>&1)
+
+if echo "$out7" | grep -q "PRAXIS_VERSION_BUMP_BYPASS"; then
+  assert_pass "--dir: reads from override directory"
+else
+  assert_fail "--dir: reads from override directory" "var missing; output: $out7"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8: Malformed JSONL lines — skipped without crash
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== bypass-review: malformed JSONL lines skipped ==="
+
+DIR8="$TMP_DIR/t8"
+mkdir -p "$DIR8"
+ev_good=$(make_event '["CLAUDE_HOOK_BYPASS_SCIOMC_GATE"]' "ok")
+{
+  echo "not-json-at-all"
+  echo ""
+  echo "{broken: json}"
+  echo "$ev_good"
+} > "$DIR8/bypass-events-$TODAY.jsonl"
+
+out8=$(python3 "$CLI" --dir "$DIR8" --days 1 2>&1)
+rc8=$?
+
+if [ "$rc8" -ne 0 ]; then
+  assert_fail "malformed lines: exit 0" "exited $rc8"
+else
+  assert_pass "malformed lines: exit 0"
+fi
+
+if echo "$out8" | grep -q "CLAUDE_HOOK_BYPASS_SCIOMC_GATE"; then
+  assert_pass "malformed lines: valid events still aggregated"
+else
+  assert_fail "malformed lines: valid events still aggregated" "good event missing; output: $out8"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 9: Missing fields in record — no crash
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== bypass-review: missing fields in record ==="
+
+DIR9="$TMP_DIR/t9"
+mkdir -p "$DIR9"
+# Minimal record: only timestamp and bypass_env_vars, other fields absent
+python3 -c "
+import json
+from datetime import datetime, timezone
+print(json.dumps({
+    'timestamp': datetime.now(tz=timezone.utc).isoformat(),
+    'bypass_env_vars': ['CLAUDE_HOOK_BYPASS_SCIOMC_GATE'],
+}))
+" > "$DIR9/bypass-events-$TODAY.jsonl"
+
+out9=$(python3 "$CLI" --dir "$DIR9" --days 1 2>&1)
+rc9=$?
+
+if [ "$rc9" -ne 0 ]; then
+  assert_fail "missing fields: exit 0" "exited $rc9; output: $out9"
+else
+  assert_pass "missing fields: exit 0 (no crash)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 10: Privacy — bypass var VALUES do not appear in output
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== bypass-review: bypass var values never in output ==="
+
+DIR10="$TMP_DIR/t10"
+mkdir -p "$DIR10"
+# Craft a record where tool_input contains a redacted bypass value
+secret_indicator="super-secret-bypass-value-99"
+python3 -c "
+import json, sys
+from datetime import datetime, timezone
+secret = sys.argv[1]
+print(json.dumps({
+    'timestamp': datetime.now(tz=timezone.utc).isoformat(),
+    'session_id': 'test-privacy',
+    'tool': 'Bash',
+    'bypass_env_vars': ['CLAUDE_HOOK_BYPASS_SCIOMC_GATE'],
+    'tool_input': 'CLAUDE_HOOK_BYPASS_SCIOMC_GATE=<redacted> git commit',
+    'tool_result_status': 'ok',
+}))" "$secret_indicator" > "$DIR10/bypass-events-$TODAY.jsonl"
+
+out10=$(python3 "$CLI" --dir "$DIR10" --days 1 2>&1)
+
+# The secret value is NOT in the JSONL at all (redacted by writer);
+# verify it also doesn't appear in output (belt-and-suspenders).
+if echo "$out10" | grep -q "$secret_indicator"; then
+  assert_fail "privacy: bypass var value not in output" "secret_indicator appeared"
+else
+  assert_pass "privacy: bypass var value not in output"
+fi
+
+# tool_result_status field name should NOT appear in the output (internal field name)
+# but the var NAME should appear
+if echo "$out10" | grep -q "CLAUDE_HOOK_BYPASS_SCIOMC_GATE"; then
+  assert_pass "privacy: bypass var NAME present in output"
+else
+  assert_fail "privacy: bypass var NAME present in output" "var name missing; output: $out10"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 11: Exit code 1 on --days < 1
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== bypass-review: exit 1 on bad --days ==="
+
+DIR11="$TMP_DIR/t11"
+mkdir -p "$DIR11"
+
+python3 "$CLI" --dir "$DIR11" --days 0 >/dev/null 2>&1
+rc11=$?
+
+if [ "$rc11" -eq 1 ]; then
+  assert_pass "--days=0 returns exit 1"
+else
+  assert_fail "--days=0 returns exit 1" "got exit $rc11 instead"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "================================"
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed tests:"
+  for n in "${FAILED_NAMES[@]}"; do echo "  - $n"; done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 배경

`bypass-telemetry` PostToolUse hook 이 #441 (PR #454) 에서 **Phase 1** (bypass env 사용을 `~/.praxis/telemetry/bypass-events-YYYY-MM-DD.jsonl` 에 기록하는 observe-only hook) 만 구현됐습니다. 이 PR 은 축적된 JSONL 을 사람이 읽도록 집계하는 **Phase 2 CLI** 입니다.

## 변경 (Phase 2 only)

- `skills/bypass-review/bypass-review` — 읽기 전용 집계 CLI (shell 래퍼, skill 아님 — `cmux-browser` 와 동일 분류)
  - `-d/--days N` (기본 7), `--dir PATH`, `--errors-only` 플래그
  - hook/tool 별 그룹핑 + 가장 많이 우회된 규칙 표면화 + bypass 후 tool error 이벤트 강조 (bad-bypass 후보)
- `scripts/install.sh` CLI_SCRIPTS 에 추가 → `~/.local/bin/bypass-review` 심링크
- `docs/bypass-telemetry.md` Phase 2 구현 반영 (Phase 3 deferred 유지)

## 프라이버시 계약 (유지)

읽기 전용 — bypass var **값** 미출력 (writer 가 이름만 저장), `tool_response` 내용 미저장, `tool_input` 은 writer 가 이미 redact + 200자 truncate. CLI 는 누락 필드를 재구성하지 않음.

## 비범위

Phase 3 (HTTP forwarding) 는 범위가 커 분리 — 미구현, 문서에 deferred 유지.

## 검증

- shell 테스트 **23 케이스 통과** (합성 fixture, 실제 `~/.praxis` 미접근)
- CLI end-to-end 실행으로 집계 출력 확인
- `pytest tests/` 58 passed · `check-plugin-manifests.py` OK

Pre-commit verified: `pytest tests/` 58 passed + `test_bypass_review.sh` 23 passed + `check-plugin-manifests.py` OK — 수동 실행 (repo 에 pre-commit hook / CI 없음).

Caller chain verified: 신규 심볼 (CLI 바이너리), 기존 호출자 없음 — `scripts/install.sh` 설치 후 `~/.local/bin/bypass-review` 로 직접 실행. writer 필드 스키마는 `hooks/postuse-correction/bypass-telemetry/impl.py` L250-257 에서 verbatim 대조.

## 리뷰

codex 사용량 한도로 Claude 기반 리뷰로 대체 (사용자 승인). 프라이버시 writer 의존성 검증 완료. 차단 이슈 HIGH 0.

Refs #456 (Phase 2 구현; Phase 3 deferred)
