### PR TITLE
fix(hooks): flag-aware + quote-aware gh command parsing

### DIFF
--- a/hooks/preflight-gate/block-child-repo-issue-create/impl.py
+++ b/hooks/preflight-gate/block-child-repo-issue-create/impl.py
@@ -52,13 +52,17 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import sys
 from pathlib import Path
 from typing import NamedTuple
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "_lib"))
 from block_message import emit_block  # type: ignore[import-not-found]  # noqa: E402
+from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    iter_command_starts,
+    safe_tokenize,
+    strip_prefix,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -109,44 +113,101 @@ def _parse_hub_mediated_orgs(raw: str) -> list[OrgConfig]:
 # Repo flag extraction
 # ---------------------------------------------------------------------------
 
-# Matches --repo X, --repo=X, -R X, -R=X, -R<value> (concatenated short form).
-# gh -R accepts OWNER/REPO or HOST/OWNER/REPO; host stripping happens in main().
-# Capture group 1: the repo value.
-_REPO_FLAG_RE = re.compile(
-    r"(?:--repo[ =]|-R[ =]?)([^\s]+)"
-)
-
-# Matches any of the four gh-issue-create invocation forms:
-#   1. gh [global-flags] issue [flags] (create|new) ...  (global -R before command group)
-#   2. gh issue [flags] (create|new) ...                 (standard, alias, flag-before-subcommand)
-# "flags" = sequences of -X[=val] or --flag[=val]; non-flag tokens end the flag run.
-# Pattern gates on subcommand keyword appearing as the first non-flag token after
-# "issue" to avoid matching "create"/"new" as a flag value.
-_GH_ISSUE_CREATE_RE = re.compile(
-    r"\bgh(?:\s+(?:-\S+(?:\s+[^-\s]\S*)?))*\s+issue(?:\s+(?:-\S+(?:\s+[^-\s]\S*)?))*\s+(?:create|new)\b"
-)
-
-# Splits a shell command on pipeline/sequential operators to isolate each
-# individual invocation.  Simple split — does not handle quoting around &&/;.
-_CMD_SEP_RE = re.compile(r"\s*(?:&&|\|\||;|\|)\s*")
+# gh global flags that consume the following token as their value, so the
+# subcommand walk skips both (e.g. `gh -R o/r issue create`).
+_GH_GLOBAL_VALUE_FLAGS: frozenset[str] = frozenset({
+    "-R", "--repo", "--hostname", "--color",
+})
+# --repo / -R value forms on the create argv.
+_REPO_FLAGS: frozenset[str] = frozenset({"--repo", "-R"})
 
 
 def _extract_repos_for_creates(command: str) -> list[str]:
     """Return repo values for every gh-issue-create invocation in *command*.
 
-    Splits on shell operators first so that each segment is checked
-    independently, preventing a hub-repo invocation from masking a later
-    child-repo invocation in a compound command.  Within each segment,
-    searches for a repo flag if that segment contains a gh-issue-create call.
+    Tokenizes quote-aware (safe_tokenize → iter_command_starts) so each
+    command segment is isolated independently — preventing a hub-repo
+    invocation from masking a later child-repo one in a compound command,
+    AND keeping shell separators *inside a quoted title* (`--title "a; b"`)
+    from fragmenting the command (issue #514 결함3 HIGH). The raw-regex
+    `\\bgh\\s+issue\\s+create\\b` also matched inside quoted strings / grep
+    literals → over-block (결함3 MED); token-based detection avoids both.
     """
     repos: list[str] = []
-    for segment in _CMD_SEP_RE.split(command):
-        if not _GH_ISSUE_CREATE_RE.search(segment):
+    tokens = safe_tokenize(command)
+    if not tokens:
+        return repos
+    for raw_argv in iter_command_starts(tokens):
+        argv = strip_prefix(list(raw_argv))
+        if not _is_gh_issue_create(argv):
             continue
-        m = _REPO_FLAG_RE.search(segment)
-        if m:
-            repos.append(m.group(1).strip("'\""))
+        repo = _flag_value_from_argv(argv, _REPO_FLAGS)
+        if repo:
+            repos.append(repo.strip("'\""))
     return repos
+
+
+def _is_gh_issue_create(argv: list[str]) -> bool:
+    """True iff argv is `gh [global flags] issue [flags] (create|new) ...`.
+
+    Flags between `issue` and the action token are skipped, including the
+    value of value-taking flags in their separate-token form
+    (`gh issue -R owner/repo create`).
+    """
+    if not argv or argv[0].rsplit("/", 1)[-1] != "gh":
+        return False
+    i = _skip_gh_global_flags(argv)
+    if i >= len(argv) or argv[i] != "issue":
+        return False
+    j = i + 1
+    n = len(argv)
+    while j < n and argv[j].startswith("-") and argv[j] != "--":
+        tok = argv[j]
+        j += 1
+        # Separate-token value flag (`-R repo`, `--repo repo`) consumes the
+        # following token so it is not mistaken for the action.
+        if "=" not in tok and tok in _GH_GLOBAL_VALUE_FLAGS and j < n:
+            j += 1
+    return j < n and argv[j] in ("create", "new")
+
+
+def _skip_gh_global_flags(argv: list[str]) -> int:
+    """Index of the first positional after gh's leading global flags."""
+    i = 1
+    n = len(argv)
+    while i < n:
+        tok = argv[i]
+        if tok == "--":
+            return i + 1
+        if not tok.startswith("-"):
+            break
+        i += 1
+        if "=" not in tok and tok in _GH_GLOBAL_VALUE_FLAGS and i < n:
+            i += 1
+    return i
+
+
+def _flag_value_from_argv(argv: list[str], flags: frozenset[str]) -> str:
+    """Return the value of the first matching flag in *argv*.
+
+    Handles separate-token (`--repo X`, `-R X`), inline (`--repo=X`,
+    `-R=X`), and concatenated short-flag (`-Rvalue`) forms.
+    """
+    # Short flags (`-R`) eligible for the concatenated `-Rvalue` form.
+    short_flags = tuple(f for f in flags if len(f) == 2 and f.startswith("-") and not f.startswith("--"))
+    n = len(argv)
+    for i, tok in enumerate(argv):
+        if "=" in tok:
+            name, _, val = tok.partition("=")
+            if name in flags:
+                return val
+            continue
+        if tok in flags and i + 1 < n:
+            return argv[i + 1]
+        for sf in short_flags:
+            if tok.startswith(sf) and len(tok) > 2:
+                return tok[2:]
+    return ""
 
 
 def _repo_org(repo: str) -> str:

--- a/hooks/preflight-gate/block-child-repo-issue-create/spec.md
+++ b/hooks/preflight-gate/block-child-repo-issue-create/spec.md
@@ -33,6 +33,8 @@ A `gh issue create` call is blocked (exit 2) when ALL hold:
 |-----------|--------|
 | `PRAXIS_HUB_MEDIATED_ORGS` unset | **PASS** (NO-OP) |
 | `gh issue create --repo example-org/child` (org configured) | **BLOCKED** |
+| `gh issue create --title "a; b" --repo example-org/child` (separator inside quoted title) | **BLOCKED** (quote-aware tokenization; issue #514) |
+| `grep -rn "gh issue create --repo example-org/child" .` (literal in a quoted string) | **PASS** (not a real invocation; issue #514) |
 | `gh issue create --repo example-org/hub` (this IS the hub) | **PASS** |
 | `gh issue create --repo other-org/anything` (org not in allowlist) | **PASS** |
 | `gh issue create` (no `--repo` flag) | **PASS** |

--- a/hooks/preflight-gate/block-gh-issue-create-without-dup-search/impl.py
+++ b/hooks/preflight-gate/block-gh-issue-create-without-dup-search/impl.py
@@ -44,6 +44,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "_lib"))
 from block_message import emit_block  # type: ignore[import-not-found]  # noqa: E402
+from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    iter_command_starts,
+    safe_tokenize,
+    strip_prefix,
+)
 
 
 def _main_inner() -> int:
@@ -59,15 +64,21 @@ def _main_inner() -> int:
         return 0
 
     command = (payload.get("tool_input") or {}).get("command", "")
-    if not _GH_ISSUE_CREATE_RE.search(command):
+
+    # Quote-aware tokenization: locate a real `gh issue create` argv among the
+    # command segments. A raw regex over the command string matches the
+    # literal inside quoted strings / grep patterns (e.g.
+    # `grep -rn "gh issue create" hooks/`) → over-block (issue #514 결함2 MED).
+    create_argv = _find_gh_issue_create_argv(command)
+    if create_argv is None:
         return 0
 
-    # Personal-repo escape hatch.
-    repo_match = _REPO_FLAG_RE.search(command)
-    if repo_match and _PERSONAL_REPO_RE.match(repo_match.group(1)):
+    # Personal-repo escape hatch (parsed from the create argv only).
+    repo = _extract_repo(create_argv)
+    if repo and _PERSONAL_REPO_RE.match(repo):
         return 0
 
-    title = _extract_title(command)
+    title = _extract_title_from_argv(create_argv)
     if _DUP_TOKEN_RE.search(title):
         return 0
 
@@ -110,13 +121,18 @@ def main() -> int:
 # Constants
 # ---------------------------------------------------------------------------
 
-_GH_ISSUE_CREATE_RE = re.compile(r"\bgh\s+issue\s+create\b")
-_REPO_FLAG_RE = re.compile(r"--repo\s+(\S+)")
 _PERSONAL_REPO_RE = re.compile(r"^devseunggwan/", re.IGNORECASE)
 
-_TITLE_RE = re.compile(
-    r"""--title\s+(?:"((?:[^"\\]|\\.)*)"|'([^']*)'|(\S+))""",
-)
+# gh global flags that consume the following token as their value, so the
+# `issue` / `create` subcommand walk skips both (e.g. `gh -R o/r issue create`).
+_GH_GLOBAL_VALUE_FLAGS: frozenset[str] = frozenset({
+    "-R", "--repo", "--hostname", "--color",
+})
+# Title flags on `gh issue create` (separate-token value forms).
+_TITLE_FLAGS: frozenset[str] = frozenset({"--title", "-t"})
+# --repo / -R value forms on the create argv.
+_REPO_FLAGS: frozenset[str] = frozenset({"--repo", "-R"})
+
 _DUP_TOKEN_RE = re.compile(
     r"\[(?:dup-checked|no-search-needed|dup-verified)\]",
     re.IGNORECASE,
@@ -190,11 +206,88 @@ _TRAILING_STRIP = '"}],'
 # ---------------------------------------------------------------------------
 
 
-def _extract_title(command: str) -> str:
-    m = _TITLE_RE.search(command)
-    if not m:
-        return ""
-    return m.group(1) or m.group(2) or m.group(3) or ""
+def _find_gh_issue_create_argv(command: str) -> list[str] | None:
+    """Return the argv of a real `gh [globals] issue create|new` invocation,
+    or None when no such command segment exists.
+
+    Quote-aware: uses safe_tokenize → iter_command_starts so the literal
+    `gh issue create` inside a quoted string (`grep -rn "gh issue create"`)
+    is NOT a match — those tokens are a single shlex token, not separate
+    `gh`/`issue`/`create` words (issue #514 결함2 MED).
+    """
+    tokens = safe_tokenize(command)
+    if not tokens:
+        return None
+    for raw_argv in iter_command_starts(tokens):
+        argv = strip_prefix(list(raw_argv))
+        if not argv:
+            continue
+        if argv[0].rsplit("/", 1)[-1] != "gh":
+            continue
+        i = _skip_gh_global_flags(argv)
+        if i < len(argv) and argv[i] == "issue":
+            j = _skip_subcommand_flags(argv, i + 1)
+            if j < len(argv) and argv[j] in ("create", "new"):
+                return argv
+    return None
+
+
+def _skip_gh_global_flags(argv: list[str]) -> int:
+    """Index of the first positional after gh's leading global flags."""
+    i = 1
+    n = len(argv)
+    while i < n:
+        tok = argv[i]
+        if tok == "--":
+            return i + 1
+        if not tok.startswith("-"):
+            break
+        i += 1
+        if "=" not in tok and tok in _GH_GLOBAL_VALUE_FLAGS and i < n:
+            i += 1
+    return i
+
+
+def _skip_subcommand_flags(argv: list[str], i: int) -> int:
+    """Skip flags between `issue` and the `create`/`new` action token."""
+    n = len(argv)
+    while i < n and argv[i].startswith("-") and argv[i] != "--":
+        i += 1
+    return i
+
+
+def _flag_value_from_argv(argv: list[str], flags: frozenset[str]) -> str:
+    """Return the value of the first matching flag in *argv*.
+
+    Handles separate-token (`--title X`, `-t X`), inline (`--title=X`,
+    `-t=X`), and concatenated short-flag (`-tX`, `-Rowner/repo`) forms
+    (issue #514 결함2 HIGH).
+    """
+    short_flags = tuple(
+        f for f in flags
+        if len(f) == 2 and f.startswith("-") and not f.startswith("--")
+    )
+    n = len(argv)
+    for i, tok in enumerate(argv):
+        if "=" in tok:
+            name, _, val = tok.partition("=")
+            if name in flags:
+                return val
+            continue
+        if tok in flags and i + 1 < n:
+            return argv[i + 1]
+        for sf in short_flags:
+            if tok.startswith(sf) and len(tok) > 2:
+                return tok[2:]
+    return ""
+
+
+def _extract_title_from_argv(argv: list[str]) -> str:
+    return _flag_value_from_argv(argv, _TITLE_FLAGS)
+
+
+def _extract_repo(argv: list[str]) -> str:
+    return _flag_value_from_argv(argv, _REPO_FLAGS)
 
 
 def _extract_keywords(title: str) -> list[str]:

--- a/hooks/preflight-gate/block-gh-issue-create-without-dup-search/impl.py
+++ b/hooks/preflight-gate/block-gh-issue-create-without-dup-search/impl.py
@@ -249,10 +249,19 @@ def _skip_gh_global_flags(argv: list[str]) -> int:
 
 
 def _skip_subcommand_flags(argv: list[str], i: int) -> int:
-    """Skip flags between `issue` and the `create`/`new` action token."""
+    """Skip flags between `issue` and the `create`/`new` action token.
+
+    A separate-token value flag (`gh issue -R owner/repo create`) consumes the
+    following token as its value, so it must not be mistaken for the action.
+    Symmetric with `block-child-repo-issue-create._is_gh_issue_create` — keeps
+    the two hooks' `issue [flags] create` parsing aligned (PR #523 review).
+    """
     n = len(argv)
     while i < n and argv[i].startswith("-") and argv[i] != "--":
+        tok = argv[i]
         i += 1
+        if "=" not in tok and tok in _GH_GLOBAL_VALUE_FLAGS and i < n:
+            i += 1
     return i
 
 

--- a/hooks/preflight-gate/block-gh-issue-create-without-dup-search/spec.md
+++ b/hooks/preflight-gate/block-gh-issue-create-without-dup-search/spec.md
@@ -42,6 +42,8 @@ literally in a prior search command.
 | `gh issue create --repo devseunggwan/scratchs ...` | **PASS** (personal-repo carve-out) |
 | `gh issue create --title "feat: foo bar [dup-checked]"` | **PASS** (dup token) |
 | `gh issue create --title "fix: ci"` (no keyword ≥4 chars) | **PASS** (cannot enforce) |
+| `gh issue create --title="…"` / `-t "…"` / `-t="…"` / `gh -R o/r issue create --title …` | **BLOCKED** (title parsed from all flag forms; issue #514) |
+| `grep -rn "gh issue create" hooks/` / `echo gh issue create --title x` | **PASS** (literal inside a quoted string is not a real invocation; issue #514) |
 
 ### Escape hatches
 
@@ -60,7 +62,8 @@ literally in a prior search command.
 bash tests/test_block_gh_issue_create_without_dup_search.sh
 ```
 
-Covers 14 cases: both block paths (no search, no overlap), silent paths
-(each escape hatch, personal-repo carve-out, keyword overlap, unkeyworded
-title), non-Bash tool passthrough, missing `transcript_path`, and malformed
+Covers both block paths (no search, no overlap), silent paths (each escape
+hatch, personal-repo carve-out, keyword overlap, unkeyworded title), the
+title-flag forms and quote-aware over-block guards (issue #514),
+non-Bash tool passthrough, missing `transcript_path`, and malformed
 JSON fail-open.

--- a/hooks/preflight-gate/gh-json-validator/impl.py
+++ b/hooks/preflight-gate/gh-json-validator/impl.py
@@ -300,6 +300,14 @@ def _check_segment(
     if json_fields is None:
         return False, ""
 
+    # `--json help` is gh's OWN field-introspection request — gh prints the
+    # valid field list rather than projecting data. Blocking it is
+    # self-contradictory: the remediation message itself tells the agent to
+    # run `gh <subcmd> --json help` to discover valid fields (issue #514
+    # 결함5). Treat a lone `help` field as a pass.
+    if json_fields == ["help"]:
+        return False, ""
+
     valid_fields = _get_valid_fields(subcommand_tokens, cache_dir)
     if valid_fields is None:
         return False, ""  # fail-open on gh/network errors

--- a/hooks/preflight-gate/gh-json-validator/impl.py
+++ b/hooks/preflight-gate/gh-json-validator/impl.py
@@ -300,11 +300,9 @@ def _check_segment(
     if json_fields is None:
         return False, ""
 
-    # `--json help` is gh's OWN field-introspection request — gh prints the
-    # valid field list rather than projecting data. Blocking it is
-    # self-contradictory: the remediation message itself tells the agent to
-    # run `gh <subcmd> --json help` to discover valid fields (issue #514
-    # 결함5). Treat a lone `help` field as a pass.
+    # `--json help` is gh's own field-introspection (prints valid fields, not
+    # data) — the very command our remediation tells the agent to run, so it
+    # must pass (issue #514 결함5).
     if json_fields == ["help"]:
         return False, ""
 

--- a/hooks/preflight-gate/gh-json-validator/spec.md
+++ b/hooks/preflight-gate/gh-json-validator/spec.md
@@ -30,6 +30,8 @@ so chained segments and env-prefixed invocations are covered uniformly.
 | `gh pr view 1 --json merged` | **BLOCKED** (`merged` not in gh pr fields; suggests `mergedAt`) |
 | `gh pr view 1 --json state,title,url` | **PASS** |
 | `gh pr view 1 --json state,merged` | **BLOCKED** (one invalid field) |
+| `gh pr view 1 --json help` / `--json=help` | **PASS** (gh's own field introspection — the remediation tells you to run this; issue #514) |
+| `gh pr view 1 --json help,merged` | **BLOCKED** (`help` + a real invalid field = data projection) |
 | `gh issue view 5 --json merged` | **BLOCKED** (`merged` not in gh issue fields) |
 | `gh issue view 5 --json state,number,title` | **PASS** |
 | `gh pr list --json state && gh pr view 1 --json merged` | **BLOCKED** (chained segment scanned) |

--- a/hooks/preflight-gate/side-effect-scan/impl.py
+++ b/hooks/preflight-gate/side-effect-scan/impl.py
@@ -100,22 +100,72 @@ def argv_matches(argv: list[str], positions, expected) -> bool:
 GH_GLOBAL_FLAGS_WITH_ARG = frozenset({"-R", "--repo", "--hostname", "--color"})
 
 
-def _is_gh_pr_merge(argv: list[str]) -> bool:
-    """Return True iff argv is `gh [global flags] pr merge ...`."""
-    if not argv or argv[0] != "gh":
-        return False
+def _gh_skip_global_flags(argv: list[str]) -> int:
+    """Return the index of the first positional token after gh's leading
+    global flags (`gh [--repo X] [-R Y] ...`).
+
+    A leading global flag (e.g. `gh --repo owner/repo pr merge`) shifts the
+    subcommand off the fixed `argv[1]`/`argv[2]` positions the old
+    fixed-position walk assumed. Skipping the flags first makes the gh
+    detector position-independent — issue #514 결함1.
+    """
     i = 1
-    while i < len(argv):
+    n = len(argv)
+    while i < n:
         tok = argv[i]
         if tok == "--":
-            i += 1
-            break
+            return i + 1
         if not tok.startswith("-"):
             break
         i += 1
-        if "=" not in tok and tok in GH_GLOBAL_FLAGS_WITH_ARG and i < len(argv):
+        if "=" not in tok and tok in GH_GLOBAL_FLAGS_WITH_ARG and i < n:
             i += 1
-    return i + 1 < len(argv) and argv[i] == "pr" and argv[i + 1] == "merge"
+    return i
+
+
+def _gh_subcommand_pair(argv: list[str]) -> tuple[str, str]:
+    """Return the (group, action) subcommand pair for a gh invocation,
+    skipping any leading global flags. Empty strings when absent.
+
+    Examples:
+      ['gh', 'pr', 'merge', ...]               → ('pr', 'merge')
+      ['gh', '--repo', 'o/r', 'pr', 'merge']   → ('pr', 'merge')
+      ['gh', 'workflow', 'run', ...]           → ('workflow', 'run')
+    """
+    if not argv or argv[0] != "gh":
+        return ("", "")
+    i = _gh_skip_global_flags(argv)
+    group = argv[i] if i < len(argv) else ""
+    action = argv[i + 1] if i + 1 < len(argv) else ""
+    return (group, action)
+
+
+def _is_gh_pr_merge(argv: list[str]) -> bool:
+    """Return True iff argv is `gh [global flags] pr merge ...`."""
+    return _gh_subcommand_pair(argv) == ("pr", "merge")
+
+
+# Flag-aware gh detector: maps a (group, {actions}) subcommand pair to the
+# CATEGORIES key it triggers. Replaces the fixed-position argv_matches walk
+# for gh so leading global flags can no longer shift the subcommand out of
+# detection range (issue #514 결함1).
+_GH_CATEGORY_BY_PAIR: list[tuple[str, frozenset[str], str]] = [
+    ("pr", frozenset({"merge", "create"}), "gh-merge"),
+    ("workflow", frozenset({"run"}), "gh-merge"),
+]
+
+
+def _detect_gh(argv: list[str]) -> list[str]:
+    """Flag-aware detection for gh invocations (issue #514 결함1)."""
+    group, action = _gh_subcommand_pair(argv)
+    if not group or not action:
+        return []
+    matched: list[str] = []
+    for want_group, want_actions, category in _GH_CATEGORY_BY_PAIR:
+        if group == want_group and action in want_actions:
+            if category not in matched:
+                matched.append(category)
+    return matched
 
 
 def detect(argv: list[str], delegate_bypass: bool = False) -> list[str]:
@@ -125,9 +175,14 @@ def detect(argv: list[str], delegate_bypass: bool = False) -> list[str]:
     if delegate_bypass and _is_gh_pr_merge(argv):
         return []
     cmd = argv[0].rsplit("/", 1)[-1]
+    if cmd == "gh":
+        # Flag-aware walk — primary gh detector (issue #514 결함1).
+        return _detect_gh(argv)
     matched = []
     for category, spec in CATEGORIES.items():
         for cmd_name, positions, expected in spec["patterns"]:
+            if cmd_name == "gh":
+                continue  # gh handled by the flag-aware _detect_gh walk
             if cmd != cmd_name:
                 continue
             if argv_matches(argv, positions, expected):

--- a/hooks/preflight-gate/side-effect-scan/spec.md
+++ b/hooks/preflight-gate/side-effect-scan/spec.md
@@ -13,7 +13,7 @@ prod deploys, and stray auto-commits from CLIs that write to git internally.
 |----------|------------------|------|
 | `git-commit` | `git commit`, `git merge`, `git rebase`, `git cherry-pick`, `git revert`, `iceberg-schema migrate`, `iceberg-schema promote`, `omc ralph` | Commits to the wrong branch or under the wrong author |
 | `git-push` | `git push` | Remote published without intent |
-| `gh-merge` | `gh pr merge`, `gh pr create`, `gh workflow run` | Unintended PR state change or workflow dispatch |
+| `gh-merge` | `gh pr merge`, `gh pr create`, `gh workflow run` (including a leading global flag, e.g. `gh --repo o/r pr merge`, `gh -R o/r workflow run`) | Unintended PR state change or workflow dispatch |
 | `kubectl-apply` | `kubectl apply`, `kubectl delete`, `kubectl replace`, `kubectl patch` | Shared cluster mutation |
 
 ### Response

--- a/hooks/preflight-gate/skill-gate-commands/impl.py
+++ b/hooks/preflight-gate/skill-gate-commands/impl.py
@@ -58,14 +58,13 @@ from __future__ import annotations
 
 import json
 import os
-import re
-import shlex
 import sys
 from pathlib import Path
 from typing import NamedTuple
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "_lib"))
 from block_message import emit_block  # type: ignore[import-not-found]  # noqa: E402
+from _hook_utils import safe_tokenize  # type: ignore[import-not-found]  # noqa: E402
 
 _MAX_BYTES = 50 * 1024 * 1024
 
@@ -135,25 +134,23 @@ _KNOWN_BINARY_GLOBAL_OPTS = {
 # the ``=``-joined form is already a single token and is handled by startswith("-")).
 _GIT_PUSH_OPTS_WITH_VALUE = {"-o", "--push-option", "--receive-pack", "--exec"}
 
-# Regex matching one or more trailing shell-separator characters attached to the
-# end of a token, e.g. ``create;`` produced by shlex when there is no space
-# before the semicolon.  We strip these so ``gh pr create;`` still matches
-# the pattern ``gh pr create``.
-_TRAIL_SEP_RE = re.compile(r"[;&|]+$")
-
-
 def _tokenize(command: str) -> list[str] | None:
-    """Return shlex tokens or None on parse error (fail-open).
+    """Tokenize via the shared ``safe_tokenize`` primitive (issue #514).
 
-    Post-processes to strip trailing shell-separator characters that shlex
-    attaches to the preceding token when the separator is not space-delimited
-    (e.g. ``gh pr create; echo done`` produces ``['gh', 'pr', 'create;', ...]``).
+    ``safe_tokenize`` (``shlex.shlex`` with ``punctuation_chars=';|&'``) emits
+    shell operators as their own tokens, so a whitespace-free one-liner like
+    ``gh pr create&&echo`` splits to ``['gh', 'pr', 'create', '&&', 'echo']``
+    rather than gluing ``create&&echo`` into a single token that slips past the
+    pattern matchers. Plain ``shlex.split`` keeps operators attached to the
+    adjacent word, which let that form bypass the gate entirely — exactly the
+    failure the shared primitive exists to prevent (see DESIGN.md →
+    "Structural tokenization, not regex").
+
+    Returns ``[]`` for an unparseable command (``safe_tokenize`` swallows
+    per-line parse errors); the matchers then find nothing and the gate fails
+    open. The ``None`` arm is retained for caller-contract stability.
     """
-    try:
-        raw = shlex.split(command, comments=False, posix=True)
-    except ValueError:
-        return None
-    return [_TRAIL_SEP_RE.sub("", t) for t in raw]
+    return safe_tokenize(command)
 
 
 def _skip_global_flags(tokens: list[str], i: int, opts_with_value: set[str]) -> int:

--- a/hooks/preflight-gate/skill-gate-commands/impl.py
+++ b/hooks/preflight-gate/skill-gate-commands/impl.py
@@ -135,20 +135,11 @@ _KNOWN_BINARY_GLOBAL_OPTS = {
 _GIT_PUSH_OPTS_WITH_VALUE = {"-o", "--push-option", "--receive-pack", "--exec"}
 
 def _tokenize(command: str) -> list[str] | None:
-    """Tokenize via the shared ``safe_tokenize`` primitive (issue #514).
-
-    ``safe_tokenize`` (``shlex.shlex`` with ``punctuation_chars=';|&'``) emits
-    shell operators as their own tokens, so a whitespace-free one-liner like
-    ``gh pr create&&echo`` splits to ``['gh', 'pr', 'create', '&&', 'echo']``
-    rather than gluing ``create&&echo`` into a single token that slips past the
-    pattern matchers. Plain ``shlex.split`` keeps operators attached to the
-    adjacent word, which let that form bypass the gate entirely — exactly the
-    failure the shared primitive exists to prevent (see DESIGN.md →
-    "Structural tokenization, not regex").
-
-    Returns ``[]`` for an unparseable command (``safe_tokenize`` swallows
-    per-line parse errors); the matchers then find nothing and the gate fails
-    open. The ``None`` arm is retained for caller-contract stability.
+    """Tokenize via the shared ``safe_tokenize`` so whitespace-free operators
+    (``gh pr create&&echo``) split into their own tokens instead of gluing
+    ``create&&echo`` past the matchers — the bypass plain ``shlex.split`` left
+    open (issue #514; DESIGN.md "Structural tokenization, not regex"). Empty
+    list on an unparseable command → matchers find nothing → fail-open.
     """
     return safe_tokenize(command)
 

--- a/hooks/preflight-gate/skill-gate-commands/impl.py
+++ b/hooks/preflight-gate/skill-gate-commands/impl.py
@@ -123,6 +123,14 @@ _SHELL_SEPARATORS = {";", "&", "&&", "|", "||", "\n"}
 _GH_GLOBAL_OPTS_WITH_VALUE = {"-R", "--repo", "-C", "--config"}
 _GIT_GLOBAL_OPTS_WITH_VALUE = {"-C", "-c", "--git-dir", "--work-tree", "--namespace"}
 
+# Per-binary global-flag value sets, used by the custom-pattern fallback so a
+# global flag's value (e.g. `gh -R owner/repo issue create`) does not break
+# contiguity of the pattern tokens (issue #514 결함4).
+_KNOWN_BINARY_GLOBAL_OPTS = {
+    "gh": _GH_GLOBAL_OPTS_WITH_VALUE,
+    "git": _GIT_GLOBAL_OPTS_WITH_VALUE,
+}
+
 # git-push options that consume the next token as their value (space form only;
 # the ``=``-joined form is already a single token and is handled by startswith("-")).
 _GIT_PUSH_OPTS_WITH_VALUE = {"-o", "--push-option", "--receive-pack", "--exec"}
@@ -238,19 +246,66 @@ _PATTERN_MATCHERS = {
 }
 
 
+def _matches_custom_pattern(tokens: list[str], pattern_tokens: list[str]) -> bool:
+    """Flag-aware fallback matcher for custom (non-built-in) patterns.
+
+    Walks each command start; for a known binary (``gh``/``git``) it skips
+    leading global flags (and their values) before comparing the pattern
+    tokens against the contiguous run of subsequent non-flag tokens. This
+    fixes ``gh -R owner/repo issue create`` breaking contiguity because the
+    flag value ``owner/repo`` previously landed in the non-flag list between
+    ``gh`` and ``issue`` (issue #514 결함4).
+
+    Patterns whose first token is not a known binary fall back to the prior
+    naive contiguous non-flag-token subsequence match.
+    """
+    if not pattern_tokens:
+        return False
+    binary = pattern_tokens[0]
+    opts_with_value = _KNOWN_BINARY_GLOBAL_OPTS.get(binary)
+    if opts_with_value is None:
+        # Unknown binary — preserve prior naive contiguous match.
+        non_flag = [
+            t for t in tokens
+            if t not in _SHELL_SEPARATORS and not t.startswith("-")
+        ]
+        plen = len(pattern_tokens)
+        for i in range(len(non_flag) - plen + 1):
+            if non_flag[i:i + plen] == pattern_tokens:
+                return True
+        return False
+
+    n = len(tokens)
+    i = 0
+    while i < n:
+        tok = tokens[i]
+        if tok in _SHELL_SEPARATORS:
+            i += 1
+            continue
+        if tok == binary or tok.endswith("/" + binary):
+            j = _skip_global_flags(tokens, i + 1, opts_with_value)
+            # Compare the remaining pattern tokens against the contiguous run
+            # of non-flag tokens beginning at j.
+            ok = True
+            k = j
+            for pt in pattern_tokens[1:]:
+                if k >= n or tokens[k] in _SHELL_SEPARATORS or tokens[k] != pt:
+                    ok = False
+                    break
+                k += 1
+            if ok:
+                return True
+        i += 1
+    return False
+
+
 def _command_matches_pattern(tokens: list[str], pattern: str) -> bool:
     """Return True if ``tokens`` match ``pattern``."""
     matcher = _PATTERN_MATCHERS.get(pattern)
     if matcher is not None:
         return matcher(tokens)
-    # Fallback: naive contiguous non-flag token subsequence match.
-    # Useful for future custom patterns without requiring a new matcher.
-    pattern_tokens = pattern.split()
-    non_flag = [t for t in tokens if t not in _SHELL_SEPARATORS and not t.startswith("-")]
-    for i in range(len(non_flag) - len(pattern_tokens) + 1):
-        if non_flag[i:i + len(pattern_tokens)] == pattern_tokens:
-            return True
-    return False
+    # Custom pattern: flag-aware fallback (issue #514 결함4).
+    return _matches_custom_pattern(tokens, pattern.split())
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/preflight-gate/skill-gate-commands/spec.md
+++ b/hooks/preflight-gate/skill-gate-commands/spec.md
@@ -42,6 +42,7 @@ A command is blocked (exit 2) when ALL hold:
 | non-Bash tool call | **PASS** |
 | Global flags before subcommand (`gh -R X pr create`) | matched correctly |
 | Custom (non-built-in) pattern with leading global flag (`gh -R X issue create`, `git -C dir tag`) | matched correctly — the fallback matcher skips known-binary global flags so the flag value no longer breaks token contiguity (issue #514) |
+| Whitespace-free shell operator (`gh pr create&&echo`, `gh pr create;echo`) | matched correctly — tokenisation uses the shared `safe_tokenize` (`shlex.shlex` with `punctuation_chars=';\|&'`), which splits the operator into its own token instead of gluing `create&&echo` into one. Plain `shlex.split` glued it and let the form bypass the gate (issue #514) |
 
 ## Config env var
 

--- a/hooks/preflight-gate/skill-gate-commands/spec.md
+++ b/hooks/preflight-gate/skill-gate-commands/spec.md
@@ -41,6 +41,7 @@ A command is blocked (exit 2) when ALL hold:
 | Malformed JSON stdin | **PASS** (fail-open) |
 | non-Bash tool call | **PASS** |
 | Global flags before subcommand (`gh -R X pr create`) | matched correctly |
+| Custom (non-built-in) pattern with leading global flag (`gh -R X issue create`, `git -C dir tag`) | matched correctly — the fallback matcher skips known-binary global flags so the flag value no longer breaks token contiguity (issue #514) |
 
 ## Config env var
 

--- a/tests/hooks/preflight-gate/test_block_child_repo_issue_create.sh
+++ b/tests/hooks/preflight-gate/test_block_child_repo_issue_create.sh
@@ -334,6 +334,41 @@ run_case "compound child then hub (block)" \
   "PRAXIS_HUB_MEDIATED_ORGS=$ORGS_CFG"
 
 # ---------------------------------------------------------------------------
+# issue #514 결함3 — quote-aware tokenization (separator inside quoted title)
+# ---------------------------------------------------------------------------
+
+# A shell separator inside the quoted --title value (`--title "a; b"`) used to
+# fragment the raw-regex command split, dropping the `--repo` token into a
+# segment without `gh issue create` → child-repo block skipped. Quote-aware
+# tokenization keeps the title intact and must BLOCK.
+run_case "514: semicolon in quoted title still blocks child (block)" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh issue create --title 'a; b' --repo example-org/child\"}}" \
+  "PRAXIS_HUB_MEDIATED_ORGS=$ORGS_CFG"
+
+run_case "514: && in quoted title still blocks child (block)" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh issue create --title 'a && b' --repo example-org/child\"}}" \
+  "PRAXIS_HUB_MEDIATED_ORGS=$ORGS_CFG"
+
+run_case "514: pipe in quoted title still blocks child (block)" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh issue create --title 'a | b' -R example-org/child\"}}" \
+  "PRAXIS_HUB_MEDIATED_ORGS=$ORGS_CFG"
+
+# Over-block: literal `gh issue create --repo …` inside a grep / echo string is
+# not a real invocation — token-aware detection must PASS.
+run_case "514: grep literal not blocked (silent)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"grep -rn 'gh issue create --repo example-org/child' .\"}}" \
+  "PRAXIS_HUB_MEDIATED_ORGS=$ORGS_CFG"
+
+run_case "514: echo string not blocked (silent)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo run gh issue create --repo example-org/child\"}}" \
+  "PRAXIS_HUB_MEDIATED_ORGS=$ORGS_CFG"
+
+# ---------------------------------------------------------------------------
 # Uncaught exception fail-open (outer Exception guard)
 # ---------------------------------------------------------------------------
 

--- a/tests/hooks/preflight-gate/test_block_child_repo_issue_create.sh
+++ b/tests/hooks/preflight-gate/test_block_child_repo_issue_create.sh
@@ -337,10 +337,8 @@ run_case "compound child then hub (block)" \
 # issue #514 결함3 — quote-aware tokenization (separator inside quoted title)
 # ---------------------------------------------------------------------------
 
-# A shell separator inside the quoted --title value (`--title "a; b"`) used to
-# fragment the raw-regex command split, dropping the `--repo` token into a
-# segment without `gh issue create` → child-repo block skipped. Quote-aware
-# tokenization keeps the title intact and must BLOCK.
+# A separator inside the quoted --title (`--title "a; b"`) once fragmented the
+# raw-regex split and dropped --repo; quote-aware tokenization keeps it intact.
 run_case "514: semicolon in quoted title still blocks child (block)" \
   "block" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh issue create --title 'a; b' --repo example-org/child\"}}" \

--- a/tests/hooks/preflight-gate/test_block_gh_issue_create_without_dup_search.sh
+++ b/tests/hooks/preflight-gate/test_block_gh_issue_create_without_dup_search.sh
@@ -209,6 +209,15 @@ run_case "514: gh -R o/r issue create --title= (block)" \
   "block:no-search" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh -R acme/repo issue create --title='feat: zeta brands lookup pattern'\"},\"transcript_path\":\"$TX_EMPTY\"}"
 
+# PR #523 review: a separate-token value flag BETWEEN `issue` and `create`
+# (`gh issue -R owner/repo create`) must not let its value masquerade as the
+# action token — _skip_subcommand_flags now consumes the value so the create
+# is still detected and BLOCKED. (Keeps parsing symmetric with the child-repo
+# hook's _is_gh_issue_create.)
+run_case "523: gh issue -R o/r create (value flag before action, block)" \
+  "block:no-search" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh issue -R acme/repo create --title 'feat: zeta brands lookup pattern'\"},\"transcript_path\":\"$TX_EMPTY\"}"
+
 # Over-block: the literal `gh issue create` inside a grep pattern is NOT a real
 # invocation — the old raw regex matched it and could block. Token-aware
 # detection must PASS.

--- a/tests/hooks/preflight-gate/test_block_gh_issue_create_without_dup_search.sh
+++ b/tests/hooks/preflight-gate/test_block_gh_issue_create_without_dup_search.sh
@@ -183,6 +183,45 @@ run_case "gh issue create with title that has no usable keywords (silent)" \
   "silent" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh issue create --repo acme/foo --title 'fix: a b c d'\"},\"transcript_path\":\"$TX_EMPTY\"}"
 
+# ---------------------------------------------------------------------------
+# issue #514 결함2 — title-flag forms + quote-aware over-block
+# ---------------------------------------------------------------------------
+
+# --title=value form: the old _TITLE_RE matched only `--title <value>`, so the
+# `=`-joined form left the title (and keywords) empty → gate passed silently.
+# Must now extract the title and BLOCK (no prior search).
+run_case "514: --title=value form extracts title (block)" \
+  "block:no-search" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh issue create --repo acme/repo --title='feat(provider): add zeta brands lookup pattern'\"},\"transcript_path\":\"$TX_EMPTY\"}"
+
+# -t value short-flag form for --title.
+run_case "514: -t value short-flag title (block)" \
+  "block:no-search" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh issue create --repo acme/repo -t 'feat(provider): add zeta brands lookup pattern'\"},\"transcript_path\":\"$TX_EMPTY\"}"
+
+# -t=value inline short-flag form.
+run_case "514: -t=value inline title (block)" \
+  "block:no-search" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh issue create --repo acme/repo -t='feat: zeta brands lookup pattern'\"},\"transcript_path\":\"$TX_EMPTY\"}"
+
+# gh global flag before the issue/create group with --title= form.
+run_case "514: gh -R o/r issue create --title= (block)" \
+  "block:no-search" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh -R acme/repo issue create --title='feat: zeta brands lookup pattern'\"},\"transcript_path\":\"$TX_EMPTY\"}"
+
+# Over-block: the literal `gh issue create` inside a grep pattern is NOT a real
+# invocation — the old raw regex matched it and could block. Token-aware
+# detection must PASS.
+run_case "514: grep literal 'gh issue create' not blocked (silent)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"grep -rn 'gh issue create' hooks/\"},\"transcript_path\":\"$TX_EMPTY\"}"
+
+# Over-block: an echo string mentioning gh issue create + a title flag must
+# not be treated as a real create.
+run_case "514: echo string with gh issue create --title not blocked (silent)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo run gh issue create --title someBigKeyword\"},\"transcript_path\":\"$TX_EMPTY\"}"
+
 run_case "malformed JSON (silent — fail-open)" \
   "silent" \
   "not-json"

--- a/tests/hooks/preflight-gate/test_block_gh_issue_create_without_dup_search.sh
+++ b/tests/hooks/preflight-gate/test_block_gh_issue_create_without_dup_search.sh
@@ -209,11 +209,8 @@ run_case "514: gh -R o/r issue create --title= (block)" \
   "block:no-search" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh -R acme/repo issue create --title='feat: zeta brands lookup pattern'\"},\"transcript_path\":\"$TX_EMPTY\"}"
 
-# PR #523 review: a separate-token value flag BETWEEN `issue` and `create`
-# (`gh issue -R owner/repo create`) must not let its value masquerade as the
-# action token — _skip_subcommand_flags now consumes the value so the create
-# is still detected and BLOCKED. (Keeps parsing symmetric with the child-repo
-# hook's _is_gh_issue_create.)
+# A value flag between `issue` and `create` (`gh issue -R o/r create`) must not
+# let its value masquerade as the action token — the create is still BLOCKED.
 run_case "523: gh issue -R o/r create (value flag before action, block)" \
   "block:no-search" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh issue -R acme/repo create --title 'feat: zeta brands lookup pattern'\"},\"transcript_path\":\"$TX_EMPTY\"}"

--- a/tests/hooks/preflight-gate/test_gh_json_validator.sh
+++ b/tests/hooks/preflight-gate/test_gh_json_validator.sh
@@ -258,6 +258,26 @@ run_case "skip: no --json flag" \
   "gh pr view 1"
 
 # ---------------------------------------------------------------------------
+# issue #514 결함5: `--json help` is gh's OWN field introspection — gh prints
+# the valid field list. Blocking it is self-contradictory because the
+# remediation message tells the agent to run exactly `gh <subcmd> --json help`.
+# A lone `help` field must PASS.
+# ---------------------------------------------------------------------------
+run_case "514: --json help introspection passes" \
+  "pass" \
+  "gh pr view 1 --json help"
+
+run_case "514: --json=help inline introspection passes" \
+  "pass" \
+  "gh pr view 1 --json=help"
+
+# But `help` combined with a real invalid field is a data projection request —
+# still block.
+run_case "514: --json help,merged still blocks" \
+  "block:BLOCKED" \
+  "gh pr view 1 --json help,merged"
+
+# ---------------------------------------------------------------------------
 # Summary
 # Fail-open guard opt-in (issue #498): main() must be @fail_open-wrapped;
 # guard behavior is tested centrally in tests/test_hook_runtime.sh.

--- a/tests/hooks/preflight-gate/test_side_effect_scan.sh
+++ b/tests/hooks/preflight-gate/test_side_effect_scan.sh
@@ -82,6 +82,15 @@ run_case "gh pr merge"              ask  "gh pr merge 42 --squash"
 run_case "gh pr create"             ask  "gh pr create --title x --body y"
 run_case "gh workflow run"          ask  "gh workflow run deploy.yml"
 
+# issue #514 결함1 — a leading gh global flag shifts the subcommand off the
+# fixed argv[1]/argv[2] positions the old detector assumed, so these forms
+# were undetected (no ask). The flag-aware walk must still ask.
+run_case "514: gh --repo pr merge"     ask  "gh --repo owner/repo pr merge --squash"
+run_case "514: gh -R pr merge"         ask  "gh -R owner/repo pr merge"
+run_case "514: gh --repo= pr merge"    ask  "gh --repo=owner/repo pr merge"
+run_case "514: gh -R pr create"        ask  "gh -R owner/repo pr create --title x"
+run_case "514: gh -R workflow run"     ask  "gh -R owner/repo workflow run deploy.yml"
+
 # --- detection: kubectl shared write ---------------------------------------
 run_case "kubectl apply"            ask  "kubectl apply -f pod.yaml"
 run_case "kubectl delete"           ask  "kubectl delete ns my-ns"
@@ -98,6 +107,7 @@ run_case "kubectl apply --env prod" ask  "kubectl apply -f app.yaml --env prod" 
 run_case "git status"               pass "git status"
 run_case "git log"                  pass "git log --oneline -5"
 run_case "gh pr view"               pass "gh pr view 42"
+run_case "514: gh -R pr view (neg)"  pass "gh -R owner/repo pr view 42"
 run_case "kubectl get"              pass "kubectl get pods -n default"
 run_case "ls with git in path"      pass "ls /usr/local/git-lfs"
 run_case "echo commit word"         pass "echo 'i will commit later'"

--- a/tests/hooks/preflight-gate/test_skill_gate_commands.sh
+++ b/tests/hooks/preflight-gate/test_skill_gate_commands.sh
@@ -429,6 +429,43 @@ run_case "git push --push-option=ci.skip origin (= form, block)" \
   "$(mk_payload Bash 'git push --push-option=ci.skip origin main' "$TX_WITHOUT")" \
   "PRAXIS_SKILL_GATED_COMMANDS=$CFG_PUSH"
 
+# ---------------------------------------------------------------------------
+# issue #514 결함4 — custom (non-built-in) pattern with leading gh/git global
+# flag. The naive contiguous fallback put the flag VALUE (`owner/repo`) into
+# the non-flag token list between `gh` and `issue`, breaking contiguity →
+# pattern did not match → gate skipped. The flag-aware fallback skips global
+# flags for known binaries first.
+# ---------------------------------------------------------------------------
+
+CFG_ISSUE_CREATE="gh issue create=>praxis:create-hub-pr"
+
+run_case "514: custom pattern gh -R o/r issue create (block)" \
+  "block" \
+  "$(mk_payload Bash 'gh -R owner/repo issue create --title x' "$TX_WITHOUT")" \
+  "PRAXIS_SKILL_GATED_COMMANDS=$CFG_ISSUE_CREATE"
+
+run_case "514: custom pattern gh --repo o/r issue create (block)" \
+  "block" \
+  "$(mk_payload Bash 'gh --repo owner/repo issue create --title x' "$TX_WITHOUT")" \
+  "PRAXIS_SKILL_GATED_COMMANDS=$CFG_ISSUE_CREATE"
+
+run_case "514: custom pattern plain gh issue create still blocks (block)" \
+  "block" \
+  "$(mk_payload Bash 'gh issue create --title x' "$TX_WITHOUT")" \
+  "PRAXIS_SKILL_GATED_COMMANDS=$CFG_ISSUE_CREATE"
+
+run_case "514: custom pattern gh issue list not matched (silent)" \
+  "silent" \
+  "$(mk_payload Bash 'gh -R owner/repo issue list' "$TX_WITHOUT")" \
+  "PRAXIS_SKILL_GATED_COMMANDS=$CFG_ISSUE_CREATE"
+
+# git custom pattern with global -C flag value.
+CFG_GIT_TAG="git tag=>praxis:create-hub-pr"
+run_case "514: custom pattern git -C dir tag (block)" \
+  "block" \
+  "$(mk_payload Bash 'git -C /tmp tag v1.2.3' "$TX_WITHOUT")" \
+  "PRAXIS_SKILL_GATED_COMMANDS=$CFG_GIT_TAG"
+
 run_case "malformed config entry no => (fail-safe, silent)" \
   "silent" \
   "$(mk_payload Bash 'gh pr create --title "feat: x"' "$TX_WITHOUT")" \

--- a/tests/hooks/preflight-gate/test_skill_gate_commands.sh
+++ b/tests/hooks/preflight-gate/test_skill_gate_commands.sh
@@ -411,13 +411,9 @@ run_case "echo x; gh pr create (prefix cmd, block)" \
   "PRAXIS_SKILL_GATED_COMMANDS=$CFG_PR_CREATE"
 
 # ---------------------------------------------------------------------------
-# 19b. issue #514 — whitespace-free shell operator (no space on EITHER side).
-# Plain shlex.split glued `create&&echo` / `create;echo` into one token, which
-# the matchers never equalled to `create`, so the gate was bypassed entirely.
-# The trailing-separator strip only handled `create;` (trailing), not the
-# embedded operator. Switching _tokenize to the shared safe_tokenize splits the
-# operator into its own token and closes the bypass. The negative case ensures
-# the split did not start over-blocking a non-gated subcommand.
+# 19b. issue #514 — whitespace-free shell operator (`create&&echo`). shlex.split
+# glued it into one token and bypassed the gate; safe_tokenize splits it. Last
+# case guards against the split over-blocking a non-gated subcommand.
 # ---------------------------------------------------------------------------
 
 run_case "514: gh pr create&&echo (glued &&, was bypass, block)" \

--- a/tests/hooks/preflight-gate/test_skill_gate_commands.sh
+++ b/tests/hooks/preflight-gate/test_skill_gate_commands.sh
@@ -411,6 +411,36 @@ run_case "echo x; gh pr create (prefix cmd, block)" \
   "PRAXIS_SKILL_GATED_COMMANDS=$CFG_PR_CREATE"
 
 # ---------------------------------------------------------------------------
+# 19b. issue #514 — whitespace-free shell operator (no space on EITHER side).
+# Plain shlex.split glued `create&&echo` / `create;echo` into one token, which
+# the matchers never equalled to `create`, so the gate was bypassed entirely.
+# The trailing-separator strip only handled `create;` (trailing), not the
+# embedded operator. Switching _tokenize to the shared safe_tokenize splits the
+# operator into its own token and closes the bypass. The negative case ensures
+# the split did not start over-blocking a non-gated subcommand.
+# ---------------------------------------------------------------------------
+
+run_case "514: gh pr create&&echo (glued &&, was bypass, block)" \
+  "block" \
+  "$(mk_payload Bash 'gh pr create&&echo done' "$TX_WITHOUT")" \
+  "PRAXIS_SKILL_GATED_COMMANDS=$CFG_PR_CREATE"
+
+run_case "514: gh pr create;echo (glued ;, was bypass, block)" \
+  "block" \
+  "$(mk_payload Bash 'gh pr create;echo done' "$TX_WITHOUT")" \
+  "PRAXIS_SKILL_GATED_COMMANDS=$CFG_PR_CREATE"
+
+run_case "514: git push origin&&echo (glued &&, was bypass, block)" \
+  "block" \
+  "$(mk_payload Bash 'git push origin&&echo done' "$TX_WITHOUT")" \
+  "PRAXIS_SKILL_GATED_COMMANDS=$CFG_PUSH"
+
+run_case "514: gh pr list&&echo (non-gated subcmd, no over-block, silent)" \
+  "silent" \
+  "$(mk_payload Bash 'gh pr list&&echo done' "$TX_WITHOUT")" \
+  "PRAXIS_SKILL_GATED_COMMANDS=$CFG_PR_CREATE"
+
+# ---------------------------------------------------------------------------
 # 20. git push value-consuming flags (-o/--push-option) before origin (P2-2)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

gh command parsing mishandled leading global flags, `--title=`/`-t` title forms, and shell separators inside quoted titles — letting gates be bypassed and normal commands be over-blocked. This unifies gh parsing toward the shared role-aware tokenizer + flag-aware walks, reusing the existing `safe_tokenize` / `iter_command_starts` / `strip_prefix` / `_is_gh_pr_merge` helpers rather than hand-rolling.

## Per-defect fixes

### 결함1 (HIGH) — `side-effect-scan`
`CATEGORIES["gh-merge"]` matched fixed argv positions (`argv[1]=="pr"`, `argv[2]=="merge"`). A leading global flag shifted the subcommand off those positions, so `gh --repo owner/repo pr merge --squash` was undetected (no `ask`).
- **Fix:** replace the fixed-position gh match with a flag-aware `(group, action)` detector built on the existing `_is_gh_pr_merge` walk (now generalized to `_gh_subcommand_pair`). gh is now routed exclusively through the flag-aware walk.
- **Repro (before → after):** `gh --repo owner/repo pr merge --squash` → was silent / now `ask`. Also covers `-R`, `--repo=`, `gh -R o/r pr create`, `gh -R o/r workflow run`.

### 결함2 (HIGH + MED) — `block-gh-issue-create-without-dup-search`
`_TITLE_RE` matched only `--title <value>`, so `--title=`, `-t`, `-t=` left the title (and keywords) empty → dup-search gate passed silently. The raw `\bgh\s+issue\s+create\b` regex also matched inside quoted strings / grep literals → over-block.
- **Fix:** detect a real `gh [globals] issue create|new` argv via quote-aware tokenization; parse title/repo from all flag forms (separate-token, inline `=`, concatenated short).
- **Repro:** `gh issue create --title="..."` / `-t "..."` → was exit 0 / now exit 2. `grep -rn "gh issue create" hooks/` and `echo gh issue create --title x` → were blocked / now pass.

### 결함3 (HIGH + MED) — `block-child-repo-issue-create`
`_CMD_SEP_RE` was a quote-unaware raw split — a separator inside `--title "a; b"` fragmented the command so the `--repo acme/widget` token fell into a segment without `gh issue create`, skipping the child-repo block. Raw-regex over-block also present.
- **Fix:** replace with quote-aware tokenization; parse repo (incl. `-Rvalue`, inline, and flag-before-subcommand forms) from the create argv.
- **Repro:** `gh issue create --title "a; b" --repo acme/widget` → was silent / now blocked. grep/echo literals → were blocked / now pass.

### 결함4 (MED) — `skill-gate-commands`
Custom (non-built-in) patterns fell back to naive contiguous matching; `gh -R owner/repo issue create` broke contiguity because the flag value landed between `gh` and `issue`.
- **Fix:** flag-aware fallback (`_matches_custom_pattern`) skips known-binary (gh/git) global flags via `_skip_global_flags` before comparing pattern tokens.
- **Repro:** custom pattern `gh issue create` + `gh -R owner/repo issue create` → was silent / now blocked.

### 결함5 (MED) — `gh-json-validator`
`gh pr view --json help` is gh's own field introspection, but it was blocked — self-contradictory since the remediation message tells you to run exactly that.
- **Fix:** when the field list is `["help"]`, pass. `help` combined with a real invalid field still blocks.
- **Repro:** `gh pr view 1 --json help` → was exit 2 / now exit 0.

## Tests / gates

- Regression tests added per defect under `tests/hooks/preflight-gate/` (bypass now caught; over-block now passes; `--json help` introspection passes).
- `bash scripts/run-tests.sh`: all suites pass **except** `test_codex_review_route.sh` and `test_worktree_edit_gate.sh`, which fail on the gpg signing server returning HTTP 400 (`fatal: failed to write commit object`) — environmental/pre-existing, and their hooks/tests are untouched by this change.
- `python3 scripts/check-plugin-manifests.py`: `plugin-manifest check OK`.
- Per-hook `spec.md` files synced with the new flag-aware / quote-aware behavior.

Target suite results: side-effect-scan 70 pass, dup-search 22 pass, child-repo 43 pass, skill-gate 40 pass, gh-json-validator 13 pass.

Closes #514

https://claude.ai/code/session_01F1feUhQztxe8rz6MCZdxFh

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1feUhQztxe8rz6MCZdxFh)_