### PR TITLE
fix(preflight): unify fail-open across gates

### DIFF
--- a/hooks/preflight-gate/block-child-repo-issue-create/impl.py
+++ b/hooks/preflight-gate/block-child-repo-issue-create/impl.py
@@ -166,7 +166,7 @@ def _repo_org(repo: str) -> str:
 # Main
 # ---------------------------------------------------------------------------
 
-def main() -> int:
+def _main_inner() -> int:
     try:
         payload = json.loads(sys.stdin.read())
     except (json.JSONDecodeError, ValueError):
@@ -223,6 +223,14 @@ def main() -> int:
         return 2
 
     return 0
+
+
+def main() -> int:
+    """Preflight gate — fail-open on uncaught exception."""
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
 
 
 def _emit_block(repo: str, cfg: OrgConfig) -> None:

--- a/hooks/preflight-gate/block-commit-without-codex-review/impl.py
+++ b/hooks/preflight-gate/block-commit-without-codex-review/impl.py
@@ -60,7 +60,7 @@ _TARGET_SKILL = "praxis:codex-review-wrap"
 _MAX_BYTES = 50 * 1024 * 1024
 
 
-def main() -> int:
+def _main_inner() -> int:
     try:
         payload = json.loads(sys.stdin.read())
     except (json.JSONDecodeError, ValueError):
@@ -95,6 +95,14 @@ def main() -> int:
 
     _emit_block_message()
     return 2
+
+
+def main() -> int:
+    """Preflight gate — fail-open on uncaught exception."""
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/preflight-gate/block-gh-issue-create-without-dup-search/impl.py
+++ b/hooks/preflight-gate/block-gh-issue-create-without-dup-search/impl.py
@@ -46,7 +46,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "_lib"))
 from block_message import emit_block  # type: ignore[import-not-found]  # noqa: E402
 
 
-def main() -> int:
+def _main_inner() -> int:
     try:
         payload = json.loads(sys.stdin.read())
     except (json.JSONDecodeError, ValueError):
@@ -96,6 +96,14 @@ def main() -> int:
 
     _emit_no_overlap_block(keywords, search_cmds[-3:])
     return 2
+
+
+def main() -> int:
+    """Preflight gate — fail-open on uncaught exception."""
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
+++ b/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
@@ -67,7 +67,7 @@ import sys
 from pathlib import Path
 
 
-def main() -> int:
+def _main_inner() -> int:
     try:
         payload = json.loads(sys.stdin.read())
     except (json.JSONDecodeError, ValueError):
@@ -111,6 +111,14 @@ def main() -> int:
     matched = sorted({m.group(0).strip() for m in _iter_marker_matches(tail, _FINDING_MARKERS)})[:3]
     _emit_block_message(matched)
     return 2
+
+
+def main() -> int:
+    """Preflight gate — fail-open on uncaught exception."""
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/preflight-gate/gh-label-verify/impl.py
+++ b/hooks/preflight-gate/gh-label-verify/impl.py
@@ -88,7 +88,7 @@ _REPO_URL_RE = re.compile(r"[:/]([^/:\s]+)/([^/\s]+?)(?:\.git)?/?$")
 # ---------------------------------------------------------------------------
 
 
-def main() -> int:
+def _main_inner() -> int:
     try:
         payload = json.loads(sys.stdin.read())
     except (json.JSONDecodeError, ValueError):
@@ -115,6 +115,14 @@ def main() -> int:
         if rc != 0:
             return rc
     return 0
+
+
+def main() -> int:
+    """Preflight gate — fail-open on uncaught exception."""
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
 
 
 def _process_segment(argv: list[str], cwd: str) -> int:

--- a/hooks/preflight-gate/skill-gate-commands/impl.py
+++ b/hooks/preflight-gate/skill-gate-commands/impl.py
@@ -309,7 +309,7 @@ def _has_skill_tool_use(obj: dict, required_skill: str) -> bool:
 # Main
 # ---------------------------------------------------------------------------
 
-def main() -> int:
+def _main_inner() -> int:
     try:
         payload = json.loads(sys.stdin.read())
     except (json.JSONDecodeError, ValueError):
@@ -353,6 +353,14 @@ def main() -> int:
         return 2
 
     return 0
+
+
+def main() -> int:
+    """Preflight gate — fail-open on uncaught exception."""
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
 
 
 def _emit_block(cfg: GatedCommand) -> None:

--- a/tests/hooks/preflight-gate/test_block_child_repo_issue_create.sh
+++ b/tests/hooks/preflight-gate/test_block_child_repo_issue_create.sh
@@ -334,6 +334,32 @@ run_case "compound child then hub (block)" \
   "PRAXIS_HUB_MEDIATED_ORGS=$ORGS_CFG"
 
 # ---------------------------------------------------------------------------
+# Uncaught exception fail-open (outer Exception guard)
+# ---------------------------------------------------------------------------
+
+# Simulate an uncaught exception inside _main_inner (e.g. MemoryError) and
+# verify the outer try/except Exception wrapper in main() returns 0 (fail-open).
+_uncaught_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, io
+spec = importlib.util.spec_from_file_location("impl", "$HOOK")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+def _raise(): raise MemoryError("simulated OOM")
+mod._main_inner = _raise
+sys.stdin = io.StringIO('{}')
+sys.exit(mod.main())
+PYEOF
+)
+_uncaught_rc=$?
+if [ "$_uncaught_rc" -eq 0 ] && [ -z "$_uncaught_out" ]; then
+  echo "  PASS  uncaught exception in _main_inner fails open (exit 0, no stderr)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  uncaught exception in _main_inner (rc=$_uncaught_rc, out=$(echo "$_uncaught_out" | head -c 200))"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("uncaught exception in _main_inner fails open")
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/tests/hooks/preflight-gate/test_block_commit_without_codex_review.sh
+++ b/tests/hooks/preflight-gate/test_block_commit_without_codex_review.sh
@@ -293,6 +293,30 @@ fi
 rm -f "$_malformed_err"
 
 # ---------------------------------------------------------------------------
+# Uncaught exception fail-open (outer Exception guard)
+# ---------------------------------------------------------------------------
+
+# Simulate an uncaught exception inside _main_inner (e.g. MemoryError) and
+# verify the outer try/except Exception wrapper in main() returns 0 (fail-open).
+_uncaught_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, io
+spec = importlib.util.spec_from_file_location("impl", "$HOOK")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+def _raise(): raise MemoryError("simulated OOM")
+mod._main_inner = _raise
+sys.stdin = io.StringIO('{}')
+sys.exit(mod.main())
+PYEOF
+)
+_uncaught_rc=$?
+if [ "$_uncaught_rc" -eq 0 ] && [ -z "$_uncaught_out" ]; then
+  echo "PASS [pass] uncaught exception in _main_inner fails open"; ((PASS++))
+else
+  echo "FAIL [pass→rc=$_uncaught_rc] uncaught exception in _main_inner fails open"; ((FAIL++)); FAILED_NAMES+=("uncaught exception in _main_inner fails open")
+fi
+
+# ---------------------------------------------------------------------------
 # Cleanup + summary
 # ---------------------------------------------------------------------------
 

--- a/tests/hooks/preflight-gate/test_block_gh_issue_create_without_dup_search.sh
+++ b/tests/hooks/preflight-gate/test_block_gh_issue_create_without_dup_search.sh
@@ -188,6 +188,32 @@ run_case "malformed JSON (silent — fail-open)" \
   "not-json"
 
 # ---------------------------------------------------------------------------
+# Uncaught exception fail-open (outer Exception guard)
+# ---------------------------------------------------------------------------
+
+# Simulate an uncaught exception inside _main_inner (e.g. MemoryError) and
+# verify the outer try/except Exception wrapper in main() returns 0 (fail-open).
+_uncaught_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, io
+spec = importlib.util.spec_from_file_location("impl", "$HOOK")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+def _raise(): raise MemoryError("simulated OOM")
+mod._main_inner = _raise
+sys.stdin = io.StringIO('{}')
+sys.exit(mod.main())
+PYEOF
+)
+_uncaught_rc=$?
+if [ "$_uncaught_rc" -eq 0 ] && [ -z "$_uncaught_out" ]; then
+  echo "  PASS  uncaught exception in _main_inner fails open (exit 0, no stderr)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  uncaught exception in _main_inner (rc=$_uncaught_rc, out=$(echo "$_uncaught_out" | head -c 200))"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("uncaught exception in _main_inner fails open")
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
+++ b/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
@@ -431,6 +431,32 @@ run_case "[STAGE_COMPLETE: without digit does not block (silent)" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'chore: doc'\"},\"transcript_path\":\"$TX_STAGE_COMPLETE_NO_DIGIT\"}"
 
 # ---------------------------------------------------------------------------
+# Uncaught exception fail-open (outer Exception guard)
+# ---------------------------------------------------------------------------
+
+# Simulate an uncaught exception inside _main_inner (e.g. MemoryError) and
+# verify the outer try/except Exception wrapper in main() returns 0 (fail-open).
+_uncaught_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, io
+spec = importlib.util.spec_from_file_location("impl", "$HOOK")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+def _raise(): raise MemoryError("simulated OOM")
+mod._main_inner = _raise
+sys.stdin = io.StringIO('{}')
+sys.exit(mod.main())
+PYEOF
+)
+_uncaught_rc=$?
+if [ "$_uncaught_rc" -eq 0 ] && [ -z "$_uncaught_out" ]; then
+  echo "  PASS  uncaught exception in _main_inner fails open (exit 0, no stderr)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  uncaught exception in _main_inner (rc=$_uncaught_rc, out=$(echo "$_uncaught_out" | head -c 200))"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("uncaught exception in _main_inner fails open")
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/tests/hooks/preflight-gate/test_gh_label_verify.sh
+++ b/tests/hooks/preflight-gate/test_gh_label_verify.sh
@@ -328,6 +328,32 @@ run_inline_case "TTL=0 expires cache; gh missing → fail-open silent" \
   "PRAXIS_GH_LABEL_CACHE_TTL_SEC=0"
 
 # ---------------------------------------------------------------------------
+# Uncaught exception fail-open (outer Exception guard)
+# ---------------------------------------------------------------------------
+
+# Simulate an uncaught exception inside _main_inner (e.g. MemoryError) and
+# verify the outer try/except Exception wrapper in main() returns 0 (fail-open).
+_uncaught_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, io
+spec = importlib.util.spec_from_file_location("impl", "$HOOK")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+def _raise(): raise MemoryError("simulated OOM")
+mod._main_inner = _raise
+sys.stdin = io.StringIO('{}')
+sys.exit(mod.main())
+PYEOF
+)
+_uncaught_rc=$?
+if [ "$_uncaught_rc" -eq 0 ] && [ -z "$_uncaught_out" ]; then
+  echo "  PASS  uncaught exception in _main_inner fails open (exit 0, no stderr)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  uncaught exception in _main_inner (rc=$_uncaught_rc, out=$(echo "$_uncaught_out" | head -c 200))"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("uncaught exception in _main_inner fails open")
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/tests/hooks/preflight-gate/test_skill_gate_commands.sh
+++ b/tests/hooks/preflight-gate/test_skill_gate_commands.sh
@@ -435,6 +435,32 @@ run_case "malformed config entry no => (fail-safe, silent)" \
   "PRAXIS_SKILL_GATED_COMMANDS=gh pr create:praxis:create-hub-pr"
 
 # ---------------------------------------------------------------------------
+# Uncaught exception fail-open (outer Exception guard)
+# ---------------------------------------------------------------------------
+
+# Simulate an uncaught exception inside _main_inner (e.g. MemoryError) and
+# verify the outer try/except Exception wrapper in main() returns 0 (fail-open).
+_uncaught_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, io
+spec = importlib.util.spec_from_file_location("impl", "$HOOK")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+def _raise(): raise MemoryError("simulated OOM")
+mod._main_inner = _raise
+sys.stdin = io.StringIO('{}')
+sys.exit(mod.main())
+PYEOF
+)
+_uncaught_rc=$?
+if [ "$_uncaught_rc" -eq 0 ] && [ -z "$_uncaught_out" ]; then
+  echo "  PASS  uncaught exception in _main_inner fails open (exit 0, no stderr)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  uncaught exception in _main_inner (rc=$_uncaught_rc, out=$(echo "$_uncaught_out" | head -c 200))"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("uncaught exception in _main_inner fails open")
+fi
+
+# ---------------------------------------------------------------------------
 # Cleanup + summary
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 배경

다각 평가(코드 품질 축)에서 도출. 문서화된 fail-open 계약과 일부 차단 hook의 실제 동작이 불일치했습니다.

## 변경

- 차단 severity의 preflight-gate hook 중 broad outer catch가 없던 **6개**(전수 분류 결과 — 이슈 본문 추정 "9개" 정정)에 `_main_inner()` 분리 + `main()` wrapper(`try: return _main_inner() except Exception: return 0`) 적용.
- 대상: `block-child-repo-issue-create`, `block-commit-without-codex-review`, `block-gh-issue-create-without-dup-search`, `block-sciomc-finding-commit`, `gh-label-verify`, `skill-gate-commands`.
- 차단 로직(`return 2`)은 일절 변경 없음 — fail-open 래핑만.
- 각 테스트에 MemoryError monkeypatch fail-open 케이스 추가.

## 검증

- 대상 6개 hook 테스트 전수 통과 (219 케이스)
- 라운드2 AST 검증: `return 2` 차단 경로가 `_main_inner` 내 일반 제어흐름으로 유지, `except Exception`이 `SystemExit`/차단을 삼키지 않음 확인. base 새 hook도 이미 동일 패턴 보유.
- 2차 독립 리뷰 라운드1·2 → **APPROVE**

## 미검증

- 실제 MemoryError/RecursionError 런타임 재현은 monkeypatch로만 검증.
- codex review rate-limit → Claude code-reviewer 대체.

Pre-commit verified: 6 target preflight-gate hook test suites → 219 cases pass
Caller chain verified: _main_inner called only by main() (e.g. impl.py:123); main is hook entry via sys.exit(main())

Closes #499
