### PR TITLE
fix(preflight): add outer fail-open guard to 13 blocking gate hooks

### DIFF
--- a/hooks/_lib/_hook_runtime.py
+++ b/hooks/_lib/_hook_runtime.py
@@ -19,12 +19,14 @@ a single behavioral test (`tests/test_hook_runtime.sh`).
 the session alive, but a swallowed crash with no trace is undiagnosable — the
 hook would appear to "work" while silently never enforcing its rule. So every
 swallowed exception is recorded to an append-only JSONL error log
-(``PRAXIS_HOOK_ERROR_LOG`` env override; default
-``${TMPDIR:-/tmp}/praxis-hook-errors.jsonl``) with timestamp, hook identity,
-exception type/message, full traceback, and pid. The recorder is itself fully
-self-guarded — a logging failure can never re-break the fail-open contract.
-Set ``PRAXIS_HOOK_ERROR_STDERR=1`` to additionally surface a terse one-line
-note on stderr (off by default so normal sessions stay quiet).
+(``PRAXIS_HOOK_ERROR_LOG`` env override; default the host-neutral
+``~/.praxis/logs/hook-errors.jsonl`` via ``_paths``, which itself falls back to
+``${TMPDIR:-/tmp}/praxis-hook-errors.jsonl`` when the home dir is not writable)
+with timestamp, hook identity, exception type/message, full traceback, and pid.
+The recorder is itself fully self-guarded — a logging failure can never
+re-break the fail-open contract. Set ``PRAXIS_HOOK_ERROR_STDERR=1`` to
+additionally surface a terse one-line note on stderr (off by default so normal
+sessions stay quiet).
 
 Usage::
 
@@ -50,9 +52,9 @@ Contract details:
   that attribute rather than re-testing the (centrally tested) behavior.
 
 Privacy note: a traceback may incidentally contain argument values (e.g. a
-command string) from local frames. The log is a local, ephemeral file under
-``TMPDIR`` (or an operator-chosen path) and is not committed — treat it like
-the sibling bypass-telemetry log.
+command string) from local frames. The log is a local file under
+``~/.praxis/logs`` (or an operator-chosen path) and is not committed — treat it
+like the sibling bypass-telemetry log.
 """
 from __future__ import annotations
 
@@ -66,12 +68,23 @@ from typing import Callable
 
 
 def _error_log_path() -> str:
-    """Resolve the JSONL error-log path (env override, else TMPDIR default)."""
+    """Resolve the JSONL error-log path.
+
+    ``PRAXIS_HOOK_ERROR_LOG`` wins (explicit operator override). Otherwise the
+    host-neutral ``~/.praxis/logs/hook-errors.jsonl`` via ``_paths`` (which
+    falls back to ``${TMPDIR}/praxis-hook-errors.jsonl`` when the home dir is
+    not writable). The import is guarded so a missing/broken ``_paths`` can
+    never break the recorder.
+    """
     override = os.environ.get("PRAXIS_HOOK_ERROR_LOG")
     if override:
         return override
-    tmp = os.environ.get("TMPDIR") or "/tmp"
-    return os.path.join(tmp, "praxis-hook-errors.jsonl")
+    try:
+        from _paths import resolve_writable
+        return resolve_writable("logs", "hook-errors.jsonl")
+    except Exception:
+        tmp = os.environ.get("TMPDIR") or "/tmp"
+        return os.path.join(tmp, "praxis-hook-errors.jsonl")
 
 
 def _hook_identity(fn: Callable[[], int]) -> str:

--- a/hooks/_lib/_hook_runtime.py
+++ b/hooks/_lib/_hook_runtime.py
@@ -1,60 +1,18 @@
 """Fail-open entrypoint guard for praxis PreToolUse gate hooks (issue #498).
 
-Every blocking PreToolUse gate must honor the fail-open contract documented in
-ETHOS.md ("Fail-open on infrastructure errors") and `_hook_io.py`: *a hook
-never breaks a normal session.* A hook that escapes with an uncaught exception
-exits non-zero, which the Claude Code runtime treats as a block — so a stray
-``MemoryError``, a ``RecursionError`` from catastrophic regex backtracking, or
-an unexpected ``UnicodeError`` deep in the gate logic would silently block a
-legitimate ``git commit`` / ``gh issue create``.
+A gate that escapes with an uncaught exception exits non-zero, which the
+runtime reads as a block — so a stray crash would block a legitimate
+git commit / gh issue create. `fail_open` wraps the entrypoint: any uncaught
+Exception returns 0 (allow); BaseException still propagates; a real block
+(return 2) passes through.
 
-Before this module the guard was hand-rolled as a byte-identical
-``def main(): try: return _main_inner() except Exception: return 0`` wrapper in
-each gate. That is the exact duplication issue #470 eliminated for the
-decision-emit shape (and #439 for the block message) — `fail_open` is its
-sibling for the entrypoint guard: the contract lives at a single edit site with
-a single behavioral test (`tests/test_hook_runtime.sh`).
-
-**Fail-open is NOT fail-silent.** Returning 0 on an unexpected exception keeps
-the session alive, but a swallowed crash with no trace is undiagnosable — the
-hook would appear to "work" while silently never enforcing its rule. So every
-swallowed exception is recorded to an append-only JSONL error log
-(``PRAXIS_HOOK_ERROR_LOG`` env override; default the host-neutral
-``~/.praxis/logs/hook-errors.jsonl`` via ``_paths``, which itself falls back to
-``${TMPDIR:-/tmp}/praxis-hook-errors.jsonl`` when the home dir is not writable)
-with timestamp, hook identity, exception type/message, full traceback, and pid.
-The recorder is itself fully self-guarded — a logging failure can never
-re-break the fail-open contract. Set ``PRAXIS_HOOK_ERROR_STDERR=1`` to
-additionally surface a terse one-line note on stderr (off by default so normal
-sessions stay quiet).
-
-Usage::
-
-    from _hook_runtime import fail_open
+Not fail-silent: each swallowed exception is logged as JSONL to
+PRAXIS_HOOK_ERROR_LOG (default ~/.praxis/logs/hook-errors.jsonl, TMPDIR
+fallback); PRAXIS_HOOK_ERROR_STDERR=1 also prints a one-line note. The
+recorder never raises and never writes to stderr on its own errors.
 
     @fail_open
-    def main() -> int:
-        ...            # real gate logic; return 2 to block, 0 to allow
-
-    if __name__ == "__main__":
-        sys.exit(main())
-
-Contract details:
-
-- ``except Exception`` deliberately does NOT catch ``BaseException``, so
-  ``KeyboardInterrupt`` / ``SystemExit`` propagate normally — only
-  programming / runtime errors fail open. ``MemoryError`` and
-  ``RecursionError`` are ``Exception`` subclasses and ARE intercepted.
-- The wrapped function's return value is passed through untouched, so a real
-  block (``return 2``) is never swallowed — only exceptions become ``0``.
-- ``functools.wraps`` is applied, so a decorated entrypoint exposes
-  ``main.__wrapped__``; a hook's own test asserts it opted into the guard via
-  that attribute rather than re-testing the (centrally tested) behavior.
-
-Privacy note: a traceback may incidentally contain argument values (e.g. a
-command string) from local frames. The log is a local file under
-``~/.praxis/logs`` (or an operator-chosen path) and is not committed — treat it
-like the sibling bypass-telemetry log.
+    def main() -> int: ...
 """
 from __future__ import annotations
 
@@ -66,40 +24,25 @@ import sys
 import traceback
 from typing import Callable
 
-
-# ---------------------------------------------------------------------------
-# Error logging (stdlib `logging` with a JSONL formatter)
-# ---------------------------------------------------------------------------
-#
-# A dedicated, non-propagating logger writes one JSON object per line to the
-# error log. The setup is hardened so logging can NEVER pollute the session or
-# break fail-open:
-#   - ``logging.raiseExceptions = False`` so a handler error (disk full, etc.)
-#     is swallowed instead of dumping a traceback to stderr.
-#   - ``logger.propagate = False`` so records never bubble to the root logger.
-#   - a baseline ``NullHandler`` so the logger is never "handler-less" — that
-#     would otherwise trigger ``logging.lastResort`` which writes to stderr.
-#   - the whole record path is additionally wrapped in ``try/except: pass``.
 _LOGGER_NAME = "praxis.hook"
 
 
 class _JsonlFormatter(logging.Formatter):
-    """Render a LogRecord as a single-line JSON object (JSONL)."""
+    """One JSON object per line."""
 
     def format(self, record: logging.LogRecord) -> str:
-        payload = {
+        return json.dumps({
             "ts": self.formatTime(record, "%Y-%m-%dT%H:%M:%S%z"),
             "hook": getattr(record, "hook", "<unknown>"),
             "pid": record.process,
             "exc_type": getattr(record, "exc_type", ""),
             "message": record.getMessage(),
             "traceback": getattr(record, "tb_text", ""),
-        }
-        return json.dumps(payload, ensure_ascii=False)
+        }, ensure_ascii=False)
 
 
 class _StderrFormatter(logging.Formatter):
-    """Terse one-line human-readable form for the opt-in stderr handler."""
+    """Terse one-line note for the opt-in stderr handler."""
 
     def format(self, record: logging.LogRecord) -> str:
         return (
@@ -110,23 +53,19 @@ class _StderrFormatter(logging.Formatter):
 
 
 def _get_logger() -> logging.Logger:
-    """Lazily configure and return the praxis hook-error logger.
-
-    Configured once per process; only invoked on the crash path (inside the
-    fail-open ``except``), so a normal run pays no logging cost.
-    """
+    """Configure the praxis.hook logger once per process (crash path only)."""
     logger = logging.getLogger(_LOGGER_NAME)
     if getattr(logger, "_praxis_configured", False):
         return logger
     logger.setLevel(logging.ERROR)
     logger.propagate = False
-    logger.addHandler(logging.NullHandler())  # never handler-less → no lastResort
+    logger.addHandler(logging.NullHandler())  # never handler-less -> no lastResort->stderr
     try:
         fh = logging.FileHandler(_error_log_path(), encoding="utf-8", delay=True)
         fh.setFormatter(_JsonlFormatter())
         logger.addHandler(fh)
     except Exception:
-        pass  # unwritable log must not re-break fail-open
+        pass
     if os.environ.get("PRAXIS_HOOK_ERROR_STDERR"):
         sh = logging.StreamHandler(sys.stderr)
         sh.setFormatter(_StderrFormatter())
@@ -136,14 +75,7 @@ def _get_logger() -> logging.Logger:
 
 
 def _error_log_path() -> str:
-    """Resolve the JSONL error-log path.
-
-    ``PRAXIS_HOOK_ERROR_LOG`` wins (explicit operator override). Otherwise the
-    host-neutral ``~/.praxis/logs/hook-errors.jsonl`` via ``_paths`` (which
-    falls back to ``${TMPDIR}/praxis-hook-errors.jsonl`` when the home dir is
-    not writable). The import is guarded so a missing/broken ``_paths`` can
-    never break the recorder.
-    """
+    """PRAXIS_HOOK_ERROR_LOG override, else ~/.praxis/logs/hook-errors.jsonl."""
     override = os.environ.get("PRAXIS_HOOK_ERROR_LOG")
     if override:
         return override
@@ -151,59 +83,34 @@ def _error_log_path() -> str:
         from _paths import resolve_writable
         return resolve_writable("logs", "hook-errors.jsonl")
     except Exception:
-        tmp = os.environ.get("TMPDIR") or "/tmp"
-        return os.path.join(tmp, "praxis-hook-errors.jsonl")
+        return os.path.join(os.environ.get("TMPDIR") or "/tmp", "praxis-hook-errors.jsonl")
 
 
 def _hook_identity(fn: Callable[[], int]) -> str:
-    """Best-effort hook name from the wrapped function's source file.
-
-    Hook entrypoints live at ``hooks/<role>/<name>/impl.py``, so the parent
-    directory name is the stable hook identifier.
-    """
+    """Hook name = parent dir of the entrypoint's source file."""
     try:
-        path = fn.__code__.co_filename
-        parent = os.path.basename(os.path.dirname(path))
-        return parent or fn.__name__
+        return os.path.basename(os.path.dirname(fn.__code__.co_filename)) or fn.__name__
     except Exception:
         return getattr(fn, "__name__", "<unknown>")
 
 
 def _record_swallowed_exception(fn: Callable[[], int]) -> None:
-    """Record a swallowed exception so the crash stays diagnosable.
-
-    Emits one JSONL record via the dedicated ``praxis.hook`` logger (plus a
-    terse stderr line when ``PRAXIS_HOOK_ERROR_STDERR`` is set). Fully
-    self-guarded: a handler error is swallowed by ``raiseExceptions = False``
-    and the whole body by ``try/except: pass`` — observability must NEVER
-    re-break the fail-open contract.
-    """
+    """Log a swallowed exception as JSONL. Never raises, never leaks to stderr."""
     try:
         logging.raiseExceptions = False  # handler errors must not hit stderr
         exc_type, exc, tb = sys.exc_info()
-        _get_logger().error(
-            str(exc),
-            extra={
-                "hook": _hook_identity(fn),
-                "exc_type": getattr(exc_type, "__name__", str(exc_type)),
-                "tb_text": "".join(traceback.format_exception(exc_type, exc, tb)),
-                "log_path": _error_log_path(),
-            },
-        )
+        _get_logger().error(str(exc), extra={
+            "hook": _hook_identity(fn),
+            "exc_type": getattr(exc_type, "__name__", str(exc_type)),
+            "tb_text": "".join(traceback.format_exception(exc_type, exc, tb)),
+            "log_path": _error_log_path(),
+        })
     except Exception:
-        # Last-resort: the recorder itself never propagates.
         pass
 
 
 def fail_open(fn: Callable[[], int]) -> Callable[[], int]:
-    """Wrap a hook entrypoint so any uncaught ``Exception`` returns 0 (allow).
-
-    On a swallowed exception the error is recorded (see
-    ``_record_swallowed_exception``) before returning 0, so fail-open does not
-    become fail-silent. Only exceptions are intercepted; the wrapped function's
-    own exit code (0 allow / 2 block) is returned unchanged, and
-    ``BaseException`` (KeyboardInterrupt / SystemExit) still propagates.
-    """
+    """Return 0 on any uncaught Exception (recording it); else pass through."""
     @functools.wraps(fn)
     def wrapper() -> int:
         try:

--- a/hooks/_lib/_hook_runtime.py
+++ b/hooks/_lib/_hook_runtime.py
@@ -1,0 +1,63 @@
+"""Fail-open entrypoint guard for praxis PreToolUse gate hooks (issue #498).
+
+Every blocking PreToolUse gate must honor the fail-open contract documented in
+ETHOS.md ("Fail-open on infrastructure errors") and `_hook_io.py`: *a hook
+never breaks a normal session.* A hook that escapes with an uncaught exception
+exits non-zero, which the Claude Code runtime treats as a block — so a stray
+``MemoryError``, a ``RecursionError`` from catastrophic regex backtracking, or
+an unexpected ``UnicodeError`` deep in the gate logic would silently block a
+legitimate ``git commit`` / ``gh issue create``.
+
+Before this module the guard was hand-rolled as a byte-identical
+``def main(): try: return _main_inner() except Exception: return 0`` wrapper in
+each gate. That is the exact duplication issue #470 eliminated for the
+decision-emit shape (and #439 for the block message) — `fail_open` is its
+sibling for the entrypoint guard: the contract now lives at a single edit site
+with a single behavioral test (`tests/test_hook_runtime.sh`), instead of N
+copies each carrying their own near-identical test.
+
+Usage::
+
+    from _hook_runtime import fail_open
+
+    @fail_open
+    def main() -> int:
+        ...            # real gate logic; return 2 to block, 0 to allow
+
+    if __name__ == "__main__":
+        sys.exit(main())
+
+Contract details:
+
+- ``except Exception`` deliberately does NOT catch ``BaseException``, so
+  ``KeyboardInterrupt`` / ``SystemExit`` propagate normally — only
+  programming / runtime errors fail open. ``MemoryError`` and
+  ``RecursionError`` are ``Exception`` subclasses and ARE intercepted.
+- The wrapped function's return value is passed through untouched, so a real
+  block (``return 2``) is never swallowed — only exceptions become ``0``.
+- ``functools.wraps`` is applied, so a decorated entrypoint exposes
+  ``main.__wrapped__``; a hook's own test asserts it opted into the guard via
+  that attribute rather than re-testing the (centrally tested) behavior.
+"""
+from __future__ import annotations
+
+import functools
+from typing import Callable
+
+
+def fail_open(fn: Callable[[], int]) -> Callable[[], int]:
+    """Wrap a hook entrypoint so any uncaught ``Exception`` returns 0 (allow).
+
+    See the module docstring for the fail-open rationale. Only exceptions are
+    intercepted; the wrapped function's own exit code (0 allow / 2 block) is
+    returned unchanged, and ``BaseException`` (KeyboardInterrupt / SystemExit)
+    still propagates.
+    """
+    @functools.wraps(fn)
+    def wrapper() -> int:
+        try:
+            return fn()
+        except Exception:
+            return 0
+
+    return wrapper

--- a/hooks/_lib/_hook_runtime.py
+++ b/hooks/_lib/_hook_runtime.py
@@ -12,9 +12,19 @@ Before this module the guard was hand-rolled as a byte-identical
 ``def main(): try: return _main_inner() except Exception: return 0`` wrapper in
 each gate. That is the exact duplication issue #470 eliminated for the
 decision-emit shape (and #439 for the block message) — `fail_open` is its
-sibling for the entrypoint guard: the contract now lives at a single edit site
-with a single behavioral test (`tests/test_hook_runtime.sh`), instead of N
-copies each carrying their own near-identical test.
+sibling for the entrypoint guard: the contract lives at a single edit site with
+a single behavioral test (`tests/test_hook_runtime.sh`).
+
+**Fail-open is NOT fail-silent.** Returning 0 on an unexpected exception keeps
+the session alive, but a swallowed crash with no trace is undiagnosable — the
+hook would appear to "work" while silently never enforcing its rule. So every
+swallowed exception is recorded to an append-only JSONL error log
+(``PRAXIS_HOOK_ERROR_LOG`` env override; default
+``${TMPDIR:-/tmp}/praxis-hook-errors.jsonl``) with timestamp, hook identity,
+exception type/message, full traceback, and pid. The recorder is itself fully
+self-guarded — a logging failure can never re-break the fail-open contract.
+Set ``PRAXIS_HOOK_ERROR_STDERR=1`` to additionally surface a terse one-line
+note on stderr (off by default so normal sessions stay quiet).
 
 Usage::
 
@@ -38,26 +48,99 @@ Contract details:
 - ``functools.wraps`` is applied, so a decorated entrypoint exposes
   ``main.__wrapped__``; a hook's own test asserts it opted into the guard via
   that attribute rather than re-testing the (centrally tested) behavior.
+
+Privacy note: a traceback may incidentally contain argument values (e.g. a
+command string) from local frames. The log is a local, ephemeral file under
+``TMPDIR`` (or an operator-chosen path) and is not committed — treat it like
+the sibling bypass-telemetry log.
 """
 from __future__ import annotations
 
 import functools
+import json
+import os
+import sys
+import time
+import traceback
 from typing import Callable
+
+
+def _error_log_path() -> str:
+    """Resolve the JSONL error-log path (env override, else TMPDIR default)."""
+    override = os.environ.get("PRAXIS_HOOK_ERROR_LOG")
+    if override:
+        return override
+    tmp = os.environ.get("TMPDIR") or "/tmp"
+    return os.path.join(tmp, "praxis-hook-errors.jsonl")
+
+
+def _hook_identity(fn: Callable[[], int]) -> str:
+    """Best-effort hook name from the wrapped function's source file.
+
+    Hook entrypoints live at ``hooks/<role>/<name>/impl.py``, so the parent
+    directory name is the stable hook identifier.
+    """
+    try:
+        path = fn.__code__.co_filename
+        parent = os.path.basename(os.path.dirname(path))
+        return parent or fn.__name__
+    except Exception:
+        return getattr(fn, "__name__", "<unknown>")
+
+
+def _record_swallowed_exception(fn: Callable[[], int]) -> None:
+    """Record a swallowed exception so the crash stays diagnosable.
+
+    Fully self-guarded: any failure here (unwritable path, serialization
+    error, stderr closed) is itself swallowed — observability must NEVER
+    re-break the fail-open contract. Always appends a JSONL record to the
+    error log; additionally writes a terse stderr line when
+    ``PRAXIS_HOOK_ERROR_STDERR`` is set.
+    """
+    try:
+        exc_type, exc, tb = sys.exc_info()
+        record = {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "hook": _hook_identity(fn),
+            "pid": os.getpid(),
+            "exc_type": getattr(exc_type, "__name__", str(exc_type)),
+            "message": str(exc),
+            "traceback": "".join(traceback.format_exception(exc_type, exc, tb)),
+        }
+        try:
+            with open(_error_log_path(), "a", encoding="utf-8") as f:
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        except Exception:
+            pass  # unwritable log must not re-break fail-open
+        if os.environ.get("PRAXIS_HOOK_ERROR_STDERR"):
+            try:
+                sys.stderr.write(
+                    f"[praxis:hook-error] {record['hook']} swallowed "
+                    f"{record['exc_type']}: {record['message']} "
+                    f"(fail-open; see {_error_log_path()})\n"
+                )
+            except Exception:
+                pass
+    except Exception:
+        # Last-resort: the recorder itself never propagates.
+        pass
 
 
 def fail_open(fn: Callable[[], int]) -> Callable[[], int]:
     """Wrap a hook entrypoint so any uncaught ``Exception`` returns 0 (allow).
 
-    See the module docstring for the fail-open rationale. Only exceptions are
-    intercepted; the wrapped function's own exit code (0 allow / 2 block) is
-    returned unchanged, and ``BaseException`` (KeyboardInterrupt / SystemExit)
-    still propagates.
+    On a swallowed exception the error is recorded (see
+    ``_record_swallowed_exception``) before returning 0, so fail-open does not
+    become fail-silent. Only exceptions are intercepted; the wrapped function's
+    own exit code (0 allow / 2 block) is returned unchanged, and
+    ``BaseException`` (KeyboardInterrupt / SystemExit) still propagates.
     """
     @functools.wraps(fn)
     def wrapper() -> int:
         try:
             return fn()
         except Exception:
+            _record_swallowed_exception(fn)
             return 0
 
     return wrapper

--- a/hooks/_lib/_hook_runtime.py
+++ b/hooks/_lib/_hook_runtime.py
@@ -60,11 +60,79 @@ from __future__ import annotations
 
 import functools
 import json
+import logging
 import os
 import sys
-import time
 import traceback
 from typing import Callable
+
+
+# ---------------------------------------------------------------------------
+# Error logging (stdlib `logging` with a JSONL formatter)
+# ---------------------------------------------------------------------------
+#
+# A dedicated, non-propagating logger writes one JSON object per line to the
+# error log. The setup is hardened so logging can NEVER pollute the session or
+# break fail-open:
+#   - ``logging.raiseExceptions = False`` so a handler error (disk full, etc.)
+#     is swallowed instead of dumping a traceback to stderr.
+#   - ``logger.propagate = False`` so records never bubble to the root logger.
+#   - a baseline ``NullHandler`` so the logger is never "handler-less" — that
+#     would otherwise trigger ``logging.lastResort`` which writes to stderr.
+#   - the whole record path is additionally wrapped in ``try/except: pass``.
+_LOGGER_NAME = "praxis.hook"
+
+
+class _JsonlFormatter(logging.Formatter):
+    """Render a LogRecord as a single-line JSON object (JSONL)."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "ts": self.formatTime(record, "%Y-%m-%dT%H:%M:%S%z"),
+            "hook": getattr(record, "hook", "<unknown>"),
+            "pid": record.process,
+            "exc_type": getattr(record, "exc_type", ""),
+            "message": record.getMessage(),
+            "traceback": getattr(record, "tb_text", ""),
+        }
+        return json.dumps(payload, ensure_ascii=False)
+
+
+class _StderrFormatter(logging.Formatter):
+    """Terse one-line human-readable form for the opt-in stderr handler."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        return (
+            f"[praxis:hook-error] {getattr(record, 'hook', '?')} swallowed "
+            f"{getattr(record, 'exc_type', '?')}: {record.getMessage()} "
+            f"(fail-open; see {getattr(record, 'log_path', '')})"
+        )
+
+
+def _get_logger() -> logging.Logger:
+    """Lazily configure and return the praxis hook-error logger.
+
+    Configured once per process; only invoked on the crash path (inside the
+    fail-open ``except``), so a normal run pays no logging cost.
+    """
+    logger = logging.getLogger(_LOGGER_NAME)
+    if getattr(logger, "_praxis_configured", False):
+        return logger
+    logger.setLevel(logging.ERROR)
+    logger.propagate = False
+    logger.addHandler(logging.NullHandler())  # never handler-less → no lastResort
+    try:
+        fh = logging.FileHandler(_error_log_path(), encoding="utf-8", delay=True)
+        fh.setFormatter(_JsonlFormatter())
+        logger.addHandler(fh)
+    except Exception:
+        pass  # unwritable log must not re-break fail-open
+    if os.environ.get("PRAXIS_HOOK_ERROR_STDERR"):
+        sh = logging.StreamHandler(sys.stderr)
+        sh.setFormatter(_StderrFormatter())
+        logger.addHandler(sh)
+    logger._praxis_configured = True  # type: ignore[attr-defined]
+    return logger
 
 
 def _error_log_path() -> str:
@@ -104,36 +172,24 @@ def _hook_identity(fn: Callable[[], int]) -> str:
 def _record_swallowed_exception(fn: Callable[[], int]) -> None:
     """Record a swallowed exception so the crash stays diagnosable.
 
-    Fully self-guarded: any failure here (unwritable path, serialization
-    error, stderr closed) is itself swallowed — observability must NEVER
-    re-break the fail-open contract. Always appends a JSONL record to the
-    error log; additionally writes a terse stderr line when
-    ``PRAXIS_HOOK_ERROR_STDERR`` is set.
+    Emits one JSONL record via the dedicated ``praxis.hook`` logger (plus a
+    terse stderr line when ``PRAXIS_HOOK_ERROR_STDERR`` is set). Fully
+    self-guarded: a handler error is swallowed by ``raiseExceptions = False``
+    and the whole body by ``try/except: pass`` — observability must NEVER
+    re-break the fail-open contract.
     """
     try:
+        logging.raiseExceptions = False  # handler errors must not hit stderr
         exc_type, exc, tb = sys.exc_info()
-        record = {
-            "ts": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
-            "hook": _hook_identity(fn),
-            "pid": os.getpid(),
-            "exc_type": getattr(exc_type, "__name__", str(exc_type)),
-            "message": str(exc),
-            "traceback": "".join(traceback.format_exception(exc_type, exc, tb)),
-        }
-        try:
-            with open(_error_log_path(), "a", encoding="utf-8") as f:
-                f.write(json.dumps(record, ensure_ascii=False) + "\n")
-        except Exception:
-            pass  # unwritable log must not re-break fail-open
-        if os.environ.get("PRAXIS_HOOK_ERROR_STDERR"):
-            try:
-                sys.stderr.write(
-                    f"[praxis:hook-error] {record['hook']} swallowed "
-                    f"{record['exc_type']}: {record['message']} "
-                    f"(fail-open; see {_error_log_path()})\n"
-                )
-            except Exception:
-                pass
+        _get_logger().error(
+            str(exc),
+            extra={
+                "hook": _hook_identity(fn),
+                "exc_type": getattr(exc_type, "__name__", str(exc_type)),
+                "tb_text": "".join(traceback.format_exception(exc_type, exc, tb)),
+                "log_path": _error_log_path(),
+            },
+        )
     except Exception:
         # Last-resort: the recorder itself never propagates.
         pass

--- a/hooks/_lib/_paths.py
+++ b/hooks/_lib/_paths.py
@@ -1,27 +1,11 @@
 """Host-neutral path resolver for praxis runtime files.
 
-praxis is multi-platform (Claude, Codex, Cursor, Gemini, OpenCode), so its
-durable runtime files should live under a host-neutral home rather than nested
-in any single host's directory (the legacy `~/.claude/state/praxis` default of
-`PRAXIS_STATE_DIR` assumes Claude). This module pins that home in one place:
+praxis is multi-platform, so durable files live under ~/.praxis (PRAXIS_HOME
+override) rather than the Claude-nested legacy default. `resolve_writable`
+falls back to ${TMPDIR}/praxis-<file> when the home dir is not writable.
 
-    ~/.praxis/
-      ├── logs/    durable diagnostics (e.g. hook-errors.jsonl)
-      ├── state/   durable cross-session state (e.g. strike counter)
-      └── cache/   regenerable per-session caches (gh-json, dedup markers)
-
-`PRAXIS_HOME` overrides the root. `resolve_writable` is best-effort: if the
-home dir cannot be created or written (locked-down sandbox / read-only HOME),
-it falls back to `${TMPDIR:-/tmp}/praxis-<filename>` so a caller never loses
-its file — important for the fail-open error log, whose whole purpose is to
-stay writable when things are going wrong.
-
-Scope note: only the hook-error log is wired to this module today. Migrating
-the existing `${TMPDIR}/praxis-*` ephemeral files and the
-`${PRAXIS_STATE_DIR:-~/.claude/state/praxis}` persistent files onto
-`~/.praxis` is tracked separately (cross-cutting, conflicts with in-flight
-PRs). `PRAXIS_STATE_DIR` and per-file `PRAXIS_*` overrides remain honored for
-backward compatibility until that sweep.
+Only the hook-error log uses this today; migrating the other ${TMPDIR}/praxis-*
+and ${PRAXIS_STATE_DIR} files is tracked in #527.
 """
 from __future__ import annotations
 
@@ -29,12 +13,8 @@ import os
 
 
 def praxis_home() -> str:
-    """Resolve the praxis home directory (``PRAXIS_HOME`` override, else
-    ``~/.praxis``). Path is expanded but NOT created here."""
-    override = os.environ.get("PRAXIS_HOME")
-    if override:
-        return os.path.expanduser(override)
-    return os.path.expanduser("~/.praxis")
+    """PRAXIS_HOME override, else ~/.praxis (expanded, not created)."""
+    return os.path.expanduser(os.environ.get("PRAXIS_HOME") or "~/.praxis")
 
 
 def _tmp_root() -> str:
@@ -42,13 +22,8 @@ def _tmp_root() -> str:
 
 
 def resolve_writable(subdir: str, filename: str) -> str:
-    """Return a writable path for ``<praxis_home>/<subdir>/<filename>``.
-
-    Creates the parent directory best-effort. If the home dir cannot be
-    created or is not writable (read-only HOME, locked-down sandbox), falls
-    back to ``${TMPDIR:-/tmp}/praxis-<filename>`` so the caller always gets a
-    usable path. Never raises.
-    """
+    """Path under ~/.praxis/<subdir>/, creating it; TMPDIR fallback if
+    unwritable. Never raises."""
     try:
         d = os.path.join(praxis_home(), subdir)
         os.makedirs(d, exist_ok=True)

--- a/hooks/_lib/_paths.py
+++ b/hooks/_lib/_paths.py
@@ -1,0 +1,59 @@
+"""Host-neutral path resolver for praxis runtime files.
+
+praxis is multi-platform (Claude, Codex, Cursor, Gemini, OpenCode), so its
+durable runtime files should live under a host-neutral home rather than nested
+in any single host's directory (the legacy `~/.claude/state/praxis` default of
+`PRAXIS_STATE_DIR` assumes Claude). This module pins that home in one place:
+
+    ~/.praxis/
+      ├── logs/    durable diagnostics (e.g. hook-errors.jsonl)
+      ├── state/   durable cross-session state (e.g. strike counter)
+      └── cache/   regenerable per-session caches (gh-json, dedup markers)
+
+`PRAXIS_HOME` overrides the root. `resolve_writable` is best-effort: if the
+home dir cannot be created or written (locked-down sandbox / read-only HOME),
+it falls back to `${TMPDIR:-/tmp}/praxis-<filename>` so a caller never loses
+its file — important for the fail-open error log, whose whole purpose is to
+stay writable when things are going wrong.
+
+Scope note: only the hook-error log is wired to this module today. Migrating
+the existing `${TMPDIR}/praxis-*` ephemeral files and the
+`${PRAXIS_STATE_DIR:-~/.claude/state/praxis}` persistent files onto
+`~/.praxis` is tracked separately (cross-cutting, conflicts with in-flight
+PRs). `PRAXIS_STATE_DIR` and per-file `PRAXIS_*` overrides remain honored for
+backward compatibility until that sweep.
+"""
+from __future__ import annotations
+
+import os
+
+
+def praxis_home() -> str:
+    """Resolve the praxis home directory (``PRAXIS_HOME`` override, else
+    ``~/.praxis``). Path is expanded but NOT created here."""
+    override = os.environ.get("PRAXIS_HOME")
+    if override:
+        return os.path.expanduser(override)
+    return os.path.expanduser("~/.praxis")
+
+
+def _tmp_root() -> str:
+    return os.environ.get("TMPDIR") or "/tmp"
+
+
+def resolve_writable(subdir: str, filename: str) -> str:
+    """Return a writable path for ``<praxis_home>/<subdir>/<filename>``.
+
+    Creates the parent directory best-effort. If the home dir cannot be
+    created or is not writable (read-only HOME, locked-down sandbox), falls
+    back to ``${TMPDIR:-/tmp}/praxis-<filename>`` so the caller always gets a
+    usable path. Never raises.
+    """
+    try:
+        d = os.path.join(praxis_home(), subdir)
+        os.makedirs(d, exist_ok=True)
+        if os.access(d, os.W_OK):
+            return os.path.join(d, filename)
+    except Exception:
+        pass
+    return os.path.join(_tmp_root(), "praxis-" + filename)

--- a/hooks/preflight-gate/block-ask-end-option/impl.py
+++ b/hooks/preflight-gate/block-ask-end-option/impl.py
@@ -364,7 +364,7 @@ Note: PRAXIS_ASK_END_STRICT=1 (deprecated) also forces strict when set.
 """
 
 
-def main() -> int:
+def _main_inner() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -407,6 +407,20 @@ def main() -> int:
 
     sys.stderr.write(ADVISORY_MSG)
     return 0
+
+
+def main() -> int:
+    """Preflight gate entrypoint — fail-open on any uncaught exception.
+
+    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
+    documented fail-open contract ("a hook never breaks a normal session"):
+    any unexpected exception from later IO (subprocess / read_text / glob /
+    tokenization) returns 0 instead of crashing the hook.
+    """
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/block-ask-end-option/impl.py
+++ b/hooks/preflight-gate/block-ask-end-option/impl.py
@@ -42,6 +42,9 @@ from __future__ import annotations
 import json
 import os
 import sys
+from pathlib import Path as _Path
+sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Pattern definitions
@@ -364,7 +367,8 @@ Note: PRAXIS_ASK_END_STRICT=1 (deprecated) also forces strict when set.
 """
 
 
-def _main_inner() -> int:
+@fail_open
+def main() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -407,20 +411,6 @@ def _main_inner() -> int:
 
     sys.stderr.write(ADVISORY_MSG)
     return 0
-
-
-def main() -> int:
-    """Preflight gate entrypoint — fail-open on any uncaught exception.
-
-    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
-    documented fail-open contract ("a hook never breaks a normal session"):
-    any unexpected exception from later IO (subprocess / read_text / glob /
-    tokenization) returns 0 instead of crashing the hook.
-    """
-    try:
-        return _main_inner()
-    except Exception:
-        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/block-gh-state-all/impl.py
+++ b/hooks/preflight-gate/block-gh-state-all/impl.py
@@ -23,6 +23,7 @@ import sys
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     Token,
     TokenRole,
@@ -111,7 +112,8 @@ STDERR_MESSAGE = format_block(
 )
 
 
-def _main_inner() -> int:
+@fail_open
+def main() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -137,20 +139,6 @@ def _main_inner() -> int:
             return 2
 
     return 0
-
-
-def main() -> int:
-    """Preflight gate entrypoint — fail-open on any uncaught exception.
-
-    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
-    documented fail-open contract ("a hook never breaks a normal session"):
-    any unexpected exception from later IO (subprocess / read_text / glob /
-    tokenization) returns 0 instead of crashing the hook.
-    """
-    try:
-        return _main_inner()
-    except Exception:
-        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/block-gh-state-all/impl.py
+++ b/hooks/preflight-gate/block-gh-state-all/impl.py
@@ -111,7 +111,7 @@ STDERR_MESSAGE = format_block(
 )
 
 
-def main() -> int:
+def _main_inner() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -137,6 +137,20 @@ def main() -> int:
             return 2
 
     return 0
+
+
+def main() -> int:
+    """Preflight gate entrypoint — fail-open on any uncaught exception.
+
+    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
+    documented fail-open contract ("a hook never breaks a normal session"):
+    any unexpected exception from later IO (subprocess / read_text / glob /
+    tokenization) returns 0 instead of crashing the hook.
+    """
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/block-manufactured-action-menu/impl.py
+++ b/hooks/preflight-gate/block-manufactured-action-menu/impl.py
@@ -486,7 +486,7 @@ To opt out: unset PRAXIS_BLOCK_MANUFACTURED_MENU_STRICT (default is advisory).
 """
 
 
-def main() -> int:
+def _main_inner() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -535,6 +535,20 @@ def main() -> int:
 
     sys.stderr.write(ADVISORY_MSG)
     return 0
+
+
+def main() -> int:
+    """Preflight gate entrypoint — fail-open on any uncaught exception.
+
+    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
+    documented fail-open contract ("a hook never breaks a normal session"):
+    any unexpected exception from later IO (subprocess / read_text / glob /
+    tokenization) returns 0 instead of crashing the hook.
+    """
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/block-manufactured-action-menu/impl.py
+++ b/hooks/preflight-gate/block-manufactured-action-menu/impl.py
@@ -46,6 +46,9 @@ from __future__ import annotations
 import json
 import os
 import sys
+from pathlib import Path as _Path
+sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Pattern definitions
@@ -486,7 +489,8 @@ To opt out: unset PRAXIS_BLOCK_MANUFACTURED_MENU_STRICT (default is advisory).
 """
 
 
-def _main_inner() -> int:
+@fail_open
+def main() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -535,20 +539,6 @@ def _main_inner() -> int:
 
     sys.stderr.write(ADVISORY_MSG)
     return 0
-
-
-def main() -> int:
-    """Preflight gate entrypoint — fail-open on any uncaught exception.
-
-    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
-    documented fail-open contract ("a hook never breaks a normal session"):
-    any unexpected exception from later IO (subprocess / read_text / glob /
-    tokenization) returns 0 instead of crashing the hook.
-    """
-    try:
-        return _main_inner()
-    except Exception:
-        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/block-pr-without-caller-evidence/impl.py
+++ b/hooks/preflight-gate/block-pr-without-caller-evidence/impl.py
@@ -50,6 +50,7 @@ from pathlib import Path
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]
     compound_cascade_hint,
     iter_command_starts,
@@ -255,7 +256,8 @@ Cross-project PRs (--repo other/org) are not blocked.
 """
 
 
-def _main_inner() -> int:
+@fail_open
+def main() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -290,20 +292,6 @@ def _main_inner() -> int:
         return 2
 
     return 0
-
-
-def main() -> int:
-    """Preflight gate entrypoint — fail-open on any uncaught exception.
-
-    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
-    documented fail-open contract ("a hook never breaks a normal session"):
-    any unexpected exception from later IO (subprocess / read_text / glob /
-    tokenization) returns 0 instead of crashing the hook.
-    """
-    try:
-        return _main_inner()
-    except Exception:
-        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/block-pr-without-caller-evidence/impl.py
+++ b/hooks/preflight-gate/block-pr-without-caller-evidence/impl.py
@@ -255,7 +255,7 @@ Cross-project PRs (--repo other/org) are not blocked.
 """
 
 
-def main() -> int:
+def _main_inner() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -290,6 +290,20 @@ def main() -> int:
         return 2
 
     return 0
+
+
+def main() -> int:
+    """Preflight gate entrypoint — fail-open on any uncaught exception.
+
+    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
+    documented fail-open contract ("a hook never breaks a normal session"):
+    any unexpected exception from later IO (subprocess / read_text / glob /
+    tokenization) returns 0 instead of crashing the hook.
+    """
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/block-pr-without-precommit-evidence/impl.py
+++ b/hooks/preflight-gate/block-pr-without-precommit-evidence/impl.py
@@ -221,7 +221,7 @@ target, so bypass would defeat the purpose.
 """
 
 
-def main() -> int:
+def _main_inner() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -254,6 +254,20 @@ def main() -> int:
         return 2
 
     return 0
+
+
+def main() -> int:
+    """Preflight gate entrypoint — fail-open on any uncaught exception.
+
+    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
+    documented fail-open contract ("a hook never breaks a normal session"):
+    any unexpected exception from later IO (subprocess / read_text / glob /
+    tokenization) returns 0 instead of crashing the hook.
+    """
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/block-pr-without-precommit-evidence/impl.py
+++ b/hooks/preflight-gate/block-pr-without-precommit-evidence/impl.py
@@ -44,6 +44,7 @@ from pathlib import Path
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]
     compound_cascade_hint,
     iter_command_starts,
@@ -221,7 +222,8 @@ target, so bypass would defeat the purpose.
 """
 
 
-def _main_inner() -> int:
+@fail_open
+def main() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -254,20 +256,6 @@ def _main_inner() -> int:
         return 2
 
     return 0
-
-
-def main() -> int:
-    """Preflight gate entrypoint — fail-open on any uncaught exception.
-
-    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
-    documented fail-open contract ("a hook never breaks a normal session"):
-    any unexpected exception from later IO (subprocess / read_text / glob /
-    tokenization) returns 0 instead of crashing the hook.
-    """
-    try:
-        return _main_inner()
-    except Exception:
-        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/branch-name-check/impl.py
+++ b/hooks/preflight-gate/branch-name-check/impl.py
@@ -453,7 +453,7 @@ def _emit_block(branch: str, regex_pattern: str, strict: bool) -> None:
 # Main
 # ---------------------------------------------------------------------------
 
-def main() -> int:
+def _main_inner() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -497,6 +497,20 @@ def main() -> int:
         return 0
 
     return 0
+
+
+def main() -> int:
+    """Preflight gate entrypoint — fail-open on any uncaught exception.
+
+    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
+    documented fail-open contract ("a hook never breaks a normal session"):
+    any unexpected exception from later IO (subprocess / read_text / glob /
+    tokenization) returns 0 instead of crashing the hook.
+    """
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/branch-name-check/impl.py
+++ b/hooks/preflight-gate/branch-name-check/impl.py
@@ -43,6 +43,7 @@ import sys as _sys
 from pathlib import Path as _Path
 
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     iter_command_starts,
@@ -453,7 +454,8 @@ def _emit_block(branch: str, regex_pattern: str, strict: bool) -> None:
 # Main
 # ---------------------------------------------------------------------------
 
-def _main_inner() -> int:
+@fail_open
+def main() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -497,20 +499,6 @@ def _main_inner() -> int:
         return 0
 
     return 0
-
-
-def main() -> int:
-    """Preflight gate entrypoint — fail-open on any uncaught exception.
-
-    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
-    documented fail-open contract ("a hook never breaks a normal session"):
-    any unexpected exception from later IO (subprocess / read_text / glob /
-    tokenization) returns 0 instead of crashing the hook.
-    """
-    try:
-        return _main_inner()
-    except Exception:
-        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/commit-title-format-check/impl.py
+++ b/hooks/preflight-gate/commit-title-format-check/impl.py
@@ -43,6 +43,7 @@ import sys as _sys
 from pathlib import Path as _Path
 
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     compound_cascade_hint,
     iter_command_starts,
@@ -373,7 +374,8 @@ def _build_violation_message(
 # Main
 # ---------------------------------------------------------------------------
 
-def _main_inner() -> int:
+@fail_open
+def main() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -426,20 +428,6 @@ def _main_inner() -> int:
         return 2
     else:
         _emit_advisory(f"[commit-title-format-check] ADVISORY (STRICT=0):\n{violation}")
-        return 0
-
-
-def main() -> int:
-    """Preflight gate entrypoint — fail-open on any uncaught exception.
-
-    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
-    documented fail-open contract ("a hook never breaks a normal session"):
-    any unexpected exception from later IO (subprocess / read_text / glob /
-    tokenization) returns 0 instead of crashing the hook.
-    """
-    try:
-        return _main_inner()
-    except Exception:
         return 0
 
 

--- a/hooks/preflight-gate/commit-title-format-check/impl.py
+++ b/hooks/preflight-gate/commit-title-format-check/impl.py
@@ -373,7 +373,7 @@ def _build_violation_message(
 # Main
 # ---------------------------------------------------------------------------
 
-def main() -> int:
+def _main_inner() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -426,6 +426,20 @@ def main() -> int:
         return 2
     else:
         _emit_advisory(f"[commit-title-format-check] ADVISORY (STRICT=0):\n{violation}")
+        return 0
+
+
+def main() -> int:
+    """Preflight gate entrypoint — fail-open on any uncaught exception.
+
+    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
+    documented fail-open contract ("a hook never breaks a normal session"):
+    any unexpected exception from later IO (subprocess / read_text / glob /
+    tokenization) returns 0 instead of crashing the hook.
+    """
+    try:
+        return _main_inner()
+    except Exception:
         return 0
 
 

--- a/hooks/preflight-gate/cross-boundary-preflight/impl.py
+++ b/hooks/preflight-gate/cross-boundary-preflight/impl.py
@@ -38,6 +38,7 @@ import sys
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     Token,
@@ -304,7 +305,8 @@ def _emit_ask(reason: str) -> None:
 # Main
 # ---------------------------------------------------------------------------
 
-def _main_inner() -> int:
+@fail_open
+def main() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -348,20 +350,6 @@ def _main_inner() -> int:
             return 0
 
     return 0
-
-
-def main() -> int:
-    """Preflight gate entrypoint — fail-open on any uncaught exception.
-
-    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
-    documented fail-open contract ("a hook never breaks a normal session"):
-    any unexpected exception from later IO (subprocess / read_text / glob /
-    tokenization) returns 0 instead of crashing the hook.
-    """
-    try:
-        return _main_inner()
-    except Exception:
-        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/cross-boundary-preflight/impl.py
+++ b/hooks/preflight-gate/cross-boundary-preflight/impl.py
@@ -304,7 +304,7 @@ def _emit_ask(reason: str) -> None:
 # Main
 # ---------------------------------------------------------------------------
 
-def main() -> int:
+def _main_inner() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -348,6 +348,20 @@ def main() -> int:
             return 0
 
     return 0
+
+
+def main() -> int:
+    """Preflight gate entrypoint — fail-open on any uncaught exception.
+
+    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
+    documented fail-open contract ("a hook never breaks a normal session"):
+    any unexpected exception from later IO (subprocess / read_text / glob /
+    tokenization) returns 0 instead of crashing the hook.
+    """
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/gh-flag-verify/impl.py
+++ b/hooks/preflight-gate/gh-flag-verify/impl.py
@@ -509,7 +509,7 @@ def _emit_deny(reason: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def main() -> int:
+def _main_inner() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -537,6 +537,20 @@ def main() -> int:
             return 2  # deny exit code
 
     return 0
+
+
+def main() -> int:
+    """Preflight gate entrypoint — fail-open on any uncaught exception.
+
+    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
+    documented fail-open contract ("a hook never breaks a normal session"):
+    any unexpected exception from later IO (subprocess / read_text / glob /
+    tokenization) returns 0 instead of crashing the hook.
+    """
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/gh-flag-verify/impl.py
+++ b/hooks/preflight-gate/gh-flag-verify/impl.py
@@ -44,6 +44,7 @@ import sys
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     Token,
@@ -509,7 +510,8 @@ def _emit_deny(reason: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _main_inner() -> int:
+@fail_open
+def main() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -537,20 +539,6 @@ def _main_inner() -> int:
             return 2  # deny exit code
 
     return 0
-
-
-def main() -> int:
-    """Preflight gate entrypoint — fail-open on any uncaught exception.
-
-    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
-    documented fail-open contract ("a hook never breaks a normal session"):
-    any unexpected exception from later IO (subprocess / read_text / glob /
-    tokenization) returns 0 instead of crashing the hook.
-    """
-    try:
-        return _main_inner()
-    except Exception:
-        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/gh-json-validator/impl.py
+++ b/hooks/preflight-gate/gh-json-validator/impl.py
@@ -331,7 +331,7 @@ def _check_segment(
 # Main
 # ---------------------------------------------------------------------------
 
-def main() -> int:
+def _main_inner() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -379,6 +379,20 @@ def main() -> int:
             return 2
 
     return 0
+
+
+def main() -> int:
+    """Preflight gate entrypoint — fail-open on any uncaught exception.
+
+    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
+    documented fail-open contract ("a hook never breaks a normal session"):
+    any unexpected exception from later IO (subprocess / read_text / glob /
+    tokenization) returns 0 instead of crashing the hook.
+    """
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/gh-json-validator/impl.py
+++ b/hooks/preflight-gate/gh-json-validator/impl.py
@@ -40,6 +40,7 @@ from pathlib import Path
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     iter_command_starts,
@@ -331,7 +332,8 @@ def _check_segment(
 # Main
 # ---------------------------------------------------------------------------
 
-def _main_inner() -> int:
+@fail_open
+def main() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -379,20 +381,6 @@ def _main_inner() -> int:
             return 2
 
     return 0
-
-
-def main() -> int:
-    """Preflight gate entrypoint — fail-open on any uncaught exception.
-
-    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
-    documented fail-open contract ("a hook never breaks a normal session"):
-    any unexpected exception from later IO (subprocess / read_text / glob /
-    tokenization) returns 0 instead of crashing the hook.
-    """
-    try:
-        return _main_inner()
-    except Exception:
-        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/pre-gh-pr-create-dedup-gate/impl.py
+++ b/hooks/preflight-gate/pre-gh-pr-create-dedup-gate/impl.py
@@ -305,7 +305,7 @@ def _block_gh_error(repo: str, rc: int, stderr_text: str) -> str:
     )
 
 
-def main() -> int:
+def _main_inner() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -382,6 +382,20 @@ def main() -> int:
         return 0
 
     return 0
+
+
+def main() -> int:
+    """Preflight gate entrypoint — fail-open on any uncaught exception.
+
+    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
+    documented fail-open contract ("a hook never breaks a normal session"):
+    any unexpected exception from later IO (subprocess / read_text / glob /
+    tokenization) returns 0 instead of crashing the hook.
+    """
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/pre-gh-pr-create-dedup-gate/impl.py
+++ b/hooks/preflight-gate/pre-gh-pr-create-dedup-gate/impl.py
@@ -43,6 +43,7 @@ import sys
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]
     iter_command_starts,
     safe_tokenize,
@@ -305,7 +306,8 @@ def _block_gh_error(repo: str, rc: int, stderr_text: str) -> str:
     )
 
 
-def _main_inner() -> int:
+@fail_open
+def main() -> int:
     try:
         payload = json.load(sys.stdin)
     except Exception:
@@ -382,20 +384,6 @@ def _main_inner() -> int:
         return 0
 
     return 0
-
-
-def main() -> int:
-    """Preflight gate entrypoint — fail-open on any uncaught exception.
-
-    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
-    documented fail-open contract ("a hook never breaks a normal session"):
-    any unexpected exception from later IO (subprocess / read_text / glob /
-    tokenization) returns 0 instead of crashing the hook.
-    """
-    try:
-        return _main_inner()
-    except Exception:
-        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/verify-commit-flag-override/impl.py
+++ b/hooks/preflight-gate/verify-commit-flag-override/impl.py
@@ -37,6 +37,7 @@ import sys
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     compound_cascade_hint,
@@ -259,7 +260,8 @@ def _build_reason(overrides: list[str]) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _main_inner() -> int:
+@fail_open
+def main() -> int:
     # Operator-justified bypass.
     if os.environ.get("PRAXIS_SKIP_COMMIT_FLAG_CHECK") == "1":
         return 0
@@ -292,20 +294,6 @@ def _main_inner() -> int:
 
     _emit_deny(_build_reason(all_overrides) + compound_cascade_hint(command))
     return 2
-
-
-def main() -> int:
-    """Preflight gate entrypoint — fail-open on any uncaught exception.
-
-    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
-    documented fail-open contract ("a hook never breaks a normal session"):
-    any unexpected exception from later IO (subprocess / read_text / glob /
-    tokenization) returns 0 instead of crashing the hook.
-    """
-    try:
-        return _main_inner()
-    except Exception:
-        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/verify-commit-flag-override/impl.py
+++ b/hooks/preflight-gate/verify-commit-flag-override/impl.py
@@ -259,7 +259,7 @@ def _build_reason(overrides: list[str]) -> str:
 # ---------------------------------------------------------------------------
 
 
-def main() -> int:
+def _main_inner() -> int:
     # Operator-justified bypass.
     if os.environ.get("PRAXIS_SKIP_COMMIT_FLAG_CHECK") == "1":
         return 0
@@ -292,6 +292,20 @@ def main() -> int:
 
     _emit_deny(_build_reason(all_overrides) + compound_cascade_hint(command))
     return 2
+
+
+def main() -> int:
+    """Preflight gate entrypoint — fail-open on any uncaught exception.
+
+    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
+    documented fail-open contract ("a hook never breaks a normal session"):
+    any unexpected exception from later IO (subprocess / read_text / glob /
+    tokenization) returns 0 instead of crashing the hook.
+    """
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/worktree-edit-gate/impl.py
+++ b/hooks/preflight-gate/worktree-edit-gate/impl.py
@@ -257,7 +257,7 @@ def _emit_block(file_path: str, branch: str, repo_root: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def main() -> int:
+def _main_inner() -> int:
     # Bypass env var — set to any non-empty value
     if os.environ.get("PRAXIS_HOOK_BYPASS_WORKTREE_GATE", "").strip():
         return 0
@@ -304,6 +304,20 @@ def main() -> int:
     # All conditions met: block
     _emit_block(file_path, branch, repo_root)
     return 2
+
+
+def main() -> int:
+    """Preflight gate entrypoint — fail-open on any uncaught exception.
+
+    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
+    documented fail-open contract ("a hook never breaks a normal session"):
+    any unexpected exception from later IO (subprocess / read_text / glob /
+    tokenization) returns 0 instead of crashing the hook.
+    """
+    try:
+        return _main_inner()
+    except Exception:
+        return 0
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/worktree-edit-gate/impl.py
+++ b/hooks/preflight-gate/worktree-edit-gate/impl.py
@@ -55,6 +55,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from block_message import emit_block  # type: ignore[import-not-found]  # noqa: E402
 
 # ---------------------------------------------------------------------------
@@ -257,7 +258,8 @@ def _emit_block(file_path: str, branch: str, repo_root: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _main_inner() -> int:
+@fail_open
+def main() -> int:
     # Bypass env var — set to any non-empty value
     if os.environ.get("PRAXIS_HOOK_BYPASS_WORKTREE_GATE", "").strip():
         return 0
@@ -304,20 +306,6 @@ def _main_inner() -> int:
     # All conditions met: block
     _emit_block(file_path, branch, repo_root)
     return 2
-
-
-def main() -> int:
-    """Preflight gate entrypoint — fail-open on any uncaught exception.
-
-    The blocking logic lives in ``_main_inner``; this wrapper guarantees the
-    documented fail-open contract ("a hook never breaks a normal session"):
-    any unexpected exception from later IO (subprocess / read_text / glob /
-    tokenization) returns 0 instead of crashing the hook.
-    """
-    try:
-        return _main_inner()
-    except Exception:
-        return 0
 
 
 if __name__ == "__main__":

--- a/tests/hooks/preflight-gate/test_block_ask_end_option.sh
+++ b/tests/hooks/preflight-gate/test_block_ask_end_option.sh
@@ -509,13 +509,8 @@ run_case "[false-pos] '보류 중인 이슈 확인' / '보류 상태 검토' →
 
 # ---------------------------------------------------------------------------
 # Summary
-# ---------------------------------------------------------------------------
-# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
-# ---------------------------------------------------------------------------
-# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
-# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
-# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
-# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
+# Fail-open guard opt-in (issue #498): main() must be @fail_open-wrapped;
+# guard behavior is tested centrally in tests/test_hook_runtime.sh.
 _failopen_out=$(python3 - << PYEOF 2>&1
 import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")

--- a/tests/hooks/preflight-gate/test_block_ask_end_option.sh
+++ b/tests/hooks/preflight-gate/test_block_ask_end_option.sh
@@ -510,30 +510,28 @@ run_case "[false-pos] '보류 중인 이슈 확인' / '보류 상태 검토' →
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
-# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
 # ---------------------------------------------------------------------------
-# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
-# _main_inner and assert the outer try/except Exception wrapper in main()
-# returns exit 0 with no stderr — the documented "a hook never breaks a
-# normal session" fail-open contract.
+# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
+# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
+# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
+# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
 _failopen_out=$(python3 - << PYEOF 2>&1
-import sys, importlib.util, io
+import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
-def _raise(): raise MemoryError("simulated catastrophic failure")
-mod._main_inner = _raise
-sys.stdin = io.StringIO('{}')
-sys.exit(mod.main())
+assert getattr(mod.main, "__wrapped__", None) is not None, "main is not @fail_open-wrapped"
+print("OK")
 PYEOF
 )
 _failopen_rc=$?
-if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
-  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+if [ "$_failopen_rc" -eq 0 ] && [ "$_failopen_out" = "OK" ]; then
+  echo "PASS  [fail-open] main() is wrapped by the shared @fail_open guard"
   PASS=$((PASS+1))
 else
-  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
-  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+  echo "FAIL  [fail-open] main() not @fail_open-wrapped (rc=$_failopen_rc out=$_failopen_out)"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open guard wrapping")
 fi
 
 

--- a/tests/hooks/preflight-gate/test_block_ask_end_option.sh
+++ b/tests/hooks/preflight-gate/test_block_ask_end_option.sh
@@ -510,6 +510,34 @@ run_case "[false-pos] '보류 중인 이슈 확인' / '보류 상태 검토' →
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
+# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# ---------------------------------------------------------------------------
+# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
+# _main_inner and assert the outer try/except Exception wrapper in main()
+# returns exit 0 with no stderr — the documented "a hook never breaks a
+# normal session" fail-open contract.
+_failopen_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, io
+spec = importlib.util.spec_from_file_location("impl", "$HOOK")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+def _raise(): raise MemoryError("simulated catastrophic failure")
+mod._main_inner = _raise
+sys.stdin = io.StringIO('{}')
+sys.exit(mod.main())
+PYEOF
+)
+_failopen_rc=$?
+if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
+  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+  PASS=$((PASS+1))
+else
+  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+fi
+
+
+# ---------------------------------------------------------------------------
 
 echo ""
 echo "=========================================="

--- a/tests/hooks/preflight-gate/test_block_gh_state_all.sh
+++ b/tests/hooks/preflight-gate/test_block_gh_state_all.sh
@@ -129,6 +129,34 @@ malformed_test
 
 # --- PASS: empty command → exit 0 -------------------------------------------
 run_case "pass: empty command"                        pass  Bash ''
+# ---------------------------------------------------------------------------
+# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# ---------------------------------------------------------------------------
+# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
+# _main_inner and assert the outer try/except Exception wrapper in main()
+# returns exit 0 with no stderr — the documented "a hook never breaks a
+# normal session" fail-open contract.
+_failopen_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, io
+spec = importlib.util.spec_from_file_location("impl", "$HOOK")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+def _raise(): raise MemoryError("simulated catastrophic failure")
+mod._main_inner = _raise
+sys.stdin = io.StringIO('{}')
+sys.exit(mod.main())
+PYEOF
+)
+_failopen_rc=$?
+if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
+  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+  PASS=$((PASS+1))
+else
+  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+fi
+
+
 
 # ---------- summary ----------------------------------------------------------
 echo ""

--- a/tests/hooks/preflight-gate/test_block_gh_state_all.sh
+++ b/tests/hooks/preflight-gate/test_block_gh_state_all.sh
@@ -130,30 +130,28 @@ malformed_test
 # --- PASS: empty command → exit 0 -------------------------------------------
 run_case "pass: empty command"                        pass  Bash ''
 # ---------------------------------------------------------------------------
-# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
 # ---------------------------------------------------------------------------
-# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
-# _main_inner and assert the outer try/except Exception wrapper in main()
-# returns exit 0 with no stderr — the documented "a hook never breaks a
-# normal session" fail-open contract.
+# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
+# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
+# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
+# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
 _failopen_out=$(python3 - << PYEOF 2>&1
-import sys, importlib.util, io
+import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
-def _raise(): raise MemoryError("simulated catastrophic failure")
-mod._main_inner = _raise
-sys.stdin = io.StringIO('{}')
-sys.exit(mod.main())
+assert getattr(mod.main, "__wrapped__", None) is not None, "main is not @fail_open-wrapped"
+print("OK")
 PYEOF
 )
 _failopen_rc=$?
-if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
-  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+if [ "$_failopen_rc" -eq 0 ] && [ "$_failopen_out" = "OK" ]; then
+  echo "PASS  [fail-open] main() is wrapped by the shared @fail_open guard"
   PASS=$((PASS+1))
 else
-  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
-  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+  echo "FAIL  [fail-open] main() not @fail_open-wrapped (rc=$_failopen_rc out=$_failopen_out)"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open guard wrapping")
 fi
 
 

--- a/tests/hooks/preflight-gate/test_block_gh_state_all.sh
+++ b/tests/hooks/preflight-gate/test_block_gh_state_all.sh
@@ -129,13 +129,8 @@ malformed_test
 
 # --- PASS: empty command → exit 0 -------------------------------------------
 run_case "pass: empty command"                        pass  Bash ''
-# ---------------------------------------------------------------------------
-# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
-# ---------------------------------------------------------------------------
-# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
-# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
-# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
-# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
+# Fail-open guard opt-in (issue #498): main() must be @fail_open-wrapped;
+# guard behavior is tested centrally in tests/test_hook_runtime.sh.
 _failopen_out=$(python3 - << PYEOF 2>&1
 import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")

--- a/tests/hooks/preflight-gate/test_block_manufactured_action_menu.sh
+++ b/tests/hooks/preflight-gate/test_block_manufactured_action_menu.sh
@@ -540,13 +540,8 @@ run_case "[execute-family] 'the run failed' (non-directive) + marker → pass" p
 
 # ---------------------------------------------------------------------------
 # Summary
-# ---------------------------------------------------------------------------
-# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
-# ---------------------------------------------------------------------------
-# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
-# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
-# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
-# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
+# Fail-open guard opt-in (issue #498): main() must be @fail_open-wrapped;
+# guard behavior is tested centrally in tests/test_hook_runtime.sh.
 _failopen_out=$(python3 - << PYEOF 2>&1
 import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")

--- a/tests/hooks/preflight-gate/test_block_manufactured_action_menu.sh
+++ b/tests/hooks/preflight-gate/test_block_manufactured_action_menu.sh
@@ -541,6 +541,34 @@ run_case "[execute-family] 'the run failed' (non-directive) + marker → pass" p
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
+# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# ---------------------------------------------------------------------------
+# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
+# _main_inner and assert the outer try/except Exception wrapper in main()
+# returns exit 0 with no stderr — the documented "a hook never breaks a
+# normal session" fail-open contract.
+_failopen_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, io
+spec = importlib.util.spec_from_file_location("impl", "$HOOK")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+def _raise(): raise MemoryError("simulated catastrophic failure")
+mod._main_inner = _raise
+sys.stdin = io.StringIO('{}')
+sys.exit(mod.main())
+PYEOF
+)
+_failopen_rc=$?
+if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
+  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+  PASS=$((PASS+1))
+else
+  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+fi
+
+
+# ---------------------------------------------------------------------------
 
 echo ""
 echo "=========================================="

--- a/tests/hooks/preflight-gate/test_block_manufactured_action_menu.sh
+++ b/tests/hooks/preflight-gate/test_block_manufactured_action_menu.sh
@@ -541,30 +541,28 @@ run_case "[execute-family] 'the run failed' (non-directive) + marker → pass" p
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
-# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
 # ---------------------------------------------------------------------------
-# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
-# _main_inner and assert the outer try/except Exception wrapper in main()
-# returns exit 0 with no stderr — the documented "a hook never breaks a
-# normal session" fail-open contract.
+# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
+# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
+# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
+# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
 _failopen_out=$(python3 - << PYEOF 2>&1
-import sys, importlib.util, io
+import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
-def _raise(): raise MemoryError("simulated catastrophic failure")
-mod._main_inner = _raise
-sys.stdin = io.StringIO('{}')
-sys.exit(mod.main())
+assert getattr(mod.main, "__wrapped__", None) is not None, "main is not @fail_open-wrapped"
+print("OK")
 PYEOF
 )
 _failopen_rc=$?
-if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
-  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+if [ "$_failopen_rc" -eq 0 ] && [ "$_failopen_out" = "OK" ]; then
+  echo "PASS  [fail-open] main() is wrapped by the shared @fail_open guard"
   PASS=$((PASS+1))
 else
-  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
-  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+  echo "FAIL  [fail-open] main() not @fail_open-wrapped (rc=$_failopen_rc out=$_failopen_out)"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open guard wrapping")
 fi
 
 

--- a/tests/hooks/preflight-gate/test_block_pr_without_caller_evidence.sh
+++ b/tests/hooks/preflight-gate/test_block_pr_without_caller_evidence.sh
@@ -249,13 +249,8 @@ fi
 
 # ---------------------------------------------------------------------------
 # Summary
-# ---------------------------------------------------------------------------
-# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
-# ---------------------------------------------------------------------------
-# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
-# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
-# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
-# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
+# Fail-open guard opt-in (issue #498): main() must be @fail_open-wrapped;
+# guard behavior is tested centrally in tests/test_hook_runtime.sh.
 _failopen_out=$(python3 - << PYEOF 2>&1
 import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")

--- a/tests/hooks/preflight-gate/test_block_pr_without_caller_evidence.sh
+++ b/tests/hooks/preflight-gate/test_block_pr_without_caller_evidence.sh
@@ -250,30 +250,28 @@ fi
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
-# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
 # ---------------------------------------------------------------------------
-# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
-# _main_inner and assert the outer try/except Exception wrapper in main()
-# returns exit 0 with no stderr — the documented "a hook never breaks a
-# normal session" fail-open contract.
+# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
+# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
+# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
+# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
 _failopen_out=$(python3 - << PYEOF 2>&1
-import sys, importlib.util, io
+import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
-def _raise(): raise MemoryError("simulated catastrophic failure")
-mod._main_inner = _raise
-sys.stdin = io.StringIO('{}')
-sys.exit(mod.main())
+assert getattr(mod.main, "__wrapped__", None) is not None, "main is not @fail_open-wrapped"
+print("OK")
 PYEOF
 )
 _failopen_rc=$?
-if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
-  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+if [ "$_failopen_rc" -eq 0 ] && [ "$_failopen_out" = "OK" ]; then
+  echo "PASS  [fail-open] main() is wrapped by the shared @fail_open guard"
   PASS=$((PASS+1))
 else
-  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
-  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+  echo "FAIL  [fail-open] main() not @fail_open-wrapped (rc=$_failopen_rc out=$_failopen_out)"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open guard wrapping")
 fi
 
 

--- a/tests/hooks/preflight-gate/test_block_pr_without_caller_evidence.sh
+++ b/tests/hooks/preflight-gate/test_block_pr_without_caller_evidence.sh
@@ -250,6 +250,34 @@ fi
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
+# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# ---------------------------------------------------------------------------
+# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
+# _main_inner and assert the outer try/except Exception wrapper in main()
+# returns exit 0 with no stderr — the documented "a hook never breaks a
+# normal session" fail-open contract.
+_failopen_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, io
+spec = importlib.util.spec_from_file_location("impl", "$HOOK")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+def _raise(): raise MemoryError("simulated catastrophic failure")
+mod._main_inner = _raise
+sys.stdin = io.StringIO('{}')
+sys.exit(mod.main())
+PYEOF
+)
+_failopen_rc=$?
+if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
+  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+  PASS=$((PASS+1))
+else
+  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+fi
+
+
+# ---------------------------------------------------------------------------
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/hooks/preflight-gate/test_block_pr_without_precommit_evidence.sh
+++ b/tests/hooks/preflight-gate/test_block_pr_without_precommit_evidence.sh
@@ -272,30 +272,28 @@ fi
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
-# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
 # ---------------------------------------------------------------------------
-# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
-# _main_inner and assert the outer try/except Exception wrapper in main()
-# returns exit 0 with no stderr — the documented "a hook never breaks a
-# normal session" fail-open contract.
+# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
+# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
+# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
+# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
 _failopen_out=$(python3 - << PYEOF 2>&1
-import sys, importlib.util, io
+import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
-def _raise(): raise MemoryError("simulated catastrophic failure")
-mod._main_inner = _raise
-sys.stdin = io.StringIO('{}')
-sys.exit(mod.main())
+assert getattr(mod.main, "__wrapped__", None) is not None, "main is not @fail_open-wrapped"
+print("OK")
 PYEOF
 )
 _failopen_rc=$?
-if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
-  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+if [ "$_failopen_rc" -eq 0 ] && [ "$_failopen_out" = "OK" ]; then
+  echo "PASS  [fail-open] main() is wrapped by the shared @fail_open guard"
   PASS=$((PASS+1))
 else
-  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
-  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+  echo "FAIL  [fail-open] main() not @fail_open-wrapped (rc=$_failopen_rc out=$_failopen_out)"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open guard wrapping")
 fi
 
 

--- a/tests/hooks/preflight-gate/test_block_pr_without_precommit_evidence.sh
+++ b/tests/hooks/preflight-gate/test_block_pr_without_precommit_evidence.sh
@@ -272,6 +272,34 @@ fi
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
+# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# ---------------------------------------------------------------------------
+# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
+# _main_inner and assert the outer try/except Exception wrapper in main()
+# returns exit 0 with no stderr — the documented "a hook never breaks a
+# normal session" fail-open contract.
+_failopen_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, io
+spec = importlib.util.spec_from_file_location("impl", "$HOOK")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+def _raise(): raise MemoryError("simulated catastrophic failure")
+mod._main_inner = _raise
+sys.stdin = io.StringIO('{}')
+sys.exit(mod.main())
+PYEOF
+)
+_failopen_rc=$?
+if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
+  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+  PASS=$((PASS+1))
+else
+  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+fi
+
+
+# ---------------------------------------------------------------------------
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/hooks/preflight-gate/test_block_pr_without_precommit_evidence.sh
+++ b/tests/hooks/preflight-gate/test_block_pr_without_precommit_evidence.sh
@@ -271,13 +271,8 @@ fi
 
 # ---------------------------------------------------------------------------
 # Summary
-# ---------------------------------------------------------------------------
-# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
-# ---------------------------------------------------------------------------
-# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
-# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
-# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
-# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
+# Fail-open guard opt-in (issue #498): main() must be @fail_open-wrapped;
+# guard behavior is tested centrally in tests/test_hook_runtime.sh.
 _failopen_out=$(python3 - << PYEOF 2>&1
 import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")

--- a/tests/hooks/preflight-gate/test_branch_name_check.sh
+++ b/tests/hooks/preflight-gate/test_branch_name_check.sh
@@ -530,13 +530,8 @@ else
   FAILED_NAMES+=("bypass message: no '=1 =0' artifact")
   echo "  FAIL  bypass message: no '=1 =0' artifact"
 fi
-# ---------------------------------------------------------------------------
-# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
-# ---------------------------------------------------------------------------
-# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
-# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
-# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
-# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
+# Fail-open guard opt-in (issue #498): main() must be @fail_open-wrapped;
+# guard behavior is tested centrally in tests/test_hook_runtime.sh.
 _failopen_out=$(python3 - << PYEOF 2>&1
 import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")

--- a/tests/hooks/preflight-gate/test_branch_name_check.sh
+++ b/tests/hooks/preflight-gate/test_branch_name_check.sh
@@ -530,6 +530,34 @@ else
   FAILED_NAMES+=("bypass message: no '=1 =0' artifact")
   echo "  FAIL  bypass message: no '=1 =0' artifact"
 fi
+# ---------------------------------------------------------------------------
+# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# ---------------------------------------------------------------------------
+# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
+# _main_inner and assert the outer try/except Exception wrapper in main()
+# returns exit 0 with no stderr — the documented "a hook never breaks a
+# normal session" fail-open contract.
+_failopen_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, io
+spec = importlib.util.spec_from_file_location("impl", "$HOOK")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+def _raise(): raise MemoryError("simulated catastrophic failure")
+mod._main_inner = _raise
+sys.stdin = io.StringIO('{}')
+sys.exit(mod.main())
+PYEOF
+)
+_failopen_rc=$?
+if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
+  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+  PASS=$((PASS+1))
+else
+  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+fi
+
+
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/hooks/preflight-gate/test_branch_name_check.sh
+++ b/tests/hooks/preflight-gate/test_branch_name_check.sh
@@ -531,30 +531,28 @@ else
   echo "  FAIL  bypass message: no '=1 =0' artifact"
 fi
 # ---------------------------------------------------------------------------
-# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
 # ---------------------------------------------------------------------------
-# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
-# _main_inner and assert the outer try/except Exception wrapper in main()
-# returns exit 0 with no stderr — the documented "a hook never breaks a
-# normal session" fail-open contract.
+# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
+# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
+# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
+# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
 _failopen_out=$(python3 - << PYEOF 2>&1
-import sys, importlib.util, io
+import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
-def _raise(): raise MemoryError("simulated catastrophic failure")
-mod._main_inner = _raise
-sys.stdin = io.StringIO('{}')
-sys.exit(mod.main())
+assert getattr(mod.main, "__wrapped__", None) is not None, "main is not @fail_open-wrapped"
+print("OK")
 PYEOF
 )
 _failopen_rc=$?
-if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
-  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+if [ "$_failopen_rc" -eq 0 ] && [ "$_failopen_out" = "OK" ]; then
+  echo "PASS  [fail-open] main() is wrapped by the shared @fail_open guard"
   PASS=$((PASS+1))
 else
-  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
-  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+  echo "FAIL  [fail-open] main() not @fail_open-wrapped (rc=$_failopen_rc out=$_failopen_out)"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open guard wrapping")
 fi
 
 

--- a/tests/hooks/preflight-gate/test_commit_title_format_check.sh
+++ b/tests/hooks/preflight-gate/test_commit_title_format_check.sh
@@ -416,30 +416,28 @@ run_case "git -C /path commit valid title (silent)" \
   "silent" \
   '{"tool_name":"Bash","tool_input":{"command":"git -C /some/path commit -m \"feat(scope): add feature\""}}'
 # ---------------------------------------------------------------------------
-# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
 # ---------------------------------------------------------------------------
-# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
-# _main_inner and assert the outer try/except Exception wrapper in main()
-# returns exit 0 with no stderr — the documented "a hook never breaks a
-# normal session" fail-open contract.
+# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
+# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
+# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
+# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
 _failopen_out=$(python3 - << PYEOF 2>&1
-import sys, importlib.util, io
+import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
-def _raise(): raise MemoryError("simulated catastrophic failure")
-mod._main_inner = _raise
-sys.stdin = io.StringIO('{}')
-sys.exit(mod.main())
+assert getattr(mod.main, "__wrapped__", None) is not None, "main is not @fail_open-wrapped"
+print("OK")
 PYEOF
 )
 _failopen_rc=$?
-if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
-  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+if [ "$_failopen_rc" -eq 0 ] && [ "$_failopen_out" = "OK" ]; then
+  echo "PASS  [fail-open] main() is wrapped by the shared @fail_open guard"
   PASS=$((PASS+1))
 else
-  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
-  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+  echo "FAIL  [fail-open] main() not @fail_open-wrapped (rc=$_failopen_rc out=$_failopen_out)"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open guard wrapping")
 fi
 
 

--- a/tests/hooks/preflight-gate/test_commit_title_format_check.sh
+++ b/tests/hooks/preflight-gate/test_commit_title_format_check.sh
@@ -415,6 +415,34 @@ run_case "git -c key=val commit bad title (block)" \
 run_case "git -C /path commit valid title (silent)" \
   "silent" \
   '{"tool_name":"Bash","tool_input":{"command":"git -C /some/path commit -m \"feat(scope): add feature\""}}'
+# ---------------------------------------------------------------------------
+# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# ---------------------------------------------------------------------------
+# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
+# _main_inner and assert the outer try/except Exception wrapper in main()
+# returns exit 0 with no stderr — the documented "a hook never breaks a
+# normal session" fail-open contract.
+_failopen_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, io
+spec = importlib.util.spec_from_file_location("impl", "$HOOK")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+def _raise(): raise MemoryError("simulated catastrophic failure")
+mod._main_inner = _raise
+sys.stdin = io.StringIO('{}')
+sys.exit(mod.main())
+PYEOF
+)
+_failopen_rc=$?
+if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
+  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+  PASS=$((PASS+1))
+else
+  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+fi
+
+
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/hooks/preflight-gate/test_commit_title_format_check.sh
+++ b/tests/hooks/preflight-gate/test_commit_title_format_check.sh
@@ -415,13 +415,8 @@ run_case "git -c key=val commit bad title (block)" \
 run_case "git -C /path commit valid title (silent)" \
   "silent" \
   '{"tool_name":"Bash","tool_input":{"command":"git -C /some/path commit -m \"feat(scope): add feature\""}}'
-# ---------------------------------------------------------------------------
-# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
-# ---------------------------------------------------------------------------
-# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
-# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
-# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
-# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
+# Fail-open guard opt-in (issue #498): main() must be @fail_open-wrapped;
+# guard behavior is tested centrally in tests/test_hook_runtime.sh.
 _failopen_out=$(python3 - << PYEOF 2>&1
 import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")

--- a/tests/hooks/preflight-gate/test_cross_boundary_preflight.sh
+++ b/tests/hooks/preflight-gate/test_cross_boundary_preflight.sh
@@ -318,13 +318,8 @@ if [ "$bad_rc" -eq 0 ] && [ -z "$bad_out" ]; then
 else
   echo "FAIL  [malformed JSON fail-open] rc=$bad_rc out=$bad_out"; FAIL=$((FAIL+1)); FAILED_NAMES+=("malformed JSON")
 fi
-# ---------------------------------------------------------------------------
-# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
-# ---------------------------------------------------------------------------
-# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
-# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
-# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
-# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
+# Fail-open guard opt-in (issue #498): main() must be @fail_open-wrapped;
+# guard behavior is tested centrally in tests/test_hook_runtime.sh.
 _failopen_out=$(python3 - << PYEOF 2>&1
 import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$REPO_ROOT/hooks/preflight-gate/cross-boundary-preflight/impl.py")

--- a/tests/hooks/preflight-gate/test_cross_boundary_preflight.sh
+++ b/tests/hooks/preflight-gate/test_cross_boundary_preflight.sh
@@ -319,30 +319,28 @@ else
   echo "FAIL  [malformed JSON fail-open] rc=$bad_rc out=$bad_out"; FAIL=$((FAIL+1)); FAILED_NAMES+=("malformed JSON")
 fi
 # ---------------------------------------------------------------------------
-# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
 # ---------------------------------------------------------------------------
-# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
-# _main_inner and assert the outer try/except Exception wrapper in main()
-# returns exit 0 with no stderr — the documented "a hook never breaks a
-# normal session" fail-open contract.
+# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
+# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
+# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
+# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
 _failopen_out=$(python3 - << PYEOF 2>&1
-import sys, importlib.util, io
+import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$REPO_ROOT/hooks/preflight-gate/cross-boundary-preflight/impl.py")
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
-def _raise(): raise MemoryError("simulated catastrophic failure")
-mod._main_inner = _raise
-sys.stdin = io.StringIO('{}')
-sys.exit(mod.main())
+assert getattr(mod.main, "__wrapped__", None) is not None, "main is not @fail_open-wrapped"
+print("OK")
 PYEOF
 )
 _failopen_rc=$?
-if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
-  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+if [ "$_failopen_rc" -eq 0 ] && [ "$_failopen_out" = "OK" ]; then
+  echo "PASS  [fail-open] main() is wrapped by the shared @fail_open guard"
   PASS=$((PASS+1))
 else
-  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
-  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+  echo "FAIL  [fail-open] main() not @fail_open-wrapped (rc=$_failopen_rc out=$_failopen_out)"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open guard wrapping")
 fi
 
 

--- a/tests/hooks/preflight-gate/test_cross_boundary_preflight.sh
+++ b/tests/hooks/preflight-gate/test_cross_boundary_preflight.sh
@@ -318,6 +318,34 @@ if [ "$bad_rc" -eq 0 ] && [ -z "$bad_out" ]; then
 else
   echo "FAIL  [malformed JSON fail-open] rc=$bad_rc out=$bad_out"; FAIL=$((FAIL+1)); FAILED_NAMES+=("malformed JSON")
 fi
+# ---------------------------------------------------------------------------
+# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# ---------------------------------------------------------------------------
+# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
+# _main_inner and assert the outer try/except Exception wrapper in main()
+# returns exit 0 with no stderr — the documented "a hook never breaks a
+# normal session" fail-open contract.
+_failopen_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, io
+spec = importlib.util.spec_from_file_location("impl", "$REPO_ROOT/hooks/preflight-gate/cross-boundary-preflight/impl.py")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+def _raise(): raise MemoryError("simulated catastrophic failure")
+mod._main_inner = _raise
+sys.stdin = io.StringIO('{}')
+sys.exit(mod.main())
+PYEOF
+)
+_failopen_rc=$?
+if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
+  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+  PASS=$((PASS+1))
+else
+  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+fi
+
+
 
 # ---------------------------------------------------------------------------
 echo

--- a/tests/hooks/preflight-gate/test_gh_flag_verify.sh
+++ b/tests/hooks/preflight-gate/test_gh_flag_verify.sh
@@ -304,30 +304,28 @@ run_case "T35: gh -R owner/repo issue list (known global flag, silent)" \
   "silent" \
   '{"tool_name":"Bash","tool_input":{"command":"gh -R owner/repo issue list"}}'
 # ---------------------------------------------------------------------------
-# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
 # ---------------------------------------------------------------------------
-# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
-# _main_inner and assert the outer try/except Exception wrapper in main()
-# returns exit 0 with no stderr — the documented "a hook never breaks a
-# normal session" fail-open contract.
+# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
+# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
+# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
+# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
 _failopen_out=$(python3 - << PYEOF 2>&1
-import sys, importlib.util, io
+import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
-def _raise(): raise MemoryError("simulated catastrophic failure")
-mod._main_inner = _raise
-sys.stdin = io.StringIO('{}')
-sys.exit(mod.main())
+assert getattr(mod.main, "__wrapped__", None) is not None, "main is not @fail_open-wrapped"
+print("OK")
 PYEOF
 )
 _failopen_rc=$?
-if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
-  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+if [ "$_failopen_rc" -eq 0 ] && [ "$_failopen_out" = "OK" ]; then
+  echo "PASS  [fail-open] main() is wrapped by the shared @fail_open guard"
   PASS=$((PASS+1))
 else
-  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
-  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+  echo "FAIL  [fail-open] main() not @fail_open-wrapped (rc=$_failopen_rc out=$_failopen_out)"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open guard wrapping")
 fi
 
 

--- a/tests/hooks/preflight-gate/test_gh_flag_verify.sh
+++ b/tests/hooks/preflight-gate/test_gh_flag_verify.sh
@@ -303,13 +303,8 @@ run_case "T34: gh -R owner/repo --hostname x issue list (valid+invalid global fl
 run_case "T35: gh -R owner/repo issue list (known global flag, silent)" \
   "silent" \
   '{"tool_name":"Bash","tool_input":{"command":"gh -R owner/repo issue list"}}'
-# ---------------------------------------------------------------------------
-# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
-# ---------------------------------------------------------------------------
-# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
-# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
-# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
-# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
+# Fail-open guard opt-in (issue #498): main() must be @fail_open-wrapped;
+# guard behavior is tested centrally in tests/test_hook_runtime.sh.
 _failopen_out=$(python3 - << PYEOF 2>&1
 import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")

--- a/tests/hooks/preflight-gate/test_gh_flag_verify.sh
+++ b/tests/hooks/preflight-gate/test_gh_flag_verify.sh
@@ -303,6 +303,34 @@ run_case "T34: gh -R owner/repo --hostname x issue list (valid+invalid global fl
 run_case "T35: gh -R owner/repo issue list (known global flag, silent)" \
   "silent" \
   '{"tool_name":"Bash","tool_input":{"command":"gh -R owner/repo issue list"}}'
+# ---------------------------------------------------------------------------
+# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# ---------------------------------------------------------------------------
+# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
+# _main_inner and assert the outer try/except Exception wrapper in main()
+# returns exit 0 with no stderr — the documented "a hook never breaks a
+# normal session" fail-open contract.
+_failopen_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, io
+spec = importlib.util.spec_from_file_location("impl", "$HOOK")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+def _raise(): raise MemoryError("simulated catastrophic failure")
+mod._main_inner = _raise
+sys.stdin = io.StringIO('{}')
+sys.exit(mod.main())
+PYEOF
+)
+_failopen_rc=$?
+if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
+  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+  PASS=$((PASS+1))
+else
+  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+fi
+
+
 
 echo ""
 echo "Result: $PASS passed, $FAIL failed"

--- a/tests/hooks/preflight-gate/test_gh_json_validator.sh
+++ b/tests/hooks/preflight-gate/test_gh_json_validator.sh
@@ -260,6 +260,34 @@ run_case "skip: no --json flag" \
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
+# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# ---------------------------------------------------------------------------
+# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
+# _main_inner and assert the outer try/except Exception wrapper in main()
+# returns exit 0 with no stderr — the documented "a hook never breaks a
+# normal session" fail-open contract.
+_failopen_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, io
+spec = importlib.util.spec_from_file_location("impl", "$HOOK_PY")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+def _raise(): raise MemoryError("simulated catastrophic failure")
+mod._main_inner = _raise
+sys.stdin = io.StringIO('{}')
+sys.exit(mod.main())
+PYEOF
+)
+_failopen_rc=$?
+if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
+  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+  PASS=$((PASS+1))
+else
+  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+fi
+
+
+# ---------------------------------------------------------------------------
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/hooks/preflight-gate/test_gh_json_validator.sh
+++ b/tests/hooks/preflight-gate/test_gh_json_validator.sh
@@ -260,30 +260,28 @@ run_case "skip: no --json flag" \
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
-# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
 # ---------------------------------------------------------------------------
-# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
-# _main_inner and assert the outer try/except Exception wrapper in main()
-# returns exit 0 with no stderr — the documented "a hook never breaks a
-# normal session" fail-open contract.
+# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
+# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
+# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
+# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
 _failopen_out=$(python3 - << PYEOF 2>&1
-import sys, importlib.util, io
+import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK_PY")
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
-def _raise(): raise MemoryError("simulated catastrophic failure")
-mod._main_inner = _raise
-sys.stdin = io.StringIO('{}')
-sys.exit(mod.main())
+assert getattr(mod.main, "__wrapped__", None) is not None, "main is not @fail_open-wrapped"
+print("OK")
 PYEOF
 )
 _failopen_rc=$?
-if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
-  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+if [ "$_failopen_rc" -eq 0 ] && [ "$_failopen_out" = "OK" ]; then
+  echo "PASS  [fail-open] main() is wrapped by the shared @fail_open guard"
   PASS=$((PASS+1))
 else
-  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
-  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+  echo "FAIL  [fail-open] main() not @fail_open-wrapped (rc=$_failopen_rc out=$_failopen_out)"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open guard wrapping")
 fi
 
 

--- a/tests/hooks/preflight-gate/test_gh_json_validator.sh
+++ b/tests/hooks/preflight-gate/test_gh_json_validator.sh
@@ -259,13 +259,8 @@ run_case "skip: no --json flag" \
 
 # ---------------------------------------------------------------------------
 # Summary
-# ---------------------------------------------------------------------------
-# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
-# ---------------------------------------------------------------------------
-# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
-# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
-# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
-# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
+# Fail-open guard opt-in (issue #498): main() must be @fail_open-wrapped;
+# guard behavior is tested centrally in tests/test_hook_runtime.sh.
 _failopen_out=$(python3 - << PYEOF 2>&1
 import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK_PY")

--- a/tests/hooks/preflight-gate/test_pre_gh_pr_create_dedup_gate.sh
+++ b/tests/hooks/preflight-gate/test_pre_gh_pr_create_dedup_gate.sh
@@ -346,30 +346,28 @@ rm -f "$bad_json_err"
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
-# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
 # ---------------------------------------------------------------------------
-# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
-# _main_inner and assert the outer try/except Exception wrapper in main()
-# returns exit 0 with no stderr — the documented "a hook never breaks a
-# normal session" fail-open contract.
+# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
+# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
+# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
+# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
 _failopen_out=$(python3 - << PYEOF 2>&1
-import sys, importlib.util, io
+import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
-def _raise(): raise MemoryError("simulated catastrophic failure")
-mod._main_inner = _raise
-sys.stdin = io.StringIO('{}')
-sys.exit(mod.main())
+assert getattr(mod.main, "__wrapped__", None) is not None, "main is not @fail_open-wrapped"
+print("OK")
 PYEOF
 )
 _failopen_rc=$?
-if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
-  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+if [ "$_failopen_rc" -eq 0 ] && [ "$_failopen_out" = "OK" ]; then
+  echo "PASS  [fail-open] main() is wrapped by the shared @fail_open guard"
   PASS=$((PASS+1))
 else
-  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
-  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+  echo "FAIL  [fail-open] main() not @fail_open-wrapped (rc=$_failopen_rc out=$_failopen_out)"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open guard wrapping")
 fi
 
 

--- a/tests/hooks/preflight-gate/test_pre_gh_pr_create_dedup_gate.sh
+++ b/tests/hooks/preflight-gate/test_pre_gh_pr_create_dedup_gate.sh
@@ -345,13 +345,8 @@ rm -f "$bad_json_err"
 
 # ---------------------------------------------------------------------------
 # Summary
-# ---------------------------------------------------------------------------
-# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
-# ---------------------------------------------------------------------------
-# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
-# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
-# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
-# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
+# Fail-open guard opt-in (issue #498): main() must be @fail_open-wrapped;
+# guard behavior is tested centrally in tests/test_hook_runtime.sh.
 _failopen_out=$(python3 - << PYEOF 2>&1
 import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")

--- a/tests/hooks/preflight-gate/test_pre_gh_pr_create_dedup_gate.sh
+++ b/tests/hooks/preflight-gate/test_pre_gh_pr_create_dedup_gate.sh
@@ -346,6 +346,34 @@ rm -f "$bad_json_err"
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
+# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# ---------------------------------------------------------------------------
+# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
+# _main_inner and assert the outer try/except Exception wrapper in main()
+# returns exit 0 with no stderr — the documented "a hook never breaks a
+# normal session" fail-open contract.
+_failopen_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, io
+spec = importlib.util.spec_from_file_location("impl", "$HOOK")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+def _raise(): raise MemoryError("simulated catastrophic failure")
+mod._main_inner = _raise
+sys.stdin = io.StringIO('{}')
+sys.exit(mod.main())
+PYEOF
+)
+_failopen_rc=$?
+if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
+  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+  PASS=$((PASS+1))
+else
+  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+fi
+
+
+# ---------------------------------------------------------------------------
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/hooks/preflight-gate/test_verify_commit_flag_override.sh
+++ b/tests/hooks/preflight-gate/test_verify_commit_flag_override.sh
@@ -233,6 +233,34 @@ fi
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
+# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# ---------------------------------------------------------------------------
+# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
+# _main_inner and assert the outer try/except Exception wrapper in main()
+# returns exit 0 with no stderr — the documented "a hook never breaks a
+# normal session" fail-open contract.
+_failopen_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, io
+spec = importlib.util.spec_from_file_location("impl", "$HOOK")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+def _raise(): raise MemoryError("simulated catastrophic failure")
+mod._main_inner = _raise
+sys.stdin = io.StringIO('{}')
+sys.exit(mod.main())
+PYEOF
+)
+_failopen_rc=$?
+if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
+  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+  PASS=$((PASS+1))
+else
+  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+fi
+
+
+# ---------------------------------------------------------------------------
 
 echo
 echo "==========================="

--- a/tests/hooks/preflight-gate/test_verify_commit_flag_override.sh
+++ b/tests/hooks/preflight-gate/test_verify_commit_flag_override.sh
@@ -232,13 +232,8 @@ fi
 
 # ---------------------------------------------------------------------------
 # Summary
-# ---------------------------------------------------------------------------
-# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
-# ---------------------------------------------------------------------------
-# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
-# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
-# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
-# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
+# Fail-open guard opt-in (issue #498): main() must be @fail_open-wrapped;
+# guard behavior is tested centrally in tests/test_hook_runtime.sh.
 _failopen_out=$(python3 - << PYEOF 2>&1
 import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")

--- a/tests/hooks/preflight-gate/test_verify_commit_flag_override.sh
+++ b/tests/hooks/preflight-gate/test_verify_commit_flag_override.sh
@@ -233,30 +233,28 @@ fi
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
-# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
 # ---------------------------------------------------------------------------
-# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
-# _main_inner and assert the outer try/except Exception wrapper in main()
-# returns exit 0 with no stderr — the documented "a hook never breaks a
-# normal session" fail-open contract.
+# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
+# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
+# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
+# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
 _failopen_out=$(python3 - << PYEOF 2>&1
-import sys, importlib.util, io
+import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
-def _raise(): raise MemoryError("simulated catastrophic failure")
-mod._main_inner = _raise
-sys.stdin = io.StringIO('{}')
-sys.exit(mod.main())
+assert getattr(mod.main, "__wrapped__", None) is not None, "main is not @fail_open-wrapped"
+print("OK")
 PYEOF
 )
 _failopen_rc=$?
-if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
-  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+if [ "$_failopen_rc" -eq 0 ] && [ "$_failopen_out" = "OK" ]; then
+  echo "PASS  [fail-open] main() is wrapped by the shared @fail_open guard"
   PASS=$((PASS+1))
 else
-  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
-  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+  echo "FAIL  [fail-open] main() not @fail_open-wrapped (rc=$_failopen_rc out=$_failopen_out)"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open guard wrapping")
 fi
 
 

--- a/tests/hooks/preflight-gate/test_worktree_edit_gate.sh
+++ b/tests/hooks/preflight-gate/test_worktree_edit_gate.sh
@@ -388,6 +388,34 @@ run_case "Bash tool → pass (not in scope)" pass \
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
+# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# ---------------------------------------------------------------------------
+# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
+# _main_inner and assert the outer try/except Exception wrapper in main()
+# returns exit 0 with no stderr — the documented "a hook never breaks a
+# normal session" fail-open contract.
+_failopen_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, io
+spec = importlib.util.spec_from_file_location("impl", "$HOOK")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+def _raise(): raise MemoryError("simulated catastrophic failure")
+mod._main_inner = _raise
+sys.stdin = io.StringIO('{}')
+sys.exit(mod.main())
+PYEOF
+)
+_failopen_rc=$?
+if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
+  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+  PASS=$((PASS+1))
+else
+  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+fi
+
+
+# ---------------------------------------------------------------------------
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/hooks/preflight-gate/test_worktree_edit_gate.sh
+++ b/tests/hooks/preflight-gate/test_worktree_edit_gate.sh
@@ -387,13 +387,8 @@ run_case "Bash tool → pass (not in scope)" pass \
 
 # ---------------------------------------------------------------------------
 # Summary
-# ---------------------------------------------------------------------------
-# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
-# ---------------------------------------------------------------------------
-# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
-# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
-# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
-# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
+# Fail-open guard opt-in (issue #498): main() must be @fail_open-wrapped;
+# guard behavior is tested centrally in tests/test_hook_runtime.sh.
 _failopen_out=$(python3 - << PYEOF 2>&1
 import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")

--- a/tests/hooks/preflight-gate/test_worktree_edit_gate.sh
+++ b/tests/hooks/preflight-gate/test_worktree_edit_gate.sh
@@ -388,30 +388,28 @@ run_case "Bash tool → pass (not in scope)" pass \
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
-# Fail-open: uncaught exception in _main_inner returns 0 (issue #498)
+# Fail-open: entrypoint wrapped by the shared @fail_open guard (issue #498)
 # ---------------------------------------------------------------------------
-# Inject an unexpected exception (e.g. MemoryError / RecursionError) into
-# _main_inner and assert the outer try/except Exception wrapper in main()
-# returns exit 0 with no stderr — the documented "a hook never breaks a
-# normal session" fail-open contract.
+# The blocking logic returns 2; _hook_runtime.fail_open turns any uncaught
+# exception into exit 0. The decorator's BEHAVIOR is tested centrally in
+# tests/test_hook_runtime.sh — here we assert only that THIS hook opted into
+# the guard (functools.wraps exposes __wrapped__ on a decorated main()).
 _failopen_out=$(python3 - << PYEOF 2>&1
-import sys, importlib.util, io
+import importlib.util
 spec = importlib.util.spec_from_file_location("impl", "$HOOK")
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
-def _raise(): raise MemoryError("simulated catastrophic failure")
-mod._main_inner = _raise
-sys.stdin = io.StringIO('{}')
-sys.exit(mod.main())
+assert getattr(mod.main, "__wrapped__", None) is not None, "main is not @fail_open-wrapped"
+print("OK")
 PYEOF
 )
 _failopen_rc=$?
-if [ "$_failopen_rc" -eq 0 ] && [ -z "$_failopen_out" ]; then
-  echo "PASS  [fail-open] uncaught exception in _main_inner -> exit 0, no stderr"
+if [ "$_failopen_rc" -eq 0 ] && [ "$_failopen_out" = "OK" ]; then
+  echo "PASS  [fail-open] main() is wrapped by the shared @fail_open guard"
   PASS=$((PASS+1))
 else
-  echo "FAIL  [fail-open] uncaught exception in _main_inner (rc=$_failopen_rc out=$(echo "$_failopen_out" | head -c 160))"
-  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open uncaught exception in _main_inner")
+  echo "FAIL  [fail-open] main() not @fail_open-wrapped (rc=$_failopen_rc out=$_failopen_out)"
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("fail-open guard wrapping")
 fi
 
 

--- a/tests/test_hook_runtime.sh
+++ b/tests/test_hook_runtime.sh
@@ -150,6 +150,23 @@ PYEOF
 )
 assert_eq "unwritable error log still fails open -> 0" "0" "$rc_unwritable"
 
+# Unwritable log + stderr opt-in OFF must leak NOTHING to stderr. This guards
+# the logging-specific hazard: a handler-less logger would trigger
+# logging.lastResort (writes to stderr), and handleError would print a
+# traceback unless raiseExceptions is False. The NullHandler baseline +
+# raiseExceptions=False must keep stderr empty even when the FileHandler fails.
+stderr_unwritable=$(env -u PRAXIS_HOOK_ERROR_STDERR PRAXIS_HOOK_ERROR_LOG="/proc/nonexistent-dir/err.jsonl" python3 - "$LIB" << 'PYEOF' 2>&1 1>/dev/null
+import sys
+sys.path.insert(0, sys.argv[1])
+from _hook_runtime import fail_open
+@fail_open
+def boom():
+    raise ValueError("no-stderr-leak")
+boom()
+PYEOF
+)
+assert_eq "unwritable log leaks nothing to stderr (no lastResort)" "" "$stderr_unwritable"
+
 # Opt-in stderr surfacing: off by default, on with PRAXIS_HOOK_ERROR_STDERR=1.
 TMP_LOG2="$(mktemp -u "${TMPDIR:-/tmp}/praxis-hook-err-test2-XXXXXX").jsonl"
 stderr_default=$(PRAXIS_HOOK_ERROR_LOG="$TMP_LOG2" python3 - "$LIB" << 'PYEOF' 2>&1 1>/dev/null

--- a/tests/test_hook_runtime.sh
+++ b/tests/test_hook_runtime.sh
@@ -115,6 +115,28 @@ else
 fi
 rm -f "$TMP_LOG"
 
+# Default placement (no PRAXIS_HOOK_ERROR_LOG): lands under ~/.praxis/logs via
+# _paths (PRAXIS_HOME points the home at a temp dir for the test).
+TMP_HOME=$(mktemp -d)
+rc_default=$(env -u PRAXIS_HOOK_ERROR_LOG PRAXIS_HOME="$TMP_HOME" python3 - "$LIB" << 'PYEOF'
+import sys
+sys.path.insert(0, sys.argv[1])
+from _hook_runtime import fail_open
+@fail_open
+def boom():
+    raise ValueError("home-routed")
+print(boom())
+PYEOF
+)
+assert_eq "default error log routes via ~/.praxis (returns 0)" "0" "$rc_default"
+if [ -s "$TMP_HOME/logs/hook-errors.jsonl" ] \
+   && grep -q '"message": "home-routed"' "$TMP_HOME/logs/hook-errors.jsonl"; then
+  echo "PASS  [default error log written under <PRAXIS_HOME>/logs/hook-errors.jsonl]"; PASS=$((PASS + 1))
+else
+  echo "FAIL  [default error log not under PRAXIS_HOME/logs]"; FAIL=$((FAIL + 1)); FAILED_NAMES+=("default error log placement")
+fi
+rm -rf "$TMP_HOME"
+
 # Unwritable log path must NOT re-break fail-open (recorder is self-guarded).
 rc_unwritable=$(PRAXIS_HOOK_ERROR_LOG="/proc/nonexistent-dir/err.jsonl" python3 - "$LIB" << 'PYEOF'
 import sys

--- a/tests/test_hook_runtime.sh
+++ b/tests/test_hook_runtime.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# test_hook_runtime.sh — behavioral coverage for hooks/_lib/_hook_runtime.py
+#
+# fail_open is the single, shared entrypoint guard for blocking PreToolUse
+# gates (issue #498). Its contract is tested HERE once, instead of being
+# re-tested in every hook (issue #470 DRY playbook). Each hook's own suite
+# only asserts it opted into the guard (main.__wrapped__ is set).
+#
+# Asserts:
+#   - an uncaught Exception (MemoryError / RecursionError) -> exit 0 (allow)
+#   - a real block return (2) is passed through untouched
+#   - a normal allow return (0) is passed through
+#   - BaseException (KeyboardInterrupt / SystemExit) is NOT swallowed
+#   - functools.wraps exposes __wrapped__ on the decorated function
+
+set +e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+LIB="$ROOT_DIR/hooks/_lib"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS  [$name]"; PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expected=$expected actual=$actual"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# Each check prints a single token we compare against.
+run() {
+  python3 - "$LIB" << 'PYEOF'
+import sys
+sys.path.insert(0, sys.argv[1])
+from _hook_runtime import fail_open
+
+results = []
+
+@fail_open
+def boom_mem():
+    raise MemoryError("catastrophic")
+results.append(("mem", boom_mem()))
+
+@fail_open
+def boom_rec():
+    raise RecursionError("deep")
+results.append(("rec", boom_rec()))
+
+@fail_open
+def real_block():
+    return 2
+results.append(("block", real_block()))
+
+@fail_open
+def allow():
+    return 0
+results.append(("allow", allow()))
+
+# BaseException must propagate (not become 0).
+@fail_open
+def interrupt():
+    raise KeyboardInterrupt()
+try:
+    interrupt()
+    results.append(("base", "SWALLOWED"))
+except KeyboardInterrupt:
+    results.append(("base", "PROPAGATED"))
+
+# functools.wraps seam
+results.append(("wrapped", "yes" if getattr(real_block, "__wrapped__", None) else "no"))
+
+print(";".join(f"{k}={v}" for k, v in results))
+PYEOF
+}
+
+OUT="$(run)"
+echo "raw: $OUT"
+
+get() { echo "$OUT" | tr ';' '\n' | grep "^$1=" | cut -d= -f2; }
+
+assert_eq "MemoryError fails open -> 0"      "0"          "$(get mem)"
+assert_eq "RecursionError fails open -> 0"   "0"          "$(get rec)"
+assert_eq "real block (2) passed through"    "2"          "$(get block)"
+assert_eq "allow (0) passed through"         "0"          "$(get allow)"
+assert_eq "BaseException propagates"         "PROPAGATED" "$(get base)"
+assert_eq "functools.wraps __wrapped__ set"  "yes"        "$(get wrapped)"
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  printf '  - %s\n' "${FAILED_NAMES[@]}"
+  exit 1
+fi
+exit 0

--- a/tests/test_hook_runtime.sh
+++ b/tests/test_hook_runtime.sh
@@ -90,6 +90,73 @@ assert_eq "allow (0) passed through"         "0"          "$(get allow)"
 assert_eq "BaseException propagates"         "PROPAGATED" "$(get base)"
 assert_eq "functools.wraps __wrapped__ set"  "yes"        "$(get wrapped)"
 
+# ---------------------------------------------------------------------------
+# Observability: fail-open is NOT fail-silent — a swallowed exception is
+# recorded to the JSONL error log, and a log-write failure still fails open.
+# ---------------------------------------------------------------------------
+TMP_LOG="$(mktemp -u "${TMPDIR:-/tmp}/praxis-hook-err-test-XXXXXX").jsonl"
+rc_logged=$(PRAXIS_HOOK_ERROR_LOG="$TMP_LOG" python3 - "$LIB" << 'PYEOF'
+import sys
+sys.path.insert(0, sys.argv[1])
+from _hook_runtime import fail_open
+@fail_open
+def boom():
+    raise ValueError("diagnose me")
+print(boom())
+PYEOF
+)
+assert_eq "swallowed exc still returns 0 (with logging)" "0" "$rc_logged"
+if [ -s "$TMP_LOG" ] && grep -q '"exc_type": "ValueError"' "$TMP_LOG" \
+   && grep -q '"message": "diagnose me"' "$TMP_LOG" && grep -q '"traceback"' "$TMP_LOG"; then
+  echo "PASS  [error log records swallowed exception (type+message+traceback)]"; PASS=$((PASS + 1))
+else
+  echo "FAIL  [error log missing/incomplete] content=$(cat "$TMP_LOG" 2>/dev/null | head -c 200)"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("error log records swallowed exception")
+fi
+rm -f "$TMP_LOG"
+
+# Unwritable log path must NOT re-break fail-open (recorder is self-guarded).
+rc_unwritable=$(PRAXIS_HOOK_ERROR_LOG="/proc/nonexistent-dir/err.jsonl" python3 - "$LIB" << 'PYEOF'
+import sys
+sys.path.insert(0, sys.argv[1])
+from _hook_runtime import fail_open
+@fail_open
+def boom():
+    raise RuntimeError("x")
+print(boom())
+PYEOF
+)
+assert_eq "unwritable error log still fails open -> 0" "0" "$rc_unwritable"
+
+# Opt-in stderr surfacing: off by default, on with PRAXIS_HOOK_ERROR_STDERR=1.
+TMP_LOG2="$(mktemp -u "${TMPDIR:-/tmp}/praxis-hook-err-test2-XXXXXX").jsonl"
+stderr_default=$(PRAXIS_HOOK_ERROR_LOG="$TMP_LOG2" python3 - "$LIB" << 'PYEOF' 2>&1 1>/dev/null
+import sys
+sys.path.insert(0, sys.argv[1])
+from _hook_runtime import fail_open
+@fail_open
+def boom():
+    raise ValueError("q")
+boom()
+PYEOF
+)
+assert_eq "stderr quiet by default" "" "$stderr_default"
+stderr_optin=$(PRAXIS_HOOK_ERROR_LOG="$TMP_LOG2" PRAXIS_HOOK_ERROR_STDERR=1 python3 - "$LIB" << 'PYEOF' 2>&1 1>/dev/null
+import sys
+sys.path.insert(0, sys.argv[1])
+from _hook_runtime import fail_open
+@fail_open
+def boom():
+    raise ValueError("q")
+boom()
+PYEOF
+)
+case "$stderr_optin" in
+  *"[praxis:hook-error]"*"ValueError"*) echo "PASS  [opt-in stderr surfaces hook error]"; PASS=$((PASS + 1)) ;;
+  *) echo "FAIL  [opt-in stderr] got=$stderr_optin"; FAIL=$((FAIL + 1)); FAILED_NAMES+=("opt-in stderr surfaces hook error") ;;
+esac
+rm -f "$TMP_LOG2"
+
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/tests/test_hook_runtime.sh
+++ b/tests/test_hook_runtime.sh
@@ -90,10 +90,8 @@ assert_eq "allow (0) passed through"         "0"          "$(get allow)"
 assert_eq "BaseException propagates"         "PROPAGATED" "$(get base)"
 assert_eq "functools.wraps __wrapped__ set"  "yes"        "$(get wrapped)"
 
-# ---------------------------------------------------------------------------
-# Observability: fail-open is NOT fail-silent — a swallowed exception is
-# recorded to the JSONL error log, and a log-write failure still fails open.
-# ---------------------------------------------------------------------------
+# Observability: swallowed exception is recorded to the JSONL log; a failed
+# log write still fails open.
 TMP_LOG="$(mktemp -u "${TMPDIR:-/tmp}/praxis-hook-err-test-XXXXXX").jsonl"
 rc_logged=$(PRAXIS_HOOK_ERROR_LOG="$TMP_LOG" python3 - "$LIB" << 'PYEOF'
 import sys
@@ -115,8 +113,7 @@ else
 fi
 rm -f "$TMP_LOG"
 
-# Default placement (no PRAXIS_HOOK_ERROR_LOG): lands under ~/.praxis/logs via
-# _paths (PRAXIS_HOME points the home at a temp dir for the test).
+# Default placement (no PRAXIS_HOOK_ERROR_LOG): lands under <PRAXIS_HOME>/logs.
 TMP_HOME=$(mktemp -d)
 rc_default=$(env -u PRAXIS_HOOK_ERROR_LOG PRAXIS_HOME="$TMP_HOME" python3 - "$LIB" << 'PYEOF'
 import sys
@@ -150,11 +147,8 @@ PYEOF
 )
 assert_eq "unwritable error log still fails open -> 0" "0" "$rc_unwritable"
 
-# Unwritable log + stderr opt-in OFF must leak NOTHING to stderr. This guards
-# the logging-specific hazard: a handler-less logger would trigger
-# logging.lastResort (writes to stderr), and handleError would print a
-# traceback unless raiseExceptions is False. The NullHandler baseline +
-# raiseExceptions=False must keep stderr empty even when the FileHandler fails.
+# Unwritable log + stderr opt-in OFF must leak NOTHING to stderr (guards the
+# lastResort/handleError hazard; NullHandler + raiseExceptions=False).
 stderr_unwritable=$(env -u PRAXIS_HOOK_ERROR_STDERR PRAXIS_HOOK_ERROR_LOG="/proc/nonexistent-dir/err.jsonl" python3 - "$LIB" << 'PYEOF' 2>&1 1>/dev/null
 import sys
 sys.path.insert(0, sys.argv[1])

--- a/tests/test_paths.sh
+++ b/tests/test_paths.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# test_paths.sh — coverage for hooks/_lib/_paths.py
+#
+# Asserts the host-neutral praxis home resolution and writable fallback:
+#   - praxis_home() default = ~/.praxis (expanduser)
+#   - PRAXIS_HOME override is honored (and expanded)
+#   - resolve_writable creates <home>/<subdir> and returns the file path
+#   - resolve_writable falls back to ${TMPDIR}/praxis-<file> when home is
+#     not writable, and never raises
+
+set +e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+LIB="$ROOT_DIR/hooks/_lib"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS  [$name]"; PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expected=$expected actual=$actual"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# 1. default home ends with /.praxis
+default_home=$(env -u PRAXIS_HOME python3 - "$LIB" << 'PYEOF'
+import sys
+sys.path.insert(0, sys.argv[1])
+from _paths import praxis_home
+h = praxis_home()
+print("yes" if h.endswith("/.praxis") and "~" not in h else f"no:{h}")
+PYEOF
+)
+assert_eq "default home = ~/.praxis (expanded)" "yes" "$default_home"
+
+# 2. PRAXIS_HOME override honored + a real file created under <home>/logs
+TMP_HOME=$(mktemp -d)
+override_path=$(PRAXIS_HOME="$TMP_HOME" python3 - "$LIB" << 'PYEOF'
+import sys
+sys.path.insert(0, sys.argv[1])
+from _paths import resolve_writable
+p = resolve_writable("logs", "x.jsonl")
+open(p, "a").close()
+print(p)
+PYEOF
+)
+assert_eq "resolve_writable under PRAXIS_HOME" "$TMP_HOME/logs/x.jsonl" "$override_path"
+if [ -d "$TMP_HOME/logs" ]; then
+  echo "PASS  [resolve_writable created the subdir]"; PASS=$((PASS + 1))
+else
+  echo "FAIL  [resolve_writable did not create subdir]"; FAIL=$((FAIL + 1)); FAILED_NAMES+=("subdir created")
+fi
+rm -rf "$TMP_HOME"
+
+# 3. Unwritable home -> TMPDIR fallback (never raises)
+fallback=$(PRAXIS_HOME="/proc/nonexistent-praxis-home" TMPDIR="/tmp" python3 - "$LIB" << 'PYEOF'
+import sys
+sys.path.insert(0, sys.argv[1])
+from _paths import resolve_writable
+print(resolve_writable("logs", "hook-errors.jsonl"))
+PYEOF
+)
+assert_eq "unwritable home falls back to TMPDIR" "/tmp/praxis-hook-errors.jsonl" "$fallback"
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  printf '  - %s\n' "${FAILED_NAMES[@]}"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## ⟳ Revised approach (review feedback — architecture + naming)

The original revision hand-rolled a byte-identical `_main_inner()` / `main()`
wrapper pair in each of the 13 hooks. Review feedback correctly flagged that
this (a) duplicates a cross-cutting concern that the codebase's own doctrine
says belongs in `_lib` — the exact pattern `_hook_io.py` (#470) and
`block_message.py` (#439) were created to eliminate — and (b) names the real
gate logic `_main_inner`, which describes position, not intent.

**Now:** the fail-open contract lives in a single shared decorator,
`hooks/_lib/_hook_runtime.py::fail_open`. Each of the 13 hooks is just:

```python
from _hook_runtime import fail_open

@fail_open
def main() -> int:
    ...        # real gate logic; return 2 to block, 0 to allow
```

- **One edit site, one behavioral test.** `tests/test_hook_runtime.sh` tests the
  contract once: `MemoryError`/`RecursionError` → exit 0; a real block
  (`return 2`) passed through untouched; `BaseException`
  (KeyboardInterrupt/SystemExit) still propagates; `functools.wraps` exposes
  `__wrapped__`. Each hook's suite now asserts only that it opted in
  (`main.__wrapped__` is set) instead of carrying its own ~28-line copy.
- **Behavior unchanged** from the original revision — only the structure/naming.
- **Scope note:** the ~20 sibling hooks fixed in #508 still use the old
  `_main_inner` pattern. Sweeping them onto `@fail_open` is a deliberate
  follow-up to keep this PR's scope contained (two patterns coexist until then).

Gates: 12/13 hook suites green; `test_worktree_edit_gate.sh` shows only the
pre-existing sandbox `gpgsign` HTTP 400 failures (identical with this change
stashed). `test_hook_runtime.sh` 6/6 green. `check-plugin-manifests.py` →
`plugin-manifest check OK`.

---

<details><summary>Original PR description (the per-hook wrapper approach — superseded above)</summary>

## Summary

13 BLOCKING preflight-gate hooks caught only stdin parse errors (`except Exception` around `json.load(sys.stdin)`) and ran later IO — `subprocess` / `read_text` / `glob` / tokenization / backtracking-prone regex — **outside any outer exception guard**. An unexpected exception (MemoryError, RecursionError from catastrophic backtracking, an uncaught UnicodeError variant) would propagate, crash the hook, and block a legitimate `git commit` / `gh issue create` — violating the documented fail-open contract ("a hook never breaks a normal session", `_hook_io.py` / `destructive-bash-guard`).

This applies the same `_main_inner()` + outer `try/except Exception: return 0` wrapper that sibling hooks (fixed in #508) already use. **Blocking logic is unchanged — only the outer wrapper is added.**

### Hooks fixed (13)

`block-ask-end-option`, `block-gh-state-all`, `block-manufactured-action-menu`, `block-pr-without-caller-evidence`, `block-pr-without-precommit-evidence`, `branch-name-check`, `commit-title-format-check`, `cross-boundary-preflight`, `gh-flag-verify`, `gh-json-validator`, `pre-gh-pr-create-dedup-gate`, `verify-commit-flag-override`, `worktree-edit-gate`

Closes #498

</details>

https://claude.ai/code/session_018kbj976pDgrh11A2xCvfPc