### PR TITLE
ci: add secret scanning, link checking, and CI hygiene

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,11 @@ on:
     # code hasn't changed. Monday 07:00 UTC.
     - cron: "0 7 * * 1"
 
+# A newer push to the same ref cancels the in-flight run.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: analyze (python)

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,39 @@
+name: link-check
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+  schedule:
+    # Weekly run catches external links that rot even when docs don't change.
+    - cron: "0 8 * * 1"
+
+# Prevent redundant runs on rapid pushes to the same ref.
+concurrency:
+  group: link-check-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: only needs to read the docs.
+permissions:
+  contents: read
+
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # lychee resolves relative file links through symlinks (the
+      # plugins/praxis/{hooks,skills,scripts} mirror dirs are symlinks into the
+      # repo root), so cross-tree relative links validate correctly.
+      - name: link check
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --include-fragments
+            './**/*.md'
+          fail: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: ["**"]
 
+# A newer push to the same ref cancels the in-flight run.
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
 # Least privilege: linting only needs to read the checked-out code.
 permissions:
   contents: read
@@ -22,6 +27,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.x"
+          # No dependency manifest in the repo; hash the workflow file (which
+          # pins the ruff version) so the pip cache has a stable key.
+          cache: pip
+          cache-dependency-path: .github/workflows/lint.yml
 
       # Pinned so a future Ruff release can't widen rule coverage and turn
       # CI red without an explicit bump. Matches ruff.toml's rule selection.

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,33 @@
+name: secret-scan
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+# Prevent redundant runs: a newer push to the same ref cancels the in-flight one.
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: scanning only reads the checked-out tree.
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      # Full history so gitleaks can scan commits, not just the working tree.
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # Synthetic test secrets are allowlisted in .gitleaks.toml.
+      - name: gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITLEAKS_CONFIG: .gitleaks.toml

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: ["**"]
 
+# A newer push to the same ref cancels the in-flight run.
+concurrency:
+  group: shellcheck-${{ github.ref }}
+  cancel-in-progress: true
+
 # Least privilege: linting only needs to read the checked-out code.
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: ["**"]
 
+# A newer push to the same ref cancels the in-flight run.
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -18,6 +23,12 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.x"
+          # No requirements.txt/pyproject.toml in the repo, so hash the
+          # workflow file (where the pinned install lives) to give the pip
+          # cache a stable key without setup-python erroring on a missing
+          # dependency manifest.
+          cache: pip
+          cache-dependency-path: .github/workflows/test.yml
 
       - name: install python deps
         run: python3 -m pip install pytest

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,15 @@
+# Gitleaks configuration.
+#
+# Extends the upstream default ruleset, then allowlists the synthetic secrets
+# that the hook test suite deliberately embeds to verify the bypass-telemetry
+# redaction path. These are not real credentials.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Synthetic test fixtures — not real secrets"
+paths = [
+  # test_bypass_telemetry.sh asserts that a fake AWS-style secret is redacted
+  # in captured tool_input; the literal value must stay in the test source.
+  '''tests/hooks/postuse-correction/test_bypass_telemetry\.sh''',
+]

--- a/hooks/advisory-nudge/memory-hint/spec.md
+++ b/hooks/advisory-nudge/memory-hint/spec.md
@@ -46,7 +46,7 @@ hookEvents: [Bash, Edit, AskUserQuestion]       # event whitelist (default [Bash
 
 ### Authoring
 
-The fields above are not authored by hand in the typical flow. The `retrospect` skill emits them at memory-write time. See [`skills/retrospect/SKILL.md`](../../skills/retrospect/SKILL.md) Stage 4 Action 1 — specifically the "Frontmatter contract — `memory-hint` opt-in" subsection — for the per-category `hookable` default matrix and `hookKeywords` selection rules. This file specifies the **runtime parser contract** (what the hook accepts); the SKILL.md section specifies the **authoring decision** (which memories should opt in, which keywords to pick).
+The fields above are not authored by hand in the typical flow. The `retrospect` skill emits them at memory-write time. See [`skills/retrospect/SKILL.md`](../../../skills/retrospect/SKILL.md) Stage 4 Action 1 — specifically the "Frontmatter contract — `memory-hint` opt-in" subsection — for the per-category `hookable` default matrix and `hookKeywords` selection rules. This file specifies the **runtime parser contract** (what the hook accepts); the SKILL.md section specifies the **authoring decision** (which memories should opt in, which keywords to pick).
 
 ### Per-event tokenization
 

--- a/hooks/preflight-gate/block-commit-without-codex-review/spec.md
+++ b/hooks/preflight-gate/block-commit-without-codex-review/spec.md
@@ -15,7 +15,7 @@ defects a single reviewer misses. Prose alone is unreliable (prompt-layer
 retrieval failure); per the established escalation pattern, structural
 enforcement at the commit checkpoint backs the rule.
 
-This is the inverse of [`block-sciomc-finding-commit`](block-sciomc-finding-commit.md):
+This is the inverse of [`block-sciomc-finding-commit`](../block-sciomc-finding-commit/spec.md):
 that hook blocks on the **presence** of a finding marker; this one blocks on the
 **absence** of the required skill invocation.
 

--- a/hooks/preflight-gate/skill-gate-commands/spec.md
+++ b/hooks/preflight-gate/skill-gate-commands/spec.md
@@ -61,7 +61,7 @@ for the full schema, supported patterns, and examples.
 
 Whole-transcript scan: one skill invocation anywhere in the session satisfies
 all subsequent matching commands. The mechanism is identical to
-[`block-commit-without-codex-review`](block-commit-without-codex-review.md)
+[`block-commit-without-codex-review`](../block-commit-without-codex-review/spec.md)
 (`_scan_transcript` + `_has_skill_tool_use`).
 
 ## Escape hatches


### PR DESCRIPTION
## Summary

Three more free CI improvements on top of the quality gates from #532.

### New workflows

| File | Gate | Notes |
|------|------|-------|
| `secret-scan.yml` + `.gitleaks.toml` | gitleaks | push/PR; full-history scan. `.gitleaks.toml` allowlists the synthetic fixture secret in `test_bypass_telemetry.sh` (exercises the redaction path — not a real credential) |
| `link-check.yml` | lychee | push/PR + weekly cron; validates internal `.md` cross-links and external URLs |

### CI hygiene (existing workflows)

- **`concurrency` (cancel-in-progress)** added to all five workflows so rapid pushes to a ref don't pile up redundant runs.
- **`cache: pip`** added to the two Python workflows (`test.yml`, `lint.yml`). The repo has no dependency manifest, so `cache-dependency-path` points at the workflow file (where the pinned install lives) — a stable cache key without setup-python erroring on a missing manifest.

### Doc-link fixes

Enabling the link checker surfaced **3 genuinely broken internal links** (the dozen other apparent breakages resolve correctly through the `plugins/praxis/{hooks,skills,scripts}` symlinks into the repo root, which lychee follows). All three were wrong relative paths in hook `spec.md` files:

- `memory-hint/spec.md` — `../../skills/...` → `../../../skills/...` (one level too shallow)
- `block-commit-without-codex-review/spec.md` — `block-sciomc-finding-commit.md` → `../block-sciomc-finding-commit/spec.md`
- `skill-gate-commands/spec.md` — `block-commit-without-codex-review.md` → `../block-commit-without-codex-review/spec.md`

### Verification

- gitleaks — clean with the allowlist
- internal links — all resolve (symlink-aware check)
- `ruff` / `shellcheck --severity=warning` / `pytest` (67) / manifest check — all pass

### Note

gitleaks-action's free tier covers **public** repos; org/private use may require a license key.

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EahXW5RZgjDxFAvNYpRR5n)_