### PR TITLE
ci: add top-level permissions to two jobs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,12 @@ concurrency:
   group: codeql-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege at the top level: any scope not explicitly widened by a job
+# stays read-only. The analyze job below adds security-events: write for the
+# CodeQL upload — the only scope that needs more than read.
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: analyze (python)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ concurrency:
   group: tests-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: the suite only reads the checked-out code.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 배경

`#531`로 도입한 코드 품질/보안 게이트 6개 중 4개(`lint`, `shellcheck`, `secret-scan`, `link-check`)는 top-level `permissions: contents: read`로 최소권한을 명시했으나, `test.yml`과 `codeql.yml`에는 top-level `permissions` 블록이 없어 토큰이 저장소 기본 권한을 상속하던 일관성 갭을 해소한다.

## 변경

- `test.yml`: top-level `permissions: contents: read` 추가 (4 lines)
- `codeql.yml`: top-level `permissions: contents: read` 추가 (6 lines). job-level `security-events: write`는 CodeQL 업로드에 필요하므로 유지 — top-level은 read로 좁히고 필요한 스코프만 job에서 확장하는 표준 패턴.

## 검증

Pre-commit verified: `bash scripts/run-tests.sh` → `ALL TESTS PASSED` (exit 0, pytest + shell + manifest 전부 통과)

- YAML 파싱 OK (`python3 -c "yaml.safe_load(...)"` → `YAML OK`)
- codex review 통과 (findings 0건)

## 영향 범위

- CI 권한 축소만, 런타임/제품 코드 무변경. 두 워크플로우가 실제로 read만 사용하므로 기능 회귀 없음.

Refs #549
