### PR TITLE
docs(retrospect): specify Stage 2.7 scope window for trigger detection

### DIFF
--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -411,7 +411,9 @@ Both the checklist block and the dismissed_candidates block live in Stage 3 outp
 
 Stage 2.7 runs between Stage 2 (Analyze) and Stage 2.5 (Distribution Audit). Its purpose is to surface output-quality defects in artifacts the session produced — defects that the friction-event scanner (Stage 2) cannot see because they are *silent-pass* failures (no observable session friction).
 
-**Adaptive trigger** — Stage 2.7 fires ONLY when the session transcript contains at least one of these artifact-write signals. With zero triggers, Stage 2.7 silently skips.
+**Scope window** — same as Stage 2: scan the most recent 50 turns, or back to the last session boundary (whichever is narrower). The window is intentionally identical so that trigger detection (below) and friction-event analysis operate over the same transcript slice — divergent windows would make `output_quality` findings non-deterministic across invocations and could surface artifacts whose context is no longer visible to Stage 2. If the transcript is unreachable post-compaction, fall through to the `transcript unreachable` failure-mode rule below (skip with `<!-- retrospect:audit_skipped: transcript unreachable -->`).
+
+**Adaptive trigger** — Stage 2.7 fires ONLY when the session transcript (within the Scope window above) contains at least one of these artifact-write signals. With zero triggers, Stage 2.7 silently skips.
 
 Trigger detection (scan the session's Bash invocations + MCP tool calls):
 - `gh pr create | edit | merge | comment` Bash invocations


### PR DESCRIPTION
## Summary

- Stage 2 explicitly bounds its conversation scan to "the most recent 50 turns, or back to the last session boundary," but Stage 2.7's Adaptive trigger detection scanned "the session's Bash invocations + MCP tool calls" without specifying a window — leaving the scope to implicit inference and risking non-deterministic `output_quality` findings across invocations.
- Adds a new **Scope window** paragraph at the top of Stage 2.7 in `skills/retrospect/SKILL.md` that reuses Stage 2's window (50 turns or last session boundary, whichever is narrower), so trigger detection and friction-event analysis operate over the same transcript slice.
- Cross-references the existing transcript-unreachable failure-mode rule (already documented later in Stage 2.7) so post-compaction sessions still skip deterministically with `<!-- retrospect:audit_skipped: transcript unreachable -->` — no duplicate failure-mode entry introduced.

## Rationale for "same as Stage 2" (not a separate window)

A wider lookback for Stage 2.7 (e.g., full session) was considered to capture PR / external-write artifacts whose lifecycle predates the 50-turn window. Rejected because:

- Divergent windows make `output_quality` findings non-deterministic: an artifact written 80 turns ago could be flagged on one invocation and ignored on another, depending on whether Stage 2's friction context still surrounds it.
- Stage 2.7 findings rely on Stage 2's friction context to ground severity (e.g., distinguishing first-occurrence from repeat). A scope wider than Stage 2 would surface artifacts whose surrounding context Stage 2 no longer sees.
- Aligning windows preserves the existing `<!-- retrospect:audit_skipped: transcript unreachable -->` failure mode — no new edge case.

## Acceptance

- [x] Stage 2.7 body explicitly states its scope window (same as Stage 2)
- [x] Rationale documented in-line for the chosen scope (cohesion with Stage 2 friction context, determinism across invocations)

## Test plan

- [x] `python3 scripts/check-plugin-manifests.py` passes (`plugin-manifest check OK`)
- [x] Diff is docs-only, surgical (3 insertions, 1 deletion in `skills/retrospect/SKILL.md`)
- [x] No broken markdown: bold-label paragraph style matches surrounding Stage 2.7 paragraphs ("**Adaptive trigger** — ...", "**0-trigger silent skip** — ...")

Closes #481

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKghuPdLuF2nBAG91XS4DA)_