### PR TITLE
fix(hooks): safe_tokenize drops argv[0] on backslash-newline

### DIFF
--- a/hooks/_lib/_hook_utils.py
+++ b/hooks/_lib/_hook_utils.py
@@ -78,6 +78,14 @@ def safe_tokenize(command: str) -> list[str]:
     Lines that fail to parse (unmatched quote, runaway heredoc, etc.) are
     skipped — better a silent pass than a crashed hook.
 
+    A bash line continuation (a `\\` immediately followed by a newline) is
+    *not* a command separator — it splices the two physical lines into one
+    logical line. We rejoin those before the newline split so argv[0] on the
+    leading line is preserved. Without this, the dangling `\\` left on the
+    first line makes shlex raise ``ValueError: No escaped character`` and the
+    ``except ValueError`` arm below would silently drop the entire first line
+    (issue #510 — neutralised dozens of hooks).
+
     Caller note: a multi-line value inside a quoted flag (e.g.
     ``gh pr create --body "line1\\nline2"``) is split at the unescaped
     newline, separating ``--body`` from its value. In test payloads, use a
@@ -89,6 +97,12 @@ def safe_tokenize(command: str) -> list[str]:
         )
         gh pr create --body "$BODY"
     """
+    # Splice bash line continuations (`\` + newline) into one logical line so
+    # the leading line's argv[0] survives the per-line shlex pass below. A
+    # backslash that is itself escaped (`\\` then newline) is a literal
+    # backslash followed by a real newline separator, so only collapse an
+    # odd-length run of trailing backslashes.
+    command = re.sub(r"(?<!\\)((?:\\\\)*)\\\n", r"\1 ", command)
     lines = [ln for ln in command.split("\n") if ln.strip()]
     if not lines:
         return []

--- a/tests/test_hook_utils.sh
+++ b/tests/test_hook_utils.sh
@@ -339,6 +339,53 @@ run_roles_negative "post-DD \$(): \$() after -- must NOT be SUBST_RUN" \
   'kubectl exec pod -- $(echo --flag)'
 
 # ---------------------------------------------------------------------------
+# safe_tokenize — bash line-continuation handling (issue #510)
+# ---------------------------------------------------------------------------
+#
+# A `\` immediately before a newline is a bash line continuation, not a
+# command separator. It must be rejoined before the per-line shlex pass so
+# the leading line's argv[0] is preserved. Each case asserts the full token
+# list (Python repr) matches exactly.
+
+# run_tokens name "<expected python list repr>" <command-as-argv...>
+run_tokens() {
+  local name="$1" expected="$2"
+  shift 2
+  local actual
+  actual=$(python3 -c '
+import sys
+from _hook_utils import safe_tokenize
+print(safe_tokenize(sys.argv[1]))
+' "$1")
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS [tokenize] $name"; PASS=$((PASS + 1))
+  else
+    echo "FAIL [tokenize] $name"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# Issue #510 regression: `git \<newline>commit` must keep argv[0] ('git').
+run_tokens "line-continuation rejoins argv[0]" \
+  "['git', 'commit']" \
+  $'git \\\ncommit'
+
+run_tokens "line-continuation with trailing flags" \
+  "['git', 'commit', '-m', 'x']" \
+  $'git \\\ncommit -m x'
+
+run_tokens "multiple line continuations collapse" \
+  "['a', 'b', 'c']" \
+  $'a \\\nb \\\nc'
+
+# A genuine newline (no preceding backslash) is still a `;` separator.
+run_tokens "bare newline stays a separator" \
+  "['git', 'status', ';', 'git', 'log']" \
+  $'git status\ngit log'
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`safe_tokenize` in `hooks/_lib/_hook_utils.py` split the raw command on newlines and ran `shlex` per line. A bash line continuation (`\` + newline) left a dangling backslash on the leading line, so `shlex` raised `ValueError: No escaped character` and the `except ValueError: continue` arm silently dropped that entire line — including `argv[0]`. This could neutralise 28+ hooks that inspect the executable name.

The fix splices bash line continuations into one logical line *before* the per-line shlex pass, preserving the leading line's `argv[0]`. Only an odd-length run of trailing backslashes is collapsed, so an escaped backslash (`\\` then newline) still acts as a real separator. Fail-open behaviour for genuinely unparseable lines is unchanged.

## Reproduction

```
python3 -c 'import sys; sys.path.insert(0,"hooks/_lib"); from _hook_utils import safe_tokenize; bs=chr(92); nl=chr(10); print(safe_tokenize("git "+bs+nl+"commit -m x"))'
# before: [';', 'commit', '-m', 'x']   (argv[0] 'git' lost)
# after:  ['git', 'commit', '-m', 'x']
```

## Tests

Added regression coverage in `tests/test_hook_utils.sh` asserting:
- `git \<newline>commit` → `['git', 'commit']`
- `git \<newline>commit -m x` → `['git', 'commit', '-m', 'x']`
- multiple continuations collapse → `['a', 'b', 'c']`
- a bare newline (no preceding backslash) still becomes a `;` separator

`bash scripts/run-tests.sh` → ALL TESTS PASSED (pytest 67 passed; all 4 new tokenize cases pass). `python3 scripts/check-plugin-manifests.py` → plugin-manifest check OK.

Closes #510

https://claude.ai/code/session_01F1feUhQztxe8rz6MCZdxFh

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1feUhQztxe8rz6MCZdxFh)_