### PR TITLE
refactor(hooks): extract emit-decision helper

### DIFF
--- a/hooks/_lib/_hook_io.py
+++ b/hooks/_lib/_hook_io.py
@@ -1,0 +1,76 @@
+"""Standard decision-emit format for praxis PreToolUse hooks (issue #470).
+
+13 PreToolUse hooks each hand-rolled the identical `permissionDecision` JSON
+dump to stdout — `json.dump({"hookSpecificOutput": {"hookEventName":
+"PreToolUse", "permissionDecision": <ask|deny>, "permissionDecisionReason":
+<reason>}}, sys.stdout)` followed by a trailing newline. When the Claude Code
+decision protocol changes (field rename, new field, event-name variant), that
+is 13 edit sites instead of one.
+
+This module pins that shape in a single place, mirroring the sibling
+`block_message.py` (issue #439) extraction: a pure `format_*` function plus a
+thin I/O `emit_*` wrapper with an injectable stream for testing. Neither
+function exits — the caller owns the exit code (2 for a PreToolUse block path,
+0 for the ask/advisory path).
+
+Scope note: `builtin-task-postuse` emits a different shape (`additionalContext`
+plus a top-level `"continue": True` field) and is the *only* such caller, so it
+is intentionally NOT covered here — extracting a helper for a single call site
+would add indirection without removing duplication (DRY rule-of-three / YAGNI).
+
+Byte-identity guarantee: `format_decision` inserts keys in the exact order the
+hand-rolled form used (`hookEventName`, `permissionDecision`,
+`permissionDecisionReason`), and `emit_decision` serializes via `json.dump`
+with no `separators=` kwarg — i.e. the default `(', ', ': ')` (note the
+spaces) — plus a trailing `"\\n"`, so the bytes written are identical to every
+pre-extraction call site. A re-implementation in another language must use the
+spaced form, not the compact `(',', ':')`.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from typing import Optional, TextIO
+
+
+def format_decision(
+    decision: str,
+    reason: str,
+    event_name: str = "PreToolUse",
+) -> dict:
+    """Return the `hookSpecificOutput` decision dict (no I/O).
+
+    Args:
+      decision: "ask" or "deny". "allow" is never emitted — a silent pass is
+        signaled by writing no JSON at all (the caller just returns 0).
+      reason: the `permissionDecisionReason` text shown to the agent.
+      event_name: the `hookEventName`. Defaults to "PreToolUse" (every current
+        caller); parameterized so a future UserPromptSubmit caller can reuse it.
+
+    Returns:
+      The dict ready for `json.dump`. Key order is fixed to match the
+      pre-extraction hand-rolled form for byte-identical serialization.
+    """
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": event_name,
+            "permissionDecision": decision,
+            "permissionDecisionReason": reason,
+        }
+    }
+
+
+def emit_decision(
+    decision: str,
+    reason: str,
+    event_name: str = "PreToolUse",
+    stream: Optional[TextIO] = None,
+) -> None:
+    """Write the `permissionDecision` JSON to stdout (+ trailing newline).
+
+    Mirrors `block_message.emit_block`: `stream` is injectable for testing and
+    defaults to `sys.stdout`. Does NOT exit — the caller owns the exit code.
+    """
+    out = stream if stream is not None else sys.stdout
+    json.dump(format_decision(decision, reason, event_name), out)
+    out.write("\n")

--- a/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
@@ -51,6 +51,11 @@ import json
 import re
 import sys
 
+import sys as _sys
+from pathlib import Path as _Path
+_sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
+
 # ---------------------------------------------------------------------------
 # Messages
 # ---------------------------------------------------------------------------
@@ -219,33 +224,15 @@ def _collect_option_texts(options: list) -> list[str]:
     return texts
 
 
-def _emit_decision(decision: str, message: str) -> None:
-    """Output permissionDecision JSON to stdout.
-
-    decision must be "ask" or "deny" (the two tiers used by this hook).
-    "allow" is not used — silent-pass is signaled by no JSON output.
-    """
-    json.dump(
-        {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": decision,
-                "permissionDecisionReason": message,
-            }
-        },
-        sys.stdout,
-    )
-    sys.stdout.write("\n")
-
-
 def _emit_ask(message: str) -> None:
-    """T2 path: soft gate."""
-    _emit_decision("ask", message)
+    """T2 path: soft gate. (decision must be "ask"/"deny" — "allow" is never
+    emitted; silent-pass is signaled by no JSON output.)"""
+    emit_decision("ask", message)
 
 
 def _emit_deny(message: str) -> None:
     """T1 path: hard block (issue #393 upgrade)."""
-    _emit_decision("deny", message)
+    emit_decision("deny", message)
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/advisory-nudge/path-probe-gate/impl.py
+++ b/hooks/advisory-nudge/path-probe-gate/impl.py
@@ -63,6 +63,11 @@ import os
 import subprocess
 import sys
 
+import sys as _sys
+from pathlib import Path as _Path
+_sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -251,17 +256,7 @@ def _emit_deny(
         depth=depth,
         worktree_root=worktree_root,
     )
-    json.dump(
-        {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "deny",
-                "permissionDecisionReason": reason,
-            }
-        },
-        sys.stdout,
-    )
-    sys.stdout.write("\n")
+    emit_decision("deny", reason)
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/postuse-correction/pre-edit-md-escape-advisory/impl.py
+++ b/hooks/postuse-correction/pre-edit-md-escape-advisory/impl.py
@@ -105,6 +105,11 @@ import re
 import sys
 import time
 
+import sys as _sys
+from pathlib import Path as _Path
+_sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -260,17 +265,7 @@ def find_escape_tokens(old_string: str) -> list[str]:
 
 
 def emit_deny(reason: str) -> None:
-    json.dump(
-        {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "deny",
-                "permissionDecisionReason": reason,
-            }
-        },
-        sys.stdout,
-    )
-    sys.stdout.write("\n")
+    emit_decision("deny", reason)
 
 
 def run_pre() -> int:

--- a/hooks/preflight-gate/branch-name-check/impl.py
+++ b/hooks/preflight-gate/branch-name-check/impl.py
@@ -43,6 +43,7 @@ import sys as _sys
 from pathlib import Path as _Path
 
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     iter_command_starts,
     safe_tokenize,
@@ -443,17 +444,7 @@ def _emit_block(branch: str, regex_pattern: str, strict: bool) -> None:
         reference="CLAUDE.md → Git Commit & Title Rules; hooks/preflight-gate/branch-name-check/spec.md",
     )
     if strict:
-        json.dump(
-            {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "deny",
-                    "permissionDecisionReason": reason,
-                }
-            },
-            sys.stdout,
-        )
-        sys.stdout.write("\n")
+        emit_decision("deny", reason)
     else:
         sys.stderr.write(reason + "\n")
 

--- a/hooks/preflight-gate/commit-title-length-check/impl.py
+++ b/hooks/preflight-gate/commit-title-length-check/impl.py
@@ -31,6 +31,7 @@ import sys
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     compound_cascade_hint,
     iter_command_starts,
@@ -275,17 +276,7 @@ def _extract_titles(argv: list[str]) -> list[str]:
 # ---------------------------------------------------------------------------
 
 def _emit_ask(reason: str) -> None:
-    json.dump(
-        {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "ask",
-                "permissionDecisionReason": reason,
-            }
-        },
-        sys.stdout,
-    )
-    sys.stdout.write("\n")
+    emit_decision("ask", reason)
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/preflight-gate/cross-boundary-preflight/impl.py
+++ b/hooks/preflight-gate/cross-boundary-preflight/impl.py
@@ -38,6 +38,7 @@ import sys
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     Token,
     TokenRole,
@@ -296,17 +297,7 @@ def _build_checklist(subcommand: tuple[str, str], repo: str) -> str:
 
 
 def _emit_ask(reason: str) -> None:
-    json.dump(
-        {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "ask",
-                "permissionDecisionReason": reason,
-            }
-        },
-        sys.stdout,
-    )
-    sys.stdout.write("\n")
+    emit_decision("ask", reason)
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/preflight-gate/gh-flag-verify/impl.py
+++ b/hooks/preflight-gate/gh-flag-verify/impl.py
@@ -44,6 +44,7 @@ import sys
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     Token,
     TokenRole,
@@ -500,17 +501,7 @@ def check_gh_flags(seg: list[Token]) -> tuple[bool, str]:
 
 
 def _emit_deny(reason: str) -> None:
-    json.dump(
-        {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "deny",
-                "permissionDecisionReason": reason,
-            }
-        },
-        sys.stdout,
-    )
-    sys.stdout.write("\n")
+    emit_decision("deny", reason)
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/preflight-gate/gh-json-validator/impl.py
+++ b/hooks/preflight-gate/gh-json-validator/impl.py
@@ -40,6 +40,7 @@ from pathlib import Path
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     iter_command_starts,
     safe_tokenize,
@@ -267,17 +268,7 @@ def _suggest_field(bad_field: str, valid_fields: frozenset[str]) -> str | None:
 # ---------------------------------------------------------------------------
 
 def _emit_deny(reason: str) -> None:
-    json.dump(
-        {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "deny",
-                "permissionDecisionReason": reason,
-            }
-        },
-        sys.stdout,
-    )
-    sys.stdout.write("\n")
+    emit_decision("deny", reason)
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/preflight-gate/pre-edit-protected-branch-guard/impl.py
+++ b/hooks/preflight-gate/pre-edit-protected-branch-guard/impl.py
@@ -47,6 +47,11 @@ import re
 import subprocess
 import sys
 
+import sys as _sys
+from pathlib import Path as _Path
+_sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -344,17 +349,7 @@ def is_self_edit(path: str) -> bool:
 
 
 def emit_deny(reason: str) -> None:
-    json.dump(
-        {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "deny",
-                "permissionDecisionReason": reason,
-            }
-        },
-        sys.stdout,
-    )
-    sys.stdout.write("\n")
+    emit_decision("deny", reason)
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/preflight-gate/pre-merge-approval-gate/impl.py
+++ b/hooks/preflight-gate/pre-merge-approval-gate/impl.py
@@ -38,6 +38,7 @@ import sys
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     compound_cascade_hint,
     iter_command_starts,
@@ -101,17 +102,7 @@ def is_gh_pr_merge(argv: list[str]) -> bool:
 
 
 def emit_ask(reason: str) -> None:
-    json.dump(
-        {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "ask",
-                "permissionDecisionReason": reason,
-            }
-        },
-        sys.stdout,
-    )
-    sys.stdout.write("\n")
+    emit_decision("ask", reason)
 
 
 def main() -> int:

--- a/hooks/preflight-gate/session-intent/impl.py
+++ b/hooks/preflight-gate/session-intent/impl.py
@@ -75,6 +75,7 @@ import sys
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     iter_command_starts,
     safe_tokenize,
@@ -426,20 +427,6 @@ def handle_user_prompt_submit(payload: dict) -> int:
     if changed:
         write_state(path, state)
     return 0
-
-
-def emit_decision(decision: str, reason: str) -> None:
-    json.dump(
-        {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": decision,
-                "permissionDecisionReason": reason,
-            }
-        },
-        sys.stdout,
-    )
-    sys.stdout.write("\n")
 
 
 def handle_pre_tool_use(payload: dict) -> int:

--- a/hooks/preflight-gate/side-effect-scan/impl.py
+++ b/hooks/preflight-gate/side-effect-scan/impl.py
@@ -20,6 +20,7 @@ import sys
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     compound_cascade_hint,
     iter_command_starts,
@@ -165,17 +166,7 @@ def build_reason(categories: list[str], prod: bool, command: str) -> str:
 
 
 def emit_ask(reason: str) -> None:
-    json.dump(
-        {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "ask",
-                "permissionDecisionReason": reason,
-            }
-        },
-        sys.stdout,
-    )
-    sys.stdout.write("\n")
+    emit_decision("ask", reason)
 
 
 def main() -> int:

--- a/hooks/preflight-gate/verify-commit-flag-override/impl.py
+++ b/hooks/preflight-gate/verify-commit-flag-override/impl.py
@@ -37,6 +37,7 @@ import sys
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     compound_cascade_hint,
     iter_command_starts,
@@ -208,17 +209,7 @@ To proceed:
 
 
 def _emit_deny(reason: str) -> None:
-    json.dump(
-        {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "deny",
-                "permissionDecisionReason": reason,
-            }
-        },
-        sys.stdout,
-    )
-    sys.stdout.write("\n")
+    emit_decision("deny", reason)
 
 
 def _build_reason(overrides: list[str]) -> str:

--- a/tests/test_hook_io.py
+++ b/tests/test_hook_io.py
@@ -1,0 +1,198 @@
+"""Tests + lint for the standard decision-emit helper (issue #470).
+
+Two concerns, mirroring tests/test_block_message.py (issue #439):
+
+  1. Helper format contract — `format_decision` / `emit_decision` produce the
+     exact byte-identical `permissionDecision` JSON shape every hook used to
+     hand-roll (fixed key order + trailing newline).
+
+  2. Adoption lint — any hook that emits a `permissionDecision` JSON must build
+     it via `hooks/_lib/_hook_io.py` rather than hand-rolling the `json.dump`.
+     After migration the hand-rolled `permissionDecision` literal is GONE from a
+     compliant hook (it lives only in _hook_io), so the lint detects an
+     *offender* as "still hand-rolls the literal AND does not import the helper
+     AND is not on the LEGACY_UNMIGRATED allowlist", and separately asserts the
+     13 migrated hooks DO import the helper. Adding a NEW hand-rolled
+     permissionDecision hook fails this test.
+
+`builtin-task-postuse` is intentionally out of scope: it emits a different
+shape (`additionalContext` + top-level `"continue": True`) and is the only such
+caller, so it carries no `permissionDecision` literal and is never flagged.
+
+Run: python3 -m pytest tests/test_hook_io.py -q
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LIB_DIR = REPO_ROOT / "hooks" / "_lib"
+HOOKS_DIR = REPO_ROOT / "hooks"
+
+sys.path.insert(0, str(LIB_DIR))
+
+_spec = importlib.util.spec_from_file_location("_hook_io", LIB_DIR / "_hook_io.py")
+assert _spec is not None and _spec.loader is not None
+hio = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hio)  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# 1. Helper format contract — byte-identical to the pre-extraction hand-roll
+# ---------------------------------------------------------------------------
+
+def test_format_decision_key_order_is_fixed() -> None:
+    d = hio.format_decision("ask", "because reasons")
+    assert list(d.keys()) == ["hookSpecificOutput"]
+    inner = d["hookSpecificOutput"]
+    # Order is load-bearing for byte-identical serialization.
+    assert list(inner.keys()) == [
+        "hookEventName",
+        "permissionDecision",
+        "permissionDecisionReason",
+    ]
+    assert inner["hookEventName"] == "PreToolUse"
+    assert inner["permissionDecision"] == "ask"
+    assert inner["permissionDecisionReason"] == "because reasons"
+
+
+def test_emit_decision_is_byte_identical_to_handrolled() -> None:
+    """The emitted bytes must equal exactly what every hook hand-rolled:
+    json.dump(obj, stdout) + a trailing newline, default separators."""
+    for decision in ("ask", "deny"):
+        buf = io.StringIO()
+        hio.emit_decision(decision, "msg text", stream=buf)
+        got = buf.getvalue()
+
+        expected_obj = {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": decision,
+                "permissionDecisionReason": "msg text",
+            }
+        }
+        ref = io.StringIO()
+        json.dump(expected_obj, ref)
+        ref.write("\n")
+        assert got == ref.getvalue()
+        # And it round-trips to the same object.
+        assert json.loads(got) == expected_obj
+        assert got.endswith("\n")
+
+
+def test_emit_decision_event_name_override() -> None:
+    buf = io.StringIO()
+    hio.emit_decision("deny", "x", event_name="UserPromptSubmit", stream=buf)
+    obj = json.loads(buf.getvalue())
+    assert obj["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+
+
+def test_emit_decision_does_not_exit() -> None:
+    """Helper never calls sys.exit — caller owns the exit code."""
+    buf = io.StringIO()
+    # If this raised SystemExit the test would error, not fail silently.
+    hio.emit_decision("ask", "x", stream=buf)
+    assert buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# 2. Adoption lint
+# ---------------------------------------------------------------------------
+
+# The 13 hooks that hand-rolled a permissionDecision JSON, migrated in #470.
+# Stored as bare dir names (unique across role dirs).
+EXPECTED_MIGRATED = {
+    "output-block-falsify-advisory",
+    "path-probe-gate",
+    "pre-edit-md-escape-advisory",
+    "branch-name-check",
+    "commit-title-length-check",
+    "cross-boundary-preflight",
+    "gh-flag-verify",
+    "gh-json-validator",
+    "pre-edit-protected-branch-guard",
+    "pre-merge-approval-gate",
+    "session-intent",
+    "side-effect-scan",
+    "verify-commit-flag-override",
+}
+
+# Hooks that emit a permissionDecision but are intentionally not yet migrated.
+# Empty: issue #470 migrated every permissionDecision emitter in one pass.
+LEGACY_UNMIGRATED: set[str] = set()
+
+# Hand-rolled emit = the literal JSON key appears in source.
+_HANDROLLS_RE = re.compile(r'"permissionDecision"')
+# Compliant = imports the shared helper.
+_USES_HELPER_RE = re.compile(r"from _hook_io import|import _hook_io")
+
+
+def _hook_impls() -> list[Path]:
+    return sorted(HOOKS_DIR.glob("*/*/impl.py"))
+
+
+def test_migrated_hooks_import_helper() -> None:
+    """Each #470 hook must import _hook_io and must NOT hand-roll the literal."""
+    by_name = {p.parent.name: p for p in _hook_impls()}
+    for name in sorted(EXPECTED_MIGRATED):
+        impl = by_name.get(name)
+        assert impl is not None and impl.is_file(), f"missing impl for {name}"
+        src = impl.read_text(encoding="utf-8")
+        assert _USES_HELPER_RE.search(src), (
+            f"{name} must emit via hooks/_lib/_hook_io.py (from _hook_io import emit_decision)"
+        )
+        assert not _HANDROLLS_RE.search(src), (
+            f"{name} still hand-rolls the permissionDecision literal — "
+            "the JSON shape must live only in _hook_io.py"
+        )
+        assert name not in LEGACY_UNMIGRATED, (
+            f"{name} is migrated — remove it from LEGACY_UNMIGRATED"
+        )
+
+
+def test_no_unaccounted_handrolled_decision_hook() -> None:
+    """Any hook that still hand-rolls a permissionDecision JSON without the
+    helper, and is not on the legacy allowlist, fails here."""
+    offenders: list[str] = []
+    for impl in _hook_impls():
+        name = impl.parent.name
+        src = impl.read_text(encoding="utf-8")
+        if not _HANDROLLS_RE.search(src):
+            continue  # no hand-rolled literal (compliant or non-emitter)
+        if _USES_HELPER_RE.search(src):
+            # Uses helper → compliant. A residual `permissionDecision` literal
+            # here is only a comment/docstring, not executable emit code (the
+            # JSON shape lives solely in _hook_io). Boundary: this lint does NOT
+            # catch a hook that imports the helper AND ALSO hand-rolls the dump;
+            # that regression is guarded by per-hook tests + code review.
+            continue
+        if name in LEGACY_UNMIGRATED:
+            continue
+        offenders.append(name)
+    assert not offenders, (
+        "hook(s) hand-roll a permissionDecision JSON without using "
+        f"hooks/_lib/_hook_io.py and are not on LEGACY_UNMIGRATED: {offenders}. "
+        "Use emit_decision (see hooks/_lib/_hook_io.py), or add to LEGACY_UNMIGRATED."
+    )
+
+
+def test_legacy_allowlist_has_no_phantom_entries() -> None:
+    existing = {p.parent.name for p in _hook_impls()}
+    phantom = sorted(LEGACY_UNMIGRATED - existing)
+    assert not phantom, f"LEGACY_UNMIGRATED names non-existent hooks: {phantom}"
+
+
+def test_expected_migrated_all_exist() -> None:
+    existing = {p.parent.name for p in _hook_impls()}
+    missing = sorted(EXPECTED_MIGRATED - existing)
+    assert not missing, f"EXPECTED_MIGRATED names non-existent hooks: {missing}"
+
+
+def test_legacy_and_migrated_are_disjoint() -> None:
+    overlap = EXPECTED_MIGRATED & LEGACY_UNMIGRATED
+    assert not overlap, f"hook listed as both migrated and legacy: {overlap}"


### PR DESCRIPTION
## 요약

13개 PreToolUse hook이 동일한 `permissionDecision` JSON dump를 각자 손으로 굴리던 것을, 공유 헬퍼 `_lib/_hook_io.py`로 추출하고 13개를 모두 그곳으로 라우팅했습니다. emit 셰이프 변경이 **14곳 → 1곳**이 됩니다.

`/deep-dive` 분석 결과 이 스위트는 이미 Clean-Architecture-in-spirit(순수 entity `_hook_utils` + per-hook use-case 술어 + `main()` adapter)이며, 유일하게 미완성이던 adapter 계층의 emit 중복을 닫는 키스톤 작업입니다. `_lib/block_message.py`(#439)가 동일 패턴의 선례입니다.

## 변경 내용

- **신규 `_lib/_hook_io.py`**: `format_decision`(순수, dict 반환) + `emit_decision`(stdout 출력, stream 주입 가능, exit 안 함). key 순서·default json separators·trailing newline까지 **byte-identical**.
- **신규 `tests/test_hook_io.py`**: byte-identity 계약 테스트 + **adoption lint**(모든 `permissionDecision` emitter가 헬퍼를 import하도록 강제 — 회귀 게이트).
- **13개 hook 마이그레이션**: deny 7 / ask 4 / 가변 2. 각 hook의 로컬 emit을 공유 헬퍼 호출로 전환.
- preamble 없던 4개(output-block-falsify, path-probe-gate, pre-edit-md-escape, pre-edit-protected-branch-guard)에 표준 4-line preamble 추가.
- `session-intent`: 로컬 `emit_decision`(시그니처 동일) 제거 → 호출부가 import로 해석.
- `builtin-task-postuse`는 유지: `additionalContext` 셰이프 + 단일 호출처 → 스코프 밖(DRY rule-of-three).

## 검증

- `pytest tests/` → **67 passed**
- `pytest tests/test_hook_io.py` → **9 passed** (format 계약 + adoption lint)
- `scripts/check-plugin-manifests.py` → **OK** (생성물 byte-identical, drift 없음)
- 기능 테스트: 실제 wrapper emit이 기존과 byte-identical (`ensure_ascii` 기본까지 동일)

## 리뷰

- `oh-my-claudecode:code-reviewer`: MEDIUM 1(3단 패스스루 제거) + LOW 2(docstring 명확화·lint 경계 주석) 반영. LOW 2건은 sibling 컨벤션 일치로 기각(근거: 9개 기존 hook이 `import sys`+`import sys as _sys`를 이미 동시 보유).
- `praxis:codex-review-wrap`: 런타임 동작 깨뜨릴 결함 없음(clean).

Caller chain verified: emit_decision의 호출부 = 13개 hook. 전부 헬퍼를 import(adoption lint 통과)하고, session-intent의 로컬 def 제거 후 호출부가 시그니처 동일한 import로 해석됨을 확인. output-block-falsify의 `_emit_ask`/`_emit_deny`는 헬퍼를 직접 호출. 67개 테스트가 호출 경로를 실제 실행하여 통과.

Pre-commit verified: pytest tests/ (67 passed) + tests/test_hook_io.py (9 passed) + scripts/check-plugin-manifests.py (OK) + functional emit byte-identical.

Closes #470
