### PR TITLE
fix(protected-paths): self-edit abs-path only

### DIFF
--- a/hooks/advisory-nudge/protected-paths-guard/impl.py
+++ b/hooks/advisory-nudge/protected-paths-guard/impl.py
@@ -182,7 +182,9 @@ def _is_self_edit(path: str) -> bool:
         rel = os.path.relpath(os.path.normpath(path), os.path.abspath(plugin_root))
     except ValueError:
         return False
-    return rel == "." or not rel.startswith(".." + os.sep)
+    # rel == ".." means `path` IS the parent of plugin_root (outside it), so it
+    # must not be exempted; `rel == "."` (path == plugin_root) is inside.
+    return rel != ".." and not rel.startswith(".." + os.sep)
 
 
 def _is_planning_artifact(path: str) -> bool:

--- a/hooks/advisory-nudge/protected-paths-guard/impl.py
+++ b/hooks/advisory-nudge/protected-paths-guard/impl.py
@@ -21,9 +21,10 @@ Detection model:
     `.env.example`, `.env.sample`, `.env.template` (exact basename, not
     substring).
   • **Extension** — `*.pem`, `*.key`, `*.p12`, `*.keystore`.
-  • **Directory component** — any path containing a `.ssh` directory component
-    matches (`.ssh/config`, `.ssh/known_hosts`, `.ssh/id_rsa.pub` all match —
-    public keys included because the directory itself is the trust anchor).
+  • **Directory component** — any path containing a `.ssh`, `.aws`, `.kube`,
+    or `.gnupg` directory component matches (e.g. `.ssh/config`,
+    `.aws/credentials`, `.kube/config`, `.gnupg/secring.gpg` — public keys
+    included under `.ssh/` because the directory itself is the trust anchor).
 
 Skip / allowlist:
 
@@ -60,6 +61,8 @@ _PROTECTED_BASENAMES = frozenset({
     ".env",
     ".netrc",
     ".npmrc",
+    ".git-credentials",  # plain-text GitHub token store (git-credential-store)
+    ".pgpass",           # PostgreSQL password file
     "credentials",
     "id_rsa",
     "id_dsa",
@@ -105,6 +108,16 @@ _PLANNING_FRAGMENTS = (
     "/.claude/projects/",
 )
 
+# Directory components that act as trust anchors — any file nested inside
+# these directories inherits the sensitivity of the credential store.
+# `.ssh/id_rsa.pub` matches even though the basename is otherwise allow-listed.
+_PROTECTED_DIR_COMPONENTS = frozenset({
+    ".ssh",
+    ".aws",    # AWS CLI credentials and config
+    ".kube",   # Kubernetes kubeconfig (service-account tokens, cluster certs)
+    ".gnupg",  # GnuPG key material and trustdb
+})
+
 # Under `.ssh/`, the directory-component rule fires first (the directory IS
 # the trust anchor); the public-key allow only applies when the file is
 # elsewhere (e.g. `pubkeys/id_rsa.pub` in a config repo).
@@ -149,17 +162,27 @@ def _self_plugin_root() -> str:
 
 
 def _is_self_edit(path: str) -> bool:
-    """True if path is inside CLAUDE_PLUGIN_ROOT (the praxis plugin itself)."""
+    """True if path is inside CLAUDE_PLUGIN_ROOT (the praxis plugin itself).
+
+    Relative paths are rejected unconditionally: `os.path.abspath` resolves
+    them against the hook process's cwd, so when cwd happens to be inside the
+    plugin root a bare `.env` would resolve to a plugin-root path and trigger
+    a false-positive self-edit exemption — bypassing the check entirely in
+    strict mode.  Only absolute paths carry enough location signal to be
+    trusted.
+    """
+    if not os.path.isabs(path):
+        return False
     plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
     if not plugin_root:
         plugin_root = _self_plugin_root()
     if not plugin_root:
         return False
     try:
-        rel = os.path.relpath(os.path.abspath(path), os.path.abspath(plugin_root))
+        rel = os.path.relpath(os.path.normpath(path), os.path.abspath(plugin_root))
     except ValueError:
         return False
-    return not rel.startswith("..")
+    return rel == "." or not rel.startswith(".." + os.sep)
 
 
 def _is_planning_artifact(path: str) -> bool:
@@ -197,11 +220,14 @@ def _classify(path: str) -> str | None:
         return None
     basename = components[-1]
 
-    # The `.ssh/` rule fires first because the directory itself is the trust
-    # anchor — `.ssh/id_rsa.pub` matches even though `id_rsa.pub` is otherwise
-    # allow-listed elsewhere.
-    if ".ssh" in components:
-        return "path contains a protected directory component (`.ssh/`)"
+    # Directory-component rules fire first — the directory itself is the trust
+    # anchor.  `.ssh/id_rsa.pub` matches even though `id_rsa.pub` is otherwise
+    # allow-listed elsewhere.  `.aws/`, `.kube/`, `.gnupg/` follow the same
+    # pattern: any file inside the directory inherits the sensitivity of the
+    # credential store.
+    for _dir in _PROTECTED_DIR_COMPONENTS:
+        if _dir in components:
+            return f"path contains a protected directory component (`{_dir}/`)"
 
     if basename in _PUBKEY_BASENAMES:
         return None

--- a/hooks/advisory-nudge/protected-paths-guard/spec.md
+++ b/hooks/advisory-nudge/protected-paths-guard/spec.md
@@ -34,10 +34,10 @@ The hook fires when **all** are true:
 
 | Rule | Matches | Examples |
 |------|---------|----------|
-| Basename-exact | `.env`, `.netrc`, `.npmrc`, `credentials`, `id_rsa`, `id_dsa`, `id_ecdsa`, `id_ed25519` | `~/.netrc`, `aws/credentials` |
+| Basename-exact | `.env`, `.netrc`, `.npmrc`, `.git-credentials`, `.pgpass`, `credentials`, `id_rsa`, `id_dsa`, `id_ecdsa`, `id_ed25519` | `~/.netrc`, `aws/credentials`, `~/.git-credentials`, `~/.pgpass` |
 | `.env.<env>` prefix | basename starts with `.env.` AND is not in the env allowlist | `.env.production`, `.env.local` |
 | Extension | `*.pem`, `*.key`, `*.p12`, `*.keystore` | `keys/server.pem`, `tls/cert.p12` |
-| Directory-component | any path component equals `.ssh` | `~/.ssh/config`, `~/.ssh/id_rsa.pub` (under `.ssh/`) |
+| Directory-component | any path component equals `.ssh`, `.aws`, `.kube`, or `.gnupg` | `~/.ssh/config`, `~/.aws/credentials`, `~/.kube/config`, `~/.gnupg/secring.gpg` |
 
 #### Env allowlist (exact basename match)
 
@@ -76,6 +76,11 @@ rule still fires because the directory itself is the trust anchor.
 | `~/.ssh/id_rsa.pub` | **ADVISORY** | directory-component fires first |
 | `~/.ssh/known_hosts` | **ADVISORY** | directory-component |
 | `pubkeys/id_rsa.pub` | **SILENT** | public-key allow (not under `.ssh/`) |
+| `~/.aws/credentials` | **ADVISORY** | directory-component (`.aws/`) |
+| `~/.kube/config` | **ADVISORY** | directory-component (`.kube/`) |
+| `~/.gnupg/secring.gpg` | **ADVISORY** | directory-component (`.gnupg/`) |
+| `~/.git-credentials` | **ADVISORY** | basename-exact |
+| `~/.pgpass` | **ADVISORY** | basename-exact |
 | `keys/server.pem` | **ADVISORY** | extension `.pem` |
 | `tls/cert.p12` | **ADVISORY** | extension `.p12` |
 | `aws/credentials` | **ADVISORY** | basename-exact |
@@ -126,11 +131,11 @@ exit 0 (advisory) or 2 (strict)
   verbatim. If the path is a symlink to a protected file (e.g. `config.json` →
   `.env`), the hook does NOT follow symlinks; the unsuspecting basename
   (`config.json`) passes silently.
-- **Custom credential filenames**: `.aws/config` (without the `credentials`
-  basename), `.kube/config`, `.docker/config.json` are NOT in the basename set
-  — they are config files that may contain non-credential settings, and the
-  false-positive rate would be high. Authors that want to guard these can add
-  a wrapper hook or extend the basename set in a fork.
+- **Custom credential filenames**: `.docker/config.json` is NOT guarded —
+  it is a config file that may contain non-credential settings and the
+  false-positive rate would be high. Authors that want to guard it can add
+  a wrapper hook or extend the directory-component set. (`.aws/` and `.kube/`
+  are now covered by the directory-component rule.)
 - **Allow-list extension form**: `.pem.example` does NOT match the env
   allowlist (which is `.env.<allowed>` only). A test fixture named `.pem` is
   protected unless placed under a fixture directory.

--- a/tests/hooks/advisory-nudge/test_protected_paths_guard.sh
+++ b/tests/hooks/advisory-nudge/test_protected_paths_guard.sh
@@ -180,6 +180,55 @@ run_case ".claude/projects/X/log.env" silent Write "/proj/.claude/projects/X/log
 # Use a temp dir as CLAUDE_PLUGIN_ROOT and a path under it
 run_case "self-edit under plugin root" silent Write "/nonexistent-plugin-root-for-tests/hooks/foo/.env" "CLAUDE_PLUGIN_ROOT=/nonexistent-plugin-root-for-tests"
 
+# === issue #495 — relative-path self-edit exemption bypass fix =============
+#
+# Regression: cwd=plugin_root, relative ".env" → _is_self_edit must return False
+# so the write is NOT silently exempted.
+#
+# CLAUDE_PLUGIN_ROOT is set to ROOT_DIR (this very worktree) so that the
+# abspath-based path would previously have resolved ".env" to inside the root
+# and returned True (false exemption). After the fix it must return False and
+# the write must be detected (advisory/block).
+
+run_case "relative .env blocked in strict (cwd=plugin root, issue #495)" block \
+  Write ".env" \
+  "PRAXIS_PROTECTED_PATHS_STRICT=1 CLAUDE_PLUGIN_ROOT=$ROOT_DIR"
+
+run_case "relative .env advisory (cwd=plugin root, issue #495)" advisory \
+  Write ".env" \
+  "CLAUDE_PLUGIN_ROOT=$ROOT_DIR"
+
+# Absolute path to a file that genuinely lives inside the plugin root must
+# still be silently exempted (regression guard for the legitimate self-edit path).
+run_case "abs-path self-edit still silent (issue #495 regression)" silent \
+  Write "$ROOT_DIR/hooks/advisory-nudge/protected-paths-guard/impl.py" \
+  "CLAUDE_PLUGIN_ROOT=$ROOT_DIR"
+
+# === ADVISORY — .git-credentials / .pgpass (issue #495 LOW additions) ======
+
+run_case ".git-credentials advisory" advisory Write "$HOME/.git-credentials"
+run_case ".git-credentials in dir" advisory Write "config/.git-credentials"
+run_case ".pgpass advisory" advisory Write "$HOME/.pgpass"
+run_case ".pgpass in dir" advisory Write "db/.pgpass"
+
+run_case ".git-credentials block (strict)" block Write "$HOME/.git-credentials" "PRAXIS_PROTECTED_PATHS_STRICT=1"
+run_case ".pgpass block (strict)" block Write "$HOME/.pgpass" "PRAXIS_PROTECTED_PATHS_STRICT=1"
+
+# === ADVISORY — .aws / .kube / .gnupg directory components (issue #495 LOW)
+
+run_case ".aws/credentials" advisory Write "$HOME/.aws/credentials"
+run_case ".aws/config" advisory Write "$HOME/.aws/config"
+run_case ".kube/config" advisory Write "$HOME/.kube/config"
+run_case ".gnupg/secring.gpg" advisory Write "$HOME/.gnupg/secring.gpg"
+run_case ".gnupg/trustdb.gpg" advisory Edit "$HOME/.gnupg/trustdb.gpg"
+
+run_case ".aws/credentials block (strict)" block Write "$HOME/.aws/credentials" "PRAXIS_PROTECTED_PATHS_STRICT=1"
+run_case ".kube/config block (strict)" block Write "$HOME/.kube/config" "PRAXIS_PROTECTED_PATHS_STRICT=1"
+
+# fixture paths under protected dirs must still be silent
+run_case ".aws in fixture dir (silent)" silent Write "tests/fixtures/.aws/credentials"
+run_case ".kube in fixture dir (silent)" silent Write "src/__fixtures__/.kube/config"
+
 # === BLOCK — strict mode escalates exit code ===============================
 
 run_case ".env in strict mode (block)" block Write ".env" "PRAXIS_PROTECTED_PATHS_STRICT=1"

--- a/tests/hooks/advisory-nudge/test_protected_paths_guard.sh
+++ b/tests/hooks/advisory-nudge/test_protected_paths_guard.sh
@@ -102,6 +102,25 @@ print(json.dumps({
   fi
 }
 
+# White-box assertion for _is_self_edit — black-box run_case cannot distinguish
+# the rel == ".." parent-dir case (its basename is never a protected file, so
+# the hook is silent either way). Assert the function return value directly.
+assert_self_edit() {
+  local name="$1" path="$2" plugin_root="$3" expected="$4"
+  local got
+  got=$(CLAUDE_PLUGIN_ROOT="$plugin_root" python3 -c '
+import os, sys, importlib.util
+spec = importlib.util.spec_from_file_location("pg", sys.argv[1])
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+print(m._is_self_edit(sys.argv[2]))' "$HOOK" "$path")
+  if [ "$got" = "$expected" ]; then
+    echo "PASS  [$name]"; PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] _is_self_edit=$got expected=$expected"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
 # === ADVISORY — basename-exact protected files =============================
 
 run_case ".env (bare)" advisory Write ".env"
@@ -203,6 +222,13 @@ run_case "relative .env advisory (cwd=plugin root, issue #495)" advisory \
 run_case "abs-path self-edit still silent (issue #495 regression)" silent \
   Write "$ROOT_DIR/hooks/advisory-nudge/protected-paths-guard/impl.py" \
   "CLAUDE_PLUGIN_ROOT=$ROOT_DIR"
+
+# White-box: rel == "." (path == plugin_root) is inside; rel == ".." (path is the
+# parent dir, outside) must NOT be exempted — the bug this guards against.
+assert_self_edit "self-edit: plugin_root itself (rel '.')" "$ROOT_DIR" "$ROOT_DIR" True
+assert_self_edit "self-edit: file inside plugin_root" "$ROOT_DIR/hooks/x/.env" "$ROOT_DIR" True
+assert_self_edit "self-edit: parent dir not exempt (rel '..')" "$(dirname "$ROOT_DIR")" "$ROOT_DIR" False
+assert_self_edit "self-edit: relative path never exempt" ".env" "$ROOT_DIR" False
 
 # === ADVISORY — .git-credentials / .pgpass (issue #495 LOW additions) ======
 


### PR DESCRIPTION
## 배경

다각 평가(보안 축)에서 도출된 최우선 보안 수정입니다.

## 변경

- `_is_self_edit`가 상대 경로를 hook cwd 기준으로 해석해, cwd가 plugin root 안일 때 상대 경로 `.env`/`*.pem` 쓰기를 strict 모드에서도 self-edit으로 오분류해 통과시키던 결함 수정 — 절대 경로일 때만 예외 인정.
- 라운드2 리뷰 반영: `rel == ".."`(plugin_root 부모 dir) 오분류도 차단.
- `_PROTECTED_DIR_COMPONENTS`(`.aws`/`.kube`/`.gnupg`) + `.git-credentials`/`.pgpass` basename 추가.
- white-box `assert_self_edit` 테스트 4개(black-box로 구분 불가한 케이스 보완).

## 검증

- `test_protected_paths_guard.sh` → 81 passed, 0 failed
- 2차 독립 리뷰(`oh-my-claudecode:code-reviewer`) 라운드1·2 → **APPROVE**

## 미검증

- codex review는 rate-limit으로 미실행 → Claude code-reviewer 대체(커밋 `[skip-codex-review]` 표기).
- 잔여 LOW: `CLAUDE_PLUGIN_ROOT` 상대 경로 시 동일 패턴 재발 가능(신뢰 env라 defer).

Pre-commit verified: bash tests/hooks/advisory-nudge/test_protected_paths_guard.sh → 81 passed, 0 failed
Caller chain verified: _is_self_edit has 1 internal caller (impl.py:290); hook invoked by Claude Code runtime via wrapper

Closes #495
