### PR TITLE
fix(hooks): handle negation/progressive forms in completion & stop detection

### DIFF
--- a/hooks/completion-verify/completion-signal-gate/impl.py
+++ b/hooks/completion-verify/completion-signal-gate/impl.py
@@ -73,15 +73,92 @@ _COMPLETION_KO_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"이상\s*없음"),
 ]
 
+# Negation / progressive markers that flip a completion phrase into a
+# NOT-yet-complete statement. Without these, "not done yet", "this isn't
+# complete", "not ready to merge", "still completing", "완료되지 않았습니다",
+# "완료 안 됨" false-trigger the advisory (negation/status-form rule).
+#
+# English: a negation token in the window immediately BEFORE the matched
+# completion phrase ("not done", "isn't complete", "won't be ready to
+# merge"). Progressive "-ing" forms are already excluded by the ASCII
+# word-boundary lookarounds in _COMPLETION_EN_PATTERNS ("completing" does
+# not match "complete"), so only the preceding-negation case needs a guard.
+_NEGATION_WINDOW_EN = 24  # chars preceding the matched completion phrase
+_NEGATION_MARKERS_EN = (
+    "not ",
+    "n't ",
+    "no ",
+    "never ",
+    "without ",
+    "yet to ",
+    "isn't",
+    "aren't",
+    "won't",
+    "can't",
+    "cannot",
+    "wasn't",
+)
+
+# Korean: a negation form FOLLOWING the completion token within a small
+# window ("완료되지 않", "완료 안", "완료 못", "완료 안 됨", "완료 안됐").
+_NEGATION_WINDOW_KO = 12  # chars following the matched completion token
+_NEGATION_MARKERS_KO = (
+    "되지 않",
+    "되지않",
+    "지 않",
+    "지않",
+    "안 됨",
+    "안됨",
+    "안 됐",
+    "안됐",
+    "안 된",
+    "안된",
+    "못 ",
+    "못함",
+    "못했",
+    "아직",
+)
+
+
+def _is_negated_en(text: str, start: int) -> bool:
+    """True if an English completion match at `start` is under negation.
+
+    Scans the window immediately preceding the match for a negation token.
+    """
+    prefix = text[max(0, start - _NEGATION_WINDOW_EN):start].lower()
+    return any(neg in prefix for neg in _NEGATION_MARKERS_EN)
+
+
+def _is_negated_ko(text: str, end: int) -> bool:
+    """True if a Korean completion match ending at `end` is negated.
+
+    Korean negation trails the verb ("완료되지 않았다", "완료 안 됨"), so the
+    window FOLLOWING the match is scanned. "아직" (still / not yet) is also
+    treated as a negation cue for progressive non-completion.
+    """
+    suffix = text[end:end + _NEGATION_WINDOW_KO]
+    if any(neg in suffix for neg in _NEGATION_MARKERS_KO):
+        return True
+    # "아직 완료 전" — progressive "not yet" cue can also precede the token.
+    prefix = text[max(0, end - 24):end]
+    return "아직" in prefix
+
 
 def _has_completion_signal(text: str) -> bool:
-    """True if text contains a completion-signal phrase."""
+    """True if text contains a completion-signal phrase that is NOT negated.
+
+    A completion phrase under negation or in a not-yet-complete status form
+    ("not done yet", "isn't complete", "완료되지 않았습니다", "완료 안 됨") does
+    NOT count — the assistant is reporting incompletion, not claiming done.
+    """
     for pat in _COMPLETION_EN_PATTERNS:
-        if pat.search(text):
-            return True
+        for m in pat.finditer(text):
+            if not _is_negated_en(text, m.start()):
+                return True
     for pat in _COMPLETION_KO_PATTERNS:
-        if pat.search(text):
-            return True
+        for m in pat.finditer(text):
+            if not _is_negated_ko(text, m.end()):
+                return True
     return False
 
 

--- a/hooks/completion-verify/completion-signal-gate/impl.py
+++ b/hooks/completion-verify/completion-signal-gate/impl.py
@@ -73,16 +73,10 @@ _COMPLETION_KO_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"이상\s*없음"),
 ]
 
-# Negation / progressive markers that flip a completion phrase into a
-# NOT-yet-complete statement. Without these, "not done yet", "this isn't
-# complete", "not ready to merge", "still completing", "완료되지 않았습니다",
-# "완료 안 됨" false-trigger the advisory (negation/status-form rule).
-#
-# English: a negation token in the window immediately BEFORE the matched
-# completion phrase ("not done", "isn't complete", "won't be ready to
-# merge"). Progressive "-ing" forms are already excluded by the ASCII
-# word-boundary lookarounds in _COMPLETION_EN_PATTERNS ("completing" does
-# not match "complete"), so only the preceding-negation case needs a guard.
+# Negation markers that flip a completion phrase into a not-yet-complete
+# statement (negation/status-form rule, issue #515). EN: token immediately
+# BEFORE the match ("not done"). Progressive "-ing" forms are already
+# excluded by the word-boundary lookarounds ("completing" != "complete").
 _NEGATION_WINDOW_EN = 24  # chars preceding the matched completion phrase
 _NEGATION_MARKERS_EN = (
     "not ",
@@ -99,8 +93,7 @@ _NEGATION_MARKERS_EN = (
     "wasn't",
 )
 
-# Korean: a negation form FOLLOWING the completion token within a small
-# window ("완료되지 않", "완료 안", "완료 못", "완료 안 됨", "완료 안됐").
+# KO: a negation form FOLLOWING the completion token ("완료되지 않", "완료 안 됨").
 _NEGATION_WINDOW_KO = 12  # chars following the matched completion token
 _NEGATION_MARKERS_KO = (
     "되지 않",
@@ -121,10 +114,7 @@ _NEGATION_MARKERS_KO = (
 
 
 def _is_negated_en(text: str, start: int) -> bool:
-    """True if an English completion match at `start` is under negation.
-
-    Scans the window immediately preceding the match for a negation token.
-    """
+    """True if an English completion match at `start` is under negation."""
     prefix = text[max(0, start - _NEGATION_WINDOW_EN):start].lower()
     return any(neg in prefix for neg in _NEGATION_MARKERS_EN)
 
@@ -133,13 +123,12 @@ def _is_negated_ko(text: str, end: int) -> bool:
     """True if a Korean completion match ending at `end` is negated.
 
     Korean negation trails the verb ("완료되지 않았다", "완료 안 됨"), so the
-    window FOLLOWING the match is scanned. "아직" (still / not yet) is also
-    treated as a negation cue for progressive non-completion.
+    window FOLLOWING the match is scanned. "아직" (not yet) also counts.
     """
     suffix = text[end:end + _NEGATION_WINDOW_KO]
     if any(neg in suffix for neg in _NEGATION_MARKERS_KO):
         return True
-    # "아직 완료 전" — progressive "not yet" cue can also precede the token.
+    # "아직 완료 전" — the "not yet" cue can also precede the token.
     prefix = text[max(0, end - 24):end]
     return "아직" in prefix
 

--- a/hooks/completion-verify/completion-signal-gate/spec.md
+++ b/hooks/completion-verify/completion-signal-gate/spec.md
@@ -70,6 +70,19 @@ no evidence-block indicator is present in the same turn, an advisory is emitted.
 | `결함 없음` | "결함 없음." |
 | `이상 없음` | "이상 없음." |
 
+**Negation / progressive guard (issue #515):** a completion phrase under
+negation or in a not-yet-complete status form does NOT count as a completion
+signal — the assistant is reporting incompletion, not claiming done. English
+matches are disqualified when a negation token (`not `, `n't `, `no `,
+`never `, `without `, `isn't`, `won't`, `can't`, `cannot`, …) appears in the
+24 chars preceding the phrase ("not done yet", "this is not complete", "not
+ready to merge"); progressive `-ing` forms are already excluded by the
+ASCII word-boundary lookarounds ("completing" ≠ "complete"). Korean matches
+are disqualified when a negation form trails the token within 12 chars
+(`되지 않`, `지 않`, `안 됨`, `안 돼`, `안 된`, `못 …`) or when `아직` precedes
+it — so `완료되지 않았습니다`, `완료 안 됨`, `아직 완료 전입니다`, and
+`완료하지 못했습니다` no longer trigger the advisory.
+
 **Evidence-block indicators (any of these suppresses the advisory):**
 
 | Indicator | What counts |

--- a/hooks/preflight-gate/block-ask-end-option/impl.py
+++ b/hooks/preflight-gate/block-ask-end-option/impl.py
@@ -141,6 +141,37 @@ NEGATION_PATTERNS_EN = (
 )
 NEGATION_WINDOW = 30  # characters preceding the phrase match
 
+# Ambiguous phrases that read as stop signals in isolation but are routinely
+# used as action directives when followed by an object + action verb, e.g.
+# "I'm done with the analysis, proceed to implementation" or "wrap up the PR
+# tests and deploy". For these, a stop match is disqualified when an action
+# verb follows the phrase within ACTION_FOLLOWUP_WINDOW characters — the
+# message is directing further work, not requesting termination.
+#
+# Termination-specific phrases ("stop here", "end the session", "session
+# end", "that's all", "quit now", "cancel this") are deliberately NOT listed
+# here: they resist the action-directive reading and stay unconditional stop
+# signals.
+AMBIGUOUS_STOP_PHRASES_EN = (
+    "wrap up", "wrap this up",
+    "finish up",
+    "no more",
+    "we're done", "we are done", "i'm done", "i am done",
+)
+# Action verbs that, when they appear shortly after an ambiguous stop phrase,
+# reveal the message as a directive to continue working rather than to stop.
+# Matched as whole words to avoid substring false positives ("running" should
+# not count, but a directive "run the tests" should). Multi-word entries
+# ("go ahead", "move on") are matched as phrases.
+ACTION_VERBS_EN = (
+    "proceed", "continue", "implement", "deploy", "merge", "push",
+    "run", "execute", "review", "test", "build", "create", "start",
+    "move on", "go ahead", "commit", "ship", "release", "fix", "add",
+    "update", "write", "refactor", "investigate", "analyze", "check",
+)
+# Characters after an ambiguous phrase to scan for an action verb.
+ACTION_FOLLOWUP_WINDOW = 80
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -303,6 +334,7 @@ def _has_stop_signal(user_message: str) -> bool:
     # English: phrase match with negation guard.
     for phrase in STOP_SIGNALS_EN_PHRASES:
         phrase_lower = phrase.lower()
+        ambiguous = phrase_lower in AMBIGUOUS_STOP_PHRASES_EN
         start = 0
         while True:
             idx = lower.find(phrase_lower, start)
@@ -310,7 +342,17 @@ def _has_stop_signal(user_message: str) -> bool:
                 break
             prefix = lower[max(0, idx - NEGATION_WINDOW):idx]
             if not _has_negation(prefix):
-                return True
+                # Ambiguous phrases are NOT a stop signal when an action verb
+                # follows them ("I'm done with the analysis, proceed ...",
+                # "wrap up the PR tests and deploy") — the user is directing
+                # further work, not asking to terminate.
+                if ambiguous:
+                    suffix = lower[idx + len(phrase_lower):
+                                   idx + len(phrase_lower) + ACTION_FOLLOWUP_WINDOW]
+                    if not _has_action_verb(suffix):
+                        return True
+                else:
+                    return True
             start = idx + 1
 
     return False
@@ -325,6 +367,27 @@ def _has_negation(prefix: str) -> bool:
     negation.
     """
     return any(neg in prefix for neg in NEGATION_PATTERNS_EN)
+
+
+def _has_action_verb(suffix: str) -> bool:
+    """True if the window following an ambiguous stop phrase contains an
+    action verb — i.e. the message is directing further work.
+
+    Single-word verbs are matched as whole words (ASCII lookaround, not
+    Python `\\b`, mirroring the boundary strategy used elsewhere in the
+    suite) so "run the tests" counts but "running smoothly" does not.
+    Multi-word verb phrases ("go ahead", "move on") are matched as
+    substrings since their internal spaces already anchor them.
+    """
+    import re
+    for verb in ACTION_VERBS_EN:
+        if " " in verb:
+            if verb in suffix:
+                return True
+        else:
+            if re.search(r"(?<![a-z])" + re.escape(verb) + r"(?![a-z])", suffix):
+                return True
+    return False
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/preflight-gate/block-ask-end-option/impl.py
+++ b/hooks/preflight-gate/block-ask-end-option/impl.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
@@ -379,7 +380,6 @@ def _has_action_verb(suffix: str) -> bool:
     Multi-word verb phrases ("go ahead", "move on") are matched as
     substrings since their internal spaces already anchor them.
     """
-    import re
     for verb in ACTION_VERBS_EN:
         if " " in verb:
             if verb in suffix:

--- a/hooks/preflight-gate/block-ask-end-option/impl.py
+++ b/hooks/preflight-gate/block-ask-end-option/impl.py
@@ -142,28 +142,21 @@ NEGATION_PATTERNS_EN = (
 )
 NEGATION_WINDOW = 30  # characters preceding the phrase match
 
-# Ambiguous phrases that read as stop signals in isolation but are routinely
-# used as action directives when followed by an object + action verb, e.g.
-# "I'm done with the analysis, proceed to implementation" or "wrap up the PR
-# tests and deploy". For these, a stop match is disqualified when an action
-# verb follows the phrase within ACTION_FOLLOWUP_WINDOW characters — the
-# message is directing further work, not requesting termination.
-#
-# Termination-specific phrases ("stop here", "end the session", "session
-# end", "that's all", "quit now", "cancel this") are deliberately NOT listed
-# here: they resist the action-directive reading and stay unconditional stop
-# signals.
+# Phrases that read as stop signals in isolation but are routinely action
+# directives when followed by an action verb ("I'm done with the analysis,
+# proceed ..."): a stop match here is disqualified when an action verb follows
+# within ACTION_FOLLOWUP_WINDOW chars (issue #515). Termination-specific
+# phrases ("stop here", "that's all", "quit now") are deliberately excluded —
+# they stay unconditional stop signals.
 AMBIGUOUS_STOP_PHRASES_EN = (
     "wrap up", "wrap this up",
     "finish up",
     "no more",
     "we're done", "we are done", "i'm done", "i am done",
 )
-# Action verbs that, when they appear shortly after an ambiguous stop phrase,
-# reveal the message as a directive to continue working rather than to stop.
-# Matched as whole words to avoid substring false positives ("running" should
-# not count, but a directive "run the tests" should). Multi-word entries
-# ("go ahead", "move on") are matched as phrases.
+# Action verbs that, after an ambiguous stop phrase, mark the message as a
+# directive to keep working. Single words matched whole-word ("run the tests"
+# counts, "running" does not); multi-word entries matched as phrases.
 ACTION_VERBS_EN = (
     "proceed", "continue", "implement", "deploy", "merge", "push",
     "run", "execute", "review", "test", "build", "create", "start",
@@ -344,9 +337,7 @@ def _has_stop_signal(user_message: str) -> bool:
             prefix = lower[max(0, idx - NEGATION_WINDOW):idx]
             if not _has_negation(prefix):
                 # Ambiguous phrases are NOT a stop signal when an action verb
-                # follows them ("I'm done with the analysis, proceed ...",
-                # "wrap up the PR tests and deploy") — the user is directing
-                # further work, not asking to terminate.
+                # follows (the user is directing further work, not stopping).
                 if ambiguous:
                     suffix = lower[idx + len(phrase_lower):
                                    idx + len(phrase_lower) + ACTION_FOLLOWUP_WINDOW]
@@ -371,14 +362,11 @@ def _has_negation(prefix: str) -> bool:
 
 
 def _has_action_verb(suffix: str) -> bool:
-    """True if the window following an ambiguous stop phrase contains an
-    action verb — i.e. the message is directing further work.
+    """True if the window after an ambiguous stop phrase contains an action verb.
 
-    Single-word verbs are matched as whole words (ASCII lookaround, not
-    Python `\\b`, mirroring the boundary strategy used elsewhere in the
-    suite) so "run the tests" counts but "running smoothly" does not.
-    Multi-word verb phrases ("go ahead", "move on") are matched as
-    substrings since their internal spaces already anchor them.
+    Single-word verbs use ASCII-lookaround whole-word matching (mirroring the
+    suite's boundary strategy) so "run the tests" counts but "running" does
+    not; multi-word phrases are matched as substrings.
     """
     for verb in ACTION_VERBS_EN:
         if " " in verb:

--- a/hooks/preflight-gate/block-ask-end-option/spec.md
+++ b/hooks/preflight-gate/block-ask-end-option/spec.md
@@ -128,6 +128,17 @@ Negation guard: a match preceded by `don't`, `do not`, `never`, `no`, `not`,
 `won't`, `wouldn't`, `shouldn't`, `can't`, or `cannot` within 30 characters
 is disqualified (prevents "don't stop" from being a stop signal).
 
+Action-directive guard (issue #515): a small set of ambiguous phrases —
+`wrap up`, `wrap this up`, `finish up`, `no more`, `we're done`,
+`we are done`, `i'm done`, `i am done` — read as stop signals in isolation
+but are routinely action directives when followed by an object + action
+verb (`proceed`, `continue`, `implement`, `deploy`, `merge`, `run`, …)
+within 80 characters. Such a match is NOT treated as a stop signal:
+"I'm done with the analysis, proceed to implementation" and "wrap up the PR
+tests and deploy" keep the end-option block. Termination-specific phrases
+(`stop here`, `end the session`, `session end`, `that's all`, `quit now`,
+`cancel this`) are excluded from this guard and stay unconditional.
+
 ### Response
 
 Block response (exit 2):

--- a/hooks/preflight-gate/block-manufactured-action-menu/impl.py
+++ b/hooks/preflight-gate/block-manufactured-action-menu/impl.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
@@ -259,7 +260,6 @@ def _has_manufactured_marker(labels: list[str]) -> bool:
     """
     if not labels:
         return False
-    import re
     ko_markers = MANUFACTURED_MARKERS_KO + AFFIRMATIVE_MARKERS_KO
     en_markers = MANUFACTURED_MARKERS_EN + AFFIRMATIVE_MARKERS_EN
     for label in labels:
@@ -372,7 +372,6 @@ def _has_destructive_label(labels: list[str]) -> bool:
     """
     if not labels:
         return False
-    import re
     for label in labels:
         lower = label.lower()
         for token in DESTRUCTIVE_LABEL_TOKENS_KO:
@@ -466,7 +465,6 @@ def _has_command_signal(user_message: str) -> bool:
     # English: whole-word match (case-insensitive) with negation guard on
     # the preceding window ("don't proceed", "do not continue").
     lower = user_message.lower()
-    import re
     for token in COMMAND_SIGNALS_EN_TOKENS:
         pattern = r"\b" + re.escape(token.lower()) + r"\b"
         for m in re.finditer(pattern, lower):

--- a/hooks/preflight-gate/block-manufactured-action-menu/impl.py
+++ b/hooks/preflight-gate/block-manufactured-action-menu/impl.py
@@ -111,15 +111,10 @@ COMMAND_SIGNALS_KO = (
     "계속",
 )
 
-# Negation markers that, when found following a Korean signal token,
-# convert the directive into "do not <action>" — must NOT register as
-# command-intent. Examples: "진행하지 마", "계속하지 마", "머지하지 마",
-# "진행하면 안 됩니다", "진행하지 않습니다", "진행 안 됩니다".
-#
-# Three negation shapes are covered:
-#   - prohibitive  "...하지 마/말"   ("don't do it")
-#   - conditional  "...하면 안 ..."  ("must not do it")
-#   - declarative  "...하지 않 ..." / "...안 됩니다/돼/된다" ("is/will not do it")
+# Negation markers following a Korean signal token that turn the directive
+# into "do not <action>" — must NOT register as command-intent (issue #515).
+# Three shapes covered: prohibitive "...하지 마/말", conditional "...하면 안 ...",
+# declarative "...하지 않 ..." / "...안 됩니다/돼/된다".
 NEGATION_FOLLOWUP_KO = (
     "하지 마",
     "하지 말",
@@ -248,15 +243,10 @@ def _collect_option_labels(tool_input: dict) -> list[str]:
 def _has_manufactured_marker(labels: list[str]) -> bool:
     """True if any option label carries a manufactured-menu marker.
 
-    Korean markers stay substring-matched (CJK has no ASCII word boundary
-    and these inflected verb forms have low collision risk). English
-    markers are matched with ASCII-letter lookaround instead of a raw
-    substring so that genuine alternative-path labels are not swept up:
-    `proceed`/`continue`/`go ahead` must not match `Discontinue support`,
-    and `as requested`/`as instructed` must not match arbitrary prose
-    embedding those words. The lookaround mirrors `_has_destructive_label`
-    — it rejects an alphabetic neighbour on either side while still
-    matching mixed-script labels (e.g. `proceed?` / `proceed 합니다`).
+    Korean markers stay substring-matched (CJK has no ASCII word boundary,
+    low collision risk). English markers use ASCII-letter lookaround so
+    alternative-path labels are not swept up (`continue` must not match
+    `Discontinue support`) while mixed-script labels still match (issue #515).
     """
     if not labels:
         return False

--- a/hooks/preflight-gate/block-manufactured-action-menu/impl.py
+++ b/hooks/preflight-gate/block-manufactured-action-menu/impl.py
@@ -112,12 +112,28 @@ COMMAND_SIGNALS_KO = (
 
 # Negation markers that, when found following a Korean signal token,
 # convert the directive into "do not <action>" — must NOT register as
-# command-intent. Examples: "진행하지 마", "계속하지 마", "머지하지 마".
+# command-intent. Examples: "진행하지 마", "계속하지 마", "머지하지 마",
+# "진행하면 안 됩니다", "진행하지 않습니다", "진행 안 됩니다".
+#
+# Three negation shapes are covered:
+#   - prohibitive  "...하지 마/말"   ("don't do it")
+#   - conditional  "...하면 안 ..."  ("must not do it")
+#   - declarative  "...하지 않 ..." / "...안 됩니다/돼/된다" ("is/will not do it")
 NEGATION_FOLLOWUP_KO = (
     "하지 마",
     "하지 말",
     "하지마",
     "하지말",
+    "하면 안",
+    "하면안",
+    "하지 않",
+    "하지않",
+    "안 됩니다",
+    "안됩니다",
+    "안 돼",
+    "안돼",
+    "안 된다",
+    "안된다",
 )
 
 # English negation window: # of chars to scan before an EN command token.
@@ -229,13 +245,33 @@ def _collect_option_labels(tool_input: dict) -> list[str]:
 
 
 def _has_manufactured_marker(labels: list[str]) -> bool:
+    """True if any option label carries a manufactured-menu marker.
+
+    Korean markers stay substring-matched (CJK has no ASCII word boundary
+    and these inflected verb forms have low collision risk). English
+    markers are matched with ASCII-letter lookaround instead of a raw
+    substring so that genuine alternative-path labels are not swept up:
+    `proceed`/`continue`/`go ahead` must not match `Discontinue support`,
+    and `as requested`/`as instructed` must not match arbitrary prose
+    embedding those words. The lookaround mirrors `_has_destructive_label`
+    — it rejects an alphabetic neighbour on either side while still
+    matching mixed-script labels (e.g. `proceed?` / `proceed 합니다`).
+    """
     if not labels:
         return False
-    markers = _all_markers()
+    import re
+    ko_markers = MANUFACTURED_MARKERS_KO + AFFIRMATIVE_MARKERS_KO
+    en_markers = MANUFACTURED_MARKERS_EN + AFFIRMATIVE_MARKERS_EN
     for label in labels:
         lower = label.lower()
-        for marker in markers:
-            if marker.lower() in lower:
+        for marker in ko_markers:
+            if marker in label or marker.lower() in lower:
+                return True
+        for marker in en_markers:
+            pattern = (
+                r"(?<![a-z])" + re.escape(marker.lower()) + r"(?![a-z])"
+            )
+            if re.search(pattern, lower):
                 return True
     return False
 
@@ -422,7 +458,7 @@ def _has_command_signal(user_message: str) -> bool:
             idx = user_message.find(ko, start)
             if idx < 0:
                 break
-            tail = user_message[idx + len(ko): idx + len(ko) + 12]
+            tail = user_message[idx + len(ko): idx + len(ko) + 16]
             if not any(neg in tail for neg in NEGATION_FOLLOWUP_KO):
                 return True
             start = idx + len(ko)

--- a/hooks/preflight-gate/block-manufactured-action-menu/spec.md
+++ b/hooks/preflight-gate/block-manufactured-action-menu/spec.md
@@ -83,10 +83,16 @@ retrieval state.
 - `as directed`
 - `as requested`
 
-All matches are case-insensitive substring checks against the option label.
-Affirmative-form phrases are deliberately multi-word and execute-verb-anchored
-so they do not collide with "leave as-is" labels (`그대로 둬`, `keep as-is`)
-or genuine alternative-path labels.
+Marker matching is case-insensitive. Korean markers use substring matching
+(CJK has no ASCII word boundary and the inflected verb forms have low
+collision risk). English markers use ASCII-letter lookaround (issue #515):
+`proceed` / `continue` / `go ahead` and the affirmative-form phrases match
+only on a word boundary, so a genuine alternative-path label such as
+`Discontinue support for v1` is no longer swept up by the `continue`
+substring while `proceed?` / `proceed 합니다` still match. Affirmative-form
+phrases are additionally multi-word and execute-verb-anchored so they do
+not collide with "leave as-is" labels (`그대로 둬`, `keep as-is`) or genuine
+alternative-path labels.
 
 ### Command-intent signals (user message)
 
@@ -153,10 +159,14 @@ phrasings like `진행 상황 알려줘` or `where should we go from here?`
 do not register as command-intent and therefore never reach the
 manufactured-marker check. Negated directives (`don't proceed yet`,
 `do not continue`, `진행하지 마`, `계속하지 말아줘`) are also rejected:
-Korean tokens require the following 12 chars to not contain
-`하지 마` / `하지 말`, and English tokens require the preceding 30
-chars to not contain a negation marker (`don't`, `do not`, `won't`,
-`will not`, `cannot`, `should not`, `never`, ` not `, ...).
+Korean tokens require the following 16 chars to not contain a negation
+form, and English tokens require the preceding 30 chars to not contain a
+negation marker (`don't`, `do not`, `won't`, `will not`, `cannot`,
+`should not`, `never`, ` not `, ...). The Korean negation set (issue #515)
+covers three shapes — prohibitive `하지 마` / `하지 말`, conditional
+`하면 안`, and declarative `하지 않` / `안 됩니다` / `안 돼` / `안 된다` — so
+`진행하면 안 됩니다`, `진행하지 않습니다`, and `진행 안 됩니다` are no longer
+misread as command-intent.
 
 The Korean command-signal list also includes `계속` so that
 continuation messages like `계속해` / `계속 진행` correctly pair with

--- a/tests/hooks/completion-verify/test_completion_signal_gate.py
+++ b/tests/hooks/completion-verify/test_completion_signal_gate.py
@@ -568,3 +568,86 @@ def test_has_evidence_block(
     last_text: str, has_bash: bool, has_read: bool, expected: bool
 ) -> None:
     assert csg._has_evidence_block(last_text, has_bash, has_read) == expected
+
+
+# ---------------------------------------------------------------------------
+# Defect 3 (issue #515) — negation / progressive completion phrasing must NOT
+# count as a completion signal (negation/status-form rule).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # English negated / not-yet forms
+        "not done yet",
+        "this is not complete",
+        "not ready to merge",
+        "it isn't done",
+        "the migration is not done",
+        "still completing the work",  # progressive: "completing" != "complete"
+        "we are not all set",
+        # Korean negated / not-yet forms
+        "완료되지 않았습니다",
+        "완료 안 됨",
+        "아직 완료 전입니다",
+        "완료하지 못했습니다",
+        "완료 안 됐어요",
+    ],
+)
+def test_negated_completion_not_signal(text: str) -> None:
+    """Negated/progressive completion phrasing → _has_completion_signal False."""
+    assert csg._has_completion_signal(text) is False, (
+        f"negated phrase {text!r} must NOT count as a completion signal"
+    )
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # Genuine (un-negated) completion forms must still register.
+        "done",
+        "the implementation is complete",
+        "ready to merge",
+        "no fixes needed",
+        "all set",
+        "완료",
+        "실질적 수정은 없습니다",
+        "결함 없음",
+        "이상 없음",
+        "머지하셔도 됩니다",
+    ],
+)
+def test_genuine_completion_still_signal(text: str) -> None:
+    """Genuine completion phrasing must still register after negation guard."""
+    assert csg._has_completion_signal(text) is True, (
+        f"genuine completion {text!r} must still count as a completion signal"
+    )
+
+
+def test_negated_completion_no_advisory_end_to_end(tmp_path: Path) -> None:
+    """End-to-end: a negated completion last turn → no Rule 1 advisory."""
+    events = [
+        mk_user("작업 상태 보고"),
+        mk_assistant("아직 작업이 완료되지 않았습니다. 다음 단계가 남아 있습니다."),
+    ]
+    tp = write_jsonl(events, tmp_path)
+    _, stderr, rc = run_hook(tp)
+    assert rc == 0
+    assert "[praxis:completion-signal-gate]" not in stderr, (
+        f"negated completion must not trigger Rule 1 advisory; stderr={stderr!r}"
+    )
+
+
+def test_negated_completion_en_no_advisory_end_to_end(tmp_path: Path) -> None:
+    """End-to-end (EN): 'not done yet' last turn → no Rule 1 advisory."""
+    events = [
+        mk_user("status?"),
+        mk_assistant("The refactor is not done yet — two modules remain."),
+    ]
+    tp = write_jsonl(events, tmp_path)
+    _, stderr, rc = run_hook(tp)
+    assert rc == 0
+    assert "[praxis:completion-signal-gate]" not in stderr, (
+        f"negated EN completion must not trigger advisory; stderr={stderr!r}"
+    )

--- a/tests/hooks/preflight-gate/test_block_ask_end_option.sh
+++ b/tests/hooks/preflight-gate/test_block_ask_end_option.sh
@@ -509,10 +509,7 @@ run_case "[false-pos] '보류 중인 이슈 확인' / '보류 상태 검토' →
 
 # ---------------------------------------------------------------------------
 # (o) Defect 1 (issue #515) — ambiguous stop phrase + action verb is NOT a
-#     stop signal. "I'm done with the analysis, proceed to implementation"
-#     must NOT false-allow the end-option surface; the end-option block must
-#     still fire. The genuine termination form of the same phrase still
-#     short-circuits to pass.
+#     stop signal (block still fires); the genuine termination form passes.
 # ---------------------------------------------------------------------------
 
 # Action-directive readings — ambiguous phrase followed by an action verb →

--- a/tests/hooks/preflight-gate/test_block_ask_end_option.sh
+++ b/tests/hooks/preflight-gate/test_block_ask_end_option.sh
@@ -508,6 +508,56 @@ P_fp5=$(build_payload "$T_fp5" '["보류 중인 이슈 확인", "보류 상태 �
 run_case "[false-pos] '보류 중인 이슈 확인' / '보류 상태 검토' → pass" pass default "$P_fp5"
 
 # ---------------------------------------------------------------------------
+# (o) Defect 1 (issue #515) — ambiguous stop phrase + action verb is NOT a
+#     stop signal. "I'm done with the analysis, proceed to implementation"
+#     must NOT false-allow the end-option surface; the end-option block must
+#     still fire. The genuine termination form of the same phrase still
+#     short-circuits to pass.
+# ---------------------------------------------------------------------------
+
+# Action-directive readings — ambiguous phrase followed by an action verb →
+# NOT a stop signal → end-option block must still fire.
+T_d1a=$(build_transcript "I'm done with the analysis, proceed to implementation")
+P_d1a=$(build_payload "$T_d1a" '["Plan A", "End here"]')
+run_case "[#515-d1] \"I'm done ..., proceed\" is NOT a stop signal → block" block default "$P_d1a"
+
+T_d1b=$(build_transcript "wrap up the PR tests and deploy")
+P_d1b=$(build_payload "$T_d1b" '["Plan A", "End here"]')
+run_case "[#515-d1] 'wrap up the PR tests and deploy' is NOT a stop → block" block default "$P_d1b"
+
+T_d1c=$(build_transcript "we're done with phase 1, continue to phase 2")
+P_d1c=$(build_payload "$T_d1c" '["Plan A", "End here"]')
+run_case "[#515-d1] \"we're done ..., continue\" is NOT a stop → block" block default "$P_d1c"
+
+T_d1d=$(build_transcript "finish up the migration then run the suite")
+P_d1d=$(build_payload "$T_d1d" '["Plan A", "End here"]')
+run_case "[#515-d1] 'finish up ... then run' is NOT a stop → block" block default "$P_d1d"
+
+T_d1e=$(build_transcript "no more discussion, implement the fix")
+P_d1e=$(build_payload "$T_d1e" '["Plan A", "End here"]')
+run_case "[#515-d1] 'no more discussion, implement' is NOT a stop → block" block default "$P_d1e"
+
+# Genuine termination forms of the SAME ambiguous phrases must still pass —
+# no trailing action verb, so the stop signal stands.
+T_d1f=$(build_transcript "let's wrap up for today")
+P_d1f=$(build_payload "$T_d1f" '["Plan A", "End here"]')
+run_case "[#515-d1+] 'wrap up for today' (genuine stop) → pass" pass default "$P_d1f"
+
+T_d1g=$(build_transcript "we're done for now")
+P_d1g=$(build_payload "$T_d1g" '["Plan A", "End here"]')
+run_case "[#515-d1+] \"we're done for now\" (genuine stop) → pass" pass default "$P_d1g"
+
+T_d1h=$(build_transcript "no more changes, thanks")
+P_d1h=$(build_payload "$T_d1h" '["Plan A", "End here"]')
+run_case "[#515-d1+] 'no more changes, thanks' (genuine stop) → pass" pass default "$P_d1h"
+
+# Termination-specific phrases stay unconditional even when an action verb
+# trails — "stop here" / "that's all" are not in the ambiguous set.
+T_d1i=$(build_transcript "stop here, proceed only tomorrow")
+P_d1i=$(build_payload "$T_d1i" '["Plan A", "End here"]')
+run_case "[#515-d1+] 'stop here' stays a stop signal even before a verb → pass" pass default "$P_d1i"
+
+# ---------------------------------------------------------------------------
 # Summary
 # Fail-open guard opt-in (issue #498): main() must be @fail_open-wrapped;
 # guard behavior is tested centrally in tests/test_hook_runtime.sh.

--- a/tests/hooks/preflight-gate/test_block_manufactured_action_menu.sh
+++ b/tests/hooks/preflight-gate/test_block_manufactured_action_menu.sh
@@ -539,6 +539,79 @@ P_ef7=$(build_payload "$T_ef7" '["revise", "as instructed"]')
 run_case "[execute-family] 'the run failed' (non-directive) + marker → pass" pass default "$P_ef7"
 
 # ---------------------------------------------------------------------------
+# (l) Defect 2 (issue #515) — extended Korean negation forms. Before the
+#     fix only "하지 마/말" was handled, so "진행하면 안 됩니다" / "진행하지
+#     않습니다" / "진행 안 됩니다" were misread as command-intent → false
+#     advisory. These negated directives must NOT register as command-intent.
+# ---------------------------------------------------------------------------
+
+T_d2a=$(build_transcript "진행하면 안 됩니다")
+P_d2a=$(build_payload "$T_d2a" '["Plan A", "진행할까요"]')
+run_case "[#515-d2] '진행하면 안 됩니다' (conditional negation) → pass" pass default "$P_d2a"
+
+T_d2b=$(build_transcript "진행하지 않습니다")
+P_d2b=$(build_payload "$T_d2b" '["Plan A", "진행할까요"]')
+run_case "[#515-d2] '진행하지 않습니다' (declarative negation) → pass" pass default "$P_d2b"
+
+T_d2c=$(build_transcript "진행 안 됩니다")
+P_d2c=$(build_payload "$T_d2c" '["Plan A", "진행할까요"]')
+run_case "[#515-d2] '진행 안 됩니다' (안 됩니다 negation) → pass" pass default "$P_d2c"
+
+T_d2d=$(build_transcript "계속하면 안 돼")
+P_d2d=$(build_payload "$T_d2d" '["Plan A", "계속할까요"]')
+run_case "[#515-d2] '계속하면 안 돼' (안 돼 negation) → pass" pass default "$P_d2d"
+
+T_d2e=$(build_transcript "머지하지 않습니다")
+P_d2e=$(build_payload "$T_d2e" '["Plan A", "진행할까요"]')
+run_case "[#515-d2] '머지하지 않습니다' (declarative negation) → pass" pass default "$P_d2e"
+
+# Genuine positive directive must STILL advisory (negation guard didn't
+# swallow legitimate command-intent).
+T_d2f=$(build_transcript "진행하면 됩니다")
+P_d2f=$(build_payload "$T_d2f" '["Plan A", "진행할까요"]')
+run_case "[#515-d2+] '진행하면 됩니다' (affirmative) → advisory" advisory default "$P_d2f"
+
+# Strict-mode variant of the negation guard.
+T_d2g=$(build_transcript "진행하면 안 됩니다")
+P_d2g=$(build_payload "$T_d2g" '["Plan A", "진행할까요"]')
+run_case "[#515-d2] strict + '진행하면 안 됩니다' → pass" pass strict "$P_d2g"
+
+# ---------------------------------------------------------------------------
+# (m) Defect 2 (issue #515) — English marker word-boundary. Before the fix,
+#     markers "proceed" / "continue" / "as requested" substring-matched
+#     genuine alternative-path labels ("Discontinue support") → false
+#     advisory. Word-boundary matching rejects the substring case while
+#     still matching real markers.
+# ---------------------------------------------------------------------------
+
+# "Discontinue support" contains "continue" as a substring only — NOT a
+# manufactured marker. No marker → pass regardless of command signal.
+T_d2h=$(build_transcript "go ahead")
+P_d2h=$(build_payload "$T_d2h" '["Discontinue support for v1", "Keep v1"]')
+run_case "[#515-d2] 'Discontinue support' is NOT a 'continue' marker → pass" pass default "$P_d2h"
+
+# "unprocessed" embeds "proceed"-ish letters but not the token; sanity check
+# that an alternative label naming a real noun does not false-match.
+T_d2i=$(build_transcript "proceed")
+P_d2i=$(build_payload "$T_d2i" '["Reprocess the queue", "Skip the queue"]')
+run_case "[#515-d2] 'Reprocess'/'process' label is NOT a 'proceed' marker → pass" pass default "$P_d2i"
+
+# Genuine English markers must STILL match (word-boundary positive).
+T_d2j=$(build_transcript "go ahead and implement it")
+P_d2j=$(build_payload "$T_d2j" '["Step 1", "proceed"]')
+run_case "[#515-d2+] standalone 'proceed' marker still matches → advisory" advisory default "$P_d2j"
+
+T_d2k=$(build_transcript "continue please")
+P_d2k=$(build_payload "$T_d2k" '["Step A", "continue"]')
+run_case "[#515-d2+] standalone 'continue' marker still matches → advisory" advisory default "$P_d2k"
+
+# Mixed-script label — "proceed" followed by Korean must still match
+# (lookaround rejects only an ASCII-letter neighbour).
+T_d2l=$(build_transcript "진행해주세요")
+P_d2l=$(build_payload "$T_d2l" '["다른 방식", "proceed 합니다"]')
+run_case "[#515-d2+] mixed-script 'proceed 합니다' marker still matches → advisory" advisory default "$P_d2l"
+
+# ---------------------------------------------------------------------------
 # Summary
 # Fail-open guard opt-in (issue #498): main() must be @fail_open-wrapped;
 # guard behavior is tested centrally in tests/test_hook_runtime.sh.

--- a/tests/hooks/preflight-gate/test_block_manufactured_action_menu.sh
+++ b/tests/hooks/preflight-gate/test_block_manufactured_action_menu.sh
@@ -539,10 +539,8 @@ P_ef7=$(build_payload "$T_ef7" '["revise", "as instructed"]')
 run_case "[execute-family] 'the run failed' (non-directive) + marker → pass" pass default "$P_ef7"
 
 # ---------------------------------------------------------------------------
-# (l) Defect 2 (issue #515) — extended Korean negation forms. Before the
-#     fix only "하지 마/말" was handled, so "진행하면 안 됩니다" / "진행하지
-#     않습니다" / "진행 안 됩니다" were misread as command-intent → false
-#     advisory. These negated directives must NOT register as command-intent.
+# (l) Defect 2 (issue #515) — extended Korean negation forms (conditional /
+#     declarative, beyond "하지 마/말") must NOT register as command-intent.
 # ---------------------------------------------------------------------------
 
 T_d2a=$(build_transcript "진행하면 안 됩니다")
@@ -577,11 +575,8 @@ P_d2g=$(build_payload "$T_d2g" '["Plan A", "진행할까요"]')
 run_case "[#515-d2] strict + '진행하면 안 됩니다' → pass" pass strict "$P_d2g"
 
 # ---------------------------------------------------------------------------
-# (m) Defect 2 (issue #515) — English marker word-boundary. Before the fix,
-#     markers "proceed" / "continue" / "as requested" substring-matched
-#     genuine alternative-path labels ("Discontinue support") → false
-#     advisory. Word-boundary matching rejects the substring case while
-#     still matching real markers.
+# (m) Defect 2 (issue #515) — English marker word-boundary: substring matches
+#     ("Discontinue" → "continue") are rejected; real markers still match.
 # ---------------------------------------------------------------------------
 
 # "Discontinue support" contains "continue" as a substring only — NOT a


### PR DESCRIPTION
## Summary

Completion/stop-intent hooks failed to distinguish negation/progressive forms and over-matched action directives as stop/command/completion signals, violating the global CLAUDE.md "NLP signal detection — negation/status forms" rule. This fixes all three defects in #515.

### 결함1 (HIGH) `block-ask-end-option`
`STOP_SIGNALS_EN_PHRASES` included context-free ambiguous phrases (`wrap up`, `finish up`, `no more`, `i'm done`, `we're done`) that read as stop signals in isolation but are action directives in context, so the end-option block was missed.

**Fix:** ambiguous phrases are no longer treated as a stop signal when an action verb (`proceed`, `continue`, `implement`, `deploy`, `merge`, `run`, …) follows within 80 chars. `"I'm done with the analysis, proceed to implementation"` and `"wrap up the PR tests and deploy"` now keep the end-option block. Termination-specific phrases (`stop here`, `end the session`, `session end`, `that's all`, `quit now`, `cancel this`) are excluded from the guard and stay unconditional. Genuine terminations (`wrap up for today`, `we're done for now`) still pass.

### 결함2 (MED) `block-manufactured-action-menu`
`NEGATION_FOLLOWUP_KO` handled only `하지 마/말`, so `진행하면 안 됩니다` / `진행하지 않습니다` / `진행 안 됩니다` were misread as command-intent → false advisory. English markers (`proceed`, `continue`, `as requested`) over-matched as substrings of genuine alternative-path labels.

**Fix:** extended the Korean negation set to three shapes — prohibitive (`하지 마/말`), conditional (`하면 안`), declarative (`하지 않` / `안 됩니다` / `안 돼` / `안 된다`). English markers now match on a word boundary (ASCII lookaround), so `Discontinue support for v1` no longer substring-matches `continue` while `proceed?` / `proceed 합니다` still match.

### 결함3 (LOW) `completion-signal-gate`
Negated/progressive completion phrasing false-triggered the advisory.

**Fix:** a completion phrase under negation or in a not-yet-complete status form does not count. EN: negation token (`not `, `n't `, `isn't`, `won't`, `cannot`, …) in the 24 chars preceding the phrase disqualifies it ("not done yet", "isn't complete"); progressive `-ing` forms already excluded by the existing word-boundary lookarounds. KO: trailing negation (`되지 않`, `지 않`, `안 됨`, `안 돼`, `못 …`) within 12 chars or a preceding `아직` disqualifies it (`완료되지 않았습니다`, `완료 안 됨`, `아직 완료 전입니다`).

## Tests

Regression tests added per defect — a negated/action-followed phrase must NOT be treated as stop/command/completion, and the genuine termination/command/completion form still is. Specs synced for all three hooks.

- `block_ask_end_option`: 67 pass / 0 fail
- `block_manufactured_action_menu`: 77 pass / 0 fail
- `completion_signal_gate` (pytest): all pass

## Gates

- `python3 scripts/check-plugin-manifests.py` → `plugin-manifest check OK`
- `bash scripts/run-tests.sh` → all target suites green. The only failing suites (`test_codex_review_route.sh`, `test_worktree_edit_gate.sh`) are pre-existing sandbox gpg-signing HTTP 400 failures (`fatal: failed to write commit object`), confirmed identical to clean `origin/main` and unrelated to this change.

Closes #515

https://claude.ai/code/session_01F1feUhQztxe8rz6MCZdxFh

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1feUhQztxe8rz6MCZdxFh)_