### PR TITLE
docs: fix stale post-ADR-0001 hook paths

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -21,6 +21,7 @@ user message or recent Bash commands.
 | `hooks/preflight-gate/block-ask-end-option/impl.py` | Most recent user message | Detect whether the user sent a stop signal before blocking an end-option menu item |
 | `hooks/preflight-gate/block-manufactured-action-menu/impl.py` | Most recent user message | Detect command-intent signals to suppress unnecessary confirmation menus |
 | `hooks/advisory-nudge/external-write-falsify-check/impl.py` | Recent Bash commands | Confirm a verification call precedes an external write |
+| `hooks/advisory-nudge/pre-output-falsification-gate/impl.py` | Last ~400 lines of transcript | Detect negative-evidence context before surfacing a (Recommended) option |
 
 Transcript data is read locally only, never forwarded or stored beyond the
 hook's in-process execution.
@@ -36,6 +37,7 @@ back-compat fallback.
 |------|-----------|---------|
 | `hooks/preflight-gate/session-intent/impl.py` | `${TMPDIR:-/tmp}/praxis-session-intent-<session_id>.json` | Detected session intent flag (read vs. mutation) |
 | `hooks/postuse-correction/pre-edit-md-escape-advisory/impl.py` | `${TMPDIR:-/tmp}/praxis-md-read-history-<session_id>.json` | Set of `.md` file paths Read in this session |
+| `hooks/advisory-nudge/pre-output-falsification-gate/impl.py` | `${TMPDIR:-/tmp}/praxis-pre-output-falsification-gate/<session_id_hash>/<key_hash>` | Per-session command-repetition counters (Lane B) |
 
 Strike counter state is stored in a dedicated directory:
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -18,9 +18,9 @@ user message or recent Bash commands.
 |------|--------------|---------|
 | `completion-verify.sh` | Last ~400 lines of transcript | Verify that a Bash verification command was run in the same turn as a completion claim |
 | `retrospect-mix-check.sh` | Last ~400 lines of transcript | Confirm that retrospect Stage 3 outputs include non-memory action types |
-| `block-ask-end-option.py` | Most recent user message | Detect whether the user sent a stop signal before blocking an end-option menu item |
-| `block-manufactured-action-menu.py` | Most recent user message | Detect command-intent signals to suppress unnecessary confirmation menus |
-| `external-write-falsify-check.py` | Recent Bash commands | Confirm a verification call precedes an external write |
+| `hooks/preflight-gate/block-ask-end-option/impl.py` | Most recent user message | Detect whether the user sent a stop signal before blocking an end-option menu item |
+| `hooks/preflight-gate/block-manufactured-action-menu/impl.py` | Most recent user message | Detect command-intent signals to suppress unnecessary confirmation menus |
+| `hooks/advisory-nudge/external-write-falsify-check/impl.py` | Recent Bash commands | Confirm a verification call precedes an external write |
 
 Transcript data is read locally only, never forwarded or stored beyond the
 hook's in-process execution.
@@ -34,8 +34,8 @@ back-compat fallback.
 
 | Hook | State file | Contents |
 |------|-----------|---------|
-| `session-intent.py` | `${TMPDIR:-/tmp}/praxis-session-intent-<session_id>.json` | Detected session intent flag (read vs. mutation) |
-| `pre-edit-md-escape-advisory.py` | `${TMPDIR:-/tmp}/praxis-md-read-history-<session_id>.json` | Set of `.md` file paths Read in this session |
+| `hooks/preflight-gate/session-intent/impl.py` | `${TMPDIR:-/tmp}/praxis-session-intent-<session_id>.json` | Detected session intent flag (read vs. mutation) |
+| `hooks/postuse-correction/pre-edit-md-escape-advisory/impl.py` | `${TMPDIR:-/tmp}/praxis-md-read-history-<session_id>.json` | Set of `.md` file paths Read in this session |
 
 Strike counter state is stored in a dedicated directory:
 
@@ -48,7 +48,7 @@ counters). They never contain the text of user messages or assistant responses.
 
 ## Memory Access
 
-`memory-hint.py` reads `*.md` files from the project memory directory
+`hooks/advisory-nudge/memory-hint/impl.py` reads `*.md` files from the project memory directory
 (`~/.claude/projects/<slugified-cwd>/memory/`, or `PRAXIS_MEMORY_DIR` if set).
 This is a read-only scan to surface relevant memory entry descriptions as
 advisory stderr output. Hooks never modify memory files.
@@ -69,7 +69,7 @@ However, praxis hooks and skills DO invoke external CLIs (`git`, `gh`,
 `cmux`, `claude`, `codex`, `gemini`) with the user's own credentials.
 Some of those invocations make network calls — most notably:
 
-- `hooks/pre-gh-pr-create-dedup-gate.py` runs `gh pr list` against the
+- `hooks/preflight-gate/pre-gh-pr-create-dedup-gate/impl.py` runs `gh pr list` against the
   target repo's PR search API to detect duplicate PRs.
 - `skills/cmux-delegate` performs two distinct egress steps when run
   in a GitHub-backed repo:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,17 +36,17 @@ Every entry was verified against the hook source files listed.
 
 | Hook | Command | Purpose |
 |------|---------|---------|
-| `pre-gh-pr-create-dedup-gate.py` | `git remote get-url origin` | Resolve the repo owner/name for the dedup search |
-| `pre-edit-protected-branch-guard.py` | `git rev-parse --show-toplevel` | Locate the git repo root |
-| `pre-edit-protected-branch-guard.py` | `git rev-parse --abbrev-ref HEAD` | Read the current branch name |
-| `pre-edit-protected-branch-guard.py` | `git status --porcelain` | Check for a dirty working tree |
-| `pre-edit-protected-branch-guard.py` | `git log --oneline -3` | Detect recent PR-suffix commits on a clean tree |
+| `hooks/preflight-gate/pre-gh-pr-create-dedup-gate/impl.py` | `git remote get-url origin` | Resolve the repo owner/name for the dedup search |
+| `hooks/preflight-gate/pre-edit-protected-branch-guard/impl.py` | `git rev-parse --show-toplevel` | Locate the git repo root |
+| `hooks/preflight-gate/pre-edit-protected-branch-guard/impl.py` | `git rev-parse --abbrev-ref HEAD` | Read the current branch name |
+| `hooks/preflight-gate/pre-edit-protected-branch-guard/impl.py` | `git status --porcelain` | Check for a dirty working tree |
+| `hooks/preflight-gate/pre-edit-protected-branch-guard/impl.py` | `git log --oneline -3` | Detect recent PR-suffix commits on a clean tree |
 
 ### `gh` — GitHub CLI
 
 | Hook | Command | Purpose |
 |------|---------|---------|
-| `pre-gh-pr-create-dedup-gate.py` | `gh pr list --repo <r> --state all --search <kw> --json ...` | Search existing PRs before creating a new one |
+| `hooks/preflight-gate/pre-gh-pr-create-dedup-gate/impl.py` | `gh pr list --repo <r> --state all --search <kw> --json ...` | Search existing PRs before creating a new one |
 
 All `git` and `gh` invocations are **read-only**. No hook writes to remote
 state. Hooks fail-open (exit 0) when the binary is missing or times out.


### PR DESCRIPTION
## 배경

다각 평가(문서 축)에서 도출. ADR-0001(hook을 `hooks/<role>/<name>/impl.py`로 이전) 이후 보안/프라이버시 문서가 stale flat 경로를 참조했습니다.

## 변경

- `SECURITY.md`/`PRIVACY.md`의 stale `*.py` 경로 13개를 실제 `hooks/<role>/<name>/impl.py`로 정정. 각 경로는 `test -f`로 존재 검증(MISSING 0).
- 라운드2 반영: rebase로 base에 머지된 `pre-output-falsification-gate` hook(#502)이 transcript 읽기 + state 쓰기를 하는데 PRIVACY.md에 미등재였던 갭을 보강.
- `.sh` wrapper 참조는 flat 경로에 실제 존재하므로 유지.

## 검증

- 정정된 경로 전수 `test -f` 존재 확인
- 신규 hook 동작 직접 확인: `impl.py:134 _TRANSCRIPT_SCAN_LINES=400`, `impl.py:130 TMPDIR state dir`
- 2차 독립 리뷰 라운드1·2 → 라운드2 MEDIUM 반영 후 clean

## 미검증

- codex review rate-limit → Claude code-reviewer 대체.

Pre-commit verified: all corrected hook paths exist (test -f → MISSING 0); new-hook fields cross-checked against impl.py
Caller chain verified: N/A -- docs-only change

Closes #497
