### PR TITLE
fix(hooks): decompose bundled short flags in commit/push guards

### DIFF
--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -363,10 +363,9 @@ def _is_force_push(argv: list[str]) -> bool:
         bare = tok.split("=", 1)[0]
         if bare in force_flags or tok in force_flags:
             return True
-        # Bundled POSIX short cluster (e.g. `-fu`, `-vf`) — decompose into
-        # individual chars and look for `f` (=`--force`). `git push` short opts
-        # are all value-less, so a bare `^-[a-zA-Z]+$` token (no `=`, no `--`)
-        # is a plain cluster of flags (#512).
+        # Bundled POSIX short cluster carrying `f` (=`--force`), e.g. `-fu`, `-vf`.
+        # All `git push` short opts are value-less, so a bare `^-[a-zA-Z]+$` token
+        # is a plain flag cluster (#512).
         if (
             len(tok) > 2
             and tok.startswith("-")

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -363,6 +363,19 @@ def _is_force_push(argv: list[str]) -> bool:
         bare = tok.split("=", 1)[0]
         if bare in force_flags or tok in force_flags:
             return True
+        # Bundled POSIX short cluster (e.g. `-fu`, `-vf`) — decompose into
+        # individual chars and look for `f` (=`--force`). `git push` short opts
+        # are all value-less, so a bare `^-[a-zA-Z]+$` token (no `=`, no `--`)
+        # is a plain cluster of flags (#512).
+        if (
+            len(tok) > 2
+            and tok.startswith("-")
+            and not tok.startswith("--")
+            and "=" not in tok
+            and tok[1:].isalpha()
+            and "f" in tok[1:]
+        ):
+            return True
     return False
 
 

--- a/hooks/preflight-gate/verify-commit-flag-override/impl.py
+++ b/hooks/preflight-gate/verify-commit-flag-override/impl.py
@@ -84,6 +84,13 @@ COMMIT_FLAG_TOKENS: dict[str, str] = {
     "--gpg-sign": "-S (force signing)",
 }
 
+# git commit short options that take NO value — valid inner chars of a bundled
+# POSIX short cluster (e.g. -vn, -anm). Mirrors the sibling commit-title-*-check
+# helper of the same name. Excludes value-taking short opts (-S, -F, -C, -c, -t,
+# -u, -m), so a cluster ending in one of those is left to the per-token branches
+# below rather than being decomposed here.
+GIT_COMMIT_NO_VALUE_SHORT = frozenset("aesvnqzp")
+
 # Why each override is blocked (one line per distinct override).
 ENV_ISSUE_FOR: dict[str, str] = {
     "-n (short form of --no-verify)": (
@@ -103,6 +110,32 @@ ENV_ISSUE_FOR: dict[str, str] = {
         "(gpg --list-secret-keys) and the repo expects signing."
     ),
 }
+
+
+# git commit short options that take a value — when one appears inside a
+# cluster it consumes the remaining chars as its value, so decomposition stops
+# there (e.g. `-nm"msg"` is `-n -m "msg"`, but `-mn` is `-m "n"`).
+_GIT_COMMIT_VALUE_SHORT = frozenset("mFCctuS")
+
+
+def _cluster_has_no_verify(tok: str) -> bool:
+    """True iff a bundled short cluster (e.g. `-vn`, `-anm`) carries `-n`.
+
+    Walks the cluster char-by-char. A value-taking short option (e.g. `m`)
+    swallows the rest of the cluster as its argument, so scanning stops at the
+    first one. To avoid false positives on unrecognized clusters, every char
+    preceding the first value-taker must be a known value-less short option.
+    """
+    for ch in tok[1:]:
+        if ch == "n":
+            return True
+        if ch in _GIT_COMMIT_VALUE_SHORT:
+            # Value-taker consumes the remainder; no `-n` seen before it.
+            return False
+        if ch not in GIT_COMMIT_NO_VALUE_SHORT:
+            # Unknown short option — don't speculate about cluster semantics.
+            return False
+    return False
 
 
 def detect_overrides(argv: list[str]) -> list[str]:
@@ -171,6 +204,17 @@ def detect_overrides(argv: list[str]) -> list[str]:
         tok = argv[j]
         if tok in COMMIT_FLAG_TOKENS:
             overrides.append(COMMIT_FLAG_TOKENS[tok])
+        elif (
+            tok.startswith("-")
+            and not tok.startswith("--")
+            and len(tok) > 2
+            and _cluster_has_no_verify(tok)
+        ):
+            # Bundled POSIX short cluster carrying `n` (=`--no-verify`), e.g.
+            # `-vn`, `-nv`, `-anm`, `-nm`. Decompose the cluster into individual
+            # short options; the exact-match branch above only sees standalone
+            # `-n`, so without this the bundled forms slip through (#512).
+            overrides.append(COMMIT_FLAG_TOKENS["-n"])
         elif tok.startswith("-S") and len(tok) > 2:
             # `-S<keyid>` (signing with explicit keyid, no space).
             overrides.append("-S (force signing)")

--- a/hooks/preflight-gate/verify-commit-flag-override/impl.py
+++ b/hooks/preflight-gate/verify-commit-flag-override/impl.py
@@ -84,11 +84,8 @@ COMMIT_FLAG_TOKENS: dict[str, str] = {
     "--gpg-sign": "-S (force signing)",
 }
 
-# git commit short options that take NO value — valid inner chars of a bundled
-# POSIX short cluster (e.g. -vn, -anm). Mirrors the sibling commit-title-*-check
-# helper of the same name. Excludes value-taking short opts (-S, -F, -C, -c, -t,
-# -u, -m), so a cluster ending in one of those is left to the per-token branches
-# below rather than being decomposed here.
+# git commit value-less short options — valid inner chars of a bundled POSIX
+# short cluster (e.g. -vn, -anm). See _GIT_COMMIT_VALUE_SHORT for the rest.
 GIT_COMMIT_NO_VALUE_SHORT = frozenset("aesvnqzp")
 
 # Why each override is blocked (one line per distinct override).
@@ -121,19 +118,16 @@ _GIT_COMMIT_VALUE_SHORT = frozenset("mFCctuS")
 def _cluster_has_no_verify(tok: str) -> bool:
     """True iff a bundled short cluster (e.g. `-vn`, `-anm`) carries `-n`.
 
-    Walks the cluster char-by-char. A value-taking short option (e.g. `m`)
-    swallows the rest of the cluster as its argument, so scanning stops at the
-    first one. To avoid false positives on unrecognized clusters, every char
-    preceding the first value-taker must be a known value-less short option.
+    Walks char-by-char; a value-taking short option swallows the cluster
+    remainder as its argument, so scanning stops there. Unknown chars also
+    stop the scan to avoid false positives on clusters we don't recognize.
     """
     for ch in tok[1:]:
         if ch == "n":
             return True
         if ch in _GIT_COMMIT_VALUE_SHORT:
-            # Value-taker consumes the remainder; no `-n` seen before it.
             return False
         if ch not in GIT_COMMIT_NO_VALUE_SHORT:
-            # Unknown short option — don't speculate about cluster semantics.
             return False
     return False
 
@@ -210,10 +204,9 @@ def detect_overrides(argv: list[str]) -> list[str]:
             and len(tok) > 2
             and _cluster_has_no_verify(tok)
         ):
-            # Bundled POSIX short cluster carrying `n` (=`--no-verify`), e.g.
-            # `-vn`, `-nv`, `-anm`, `-nm`. Decompose the cluster into individual
-            # short options; the exact-match branch above only sees standalone
-            # `-n`, so without this the bundled forms slip through (#512).
+            # Bundled short cluster carrying `n` (=`--no-verify`), e.g. `-vn`,
+            # `-anm`. The exact-match branch above only sees standalone `-n`, so
+            # without this the bundled forms slip through (#512).
             overrides.append(COMMIT_FLAG_TOKENS["-n"])
         elif tok.startswith("-S") and len(tok) > 2:
             # `-S<keyid>` (signing with explicit keyid, no space).

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -242,9 +242,8 @@ run_case "git_super_prefix_fused_force_push" \
   "" \
   "git --super-prefix=x push --force"
 
-# Issue #512: bundled short-flag clusters carrying `f` (=--force) must fire.
-# `_is_force_push` checked `bare in force_flags` exactly, so `-fu`/`-fv`/`-vf`
-# (where `f` is bundled with another short flag) bypassed the gate.
+# Issue #512: bundled short-flag clusters carrying `f` (=--force) must fire
+# (the prior exact-match force check let `-fu`/`-fv`/`-vf` bypass the gate).
 run_case "git_push_bundled_fu_force" \
   "advisory:feedback_force_history_rewrite_mutation" \
   "" \

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -242,6 +242,30 @@ run_case "git_super_prefix_fused_force_push" \
   "" \
   "git --super-prefix=x push --force"
 
+# Issue #512: bundled short-flag clusters carrying `f` (=--force) must fire.
+# `_is_force_push` checked `bare in force_flags` exactly, so `-fu`/`-fv`/`-vf`
+# (where `f` is bundled with another short flag) bypassed the gate.
+run_case "git_push_bundled_fu_force" \
+  "advisory:feedback_force_history_rewrite_mutation" \
+  "" \
+  "git push origin main -fu"
+
+run_case "git_push_bundled_fv_force" \
+  "advisory:feedback_force_history_rewrite_mutation" \
+  "" \
+  "git push origin main -fv"
+
+run_case "git_push_bundled_vf_force" \
+  "advisory:feedback_force_history_rewrite_mutation" \
+  "" \
+  "git push origin main -vf"
+
+# Clean push with a bundled non-force cluster must stay silent.
+run_case "silent_git_push_bundled_no_force" \
+  "silent" \
+  "" \
+  "git push origin main -u"
+
 # --- dynamic memory loading negative cases (issue #359) ----------------------
 # Memory with no momentum: field must NOT surface on any trigger.
 negative_no_momentum_case() {

--- a/tests/hooks/preflight-gate/test_verify_commit_flag_override.sh
+++ b/tests/hooks/preflight-gate/test_verify_commit_flag_override.sh
@@ -211,6 +211,41 @@ run_case "S04: --gpg-sign text inside -m body" silent \
   "$(payload 'git commit -m "discuss --gpg-sign policy in docs"')"
 
 # ---------------------------------------------------------------------------
+# Bundled short-flag clusters carrying -n (=--no-verify) (#512).
+#
+# `detect_overrides` matched COMMIT_FLAG_TOKENS exactly, so a standalone `-n`
+# was blocked but bundled clusters like `-vn`, `-nv`, `-anm`, `-nm` slipped
+# through. The decomposition must split the cluster and detect the embedded
+# `n` while leaving clean clusters (no `n`) alone.
+# ---------------------------------------------------------------------------
+
+run_case "C01: git commit -vn -m msg (bundled no-verify)" deny \
+  "$(payload 'git commit -vn -m "msg"')"
+
+run_case "C02: git commit -nv -m msg (order swapped)" deny \
+  "$(payload 'git commit -nv -m "msg"')"
+
+run_case "C03: git commit -anm msg (-a -n -m bundled)" deny \
+  "$(payload 'git commit -anm "msg"')"
+
+run_case "C04: git commit -nm msg (-n -m bundled)" deny \
+  "$(payload 'git commit -nm "msg"')"
+
+# Clean bundled clusters with NO -n must pass.
+run_case "C05: git commit -v -m msg (separate, no override)" silent \
+  "$(payload 'git commit -v -m "msg"')"
+
+run_case "C06: git commit -am msg (bundled, no override)" silent \
+  "$(payload 'git commit -am "msg"')"
+
+run_case "C07: git commit -vs -m msg (bundled value-less, no n)" silent \
+  "$(payload 'git commit -vs -m "msg"')"
+
+# `-mn` is `-m` with value `n` — the message, NOT a no-verify cluster.
+run_case "C08: git commit -mn (message value 'n', not no-verify)" silent \
+  "$(payload 'git commit -mn')"
+
+# ---------------------------------------------------------------------------
 # Bypass case (PRAXIS_SKIP_COMMIT_FLAG_CHECK=1 must short-circuit to pass)
 # ---------------------------------------------------------------------------
 

--- a/tests/hooks/preflight-gate/test_verify_commit_flag_override.sh
+++ b/tests/hooks/preflight-gate/test_verify_commit_flag_override.sh
@@ -210,12 +210,9 @@ run_case "S04: --gpg-sign text inside -m body" silent \
   "$(payload 'git commit -m "discuss --gpg-sign policy in docs"')"
 
 # ---------------------------------------------------------------------------
-# Bundled short-flag clusters carrying -n (=--no-verify) (#512).
-#
-# `detect_overrides` matched COMMIT_FLAG_TOKENS exactly, so a standalone `-n`
-# was blocked but bundled clusters like `-vn`, `-nv`, `-anm`, `-nm` slipped
-# through. The decomposition must split the cluster and detect the embedded
-# `n` while leaving clean clusters (no `n`) alone.
+# Bundled short-flag clusters carrying -n (=--no-verify) (#512). The prior
+# exact COMMIT_FLAG_TOKENS match let clusters like `-vn`/`-anm` slip through;
+# clean clusters (no `n`) must stay silent.
 # ---------------------------------------------------------------------------
 
 run_case "C01: git commit -vn -m msg (bundled no-verify)" deny \


### PR DESCRIPTION
## Summary

Bundled POSIX short-flag clusters (e.g. `-vn`, `-fu`) were not decomposed into individual chars, so dangerous flags hidden inside a cluster bypassed two guards.

- **`verify-commit-flag-override`** — `detect_overrides` (`impl.py:171`) exact-matched `COMMIT_FLAG_TOKENS`, so standalone `-n` was blocked but bundled `-vn`/`-nv`/`-anm`/`-nm` slipped through. Now decomposes a `^-[a-zA-Z]+$` cluster char-by-char (reusing the sibling commit-title hook's `GIT_COMMIT_NO_VALUE_SHORT` pattern), stopping at the first value-taking short option so `-mn` (message value `"n"`) is correctly left alone.
- **`momentum-rule-retrieval-gate`** — `_is_force_push` (`impl.py:361`) only checked `bare in force_flags or tok in force_flags`, so bundled `-fu`/`-fv`/`-vf` carrying `f` (=`--force`) failed to surface. Now decomposes value-less clusters and detects an embedded `f`.

Both preserve `--` end-of-options handling, `=`-valued flags, and the fail-open contract.

## Reproductions (before → after)

Defect 1 — `verify-commit-flag-override`:
```
printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git commit -vn -m x"}}' | python3 hooks/preflight-gate/verify-commit-flag-override/impl.py; echo "exit=$?"
# before: exit=0 (bypass)   after: exit=2 (blocked)
```

Defect 2 — `momentum-rule-retrieval-gate`:
```
printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git push origin main -fu"},"session_id":"t"}' | python3 hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py 2>&1
# before: (no output)   after: force-push momentum surface fires
```

## Tests

Regression cases added under `tests/hooks/preflight-gate/` and `tests/hooks/advisory-nudge/`:
- `git commit -vn/-nv/-anm/-nm -m x` → deny (exit 2); clean `-v -m`, `-am`, `-vs`, and `-mn` (message value `n`) still pass.
- `git push origin main -fu/-fv/-vf` → momentum surface fires; clean `-u` push stays silent.

`bash scripts/run-tests.sh`: both touched test files pass (37 + 52 cases, 0 fail). The 4 remaining failures in `tests/hooks/advisory-nudge/test_codex_review_route.sh` are pre-existing and environmental (git-signing server 400 / `gh` PR-state lookups unavailable in the sandbox); they reproduce identically with the changes stashed and are unrelated to this PR.

`python3 scripts/check-plugin-manifests.py`: `plugin-manifest check OK`.

Closes #512

https://claude.ai/code/session_01F1feUhQztxe8rz6MCZdxFh

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1feUhQztxe8rz6MCZdxFh)_