### PR TITLE
docs: align skill count with EXPECTED_SKILLS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,16 +19,23 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 | Tier | What works | Dependencies |
 |------|-----------|--------------|
 | **Standalone** | recover-sessions, strike / strikes / reset-strikes | `gh` CLI, `jq` (for strike skills) |
-| **Enhanced** | + retrospect | + oh-my-claudecode |
+| **Enhanced** | + retrospect, codex-review-wrap | + oh-my-claudecode |
 | **Full** | + all cmux-* skills | + cmux |
 | **Multi-provider** | + codex/gemini routing in cmux-* | + codex-cli, gemini-cli |
 
-## Skills (12)
+## Skills (15)
 
 > **Invocation**: praxis entries are *skills*, not subagents. Always call them
 > via `Skill(skill="praxis:<name>")` — `Agent(subagent_type="praxis:<name>")`
 > returns `Agent type not found`. See [RUNTIME_CONSTRAINTS.md §3](RUNTIME_CONSTRAINTS.md)
 > for the full rationale and Agent-vs-Skill mapping table.
+
+### Discovery
+
+| Skill | Purpose |
+|-------|---------|
+| `using-praxis` | Onboarding entry point — maps scenarios to the right skill for new praxis users |
+| `writing-praxis-skill` | Guide for authoring a new SKILL.md — template, SRP, trigger keyword design, frontmatter conventions |
 
 ### Development
 
@@ -41,6 +48,7 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 
 | Skill | Purpose |
 |-------|---------|
+| `bypass-review` | Review bypass-telemetry event logs written by the bypass-telemetry hook — aggregate and inspect JSONL records |
 | `strike` | Declare a rule violation — session-scoped counter, escalating signal (1진 warning → 2진 review → 3진 Stop-hook block) |
 | `strikes` | Show current strike count + recorded violation reasons for the active session |
 | `reset-strikes` | Reset the session strike counter to 0 after a 3진 block (required to unblock responses) |

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Development workflow skills for Claude Code — disciplined, fast, resilient.
 
 | Skill | Trigger keywords | When to use | Example invocation |
 |-------|-----------------|-------------|-------------------|
+| `bypass-review` | `bypass review`, `bypass telemetry`, `우회 이벤트 확인`, `bypass log` | bypass-telemetry hook이 기록한 JSONL 이벤트 로그를 집계·검토할 때 | `/praxis:bypass-review` |
 | `strike` | `/strike`, `/praxis:strike`, `strike 1/2/3`, `삼진` | 규칙 위반 발생 시 명시적으로 기록할 때 (colloquial "strike a balance" 등은 제외) | `/praxis:strike <위반 이유>` |
 | `strikes` | `/strikes`, `strike status`, `몇 진`, `check strikes` | 현재 세션의 strike 횟수와 위반 내역을 확인할 때 | `/praxis:strikes` |
 | `reset-strikes` | `/reset-strikes`, `strike 초기화`, `clear strikes` | 3진 블록 후 카운터를 초기화해 응답을 재개할 때 | `/praxis:reset-strikes` |

--- a/scripts/check-plugin-manifests.py
+++ b/scripts/check-plugin-manifests.py
@@ -23,6 +23,9 @@ Phase 2 (ADR-0001) invariants:
       hook (Phase 3, ADR-0001 §5.3 — specs collocated with impl).
   11. skills/<skill-name>/ on disk matches the EXPECTED_SKILLS frozen set
      (issue #465 — surface freeze gate against silent skill proliferation).
+  12. AGENTS.md "## Skills (N)" count and per-skill backtick tokens, and
+     README.md per-skill backtick tokens, all match EXPECTED_SKILLS
+     (issue #498 — doc drift invariant).
 
 CI invokes this; developers can too, via `./scripts/check-plugin-manifests.py`.
 """
@@ -350,6 +353,67 @@ def main() -> int:
             f"REMOVED SKILL(S): {sorted(removed)!r} — declared in "
             "EXPECTED_SKILLS but missing on disk. If intentional, update "
             "EXPECTED_SKILLS in scripts/constants.py."
+        )
+
+    # ------------------------------------------------------------------
+    # Rule 12 — Doc skill-count invariant (#498)
+    #
+    # AGENTS.md carries an explicit "## Skills (N)" header whose count must
+    # equal len(EXPECTED_SKILLS).  Both AGENTS.md and README.md embed skill
+    # names inside table cells as `backtick` tokens; every EXPECTED_SKILLS
+    # member must appear at least once in each document.
+    #
+    # Parsing is intentionally coarse — we match the pattern
+    # `skill-name` (backtick-delimited) so the check is robust to table
+    # reformatting while still catching silent drift.
+    # ------------------------------------------------------------------
+    import re as _re  # local import — avoids polluting module scope
+
+    agents_md_path = REPO_ROOT / "AGENTS.md"
+    readme_md_path = REPO_ROOT / "README.md"
+
+    agents_text = agents_md_path.read_text()
+    readme_text = readme_md_path.read_text()
+
+    # Rule 12a — AGENTS.md "## Skills (N)" count header must match
+    count_match = _re.search(r"^##\s+Skills\s+\((\d+)\)", agents_text, _re.MULTILINE)
+    if count_match is None:
+        drifts.append(
+            "DOC SKILL COUNT MISSING AGENTS.md: expected '## Skills (N)' header — "
+            "add it to keep the count in sync with EXPECTED_SKILLS"
+        )
+    else:
+        declared_count = int(count_match.group(1))
+        expected_count = len(EXPECTED_SKILLS)
+        if declared_count != expected_count:
+            drifts.append(
+                f"DOC SKILL COUNT AGENTS.md: header says {declared_count} but "
+                f"EXPECTED_SKILLS has {expected_count} — update the header"
+            )
+
+    # Rule 12b — every EXPECTED_SKILLS member appears in AGENTS.md
+    agents_backtick_skills = set(_re.findall(r"`([^`]+)`", agents_text))
+    missing_in_agents = EXPECTED_SKILLS - agents_backtick_skills
+    if missing_in_agents:
+        drifts.append(
+            f"DOC SKILL LIST AGENTS.md: {sorted(missing_in_agents)!r} declared in "
+            "EXPECTED_SKILLS but not found as `backtick` tokens — add them to "
+            "the skill table"
+        )
+
+    # Rule 12c — every EXPECTED_SKILLS member appears as the first column of
+    # a README.md skill table row.  We match `| \`skill-name\` |` so that a
+    # skill name mentioned only in a description cell (cross-reference noise)
+    # does not satisfy the check.
+    readme_table_skills = set(
+        _re.findall(r"^\|\s*`([^`]+)`\s*\|", readme_text, _re.MULTILINE)
+    )
+    missing_in_readme = EXPECTED_SKILLS - readme_table_skills
+    if missing_in_readme:
+        drifts.append(
+            f"DOC SKILL LIST README.md: {sorted(missing_in_readme)!r} declared in "
+            "EXPECTED_SKILLS but not found as a first-column `backtick` token in a "
+            "table row — add them to the skill table"
         )
 
     if drifts:


### PR DESCRIPTION
## 배경

다각 평가(아키텍처 + 문서 축, 독립 2개 에이전트 교차 확인)에서 도출.

## 변경

- `AGENTS.md`/`README.md`의 "Skills (12)" → 실제 15개로 정정(`EXPECTED_SKILLS`와 일치). 누락 skill(`bypass-review`/`using-praxis`/`writing-praxis-skill`) 추가 + Enhanced 티어 표 통일.
- `scripts/check-plugin-manifests.py`에 invariant(rule 12) 추가 — 문서 skill count·목록이 `EXPECTED_SKILLS`와 일치하는지 CI 검증. 재발 구조적 차단.

## 검증

- `python3 scripts/check-plugin-manifests.py` → `plugin-manifest check OK` (rebase 후 base 새 hook 포함 통과)
- `test_skill_surface_freeze.sh` → 5/5
- 2차 독립 리뷰 라운드1·2 → **APPROVE**

## 미검증 / deferred

- `skills/bypass-review/`에 `SKILL.md` 부재(실행 바이너리만). SKILL.md 작성은 스킬 설계 결정이라 범위 밖 → 별도 처리 필요.
- rule 12b가 AGENTS.md에서 first-column 미한정(현재 미발화, defer).
- codex review rate-limit → Claude code-reviewer 대체.

Pre-commit verified: python3 scripts/check-plugin-manifests.py → plugin-manifest check OK; test_skill_surface_freeze.sh → 5/5
Caller chain verified: rule 12 runs within check-plugin-manifests.py main(); AGENTS.md/README.md docs-only

Refs #498 (bypass-review SKILL.md deferred)
