### PR TITLE
fix(hooks): close gh gate bypass via path-prefix and command wrapper

### DIFF
--- a/hooks/_lib/_hook_utils.py
+++ b/hooks/_lib/_hook_utils.py
@@ -45,7 +45,15 @@ SHELL_KEYWORDS = {
 # dictionaries list *only* flags that take a separate-token argument so that
 # `sudo --user admin kubectl ...` peels both `--user` and `admin`. Bare flags
 # (with no arg) and `--long=value` forms are handled generically below.
-PREFIX_WRAPPERS = {"env", "sudo", "nice", "time", "stdbuf", "ionice"}
+#
+# `command` / `builtin` are bash shell wrappers that run the following word as
+# a command (`command gh pr merge` executes `gh pr merge`). Without peeling
+# them, an `argv[0] == "gh"` gate is silently bypassed via `command gh ...`.
+# Their flags (`-p`, `-v`, `-V`) take no separate-token argument, so the
+# generic bare-flag peel below handles them.
+PREFIX_WRAPPERS = {
+    "env", "sudo", "nice", "time", "stdbuf", "ionice", "command", "builtin",
+}
 WRAPPER_OPTS_WITH_ARG = {
     "env": {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"},
     "sudo": {
@@ -153,6 +161,29 @@ def strip_prefix(argv: list[str]) -> list[str]:
             continue
         break
     return argv[i:]
+
+
+def _is_gh_binary(token: str) -> bool:
+    """True iff `token` names the GitHub CLI binary `gh`.
+
+    Symmetric with `_is_git_binary` in the commit-gate hooks: accepts the bare
+    name (`gh`) and any path-prefixed form (`/usr/bin/gh`, `./gh`). gh-based
+    PreToolUse gates previously compared `argv[0] == "gh"` exactly, which a
+    path prefix (`/usr/bin/gh pr merge`) bypassed silently. Strip a leading run
+    of shell grouping / command-substitution chars first so a subshell-wrapped
+    form (`(gh …)`, `$(gh …)`) normalizes too — matching the `_is_git_binary`
+    pattern.
+    """
+    stripped = token.lstrip(_GROUP_PREFIX_CHARS)
+    return stripped == "gh" or stripped.endswith("/gh")
+
+
+# Shell grouping / command-substitution chars that may prefix a binary token
+# when it sits inside a subshell or substitution (`(gh …)`, `$(gh …)`,
+# `` `gh …` ``). Stripped before the basename comparison so the binary-name
+# check is not fooled by the wrapper syntax. Mirrors the same constant in the
+# commit-gate hooks' `_is_git_binary`.
+_GROUP_PREFIX_CHARS = "(){}$`"
 
 
 def iter_command_starts(tokens: list[str]):

--- a/hooks/_lib/_hook_utils.py
+++ b/hooks/_lib/_hook_utils.py
@@ -163,6 +163,14 @@ def strip_prefix(argv: list[str]) -> list[str]:
     return argv[i:]
 
 
+# Shell grouping / command-substitution chars that may prefix a binary token
+# when it sits inside a subshell or substitution (`(gh …)`, `$(gh …)`,
+# `` `gh …` ``). Stripped before the basename comparison so the binary-name
+# check is not fooled by the wrapper syntax. Mirrors the same constant in the
+# commit-gate hooks' `_is_git_binary`.
+_GROUP_PREFIX_CHARS = "(){}$`"
+
+
 def _is_gh_binary(token: str) -> bool:
     """True iff `token` names the GitHub CLI binary `gh`.
 
@@ -176,14 +184,6 @@ def _is_gh_binary(token: str) -> bool:
     """
     stripped = token.lstrip(_GROUP_PREFIX_CHARS)
     return stripped == "gh" or stripped.endswith("/gh")
-
-
-# Shell grouping / command-substitution chars that may prefix a binary token
-# when it sits inside a subshell or substitution (`(gh …)`, `$(gh …)`,
-# `` `gh …` ``). Stripped before the basename comparison so the binary-name
-# check is not fooled by the wrapper syntax. Mirrors the same constant in the
-# commit-gate hooks' `_is_git_binary`.
-_GROUP_PREFIX_CHARS = "(){}$`"
 
 
 def iter_command_starts(tokens: list[str]):

--- a/hooks/preflight-gate/block-pr-without-caller-evidence/impl.py
+++ b/hooks/preflight-gate/block-pr-without-caller-evidence/impl.py
@@ -51,6 +51,7 @@ import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_utils import (  # type: ignore[import-not-found]
+    _is_gh_binary,
     compound_cascade_hint,
     iter_command_starts,
     safe_tokenize,
@@ -189,7 +190,7 @@ def _get_effective_body(argv: list[str], hmap: dict[str, str], command: str) -> 
 def _is_pr_create(argv: list[str]) -> bool:
     """True if argv is `gh pr create/new` (not --help)."""
     argv = strip_prefix(argv)
-    if not argv or argv[0] != "gh":
+    if not argv or not _is_gh_binary(argv[0]):
         return False
     if any(t in ("--help", "-h") or t.startswith(("--help=", "-h="))
            for t in argv):

--- a/hooks/preflight-gate/block-pr-without-precommit-evidence/impl.py
+++ b/hooks/preflight-gate/block-pr-without-precommit-evidence/impl.py
@@ -45,6 +45,7 @@ import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_utils import (  # type: ignore[import-not-found]
+    _is_gh_binary,
     compound_cascade_hint,
     iter_command_starts,
     safe_tokenize,
@@ -166,7 +167,7 @@ def _has_precommit_marker(body: str) -> bool:
 
 def _is_pr_create(argv: list[str]) -> bool:
     argv = strip_prefix(argv)
-    if not argv or argv[0] != "gh":
+    if not argv or not _is_gh_binary(argv[0]):
         return False
     if any(t in ("--help", "-h") or t.startswith(("--help=", "-h="))
            for t in argv):

--- a/hooks/preflight-gate/pre-gh-pr-create-dedup-gate/impl.py
+++ b/hooks/preflight-gate/pre-gh-pr-create-dedup-gate/impl.py
@@ -44,6 +44,7 @@ import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_utils import (  # type: ignore[import-not-found]
+    _is_gh_binary,
     iter_command_starts,
     safe_tokenize,
     strip_prefix,
@@ -92,7 +93,7 @@ _ORIGIN_URL_RE = re.compile(
 def _is_pr_create(argv: list[str]) -> bool:
     """True if argv is `gh [global flags] pr create/new` (not --help)."""
     argv = strip_prefix(argv)
-    if not argv or argv[0] != "gh":
+    if not argv or not _is_gh_binary(argv[0]):
         return False
     if any(t in ("--help", "-h") or t.startswith(("--help=", "-h="))
            for t in argv):

--- a/hooks/preflight-gate/pre-gh-pr-create-dedup-gate/spec.md
+++ b/hooks/preflight-gate/pre-gh-pr-create-dedup-gate/spec.md
@@ -136,15 +136,21 @@ shell semantics. The following bypass patterns are accepted limits shared
 with `block-pr-without-caller-evidence` and `block-gh-state-all`:
 
 - Variable command name: `SUB=create; gh pr $SUB --title ...`
-- Subshell: `(gh pr create --title ...)`
 - `eval`: `eval gh pr create --title ...`
-- Wrapper indirection: `command gh pr create`, `xargs gh pr`
+- Wrapper indirection: `xargs gh pr`
 - Re-entry via `bash -c "gh pr create ..."`
 - Shell function/alias shadowing of `gh`
 
 Closing these would require a real shell parser. Empirically the failure
 modes the hook targets (forgotten dedup check under task momentum) do not
 involve such patterns; the cost/benefit doesn't favor full coverage.
+
+Closed bypasses (issue #511): path-prefix (`/usr/bin/gh pr create`) and the
+`command`/`builtin` shell wrappers (`command gh pr create`) are now caught.
+`strip_prefix` peels `command`/`builtin`, and gh detection uses the
+basename-aware `_is_gh_binary` helper (symmetric with the commit gates'
+`_is_git_binary`), which also normalizes leading subshell/substitution chars
+(`(gh …)`, `$(gh …)`).
 
 ### Relationship to sibling hooks
 

--- a/hooks/preflight-gate/pre-merge-approval-gate/impl.py
+++ b/hooks/preflight-gate/pre-merge-approval-gate/impl.py
@@ -40,6 +40,7 @@ from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    _is_gh_binary,
     compound_cascade_hint,
     iter_command_starts,
     safe_tokenize,
@@ -80,7 +81,7 @@ def is_gh_pr_merge(argv: list[str]) -> bool:
     `gh -R owner/repo pr merge` is detected correctly.
     """
     argv = strip_prefix(argv)
-    if not argv or argv[0] != "gh":
+    if not argv or not _is_gh_binary(argv[0]):
         return False
 
     # Walk past any global flags (and their arguments) to find the subcommand.

--- a/tests/hooks/preflight-gate/test_pre_merge_approval_gate.sh
+++ b/tests/hooks/preflight-gate/test_pre_merge_approval_gate.sh
@@ -207,6 +207,31 @@ run_case "inline CMUX_DELEGATE=1 gh -R owner/repo pr merge (ask, not delegate se
   "ask" "no-delegate" \
   '{"tool_name":"Bash","tool_input":{"command":"CMUX_DELEGATE=1 gh -R owner/repo pr merge 1"}}'
 
+# --- #511: path-prefix / command-wrapper bypass must NOT slip past the gate → ASK
+# `argv[0] == "gh"` exact match previously let `/usr/bin/gh pr merge` and
+# `command gh pr merge` through silently. _is_gh_binary (basename) + the
+# command/builtin peel in strip_prefix close both.
+
+run_case "direct session: /usr/bin/gh pr merge 5 (path-prefix, ask)" \
+  "ask" "no-delegate" \
+  '{"tool_name":"Bash","tool_input":{"command":"/usr/bin/gh pr merge 5"}}'
+
+run_case "direct session: command gh pr merge 5 (command wrapper, ask)" \
+  "ask" "no-delegate" \
+  '{"tool_name":"Bash","tool_input":{"command":"command gh pr merge 5"}}'
+
+run_case "direct session: builtin command gh pr merge 5 (builtin wrapper, ask)" \
+  "ask" "no-delegate" \
+  '{"tool_name":"Bash","tool_input":{"command":"builtin command gh pr merge 5"}}'
+
+run_case "direct session: /usr/bin/gh -R owner/repo pr merge (path-prefix + global flag, ask)" \
+  "ask" "no-delegate" \
+  '{"tool_name":"Bash","tool_input":{"command":"/usr/bin/gh -R owner/repo pr merge 5"}}'
+
+run_case "direct session: /usr/bin/gh pr list (path-prefix read, not merge, silent)" \
+  "silent" "no-delegate" \
+  '{"tool_name":"Bash","tool_input":{"command":"/usr/bin/gh pr list"}}'
+
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/tests/test_hook_utils.sh
+++ b/tests/test_hook_utils.sh
@@ -126,6 +126,74 @@ run_hint "empty command no hint"           false ''
 run_hint "quoted heredoc-like in compound" false 'echo "<<EOF foo" && git push'
 
 # ---------------------------------------------------------------------------
+# strip_prefix / _is_gh_binary — gh-gate normalization (issue #511)
+# ---------------------------------------------------------------------------
+#
+# strip_prefix must peel the `command`/`builtin` shell wrappers so that
+# `command gh pr merge` normalizes to argv[0]=="gh". A path-prefixed binary
+# (`/usr/bin/gh`) is left intact by strip_prefix and instead recognized via
+# the basename-aware _is_gh_binary helper (symmetric with _is_git_binary).
+
+# run_strip name "expected_json_list" "tok1|tok2|..."
+#   argv tokens are passed via the `|`-separated string; expected is a JSON
+#   list compared against repr(strip_prefix(argv)).
+run_strip() {
+  local name="$1" expected="$2" tokens="$3"
+  local actual
+  actual=$(python3 - "$tokens" <<'PYEOF'
+import json, sys
+from _hook_utils import strip_prefix
+argv = sys.argv[1].split("|")
+print(json.dumps(strip_prefix(argv)))
+PYEOF
+)
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS [strip_prefix] $name"; PASS=$((PASS + 1))
+  else
+    echo "FAIL [strip_prefix expected=$expected got=$actual] $name"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# run_gh_bin name expected(true|false) token
+run_gh_bin() {
+  local name="$1" expected="$2" token="$3"
+  local actual
+  actual=$(python3 - "$token" <<'PYEOF'
+import sys
+from _hook_utils import _is_gh_binary
+print(str(_is_gh_binary(sys.argv[1])).lower())
+PYEOF
+)
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS [_is_gh_binary:$expected] $name"; PASS=$((PASS + 1))
+  else
+    echo "FAIL [_is_gh_binary expected=$expected got=$actual] $name"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# command/builtin wrappers peel to the real argv[0]
+run_strip "command wrapper peels"        '["gh", "pr", "merge"]'      'command|gh|pr|merge'
+run_strip "builtin wrapper peels"         '["gh", "pr", "merge"]'      'builtin|gh|pr|merge'
+run_strip "builtin command nested peels"  '["gh", "pr", "merge"]'      'builtin|command|gh|pr|merge'
+run_strip "command after env peels"       '["gh", "pr", "merge"]'      'env|command|gh|pr|merge'
+# path-prefixed gh is left intact by strip_prefix (basename handled downstream)
+run_strip "path-prefix gh untouched"      '["/usr/bin/gh", "pr", "merge"]' '/usr/bin/gh|pr|merge'
+run_strip "command + path-prefix gh"      '["/usr/bin/gh", "pr", "merge"]' 'command|/usr/bin/gh|pr|merge'
+
+# _is_gh_binary basename recognition
+run_gh_bin "bare gh"            true  'gh'
+run_gh_bin "abs path /usr/bin/gh" true '/usr/bin/gh'
+run_gh_bin "rel path ./gh"      true  './gh'
+run_gh_bin "subshell \$(gh"     true  '$(gh'
+run_gh_bin "group (gh"          true  '(gh'
+run_gh_bin "not gh: github"     false 'github'
+run_gh_bin "not gh: ghi"        false 'ghi'
+run_gh_bin "not gh: git"        false 'git'
+run_gh_bin "not gh: foogh"      false 'foogh'
+
+# ---------------------------------------------------------------------------
 # tokenize_with_roles — role-aware token API (issue #263)
 # ---------------------------------------------------------------------------
 #


### PR DESCRIPTION
## Summary

`strip_prefix` (`hooks/_lib/_hook_utils.py`) did not peel the `command`/`builtin` shell wrappers, and the gh-based PreToolUse gates compared `argv[0] == "gh"` exactly. As a result a path prefix (`/usr/bin/gh pr merge`) or a `command gh pr merge` wrapper silently bypassed the approval/evidence gates while the bare `gh pr merge ...` form was correctly gated.

Fix:
- Add `command`/`builtin` to `PREFIX_WRAPPERS` so `strip_prefix` peels them (their flags take no separate-token arg, so the generic bare-flag peel covers them).
- Add `_is_gh_binary` helper — basename- and group-prefix-aware (`gh`, `/usr/bin/gh`, `./gh`, `(gh`, `$(gh`) — symmetric with the commit gates' `_is_git_binary`.
- Switch the 4 affected gates to basename-aware gh detection (fail-open preserved):
  - `pre-merge-approval-gate`
  - `block-pr-without-caller-evidence`
  - `block-pr-without-precommit-evidence`
  - `pre-gh-pr-create-dedup-gate`
- Update `pre-gh-pr-create-dedup-gate/spec.md` known-limits: command-wrapper and path-prefix bypasses are now closed.

## Reproduction (before)

```
python3 -c 'import sys; sys.path.insert(0,"hooks/_lib"); from _hook_utils import strip_prefix; print(strip_prefix(["command","gh","pr","merge"]))'
# -> ['command', 'gh', 'pr', 'merge']  (gh not normalized to argv[0])

printf '%s' '{"tool_name":"Bash","tool_input":{"command":"/usr/bin/gh pr merge 5"},"session_id":"sc"}' | python3 hooks/preflight-gate/pre-merge-approval-gate/impl.py
# (exit 0, no output) — approval gate silently bypassed
```

## After

- `strip_prefix(["command","gh","pr","merge"])` → `['gh', 'pr', 'merge']`
- `/usr/bin/gh pr merge 5` and `command gh pr merge 5` now emit `ask` from `pre-merge-approval-gate`; `/usr/bin/gh pr list` stays silent (read, not merge).

## Tests / verification

- `tests/test_hook_utils.sh` — added `strip_prefix` (command/builtin peel, path-prefix passthrough) and `_is_gh_binary` recognition cases → 84 passed, 0 failed.
- `tests/hooks/preflight-gate/test_pre_merge_approval_gate.sh` — added end-to-end path-prefix / `command` / `builtin` wrapper cases → 30 passed, 0 failed.
- Affected siblings green: caller-evidence 34/34, precommit-evidence 42/42, dedup-gate 27/27. Adjacent `strip_prefix` consumers green: side-effect-scan 64/64, gh-state-all 29/29.
- `python3 scripts/check-plugin-manifests.py` → `plugin-manifest check OK`.

Note: `scripts/run-tests.sh` reports two pre-existing, sandbox-environment failures unrelated to this change — `test_worktree_edit_gate.sh` and `test_codex_review_route.sh`. Both fail identically on the clean `origin/main` tree (git branch/repo enforcement and `gh`/network not available in the sandbox), and neither touches the gh-normalization code path.

Closes #511

https://claude.ai/code/session_01F1feUhQztxe8rz6MCZdxFh

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1feUhQztxe8rz6MCZdxFh)_