### PR TITLE
fix(manifest): declare hooks in claude plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,5 +14,6 @@
     "session-management",
     "cleanup"
   ],
-  "skills": "./skills/"
+  "skills": "./skills/",
+  "hooks": "./.claude-plugin/hooks/hooks.json"
 }

--- a/manifests/platforms/claude.json
+++ b/manifests/platforms/claude.json
@@ -6,7 +6,8 @@
       "kind": "plugin",
       "path": ".claude-plugin/plugin.json",
       "plugin_overrides": {
-        "skills": "./skills/"
+        "skills": "./skills/",
+        "hooks": "./.claude-plugin/hooks/hooks.json"
       }
     },
     {


### PR DESCRIPTION
## What

Add `"hooks": "./.claude-plugin/hooks/hooks.json"` to the claude `plugin_overrides` in `manifests/platforms/claude.json`, then regenerate `.claude-plugin/plugin.json`.

## Why

The generated Claude `plugin.json` declared only `skills`, so Claude Code registered no hooks — the entire suite (PreToolUse / Stop / SessionStart) was dormant while skills loaded normally. `cursor` and `opencode` already declared a `hooks` override; only `claude` was missing it (regression from the ADR-0001 Phase 2 layout move).

Closes #490

## Verification

- `./scripts/build-plugin-manifests.py` regenerates `.claude-plugin/plugin.json` with the `hooks` field (only file changed).
- `./scripts/check-plugin-manifests.py` — OK (no drift).
- `python -m pytest tests/` — 67 passed.
- `claude plugin validate --strict` — passed.
- All 52 scripts referenced by the generated `hooks.json` exist in the build output (no second-layer breakage).

## Not verified

Runtime hook firing requires `/reload-plugins` or a session restart after the plugin updates — `claude plugin validate` does not resolve the hooks path, so static checks cannot confirm activation. Acceptance test: reload, attempt a `git commit` without a codex review in-session, confirm the gate fires.
