### PR TITLE
refactor(hooks): move durable state under host-neutral ~/.praxis (phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `retrospect`: Stage 2 multi-oracle completeness gate (Gate-6) + Stage 1.5 oracle-annotation signal 5 — stored-value falsification requires same-oracle confirmation; different-oracle results emit a separate cohort-shift finding (#489)
 
 ### Changed
+- `hooks`: durable cross-session state now defaults to the host-neutral `~/.praxis/state` instead of the Claude-nested `~/.claude/state/praxis` (strike counter, phantom-path markers, and the strike state read by `postcompact-context`). `PRAXIS_STATE_DIR` still overrides the base (back-compat); strike-counter migrates existing state across once on first run, and the readers fall back to the legacy location. New `_paths` helpers (`praxis_state_dir`/`praxis_cache_dir`/`legacy_state_dir`) + layout doc `docs/runtime-state-layout.md`. Volatile `${TMPDIR}/praxis-*` caches are swept in a follow-up (partial of #527)
 - `hooks`: swept the remaining 20 `_main_inner`/`main()` hand-rolled fail-open wrappers onto the shared `@fail_open` decorator (`hooks/_lib/_hook_runtime.py`), so all blocking/advisory Python hooks now use a single fail-open pattern. No behavior change; each hook's copied fail-open test block is replaced by a `main.__wrapped__` structural assertion (behaviour is verified once in `tests/test_hook_runtime.sh`) (#526)
 
 ## [6.0.3] - 2026-05-29

--- a/docs/runtime-state-layout.md
+++ b/docs/runtime-state-layout.md
@@ -1,0 +1,55 @@
+# Praxis runtime state layout
+
+Praxis hooks write three kinds of runtime files. Since praxis is multi-platform
+(Claude, Codex, Cursor, Gemini, OpenCode), these live under a **host-neutral**
+`~/.praxis` root rather than the Claude-nested legacy location. The resolver is
+[`hooks/_lib/_paths.py`](../hooks/_lib/_paths.py).
+
+## Roots
+
+| Root | Purpose | Resolver | Override |
+|------|---------|----------|----------|
+| `~/.praxis/state/` | Durable, cross-session state | `praxis_state_dir()` | `PRAXIS_STATE_DIR` (base), `PRAXIS_HOME` |
+| `~/.praxis/cache/` | Regenerable, session-scoped caches / dedup markers | `praxis_cache_dir()` | `PRAXIS_HOME` |
+| `~/.praxis/logs/` | Diagnostics | `resolve_writable("logs", …)` | `PRAXIS_HOME`, per-file env |
+
+`PRAXIS_HOME` relocates the whole tree (used by tests for isolation).
+`resolve_writable` falls back to `${TMPDIR}/praxis-<file>` when the home dir is
+not writable, and never raises.
+
+## Durable state (`~/.praxis/state/`)
+
+| File | Producer | Consumers |
+|------|----------|-----------|
+| `strikes/<sid>.json`, `strikes/.current-session`, … | [`strike-counter`](../hooks/completion-verify/strike-counter/spec.md) | strike-counter; read by [`postcompact-context`](../hooks/advisory-nudge/postcompact-context/spec.md) |
+| `phantom-path/<hash>` | [`external-write-path-existence-check`](../hooks/advisory-nudge/external-write-path-existence-check/spec.md) | itself (dedup) |
+
+### Back-compat and migration (#527)
+
+- An explicit `PRAXIS_STATE_DIR` override always wins — pre-#527 deployments that
+  set it keep their existing location.
+- When no override is set, the default moved from `~/.claude/state/praxis` to
+  `~/.praxis/state`. To preserve continuity:
+  - **strike-counter** performs a one-time copy of
+    `~/.claude/state/praxis/strikes` into the new location on first run if the
+    new location is absent.
+  - **postcompact-context** read-falls-back to the legacy location when the new
+    one has no entry for the session.
+  - **phantom-path** markers are regenerable dedup state, so no fallback is
+    needed — a relocated marker simply lets one advisory re-fire once.
+
+## Logs (`~/.praxis/logs/`)
+
+- `hook-errors.jsonl` — swallowed-exception log from the shared `@fail_open`
+  guard (`PRAXIS_HOOK_ERROR_LOG` overrides). See
+  [`hooks/_lib/_hook_runtime.py`](../hooks/_lib/_hook_runtime.py).
+- bypass telemetry — see [`bypass-telemetry.md`](bypass-telemetry.md).
+
+## Volatile caches (`~/.praxis/cache/`) — follow-up
+
+The session-scoped `${TMPDIR}/praxis-*` dedup files (jq-config, path-probe,
+bulk-write, pre-output-falsification, bash-worktree, session-intent,
+postcompact-context, md-read-history, gh-json) are tracked for migration onto
+`praxis_cache_dir()` / `resolve_writable("cache", …)` in #527's follow-up. The
+foundation (`praxis_cache_dir()`) is in place; the consumers are swept
+separately to keep each hook's dedup-behaviour change reviewable in isolation.

--- a/hooks/_lib/_paths.py
+++ b/hooks/_lib/_paths.py
@@ -4,17 +4,50 @@ praxis is multi-platform, so durable files live under ~/.praxis (PRAXIS_HOME
 override) rather than the Claude-nested legacy default. `resolve_writable`
 falls back to ${TMPDIR}/praxis-<file> when the home dir is not writable.
 
-Only the hook-error log uses this today; migrating the other ${TMPDIR}/praxis-*
-and ${PRAXIS_STATE_DIR} files is tracked in #527.
+Layout (#527):
+  ~/.praxis/state/  — durable, cross-session state (strike counter, phantom-path
+                      markers). PRAXIS_STATE_DIR overrides the base (back-compat).
+  ~/.praxis/cache/  — regenerable, session-scoped caches / dedup markers.
+  ~/.praxis/logs/   — diagnostics (hook-errors.jsonl, bypass telemetry).
+
+Durable state migrated off the Claude-nested ${PRAXIS_STATE_DIR:-~/.claude/state/
+praxis} default reads back from `legacy_state_dir()` when the new location is
+empty so existing strike/phantom state survives the move. The volatile
+${TMPDIR}/praxis-* dedup files are tracked separately in #527's follow-up.
 """
 from __future__ import annotations
 
 import os
 
+_LEGACY_STATE_DIRNAME = ("~", ".claude", "state", "praxis")
+
 
 def praxis_home() -> str:
     """PRAXIS_HOME override, else ~/.praxis (expanded, not created)."""
     return os.path.expanduser(os.environ.get("PRAXIS_HOME") or "~/.praxis")
+
+
+def praxis_state_dir() -> str:
+    """Durable, cross-session state root.
+
+    An explicit PRAXIS_STATE_DIR override always wins (back-compat with the
+    pre-#527 convention); otherwise the host-neutral default ~/.praxis/state
+    (PRAXIS_HOME-aware). Not created here.
+    """
+    override = os.environ.get("PRAXIS_STATE_DIR")
+    if override:
+        return os.path.expanduser(override)
+    return os.path.join(praxis_home(), "state")
+
+
+def praxis_cache_dir() -> str:
+    """Volatile, regenerable, session-scoped cache root (~/.praxis/cache)."""
+    return os.path.join(praxis_home(), "cache")
+
+
+def legacy_state_dir() -> str:
+    """The pre-#527 Claude-nested durable state root (~/.claude/state/praxis)."""
+    return os.path.expanduser(os.path.join(*_LEGACY_STATE_DIRNAME))
 
 
 def _tmp_root() -> str:
@@ -32,3 +65,4 @@ def resolve_writable(subdir: str, filename: str) -> str:
     except Exception:
         pass
     return os.path.join(_tmp_root(), "praxis-" + filename)
+

--- a/hooks/advisory-nudge/external-write-path-existence-check/impl.py
+++ b/hooks/advisory-nudge/external-write-path-existence-check/impl.py
@@ -43,6 +43,7 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     safe_tokenize,
     strip_prefix,
 )
+from _paths import praxis_state_dir  # type: ignore[import-not-found]  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -87,10 +88,11 @@ _GH_BODY_FILE_SUBCOMMANDS = frozenset({
 _GH_GLOBAL_FLAGS_WITH_ARG = frozenset({"-R", "--repo", "--hostname", "--color"})
 _GH_BODY_FILE_FLAGS = frozenset({"-F", "--body-file"})
 
-# State dir for session-scoped dedup.
-_STATE_DIR = Path(
-    os.environ.get("PRAXIS_STATE_DIR", os.path.expanduser("~/.claude/state/praxis"))
-) / "phantom-path"
+# State dir for session-scoped dedup. Durable root is ~/.praxis/state (#527);
+# PRAXIS_STATE_DIR still overrides the base (back-compat). These markers are
+# regenerable dedup state, so no legacy read-fallback is needed — a moved
+# marker simply lets one advisory re-fire once.
+_STATE_DIR = Path(praxis_state_dir()) / "phantom-path"
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/advisory-nudge/external-write-path-existence-check/spec.md
+++ b/hooks/advisory-nudge/external-write-path-existence-check/spec.md
@@ -70,7 +70,8 @@ outside the repo tree.
 ### Session-scoped dedup
 
 Advisory is emitted at most once per `(session_id, body content SHA-256)` pair.
-State marker written to `${PRAXIS_STATE_DIR:-~/.claude/state/praxis}/phantom-path/<hash>`.
+State marker written to `${PRAXIS_STATE_DIR:-~/.praxis/state}/phantom-path/<hash>`
+(host-neutral durable root, #527; `PRAXIS_STATE_DIR` still overrides the base).
 
 ### Parsing guarantees
 

--- a/hooks/advisory-nudge/postcompact-context/impl.py
+++ b/hooks/advisory-nudge/postcompact-context/impl.py
@@ -31,7 +31,10 @@ On every `UserPromptSubmit`:
      - `cwd`               — from payload (worktree absolute path)
      - `git branch`        — `git -C <cwd> branch --show-current`
      - `active PR`         — `gh pr list --state open --head <branch>` (JSON)
-     - `strike state`      — read `$HOME/.claude/state/praxis/strikes/<sid>.json`
+     - `strike state`      — read `~/.praxis/state/strikes/<sid>.json` first;
+                             fallback to `~/.claude/state/praxis/strikes/<sid>.json`
+                             when no `PRAXIS_STATE_DIR` override is set and the
+                             new location is absent (pre-#527 legacy support)
 6. Emit `hookSpecificOutput.additionalContext` JSON to stdout.
 7. Update state file with `last_compact_uuid_emitted = <uuid>`.
 

--- a/hooks/advisory-nudge/postcompact-context/impl.py
+++ b/hooks/advisory-nudge/postcompact-context/impl.py
@@ -68,6 +68,11 @@ import sys
 from collections import deque
 from pathlib import Path
 
+import sys as _sys
+from pathlib import Path as _Path
+_sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _paths import praxis_state_dir, legacy_state_dir  # type: ignore[import-not-found]  # noqa: E402
+
 DEFAULT_TAIL_LINES = 100
 BYPASS_ENV = "PRAXIS_HOOK_BYPASS_POSTCOMPACT_CONTEXT"
 STATE_FILE_ENV = "PRAXIS_POSTCOMPACT_CONTEXT_FILE"
@@ -246,16 +251,26 @@ def _active_pr(cwd: str, branch: str) -> dict | None:
 
 
 def _strike_state(session_id: str) -> dict | None:
-    """Read the praxis strike state for this session. None if absent/empty."""
-    state_dir = os.environ.get(
-        "PRAXIS_STATE_DIR",
-        os.path.join(os.path.expanduser("~"), ".claude", "state", "praxis"),
-    )
-    path = os.path.join(state_dir, "strikes", f"{session_id}.json")
-    try:
-        with open(path, "r", encoding="utf-8") as fh:
-            data = json.load(fh)
-    except (OSError, ValueError, UnicodeDecodeError):
+    """Read the praxis strike state for this session. None if absent/empty.
+
+    Reads the host-neutral ~/.praxis/state default (#527), with a read-fallback
+    to the pre-#527 ~/.claude/state/praxis location when no PRAXIS_STATE_DIR
+    override is set and the new location is absent — so strike state written by
+    an older strike-counter still surfaces here.
+    """
+    bases = [praxis_state_dir()]
+    if not os.environ.get("PRAXIS_STATE_DIR"):
+        bases.append(legacy_state_dir())
+    data = None
+    for base in bases:
+        path = os.path.join(base, "strikes", f"{session_id}.json")
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            break
+        except (OSError, ValueError, UnicodeDecodeError):
+            continue
+    if data is None:
         return None
     if not isinstance(data, dict):
         return None

--- a/hooks/advisory-nudge/postcompact-context/spec.md
+++ b/hooks/advisory-nudge/postcompact-context/spec.md
@@ -71,7 +71,7 @@ degrades gracefully — `(none for current branch)` / `0/3` /
 | `PRAXIS_HOOK_BYPASS_POSTCOMPACT_CONTEXT` | unset | hook | When `1`, exits silently before reading stdin |
 | `PRAXIS_POSTCOMPACT_CONTEXT_FILE` | unset | hook | Explicit dedup state file path (test override) |
 | `PRAXIS_POSTCOMPACT_TAIL_LINES` | `100` | hook | Transcript tail line count to scan; non-int / <1 falls back to default |
-| `PRAXIS_STATE_DIR` | `~/.claude/state/praxis` | external lookup only | Strike-counter state directory the hook *reads*; does NOT redirect this hook's own dedup state file |
+| `PRAXIS_STATE_DIR` | `~/.praxis/state` | external lookup only | Strike-counter state directory the hook *reads* (host-neutral default, #527; falls back to the legacy `~/.claude/state/praxis` when unset and the new location is absent); does NOT redirect this hook's own dedup state file |
 
 ### State file
 

--- a/hooks/completion-verify/strike-counter/impl.sh
+++ b/hooks/completion-verify/strike-counter/impl.sh
@@ -40,7 +40,18 @@ fi
 # multi-plugin installs it can resolve to a sibling plugin's directory and
 # our state would leak there — silently vulnerable to that plugin's
 # cleanup/uninstall.
-STATE_DIR="${PRAXIS_STATE_DIR:-$HOME/.claude/state/praxis}/strikes"
+# [#527] Durable state lives under the host-neutral ~/.praxis/state by default
+# (PRAXIS_HOME-aware); PRAXIS_STATE_DIR still overrides the base (back-compat).
+STATE_DIR="${PRAXIS_STATE_DIR:-${PRAXIS_HOME:-$HOME/.praxis}/state}/strikes"
+# One-time migration: if no override is set and the new location does not yet
+# exist but the pre-#527 ~/.claude/state/praxis/strikes does, move the strike
+# state across so existing counters/latches survive the relocation.
+_LEGACY_STRIKE_DIR="$HOME/.claude/state/praxis/strikes"
+if [ -z "${PRAXIS_STATE_DIR:-}" ] && [ ! -d "$STATE_DIR" ] && [ -d "$_LEGACY_STRIKE_DIR" ]; then
+  if mkdir -p "$STATE_DIR" 2>/dev/null; then
+    cp -a "$_LEGACY_STRIKE_DIR/." "$STATE_DIR/" 2>/dev/null || true
+  fi
+fi
 mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
 LATCH="$STATE_DIR/.current-session"
 BLOCK_LOG="$STATE_DIR/last-block.log"

--- a/hooks/completion-verify/strike-counter/spec.md
+++ b/hooks/completion-verify/strike-counter/spec.md
@@ -43,8 +43,14 @@ not a free retry.
 
 ### State layout
 
+Durable state lives under the host-neutral `~/.praxis/state` by default (#527);
+`PRAXIS_STATE_DIR` still overrides the base (back-compat). On first run after the
+move, if no override is set and the new location is absent, the pre-#527
+`~/.claude/state/praxis/strikes` contents are migrated across once so existing
+counters/latches survive.
+
 ```
-$STATE_DIR = ${PRAXIS_STATE_DIR:-$HOME/.claude/state/praxis}/strikes
+$STATE_DIR = ${PRAXIS_STATE_DIR:-${PRAXIS_HOME:-$HOME/.praxis}/state}/strikes
   <sid>.json              # {"count": N, "reasons": ["...","..."]}
   <sid>.reflection.md     # user-authored reflection (required at count≥3 reset)
   .current-session        # latch — last session_id seen by session-start

--- a/tests/hooks/completion-verify/test_strike_counter.sh
+++ b/tests/hooks/completion-verify/test_strike_counter.sh
@@ -473,6 +473,24 @@ test_ac25_state_isolated_from_claude_plugin_data() {
   [ "$praxis_has_state" -eq 1 ] && [ "$sibling_has_state" -eq 0 ]
 }
 
+# ---- AC26 (issue #527): durable state migrates from the pre-#527 legacy ----
+# ~/.claude/state/praxis to the host-neutral ~/.praxis default, with no
+# PRAXIS_STATE_DIR override set.
+test_ac26_legacy_state_migration() {
+  local home sid out migrated
+  home=$(mktemp -d)
+  sid="migrate-$$-${RANDOM}"
+  mkdir -p "$home/.claude/state/praxis/strikes"
+  printf '{"count":2,"reasons":["legacy a","legacy b"]}' \
+    > "$home/.claude/state/praxis/strikes/$sid.json"
+  out=$(env -u PRAXIS_STATE_DIR -u PRAXIS_HOME HOME="$home" \
+    CLAUDE_SESSION_ID="$sid" "$STRIKE" status 2>&1)
+  migrated=0
+  [ -f "$home/.praxis/state/strikes/$sid.json" ] && migrated=1
+  rm -rf "$home"
+  [ "$migrated" -eq 1 ] && printf '%s' "$out" | grep -q "Strikes: 2/3"
+}
+
 # ---------- runner ----------------------------------------------------------
 echo "strike-counter.sh tests"
 echo "------------------------"
@@ -501,6 +519,7 @@ run "AC22 reset at count<3 not gated by reflection" test_ac22_reset_not_gated_un
 run "AC23 stop hook block message includes reflection instructions" test_ac23_stop_block_has_reflection_instructions
 run "AC24 block message includes persuasion step instructions" test_ac24_block_message_has_persuasion_step
 run "AC25 state isolated from \$CLAUDE_PLUGIN_DATA (issue #126)" test_ac25_state_isolated_from_claude_plugin_data
+run "AC26 durable strike state migrates to ~/.praxis (issue #527)" test_ac26_legacy_state_migration
 
 echo "------------------------"
 echo "Passed: $PASS  Failed: $FAIL"

--- a/tests/hooks/completion-verify/test_strike_counter.sh
+++ b/tests/hooks/completion-verify/test_strike_counter.sh
@@ -491,6 +491,30 @@ test_ac26_legacy_state_migration() {
   [ "$migrated" -eq 1 ] && printf '%s' "$out" | grep -q "Strikes: 2/3"
 }
 
+# ---- AC26b (issue #527): migration does NOT fire when PRAXIS_STATE_DIR set --
+# When an explicit override is in effect the guard `[ -z "${PRAXIS_STATE_DIR:-}" ]`
+# is false, so legacy content must NOT be copied into any location and the
+# counter must be read from the override dir (empty → 0 strikes).
+test_ac26b_no_migration_when_override_set() {
+  local home override_dir legacy_dir sid out migrated
+  home=$(mktemp -d)
+  override_dir=$(mktemp -d)
+  sid="no-migrate-$$-${RANDOM}"
+  # Seed legacy location with a non-zero strike count
+  legacy_dir="$home/.claude/state/praxis/strikes"
+  mkdir -p "$legacy_dir"
+  printf '{"count":1,"reasons":["should not migrate"]}' > "$legacy_dir/$sid.json"
+  # Run with PRAXIS_STATE_DIR set — migration guard must suppress the copy
+  out=$(HOME="$home" PRAXIS_STATE_DIR="$override_dir" \
+    CLAUDE_SESSION_ID="$sid" "$STRIKE" status 2>&1)
+  # New location must NOT contain anything copied from legacy
+  migrated=0
+  [ -f "$override_dir/strikes/$sid.json" ] && migrated=1
+  # Counter must read from the (empty) override dir → 0
+  rm -rf "$home" "$override_dir"
+  [ "$migrated" -eq 0 ] && printf '%s' "$out" | grep -q "Strikes: 0/3"
+}
+
 # ---------- runner ----------------------------------------------------------
 echo "strike-counter.sh tests"
 echo "------------------------"
@@ -520,6 +544,7 @@ run "AC23 stop hook block message includes reflection instructions" test_ac23_st
 run "AC24 block message includes persuasion step instructions" test_ac24_block_message_has_persuasion_step
 run "AC25 state isolated from \$CLAUDE_PLUGIN_DATA (issue #126)" test_ac25_state_isolated_from_claude_plugin_data
 run "AC26 durable strike state migrates to ~/.praxis (issue #527)" test_ac26_legacy_state_migration
+run "AC26b no migration when PRAXIS_STATE_DIR override is set (issue #527)" test_ac26b_no_migration_when_override_set
 
 echo "------------------------"
 echo "Passed: $PASS  Failed: $FAIL"

--- a/tests/test_paths.sh
+++ b/tests/test_paths.sh
@@ -67,6 +67,46 @@ PYEOF
 )
 assert_eq "unwritable home falls back to TMPDIR" "/tmp/praxis-hook-errors.jsonl" "$fallback"
 
+# 4. praxis_state_dir() default = ~/.praxis/state (PRAXIS_HOME-aware)
+state_default=$(env -u PRAXIS_STATE_DIR PRAXIS_HOME="/tmp/ph-527" python3 - "$LIB" << 'PYEOF'
+import sys
+sys.path.insert(0, sys.argv[1])
+from _paths import praxis_state_dir
+print(praxis_state_dir())
+PYEOF
+)
+assert_eq "praxis_state_dir default = <home>/state" "/tmp/ph-527/state" "$state_default"
+
+# 5. PRAXIS_STATE_DIR override wins (back-compat)
+state_override=$(PRAXIS_STATE_DIR="/custom/state" PRAXIS_HOME="/tmp/ph-527" python3 - "$LIB" << 'PYEOF'
+import sys
+sys.path.insert(0, sys.argv[1])
+from _paths import praxis_state_dir
+print(praxis_state_dir())
+PYEOF
+)
+assert_eq "PRAXIS_STATE_DIR override wins" "/custom/state" "$state_override"
+
+# 6. praxis_cache_dir() = ~/.praxis/cache
+cache_dir=$(PRAXIS_HOME="/tmp/ph-527" python3 - "$LIB" << 'PYEOF'
+import sys
+sys.path.insert(0, sys.argv[1])
+from _paths import praxis_cache_dir
+print(praxis_cache_dir())
+PYEOF
+)
+assert_eq "praxis_cache_dir = <home>/cache" "/tmp/ph-527/cache" "$cache_dir"
+
+# 7. legacy_state_dir() = ~/.claude/state/praxis (expanded)
+legacy=$(HOME="/tmp/fakehome-527" python3 - "$LIB" << 'PYEOF'
+import sys
+sys.path.insert(0, sys.argv[1])
+from _paths import legacy_state_dir
+print(legacy_state_dir())
+PYEOF
+)
+assert_eq "legacy_state_dir = ~/.claude/state/praxis" "/tmp/fakehome-527/.claude/state/praxis" "$legacy"
+
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then


### PR DESCRIPTION
## Summary

Phase 1 of #527 — moves **durable** cross-session state off the Claude-nested `~/.claude/state/praxis` default onto the host-neutral `~/.praxis/state`, building on the `_paths.py` foundation from #524.

### `_paths.py` helpers
- `praxis_state_dir()` — `PRAXIS_STATE_DIR` override wins (back-compat), else `~/.praxis/state` (`PRAXIS_HOME`-aware).
- `praxis_cache_dir()` — `~/.praxis/cache` (foundation for the volatile follow-up).
- `legacy_state_dir()` — `~/.claude/state/praxis`, for read-fallback.

### Consumers migrated
- **strike-counter** (`impl.sh`): default → `${PRAXIS_HOME:-~/.praxis}/state`; on first run, if no override is set and the new location is absent, the legacy `strikes/` dir is copied across once so counters/latches survive.
- **external-write-path-existence-check**: phantom-path markers under the new durable root (regenerable → no fallback needed).
- **postcompact-context**: reads strike state from the new location with a legacy read-fallback.

`PRAXIS_STATE_DIR` back-compat preserved everywhere. Layout documented in `docs/runtime-state-layout.md`.

## Tests
- `test_paths.sh` +4 cases (state/cache/legacy helpers + `PRAXIS_STATE_DIR` override).
- strike-counter **AC26** exercises the legacy → `~/.praxis` migration end-to-end (isolated `HOME`).
- All affected hook suites green; `check-plugin-manifests.py` OK.

## Scope

This is a **partial** of #527 — the volatile `${TMPDIR}/praxis-*` dedup caches (jq-config, path-probe, bulk-write, pre-output-falsification, bash-worktree, session-intent, postcompact own file, md-read-history, gh-json) are deferred to a follow-up so each hook's dedup-behaviour change stays reviewable in isolation. Per repo convention this uses `Refs`, not `Closes`, so the issue stays open to track the remainder.

Refs #527 (durable-state phase; volatile-cache sweep deferred)

## Test note

The full `scripts/run-tests.sh` shows two failures in this sandbox — `test_codex_review_route.sh` and `test_worktree_edit_gate.sh` — both pre-existing and unrelated (their git-worktree/commit fixtures are rejected by this environment's commit-signing server). They pass in CI where signing isn't forced.

## Notes

Stacked on #545 (#526) → #544 (#503) → #543 (#539) → #542 (#540) → #541 (#538) → `main`.

https://claude.ai/code/session_016EA4TkNcYQzddCVXfrA4PY

---
_Generated by [Claude Code](https://claude.ai/code/session_016EA4TkNcYQzddCVXfrA4PY)_