### PR TITLE
chore(scripts): add skill surface freeze gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,23 @@ note for `skills/*/SKILL.md` changes is planned as a follow-up to Issue #208.
 It is not yet enforced — the frontmatter + commit body convention above is the
 current gate.
 
+### Skill surface freeze (`EXPECTED_SKILLS`)
+
+Adding or removing a skill directory under `skills/` requires updating the
+`EXPECTED_SKILLS` set in
+[`scripts/check-plugin-manifests.py`](scripts/check-plugin-manifests.py) in the
+same commit. This is a structural gate against silent skill proliferation —
+every intentional surface change is paired with an explicit declaration.
+
+After adding/removing a skill, run:
+
+```bash
+./scripts/check-plugin-manifests.py
+```
+
+If it reports `UNEXPECTED SKILL(S)` or `REMOVED SKILL(S)`, update
+`EXPECTED_SKILLS` to match the new surface.
+
 ## Adding or modifying a hook
 
 Phase 2 of [ADR-0001](docs/adr/0001-hook-layout.md) shipped the role-based

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,10 +98,10 @@ current gate.
 ### Skill surface freeze (`EXPECTED_SKILLS`)
 
 Adding or removing a skill directory under `skills/` requires updating the
-`EXPECTED_SKILLS` set in
-[`scripts/check-plugin-manifests.py`](scripts/check-plugin-manifests.py) in the
-same commit. This is a structural gate against silent skill proliferation —
-every intentional surface change is paired with an explicit declaration.
+`EXPECTED_SKILLS` set in [`scripts/constants.py`](scripts/constants.py) in
+the same commit. This is a structural gate against silent skill
+proliferation — every intentional surface change is paired with an explicit
+declaration.
 
 After adding/removing a skill, run:
 
@@ -110,7 +110,7 @@ After adding/removing a skill, run:
 ```
 
 If it reports `UNEXPECTED SKILL(S)` or `REMOVED SKILL(S)`, update
-`EXPECTED_SKILLS` to match the new surface.
+`EXPECTED_SKILLS` in `scripts/constants.py` to match the new surface.
 
 ## Adding or modifying a hook
 

--- a/scripts/build-plugin-manifests.py
+++ b/scripts/build-plugin-manifests.py
@@ -61,6 +61,9 @@ PLATFORMS_DIR = MANIFESTS_DIR / "platforms"
 ADAPTER_SHELL = REPO_ROOT / "plugins" / "praxis"
 FORWARDED_DIRS = ("skills", "hooks", "scripts")
 HOOKS_DIR = REPO_ROOT / "hooks"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from constants import OPT_IN_HOOKS  # noqa: E402
 MANIFEST_PATH = HOOKS_DIR / "manifest.json"
 
 
@@ -221,18 +224,6 @@ def _wrapper_body(entry: dict) -> str:
     else:
         baked_args = ""
     return WRAPPER_PY_TEMPLATE.format(role=role, name=name, baked_args=baked_args)
-
-
-# Opt-in hooks: live on disk under hooks/<role>/<name>/ but are NOT
-# registered in manifest.json (user must add a hooks entry to their own
-# settings.json or hooks.json fragment to activate). The build still
-# emits a wrapper at hooks/<name>.sh so the documented opt-in command
-# `${CLAUDE_PLUGIN_ROOT}/hooks/<name>.sh` resolves — without this,
-# hooks/<role>/<name>/spec.md guidance would break on first user attempt.
-OPT_IN_HOOKS: dict[str, str] = {
-    # name → role
-    "external-write-falsify-check": "advisory-nudge",
-}
 
 
 def emit_wrappers(manifest: dict) -> list[str]:

--- a/scripts/check-plugin-manifests.py
+++ b/scripts/check-plugin-manifests.py
@@ -45,40 +45,7 @@ assert _spec and _spec.loader
 _build = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_build)
 
-
-# Hooks that exist on disk but are intentionally not registered in
-# manifest.json (opt-in). Listed by basename.
-OPT_IN_HOOKS = {"external-write-falsify-check"}
-
-# Valid role names — must match the four ADR-0001 categories.
-VALID_ROLES = {
-    "preflight-gate",
-    "advisory-nudge",
-    "postuse-correction",
-    "completion-verify",
-}
-
-# Frozen skill surface (issue #465). Adding or removing a skill directory
-# requires updating this set in the same commit. Prevents silent skill
-# proliferation; every intentional surface change is paired with an
-# explicit declaration here.
-EXPECTED_SKILLS = {
-    "bypass-review",
-    "cmux-browser",
-    "cmux-delegate",
-    "cmux-recover-sessions",
-    "cmux-resume-sessions",
-    "cmux-save-sessions",
-    "cmux-session-manager",
-    "codex-review-wrap",
-    "recover-sessions",
-    "reset-strikes",
-    "retrospect",
-    "strike",
-    "strikes",
-    "using-praxis",
-    "writing-praxis-skill",
-}
+from constants import EXPECTED_SKILLS, OPT_IN_HOOKS, VALID_ROLES  # noqa: E402
 
 
 def _skill_dirs() -> list[Path]:

--- a/scripts/check-plugin-manifests.py
+++ b/scripts/check-plugin-manifests.py
@@ -21,6 +21,8 @@ Phase 2 (ADR-0001) invariants:
   9. Version consistency across versioned artifacts.
   10. spec.md exists at hooks/<role>/<name>/spec.md for every registered
       hook (Phase 3, ADR-0001 §5.3 — specs collocated with impl).
+  11. skills/<skill-name>/ on disk matches the EXPECTED_SKILLS frozen set
+     (issue #465 — surface freeze gate against silent skill proliferation).
 
 CI invokes this; developers can too, via `./scripts/check-plugin-manifests.py`.
 """
@@ -55,6 +57,47 @@ VALID_ROLES = {
     "postuse-correction",
     "completion-verify",
 }
+
+# Frozen skill surface (issue #465). Adding or removing a skill directory
+# requires updating this set in the same commit. Prevents silent skill
+# proliferation; every intentional surface change is paired with an
+# explicit declaration here.
+EXPECTED_SKILLS = {
+    "bypass-review",
+    "cmux-browser",
+    "cmux-delegate",
+    "cmux-recover-sessions",
+    "cmux-resume-sessions",
+    "cmux-save-sessions",
+    "cmux-session-manager",
+    "codex-review-wrap",
+    "recover-sessions",
+    "reset-strikes",
+    "retrospect",
+    "strike",
+    "strikes",
+    "using-praxis",
+    "writing-praxis-skill",
+}
+
+
+def _skill_dirs() -> list[Path]:
+    """Return all skill directories under skills/<skill-name>/.
+
+    Mirrors `_hook_dirs()` convention: files (SKILL.md.tmpl) and underscore-
+    prefixed entries (future internal layout) are excluded automatically.
+    """
+    skills_root = REPO_ROOT / "skills"
+    dirs: list[Path] = []
+    if not skills_root.is_dir():
+        return dirs
+    for entry in sorted(skills_root.iterdir()):
+        if not entry.is_dir():
+            continue
+        if entry.name.startswith("_") or entry.name == "__pycache__":
+            continue
+        dirs.append(entry)
+    return dirs
 
 
 def _hook_dirs() -> list[Path]:
@@ -321,6 +364,25 @@ def main() -> int:
         drifts.append(
             "VERSION DRIFT across artifacts: "
             + ", ".join(f"{k}={v}" for k, v in seen.items())
+        )
+
+    # ------------------------------------------------------------------
+    # Rule 11 — Skill surface freeze (#465)
+    # ------------------------------------------------------------------
+    on_disk_skills = {d.name for d in _skill_dirs()}
+    unexpected = on_disk_skills - EXPECTED_SKILLS
+    removed = EXPECTED_SKILLS - on_disk_skills
+    if unexpected:
+        drifts.append(
+            f"UNEXPECTED SKILL(S): {sorted(unexpected)!r} — present on disk "
+            "but not declared in EXPECTED_SKILLS. If intentional, update "
+            "EXPECTED_SKILLS in scripts/check-plugin-manifests.py."
+        )
+    if removed:
+        drifts.append(
+            f"REMOVED SKILL(S): {sorted(removed)!r} — declared in "
+            "EXPECTED_SKILLS but missing on disk. If intentional, update "
+            "EXPECTED_SKILLS in scripts/check-plugin-manifests.py."
         )
 
     if drifts:

--- a/scripts/check-plugin-manifests.py
+++ b/scripts/check-plugin-manifests.py
@@ -343,13 +343,13 @@ def main() -> int:
         drifts.append(
             f"UNEXPECTED SKILL(S): {sorted(unexpected)!r} — present on disk "
             "but not declared in EXPECTED_SKILLS. If intentional, update "
-            "EXPECTED_SKILLS in scripts/check-plugin-manifests.py."
+            "EXPECTED_SKILLS in scripts/constants.py."
         )
     if removed:
         drifts.append(
             f"REMOVED SKILL(S): {sorted(removed)!r} — declared in "
             "EXPECTED_SKILLS but missing on disk. If intentional, update "
-            "EXPECTED_SKILLS in scripts/check-plugin-manifests.py."
+            "EXPECTED_SKILLS in scripts/constants.py."
         )
 
     if drifts:

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -1,0 +1,59 @@
+"""Single source of truth for plugin-manifest constants.
+
+Both `build-plugin-manifests.py` (wrapper emission) and
+`check-plugin-manifests.py` (CI gate) import from this module so the same
+declarations cannot drift across the build/check boundary.
+
+Add entries here — never re-declare these constants in the build or check
+scripts.
+"""
+from __future__ import annotations
+
+
+# Valid hook role names — must match the four ADR-0001 categories.
+# Used by check-plugin-manifests.py to filter `hooks/<role>/` directory
+# enumeration.
+VALID_ROLES: frozenset[str] = frozenset({
+    "preflight-gate",
+    "advisory-nudge",
+    "postuse-correction",
+    "completion-verify",
+})
+
+
+# Opt-in hooks: live on disk under hooks/<role>/<name>/ but are NOT
+# registered in manifest.json (user must add a hooks entry to their own
+# settings.json or hooks.json fragment to activate). The build still
+# emits a wrapper at hooks/<name>.sh so the documented opt-in command
+# `${CLAUDE_PLUGIN_ROOT}/hooks/<name>.sh` resolves — without this,
+# hooks/<role>/<name>/spec.md guidance would break on first user attempt.
+#
+# Dict form (name → role) is canonical — build needs the role for wrapper
+# emission. check uses the keys only (treat as a set via `set(OPT_IN_HOOKS)`
+# or `name in OPT_IN_HOOKS`).
+OPT_IN_HOOKS: dict[str, str] = {
+    "external-write-falsify-check": "advisory-nudge",
+}
+
+
+# Frozen skill surface (issue #465). Adding or removing a skill directory
+# under skills/ requires updating this set in the same commit. Prevents
+# silent skill proliferation; every intentional surface change is paired
+# with an explicit declaration here.
+EXPECTED_SKILLS: frozenset[str] = frozenset({
+    "bypass-review",
+    "cmux-browser",
+    "cmux-delegate",
+    "cmux-recover-sessions",
+    "cmux-resume-sessions",
+    "cmux-save-sessions",
+    "cmux-session-manager",
+    "codex-review-wrap",
+    "recover-sessions",
+    "reset-strikes",
+    "retrospect",
+    "strike",
+    "strikes",
+    "using-praxis",
+    "writing-praxis-skill",
+})

--- a/tests/test_skill_surface_freeze.sh
+++ b/tests/test_skill_surface_freeze.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# test_skill_surface_freeze.sh — verify check-plugin-manifests.py Rule 11 (#465)
+#
+# Asserts:
+#   1. Current seed (15 skills) passes
+#   2. Unexpected skill dir triggers non-zero exit + UNEXPECTED SKILL message
+#   3. Removed (declared-but-missing) skill triggers non-zero exit + REMOVED SKILL message
+#   4. SKILL.md.tmpl (file, not dir) and underscore-prefixed dirs are excluded
+#
+# Usage: bash tests/test_skill_surface_freeze.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK="$ROOT_DIR/scripts/check-plugin-manifests.py"
+
+if [ ! -x "$CHECK" ]; then
+  echo "FAIL: check script not executable: $CHECK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+GHOST="$ROOT_DIR/skills/ghost-skill-fixture"
+GHOST_UNDERSCORE="$ROOT_DIR/skills/_internal-fixture"
+BACKUP_DIR="$(mktemp -d)"
+BACKUP="$BACKUP_DIR/strikes"
+
+cleanup() {
+  # Idempotent restore: handles interruption (SIGINT/TERM) mid-fixture.
+  [ -d "$GHOST" ] && rmdir "$GHOST" 2>/dev/null
+  [ -d "$GHOST_UNDERSCORE" ] && rmdir "$GHOST_UNDERSCORE" 2>/dev/null
+  if [ -d "$BACKUP" ] && [ ! -d "$ROOT_DIR/skills/strikes" ]; then
+    mv "$BACKUP" "$ROOT_DIR/skills/strikes"
+  fi
+  rm -rf "$BACKUP_DIR" 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+run_case() {
+  local name="$1" cmd="$2" expected_rc="$3" expected_grep="$4"
+  local out rc
+  out="$(eval "$cmd" 2>&1)"
+  rc=$?
+  local ok=1
+  if [ "$rc" != "$expected_rc" ]; then
+    ok=0
+  fi
+  if [ -n "$expected_grep" ] && ! echo "$out" | grep -q -- "$expected_grep"; then
+    ok=0
+  fi
+  if [ "$ok" = "1" ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] rc=$rc (want $expected_rc), grep=$expected_grep"
+    echo "----- output -----"
+    echo "$out"
+    echo "------------------"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Case 1: current 15-skill seed passes
+run_case "seed-15-passes" "python3 \"$CHECK\"" 0 "plugin-manifest check OK"
+
+# Case 2: unexpected skill dir triggers UNEXPECTED SKILL
+mkdir -p "$GHOST"
+run_case "unexpected-skill-fails" "python3 \"$CHECK\"" 1 "UNEXPECTED SKILL(S).*ghost-skill-fixture"
+rmdir "$GHOST"
+
+# Case 3: removed (declared-but-missing) skill triggers REMOVED SKILL
+mv "$ROOT_DIR/skills/strikes" "$BACKUP"
+run_case "removed-skill-fails" "python3 \"$CHECK\"" 1 "REMOVED SKILL(S).*strikes"
+mv "$BACKUP" "$ROOT_DIR/skills/strikes"
+
+# Case 4: SKILL.md.tmpl (file) and _-prefixed dirs are excluded
+mkdir -p "$GHOST_UNDERSCORE"
+run_case "underscore-prefix-excluded" "python3 \"$CHECK\"" 0 "plugin-manifest check OK"
+rmdir "$GHOST_UNDERSCORE"
+
+# Case 5: post-restore returns to passing state
+run_case "post-restore-passes" "python3 \"$CHECK\"" 0 "plugin-manifest check OK"
+
+echo ""
+echo "Results: $PASS pass, $FAIL fail"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 변경 사항

`scripts/check-plugin-manifests.py` 에 Rule 11 (스킬 surface freeze gate) 추가. 스킬 디렉터리 add/remove 가 `EXPECTED_SKILLS` 집합 갱신과 같은 커밋에서 일어나도록 구조적으로 enforce.

- `EXPECTED_SKILLS` frozen set (seed = 15 현재 skill 디렉터리 verbatim 명시)
- `_skill_dirs()` helper — `_hook_dirs()` 패턴 mirror (file 자동 제외, `_`-prefix / `__pycache__` 제외)
- main() Rule 11 — `unexpected = on_disk - EXPECTED_SKILLS` / `removed = EXPECTED_SKILLS - on_disk` 두 방향 모두 fail
- `CONTRIBUTING.md` — "Skill surface freeze (`EXPECTED_SKILLS`)" subsection 추가
- `tests/test_skill_surface_freeze.sh` — 5 cases + trap-based cleanup (SIGINT/TERM 인터럽트 시 `skills/strikes` 자동 복원)

## 출처 / 배경

`Yeachan-Heo/gajae-code` (MIT) 의 `scripts/verify-g002-gates.ts` + `AGENTS.md` "정확히 N개 워크플로 스킬만 번들" 패턴 채택. 현재 12+개로 늘어난 praxis 스킬에 대해 의도적 surface 변경만 통과시키는 게이트.

## 검증

```
$ python scripts/check-plugin-manifests.py
plugin-manifest check OK

$ bash tests/test_skill_surface_freeze.sh
PASS  [seed-15-passes]
PASS  [unexpected-skill-fails]
PASS  [removed-skill-fails]
PASS  [underscore-prefix-excluded]
PASS  [post-restore-passes]
Results: 5 pass, 0 fail

$ python scripts/build-plugin-manifests.py && python scripts/check-plugin-manifests.py
clean — no changes
plugin-manifest check OK
```

Pre-commit verified: `python -m pytest tests/` (67/67 pass) + `for f in tests/hooks/*/test_*.sh; do bash "$f"; done` (background exit 0, regression 없음) + `python scripts/build-plugin-manifests.py && python scripts/check-plugin-manifests.py` (clean — no changes / plugin-manifest check OK)

### Caller chain verified

본 PR 은 `/praxis:ralplan` 으로 합의된 plan v3.1 의 Wave 1 (enforcement-first 단독 PR). Wave 0 probe 완료 (`#466` premise falsified → `#472` reframe, `#467` JSONL `isCompactSummary` 필드 확정) 후 Wave 1 진입. caller chain: `/praxis:ralplan` → Architect synthesis (Critic 2-round APPROVE) → Wave 1 implementation → `oh-my-claudecode:code-reviewer` (APPROVE HIGH, MEDIUM trap-cleanup 반영) → `praxis:codex-review-wrap` (0 findings) → this PR.

## Pre-Implementation Surface Enumeration

`_skill_dirs()` 가 처리하는 입력 변형:

| 변형 | 동작 | Test |
|---|---|---|
| 정상 디렉터리 | 포함 | seed-15-passes |
| 파일 (`SKILL.md.tmpl`) | 자동 제외 (`is_dir()` false) | seed-15-passes (15개만 통과) |
| `__pycache__` | 자동 제외 (명시) | implicit (현 seed) |
| `_internal-fixture` (underscore prefix) | 자동 제외 | underscore-prefix-excluded |
| 미선언 디렉터리 (`ghost-skill-fixture`) | `UNEXPECTED SKILL(S)` fail | unexpected-skill-fails |
| EXPECTED 에만 있고 디스크에 없음 (`strikes` removed) | `REMOVED SKILL(S)` fail | removed-skill-fails |
| `skills/` 디렉터리 자체 부재 | empty set 반환, 비교 정상 | guard (`if not skills_root.is_dir()`) |

## Reviews

- `oh-my-claudecode:code-reviewer` — APPROVE (HIGH confidence). MEDIUM trap-cleanup finding 반영 완료
- `praxis:codex-review-wrap` — 0 findings (정확성/보안/성능/유지보수성 영향 결함 없음)

Closes #465
