### PR TITLE
feat(recover-sessions): summary-based display name

### DIFF
--- a/skills/recover-sessions/claude-recover-scan
+++ b/skills/recover-sessions/claude-recover-scan
@@ -338,13 +338,19 @@ for base, home_label in config_homes.items():
                 mod_time = ts_local.strftime("%m/%d %H:%M")
 
             # ── Filtering ──
-            if is_teammate:
+            # When a compaction summary has been captured, the session has a
+            # meaningful display name and a real conversation history before
+            # the resume. Slash-command / teammate-only bootstrap turns at
+            # the top of the resumed file (e.g. `/continue`, `/retrospect`)
+            # are restoration artefacts, not the session's identity — do
+            # not filter the session out on their account.
+            if is_teammate and not compact_summary:
                 filter_counts["teammate"] += 1
                 continue
-            if is_command and user_count <= 5:
+            if is_command and user_count <= 5 and not compact_summary:
                 filter_counts["command"] += 1
                 continue
-            if user_count < MIN_USER_MSGS:
+            if user_count < MIN_USER_MSGS and not compact_summary:
                 filter_counts["short"] += 1
                 continue
 

--- a/skills/recover-sessions/claude-recover-scan
+++ b/skills/recover-sessions/claude-recover-scan
@@ -8,11 +8,74 @@ Usage:
 Output:
   Pipe-delimited lines: mod_time|size|session_id|cwd|first_msg|home_label
 """
-import json, os, sys, datetime
+import json, os, re, sys, datetime
 
 days_ago_str = sys.argv[1]
 from_date_str = sys.argv[2]
 to_date_str = sys.argv[3]
+
+# Claude Code emits a boilerplate prefix on every compaction-restored
+# session — strip it before extracting a display name so every compacted
+# session does not collapse to the same line. Regex (rather than exact
+# string match) tolerates minor wording drift across Claude Code versions.
+RE_COMPACT_BOILERPLATE = re.compile(
+    r"^This session is being continued from .*?conversation\.\s*",
+    re.S,
+)
+# Locate every "Original request:" / "Primary Request and Intent:" label
+# so we can pick the INNERMOST (most-specific) one. A compaction summary
+# typically nests them as "Primary Request and Intent: - Original request:
+# <text>" — matching the first label captures the wrapper section, not
+# the actual request text.
+RE_REQUEST_LABEL_TOKEN = re.compile(
+    r"(?:Original|Primary)\s+(?:request|Request)[^:\n]*:"
+)
+RE_FIRST_SENTENCE = re.compile(
+    r"^[-\s]*\*?\*?(?!Summary\b|Primary\b|\.\.\.|This session\b)"
+    r"([A-Za-zÀ-ſ가-힯\"\'].{10,200}?)(?:\.\s|\n|\*\*|$)",
+    re.MULTILINE,
+)
+
+
+def _trim(text: str) -> str:
+    """Strip surrounding whitespace + leading list/bullet markers + trailing markdown bold and sentence period."""
+    text = text.strip()
+    # Peel a leading "- " or "* " list marker if present (these are
+    # extraction artifacts, not part of the user-visible content).
+    while text.startswith(("- ", "* ")):
+        text = text[2:].lstrip()
+    # Strip trailing markdown emphasis + sentence-terminating period
+    # the captures sometimes pull in. Loop because a value can end in
+    # `**.` and both need to come off.
+    prev = None
+    while prev != text:
+        prev = text
+        text = text.rstrip("*").rstrip(".").rstrip()
+    return text.replace("\n", " ")[:80]
+
+
+def extract_compact_display(content: str) -> str:
+    """Pick a display-friendly line from a compaction summary record."""
+    after = RE_COMPACT_BOILERPLATE.sub("", content, count=1).strip()
+    # Strip the standard "Summary:" header that wraps the body of every
+    # compaction record — it has no per-session signal value.
+    if after.startswith("Summary:"):
+        after = after[len("Summary:"):].lstrip()
+    # Pick the INNERMOST request label; an outer "Primary Request and
+    # Intent:" wraps an inner "Original request:" in the common shape.
+    labels = list(RE_REQUEST_LABEL_TOKEN.finditer(after))
+    if labels:
+        rest = after[labels[-1].end():].lstrip(" *")
+        # Cut at the first newline / bold delimiter / end-of-string.
+        end_match = re.search(r"\n|\*\*", rest)
+        body = rest[: end_match.start()] if end_match else rest
+        cleaned = _trim(body)
+        if cleaned:
+            return cleaned
+    m = RE_FIRST_SENTENCE.search(after)
+    if m:
+        return _trim(m.group(1))
+    return ""
 
 def parse_date(s):
     if not s:
@@ -143,6 +206,7 @@ for base, home_label in config_homes.items():
             cwd = ""
             user_count = 0
             first_real_msg = ""
+            compact_summary = ""
             is_teammate = False
             is_command = False
             is_schedule = False
@@ -168,15 +232,32 @@ for base, home_label in config_homes.items():
                             cwd = obj["cwd"]
 
                         if obj.get("type") == "user" and not obj.get("isSidechain"):
-                            user_count += 1
-                            user_tail_buf.append(obj)
-                            if len(user_tail_buf) > USER_TAIL_SIZE:
-                                user_tail_buf.pop(0)
                             msg = obj.get("message", {})
                             raw = msg.get("content", "") if isinstance(msg, dict) else str(msg)
                             if not isinstance(raw, str):
                                 continue
                             c = raw.strip()
+
+                            # Compaction summary records: extract a display-
+                            # friendly line and short-circuit BEFORE any
+                            # user-count-driven gate (MIN_USER_MSGS,
+                            # command/teammate detection at user_count==1,
+                            # schedule prefix). The boilerplate is identical
+                            # across every compacted session, so without
+                            # this branch every restored session collapses
+                            # to the same "This session is being continued…"
+                            # line; counting it as a user message would
+                            # also let a "real" 3-message session pass the
+                            # 4-message floor with a compaction stub.
+                            if obj.get("isCompactSummary"):
+                                if not compact_summary:
+                                    compact_summary = extract_compact_display(c)
+                                continue
+
+                            user_count += 1
+                            user_tail_buf.append(obj)
+                            if len(user_tail_buf) > USER_TAIL_SIZE:
+                                user_tail_buf.pop(0)
 
                             if user_count <= 5:
                                 if c.startswith("<teammate-message"):
@@ -283,12 +364,25 @@ for base, home_label in config_homes.items():
             if was_exited:
                 filter_counts["exited"] += 1
                 continue
-            if not first_real_msg:
+            # Display-name fallback chain (per #467): compaction summary →
+            # first non-trivial user msg → session_id. The compaction
+            # summary takes precedence because a long session that has
+            # been compacted is identified by what the conversation
+            # *became*, not by the slash-command that originally booted
+            # it (e.g. "/continue" or "/retrospect"). The session_id
+            # final fallback matches the acceptance criterion verbatim —
+            # a UUID label is uninformative but lets the user resume
+            # rather than have the session silently dropped.
+            display_name = compact_summary or first_real_msg or session_id
+            if not display_name:
+                # Genuinely empty (no compact summary, no first msg, no
+                # session id) — defensive only; should never trigger
+                # because session_id is always set above.
                 filter_counts["no_msg"] += 1
                 continue
 
             cwd = cwd or "/tmp"
-            results.append((mod_time, size_h, session_id, cwd, first_real_msg, home_label))
+            results.append((mod_time, size_h, session_id, cwd, display_name, home_label))
 
 results.sort(key=lambda x: x[0], reverse=True)
 

--- a/tests/test_recover_scan_display_name.sh
+++ b/tests/test_recover_scan_display_name.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# test_recover_scan_display_name.sh — verify claude-recover-scan picks
+# display names from the compact-summary fallback chain (#467).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCAN="$REPO_ROOT/skills/recover-sessions/claude-recover-scan"
+
+if [[ ! -f "$SCAN" ]]; then
+  echo "FAIL: scanner not found at $SCAN" >&2
+  exit 1
+fi
+
+TMPHOME=$(mktemp -d)
+PROJ="$TMPHOME/.claude/projects/-tmp-fake-cwd"
+mkdir -p "$PROJ"
+
+cleanup() {
+  rm -rf "$TMPHOME"
+}
+trap cleanup EXIT INT TERM
+
+PAD=$(python3 -c "print('x' * 12000)")
+NOW=$(date +%Y-%m-%dT%H:%M:%S.000Z)
+CWD="/tmp/fake-cwd"
+
+# Each fixture file needs >= 4 real user records (MIN_USER_MSGS) — compaction
+# records no longer count toward user_count after the fix, so the padding
+# records are required to keep the file from being filtered as "short".
+emit_padding_users() {
+  local path="$1"
+  for i in 1 2 3 4 5; do
+    printf '{"type":"user","isSidechain":false,"timestamp":"%s","cwd":"%s","message":{"content":"padding %d"}}\n' \
+      "$NOW" "$CWD" "$i" >> "$path"
+  done
+  printf '{"type":"assistant","timestamp":"%s","message":{"content":"%s"}}\n' \
+    "$NOW" "$PAD" >> "$path"
+}
+
+build_fixture() {
+  local path="$1" head_payload="$2"
+  : > "$path"
+  printf '%s\n' "$head_payload" >> "$path"
+  emit_padding_users "$path"
+}
+
+# Fixture A: compact-summary with NESTED labels (the real-world shape).
+# The outer "Primary Request and Intent:" wraps an inner "Original request:".
+# The display must extract the inner request text, not leak "- Original request:".
+COMPACT_NESTED='This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.\n\nSummary:\n1. Primary Request and Intent:\n   - **Original request**: Run praxis:codex-review-wrap on each currently open PR\n'
+A_PAYLOAD=$(python3 -c "
+import json
+print(json.dumps({
+  'type': 'user', 'isSidechain': False, 'isCompactSummary': True,
+  'timestamp': '$NOW', 'cwd': '$CWD',
+  'message': {'content': '''$COMPACT_NESTED'''.replace(chr(92)+'n', chr(10))}
+}))
+")
+build_fixture "$PROJ/aaaa1111-1111-1111-1111-111111111111.jsonl" "$A_PAYLOAD"
+# Add a /retrospect record AFTER compaction to confirm compact_summary wins.
+python3 -c "
+import json
+print(json.dumps({
+  'type':'user','isSidechain':False,'timestamp':'$NOW','cwd':'$CWD',
+  'message':{'content':'/retrospect'}
+}))
+" >> "$PROJ/aaaa1111-1111-1111-1111-111111111111.jsonl"
+
+# Fixture B: no compact summary, plain first message.
+B_PAYLOAD=$(python3 -c "
+import json
+print(json.dumps({
+  'type':'user','isSidechain':False,'timestamp':'$NOW','cwd':'$CWD',
+  'message':{'content':'Investigate the broken hook chain in PR 472'}
+}))
+")
+build_fixture "$PROJ/bbbb2222-2222-2222-2222-222222222222.jsonl" "$B_PAYLOAD"
+
+# Fixture C: compact-only "Summary:" form (no Primary/Original labels).
+COMPACT_SHORT='This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.\nSummary: Investigate flaky tests in the integration suite.'
+C_PAYLOAD=$(python3 -c "
+import json
+print(json.dumps({
+  'type':'user','isSidechain':False,'isCompactSummary':True,
+  'timestamp':'$NOW','cwd':'$CWD',
+  'message':{'content':'''$COMPACT_SHORT'''.replace(chr(92)+'n', chr(10))}
+}))
+")
+build_fixture "$PROJ/cccc3333-3333-3333-3333-333333333333.jsonl" "$C_PAYLOAD"
+
+# Fixture D: Korean unicode in compact summary.
+COMPACT_KR='This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.\nSummary: 네이버 검색광고 v2 전환 현황 확인 요청'
+D_PAYLOAD=$(python3 -c "
+import json
+print(json.dumps({
+  'type':'user','isSidechain':False,'isCompactSummary':True,
+  'timestamp':'$NOW','cwd':'$CWD',
+  'message':{'content':'''$COMPACT_KR'''.replace(chr(92)+'n', chr(10))}
+}))
+")
+build_fixture "$PROJ/dddd4444-4444-4444-4444-444444444444.jsonl" "$D_PAYLOAD"
+
+# Fixture E: drifted boilerplate (one word changed). The regex strip must
+# still remove it so the next "This session…" prefix doesn't leak.
+DRIFTED='This session is being continued from the previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.\nSummary: Resume work on the auth refactor.'
+E_PAYLOAD=$(python3 -c "
+import json
+print(json.dumps({
+  'type':'user','isSidechain':False,'isCompactSummary':True,
+  'timestamp':'$NOW','cwd':'$CWD',
+  'message':{'content':'''$DRIFTED'''.replace(chr(92)+'n', chr(10))}
+}))
+")
+build_fixture "$PROJ/eeee5555-5555-5555-5555-555555555555.jsonl" "$E_PAYLOAD"
+
+# Fixture F: session with no real first message AND no compact summary.
+# Per #467 fallback chain, display_name must fall back to session_id.
+# All user records are `<...>`-wrapped so none qualify as first_real_msg.
+F_PATH="$PROJ/ffff6666-6666-6666-6666-666666666666.jsonl"
+: > "$F_PATH"
+# Use `<system-tag>`-wrapped content: all records start with `<` so
+# first_real_msg never sets, none match command/teammate triggers, and
+# none have isCompactSummary — display_name should land on session_id.
+for i in 1 2 3 4 5; do
+  python3 -c "
+import json
+print(json.dumps({
+  'type':'user','isSidechain':False,'timestamp':'$NOW','cwd':'$CWD',
+  'message':{'content':'<system-tag>placeholder $i</system-tag>'}
+}))
+" >> "$F_PATH"
+done
+printf '{"type":"assistant","timestamp":"%s","message":{"content":"%s"}}\n' \
+  "$NOW" "$PAD" >> "$F_PATH"
+
+# Run scanner against the temp config home.
+out=$(HOME="$TMPHOME" STRICT_TIMESTAMP=0 python3 "$SCAN" 3 "" "" 2>&1 || true)
+
+pass=0
+fail=0
+
+# Pick the display-name field (5th pipe-separated column) for a session id prefix.
+extract_field() {
+  local sid_prefix="$1"
+  grep -F "|${sid_prefix}" <<< "$out" | head -1 | awk -F'|' '{print $5}'
+}
+
+assert_equals() {
+  local label="$1" sid_prefix="$2" expected="$3"
+  local actual
+  actual=$(extract_field "$sid_prefix")
+  if [[ "$actual" == "$expected" ]]; then
+    echo "PASS  [$label]"
+    pass=$((pass + 1))
+  else
+    echo "FAIL  [$label]"
+    echo "  expected (exact): '$expected'"
+    echo "  actual:           '$actual'"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_no_prefix() {
+  local label="$1" sid_prefix="$2" forbidden="$3"
+  local actual
+  actual=$(extract_field "$sid_prefix")
+  if [[ "$actual" == "$forbidden"* ]]; then
+    echo "FAIL  [$label]"
+    echo "  display starts with forbidden prefix '$forbidden': '$actual'"
+    fail=$((fail + 1))
+  else
+    echo "PASS  [$label]  (no '$forbidden' prefix in: '$actual')"
+    pass=$((pass + 1))
+  fi
+}
+
+# A: nested-label extraction returns the INNER request text, no "- Original request:" leak
+assert_equals "nested-label-extracts-inner-request" \
+  "aaaa1111" \
+  "Run praxis:codex-review-wrap on each currently open PR"
+assert_no_prefix "no-dash-prefix-leak" \
+  "aaaa1111" \
+  "- "
+assert_no_prefix "no-original-request-label-leak" \
+  "aaaa1111" \
+  "Original request"
+
+# B: plain first message preserved
+assert_equals "plain-first-message" \
+  "bbbb2222" \
+  "Investigate the broken hook chain in PR 472"
+
+# C: "Summary: <body>" short form
+assert_equals "summary-prefix-stripped" \
+  "cccc3333" \
+  "Investigate flaky tests in the integration suite"
+
+# D: Korean unicode survives
+assert_equals "korean-summary" \
+  "dddd4444" \
+  "네이버 검색광고 v2 전환 현황 확인 요청"
+
+# E: drifted boilerplate stripped (regex tolerant)
+assert_equals "drifted-boilerplate-stripped" \
+  "eeee5555" \
+  "Resume work on the auth refactor"
+
+# F: session_id fallback per spec
+assert_equals "session-id-final-fallback" \
+  "ffff6666" \
+  "ffff6666-6666-6666-6666-666666666666"
+
+# Boilerplate-leak guard across the entire scan output
+if grep -F 'This session is being continued from' <<< "$out"; then
+  echo "FAIL  [boilerplate-leak-guard]"
+  fail=$((fail + 1))
+else
+  echo "PASS  [boilerplate-leak-guard]"
+  pass=$((pass + 1))
+fi
+
+echo "Results: $pass passed, $fail failed"
+exit $(( fail > 0 ? 1 : 0 ))

--- a/tests/test_recover_scan_display_name.sh
+++ b/tests/test_recover_scan_display_name.sh
@@ -114,6 +114,31 @@ print(json.dumps({
 ")
 build_fixture "$PROJ/eeee5555-5555-5555-5555-555555555555.jsonl" "$E_PAYLOAD"
 
+# Fixture G: compacted session followed by a /continue slash-command — the
+# bootstrap turn must NOT cause the session to be filtered as command.
+# Regression guard for codex round 1 P2.
+COMPACT_G='This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.\nSummary: Long-running refactor of the auth layer.'
+G_PATH="$PROJ/gggg7777-7777-7777-7777-777777777777.jsonl"
+: > "$G_PATH"
+python3 -c "
+import json
+print(json.dumps({
+  'type':'user','isSidechain':False,'isCompactSummary':True,
+  'timestamp':'$NOW','cwd':'$CWD',
+  'message':{'content':'''$COMPACT_G'''.replace(chr(92)+'n', chr(10))}
+}))
+" >> "$G_PATH"
+python3 -c "
+import json
+print(json.dumps({
+  'type':'user','isSidechain':False,'timestamp':'$NOW','cwd':'$CWD',
+  'message':{'content':'<command-name>/continue</command-name>'}
+}))
+" >> "$G_PATH"
+# Pad to clear the 10 KB / MIN_USER_MSGS threshold even though the
+# compact-summary bypass would let it through anyway.
+emit_padding_users "$G_PATH"
+
 # Fixture F: session with no real first message AND no compact summary.
 # Per #467 fallback chain, display_name must fall back to session_id.
 # All user records are `<...>`-wrapped so none qualify as first_real_msg.
@@ -210,6 +235,11 @@ assert_equals "drifted-boilerplate-stripped" \
 assert_equals "session-id-final-fallback" \
   "ffff6666" \
   "ffff6666-6666-6666-6666-666666666666"
+
+# G: compacted-then-/continue session — display from compact_summary, not filtered
+assert_equals "compacted-then-continue-survives-filter" \
+  "gggg7777" \
+  "Long-running refactor of the auth layer"
 
 # Boilerplate-leak guard across the entire scan output
 if grep -F 'This session is being continued from' <<< "$out"; then


### PR DESCRIPTION
## 변경 사항

`skills/recover-sessions/claude-recover-scan` 에 compaction summary 기반 display name fallback chain 추가. 기존엔 모든 compacted session 이 `"This session is being continued from a previous conversation…"` 같은 boilerplate 로만 표시되거나, `/continue` / `/retrospect` 같은 단발 명령이 첫 메시지인 세션은 명령 그 자체로 표시되어 복구 목록에서 식별 불능.

- **Wave 0 probe** — Claude Code JSONL 의 compaction record 는 `type:"user"` + `isCompactSummary:true` + `message.content` 가 literal boilerplate prefix 로 시작하는 것 확인 (gajae 의 `header.title` / `shortSummary` 와 schema 가 다름).
- **`extract_compact_display()`** — boilerplate strip (regex 로 wording drift 허용) → `"Summary:"` 헤더 strip → INNERMOST `"(Original|Primary) request:"` 라벨 선택. 흔한 `"Primary Request and Intent: - Original request: <text>"` nested 구조에서 outer 라벨이 아닌 inner `<text>` 만 반환.
- **`isCompactSummary` short-circuit** — compaction record 는 `user_count++` 전에 분기 처리. 기존엔 compaction record 가 user_count 1 슬롯을 잡아 `MIN_USER_MSGS` 와 `user_count <= 5` command/teammate 윈도우의 의미를 흐림.
- **fallback chain** — `display_name = compact_summary or first_real_msg or session_id`. spec 의 `id` 종결자 명시 (no_msg filter 는 방어용 잔류).
- **공유 scanner** — `cmux-recover-sessions` 가 같은 scanner output 을 소비하므로 별도 수정 없이 동일 개선 적용.

## 출처 / 배경

`Yeachan-Heo/gajae-code` (MIT) `docs/session-switching-and-recent-listing.md` 의 `header.title` → `shortSummary` → 첫 user prompt → id fallback chain 패턴 채택. Claude Code JSONL 의 실제 schema 는 gajae 와 다름 (`isCompactSummary` 플래그 + `message.content` 내 boilerplate prefix) — 실제 record probe 로 매핑 확정 (Wave 0).

## 검증

Pre-commit verified: 9-case test `tests/test_recover_scan_display_name.sh` (nested-label, no-dash-prefix-leak, no-original-request-leak, plain first message, summary-prefix strip, Korean unicode, drifted boilerplate, session-id fallback, boilerplate leak guard) — all PASS; 67 pytest tests pass (regression 없음); 8개 sibling shell test 모두 pass; `python scripts/check-plugin-manifests.py` exit 0 ("plugin-manifest check OK"); real-session scan 결과 검증 — 이전 boilerplate / `/continue` 만 표시되던 세션들이 의미 있는 요약으로 변경됨 (`"Initial request: 'check issues'"`, `"네이버 검색광고 v2 전환 현황 확인"`, `"Run praxis:codex-review-wrap on each currently open PR"` 등).

```
=== test_recover_scan_display_name.sh ===
PASS  [nested-label-extracts-inner-request]
PASS  [no-dash-prefix-leak]  (no '- ' prefix in: 'Run praxis:codex-review-wrap on each currently open PR')
PASS  [no-original-request-label-leak]
PASS  [plain-first-message]
PASS  [summary-prefix-stripped]
PASS  [korean-summary]
PASS  [drifted-boilerplate-stripped]
PASS  [session-id-final-fallback]
PASS  [boilerplate-leak-guard]
Results: 9 passed, 0 failed
```

Caller chain verified: `claude-recover-scan` 의 두 직접 consumer (`skills/recover-sessions/claude-recover`, `skills/cmux-recover-sessions/cmux-recover-sessions`) 둘 다 `mod_time|size|session_id|cwd|first_msg|home_label` pipe-delimited output 을 그대로 소비하므로 scanner 변경이 양쪽에 자동 전파됨 (`grep -rn claude-recover-scan skills/` 로 확인). 추가 caller 없음.

`/praxis:ralplan` v3.1 Wave 2.b (#467 recover-sessions display-name, sequential after #468). orchestration chain: `/praxis:ralplan` (Architect+Critic APPROVE) → Wave 0 probe (`isCompactSummary` 필드 확정) → Wave 1 #465 (PR #473 MERGED) → Wave 2.a #468 (PR #474 MERGED) → Wave 2.b 진입 → `oh-my-claudecode:code-reviewer` round 1 (1 HIGH + 2 MEDIUM + 3 LOW, 모두 반영) → this PR.

## Pre-Implementation Surface Enumeration

`extract_compact_display()` 가 처리하는 입력 변형:

| 입력 변형 | 동작 | Test |
|---|---|---|
| `COMPACT_BOILERPLATE` exact prefix | strip + `Summary:` 헤더 strip | (all compact fixtures) |
| boilerplate wording drift (`a previous` → `the previous`) | regex strip 으로 tolerant | drifted-boilerplate-stripped |
| `"Primary Request and Intent: - Original request: <text>"` (nested) | INNERMOST 라벨 선택, `<text>` 만 반환 | nested-label-extracts-inner-request |
| `"Summary: <body>"` (간단형) | `Summary:` strip 후 first sentence | summary-prefix-stripped |
| Korean / 비-ASCII content | unicode 포함 regex 로 capture | korean-summary |
| compaction record 만 있고 user prompt 없음 | compact_summary 단독으로 display_name 결정 | (covered by short-form fixtures) |
| compaction record 도 없고 first_real_msg 도 빈 세션 | display_name = session_id | session-id-final-fallback |
| trailing markdown bold `**` | `_trim()` 에서 trailing `*` strip | (in extraction path) |
| trailing sentence period `.` | `_trim()` 에서 trailing `.` strip | summary-prefix-stripped |
| leading `"- "` / `"* "` list marker | `_trim()` 에서 strip | no-dash-prefix-leak |
| isCompactSummary record 가 user_count 1 슬롯 잡음 (회귀) | short-circuit 로 user_count++ 전 처리 | (covered by fixture A 가 4개 padding + compact record 로 MIN_USER_MSGS 만족) |

## Reviews

- `oh-my-claudecode:code-reviewer` — REQUEST CHANGES (1 HIGH + 2 MEDIUM + 3 LOW), 모두 반영 완료. HIGH (nested label leak), MEDIUM 1 (boilerplate brittleness), MEDIUM 2 (user_count distortion), LOW 1 (spec deviation: id fallback 추가), LOW 3 (trailing `**` strip)
- `praxis:codex-review-wrap` round 1 — 1 P2 finding (compacted + `/continue` 슬래시 명령 세션이 command filter 에 걸려 drop → display fallback 도달 못함). flip resolved per user hybrid: omc MEDIUM 2 유지 + teammate/command/short filter 에 `and not compact_summary` clause 추가. probe `/tmp/probe-compact-then-continue.py` 로 pre-fix `Surviving: 0` → post-fix `Surviving: 1` 확인, regression test `compacted-then-continue-survives-filter` 추가

Closes #467
