### PR TITLE
ci: add Dependabot, Ruff, ShellCheck, and CodeQL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # GitHub Actions — keep workflow action versions current with security
+  # and feature updates. This is the only tracked ecosystem: the project
+  # is a Bash/Python skills framework with no package manifests (Python
+  # code uses only the standard library; pytest is installed inline in CI).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary

Four free CI additions for this Bash/Python skills framework, plus the code cleanups needed to keep every gate green.

### 1. Dependabot (`.github/dependabot.yml`)

Scoped to the **github-actions** ecosystem only — the repo has no package manifests (Python uses the stdlib; tools install inline in CI), so the workflow actions are the sole trackable dependency. Weekly, `open-pull-requests-limit: 5`, `ci` prefix, labeled. This now also tracks the new lint/shellcheck/codeql workflows' actions automatically.

### 2. Ruff lint (`.github/workflows/lint.yml` + `ruff.toml`)

- `ruff check` on push/PR, **pinned version** (`0.15.8`) so a future release can't silently widen enforcement
- least-privilege `permissions: contents: read`
- `ruff.toml` pins the default rule set (`E4/E7/E9/F`), `target-version = "py310"`

### 3. ShellCheck (`.github/workflows/shellcheck.yml` + `.shellcheckrc`)

- lints all 119 `*.sh` files at **warning** severity, least-privilege permissions
- `.shellcheckrc` disables two **test-only** false positives (`SC2154` referenced-but-not-assigned, `SC2034` unused-var) from sourced fixtures; **runtime code (`hooks/`, `scripts/`) is clean at warning level with zero suppressions**

### 4. CodeQL (`.github/workflows/codeql.yml`)

GitHub's free SAST for the **Python** sources, on push/PR to `main` plus a weekly schedule. Bash isn't a CodeQL language, so ShellCheck covers the shell side. `permissions: security-events: write` only.

### Code cleanups to pass the new gates (no behavior change)

**Ruff (16 findings):** removed 11 unused imports, fixed one `!= None` → `is not None`, renamed two ambiguous `l` loop vars to `lbl`, dropped two redundant mid-file `import os.path` lines.

**ShellCheck (11 genuine warnings, all in test files):**
- `SC2164` ×3 — guard `cd` calls with `|| exit`
- `SC2069` ×2 — reorder `2>&1 >/dev/null` → `{ …; } 2>&1`
- `SC1007` ×2 — drop a no-op `VAR=` prefix
- `SC2046` ×1 — quote a command substitution
- `SC2163` ×3 — scoped disable on intentional `export "$kv"` loops

### Verification

- `ruff check .` — clean
- `shellcheck --severity=warning` across all 119 scripts — clean
- shell tests pass, **except** two pre-existing failures (`test_worktree_edit_gate.sh`, `test_codex_review_route.sh`) that fail identically on clean `HEAD` due to the sandbox's enforced git commit-signing (fixtures can't create commits) — unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)