### PR TITLE
feat(cmux-resume): add hostname mismatch gate

### DIFF
--- a/skills/cmux-resume-sessions/SKILL.md
+++ b/skills/cmux-resume-sessions/SKILL.md
@@ -52,18 +52,17 @@ It does NOT restore runtime state of previously running commands or sessions.
 
 **How to run:**
 1. User requests "resume sessions", "session restore", etc.
-2. Snapshot resolution — resolve `snapshot` to a full path before the gate, mirroring the CLI's logic at `cmux-resume-sessions` lines 5-13, 23-30 so the gate sees the same file the CLI will open. Strip flags first (mirror of the CLI's `for arg in "$@"; case "$arg" in --no-claude) ... esac` loop), then take the first positional as the snapshot candidate:
+2. Snapshot resolution — resolve `snapshot` to a full path before the gate, mirroring the CLI's logic at `cmux-resume-sessions` lines 5-13, 23-30 so the gate sees the same file the CLI will open. Mirror the CLI parser exactly: consume `--no-claude` (the only recognized flag), and treat **every other token** — including unknown `--flag` strings — as a positional candidate, taking the first one as the snapshot candidate:
 ```bash
 SAVE_DIR="$HOME/.cmux/sessions"
 arg=""
 for a in "$@"; do
   case "$a" in
-    --no-claude) ;;  # known flag, skip (mirror of CLI parser)
-    --*) ;;          # any other flag, skip
-    *) arg="$a"; break ;;  # first non-flag is the snapshot candidate
+    --no-claude) ;;  # only recognized flag — skip (mirror of CLI line 10)
+    *) arg="$a"; break ;;  # every other token, including unknown --flag, is positional (mirror of CLI line 11)
   esac
 done
-# arg is now "" (no positional) or a bare filename / full path
+# arg is now "" (no positional) or a bare filename / full path / a literal "--flag" the CLI would also pass through
 if [[ -z "$arg" ]]; then
   snapshot=$(ls -t "$SAVE_DIR"/sessions-*.json | head -1)
 elif [[ -f "$arg" ]]; then

--- a/skills/cmux-resume-sessions/SKILL.md
+++ b/skills/cmux-resume-sessions/SKILL.md
@@ -7,6 +7,9 @@ description: >
   route to cmux-recover-sessions instead — even when the user also mentions a snapshot,
   because the snapshot may be stale and .jsonl scanning reflects the real latest state.
   Triggers on "resume sessions", "session resume", "session restore", "restore sessions", "cmux resume", "restore from snapshot", "rehydrate sessions", "세션 복원", "스냅샷 복구", "스냅샷 복원".
+verified-against-runtime: true
+runtime-verified-at: 2026-05-28
+runtime-verified-note: "jq 1.x // empty + bash hostname (cmux 1.x snapshot schema: top-level .hostname) — silent-proceed on missing field / null / empty string; emits real value when present; matches against $(hostname). 4 synthetic + 1 real-snapshot cases probed."
 ---
 
 # cmux Resume Sessions
@@ -49,14 +52,36 @@ It does NOT restore runtime state of previously running commands or sessions.
 
 **How to run:**
 1. User requests "resume sessions", "session restore", etc.
-2. Snapshot selection:
-   - No argument: use the most recent snapshot
-   - Filename or full path specified: use that snapshot
-3. Execute:
+2. Snapshot resolution — resolve `snapshot` to a full path before the gate, mirroring the CLI's logic at `cmux-resume-sessions` lines 23-30 so the gate sees the same file the CLI will open:
 ```bash
-bash "$(dirname "$0")/cmux-resume-sessions" [snapshot-file]
+SAVE_DIR="$HOME/.cmux/sessions"
+arg="$1"  # may be empty, a bare filename (sessions-*.json), or a full path
+if [[ -z "$arg" ]]; then
+  snapshot=$(ls -t "$SAVE_DIR"/sessions-*.json | head -1)
+elif [[ -f "$arg" ]]; then
+  snapshot="$arg"
+elif [[ -f "$SAVE_DIR/$arg" ]]; then
+  snapshot="$SAVE_DIR/$arg"
+else
+  echo "ERROR: snapshot '$arg' not found in cwd or $SAVE_DIR" >&2; exit 1
+fi
 ```
-4. Show output to the user
+3. **Hostname mismatch gate** — verify the snapshot's saved host matches the current machine before restoring:
+```bash
+saved_host=$(jq -r '.hostname // empty' "$snapshot")
+current_host=$(hostname)
+```
+   - If `${saved_host}` is empty (legacy snapshot without the field): proceed silently.
+   - If `${saved_host}` equals `${current_host}`: proceed silently.
+   - If `${saved_host}` differs from `${current_host}`: surface `AskUserQuestion`:
+     - Question: `"이 스냅샷은 다른 머신 (${saved_host}) 에서 저장되었습니다. 현재 머신은 ${current_host} 입니다. cwd 경로가 맞지 않을 수 있어 세션 다수가 'cwd not found' 로 스킵될 수 있습니다. 계속할까요?"`
+     - Options: `"계속 진행"` / `"취소"`
+   - If user selects `"취소"`: abort with `"Resume 취소됨 — 호스트 불일치 (${saved_host} → ${current_host})."`
+4. Execute (only after the hostname gate passes). Pass through all original args (`"$@"`) so flags like `--no-claude` survive:
+```bash
+bash "$(dirname "$0")/cmux-resume-sessions" "$@"
+```
+5. Show output to the user
 
 **What gets restored:**
 - Creates a cmux workspace per session (with `--cwd` for working directory)
@@ -128,4 +153,4 @@ Done. Created: 2 | Skipped: 1 | Failed: 1
 | "Restore every snapshot at once" | Old snapshots point to cwd paths that no longer exist. Restore the most recent that's still valid. |
 | "Skip `--no-claude`, always auto-start Claude" | If the target cwd's recent conversation is stale, auto-continue lands in the wrong context. Use `--no-claude` when in doubt. |
 | "Ignore duplicate warnings" | Duplicate workspaces are noise at best, collision at worst. Inspect existing sessions first. |
-| "Restore before verifying the snapshot's host" | Cross-machine restore may succeed with stale paths. Check `hostname` in the JSON before restoring on a new host. |
+| "Restore before verifying the snapshot's host" | Cross-machine restore may succeed with stale paths. The hostname mismatch gate (Step 3 in `resume` "How to run") surfaces an `AskUserQuestion` when `jq -r '.hostname'` differs from `$(hostname)` — do not click through without inspecting the cwd paths. |

--- a/skills/cmux-resume-sessions/SKILL.md
+++ b/skills/cmux-resume-sessions/SKILL.md
@@ -52,10 +52,18 @@ It does NOT restore runtime state of previously running commands or sessions.
 
 **How to run:**
 1. User requests "resume sessions", "session restore", etc.
-2. Snapshot resolution — resolve `snapshot` to a full path before the gate, mirroring the CLI's logic at `cmux-resume-sessions` lines 23-30 so the gate sees the same file the CLI will open:
+2. Snapshot resolution — resolve `snapshot` to a full path before the gate, mirroring the CLI's logic at `cmux-resume-sessions` lines 5-13, 23-30 so the gate sees the same file the CLI will open. Strip flags first (mirror of the CLI's `for arg in "$@"; case "$arg" in --no-claude) ... esac` loop), then take the first positional as the snapshot candidate:
 ```bash
 SAVE_DIR="$HOME/.cmux/sessions"
-arg="$1"  # may be empty, a bare filename (sessions-*.json), or a full path
+arg=""
+for a in "$@"; do
+  case "$a" in
+    --no-claude) ;;  # known flag, skip (mirror of CLI parser)
+    --*) ;;          # any other flag, skip
+    *) arg="$a"; break ;;  # first non-flag is the snapshot candidate
+  esac
+done
+# arg is now "" (no positional) or a bare filename / full path
 if [[ -z "$arg" ]]; then
   snapshot=$(ls -t "$SAVE_DIR"/sessions-*.json | head -1)
 elif [[ -f "$arg" ]]; then


### PR DESCRIPTION
## 변경 사항

`skills/cmux-resume-sessions/SKILL.md` 의 `resume` 절차에 Step 3 (hostname mismatch gate) 추가. 기존엔 rationalization 표에 "check hostname" 만 적혀 있고 실제 절차 부재.

- **Step 2 (snapshot resolution)** — CLI 의 flag parsing + 3-case positional resolution (`cmux-resume-sessions:5-13,23-30`) 을 **line-for-line mirror**: `"$@"` 를 순회하며 `--no-claude` (CLI 가 인식하는 유일한 flag) 만 소비하고, 그 외 모든 토큰 (unknown `--flag` 포함) 은 첫 번째를 snapshot 후보로 binding. 이후 no-arg → 최신, full-path → 그대로, bare filename → `$HOME/.cmux/sessions/<name>` 의 3-case 해석. gate 가 CLI 와 동일한 파일을 보도록 (CLI 가 error 일 때 gate 도 error).
- **Step 3 (hostname gate)** — `jq -r '.hostname // empty' "$snapshot"` + `$(hostname)` 비교. 일치/empty 면 silent proceed, 불일치 시 `AskUserQuestion` 2-option (계속 진행 / 취소).
- **Step 4 (execute)** — `"$@"` pass-through 로 기존 flags (`--no-claude` 등) 보존.
- **rationalization 표 row** 갱신 — 절차 cross-reference + verbatim 명령 인용.
- **frontmatter** — `verified-against-runtime: true` + probe note (CONTRIBUTING.md "wraps external CLI / AskUserQuestion" rule 적용).

## 출처 / 배경

`Yeachan-Heo/gajae-code` (MIT) `docs/session-switching-and-recent-listing.md` 의 cross-project resume 확인 패턴 채택. praxis 의 `cmux-save-sessions/SKILL.md:100` 이 이미 `hostname` 필드를 저장하지만 resume 시 비교 절차 부재.

## 검증

Pre-commit verified: jq syntax probed against 4 synthetic cases (missing/null/empty/value) — all collapse correctly via `// empty`; real snapshot `~/.cmux/sessions/sessions-20260407-232911.json` returns `nathansongui-MacBookPro-5.local`; CLI parser verified at `cmux-resume-sessions:5-13,23-30`; Step 2 parser **side-by-side compared against CLI** over 10 input permutations (no-arg / bare / full-path / `--no-claude` only / `--no-claude` + bare / `--no-claude` + full / reversed / `--foo` + bare / nonexistent / `--foo` only) — T1-T7 MATCH exactly (identical resolved file path), T8-T10 both error in gate AND CLI (semantic outcome identical — both reject `--foo` as invalid snapshot, both reject nonexistent file); `python scripts/check-plugin-manifests.py` exit 0 ("plugin-manifest check OK").

```
=== F1: bare filename resolves via SAVE_DIR ===
arg=sessions-20260407-232911.json
resolved=/Users/nathan.song/.cmux/sessions/sessions-20260407-232911.json
jq -r '.hostname' → nathansongui-MacBookPro-5.local

=== F2: --no-claude through "$@" ===
args=[--no-claude sessions-X.json]
  arg: --no-claude
  arg: sessions-X.json
```

### Caller chain verified

`/praxis:ralplan` v3.1 Wave 2.a (#468 cmux-resume hostname gate, sequential before #467). caller chain: `/praxis:ralplan` (Architect+Critic APPROVE) → Wave 0 probe (#466 falsified, #467 isCompactSummary 확정) → Wave 1 #465 (PR #473 MERGED) → Wave 2.a 진입 → `oh-my-claudecode:code-reviewer` (3 findings: MEDIUM $snapshot undefined, MEDIUM frontmatter missing, LOW brace style, 모두 반영) → `praxis:codex-review-wrap` (2 P2 findings: F1 bare-filename, F2 --no-claude flag, 둘 다 premise-verified + applied) → this PR.

## Pre-Implementation Surface Enumeration

snapshot resolution + hostname compare 의 입력 변형:

| 입력 변형 | 동작 |
|---|---|
| arg 없음 | `ls -t ~/.cmux/sessions/sessions-*.json \| head -1` |
| full path 존재 | `$arg` 그대로 |
| bare filename + `$SAVE_DIR/$arg` 존재 | resolve to `$SAVE_DIR/$arg` |
| 어디에도 없음 | error exit |
| `--no-claude` 만 (positional 없음) | flag 소비 후 latest snapshot 선택 |
| `--no-claude` + bare/full path | flag 소비 후 positional 만 snapshot 으로 해석 |
| 미확인 `--flag` (예: `--foo`) | CLI 가 positional 로 취급하므로 gate 도 동일하게 첫 positional 로 해석 → 파일 없으면 error (gate ≡ CLI) |
| snapshot `.hostname` 필드 부재 | silent proceed (legacy) |
| `.hostname` == null | silent proceed (`// empty`) |
| `.hostname` == `""` | silent proceed (`// empty`) |
| `.hostname` == `$(hostname)` | silent proceed |
| `.hostname` != `$(hostname)` | AskUserQuestion 2-option |
| 사용자 "취소" | abort with mismatch message |
| `--no-claude` flag 동반 (Step 4 execute) | `"$@"` pass-through 로 보존 |

## Reviews

- `oh-my-claudecode:code-reviewer` — REQUEST CHANGES (3 findings, 모두 반영 완료)
- `praxis:codex-review-wrap` round 1 — 2 P2 findings (F1 bare-filename resolution, F2 `"$@"` pass-through), 둘 다 premise-verified + applied
- `praxis:codex-review-wrap` round 2 — 1 P2 finding (Step 2 flag-strip 누락: `resume --no-claude [snapshot]` 시 `$1` 이 `--no-claude` 가 되어 snapshot 으로 해석 실패), CLI `cmux-resume-sessions:5-13` 의 `for arg in "$@"; case --no-claude` 패턴을 Step 2 에 mirror 하여 적용 (premise-verified + 9 case probed)
- `praxis:codex-review-wrap` round 3 — 1 P2 finding ("Mirror the CLI parser exactly": round 2 fix 가 `--*` 전체를 skip 했지만 CLI 는 catch-all `*` 으로 unknown `--flag` 도 POSITIONAL 에 push. round 2 fix 가 너무 광범위하게 strip 함). `--*) ;;` branch 제거하고 `--no-claude) ;;` 만 유지 — 10 case CLI side-by-side 비교 (T1-T7 MATCH, T8-T10 error semantic identical)

Closes #468
