### PR TITLE
fix(tests): cross-platform hook test portability

### DIFF
--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -281,7 +281,17 @@ empty_memory_dir_case() {
   if [ "$rc" -eq 0 ] && [[ "$err" == *"Pre-Merge Reporting"* ]] && [[ "$err" != *"Memory:"* ]]; then
     echo "PASS  [$name]"; PASS=$((PASS + 1))
   else
-    echo "FAIL  [$name] rc=$rc static-rule-emitted=$([[ \"$err\" == *\"Pre-Merge Reporting\"* ]] && echo yes || echo no) memory-cite=$([[ \"$err\" == *\"Memory:\"* ]] && echo yes || echo no)"
+    # Diagnostics computed into vars first — a nested $([[ ... ]] ...) inside a
+    # double-quoted echo trips the conditional-expression parser on both bashes,
+    # but with different blast radius: on bash 5.x it is a parse-time error that
+    # fails `bash -n`, aborting the whole test file on CI; on bash 3.2 it errors
+    # only at command-substitution runtime inside this FAIL branch, corrupting
+    # the diagnostic line but not the verdict — which is why the suite passed
+    # locally and the breakage surfaced only on Linux CI.
+    local _static_emitted _memory_cite
+    [[ "$err" == *"Pre-Merge Reporting"* ]] && _static_emitted=yes || _static_emitted=no
+    [[ "$err" == *"Memory:"* ]] && _memory_cite=yes || _memory_cite=no
+    echo "FAIL  [$name] rc=$rc static-rule-emitted=$_static_emitted memory-cite=$_memory_cite"
     FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
   fi
 }
@@ -307,7 +317,12 @@ empty_memory_dir_force_push_case() {
   if [ "$rc" -eq 0 ] && [[ "$err" == *"History rewrite is a mutation"* ]] && [[ "$err" != *"Memory:"* ]]; then
     echo "PASS  [$name]"; PASS=$((PASS + 1))
   else
-    echo "FAIL  [$name] rc=$rc actionable-emitted=$([[ \"$err\" == *\"History rewrite is a mutation\"* ]] && echo yes || echo no) memory-cite=$([[ \"$err\" == *\"Memory:\"* ]] && echo yes || echo no)"
+    # See note at the sibling diagnostic above: nested $([[ ... ]] ...) inside a
+    # double-quoted echo is a bash-5.x syntax error; compute into vars first.
+    local _actionable_emitted _memory_cite
+    [[ "$err" == *"History rewrite is a mutation"* ]] && _actionable_emitted=yes || _actionable_emitted=no
+    [[ "$err" == *"Memory:"* ]] && _memory_cite=yes || _memory_cite=no
+    echo "FAIL  [$name] rc=$rc actionable-emitted=$_actionable_emitted memory-cite=$_memory_cite"
     FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
   fi
 }

--- a/tests/hooks/postuse-correction/test_pre_edit_md_escape_advisory.sh
+++ b/tests/hooks/postuse-correction/test_pre_edit_md_escape_advisory.sh
@@ -33,7 +33,9 @@ PASS=0; FAIL=0; FAILED_NAMES=()
 
 # Per-test history file (overrides session-id resolution entirely).
 fresh_history() {
-  mktemp -u "${TMPDIR:-/tmp}/praxis-md-escape-test-XXXXXX.json"
+  # XXXXXX must be the template suffix: BSD mktemp (macOS) does not substitute
+  # X's when a literal suffix like ".json" follows them, so append it afterwards.
+  echo "$(mktemp -u "${TMPDIR:-/tmp}/praxis-md-escape-test-XXXXXX").json"
 }
 
 # build_edit_payload <file_path> <old_string>

--- a/tests/hooks/preflight-gate/test_gh_json_validator.sh
+++ b/tests/hooks/preflight-gate/test_gh_json_validator.sh
@@ -27,6 +27,78 @@ FAIL=0
 FAILED_NAMES=()
 
 # ---------------------------------------------------------------------------
+# Hermetic gh stub
+#
+# The hook discovers valid JSON fields by running `gh <subcmd> --json help` and
+# parsing the "Available fields:" list out of gh's error output. That output is
+# version- / auth- / repo-context-dependent, so relying on the ambient gh makes
+# the block/pass cases non-deterministic: they pass on the dev's macOS but fail
+# on the CI ubuntu runner (gh sits in /usr/bin there and the field probe behaves
+# differently). Shadow gh with a fixed-field stub so the test exercises the
+# hook's PARSING logic rather than whichever gh happens to be installed.
+# ---------------------------------------------------------------------------
+GH_STUB_DIR=$(mktemp -d)
+cat >"$GH_STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+# Deterministic stand-in for `gh <subcmd> --json help`. Emits the real
+# `gh pr view` JSON field set (state/author/title present, `merged` absent)
+# to stderr in gh's documented error shape, so the validator can classify
+# fields offline.
+for arg in "$@"; do
+  if [ "$arg" = "--json" ]; then
+    cat >&2 <<'FIELDS'
+Unknown JSON field: "help"
+Available fields:
+  additions
+  assignees
+  author
+  baseRefName
+  body
+  changedFiles
+  closed
+  closedAt
+  comments
+  commits
+  createdAt
+  deletions
+  files
+  headRefName
+  id
+  isDraft
+  labels
+  mergeStateStatus
+  mergeable
+  mergedAt
+  mergedBy
+  number
+  reviewDecision
+  reviews
+  state
+  statusCheckRollup
+  title
+  updatedAt
+  url
+FIELDS
+    exit 1
+  fi
+done
+exit 0
+STUB
+chmod +x "$GH_STUB_DIR/gh"
+
+# Curated dir for the "gh not in PATH" fail-open case: holds python3 (the hook
+# is launched via `env PATH=… python3`) but deliberately NO gh, so the field
+# probe hits FileNotFoundError regardless of where the ambient gh lives. A bare
+# PATH=/usr/bin:/bin no longer works — CI ubuntu ships gh in /usr/bin.
+# Symlink the REAL interpreter (sys.executable), not `command -v python3`: the
+# latter can resolve to a pyenv/asdf shim (a `#!/usr/bin/env bash` script) that
+# fails to launch under the restricted PATH ("env: bash: No such file").
+NO_GH_DIR=$(mktemp -d)
+ln -sf "$(python3 -c 'import sys; print(sys.executable)')" "$NO_GH_DIR/python3"
+
+trap 'rm -rf "$GH_STUB_DIR" "$NO_GH_DIR"' EXIT
+
+# ---------------------------------------------------------------------------
 # run_case name expectation command [ENV=VAL ...]
 #   expectation:
 #     "block:<marker>" — exit 2, stdout contains <marker>
@@ -54,7 +126,20 @@ print(json.dumps({
   out_file=$(mktemp)
   err_file=$(mktemp)
 
-  printf '%s' "$payload" | env "${extra_env[@]}" python3 "$HOOK_PY" >"$out_file" 2>"$err_file"
+  # Default the hook's PATH to the hermetic gh stub unless the case sets PATH
+  # itself (fail-open uses NO_GH_DIR; bypass cases override their own env).
+  local case_env=("${extra_env[@]}") _has_path=0 _e
+  for _e in "${extra_env[@]}"; do
+    case "$_e" in PATH=*) _has_path=1 ;; esac
+  done
+  if [ "$_has_path" -eq 0 ]; then
+    # Prepend the stub so it shadows the ambient gh, but inherit the rest of
+    # PATH so python3 stays resolvable wherever it lives (/usr/bin on CI ubuntu,
+    # /usr/local/bin on the python docker images) — do not hardcode a location.
+    case_env=("PATH=$GH_STUB_DIR:$PATH" "${extra_env[@]}")
+  fi
+
+  printf '%s' "$payload" | env "${case_env[@]}" python3 "$HOOK_PY" >"$out_file" 2>"$err_file"
   local rc=$?
   local out err
   out=$(cat "$out_file")
@@ -162,7 +247,7 @@ run_case "skip: non-gh bash command ls -la" \
 run_case "fail-open: gh not in PATH" \
   "pass" \
   "gh pr view 1 --json merged" \
-  "PATH=/usr/bin:/bin"
+  "PATH=$NO_GH_DIR"
 
 # ---------------------------------------------------------------------------
 # Case 10: Skip — no `--json` flag present

--- a/tests/hooks/preflight-gate/test_pre_gh_pr_create_dedup_gate.sh
+++ b/tests/hooks/preflight-gate/test_pre_gh_pr_create_dedup_gate.sh
@@ -133,6 +133,20 @@ EOF
   esac
   [ -f "$d/gh" ] && chmod +x "$d/gh"
 
+  # For the gh-absent scenario the hook runs under a PATH restricted to this
+  # dir alone (see run_case), so the binaries resolved by name via
+  # `#!/usr/bin/env <x>` — python3 for the hook itself, bash for the git shim —
+  # must live here too. Directory-exclusion PATH tricks (dropping /usr/bin) are
+  # unreliable: on usrmerge distros /bin is a symlink to /usr/bin and would
+  # re-expose the ambient gh that CI ubuntu installs at /usr/bin/gh.
+  if [ "$scenario" = "no-gh" ]; then
+    # Symlink the REAL python3 (sys.executable), not `command -v python3`: the
+    # latter may be a pyenv/asdf shim (`#!/usr/bin/env bash`) that cannot launch
+    # under the restricted PATH and fails with "env: bash: No such file".
+    ln -sf "$(python3 -c 'import sys; print(sys.executable)')" "$d/python3"
+    ln -sf "$(command -v bash)" "$d/bash"
+  fi
+
   echo "$d"
 }
 
@@ -156,7 +170,18 @@ print(json.dumps({
     "tool_input": {"command": sys.argv[2]},
 }))' "$tool_name" "$command")
   err_file=$(mktemp)
-  echo "$payload" | env PATH="$fake_bin:/usr/bin:/bin" "$HOOK" >/dev/null 2>"$err_file"
+  # gh-absent scenario: restrict PATH to the curated fake-bin (python3 + bash +
+  # git shim, no gh) so `shutil.which("gh")` in the hook returns None and the
+  # fail-open path fires. Other scenarios keep the ambient /usr/bin:/bin.
+  # Prepend the fake-bin shims (they shadow the ambient gh/git) but inherit the
+  # rest of PATH so python3 stays resolvable wherever it lives — do not hardcode
+  # /usr/bin. The no-gh scenario is the exception: it restricts PATH to the
+  # curated fake-bin alone so the ambient gh cannot leak back in.
+  local hook_path="$fake_bin:$PATH"
+  if [ "$scenario" = "no-gh" ]; then
+    hook_path="$fake_bin"
+  fi
+  echo "$payload" | env PATH="$hook_path" "$HOOK" >/dev/null 2>"$err_file"
   rc=$?
   local err_content
   err_content=$(cat "$err_file"); rm -f "$err_file"
@@ -306,7 +331,9 @@ run_case "chained command, gh part dedup-checked" pass Bash \
 # ---------------------------------------------------------------------------
 
 bad_json_err=$(mktemp)
-printf 'not-json\n' | env PATH="/usr/bin:/bin" "$HOOK" >/dev/null 2>"$bad_json_err"
+# Inherit PATH (don't hardcode /usr/bin) so python3 resolves wherever it lives;
+# this case fails open on malformed stdin before any gh lookup, so no shim needed.
+printf 'not-json\n' | "$HOOK" >/dev/null 2>"$bad_json_err"
 bad_rc=$?
 if [ "$bad_rc" -eq 0 ]; then
   echo "PASS [pass] malformed stdin fails open"; ((PASS++))


### PR DESCRIPTION
## 요약

PR #505 의 CI 도입으로 표면화된, 개발자 macOS 환경 가정을 누출하던 hook 테스트 4건의 cross-platform 이식성 버그를 수정합니다. **제품/hook 코드 무변경 — 테스트 전용.**

실제 CI 로그(run 26670811445, sha 826276d) 기준 정확히 3개 파일이 실패했고, 모두 *non-hermetic*(dev 환경 가정 누출)이 공통 원인입니다.

## 변경 내용

| 파일 | 원인 | 수정 |
|---|---|---|
| `test_momentum_rule_retrieval_gate.sh` | 이중 인용 echo 안 중첩 `$([[ ... ]] ...)` → bash 5.x parse-time 구문 에러 (`bash -n` 실패 → 파일 abort). bash 3.2 는 cmd-subst 런타임 non-fatal | yes/no 를 일반 변수로 분리 |
| `test_pre_edit_md_escape_advisory.sh` | BSD mktemp 가 `XXXXXX` 뒤 `.json` 접미사 미치환 | `.json` 을 셸에서 append |
| `test_gh_json_validator.sh` | ambient gh 의 `--json help` 동작 의존 (CI 미인증 gh → probe 실패 → block 안 함) | 결정적 gh stub PATH prepend; fail-open 은 curated NO_GH_DIR |
| `test_pre_gh_pr_create_dedup_gate.sh` | `no-gh` 가 `PATH=/usr/bin:/bin` 로 gh 부재 모사 → ubuntu `/usr/bin/gh` 누출 → block(rc2) | no-gh 만 curated fake-bin 단독 PATH 로 제한 |

**공통 함정**: curated PATH 는 `command -v python3`(macOS pyenv shim = `#!/usr/bin/env bash`) 가 아니라 real interpreter(`sys.executable`) 를 심볼릭 — shim 이 제한 PATH 에서 `env: bash: No such file` 로 깨지는 것을 회피.

## 검증

- **CI-faithful**: bash 5.2 + git + jq + pytest + 미인증 `/usr/bin/gh` 컨테이너 → `ALL TESTS PASSED` (pytest 67 passed, `FAIL: tests/` 0건)
- **macOS 네이티브**: bash 3.2 + pyenv + BSD mktemp → `ALL TESTS PASSED`
- 두 root-cause(중첩 구문 / mktemp 접미사) + gh 누출 모두 재현 후 수정 확인
- **2차 리뷰**: `oh-my-claudecode:code-reviewer` APPROVE (0 blocking; codex rate-limited 대체)

Pre-commit verified: bash 5.2 컨테이너 + macOS 네이티브 양쪽에서 `scripts/run-tests.sh` 전체 ALL TESTS PASSED, 변경 4개 파일 개별 통과(momentum 48 / md-escape 31 / gh_json_validator 10 / dedup_gate 27).

Caller chain verified: 테스트 전용 변경으로 제품 심볼 무변경. 유일한 caller 는 CI 진입점 `scripts/run-tests.sh` (push/PR trigger) 이며, 해당 entry 로 전체 스위트 green 확인.

Closes #509
