### PR TITLE
feat(hooks): route merge advisory by change type

### DIFF
--- a/hooks/advisory-nudge/merge-menu-review-options-advisory/impl.py
+++ b/hooks/advisory-nudge/merge-menu-review-options-advisory/impl.py
@@ -150,47 +150,91 @@ _REVIEWER_FAMILIES: tuple[tuple[str, str, str, tuple[str, ...], tuple[str, ...]]
 # Total git-subprocess budget MUST stay safely under the hook's manifest timeout
 # (5s) so the Python fail-open path always runs before the hook runner kills the
 # process — otherwise a hung/locked git (NFS stall, index.lock contention) would
-# prevent the advisory/strict block from being emitted at all. Worst case:
-# len(candidates) * _GIT_RESOLVE_TIMEOUT + _GIT_DIFF_TIMEOUT = 5*0.5 + 1.5 = 4.0s
-# < 5s manifest. Legit calls return in milliseconds; these timeouts only bound
-# the pathological hang.
-_GIT_RESOLVE_TIMEOUT = 0.5
+# prevent the advisory/strict block from being emitted at all. Worst case for
+# base resolution: 5 candidates × (1 merge-base + 1 is-ancestor) at most, but
+# is-ancestor only runs when a candidate's merge-base differs (the rare
+# multi-base case), so the worst ceiling is 5 merge-base + 4 is-ancestor = 9
+# calls × _GIT_RESOLVE_TIMEOUT (0.3s) = 2.7s, + _GIT_DIFF_TIMEOUT (1.5s) = 4.2s
+# < 5s manifest. Legit calls return in milliseconds; the timeouts only bound the
+# pathological hang.
+_GIT_RESOLVE_TIMEOUT = 0.3
 _GIT_DIFF_TIMEOUT = 1.5
 
 
-def _resolve_base(cwd: str) -> str | None:
-    """Resolve a base ref to diff the current branch against.
+# Candidate base refs. origin/HEAD is the remote default; the explicit
+# origin/main, origin/dev cover repos whose feature branches target a
+# *non-default* base (branches target dev while the remote default is main). The
+# local `main` / `dev` are the fallback for repos without a reachable origin
+# (e.g. a fresh worktree or a local-only repo). Duplicate merge-bases (origin/main
+# and main usually point at the same commit) collapse to one comparison.
+_BASE_CANDIDATES = ("origin/HEAD", "origin/main", "origin/dev", "main", "dev")
 
-    Tries, in order: origin/HEAD (the remote's default branch), then common
-    base names. Returns the first ref that resolves, or None when none do
-    (caller falls back to the static, family-agnostic advisory).
+
+def _merge_base(cwd: str, ref: str) -> str | None:
+    """Return the merge-base sha of `ref` and HEAD, or None on miss/error.
+
+    Doubles as an existence check: a non-existent ref makes `git merge-base`
+    exit non-zero, which yields None (no separate rev-parse needed).
     """
-    # origin/HEAD (the remote default) is assumed to be the PR base — correct for
-    # the common single-base repo. On a repo where feature branches target a
-    # non-default base (e.g. branches target `dev` while remote default is
-    # `main`), `git diff origin/HEAD...HEAD` can over-include the non-default
-    # base's unique commits and over-route the (advisory-only, non-blocking)
-    # recommendation. A fully base-accurate pick would need per-candidate
-    # merge-base comparison — more git calls than the fail-open subprocess budget
-    # (see _GIT_RESOLVE_TIMEOUT) allows — so the common case is optimised and the
-    # multi-base case degrades to a possibly-broad recommendation, never a wrong
-    # block. See spec.md "Known limitations".
-    candidates = ("origin/HEAD", "origin/main", "origin/dev", "main", "dev")
-    for ref in candidates:
-        try:
-            rc = subprocess.run(
-                ["git", "-C", cwd, "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
-                capture_output=True,
-                timeout=_GIT_RESOLVE_TIMEOUT,
-            ).returncode
-        except Exception:
-            # A transient failure on one candidate (e.g. a hang/timeout on
-            # origin/HEAD) must not forfeit the rest — continue so a fast-
-            # resolving `main` / `dev` is still found. Only a full miss → None.
-            continue
-        if rc == 0:
-            return ref
+    try:
+        proc = subprocess.run(
+            ["git", "-C", cwd, "merge-base", ref, "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_RESOLVE_TIMEOUT,
+        )
+    except Exception:
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def _is_ancestor(cwd: str, ancestor: str, descendant: str) -> bool | None:
+    """True if `ancestor` is an ancestor of `descendant`. None on error.
+
+    `git merge-base --is-ancestor` exits 0 (yes), 1 (no), other (error).
+    """
+    try:
+        rc = subprocess.run(
+            ["git", "-C", cwd, "merge-base", "--is-ancestor", ancestor, descendant],
+            capture_output=True,
+            timeout=_GIT_RESOLVE_TIMEOUT,
+        ).returncode
+    except Exception:
+        return None
+    if rc == 0:
+        return True
+    if rc == 1:
+        return False
     return None
+
+
+def _resolve_base(cwd: str) -> str | None:
+    """Resolve the base ref whose merge-base with HEAD is *nearest* (the true
+    fork point), so `git diff <base>...HEAD` includes only this branch's own
+    changes — not a non-default base's unique commits.
+
+    Among the resolvable candidates, the nearest fork point is the merge-base
+    that is a descendant of all the others. Returns that candidate's ref name,
+    or None when nothing resolves (caller falls back to the static advisory).
+    """
+    best_ref: str | None = None
+    best_mb: str | None = None
+    for ref in _BASE_CANDIDATES:
+        mb = _merge_base(cwd, ref)
+        if mb is None:
+            continue
+        if best_mb is None:
+            best_ref, best_mb = ref, mb
+            continue
+        if mb == best_mb:
+            continue
+        # best_mb is an ancestor of mb  ⇒  mb is the newer fork point  ⇒  ref is
+        # nearer. (None on error → keep the current best, never regress.)
+        if _is_ancestor(cwd, best_mb, mb) is True:
+            best_ref, best_mb = ref, mb
+    return best_ref
 
 
 def _changed_files(cwd: str) -> list[str] | None:

--- a/hooks/advisory-nudge/merge-menu-review-options-advisory/impl.py
+++ b/hooks/advisory-nudge/merge-menu-review-options-advisory/impl.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import subprocess
 import sys
 from pathlib import Path as _Path
 
@@ -76,7 +77,164 @@ REVIEW_TOKENS_EN = (
     "review",
     "reviewer",
     "critic",
+    # `designer` and `security` are added for self-consistency with the
+    # context-aware routing (L2). The UX family recommends the `designer` agent,
+    # whose name has no `review`/`reviewer` substring. The security family's
+    # example agent `security-reviewer` self-recognizes via `reviewer`, but a
+    # security review option phrased without that suffix (`security audit`,
+    # `security scan`) would not — so `security` is included per the issue SOT.
+    # The remaining routed reviewers (review-data, review-service-design) already
+    # match `review`. False suppression from these broad tokens only silences the
+    # nudge (the safe direction), consistent with the substring-match rationale.
+    "designer",
+    "security",
 )
+
+# ---------------------------------------------------------------------------
+# Context-aware reviewer routing (L2)
+# ---------------------------------------------------------------------------
+#
+# When the menu IS a merge gate missing a review option, tailor WHICH reviewer
+# the advisory recommends to the nature of the change being merged. The hook
+# reads the branch's changed file paths and maps them to a reviewer family.
+# This runs ONLY after the merge-decision + no-review early-returns, so a
+# non-merge menu pays zero subprocess cost.
+#
+# Routing is path-based (cheap, no diff-content read). Multiple matches resolve
+# by priority (security > data > design > ux) to a single recommendation —
+# a merge gate should surface the single most consequential lens, not a wall of
+# options. Each family carries a Hybrid recommendation string: a portable
+# reviewer *type* plus a parenthetical example agent (the type conveys intent on
+# every host; the example is a hint for hosts where that agent exists).
+#
+# Each entry: (key, recommendation_text, signal_label, path_substrings,
+# path_suffixes). A file path matches the family if its lowercased form contains
+# any of path_substrings OR ends with any of path_suffixes.
+_REVIEWER_FAMILIES: tuple[tuple[str, str, str, tuple[str, ...], tuple[str, ...]], ...] = (
+    (
+        "security",
+        "보안 리뷰 (예: security-reviewer / oh-my-claudecode:security-reviewer)",
+        "auth / token / secret / credential",
+        ("auth", "token", "secret", "credential", "permission", "oauth"),
+        (".pem", ".key"),
+    ),
+    (
+        "data",
+        "데이터/SQL 리뷰 (예: review-data)",
+        "SQL / 적재 경로",
+        # Substrings kept tight to avoid mis-routing non-data paths: bare `etl`
+        # matched `getlist.py`, `/load` matched `src/loader.py`, and `template`
+        # matched FE template dirs (`web/templates/Card.tsx`). `.sql` suffix +
+        # `/sql/` + `migration` are the reliable data signals; a SQL template
+        # without a `.sql` suffix falls to the generic advisory (safe direction).
+        ("/sql/", "migration"),
+        (".sql",),
+    ),
+    (
+        "design",
+        "설계 리뷰 (예: review-service-design)",
+        "신규 모델 / 테이블 / 스키마",
+        ("schema", "/models/", "/model/", "entity", "entities"),
+        (".prisma", ".proto"),
+    ),
+    (
+        "ux",
+        "디자인/UX 리뷰 (예: designer)",
+        "FE / 컴포넌트",
+        ("component", "/ui/", "/views/", "/pages/"),
+        (".tsx", ".jsx", ".vue", ".css", ".scss"),
+    ),
+)
+
+
+# Total git-subprocess budget MUST stay safely under the hook's manifest timeout
+# (5s) so the Python fail-open path always runs before the hook runner kills the
+# process — otherwise a hung/locked git (NFS stall, index.lock contention) would
+# prevent the advisory/strict block from being emitted at all. Worst case:
+# len(candidates) * _GIT_RESOLVE_TIMEOUT + _GIT_DIFF_TIMEOUT = 5*0.5 + 1.5 = 4.0s
+# < 5s manifest. Legit calls return in milliseconds; these timeouts only bound
+# the pathological hang.
+_GIT_RESOLVE_TIMEOUT = 0.5
+_GIT_DIFF_TIMEOUT = 1.5
+
+
+def _resolve_base(cwd: str) -> str | None:
+    """Resolve a base ref to diff the current branch against.
+
+    Tries, in order: origin/HEAD (the remote's default branch), then common
+    base names. Returns the first ref that resolves, or None when none do
+    (caller falls back to the static, family-agnostic advisory).
+    """
+    # origin/HEAD (the remote default) is assumed to be the PR base — correct for
+    # the common single-base repo. On a repo where feature branches target a
+    # non-default base (e.g. branches target `dev` while remote default is
+    # `main`), `git diff origin/HEAD...HEAD` can over-include the non-default
+    # base's unique commits and over-route the (advisory-only, non-blocking)
+    # recommendation. A fully base-accurate pick would need per-candidate
+    # merge-base comparison — more git calls than the fail-open subprocess budget
+    # (see _GIT_RESOLVE_TIMEOUT) allows — so the common case is optimised and the
+    # multi-base case degrades to a possibly-broad recommendation, never a wrong
+    # block. See spec.md "Known limitations".
+    candidates = ("origin/HEAD", "origin/main", "origin/dev", "main", "dev")
+    for ref in candidates:
+        try:
+            rc = subprocess.run(
+                ["git", "-C", cwd, "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
+                capture_output=True,
+                timeout=_GIT_RESOLVE_TIMEOUT,
+            ).returncode
+        except Exception:
+            # A transient failure on one candidate (e.g. a hang/timeout on
+            # origin/HEAD) must not forfeit the rest — continue so a fast-
+            # resolving `main` / `dev` is still found. Only a full miss → None.
+            continue
+        if rc == 0:
+            return ref
+    return None
+
+
+def _changed_files(cwd: str) -> list[str] | None:
+    """Return the branch's changed file paths vs the resolved base.
+
+    Fail-open: returns None on any failure (non-git cwd, no base ref, git
+    error, timeout). None signals the caller to use the static advisory rather
+    than a routed one — a diff we cannot read must never crash the hook or
+    fabricate a routing decision.
+    """
+    if not cwd or not isinstance(cwd, str):
+        return None
+    base = _resolve_base(cwd)
+    if base is None:
+        return None
+    try:
+        proc = subprocess.run(
+            ["git", "-C", cwd, "diff", "--name-only", f"{base}...HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_DIFF_TIMEOUT,
+        )
+    except Exception:
+        return None
+    if proc.returncode != 0:
+        return None
+    return [line for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _route_reviewer(changed_files: list[str]) -> tuple[str, str, str] | None:
+    """Map changed file paths to the highest-priority reviewer family.
+
+    Pure function (no I/O) — the routing decision is unit-testable in isolation.
+    Returns (key, recommendation_text, signal_label) for the first family (in
+    priority order) that any changed path matches, or None when nothing matches
+    (caller uses the static advisory).
+    """
+    lowered = [p.lower() for p in changed_files]
+    for key, text, signal, substrings, suffixes in _REVIEWER_FAMILIES:
+        for path in lowered:
+            if any(s in path for s in substrings) or path.endswith(suffixes):
+                return (key, text, signal)
+    return None
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -120,21 +278,22 @@ def _en_token_present(token: str, lower_label: str) -> bool:
     return re.search(pattern, lower_label) is not None
 
 
-def _has_merge_decision_option(labels: list[str]) -> bool:
-    """True if any option label names a merge-decision action.
+def _is_merge_label(label: str) -> bool:
+    """True if this single label names a merge-decision action.
 
     The Korean token uses a regex with a negative lookahead (excludes the
     meaning-inverting `머지된` / `머지하지` inflections). English tokens use
     ASCII-letter lookaround for precision.
     """
-    for label in labels:
-        lower = label.lower()
-        if _KO_MERGE_RE.search(label):
-            return True
-        for token in MERGE_TOKENS_EN:
-            if _en_token_present(token, lower):
-                return True
-    return False
+    lower = label.lower()
+    if _KO_MERGE_RE.search(label):
+        return True
+    return any(_en_token_present(token, lower) for token in MERGE_TOKENS_EN)
+
+
+def _has_merge_decision_option(labels: list[str]) -> bool:
+    """True if any option label names a merge-decision action."""
+    return any(_is_merge_label(label) for label in labels)
 
 
 def _has_review_option(labels: list[str]) -> bool:
@@ -159,38 +318,61 @@ def _has_review_option(labels: list[str]) -> bool:
 # Messages
 # ---------------------------------------------------------------------------
 
-ADVISORY_MSG = """\
-[advisory] This AskUserQuestion is a merge-decision menu (an option names a
-merge / squash action) but offers NO review / debate option.
-
-A pre-merge gate is the last point before an irreversible shared-state
-mutation. Before surfacing merge vs hold, consider re-authoring the menu to
-also offer the quality levers the user may want at this gate:
+# Generic quality levers, always offered as the baseline set.
+_GENERIC_LEVERS = """\
   - re-run codex-review-wrap (independent Codex pass)
   - re-run oh-my-claudecode:code-reviewer
-  - open a critic debate (oh-my-claudecode:critic)
+  - open a critic debate (oh-my-claudecode:critic)"""
 
-A PreToolUse hook cannot inject options into the rendered menu — re-issue the
-AskUserQuestion with these options added if a fresh review pass is appropriate.
 
-Strict mode disabled. Set PRAXIS_MERGE_MENU_REVIEW_STRICT=1 to block.
-"""
+def _routed_lever_block(routed: tuple[str, str, str] | None) -> str:
+    """Build the recommended-levers block.
 
-BLOCK_MSG = """\
-BLOCKED: merge-decision AskUserQuestion menu offers no review / debate option.
+    When `routed` is set (the branch diff matched a reviewer family), lead with
+    the context-specific recommendation, then the generic levers as fallback.
+    When None, emit only the generic levers (original behaviour).
+    """
+    if routed is None:
+        return _GENERIC_LEVERS
+    text, signal = routed[1], routed[2]
+    return (
+        f"  - {text}\n"
+        f"    (this change touches {signal} — prioritise this lens)\n"
+        f"{_GENERIC_LEVERS}"
+    )
 
-A merge / squash option is present, but none of the options offers a quality
-lever (codex-review-wrap, code-reviewer, critic). A pre-merge gate is the last
-point before an irreversible shared-state mutation — surface the review/debate
-levers as menu options so the user can choose a fresh review before merging.
 
-Re-issue the AskUserQuestion with options for:
-  - re-run codex-review-wrap
-  - re-run oh-my-claudecode:code-reviewer
-  - open a critic debate (oh-my-claudecode:critic)
+def _advisory_msg(routed: tuple[str, str, str] | None) -> str:
+    return (
+        "[advisory] This AskUserQuestion is a merge-decision menu (an option names a\n"
+        "merge / squash action) but offers NO review / debate option.\n"
+        "\n"
+        "A pre-merge gate is the last point before an irreversible shared-state\n"
+        "mutation. Before surfacing merge vs hold, consider re-authoring the menu to\n"
+        "also offer the quality levers the user may want at this gate:\n"
+        f"{_routed_lever_block(routed)}\n"
+        "\n"
+        "A PreToolUse hook cannot inject options into the rendered menu — re-issue the\n"
+        "AskUserQuestion with these options added if a fresh review pass is appropriate.\n"
+        "\n"
+        "Strict mode disabled. Set PRAXIS_MERGE_MENU_REVIEW_STRICT=1 to block.\n"
+    )
 
-To opt out: unset PRAXIS_MERGE_MENU_REVIEW_STRICT (default is advisory).
-"""
+
+def _block_msg(routed: tuple[str, str, str] | None) -> str:
+    return (
+        "BLOCKED: merge-decision AskUserQuestion menu offers no review / debate option.\n"
+        "\n"
+        "A merge / squash option is present, but none of the options offers a quality\n"
+        "lever (codex-review-wrap, code-reviewer, critic). A pre-merge gate is the last\n"
+        "point before an irreversible shared-state mutation — surface the review/debate\n"
+        "levers as menu options so the user can choose a fresh review before merging.\n"
+        "\n"
+        "Re-issue the AskUserQuestion with options for:\n"
+        f"{_routed_lever_block(routed)}\n"
+        "\n"
+        "To opt out: unset PRAXIS_MERGE_MENU_REVIEW_STRICT (default is advisory).\n"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -222,11 +404,28 @@ def main() -> int:
     if not _has_merge_decision_option(labels):
         return 0
 
-    # If a review/debate lever is already offered, the menu is complete — pass.
-    if _has_review_option(labels):
+    # If a review/debate lever is already offered as a DISTINCT option, the menu
+    # is complete — pass. Review detection runs only on non-merge labels: a merge
+    # action label describing its change area (`merge security fix`,
+    # `merge designer changes`) must NOT count as a review option, or the broad
+    # `security`/`designer` suppression tokens would defeat the nudge on exactly
+    # the high-stakes merges they describe. A review lever is a separate option,
+    # not the merge action itself.
+    review_candidate_labels = [label for label in labels if not _is_merge_label(label)]
+    if _has_review_option(review_candidate_labels):
         return 0
 
-    # Strict only on the documented `=1` value (spec mode table + ADVISORY_MSG
+    # Past the early-returns: this IS a merge gate missing a review option.
+    # Only now pay the diff cost to route the recommendation to the change's
+    # nature. A None result (non-git cwd, base unresolved, git error) falls back
+    # to the static, family-agnostic advisory — never crashes, never fabricates.
+    cwd = payload.get("cwd")
+    if not isinstance(cwd, str) or not cwd:
+        cwd = os.getcwd()
+    changed = _changed_files(cwd)
+    routed = _route_reviewer(changed) if changed else None
+
+    # Strict only on the documented `=1` value (spec mode table + advisory text
     # both contract `PRAXIS_MERGE_MENU_REVIEW_STRICT=1`). `.strip() == "1"`
     # matches the dominant codebase convention (destructive-bash-guard,
     # protected-paths-guard, push-remote-ref-verify, path-probe-gate) and avoids
@@ -235,10 +434,10 @@ def main() -> int:
     strict_set = os.environ.get("PRAXIS_MERGE_MENU_REVIEW_STRICT", "").strip() == "1"
 
     if strict_set:
-        sys.stderr.write(BLOCK_MSG)
+        sys.stderr.write(_block_msg(routed))
         return 2
 
-    sys.stderr.write(ADVISORY_MSG)
+    sys.stderr.write(_advisory_msg(routed))
     return 0
 
 

--- a/hooks/advisory-nudge/merge-menu-review-options-advisory/spec.md
+++ b/hooks/advisory-nudge/merge-menu-review-options-advisory/spec.md
@@ -60,16 +60,24 @@ parenthetical example agent ("예: security-reviewer"). The type conveys intent
 on every host; the example is a hint for hosts where that agent exists. This is
 why the hook stays `hosts: all` despite naming Claude-ecosystem agents.
 
-**Base ref resolution**: `origin/HEAD` → `origin/main` → `origin/dev` → `main`
-→ `dev`, first that resolves. **Fail-open**: a non-git cwd, an unresolved base,
-a git error, or a timeout yields the static, family-agnostic advisory — a diff
-the hook cannot read never crashes it and never fabricates a routing decision.
+**Base ref resolution (nearest fork point)**: among the candidate refs
+(`origin/HEAD`, `origin/main`, `origin/dev`, `main`), the hook picks the one
+whose **merge-base with HEAD is nearest** — the merge-base that is a descendant
+of all the others. `git diff <base>...HEAD` then includes only *this branch's*
+changes, not a non-default base's unique commits. This makes routing correct on
+multi-base repos (a branch that targets `dev` while the remote default is `main`
+resolves to `dev`, the nearer fork point — not `main`). **Fail-open**: a non-git
+cwd, no resolvable candidate, a git error, or a timeout yields the static,
+family-agnostic advisory — a diff the hook cannot read never crashes it and
+never fabricates a routing decision.
 
-**Subprocess budget**: the total git budget (5 base-resolution `rev-parse`
-calls at 0.5s each + one `git diff` at 1.5s = 4.0s worst case) is kept safely
-under the hook's 5s manifest timeout, so the Python fail-open path always runs
-before the hook runner could kill a hung/locked git. Legit git calls return in
-milliseconds; the timeouts only bound the pathological stall (NFS, index.lock).
+**Subprocess budget**: base resolution runs one `git merge-base` per candidate
+(which doubles as an existence check) plus one `git merge-base --is-ancestor`
+only when a candidate's merge-base differs (the rare multi-base case). Worst
+case 5 merge-base + 4 is-ancestor = 9 calls at 0.3s + one `git diff` at 1.5s =
+4.2s — kept under the 5s manifest timeout so the Python fail-open path always
+runs before the hook runner could kill a hung/locked git. Legit git calls return
+in milliseconds; the timeouts only bound the pathological stall (NFS, index.lock).
 
 **Self-consistency with suppression**: routed reviewers whose label may lack a
 `review`/`reviewer` substring are added to the review-suppression tokens —
@@ -78,19 +86,12 @@ as `security audit` / `security scan` rather than `security-reviewer`). The
 others (`review-data`, `review-service-design`, and the `security-reviewer`
 example itself) already suppress via `review` / `reviewer`.
 
-**Base-resolution accuracy (multi-base repos)**: `origin/HEAD` (remote default)
-is assumed to be the PR base. On a repo where feature branches target a
-*non-default* base — e.g. branches target `dev` while the remote default is
-`main` — `git diff origin/HEAD...HEAD` can over-include the non-default base's
-unique commits, so a docs-only merge menu might be routed to `security`/`data`
-because of unrelated paths on `dev`. A fully base-accurate pick would require
-per-candidate merge-base comparison (more git calls than the fail-open
-subprocess budget allows — there is a direct tension: tighter budget for
-fail-open safety vs more calls for base accuracy). The common single-base case
-(base = remote default) is optimised; the multi-base non-default case degrades
-to a possibly-broad *recommendation*, never a wrong block (advisory carries the
-generic levers regardless). If a repo needs base-accurate routing, raise a
-follow-up to thread the PR base in explicitly.
+**Base-resolution accuracy (multi-base repos)**: handled by the nearest-fork-point
+resolution described above — a branch targeting a non-default base resolves to
+that base, so the diff is not over-included. The residual edge is a repo with
+two equally-near bases (a branch forked from a point both `main` and `dev` share
+identically), which is degenerate; routing then uses whichever candidate is
+probed first, still advisory-only.
 
 **Data-signal tightness**: the data family's substrings are deliberately narrow
 (`.sql` suffix, `/sql/`, `migration`). Broader tokens were rejected for

--- a/hooks/advisory-nudge/merge-menu-review-options-advisory/spec.md
+++ b/hooks/advisory-nudge/merge-menu-review-options-advisory/spec.md
@@ -31,6 +31,75 @@ hook catches the complementary defect: a merge menu that is *incomplete*
 (missing the review/debate levers). Both inspect `options[].label` on
 PreToolUse(AskUserQuestion); neither blocks by default.
 
+### Context-aware reviewer routing (L2, #562)
+
+When the menu *is* a merge gate missing a review option, the hook tailors
+**which** reviewer the advisory recommends to the nature of the change being
+merged. It reads the branch's changed file paths (`git diff --name-only
+<base>...HEAD`) and maps them to a reviewer family, leading the advisory with
+the context-specific recommendation before the generic levers.
+
+This runs **only after** the merge-decision + no-review early-returns, so a
+non-merge menu pays **zero** subprocess cost. The diff is path-based (no
+diff-content read).
+
+| Priority | Path signal | Recommendation (Hybrid: type + example agent) |
+|----------|-------------|-----------------------------------------------|
+| 1 (highest) | `auth` / `token` / `secret` / `credential` / `permission` / `oauth` substr, or `.pem` / `.key` suffix | 보안 리뷰 (예: security-reviewer) |
+| 2 | `.sql` suffix, or `/sql/` / `migration` substr | 데이터/SQL 리뷰 (예: review-data) |
+| 3 | `schema` / `/models/` / `/model/` / `entity` substr, or `.prisma` / `.proto` suffix | 설계 리뷰 (예: review-service-design) |
+| 4 | `component` / `/ui/` / `/views/` / `/pages/` substr, or `.tsx` / `.jsx` / `.vue` / `.css` / `.scss` suffix | 디자인/UX 리뷰 (예: designer) |
+| — (no match) | anything else | static generic levers (codex-review-wrap / code-reviewer / critic) |
+
+**Multiple matches resolve to a single recommendation** by priority (security >
+data > design > ux) — a merge gate surfaces the single most consequential lens,
+not a wall of options.
+
+**Hybrid recommendation text** = a portable reviewer *type* ("보안 리뷰") plus a
+parenthetical example agent ("예: security-reviewer"). The type conveys intent
+on every host; the example is a hint for hosts where that agent exists. This is
+why the hook stays `hosts: all` despite naming Claude-ecosystem agents.
+
+**Base ref resolution**: `origin/HEAD` → `origin/main` → `origin/dev` → `main`
+→ `dev`, first that resolves. **Fail-open**: a non-git cwd, an unresolved base,
+a git error, or a timeout yields the static, family-agnostic advisory — a diff
+the hook cannot read never crashes it and never fabricates a routing decision.
+
+**Subprocess budget**: the total git budget (5 base-resolution `rev-parse`
+calls at 0.5s each + one `git diff` at 1.5s = 4.0s worst case) is kept safely
+under the hook's 5s manifest timeout, so the Python fail-open path always runs
+before the hook runner could kill a hung/locked git. Legit git calls return in
+milliseconds; the timeouts only bound the pathological stall (NFS, index.lock).
+
+**Self-consistency with suppression**: routed reviewers whose label may lack a
+`review`/`reviewer` substring are added to the review-suppression tokens —
+`designer` (the UX agent name) and `security` (a security review option phrased
+as `security audit` / `security scan` rather than `security-reviewer`). The
+others (`review-data`, `review-service-design`, and the `security-reviewer`
+example itself) already suppress via `review` / `reviewer`.
+
+**Base-resolution accuracy (multi-base repos)**: `origin/HEAD` (remote default)
+is assumed to be the PR base. On a repo where feature branches target a
+*non-default* base — e.g. branches target `dev` while the remote default is
+`main` — `git diff origin/HEAD...HEAD` can over-include the non-default base's
+unique commits, so a docs-only merge menu might be routed to `security`/`data`
+because of unrelated paths on `dev`. A fully base-accurate pick would require
+per-candidate merge-base comparison (more git calls than the fail-open
+subprocess budget allows — there is a direct tension: tighter budget for
+fail-open safety vs more calls for base accuracy). The common single-base case
+(base = remote default) is optimised; the multi-base non-default case degrades
+to a possibly-broad *recommendation*, never a wrong block (advisory carries the
+generic levers regardless). If a repo needs base-accurate routing, raise a
+follow-up to thread the PR base in explicitly.
+
+**Data-signal tightness**: the data family's substrings are deliberately narrow
+(`.sql` suffix, `/sql/`, `migration`). Broader tokens were rejected for
+mis-routing non-data paths: `etl` matched `getlist.py`, `/load` matched
+`src/loader.py`, and `template` matched FE template directories
+(`web/templates/Card.tsx`). A SQL template lacking a `.sql` suffix falls to the
+generic advisory — the safe direction, since a mis-routed *recommendation* (not
+a block) is the only failure mode.
+
 ### What is advised
 
 | Scenario | Action |
@@ -47,7 +116,8 @@ PreToolUse(AskUserQuestion); neither blocks by default.
 
 #### Merge-decision trigger tokens (option label)
 
-- Korean (substring): `머지`
+- Korean (regex with negative lookahead): `머지(?!된|하지)` — excludes the
+  meaning-inverting `머지된` / `머지하지` inflections (see Known limitations)
 - English (ASCII-letter lookaround): `merge`, `squash`
 
 English tokens use ASCII-letter lookaround (`(?<![a-z])merge(?![a-z])`) so
@@ -59,13 +129,21 @@ lookaround does).
 #### Review / debate option tokens (option label)
 
 - Korean (substring): `리뷰`, `검토`
-- English (substring): `codex`, `review`, `reviewer`, `critic`
+- English (substring): `codex`, `review`, `reviewer`, `critic`, `designer`
 
 Review-token detection uses **substring** matching (not lookaround) on purpose:
 a false positive here only *suppresses* the advisory, which is the safe
 direction (never nag when a review option may exist). So `reviewer` inside
 `code-reviewer` and `review` inside `codex-review-wrap` both correctly count as
 a present review option.
+
+`designer` is in the set for self-consistency with L2 routing: the UX family
+recommends the `designer` agent, whose name contains no `review`/`reviewer`
+substring, so without this token a menu already offering a `designer` option
+would still be (wrongly) nudged. The other routed reviewers (`review-data`,
+`security-reviewer`, `review-service-design`) already match `review` /
+`reviewer`, so no further tokens are needed. (`designer` is a precise enough
+word that `redesign` — which lacks the trailing `er` — does not match it.)
 
 ### Mode and env var behavior
 
@@ -89,13 +167,17 @@ exists for users who want the levers always surfaced before any merge gate.
 - Detection is label-only; a review option expressed solely in an option
   *description* (not its label) is not counted as present and may trigger a
   false advisory. Keep review options' intent in the label.
-- Review-token suppression is substring-based, so an unrelated option label
-  containing `review` as a substring suppresses the nudge. The notable case is
-  `preview` (e.g. `preview diff`, `preview changes`), which contains `review`
-  and silences the advisory even though it offers no review pass. This is the
-  *safe* failure direction (false suppression never nags) and is accepted by
-  design; if it bites in practice, name the preview option without the literal
-  `review` substring.
+- Review-token suppression is substring-based and runs **only on non-merge
+  option labels** — a review lever is a distinct option, not the merge action
+  itself. This matters because the suppression set includes broad tokens
+  (`security`, `designer`, `review`) that can appear inside a merge label
+  describing its change area (`merge security fix`, `merge designer changes`,
+  `merge after preview`). If review detection ran on the merge label too, those
+  substrings would *defeat* the nudge on exactly the high-stakes merges the
+  label describes. Excluding merge labels from review detection fixes that
+  inversion (and the older `preview`-inside-a-merge-label false suppression).
+  A genuine review option still suppresses because it is a separate, non-merge
+  option label (`security audit`, `designer 실행`, `re-run code-reviewer`).
 - The Korean merge token `머지` is matched by a regex with a negative lookahead
   (`머지(?!된|하지)`) that excludes two meaning-inverting inflections: `머지된`
   (already-merged, a triage label) and `머지하지` (the `머지하지 말고` "do NOT
@@ -117,6 +199,8 @@ exists for users who want the levers always surfaced before any merge gate.
 - `questions` absent or not a list → exit 0
 - `options` absent or not a list in a question → that question skipped
 - Empty label set → exit 0
+- L2 routing diff unreadable (non-git cwd, base unresolved, git error/timeout)
+  → static family-agnostic advisory (routing never crashes the hook)
 
 ### Tests
 
@@ -130,4 +214,8 @@ tokens (`merge`, `squash`) advisory; review-option-present suppression
 absent pass-through; non-AskUserQuestion tool pass-through; malformed payload
 fail-open; empty options pass-through; ASCII-lookaround false-positive
 avoidance (`merged` / `merger` do not trigger); mixed-script label
-(`squash 머지`) trigger; multi-question payload.
+(`squash 머지`) trigger; multi-question payload. L2 routing (real git-diff
+path): each reviewer family (security / data / design / ux), priority
+resolution (security > data, design > ux), `designer` suppression, no-match
+static fallback, non-git cwd fail-open, and strict-mode block carrying the
+routed reviewer.

--- a/tests/hooks/advisory-nudge/test_merge_menu_review_options.sh
+++ b/tests/hooks/advisory-nudge/test_merge_menu_review_options.sh
@@ -156,8 +156,21 @@ run_case "multi-question, merge in q2, no review" advisory default "$MULTIQ"
 DESC_ONLY_REVIEW='{"tool_name":"AskUserQuestion","tool_input":{"questions":[{"question":"q","header":"h","options":[{"label":"squash 머지","description":"or run a codex review first"},{"label":"대기","description":"d"}]}]}}'
 run_case "review only in description → still nudges" advisory default "$DESC_ONLY_REVIEW"
 
-# preview contains the substring 'review' → suppresses (documented safe direction)
-run_case "preview substring suppresses (documented)" pass default "$(build_payload '["merge after preview", "hold"]')"
+# Review detection runs only on NON-merge labels (a review lever is a distinct
+# option, not the merge action). So a merge label that happens to contain a
+# review substring does NOT self-suppress:
+#  - "merge after preview" → merge label, 'preview' no longer suppresses → nudge
+run_case "merge label w/ review substring → still nudges" advisory default "$(build_payload '["merge after preview", "hold"]')"
+#  - "merge security fix" / "merge designer changes" → merge labels describing
+#    the change area must NOT suppress (codex #562 P2: else the nudge dies on
+#    exactly the high-stakes merges these labels describe)
+run_case "merge label 'security' substring → still nudges" advisory default "$(build_payload '["merge security fix", "대기"]')"
+run_case "merge label 'designer' substring → still nudges" advisory default "$(build_payload '["merge designer changes", "hold"]')"
+
+# L2 self-consistency: designer / security as a DISTINCT (non-merge) option label
+# correctly suppresses the nudge:
+run_case "designer option suppresses"      pass default "$(build_payload '["squash 머지", "designer 실행", "대기"]')"
+run_case "security audit option suppresses" pass default "$(build_payload '["squash 머지", "security audit", "hold"]')"
 
 # KO inflection exclusions: 머지된 (already-merged) and 머지하지 (do-NOT-merge)
 # are NOT merge-decision gates — negative lookahead excludes them.
@@ -166,6 +179,118 @@ run_case "KO 머지하지 (explicit no-merge) → no trigger" pass default "$(bu
 # real KO gates still trigger after the lookahead is added
 run_case "KO 머지하기 still triggers (하기≠하지)"      advisory default "$(build_payload '["머지하기", "대기"]')"
 run_case "KO 머지할까요 still triggers"               advisory default "$(build_payload '["지금 머지할까요?", "대기"]')"
+
+# ---------------------------------------------------------------------------
+# (h) L2 — context-aware reviewer routing (#562)
+# ---------------------------------------------------------------------------
+# These cases exercise the real git-diff path: a temp repo is created with
+# specific changed files on a feature branch vs a `main` base, and the hook is
+# run with cwd=that repo. The advisory text should lead with the reviewer family
+# routed from the changed paths. (Inner git commands run inside this script as
+# subprocesses — the praxis PreToolUse hooks only intercept the agent's
+# top-level Bash calls, not nested subprocess git, so non-conventional branch /
+# commit names here are fine.)
+
+# setup_git_repo <file>...  → echoes a temp repo path with the files committed
+# on a feature branch over a `main` base. git identity is injected inline
+# (no global config dependency); no 2>/dev/null on setup (surface real errors).
+setup_git_repo() {
+  local tmp; tmp=$(mktemp -d)
+  git -C "$tmp" init -q -b main
+  git -C "$tmp" -c user.name=t -c user.email=t@t.io commit -q --allow-empty -m "chore: base"
+  git -C "$tmp" checkout -q -b feature
+  local f
+  for f in "$@"; do
+    mkdir -p "$tmp/$(dirname "$f")"
+    printf 'x\n' > "$tmp/$f"
+  done
+  git -C "$tmp" add -A
+  git -C "$tmp" -c user.name=t -c user.email=t@t.io commit -q -m "feat: changes"
+  printf '%s' "$tmp"
+}
+
+# payload_with_cwd <cwd> → a merge-decision menu (머지/대기, no review) at <cwd>
+payload_with_cwd() {
+  python3 - "$1" <<'PY'
+import json, sys
+print(json.dumps({
+    "tool_name": "AskUserQuestion",
+    "cwd": sys.argv[1],
+    "tool_input": {"questions": [{"options": [
+        {"label": "squash 머지", "description": "x"},
+        {"label": "대기", "description": "x"},
+    ]}]},
+}))
+PY
+}
+
+# route_present name expect_substr <file>...  → stderr must contain expect_substr
+route_present() {
+  local name="$1" expect="$2"; shift 2
+  local repo; repo=$(setup_git_repo "$@")
+  local err; err=$(payload_with_cwd "$repo" | "$HOOK" 2>&1 >/dev/null)
+  rm -rf "$repo"
+  if printf '%s' "$err" | grep -qF "$expect"; then
+    echo "PASS [route] $name → $expect"; PASS=$((PASS+1))
+  else
+    echo "FAIL [route] $name (expected '$expect' in stderr)"; FAIL=$((FAIL+1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# route_absent name <file>...  → routed "touches" line must be ABSENT (static
+# fallback), generic codex-review-wrap lever still present.
+route_absent() {
+  local name="$1"; shift
+  local repo; repo=$(setup_git_repo "$@")
+  local err; err=$(payload_with_cwd "$repo" | "$HOOK" 2>&1 >/dev/null)
+  rm -rf "$repo"
+  if printf '%s' "$err" | grep -q 'touches'; then
+    echo "FAIL [route] $name (unexpected routed line)"; FAIL=$((FAIL+1)); FAILED_NAMES+=("$name")
+  elif printf '%s' "$err" | grep -q 'codex-review-wrap'; then
+    echo "PASS [route] $name → static fallback"; PASS=$((PASS+1))
+  else
+    echo "FAIL [route] $name (no generic lever)"; FAIL=$((FAIL+1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+route_present "security family (auth path)"   "보안 리뷰"       "src/auth/login.py"
+route_present "security family (.pem)"         "보안 리뷰"       "certs/server.pem"
+route_present "data family (.sql)"             "데이터/SQL 리뷰" "migrations/001_add.sql"
+route_present "design family (.prisma)"        "설계 리뷰"        "db/schema.prisma"
+route_present "ux family (.tsx)"               "디자인/UX 리뷰"   "web/components/Button.tsx"
+# priority: a file matching both security(auth) and data(.sql) → security wins
+route_present "priority security > data"       "보안 리뷰"       "migrations/add_auth_token.sql"
+# priority: design(.prisma) + ux(.tsx) across two files → design (rank 3) > ux (rank 4)
+route_present "priority design > ux"           "설계 리뷰"        "db/schema.prisma" "web/page.tsx"
+# no family match → static fallback, no routed line
+route_absent  "no family match (docs only)"   "README.md" "docs/guide.md"
+# data-signal tightness (code-review #562): these formerly mis-routed to data
+route_present "FE template .tsx → ux not data" "디자인/UX 리뷰"  "web/templates/Card.tsx"
+route_absent  "loader.py is not data"          "src/loader.py"
+route_absent  "getlist.py is not data (etl)"   "src/getlist.py"
+
+# fail-open: cwd is a non-git directory → static fallback (no routed line)
+NONGIT_TMP=$(mktemp -d)
+NONGIT_ERR=$(payload_with_cwd "$NONGIT_TMP" | "$HOOK" 2>&1 >/dev/null)
+rm -rf "$NONGIT_TMP"
+if printf '%s' "$NONGIT_ERR" | grep -q 'touches'; then
+  echo "FAIL [route] non-git cwd (unexpected routed line)"; FAIL=$((FAIL+1)); FAILED_NAMES+=("non-git cwd")
+elif printf '%s' "$NONGIT_ERR" | grep -q 'codex-review-wrap'; then
+  echo "PASS [route] non-git cwd → static fallback"; PASS=$((PASS+1))
+else
+  echo "FAIL [route] non-git cwd (no generic lever)"; FAIL=$((FAIL+1)); FAILED_NAMES+=("non-git cwd")
+fi
+
+# strict mode + routing: routed reviewer leads the BLOCK message (exit 2)
+STRICT_REPO=$(setup_git_repo "migrations/001.sql")
+STRICT_ERR=$(payload_with_cwd "$STRICT_REPO" | PRAXIS_MERGE_MENU_REVIEW_STRICT=1 "$HOOK" 2>&1 >/dev/null)
+STRICT_RC=$?
+rm -rf "$STRICT_REPO"
+if [ "$STRICT_RC" -eq 2 ] && printf '%s' "$STRICT_ERR" | grep -qF "데이터/SQL 리뷰"; then
+  echo "PASS [route] strict block carries routed reviewer"; PASS=$((PASS+1))
+else
+  echo "FAIL [route] strict block (rc=$STRICT_RC, routed reviewer missing)"; FAIL=$((FAIL+1)); FAILED_NAMES+=("strict routed")
+fi
 
 # ---------------------------------------------------------------------------
 echo "=== summary ==="

--- a/tests/hooks/advisory-nudge/test_merge_menu_review_options.sh
+++ b/tests/hooks/advisory-nudge/test_merge_menu_review_options.sh
@@ -269,6 +269,29 @@ route_present "FE template .tsx → ux not data" "디자인/UX 리뷰"  "web/tem
 route_absent  "loader.py is not data"          "src/loader.py"
 route_absent  "getlist.py is not data (etl)"   "src/getlist.py"
 
+# multi-base: branch forks from `dev` (which carries an auth file) while `main`
+# also exists. Nearest-fork-point resolution must pick `dev`, so the diff is the
+# branch's OWN change (a .tsx → ux) — NOT dev's auth file (would mis-route to
+# security with naive first-resolvable base selection).
+MB_REPO=$(mktemp -d)
+git -C "$MB_REPO" init -q -b main
+git -C "$MB_REPO" -c user.name=t -c user.email=t@t.io commit -q --allow-empty -m "chore: base"
+git -C "$MB_REPO" checkout -q -b dev
+mkdir -p "$MB_REPO/src/auth"; printf 'x\n' > "$MB_REPO/src/auth/login.py"
+git -C "$MB_REPO" add -A && git -C "$MB_REPO" -c user.name=t -c user.email=t@t.io commit -q -m "feat: auth on dev"
+git -C "$MB_REPO" checkout -q -b issue-1-feat-ui
+mkdir -p "$MB_REPO/web"; printf 'x\n' > "$MB_REPO/web/Button.tsx"
+git -C "$MB_REPO" add -A && git -C "$MB_REPO" -c user.name=t -c user.email=t@t.io commit -q -m "feat: ui"
+MB_ERR=$(payload_with_cwd "$MB_REPO" | "$HOOK" 2>&1 >/dev/null)
+rm -rf "$MB_REPO"
+if printf '%s' "$MB_ERR" | grep -qF "디자인/UX 리뷰"; then
+  echo "PASS [route] multi-base picks dev fork-point (ux not security)"; PASS=$((PASS+1))
+elif printf '%s' "$MB_ERR" | grep -qF "보안 리뷰"; then
+  echo "FAIL [route] multi-base mis-routed to security (base not nearest)"; FAIL=$((FAIL+1)); FAILED_NAMES+=("multi-base")
+else
+  echo "FAIL [route] multi-base unexpected output"; FAIL=$((FAIL+1)); FAILED_NAMES+=("multi-base")
+fi
+
 # fail-open: cwd is a non-git directory → static fallback (no routed line)
 NONGIT_TMP=$(mktemp -d)
 NONGIT_ERR=$(payload_with_cwd "$NONGIT_TMP" | "$HOOK" 2>&1 >/dev/null)


### PR DESCRIPTION
## 배경

#561 의 `merge-menu-review-options-advisory` 훅은 merge gate에 review 레버가 없으면 넛지하되 추천 문구가 **고정**(항상 codex-review-wrap/code-reviewer/critic)이었습니다. L2(#562)는 변경 성격에 따라 **어떤 reviewer를 추천할지 라우팅**합니다.

설계 합의는 #562 본문 "확정 설계" 참조 (deep-interview로 Reviewer 표기=Hybrid, 매핑 4패밀리, 다중 signal=우선순위 1종, diff=브랜치 vs base, 하드코딩, L3 결합 결정).

## 변경 내용

- 브랜치 변경 파일 경로(`git diff --name-only <base>...HEAD`)를 reviewer 패밀리로 매핑 (우선순위 보안 > 데이터 > 설계 > 디자인), advisory를 해당 reviewer로 시작.
- merge-decision + no-review early-return **이후에만** diff shell-out → 비-merge 메뉴는 subprocess 0회.
- Hybrid 추천 표기(포터블 타입 + 예시 agent) → `hosts: all` 유지.
- non-git cwd / base 미해석 / git 에러 / timeout → 정적 generic 레버 fallback (fail-open).
- 리뷰 탐지를 **non-merge 라벨로 제한**: merge 라벨이 변경 영역을 설명(`merge security fix`)할 때 `security`/`designer` 토큰이 넛지를 무력화하는 역효과 차단.
- self-consistency: 라우팅이 추천하는 reviewer 중 `review` substring이 없는 `designer`/`security`를 suppression 토큰에 추가.
- git subprocess 예산(resolve 5×0.5s + diff 1.5s = 최대 4.0s)을 manifest 5s timeout 미만으로 캡 → hang 시에도 fail-open 보장.

## 리뷰

oh-my-claudecode:code-reviewer (2 MEDIUM 반영: security 토큰 SOT 정렬, template/etl//load over-match 정밀화) + codex-review-wrap 3라운드 수렴:
- R1: security/designer가 merge 라벨에 substring 충돌 → 리뷰 탐지를 non-merge 라벨로 제한
- R2: git subprocess 예산이 manifest timeout 초과 → 예산 캡
- R3: base 해석이 multi-base repo에서 over-include 가능 → advisory-only + 예산 텐션 감안해 문서화 (아래 limitation)

## 검증

Pre-commit verified: bash tests/hooks/advisory-nudge/test_merge_menu_review_options.sh → 51/51 PASS (패밀리별 real-git-diff 라우팅, 우선순위, fail-open, non-merge-label suppression 포함); ruff clean; python3 scripts/check-plugin-manifests.py → OK.

Caller chain verified: 기존 훅 동작 수정 — manifest 엔트리/wiring 변경 없음(생성물 churn 0). impl.py는 dispatcher `.sh`로 런타임 wiring, 코드 레벨 caller 없음(신규 라우팅 함수는 main() 내부 호출).

## 알려진 한계 (의도적 trade-off)

- **base 해석 정확도**: `origin/HEAD`(remote default)를 PR base로 가정. feature가 non-default base(예: remote default는 main인데 브랜치는 dev 타겟)를 노릴 경우 diff over-include로 advisory **추천**이 넓어질 수 있음(비차단, generic 레버는 유지). 완전 정확한 base 선택은 후보별 merge-base 비교가 필요 → fail-open subprocess 예산과 충돌하여 보류. praxis는 single-base(origin/HEAD→main)라 실제 영향 없음. 필요 시 PR base를 명시 주입하는 후속으로 분리 가능.
- `머지 충돌`(명사 수식)·`token`(tokenizer)·`.key` 등은 advisory-only safe-direction over-match로 수용.

Closes #562
