### PR TITLE
fix(hooks): misc parsing defects and test-infra collision

### DIFF
--- a/docs/bypass-telemetry.md
+++ b/docs/bypass-telemetry.md
@@ -49,7 +49,8 @@ Both naming conventions used in praxis are detected:
 
 Detection regex: `^(?:CLAUDE_HOOK_|PRAXIS_).*BYPASS`
 
-A var is only recorded if its value is truthy (non-empty and not `"0"`).
+A var is only recorded if its value is truthy: non-empty and not one of the
+shell-falsy literals `0` / `false` / `no` / `off` (case-insensitive).
 
 ## Privacy guarantees
 

--- a/hooks/advisory-nudge/bash-worktree-existence-advisory/impl.py
+++ b/hooks/advisory-nudge/bash-worktree-existence-advisory/impl.py
@@ -391,12 +391,9 @@ def _main_inner() -> int:
 
         target, is_subshell_flag = _extract_cd_target(seg_for_extract)
 
-        # Capture whether *this* segment ran inside the subshell BEFORE resetting
-        # the flag. The closing segment of `(cd A && cd B)` still belongs to the
-        # subshell, so its cwd update must land on subshell_cwd — not the outer
-        # effective_cwd. Resetting in_subshell first (then reading it at the
-        # update step below) would route the subshell path into effective_cwd
-        # and pollute the outer base for subsequent relative `cd` resolution.
+        # Capture subshell membership BEFORE resetting the flag: the closing
+        # segment of `(cd A && cd B)` still belongs to the subshell, so its cwd
+        # update must land on subshell_cwd, not pollute the outer effective_cwd.
         was_in_subshell = in_subshell
 
         if seg_closes_subshell and in_subshell:
@@ -429,8 +426,7 @@ def _main_inner() -> int:
                 _record_dedupe(session_id, real_target, "missing")
         else:
             # Path exists. Update the appropriate cwd tracker (keyed on
-            # was_in_subshell, i.e. whether *this* segment ran inside the
-            # subshell — including its closing segment):
+            # was_in_subshell, which includes the subshell's closing segment):
             # - inside a subshell: always update subshell_cwd (outer not
             #   affected regardless of is_subshell_flag; the flag only guards
             #   the outer effective_cwd update for pushd/subshell-opener).

--- a/hooks/advisory-nudge/bash-worktree-existence-advisory/impl.py
+++ b/hooks/advisory-nudge/bash-worktree-existence-advisory/impl.py
@@ -391,6 +391,14 @@ def _main_inner() -> int:
 
         target, is_subshell_flag = _extract_cd_target(seg_for_extract)
 
+        # Capture whether *this* segment ran inside the subshell BEFORE resetting
+        # the flag. The closing segment of `(cd A && cd B)` still belongs to the
+        # subshell, so its cwd update must land on subshell_cwd — not the outer
+        # effective_cwd. Resetting in_subshell first (then reading it at the
+        # update step below) would route the subshell path into effective_cwd
+        # and pollute the outer base for subsequent relative `cd` resolution.
+        was_in_subshell = in_subshell
+
         if seg_closes_subshell and in_subshell:
             in_subshell = False  # subshell closed; revert to outer cwd next seg
 
@@ -420,13 +428,15 @@ def _main_inner() -> int:
             if session_id:
                 _record_dedupe(session_id, real_target, "missing")
         else:
-            # Path exists. Update the appropriate cwd tracker:
+            # Path exists. Update the appropriate cwd tracker (keyed on
+            # was_in_subshell, i.e. whether *this* segment ran inside the
+            # subshell — including its closing segment):
             # - inside a subshell: always update subshell_cwd (outer not
             #   affected regardless of is_subshell_flag; the flag only guards
             #   the outer effective_cwd update for pushd/subshell-opener).
             # - pushd at parent-shell level (is_subshell_flag=True): skip.
             # - bare cd at parent-shell level: update effective_cwd.
-            if in_subshell:
+            if was_in_subshell:
                 subshell_cwd = abs_target
             elif not is_subshell_flag:
                 effective_cwd = abs_target

--- a/hooks/advisory-nudge/count-assertion-verify/impl.py
+++ b/hooks/advisory-nudge/count-assertion-verify/impl.py
@@ -97,16 +97,17 @@ _ERE_LONG_FLAGS = frozenset({"--extended-regexp", "--perl-regexp"})
 _GREP_SHORT_FLAGS_WITH_ARG = frozenset({"m", "A", "B", "C", "f", "D", "d"})
 
 
-def _analyze_grep_argv(argv: list[str]) -> tuple[bool, bool, str]:
-    """Return (has_count, has_ere, first_pattern) for a grep argv.
+def _analyze_grep_argv(argv: list[str]) -> tuple[bool, bool, list[str]]:
+    """Return (has_count, has_ere, patterns) for a grep argv.
 
     argv[0] is expected to be `grep` (or a path to grep). Returns three values:
       has_count  — True iff `-c` / `--count` (or combined `-cE` etc.) is present.
       has_ere    — True iff ERE/PCRE mode is active (`-E`, `-P`, long equivalents,
                    or combined short flags like `-cE`).
-      pattern    — The first detected pattern string, or "" if none found.
+      patterns   — All detected pattern strings (every `-e`/`--regexp` plus the
+                   first positional fallback), or `[]` if none found.
 
-    Fail-open: any IndexError / unexpected shape → return (False, False, "").
+    Fail-open: any IndexError / unexpected shape → return (False, False, []).
     """
     has_count = False
     has_ere = False
@@ -182,8 +183,7 @@ def _analyze_grep_argv(argv: list[str]) -> tuple[bool, bool, str]:
     if not patterns and positional:
         patterns.append(positional[0])
 
-    first_pattern = patterns[0] if patterns else ""
-    return has_count, has_ere, first_pattern
+    return has_count, has_ere, patterns
 
 
 def _has_alternation(pattern: str, ere_mode: bool) -> bool:
@@ -259,10 +259,12 @@ def check_command(command: str) -> bool:
         if not argv or not _is_grep(argv[0]):
             continue
         try:
-            has_count, has_ere, pattern = _analyze_grep_argv(argv)
+            has_count, has_ere, patterns = _analyze_grep_argv(argv)
         except Exception:
             continue
-        if has_count and _has_alternation(pattern, has_ere):
+        if has_count and any(
+            _has_alternation(p, has_ere) for p in patterns
+        ):
             return True
 
     return False

--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -98,10 +98,9 @@ DIST_CARD=$(printf '%s\n' "$MOST_RECENT_BLOCK" | awk '
 # trips the violation check below.
 # LAST occurrence wins (handles dual-card-in-block case where a stale earlier
 # PASS would otherwise shadow a corrected FAIL).
-# awk -F': *' trims only the leading delimiter whitespace, leaving any trailing
-# whitespace on the value (e.g. "FAIL " from a hand-edited card) intact. That
-# breaks the exact-string verdict comparisons below ([ "FAIL " = "FAIL" ] is
-# false → silent skip), so strip surrounding whitespace from each verdict.
+# `xargs` trims trailing whitespace that awk -F': *' leaves on the value (e.g.
+# "FAIL " from a hand-edited card), which would break the exact-string verdict
+# comparisons below ([ "FAIL " = "FAIL" ] is false → silent skip).
 GATE_1=$(printf '%s\n' "$DIST_CARD" | awk -F': *' '/^- gate_1_verdict:/ {v=$2} END{print v}' | xargs)
 GATE_2=$(printf '%s\n' "$DIST_CARD" | awk -F': *' '/^- gate_2_verdict:/ {v=$2} END{print v}' | xargs)
 GATE_3=$(printf '%s\n' "$DIST_CARD" | awk -F': *' '/^- gate_3_verdict:/ {v=$2} END{print v}' | xargs)

--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -98,10 +98,14 @@ DIST_CARD=$(printf '%s\n' "$MOST_RECENT_BLOCK" | awk '
 # trips the violation check below.
 # LAST occurrence wins (handles dual-card-in-block case where a stale earlier
 # PASS would otherwise shadow a corrected FAIL).
-GATE_1=$(printf '%s\n' "$DIST_CARD" | awk -F': *' '/^- gate_1_verdict:/ {v=$2} END{print v}')
-GATE_2=$(printf '%s\n' "$DIST_CARD" | awk -F': *' '/^- gate_2_verdict:/ {v=$2} END{print v}')
-GATE_3=$(printf '%s\n' "$DIST_CARD" | awk -F': *' '/^- gate_3_verdict:/ {v=$2} END{print v}')
-GATE_4=$(printf '%s\n' "$DIST_CARD" | awk -F': *' '/^- gate_4_verdict:/ {v=$2} END{print v}')
+# awk -F': *' trims only the leading delimiter whitespace, leaving any trailing
+# whitespace on the value (e.g. "FAIL " from a hand-edited card) intact. That
+# breaks the exact-string verdict comparisons below ([ "FAIL " = "FAIL" ] is
+# false → silent skip), so strip surrounding whitespace from each verdict.
+GATE_1=$(printf '%s\n' "$DIST_CARD" | awk -F': *' '/^- gate_1_verdict:/ {v=$2} END{print v}' | xargs)
+GATE_2=$(printf '%s\n' "$DIST_CARD" | awk -F': *' '/^- gate_2_verdict:/ {v=$2} END{print v}' | xargs)
+GATE_3=$(printf '%s\n' "$DIST_CARD" | awk -F': *' '/^- gate_3_verdict:/ {v=$2} END{print v}' | xargs)
+GATE_4=$(printf '%s\n' "$DIST_CARD" | awk -F': *' '/^- gate_4_verdict:/ {v=$2} END{print v}' | xargs)
 [ -z "$GATE_1" ] && GATE_1="MISSING"
 [ -z "$GATE_2" ] && GATE_2="MISSING"
 # Gate-3 MISSING is not blocked (newly added enforcement; old cards legitimately omit this key).

--- a/hooks/postuse-correction/bypass-telemetry/impl.py
+++ b/hooks/postuse-correction/bypass-telemetry/impl.py
@@ -72,11 +72,21 @@ def _is_bypass_name(name: str) -> bool:
     return bool(_BYPASS_NAME_RE.match(name))
 
 
+# Values that denote an *inactive* bypass even though they are non-empty.
+# Shell convention: `false`/`no`/`off` (and `0`) mean disabled, so a bypass var
+# set to one of these must not be recorded as an active bypass event.
+_FALSY_VALUES = frozenset({"0", "false", "no", "off"})
+
+
 def _is_truthy_value(raw: str) -> bool:
-    """Return True if the value is non-empty and not the literal string "0"."""
+    """Return True if the value denotes an active (enabled) bypass.
+
+    Non-empty and not one of the conventional falsy literals
+    (``0``/``false``/``no``/``off``, matched case-insensitively).
+    """
     # Strip surrounding quotes from inline assignment values
     v = raw.strip("\"'")
-    return bool(v) and v != "0"
+    return bool(v) and v.lower() not in _FALSY_VALUES
 
 
 def _parse_inline_env(command: str) -> dict[str, str]:

--- a/hooks/postuse-correction/bypass-telemetry/impl.py
+++ b/hooks/postuse-correction/bypass-telemetry/impl.py
@@ -72,9 +72,7 @@ def _is_bypass_name(name: str) -> bool:
     return bool(_BYPASS_NAME_RE.match(name))
 
 
-# Values that denote an *inactive* bypass even though they are non-empty.
-# Shell convention: `false`/`no`/`off` (and `0`) mean disabled, so a bypass var
-# set to one of these must not be recorded as an active bypass event.
+# Non-empty values that shell convention treats as disabled — not recorded.
 _FALSY_VALUES = frozenset({"0", "false", "no", "off"})
 
 

--- a/hooks/postuse-correction/bypass-telemetry/spec.md
+++ b/hooks/postuse-correction/bypass-telemetry/spec.md
@@ -40,8 +40,10 @@ Two naming families are detected (both required):
 
 Detection regex: `^(?:CLAUDE_HOOK_|PRAXIS_).*BYPASS`
 
-**Truthiness rule**: a var is only counted if its value is non-empty and
-not the literal string `"0"`.  `VAR=0` and `VAR=` are treated as inactive.
+**Truthiness rule**: a var is only counted if its value is non-empty and not
+one of the conventional shell-falsy literals `0` / `false` / `no` / `off`
+(matched case-insensitively).  `VAR=0`, `VAR=false`, `VAR=no`, `VAR=off` and
+`VAR=` are all treated as inactive.
 
 **Detection sources** (results are unioned):
 

--- a/hooks/preflight-gate/pre-edit-protected-branch-guard/impl.py
+++ b/hooks/preflight-gate/pre-edit-protected-branch-guard/impl.py
@@ -326,7 +326,12 @@ def is_planning_artifact(path: str) -> bool:
 def is_docs_file(path: str) -> bool:
     """True if the path looks like a docs-only file (README, CHANGELOG, /docs/)."""
     norm = path.replace("\\", "/")
-    if "/docs/" in norm or "/documentation/" in norm:
+    if (
+        "/docs/" in norm
+        or "/documentation/" in norm
+        or norm.startswith("docs/")
+        or norm.startswith("documentation/")
+    ):
         return True
     basename = os.path.basename(norm).lower()
     stem = basename.rsplit(".", 1)[0] if "." in basename else basename

--- a/tests/hooks/advisory-nudge/test_bash_worktree_existence_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_bash_worktree_existence_advisory.sh
@@ -239,6 +239,38 @@ run_case "compact subshell trailing-paren does not cause false advisory" \
   "silent" \
   "(cd $NON_WT_DIR && cd $ROOT_DIR)"
 
+# Regression (issue #516 defect1): the CLOSING segment of a subshell must NOT
+# pollute the outer effective_cwd. In `(cd A && cd B) && cd <rel>`, the outer
+# relative `cd` has to resolve against the hook's *original* cwd, not B.
+#
+# The old code reset in_subshell BEFORE the cwd-update step, so the closing
+# segment's target leaked into effective_cwd. Concretely: with outer cwd lacking
+# `bin/` but B (=/usr) having `bin/`, the buggy code resolved `cd bin` against
+# /usr → /usr/bin exists → no advisory. The fix keeps the closing segment's cwd
+# update on subshell_cwd (via was_in_subshell), leaving effective_cwd intact so
+# `cd bin` resolves to <outer-cwd>/bin → missing → advisory.
+#
+# Run with a controlled outer cwd (a temp dir guaranteed to lack `bin/`).
+DEF1_OUTER=$(mktemp -d)
+{
+  payload_def1=$(python3 -c '
+import json
+print(json.dumps({"tool_name": "Bash",
+    "tool_input": {"command": "(cd /tmp && cd /usr) && cd bin"}}))')
+  err_file=$(mktemp)
+  ( cd "$DEF1_OUTER" && echo "$payload_def1" | "$HOOK" >/dev/null 2>"$err_file" )
+  def1_rc=$?
+  def1_err=$(cat "$err_file"); rm -f "$err_file"
+  if [ "$def1_rc" -eq 0 ] && printf '%s' "$def1_err" | grep -q '\[worktree-missing\]'; then
+    echo "PASS  [subshell close does not pollute outer cwd (defect1)]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [subshell close does not pollute outer cwd (defect1)] rc=$def1_rc stderr=${def1_err:-<empty>}"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("subshell close does not pollute outer cwd (defect1)")
+  fi
+}
+rmdir "$DEF1_OUTER" 2>/dev/null || true
+
 # R3 P2-2: `cat<<EOF` (command-attached, no space) — body cd must be silent.
 run_case "command-attached fused heredoc body cd is silent (cat<<EOF)" \
   "silent" \

--- a/tests/hooks/advisory-nudge/test_bash_worktree_existence_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_bash_worktree_existence_advisory.sh
@@ -240,16 +240,8 @@ run_case "compact subshell trailing-paren does not cause false advisory" \
   "(cd $NON_WT_DIR && cd $ROOT_DIR)"
 
 # Regression (issue #516 defect1): the CLOSING segment of a subshell must NOT
-# pollute the outer effective_cwd. In `(cd A && cd B) && cd <rel>`, the outer
-# relative `cd` has to resolve against the hook's *original* cwd, not B.
-#
-# The old code reset in_subshell BEFORE the cwd-update step, so the closing
-# segment's target leaked into effective_cwd. Concretely: with outer cwd lacking
-# `bin/` but B (=/usr) having `bin/`, the buggy code resolved `cd bin` against
-# /usr → /usr/bin exists → no advisory. The fix keeps the closing segment's cwd
-# update on subshell_cwd (via was_in_subshell), leaving effective_cwd intact so
-# `cd bin` resolves to <outer-cwd>/bin → missing → advisory.
-#
+# pollute the outer effective_cwd. In `(cd /tmp && cd /usr) && cd bin`, the
+# outer relative `cd bin` must resolve against the original cwd, not /usr.
 # Run with a controlled outer cwd (a temp dir guaranteed to lack `bin/`).
 DEF1_OUTER=$(mktemp -d)
 {

--- a/tests/hooks/advisory-nudge/test_count_assertion_verify.sh
+++ b/tests/hooks/advisory-nudge/test_count_assertion_verify.sh
@@ -141,6 +141,15 @@ run_case "compound_cmd_semicolon" advisory \
 run_case "explicit_e_flag" advisory \
   "grep -c -e 'pat1\|pat2' file.txt"
 
+# Regression (issue #516 defect2): alternation lives only in the SECOND -e
+# pattern. The old code inspected patterns[0] alone and missed it.
+run_case "ere_alternation_second_e_flag" advisory \
+  "grep -Ec -e 'a' -e 'b|c' file.txt"
+
+# BRE variant: first -e plain, second -e carries the \| alternation.
+run_case "bre_alternation_second_e_flag" advisory \
+  "grep -c -e 'a' -e 'b\|c' file.txt"
+
 # ---------------------------------------------------------------------------
 # Pass cases — should NOT fire
 # ---------------------------------------------------------------------------

--- a/tests/hooks/completion-verify/test_retrospect_mix_check.sh
+++ b/tests/hooks/completion-verify/test_retrospect_mix_check.sh
@@ -866,13 +866,10 @@ run_case "T-NEW3_pass_output_quality_category_with_cli_layer" "pass" \
   "$(mk_assistant "$(mk_retrospect_stage3 "$T_NEW3_CARD" "$T_NEW3_ROW")")"
 
 # Regression (issue #516 defect3): a verdict value with TRAILING whitespace
-# (e.g. "FAIL " from a hand-edited / copy-pasted card) must still block. The
-# awk extractor with -F': *' only trims leading whitespace, so without an
-# explicit trailing-trim the comparison [ "FAIL " = "FAIL" ] is false and the
-# block is silently skipped. The fix pipes each verdict through `xargs`.
-# gate_1 trailing-space variant of T5 (tool label, memory-only, gate_1 FAIL).
-# NB: the trailing space after FAIL is the whole point — append it via a
-# variable so it survives editor whitespace-stripping and stays visible.
+# (e.g. "FAIL " from a hand-edited card) must still block, now that each verdict
+# is trimmed via `xargs`. gate_1 trailing-space variant of T5.
+# The trailing space is appended via a variable so it survives editor
+# whitespace-stripping and stays visible.
 SP=' '
 T_DEF3_G1_CARD=$(cat <<EOF
 - memory: 1

--- a/tests/hooks/completion-verify/test_retrospect_mix_check.sh
+++ b/tests/hooks/completion-verify/test_retrospect_mix_check.sh
@@ -865,6 +865,30 @@ T_NEW3_ROW="| 1 | output_quality | cli | PR CHANGES_REQUESTED ≥2 | weak first-
 run_case "T-NEW3_pass_output_quality_category_with_cli_layer" "pass" \
   "$(mk_assistant "$(mk_retrospect_stage3 "$T_NEW3_CARD" "$T_NEW3_ROW")")"
 
+# Regression (issue #516 defect3): a verdict value with TRAILING whitespace
+# (e.g. "FAIL " from a hand-edited / copy-pasted card) must still block. The
+# awk extractor with -F': *' only trims leading whitespace, so without an
+# explicit trailing-trim the comparison [ "FAIL " = "FAIL" ] is false and the
+# block is silently skipped. The fix pipes each verdict through `xargs`.
+# gate_1 trailing-space variant of T5 (tool label, memory-only, gate_1 FAIL).
+# NB: the trailing space after FAIL is the whole point — append it via a
+# variable so it survives editor whitespace-stripping and stays visible.
+SP=' '
+T_DEF3_G1_CARD=$(cat <<EOF
+- memory: 1
+- issue: 0
+- claude_md_draft: 0
+- skill_idea: 0
+- hook_code: 0
+- upstream_feedback: 0
+- gate_1_verdict: FAIL${SP}
+- gate_2_verdict: PASS
+EOF
+)
+T_DEF3_G1_ROW="| 1 | tool | cli | gh flag missing | tool defect | gap | No | memory | ${RATIONALE_5LINE} | HIGH |"
+run_case "T-DEF3_block_gate1_verdict_fail_trailing_space" "block" \
+  "$(mk_assistant "$(mk_retrospect_stage3 "$T_DEF3_G1_CARD" "$T_DEF3_G1_ROW")")"
+
 # Synthetic regression fixtures (AC-R1~R4) ----------------------------------
 # Each fixture pairs a .jsonl transcript with a .expected.json sidecar:
 #   {expected_decision: "pass"|"block", must_contain: [...], must_not_contain: [...]}

--- a/tests/hooks/postuse-correction/test_bypass_telemetry.sh
+++ b/tests/hooks/postuse-correction/test_bypass_telemetry.sh
@@ -235,6 +235,41 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 5b (issue #516 defect4): VAR=false / no / off -> NOT logged.
+# Shell convention treats these as inactive; the old "non-empty and != 0" rule
+# wrongly recorded them as active bypass events. Case-insensitive.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== bypass-telemetry: VAR=false/no/off falsey -> not logged ==="
+
+for falsy in false FALSE no No off OFF; do
+  TEL5b="$TMP_DIR/test5b_${falsy}.jsonl"
+  payload5b="$(make_payload Bash "CLAUDE_HOOK_BYPASS_SCIOMC_GATE=${falsy} git commit")"
+  PRAXIS_BYPASS_TELEMETRY_FILE="$TEL5b" python3 "$HOOK" <<< "$payload5b" >/dev/null 2>&1
+  if [ -f "$TEL5b" ]; then
+    lc5b=$(wc -l < "$TEL5b" 2>/dev/null | tr -d ' ')
+    if [ "${lc5b:-0}" -gt 0 ]; then
+      assert_fail "VAR=${falsy} not logged" "file has content despite VAR=${falsy}"
+    else
+      assert_pass "VAR=${falsy} not logged (empty file)"
+    fi
+  else
+    assert_pass "VAR=${falsy} not logged"
+  fi
+done
+
+# Guard against over-correction: a genuinely-truthy value (e.g. `true`) must
+# still be recorded.
+TEL5c="$TMP_DIR/test5c.jsonl"
+payload5c="$(make_payload Bash 'CLAUDE_HOOK_BYPASS_SCIOMC_GATE=true git commit')"
+PRAXIS_BYPASS_TELEMETRY_FILE="$TEL5c" python3 "$HOOK" <<< "$payload5c" >/dev/null 2>&1
+if [ -f "$TEL5c" ] && [ "$(wc -l < "$TEL5c" 2>/dev/null | tr -d ' ')" -gt 0 ]; then
+  assert_pass "VAR=true still logged"
+else
+  assert_fail "VAR=true still logged" "truthy value was not recorded"
+fi
+
+# ---------------------------------------------------------------------------
 # Test 6: VAR= (empty) -> NOT logged
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/hooks/postuse-correction/test_pre_edit_md_escape_advisory.sh
+++ b/tests/hooks/postuse-correction/test_pre_edit_md_escape_advisory.sh
@@ -33,16 +33,11 @@ PASS=0; FAIL=0; FAILED_NAMES=()
 
 # Per-test history file (overrides session-id resolution entirely).
 fresh_history() {
-  # Must yield a UNIQUE path that does NOT yet exist (state tests below assert a
-  # file was never created when the hook records nothing).
-  #
-  # `mktemp -u` only predicts a name unsafely: under a shared TMPDIR (e.g.
-  # TMPDIR=/tmp/claude-501 with a sibling suite running) it can hand back a path
-  # another process already grabbed → the hook's save_history hits an OSError and
-  # silently records nothing, failing 3 tests. Instead, atomically claim a real
-  # file with mktemp (guaranteed unique), unlink it so the returned name is free
-  # but extremely unlikely to be re-handed-out, and append the ".json" suffix the
-  # hook expects.
+  # Must yield a UNIQUE path that does not yet exist (state tests below assert no
+  # file was created when the hook records nothing). `mktemp -u` only predicts a
+  # name and can collide under a shared TMPDIR; instead atomically claim a real
+  # file (guaranteed unique), unlink it so the name is free, and add the ".json"
+  # suffix the hook expects.
   local base
   base="$(mktemp "${TMPDIR:-/tmp}/praxis-md-escape-test-XXXXXX")" || return 1
   rm -f "$base"

--- a/tests/hooks/postuse-correction/test_pre_edit_md_escape_advisory.sh
+++ b/tests/hooks/postuse-correction/test_pre_edit_md_escape_advisory.sh
@@ -33,9 +33,20 @@ PASS=0; FAIL=0; FAILED_NAMES=()
 
 # Per-test history file (overrides session-id resolution entirely).
 fresh_history() {
-  # XXXXXX must be the template suffix: BSD mktemp (macOS) does not substitute
-  # X's when a literal suffix like ".json" follows them, so append it afterwards.
-  echo "$(mktemp -u "${TMPDIR:-/tmp}/praxis-md-escape-test-XXXXXX").json"
+  # Must yield a UNIQUE path that does NOT yet exist (state tests below assert a
+  # file was never created when the hook records nothing).
+  #
+  # `mktemp -u` only predicts a name unsafely: under a shared TMPDIR (e.g.
+  # TMPDIR=/tmp/claude-501 with a sibling suite running) it can hand back a path
+  # another process already grabbed → the hook's save_history hits an OSError and
+  # silently records nothing, failing 3 tests. Instead, atomically claim a real
+  # file with mktemp (guaranteed unique), unlink it so the returned name is free
+  # but extremely unlikely to be re-handed-out, and append the ".json" suffix the
+  # hook expects.
+  local base
+  base="$(mktemp "${TMPDIR:-/tmp}/praxis-md-escape-test-XXXXXX")" || return 1
+  rm -f "$base"
+  echo "${base}.json"
 }
 
 # build_edit_payload <file_path> <old_string>

--- a/tests/hooks/preflight-gate/test_pre_edit_protected_branch_guard.sh
+++ b/tests/hooks/preflight-gate/test_pre_edit_protected_branch_guard.sh
@@ -418,8 +418,7 @@ run_case "dirty+protected+docs/guide.md → pass (docs dir skip)" pass \
 
 # Regression (issue #516 defect6): a RELATIVE docs path (no leading slash) must
 # also be recognized as a docs file. The old is_docs_file required "/docs/" in
-# the normalized path, so "docs/guide.md" slipped through and reached the deny
-# path. The fix also accepts norm.startswith("docs/").
+# the path, so "docs/guide.md" slipped through; the fix accepts startswith("docs/").
 run_case "dirty+protected+relative docs/guide.md → pass (docs dir skip)" pass \
   Edit "docs/relative-guide.md" \
   "PRAXIS_PBGUARD_TEST_REPO_ROOT=$FAKE_ROOT" \

--- a/tests/hooks/preflight-gate/test_pre_edit_protected_branch_guard.sh
+++ b/tests/hooks/preflight-gate/test_pre_edit_protected_branch_guard.sh
@@ -415,6 +415,16 @@ run_case "dirty+protected+docs/guide.md → pass (docs dir skip)" pass \
   "PRAXIS_PBGUARD_TEST_BRANCH=main" \
   "PRAXIS_PBGUARD_TEST_STATUS=$DIRTY_STATUS"
 
+# Regression (issue #516 defect6): a RELATIVE docs path (no leading slash) must
+# also be recognized as a docs file. The old is_docs_file required "/docs/" in
+# the normalized path, so "docs/guide.md" slipped through and reached the deny
+# path. The fix also accepts norm.startswith("docs/").
+run_case "dirty+protected+relative docs/guide.md → pass (docs dir skip)" pass \
+  Edit "docs/relative-guide.md" \
+  "PRAXIS_PBGUARD_TEST_REPO_ROOT=$FAKE_ROOT" \
+  "PRAXIS_PBGUARD_TEST_BRANCH=main" \
+  "PRAXIS_PBGUARD_TEST_STATUS=$DIRTY_STATUS"
+
 # ---------------------------------------------------------------------------
 # PASS: PRAXIS_PBGUARD_SKIP=1 opt-out
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the six independent parsing / test-infra defects in #516. Each carries a load-bearing regression test (verified to fail before the fix, pass after).

## Defects fixed

- **결함1 (HIGH) `bash-worktree-existence-advisory`** — The closing segment of a `(cd A && cd B)` subshell reset `in_subshell` to `False` *before* the cwd-update step, so the subshell path leaked into the outer `effective_cwd`. Captured `was_in_subshell` before the reset and key the cwd-tracker update on it, so the closing segment updates `subshell_cwd` and the outer base stays clean. Regression: `(cd /tmp && cd /usr) && cd bin` now fires the advisory for the missing outer-relative `bin`.
- **결함2 (MED) `count-assertion-verify`** — Only the first `-e` pattern was inspected for alternation. `_analyze_grep_argv` now returns the full pattern list and `check_command` uses `any(_has_alternation(p, has_ere) for p in patterns)`. Regression: `grep -Ec -e 'a' -e 'b|c' file` (and the BRE `\|` variant).
- **결함3 (MED) `retrospect-mix-check`** — `awk -F': *'` only trims leading whitespace, so a verdict like `FAIL ` (trailing space) defeated `[ "FAIL " = "FAIL" ]` and silently skipped the block. Each of the four gate-verdict extractions is now piped through `xargs`.
- **결함4 (LOW) `bypass-telemetry`** — Truthiness was "non-empty and not `0`", recording `false`/`no`/`off` as active bypasses. `_is_truthy_value` now excludes `0`/`false`/`no`/`off` case-insensitively. Spec + docs synced.
- **결함5 (TEST INFRA) `pre-edit-md-escape-advisory`** — `fresh_history()` used `mktemp -u` (TOCTOU name prediction) which collided under a shared `TMPDIR`, causing `save_history` OSErrors and silent false results. Replaced with an atomic create-then-unlink (`mktemp` then `rm`) that yields a unique, non-existent history path. All 31 tests pass, including under `TMPDIR=/tmp/claude-501`.
- **결함6 (LOW) `pre-edit-protected-branch-guard`** — `is_docs_file` required a leading `/docs/`, so a relative `docs/guide.md` was unrecognized. Now also accepts `docs/` / `documentation/` prefixes. Edit kept minimal/localized to stay trivial against #513's overlapping changes to the same function.

## Gates

- `scripts/run-tests.sh`: all targeted hook suites green. The only remaining failures are the two pre-existing, environment-only ones (`test_codex_review_route.sh`, `test_worktree_edit_gate.sh`) caused by the sandbox's `commit.gpgsign=true` returning HTTP 400 during their in-test commits — confirmed pre-existing on a clean tree (reproduce with my changes stashed) and unrelated to defect5.
- `scripts/check-plugin-manifests.py`: `plugin-manifest check OK`.

Closes #516

https://claude.ai/code/session_01F1feUhQztxe8rz6MCZdxFh

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1feUhQztxe8rz6MCZdxFh)_