### PR TITLE
chore(tests): add run-tests.sh entry and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: set up python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: install python deps
+        run: python3 -m pip install pytest
+
+      - name: install jq
+        run: sudo apt-get update -y && sudo apt-get install -y jq
+
+      - name: run tests
+        run: bash scripts/run-tests.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,12 +196,15 @@ Fixed, Removed.
 ## Testing
 
 ```bash
-# Run the full test suite from the repo root
-python -m pytest tests/
-
-# Run the shell-based hook tests directly (pytest only collects .py files)
-for f in tests/hooks/*/test_*.sh; do bash "$f"; done
+# Run the full test suite (pytest + shell tests + manifest check) from the repo root
+bash scripts/run-tests.sh
 ```
+
+This is the single entry point. It runs pytest, all shell-based hook tests, and
+`scripts/check-plugin-manifests.py` under one exit code gate.
+
+CI runs the same command on every push and pull request via
+`.github/workflows/test.yml`.
 
 New hooks must ship with a test under `tests/hooks/<role>/`:
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Single entry point for the full test suite.
+#
+# Runs:
+#   1. pytest   — Python unit tests under tests/
+#   2. shell    — shell tests at tests/hooks/*/test_*.sh and tests/test_*.sh
+#   3. manifest — scripts/check-plugin-manifests.py
+#
+# Exit code is non-zero if any step fails.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+FAILED=0
+
+# ---------------------------------------------------------------------------
+# 1. pytest
+# ---------------------------------------------------------------------------
+echo "=== pytest ==="
+if ! python3 -m pytest tests/ -q; then
+  FAILED=1
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Shell tests
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== shell tests ==="
+SHELL_FAILED=0
+
+run_sh() {
+  local f="$1"
+  if ! bash "$f"; then
+    echo "FAIL: $f" >&2
+    SHELL_FAILED=1
+  fi
+}
+
+# nullglob: an unmatched glob expands to nothing instead of the literal pattern,
+# so a missing tests/hooks/ dir does not produce a spurious "No such file" failure.
+shopt -s nullglob
+
+# hook-level shell tests
+for f in tests/hooks/*/test_*.sh; do
+  run_sh "$f"
+done
+
+# top-level shell tests
+for f in tests/test_*.sh; do
+  run_sh "$f"
+done
+
+shopt -u nullglob
+
+if [[ $SHELL_FAILED -ne 0 ]]; then
+  FAILED=1
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Manifest check
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== manifest check ==="
+if ! python3 ./scripts/check-plugin-manifests.py; then
+  FAILED=1
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+if [[ $FAILED -ne 0 ]]; then
+  echo "TEST SUITE FAILED" >&2
+  exit 1
+fi
+echo "ALL TESTS PASSED"

--- a/tests/fixtures/event1-premature.json
+++ b/tests/fixtures/event1-premature.json
@@ -1,1 +1,0 @@
-{"transcript_path": "/Users/nathan.song/projects/praxis.issue-392-completion/tests/fixtures/event1-premature.jsonl", "stop_hook_active": false, "session_id": "test-event1"}

--- a/tests/fixtures/normal-completion.json
+++ b/tests/fixtures/normal-completion.json
@@ -1,1 +1,0 @@
-{"transcript_path": "/Users/nathan.song/projects/praxis.issue-392-completion/tests/fixtures/normal-completion.jsonl", "stop_hook_active": false, "session_id": "test-normal"}


### PR DESCRIPTION
## 배경

다각 평가(테스트 축)에서 도출. hook 50개에 1:1 테스트(~1,691 케이스)가 있으나 단일 실행 진입점과 CI가 없었습니다.

## 변경

- `scripts/run-tests.sh` 신규 — pytest + 전체 shell 테스트 + manifest check를 단일 exit-code 게이트로 합산. `shopt -s nullglob`로 glob no-match 시 spurious 실패 방지(라운드1 HIGH 반영).
- `.github/workflows/test.yml` 신규 — push/PR마다 run-tests.sh 실행. `python3 -m pip`, `apt-get update`, `timeout-minutes: 15`(라운드1 MEDIUM 반영).
- `CONTRIBUTING.md` 단일 진입점으로 갱신.
- dead fixture 2개 삭제(어떤 테스트도 로드 안 함, grep 확인).

## 검증

- `python3 -m pytest tests/` → 67 passed
- 2차 독립 리뷰 라운드1·2 → **APPROVE**

## ⚠️ caveat

- **이 CI는 첫 실행부터 red**입니다: `main`에 **pre-existing 실패 테스트** `test_pre_edit_md_escape_advisory.sh`(3 케이스, 이 PR과 무관)가 있어 run-tests.sh가 이를 드러냅니다. 별도 이슈로 추적 필요.
- codex review rate-limit → Claude code-reviewer 대체.

Pre-commit verified: python3 -m pytest tests/ → 67 passed (run-tests.sh surfaces a pre-existing unrelated shell-test failure, see caveat)
Caller chain verified: N/A — new test tooling (run-tests.sh) + CI workflow, no code callers

Closes #496
