### PR TITLE
fix(hooks): replace substring matching with boundary-aware checks

### DIFF
--- a/hooks/advisory-nudge/advisory-wrapper-signature-verify/impl.py
+++ b/hooks/advisory-nudge/advisory-wrapper-signature-verify/impl.py
@@ -90,6 +90,7 @@ def _is_wrapper_shape_path(file_path: str) -> bool:
 _TEST_PATH_PATTERN = re.compile(
     r"(?:/|^)tests?/"            # /tests/, /test/, tests/foo.py, test/foo.py
     r"|/test_[^/]*\.py$"         # /test_foo.py
+    r"|^test_[^/]*\.py$"         # bare test_foo.py (no leading dir) — #513 결함5
     r"|_test\.py$"               # foo_test.py
 )
 

--- a/hooks/advisory-nudge/external-api-literal-trigger/impl.py
+++ b/hooks/advisory-nudge/external-api-literal-trigger/impl.py
@@ -52,8 +52,7 @@ from _hook_utils import safe_tokenize  # type: ignore[import-not-found]  # noqa:
 # Unicode-aware, so Hangul counts as a word char and `AUTH_TOKEN이` /
 # `VENDOR_API_KEY를` would be missed because the trailing `\b` does not see a
 # boundary between the ASCII token and the adjacent Hangul (issue #513, 결함4).
-# Mirrors the output-block-falsify-advisory `_ANCHORING_EN_PATTERN` right
-# anchor. The leading `\b` is kept so we still avoid matching inside longer
+# The leading `\b` is kept so we still avoid matching inside longer
 # mixed-case identifiers (e.g. `myAUTH_TOKEN`).
 ALLCAPS_RE = re.compile(r"\b([A-Z][A-Z0-9_]{5,})(?![A-Z0-9_])")
 

--- a/hooks/advisory-nudge/external-api-literal-trigger/impl.py
+++ b/hooks/advisory-nudge/external-api-literal-trigger/impl.py
@@ -49,8 +49,14 @@ from _hook_utils import safe_tokenize  # type: ignore[import-not-found]  # noqa:
 # ALL_CAPS_WITH_UNDERSCORES tokens of length ≥ 6.
 # Requires at least one underscore or digit (pure ALL_CAPS words like "SELECT"
 # are excluded by requiring the compound structure).
-# The boundary \b ensures we don't match inside longer identifiers.
-ALLCAPS_RE = re.compile(r"\b([A-Z][A-Z0-9_]{5,})\b")
+# ASCII right-boundary lookahead instead of a trailing `\b`: Python's `\b` is
+# Unicode-aware, so Hangul counts as a word char and `AUTH_TOKEN이` /
+# `VENDOR_API_KEY를` would be missed because the trailing `\b` does not see a
+# boundary between the ASCII token and the adjacent Hangul (issue #513, 결함4).
+# Mirrors the output-block-falsify-advisory `_ANCHORING_EN_PATTERN` right
+# anchor. The leading `\b` is kept so we still avoid matching inside longer
+# mixed-case identifiers (e.g. `myAUTH_TOKEN`).
+ALLCAPS_RE = re.compile(r"\b([A-Z][A-Z0-9_]{5,})(?![A-Z0-9_])")
 
 # 3-part SQL identifiers: catalog.schema.table (all lowercase / underscore).
 # Matches only when all three parts follow SQL identifier conventions AND the

--- a/hooks/advisory-nudge/external-api-literal-trigger/spec.md
+++ b/hooks/advisory-nudge/external-api-literal-trigger/spec.md
@@ -53,13 +53,16 @@ Up to 3 findings are reported per invocation to avoid advisory overload.
 
 #### ALL_CAPS enum candidates
 
-Tokens matching `\b[A-Z][A-Z0-9_]{5,}\b` that additionally contain at
-least one underscore or digit (compound structure). Pure SQL keywords
-(`SELECT`, `INSERT`, `UPDATE`, `DELETE`, `WHERE`) are excluded by the
-compound-structure requirement.
+Tokens matching `\b[A-Z][A-Z0-9_]{5,}(?![A-Z0-9_])` that additionally
+contain at least one underscore or digit (compound structure). Pure SQL
+keywords (`SELECT`, `INSERT`, `UPDATE`, `DELETE`, `WHERE`) are excluded by
+the compound-structure requirement. The right boundary is an ASCII
+lookahead rather than `\b`: Python's `\b` is Unicode-aware, so a Hangul
+character immediately after the token (e.g. `AUTH_TOKEN이`) would otherwise
+suppress the match (issue #513).
 
 Examples that fire: `LAST_365_DAYS`, `THIS_WEEK_OF_MONTH`,
-`SHOPBY_AUTH_TOKEN`, `PAYMENT_STATUS_APPROVED`
+`SHOPBY_AUTH_TOKEN`, `PAYMENT_STATUS_APPROVED`, `AUTH_TOKEN이`
 
 #### 3-part SQL identifiers
 

--- a/hooks/advisory-nudge/jq-config-empty-dict-advisory/impl.py
+++ b/hooks/advisory-nudge/jq-config-empty-dict-advisory/impl.py
@@ -76,12 +76,11 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
 # We do NOT anchor on ~/.claude exactly — relative paths like
 # .claude/settings.json are also config paths.
 #
-# The settings.json / hooks.json branches are anchored to the start of the
-# token with an optional leading `./` (no bare `(?:^|/)`) so a repo-root form
-# (`settings.json`, `./settings.json`) matches but an unrelated file under any
-# other directory (`/tmp/settings.json`, `sub/settings.json`) does not misfire
-# the advisory (issue #513, 결함3). Such config files under a real config dir
-# still match via the .claude/ / .codex/ branches.
+# The settings.json / hooks.json branches anchor to the token start with an
+# optional leading `./` (not `(?:^|/)`) so a repo-root form matches but a file
+# under any other directory (`/tmp/settings.json`, `sub/settings.json`) does
+# not misfire (issue #513, 결함3); such files under a real config dir still
+# match via the .claude/ / .codex/ branches.
 
 _CONFIG_PATH_RE = re.compile(
     r"""

--- a/hooks/advisory-nudge/jq-config-empty-dict-advisory/impl.py
+++ b/hooks/advisory-nudge/jq-config-empty-dict-advisory/impl.py
@@ -71,18 +71,23 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
 #
 # A path matches if it ends with .json AND satisfies at least one of:
 #   1. Has .claude/ or .codex/ anywhere in it (absolute or relative)
-#   2. Is literally "settings.json" or "hooks.json" (repo-root files)
+#   2. Is the BARE filename "settings.json" or "hooks.json" (repo-root files)
 #
 # We do NOT anchor on ~/.claude exactly — relative paths like
 # .claude/settings.json are also config paths.
+#
+# The settings.json / hooks.json branches are anchored to the start of the
+# token (no leading `(?:^|/)`) so unrelated files like /tmp/settings.json do
+# not misfire the advisory (issue #513, 결함3). Such config files under a
+# real config dir still match via the .claude/ / .codex/ branches.
 
 _CONFIG_PATH_RE = re.compile(
     r"""
     (?:
         (?:^|/)\.claude/   # under .claude/ dir
       | (?:^|/)\.codex/    # under .codex/ dir
-      | (?:^|/)settings\.json$   # repo-root settings.json
-      | (?:^|/)hooks\.json$      # repo-root hooks.json
+      | ^settings\.json$   # repo-root settings.json (bare filename only)
+      | ^hooks\.json$      # repo-root hooks.json (bare filename only)
     )
     """,
     re.VERBOSE,

--- a/hooks/advisory-nudge/jq-config-empty-dict-advisory/impl.py
+++ b/hooks/advisory-nudge/jq-config-empty-dict-advisory/impl.py
@@ -77,17 +77,19 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
 # .claude/settings.json are also config paths.
 #
 # The settings.json / hooks.json branches are anchored to the start of the
-# token (no leading `(?:^|/)`) so unrelated files like /tmp/settings.json do
-# not misfire the advisory (issue #513, 결함3). Such config files under a
-# real config dir still match via the .claude/ / .codex/ branches.
+# token with an optional leading `./` (no bare `(?:^|/)`) so a repo-root form
+# (`settings.json`, `./settings.json`) matches but an unrelated file under any
+# other directory (`/tmp/settings.json`, `sub/settings.json`) does not misfire
+# the advisory (issue #513, 결함3). Such config files under a real config dir
+# still match via the .claude/ / .codex/ branches.
 
 _CONFIG_PATH_RE = re.compile(
     r"""
     (?:
-        (?:^|/)\.claude/   # under .claude/ dir
-      | (?:^|/)\.codex/    # under .codex/ dir
-      | ^settings\.json$   # repo-root settings.json (bare filename only)
-      | ^hooks\.json$      # repo-root hooks.json (bare filename only)
+        (?:^|/)\.claude/        # under .claude/ dir
+      | (?:^|/)\.codex/         # under .codex/ dir
+      | ^(?:\./)?settings\.json$  # repo-root settings.json (bare or ./ form)
+      | ^(?:\./)?hooks\.json$     # repo-root hooks.json (bare or ./ form)
     )
     """,
     re.VERBOSE,

--- a/hooks/advisory-nudge/jq-config-empty-dict-advisory/spec.md
+++ b/hooks/advisory-nudge/jq-config-empty-dict-advisory/spec.md
@@ -23,7 +23,9 @@ Detection surface — config paths matched:
 
 - `~/.claude/*.json`
 - `~/.codex/*.json`
-- Repo-root `settings.json` or `hooks.json` (bare filename)
+- Repo-root `settings.json` or `hooks.json` (bare filename or `./`-relative
+  form; a file under any other directory such as `/tmp/settings.json` does not
+  match)
 - Any `.json` file under a `.claude/` or `.codex/` directory component
   (absolute or relative)
 

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -61,6 +61,11 @@ TRIGGER_MERGE = "merge"
 TRIGGER_DISPATCH = "dispatch"
 TRIGGER_FORCE_PUSH = "force-push"
 
+# AI-provider name match for cmux dispatch detection. ASCII word boundaries
+# (case-insensitive) so an actual provider invocation matches but an
+# identifier substring like "CLAUDE_API_KEY=abc" does not (issue #513, 결함2).
+_AI_PROVIDER_RE = re.compile(r"\b(claude|codex|gemini)\b", re.IGNORECASE)
+
 CLOSING_LINE = f"{PREFIX} ─────────────────────────────────────────────────────────────"
 
 # ---------------------------------------------------------------------------
@@ -311,8 +316,9 @@ def _is_cmux_dispatch(argv: list[str]) -> bool:
     if "new-workspace" not in argv[1:]:
         return False
 
-    # Scan for --command and inspect its value.
-    ai_provider_tokens = ("claude", "codex", "gemini")
+    # Scan for --command and inspect its value. Match provider names on ASCII
+    # word boundaries so substrings like "CLAUDE_API_KEY=abc" do not false-fire
+    # the dispatch advisory (issue #513, 결함2).
     n = len(argv)
     for i, tok in enumerate(argv):
         value: str | None = None
@@ -322,8 +328,7 @@ def _is_cmux_dispatch(argv: list[str]) -> bool:
             value = tok.split("=", 1)[1]
         if value is None:
             continue
-        lowered = value.lower()
-        if any(p in lowered for p in ai_provider_tokens):
+        if _AI_PROVIDER_RE.search(value):
             return True
     return False
 

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -316,9 +316,7 @@ def _is_cmux_dispatch(argv: list[str]) -> bool:
     if "new-workspace" not in argv[1:]:
         return False
 
-    # Scan for --command and inspect its value. Match provider names on ASCII
-    # word boundaries so substrings like "CLAUDE_API_KEY=abc" do not false-fire
-    # the dispatch advisory (issue #513, 결함2).
+    # Scan for --command and inspect its value (matched via _AI_PROVIDER_RE).
     n = len(argv)
     for i, tok in enumerate(argv):
         value: str | None = None

--- a/hooks/preflight-gate/pre-edit-protected-branch-guard/impl.py
+++ b/hooks/preflight-gate/pre-edit-protected-branch-guard/impl.py
@@ -72,7 +72,7 @@ TARGET_TOOLS = frozenset({"Edit", "Write", "NotebookEdit"})
 
 # /tmp/ scratch files are handled by get_repo_root fail-open (non-repo paths
 # return None). Patterns here cover project-internal planning paths only.
-PLANNING_PATH_PATTERNS = (".omc/plans/", ".claude/projects/")
+PLANNING_PATH_PATTERNS = ("/.omc/plans/", "/.claude/projects/")
 
 DOCS_FILENAMES = frozenset({
     "readme", "changelog", "contributing", "license",
@@ -319,7 +319,11 @@ def is_planning_artifact(path: str) -> bool:
     file will fail-open at get_repo_root (returns None → exit 0). Only
     project-internal planning paths need an explicit skip rule.
     """
-    norm = path.replace("\\", "/")
+    # Prepend a leading "/" so PLANNING_PATH_PATTERNS (which carry a leading
+    # "/") force a path-component boundary even for repo-root-relative paths.
+    # Without this, a substring like "username.omc/plans/" would bypass the
+    # protected-branch guard (issue #513, 결함1).
+    norm = "/" + path.replace("\\", "/").lstrip("/")
     return any(pat in norm for pat in PLANNING_PATH_PATTERNS)
 
 

--- a/tests/hooks/advisory-nudge/test_advisory_wrapper_signature_verify.sh
+++ b/tests/hooks/advisory-nudge/test_advisory_wrapper_signature_verify.sh
@@ -183,6 +183,18 @@ run_case "Pass: *_test.py file excluded" pass \
 run_case "Pass: /test/ directory excluded" pass \
   "$(make_write_payload '/repo/test/foo_wrapper.py' 'return create_x(1)')"
 
+# issue #513 결함5: a BARE test_*.py path (no leading dir) is a test file and
+# must be excluded — previously misfired because the pattern required a leading
+# "/". Content matches the delegation heuristic to prove the path-exclusion
+# (not the content) is what suppresses the advisory.
+run_case "Pass: bare test_*.py file excluded (issue #513 결함5)" pass \
+  "$(make_write_payload 'test_client.py' 'return get_user(1)')"
+
+# issue #513 결함5 negative: a bare NON-test file (client.py) with the same
+# delegation content must still emit the advisory — exclusion is test-only.
+run_case "Advisory: bare client.py with delegation still fires (issue #513 결함5 negative)" advisory \
+  "$(make_write_payload 'client.py' 'return get_user(1)')"
+
 # ---------------------------------------------------------------------------
 # EDGE cases — fail-open
 # ---------------------------------------------------------------------------

--- a/tests/hooks/advisory-nudge/test_external_api_literal_trigger.sh
+++ b/tests/hooks/advisory-nudge/test_external_api_literal_trigger.sh
@@ -137,6 +137,21 @@ run_case "edit_allcaps" "advisory:AUTH_TOKEN_SCOPE" \
 run_case "write_sql_3part" "advisory:prod.analytics.events" \
   "$(write_payload 'SELECT * FROM prod.analytics.events WHERE dt > now()')"
 
+# --- issue #513 결함4: Hangul-adjacent ALLCAPS tokens ---
+
+# Positive: Hangul directly after the token (Unicode \w) used to break the
+# trailing \b → now caught via the ASCII (?![A-Z0-9_]) lookahead.
+run_case "hangul_adjacent_allcaps_auth_token" "advisory:AUTH_TOKEN" \
+  "$(write_payload 'AUTH_TOKEN이 필요합니다')"
+
+run_case "hangul_adjacent_allcaps_vendor_key" "advisory:VENDOR_API_KEY" \
+  "$(edit_payload 'VENDOR_API_KEY를 발급받으세요')"
+
+# Negative: an ALLCAPS run embedded in a longer mixed-case identifier must stay
+# clean (leading \b still guards the left edge).
+run_case "mixed_case_identifier_stays_clean" "pass" \
+  "$(write_payload 'value myAUTH_TOKEN here')"
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------

--- a/tests/hooks/advisory-nudge/test_jq_config_empty_dict_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_jq_config_empty_dict_advisory.sh
@@ -440,10 +440,12 @@ run_case "empty settings.json under non-config dir is silent (issue #513 결함3
 # token resolves to the empty fixture created there.
 mkdir -p "$TMPDIR_TEST/root"
 touch "$TMPDIR_TEST/root/settings.json"
+# Unique session_id per run: the hook dedups per session in the shared system
+# TMPDIR, so a hardcoded id would suppress the advisory on re-runs (stale state).
 bare_payload=$(python3 -c '
-import json
-print(json.dumps({"tool_name":"Bash","tool_input":{"command":"jq . settings.json"},"session_id":"bare-513-case"}))
-')
+import json, sys
+print(json.dumps({"tool_name":"Bash","tool_input":{"command":"jq . settings.json"},"session_id":sys.argv[1]}))
+' "bare-513-$$-$RANDOM")
 bare_err=$(mktemp)
 ( cd "$TMPDIR_TEST/root" && echo "$bare_payload" | python3 "$HOOK" >/dev/null 2>"$bare_err" )
 bare_rc=$?
@@ -461,9 +463,9 @@ fi
 # accepts an optional leading `./` so this form is not lost alongside the bare
 # token while subdir paths like sub/settings.json stay excluded).
 dot_payload=$(python3 -c '
-import json
-print(json.dumps({"tool_name":"Bash","tool_input":{"command":"jq . ./settings.json"},"session_id":"dot-513-case"}))
-')
+import json, sys
+print(json.dumps({"tool_name":"Bash","tool_input":{"command":"jq . ./settings.json"},"session_id":sys.argv[1]}))
+' "dot-513-$$-$RANDOM")
 dot_err=$(mktemp)
 ( cd "$TMPDIR_TEST/root" && echo "$dot_payload" | python3 "$HOOK" >/dev/null 2>"$dot_err" )
 dot_rc=$?

--- a/tests/hooks/advisory-nudge/test_jq_config_empty_dict_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_jq_config_empty_dict_advisory.sh
@@ -127,6 +127,12 @@ touch "$EMPTY_CLAUDE2"                                # second empty config file
 EMPTY_CLAUDE_N="$TMPDIR_TEST/.claude/settings-n.json"
 touch "$EMPTY_CLAUDE_N"                               # config path with -n in filename
 
+# issue #513 결함3: empty settings.json under a NON-config dir (e.g. /tmp).
+# Must NOT be classified as a repo config path → hook stays silent.
+EMPTY_NONCONFIG_SETTINGS="$TMPDIR_TEST/sub/settings.json"
+mkdir -p "$TMPDIR_TEST/sub"
+touch "$EMPTY_NONCONFIG_SETTINGS"
+
 # ---------------------------------------------------------------------------
 # === Baseline: existing advisory paths still work ===
 # ---------------------------------------------------------------------------
@@ -419,6 +425,36 @@ fi
 run_case "empty command is silent" \
   "silent" \
   ""
+
+# ---------------------------------------------------------------------------
+# issue #513 결함3: settings.json path-anchor regression
+# ---------------------------------------------------------------------------
+
+# Positive: empty settings.json under a non-config dir must no longer misfire.
+run_case "empty settings.json under non-config dir is silent (issue #513 결함3)" \
+  "silent" \
+  "jq '.' $EMPTY_NONCONFIG_SETTINGS"
+
+# Negative: a bare repo-root settings.json (resolved from cwd) is still a config
+# path → empty file still emits [config-empty]. Run with cwd=TMPDIR so the bare
+# token resolves to the empty fixture created there.
+mkdir -p "$TMPDIR_TEST/root"
+touch "$TMPDIR_TEST/root/settings.json"
+bare_payload=$(python3 -c '
+import json
+print(json.dumps({"tool_name":"Bash","tool_input":{"command":"jq . settings.json"},"session_id":"bare-513-case"}))
+')
+bare_err=$(mktemp)
+( cd "$TMPDIR_TEST/root" && echo "$bare_payload" | python3 "$HOOK" >/dev/null 2>"$bare_err" )
+bare_rc=$?
+bare_err_content=$(cat "$bare_err"); rm -f "$bare_err"
+if [ "$bare_rc" -eq 0 ] && printf '%s' "$bare_err_content" | grep -qF "[config-empty]"; then
+  echo "PASS  [bare repo-root settings.json still emits config-empty (issue #513 결함3 negative)]"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL  [bare repo-root settings.json still emits config-empty] rc=$bare_rc stderr=${bare_err_content:-<empty>}"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("bare repo-root settings.json still emits config-empty (issue #513 결함3 negative)")
+fi
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/tests/hooks/advisory-nudge/test_jq_config_empty_dict_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_jq_config_empty_dict_advisory.sh
@@ -456,6 +456,26 @@ else
   FAIL=$((FAIL + 1)); FAILED_NAMES+=("bare repo-root settings.json still emits config-empty (issue #513 결함3 negative)")
 fi
 
+# Negative: the repo-root-relative `./settings.json` form is also a config path
+# and must still emit [config-empty] (PR #521 review feedback — the anchor
+# accepts an optional leading `./` so this form is not lost alongside the bare
+# token while subdir paths like sub/settings.json stay excluded).
+dot_payload=$(python3 -c '
+import json
+print(json.dumps({"tool_name":"Bash","tool_input":{"command":"jq . ./settings.json"},"session_id":"dot-513-case"}))
+')
+dot_err=$(mktemp)
+( cd "$TMPDIR_TEST/root" && echo "$dot_payload" | python3 "$HOOK" >/dev/null 2>"$dot_err" )
+dot_rc=$?
+dot_err_content=$(cat "$dot_err"); rm -f "$dot_err"
+if [ "$dot_rc" -eq 0 ] && printf '%s' "$dot_err_content" | grep -qF "[config-empty]"; then
+  echo "PASS  [./settings.json (repo-root-relative) still emits config-empty (PR #521)]"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL  [./settings.json still emits config-empty] rc=$dot_rc stderr=${dot_err_content:-<empty>}"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("./settings.json still emits config-empty (PR #521)")
+fi
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -183,6 +183,19 @@ run_case "silent_cmux_new_workspace_shell" \
   "" \
   'cmux new-workspace dev --command "bash -i"'
 
+# issue #513 결함2: provider name as an identifier substring (CLAUDE_API_KEY)
+# must NOT false-fire the dispatch advisory — word-boundary match required.
+run_case "silent_cmux_provider_substring_in_env_var" \
+  "silent" \
+  "" \
+  'cmux new-workspace --command "CLAUDE_API_KEY=abc myapp"'
+
+# issue #513 결함2 negative: a genuine provider invocation still fires.
+run_case "cmux_dispatch_provider_word_boundary" \
+  "advisory:[praxis:momentum-gate]" \
+  "" \
+  'cmux new-workspace --command "claude -p do real work"'
+
 # --- force-push triggers -------------------------------------------------------
 
 run_case "git_push_force" \

--- a/tests/hooks/preflight-gate/test_pre_edit_protected_branch_guard.sh
+++ b/tests/hooks/preflight-gate/test_pre_edit_protected_branch_guard.sh
@@ -352,6 +352,22 @@ run_case "dirty+protected+.claude/projects/ target → pass" pass \
   "PRAXIS_PBGUARD_TEST_BRANCH=main" \
   "PRAXIS_PBGUARD_TEST_STATUS=$DIRTY_STATUS"
 
+# issue #513 결함1: substring "username.omc/plans/" must NOT be treated as a
+# planning artifact (no path-component boundary) → guard still denies.
+run_case "dirty+protected+substring-omc-plans-no-boundary → deny (issue #513 결함1)" deny \
+  Edit "$FAKE_ROOT/username.omc/plans/code.py" \
+  "PRAXIS_PBGUARD_TEST_REPO_ROOT=$FAKE_ROOT" \
+  "PRAXIS_PBGUARD_TEST_BRANCH=main" \
+  "PRAXIS_PBGUARD_TEST_STATUS=$DIRTY_STATUS"
+
+# issue #513 결함1 negative: a genuine repo-root-relative .omc/plans/ path
+# (leading component boundary present) still passes as a planning artifact.
+run_case "dirty+protected+root-relative-.omc/plans/ → pass (issue #513 결함1 negative)" pass \
+  Write "$FAKE_ROOT/.omc/plans/genuine-draft.md" \
+  "PRAXIS_PBGUARD_TEST_REPO_ROOT=$FAKE_ROOT" \
+  "PRAXIS_PBGUARD_TEST_BRANCH=main" \
+  "PRAXIS_PBGUARD_TEST_STATUS=$DIRTY_STATUS"
+
 # ---------------------------------------------------------------------------
 # PASS / DENY: gitignored paths (issue #493)
 # Gitignored files can never be committed/PR'd → worktree workflow N/A → skip.


### PR DESCRIPTION
Five hooks judged path/keyword membership by raw **substring**, ignoring path-component and word boundaries. This caused both **bypass** (guards silently not firing) and **misfire** (advisories firing on unrelated input). Each is fixed to use a path-component match (leading `/`) or an ASCII boundary (`\b` / lookaround), mirroring the sibling hook that already handles it correctly. Fail-open behavior is preserved throughout.

## Defects fixed

- **결함1 (HIGH) `pre-edit-protected-branch-guard`** — `PLANNING_PATH_PATTERNS` now carry a leading `/` and `is_planning_artifact` normalizes the path with a leading `/`, forcing a path-component boundary. `…/username.omc/plans/code.py` no longer bypasses the protected-branch guard. Mirrors `protected-paths-guard`'s `/.omc/plans/` approach.
- **결함2 (MED) `momentum-rule-retrieval-gate`** — cmux dispatch provider detection now uses `\b(claude|codex|gemini)\b` (case-insensitive) instead of substring. `cmux new-workspace --command "CLAUDE_API_KEY=abc myapp"` no longer false-fires the dispatch advisory; genuine provider invocations still fire.
- **결함3 (MED) `jq-config-empty-dict-advisory`** — `settings.json` / `hooks.json` regex branches anchored to `^` (bare filename, per spec "repo-root settings.json"), so `/tmp/settings.json` no longer misfires. Config files under `.claude/` / `.codex/` still match via their own branches.
- **결함4 (LOW) `external-api-literal-trigger`** — ALLCAPS right boundary is now an ASCII lookahead `(?[A-Z0-9_])` instead of Unicode-aware `\b`. Hangul-adjacent tokens (`AUTH_TOKEN이`, `VENDOR_API_KEY를`) are now caught; leading `\b` retained so mixed-case identifiers (`myAUTH_TOKEN`) stay clean. Mirrors `output-block-falsify-advisory`'s `_ANCHORING_EN_PATTERN`.
- **결함5 (LOW) `advisory-wrapper-signature-verify`** — test-path pattern adds `^test_[^/]*\.py$` so a bare `test_client.py` (no leading dir) is recognized as a test file and excluded from the advisory.

## Tests

A positive (bypass/misfire now caught) and a negative (must stay clean) regression test added per defect, following the existing `tests/hooks/` layout. All five affected test files pass.

## Gates

- `bash scripts/run-tests.sh`: all per-hook suites green. The two pre-existing environmental failures — `test_worktree_edit_gate.sh` and `test_codex_review_route.sh` — were confirmed to fail **identically on clean `origin/main`** (unrelated to this change; caused by the sandbox's `commit.gpgsign` signing server returning HTTP 400).
- `python3 scripts/check-plugin-manifests.py`: `plugin-manifest check OK`.
- Spec sync: `external-api-literal-trigger/spec.md` updated to document the new ALLCAPS right-boundary lookahead.

Closes #513

https://claude.ai/code/session_01F1feUhQztxe8rz6MCZdxFh

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1feUhQztxe8rz6MCZdxFh)_