### PR TITLE
fix(hooks): scope sciomc finding gate to assistant-authored content

### DIFF
--- a/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
+++ b/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
@@ -32,9 +32,14 @@ Concrete retrospect pattern (praxis issue #374):
 Block conditions (ALL must hold):
   (a) Tool is Bash with a content `git commit` (not amend/merge/rebase/
       cherry-pick/revert)
-  (b) Recent transcript tail (last ~200 lines) contains a sciomc structured
+  (b) Recent ASSISTANT-AUTHORED transcript content (last ~200 entries:
+      assistant message text + Agent/Task subagent tool-results — NOT user
+      turns, system-reminder blocks, or Read/Skill tool-results that merely
+      *load* documentation such as a SKILL.md) contains a sciomc structured
       output marker: "[FINDING:", "[STAGE_COMPLETE:", "[CONFLICTS:",
-      "sibling-deviant", "의미 mismatch", "의미 충돌"
+      "sibling-deviant", "의미 mismatch", "의미 충돌". Scanning is role-aware
+      (JSONL parsed per-entry) so a SKILL.md that *documents* these tokens as
+      literal example text does not self-trip the gate (praxis issue #573).
   (c) No `gh pr view ... --json body` OR `gh issue view ... --json body` OR
       explicit ratification token was emitted AFTER the most recent finding
       marker in the transcript tail
@@ -99,21 +104,21 @@ def main() -> int:
     if not transcript_path:
         return 0  # no transcript → cannot enforce
 
-    tail = _read_transcript_tail(transcript_path, max_lines=200, max_bytes=50 * 1024 * 1024)
-    if tail is None:
+    scan = _build_finding_scan(transcript_path, max_entries=200, max_bytes=50 * 1024 * 1024)
+    if scan is None:
         return 0
+    stream, finding_offsets, matched_markers = scan
 
-    finding_indices = _find_marker_indices(tail, _FINDING_MARKERS)
-    if not finding_indices:
-        return 0  # no finding context → allow
+    if not finding_offsets:
+        return 0  # no finding context in assistant-authored content → allow
 
-    last_finding_idx = max(finding_indices)
-    after_finding = tail[last_finding_idx:]
+    last_finding_idx = max(finding_offsets)
+    after_finding = stream[last_finding_idx:]
 
     if _has_consensus_refetch(after_finding):
         return 0
 
-    matched = sorted({m.group(0).strip() for m in _iter_marker_matches(tail, _FINDING_MARKERS)})[:3]
+    matched = sorted(set(matched_markers))[:3]
     _emit_block_message(matched)
     return 2
 
@@ -426,7 +431,43 @@ def _has_ratification_token(commit_args: list[str]) -> bool:
     return any(_RATIFICATION_TOKEN_RE.search(value) for value in _message_values(commit_args))
 
 
-def _read_transcript_tail(path: str, max_lines: int, max_bytes: int) -> str | None:
+# ---------------------------------------------------------------------------
+# Role-aware transcript scan (praxis issue #573)
+#
+# The marker corpus is restricted to ASSISTANT-AUTHORED content so a loaded
+# SKILL.md — which *documents* the `[FINDING:` / `[CONFLICTS:` /
+# `[STAGE_COMPLETE:` output schema as literal example text — cannot self-trip
+# the gate. A raw-text tail scan conflated two oracles: genuine agent finding
+# output vs. documentation that merely names the tokens.
+#
+# Included in the finding corpus:
+#   - assistant message TEXT blocks (the agent emitting a finding directly)
+#   - tool_result blocks whose originating tool_use is Agent/Task — a sciomc
+#     subagent's own output. Results are recorded in `user`-type entries, so
+#     each tool_result's tool_use_id is resolved back to its tool name.
+# Excluded from the finding corpus (the #573 false-positive sources):
+#   - user-turn text (real user messages, skill-load doc payloads)
+#   - system-reminder blocks / non-user/assistant entry types
+#   - Read / Skill / Bash / other tool-results (loaded files, command output)
+#
+# The consensus-refetch check still scans the full ordered stream AFTER the
+# last finding (assistant text + assistant tool_use commands + Agent/Task
+# results), so a `gh pr view … --json body` recorded as an assistant Bash
+# tool_use still satisfies the re-fetch gate.
+# ---------------------------------------------------------------------------
+
+_ASSISTANT_TEXT = "assistant_text"
+_ASSISTANT_TOOLUSE = "assistant_tooluse"
+_AGENT_RESULT = "agent_result"
+# Kinds whose text counts as genuine, agent-authored finding output.
+_FINDING_KINDS = frozenset({_ASSISTANT_TEXT, _AGENT_RESULT})
+# tool_use names whose tool_result is a subagent's OWN output (sciomc runs as a
+# subagent). Read/Skill/Bash/etc. results are loaded docs or command output and
+# are NOT part of the finding corpus.
+_SUBAGENT_TOOLS = frozenset({"Agent", "Task"})
+
+
+def _load_transcript_objs(path: str, max_bytes: int) -> list | None:
     try:
         p = Path(path)
         if not p.is_file() or p.stat().st_size > max_bytes:
@@ -434,12 +475,136 @@ def _read_transcript_tail(path: str, max_lines: int, max_bytes: int) -> str | No
         text = p.read_text(encoding="utf-8", errors="replace")
     except (OSError, ValueError):
         return None
-    lines = text.strip().split("\n")
-    return "\n".join(lines[-max_lines:])
+    objs: list = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            objs.append(json.loads(line))
+        except (json.JSONDecodeError, ValueError):
+            continue  # skip non-JSON lines, keep scanning
+    return objs
 
 
-def _find_marker_indices(text: str, patterns: tuple[re.Pattern, ...]) -> list[int]:
-    return [m.start() for pat in patterns for m in pat.finditer(text)]
+def _map_tool_use_names(objs: list) -> dict:
+    """Map tool_use_id → tool name across the WHOLE transcript so a recent
+    tool_result can be resolved even when its originating tool_use predates the
+    recency window."""
+    names: dict = {}
+    for obj in objs:
+        if not isinstance(obj, dict) or obj.get("type") != "assistant":
+            continue
+        message = obj.get("message")
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for blk in content:
+            if isinstance(blk, dict) and blk.get("type") == "tool_use":
+                tuid, name = blk.get("id"), blk.get("name")
+                if isinstance(tuid, str) and isinstance(name, str):
+                    names[tuid] = name
+    return names
+
+
+def _tool_use_text(blk: dict) -> str:
+    inp = blk.get("input")
+    if not isinstance(inp, dict):
+        return ""
+    cmd = inp.get("command")
+    if isinstance(cmd, str):
+        return cmd  # Bash command — where a `gh pr view … --json body` lives
+    try:
+        return json.dumps(inp, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return ""
+
+
+def _tool_result_text(blk: dict) -> str:
+    content = blk.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        out: list = []
+        for item in content:
+            if isinstance(item, dict) and isinstance(item.get("text"), str):
+                out.append(item["text"])
+            elif isinstance(item, str):
+                out.append(item)
+        return "\n".join(out)
+    return ""
+
+
+def _entry_segments(obj, tool_names: dict) -> list:
+    """Return (kind, text) segments contributed by one transcript entry."""
+    if not isinstance(obj, dict):
+        return []
+    typ = obj.get("type")
+    message = obj.get("message")
+    # Simplified string message form: only an assistant string is authored text.
+    if isinstance(message, str):
+        return [(_ASSISTANT_TEXT, message)] if typ == "assistant" else []
+    if not isinstance(message, dict):
+        return []
+    content = message.get("content")
+    if isinstance(content, str):
+        blocks: list = [{"type": "text", "text": content}]
+    elif isinstance(content, list):
+        blocks = content
+    else:
+        return []
+    segs: list = []
+    for blk in blocks:
+        if not isinstance(blk, dict):
+            continue
+        btype = blk.get("type")
+        if typ == "assistant":
+            if btype == "text" and isinstance(blk.get("text"), str):
+                segs.append((_ASSISTANT_TEXT, blk["text"]))
+            elif btype == "tool_use":
+                segs.append((_ASSISTANT_TOOLUSE, _tool_use_text(blk)))
+        elif typ == "user" and btype == "tool_result":
+            # tool_results live in user-type entries; only a subagent's own
+            # output counts as finding content. Read/Skill/etc. are excluded.
+            if tool_names.get(blk.get("tool_use_id")) in _SUBAGENT_TOOLS:
+                segs.append((_AGENT_RESULT, _tool_result_text(blk)))
+        # user text blocks (real user msg / skill-load / system-reminder) and
+        # non-user/assistant entry types contribute nothing to either corpus.
+    return segs
+
+
+def _build_finding_scan(path: str, max_entries: int, max_bytes: int):
+    """Build the role-aware scan over recent transcript entries.
+
+    Returns (stream, finding_offsets, matched_markers), or None when the
+    transcript cannot be read (caller fail-opens):
+      stream          — ordered text of assistant + Agent/Task segments, used
+                        for the positional consensus-refetch check.
+      finding_offsets — offsets in `stream` of finding markers that land in
+                        agent-authored (assistant text / Agent result) spans.
+      matched_markers — the matched marker strings (for the block message).
+    """
+    objs = _load_transcript_objs(path, max_bytes)
+    if objs is None:
+        return None
+    tool_names = _map_tool_use_names(objs)
+    parts: list = []
+    finding_offsets: list = []
+    matched_markers: list = []
+    pos = 0
+    for obj in objs[-max_entries:]:
+        for kind, text in _entry_segments(obj, tool_names):
+            start = pos
+            parts.append(text)
+            parts.append("\n")
+            pos += len(text) + 1
+            if kind in _FINDING_KINDS:
+                for m in _iter_marker_matches(text, _FINDING_MARKERS):
+                    finding_offsets.append(start + m.start())
+                    matched_markers.append(m.group(0).strip())
+    return "".join(parts), finding_offsets, matched_markers
 
 
 def _iter_marker_matches(text: str, patterns: tuple[re.Pattern, ...]):

--- a/hooks/preflight-gate/block-sciomc-finding-commit/spec.md
+++ b/hooks/preflight-gate/block-sciomc-finding-commit/spec.md
@@ -40,16 +40,27 @@ All three conditions must hold for a block (exit 2):
    slip through behind them. Commits wrapped in a subshell/group (`(git …)`),
    command substitution (`$(git …)` / `` `git …` ``), or chained behind a
    space-less separator (`true;git commit …`) are detected too.
-2. The recent transcript tail (last ~200 lines) contains a sciomc structured
-   output marker: `[FINDING:`, `[STAGE_COMPLETE:<digit>]`, `[CONFLICTS:`,
-   `sibling-deviant`, `의미 mismatch`, `의미 충돌`. Loose prose terms
-   (`sciomc`, `scientist-agent`, `deep-dive`, `cross-validation`, bare
-   `Stage N analysis`) are **not** markers — they generated false-positives
-   on normal workflow discussion.
+2. Recent **assistant-authored** transcript content (last ~200 entries)
+   contains a sciomc structured output marker: `[FINDING:`,
+   `[STAGE_COMPLETE:<digit>]`, `[CONFLICTS:`, `sibling-deviant`,
+   `의미 mismatch`, `의미 충돌`. The scan is **role-aware** (praxis #573):
+   the marker corpus is restricted to assistant message `text` blocks and
+   `Agent`/`Task` subagent tool-results — the two places genuine sciomc
+   findings live. Markers inside user turns, system-reminder blocks, or
+   `Read`/`Skill` tool-results (which merely *load* a SKILL.md that
+   *documents* the token schema) are **not** findings, so loading the sciomc
+   SKILL.md no longer self-trips the gate. Loose prose terms (`sciomc`,
+   `scientist-agent`, `deep-dive`, `cross-validation`, bare `Stage N
+   analysis`) are **not** markers — they generated false-positives on normal
+   workflow discussion.
 3. No consensus re-fetch appears AFTER the most recent finding marker —
    re-fetch is `gh pr view ... --json ... body`, `gh issue view ... --json
-   ... body`, `consensus re-fetch`, `re-read PR/issue body`, `user-stated
-   design`, or a ratification token.
+   ... body`, `consensus re-fetch`, `re-read PR/issue body`, or a
+   ratification token. (`user-stated design` is intentionally NOT a re-fetch
+   marker — it appears verbatim inside `[CONFLICTS: user-stated design …]`
+   payloads and would self-satisfy the check.) The re-fetch scan runs over
+   the full ordered stream (assistant text + assistant Bash tool_use commands
+   + subagent results), so a `gh pr view` recorded as a tool_use still counts.
 
 | Situation | Action |
 |-----------|--------|
@@ -59,6 +70,8 @@ All three conditions must hold for a block (exit 2):
 | `git commit -m "..."` after `sibling-deviant` prose, no re-fetch | **BLOCKED** (exit 2) |
 | `git commit -m "..."` after `의미 mismatch` / `의미 충돌`, no re-fetch | **BLOCKED** (exit 2) |
 | `git commit` after a marker, then `gh pr view N --json body` | **PASS** (re-fetch after finding) |
+| `git commit` after a marker in an `Agent`/`Task` subagent result, no re-fetch | **BLOCKED** (genuine sciomc output) |
+| `git commit` after a marker that appears only in a loaded SKILL.md (user turn / system-reminder / `Read` result) | **PASS** (documentation, not a finding — #573) |
 | `git commit --amend` after a finding | **PASS** (amend exempt) |
 | `git commit --allow-empty -m x` (staged content) after a finding | **BLOCKED** (allow-empty not exempt) |
 | `git revert <sha>` after a finding | **PASS** (non-content op) |
@@ -97,19 +110,23 @@ scope.
 bash tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
 ```
 
-Covers 53 cases:
-- **Block paths** (22): finding + no re-fetch, `--allow-empty*` with staged
+Covers 59 cases (fixtures use the real Claude Code transcript JSONL schema):
+- **Block paths** (24): finding + no re-fetch, `--allow-empty*` with staged
   content, grouped / command-substitution / nested / separator-chained commits,
-  `-m --amend` value; new in #429: `[CONFLICTS:]`, `[STAGE_COMPLETE:2]`,
-  `sibling-deviant`, `의미 mismatch`, `의미 충돌` markers each individually;
-  also `의미 충돌이` / `의미 mismatch가` (Hangul particle attachment forms),
-  and `[CONFLICTS: user-stated design ...]` (marker payload must not
-  self-satisfy the consensus re-fetch check).
-- **Silent paths** (24): each escape hatch, amend / revert exemption,
+  `-m --amend` value; `[CONFLICTS:]`, `[STAGE_COMPLETE:2]`, `sibling-deviant`,
+  `의미 mismatch`, `의미 충돌` markers each individually; `의미 충돌이` /
+  `의미 mismatch가` (Hangul particle attachment forms); `[CONFLICTS:
+  user-stated design ...]` (marker payload must not self-satisfy the
+  consensus re-fetch check); new in #573: an `Agent` subagent tool-result
+  finding, and a design-flip `[CONFLICTS:]` in assistant text (false-negative
+  regression guards — the role-aware fix must not let genuine findings slip).
+- **Silent paths** (27): each escape hatch, amend / revert exemption,
   `commit-tree` plumbing, quoted-literal `git commit`, single-quoted
   substitution, `git --help/--version commit` terminal options, re-fetch after
-  finding, no finding context.
-- **FP-regression paths** (6, new in #429): bare `sciomc`, `scientist-agent`,
+  finding, no finding context; new in #573: markers that appear only in a
+  user-turn skill-load, a system-reminder block, or a `Read` tool-result
+  (loaded SKILL.md documentation) — none of these is a finding.
+- **FP-regression paths** (6, from #429): bare `sciomc`, `scientist-agent`,
   `deep-dive`, `cross-validation`, `Stage N analysis` prose, and
   `[STAGE_COMPLETE:` without digit — none of these should block.
 - **Non-Bash tool passthrough**, missing `transcript_path`, malformed JSON

--- a/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
+++ b/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
@@ -26,88 +26,141 @@ FAILED_NAMES=()
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-# Fixture: transcript with sciomc structured finding markers
+# Transcript fixtures use the REAL Claude Code transcript JSONL schema
+# (entries carry `type` + `message.content[]` blocks). Finding markers are
+# only honored when they appear in assistant-authored content — assistant
+# `text` blocks or Agent/Task subagent `tool_result`s. Markers inside user
+# turns, system-reminders, or Read/Skill tool-results (loaded docs) are NOT a
+# finding (praxis issue #573). The role-aware parser ignores the simplified
+# pre-#573 fixture shape, so these fixtures must use the real schema.
+
+# Fixture: assistant emits sciomc structured finding markers (true positive)
 TX_FINDING="$TMPDIR/tx-finding.jsonl"
 cat > "$TX_FINDING" <<'EOF'
-{"type":"assistant","message":"Running sciomc analysis"}
-{"type":"tool_use","content":"[FINDING:F1] sibling-deviant pattern detected"}
-{"type":"assistant","message":"about to commit"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Running sciomc analysis"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"[FINDING:F1] sibling-deviant pattern detected"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"about to commit"}]}}
 EOF
 
-# Fixture: transcript with [CONFLICTS:] marker
+# Fixture: assistant emits a [CONFLICTS:] marker
 TX_CONFLICTS="$TMPDIR/tx-conflicts.jsonl"
 cat > "$TX_CONFLICTS" <<'EOF'
-{"type":"assistant","message":"sciomc output:"}
-{"type":"tool_use","content":"[CONFLICTS: design choice in PR body vs sibling convention]"}
-{"type":"assistant","message":"about to commit"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"sciomc output:"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"[CONFLICTS: design choice in PR body vs sibling convention]"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"about to commit"}]}}
 EOF
 
 # Fixture: [CONFLICTS:] payload that includes "user-stated design" text — must still block
 TX_CONFLICTS_USD="$TMPDIR/tx-conflicts-usd.jsonl"
 cat > "$TX_CONFLICTS_USD" <<'EOF'
-{"type":"assistant","message":"sciomc output:"}
-{"type":"tool_use","content":"[CONFLICTS: user-stated design vs sibling convention]"}
-{"type":"assistant","message":"about to commit"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"sciomc output:"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"[CONFLICTS: user-stated design vs sibling convention]"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"about to commit"}]}}
 EOF
 
-# Fixture: transcript with [STAGE_COMPLETE:N] marker
+# Fixture: assistant emits a [STAGE_COMPLETE:N] marker
 TX_STAGE_COMPLETE="$TMPDIR/tx-stage-complete.jsonl"
 cat > "$TX_STAGE_COMPLETE" <<'EOF'
-{"type":"assistant","message":"sciomc output:"}
-{"type":"tool_use","content":"[STAGE_COMPLETE:2] stage 2 done"}
-{"type":"assistant","message":"about to commit"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"sciomc output:"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"[STAGE_COMPLETE:2] stage 2 done"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"about to commit"}]}}
 EOF
 
-# Fixture: transcript with 의미 mismatch marker
+# Fixture: assistant emits 의미 mismatch marker
 TX_UIMI_MISMATCH="$TMPDIR/tx-uimi-mismatch.jsonl"
 cat > "$TX_UIMI_MISMATCH" <<'EOF'
-{"type":"assistant","message":"의미 mismatch detected in sibling convention analysis"}
-{"type":"assistant","message":"about to commit"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"의미 mismatch detected in sibling convention analysis"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"about to commit"}]}}
 EOF
 
-# Fixture: transcript with 의미 충돌 marker
+# Fixture: assistant emits 의미 충돌 marker
 TX_UIMI_CONFLICT="$TMPDIR/tx-uimi-conflict.jsonl"
 cat > "$TX_UIMI_CONFLICT" <<'EOF'
-{"type":"assistant","message":"의미 충돌: 두 sibling 간 설계 불일치"}
-{"type":"assistant","message":"about to commit"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"의미 충돌: 두 sibling 간 설계 불일치"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"about to commit"}]}}
 EOF
 
-# Fixture: transcript with 의미 충돌 + Hangul particle attachment (조사 결합)
+# Fixture: 의미 충돌 + Hangul particle attachment (조사 결합)
 TX_UIMI_CONFLICT_PARTICLE="$TMPDIR/tx-uimi-conflict-particle.jsonl"
 cat > "$TX_UIMI_CONFLICT_PARTICLE" <<'EOF'
-{"type":"assistant","message":"의미 충돌이 감지됩니다 — sibling 간 설계 충돌"}
-{"type":"assistant","message":"about to commit"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"의미 충돌이 감지됩니다 — sibling 간 설계 충돌"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"about to commit"}]}}
 EOF
 
-# Fixture: transcript with 의미 mismatch + Hangul particle attachment (조사 결합)
+# Fixture: 의미 mismatch + Hangul particle attachment (조사 결합)
 TX_UIMI_MISMATCH_PARTICLE="$TMPDIR/tx-uimi-mismatch-particle.jsonl"
 cat > "$TX_UIMI_MISMATCH_PARTICLE" <<'EOF'
-{"type":"assistant","message":"의미 mismatch가 있습니다 — 정렬 필요"}
-{"type":"assistant","message":"about to commit"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"의미 mismatch가 있습니다 — 정렬 필요"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"about to commit"}]}}
 EOF
 
-# Fixture: transcript with sciomc finding AND consensus re-fetch after
+# Fixture: assistant finding, then a `gh pr view --json body` re-fetch recorded
+# as an assistant Bash tool_use (consensus re-fetch AFTER the finding)
 TX_FINDING_REFETCH="$TMPDIR/tx-finding-refetch.jsonl"
 cat > "$TX_FINDING_REFETCH" <<'EOF'
-{"type":"assistant","message":"sibling-deviant pattern detected"}
-{"type":"tool_use","content":"gh pr view 8299 --json body --jq .body"}
-{"type":"assistant","message":"compared with user design"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"sibling-deviant pattern detected"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_b1","name":"Bash","input":{"command":"gh pr view 8299 --json body --jq .body"}}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"compared with user design"}]}}
 EOF
 
-# Fixture: transcript with no finding markers (prose-only, no structured tokens)
+# Fixture: no finding markers (prose-only, no structured tokens)
 TX_NORMAL="$TMPDIR/tx-normal.jsonl"
 cat > "$TX_NORMAL" <<'EOF'
-{"type":"assistant","message":"normal fix work"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"normal fix work"}]}}
 EOF
 
-# Fixture: transcript with removed-prose-only markers (FP regression)
+# Fixture: removed-prose-only markers (FP regression)
 TX_FP_PROSE="$TMPDIR/tx-fp-prose.jsonl"
 cat > "$TX_FP_PROSE" <<'EOF'
-{"type":"assistant","message":"deep-dive 하자"}
-{"type":"assistant","message":"cross-validation 결과를 확인했다"}
-{"type":"assistant","message":"sciomc 라는 도구가 있음"}
-{"type":"assistant","message":"scientist-agent 가 실행됨"}
-{"type":"assistant","message":"Stage 2 analysis 시작"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"deep-dive 하자"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"cross-validation 결과를 확인했다"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"sciomc 라는 도구가 있음"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"scientist-agent 가 실행됨"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Stage 2 analysis 시작"}]}}
+EOF
+
+# ---------------------------------------------------------------------------
+# Role-aware corpus fixtures (praxis issue #573) — surface enumeration of
+# every place a finding marker can appear in a transcript.
+# ---------------------------------------------------------------------------
+
+# (BLOCK) Agent/Task subagent tool-result carrying real sciomc finding output.
+# The tool_use (Agent) and its tool_result are resolved by tool_use_id.
+TX_AGENT_RESULT="$TMPDIR/tx-agent-result.jsonl"
+cat > "$TX_AGENT_RESULT" <<'EOF'
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_agent1","name":"Agent","input":{"subagent_type":"sciomc","prompt":"analyze the design"}}]}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_agent1","content":"[FINDING:F2] sibling-deviant detected by subagent analysis"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"about to commit"}]}}
+EOF
+
+# (BLOCK) design-flip regression: assistant emits [CONFLICTS:] then commits
+# with no re-fetch in between — the original sciomc gate intent must hold.
+TX_DESIGN_FLIP="$TMPDIR/tx-design-flip.jsonl"
+cat > "$TX_DESIGN_FLIP" <<'EOF'
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"[CONFLICTS: user PR-body literal vs sibling convention] — flipping the literal"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_e1","name":"Edit","input":{"file_path":"/x/q.sql","old_string":"a","new_string":"b"}}]}}
+EOF
+
+# (SILENT) user-turn skill-load: SKILL.md documentation naming the tokens.
+TX_SKILL_LOAD_DOC="$TMPDIR/tx-skill-load-doc.jsonl"
+cat > "$TX_SKILL_LOAD_DOC" <<'EOF'
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"<command-message>praxis:sciomc loaded</command-message> The output schema documents [FINDING:Fn], [CONFLICTS: A vs B] and [STAGE_COMPLETE:3] tokens."}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"about to commit"}]}}
+EOF
+
+# (SILENT) system-reminder block referencing the tokens (e.g. CLAUDE.md context).
+TX_SYSTEM_REMINDER="$TMPDIR/tx-system-reminder.jsonl"
+cat > "$TX_SYSTEM_REMINDER" <<'EOF'
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"<system-reminder>The sciomc skill defines [FINDING:], [CONFLICTS:] and [STAGE_COMPLETE:2] markers in its output schema. 의미 충돌 also appears here.</system-reminder>"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"about to commit"}]}}
+EOF
+
+# (SILENT) Read tool-result returning a SKILL.md file body containing the tokens.
+TX_READ_RESULT_DOC="$TMPDIR/tx-read-result-doc.jsonl"
+cat > "$TX_READ_RESULT_DOC" <<'EOF'
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_read1","name":"Read","input":{"file_path":"/x/skills/sciomc/SKILL.md"}}]}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_read1","content":"## Output schema\nEmit [FINDING:Fn] per finding, [CONFLICTS: A vs B] on design conflict, [STAGE_COMPLETE:N] per stage. sibling-deviant 의미 충돌 의미 mismatch."}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"about to commit"}]}}
 EOF
 
 # run_case name expectation payload_json [env_vars...]
@@ -294,8 +347,44 @@ run_case "의미 mismatch가 (particle attachment) blocks commit" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'fix: align'\"},\"transcript_path\":\"$TX_UIMI_MISMATCH_PARTICLE\"}"
 
 # ---------------------------------------------------------------------------
+# Role-aware corpus BLOCK cases (praxis issue #573) — markers in genuine
+# agent-authored content must STILL block (no false-negative regression).
+# ---------------------------------------------------------------------------
+
+# Agent/Task subagent tool-result with a real finding — true positive, blocks.
+run_case "Agent subagent tool-result finding blocks commit" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'fix: apply subagent finding'\"},\"transcript_path\":\"$TX_AGENT_RESULT\"}"
+
+# Design-flip: assistant emits [CONFLICTS:] then commits without re-fetch —
+# the original gate intent must hold (regression guard against the #573 fix
+# introducing a false-negative).
+run_case "design-flip [CONFLICTS:] in assistant text still blocks" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'fix: flip literal'\"},\"transcript_path\":\"$TX_DESIGN_FLIP\"}"
+
+# ---------------------------------------------------------------------------
 # SILENT cases — should not block
 # ---------------------------------------------------------------------------
+
+# ---- Role-aware corpus FP cases (praxis issue #573) ----
+# Markers that appear only in LOADED documentation / non-agent content must
+# NOT block a benign commit.
+
+# user-turn skill-load documenting the token schema → pass
+run_case "skill-load SKILL.md doc markers do not block (silent — #573)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'docs: ingest knowledge base'\"},\"transcript_path\":\"$TX_SKILL_LOAD_DOC\"}"
+
+# system-reminder block referencing the tokens → pass
+run_case "system-reminder markers do not block (silent — #573)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'chore: tidy'\"},\"transcript_path\":\"$TX_SYSTEM_REMINDER\"}"
+
+# Read tool-result returning a SKILL.md body with the tokens → pass
+run_case "Read tool-result SKILL.md body does not block (silent — #573)" \
+  "silent" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'docs: update'\"},\"transcript_path\":\"$TX_READ_RESULT_DOC\"}"
 
 run_case "git commit + finding + gh pr view --json body AFTER (silent)" \
   "silent" \
@@ -423,8 +512,8 @@ run_case "loose Stage N analysis prose (silent — FP regression)" \
 # [STAGE_COMPLETE:<digit> is a valid sciomc output token
 TX_STAGE_COMPLETE_NO_DIGIT="$TMPDIR/tx-stage-complete-nodigit.jsonl"
 cat > "$TX_STAGE_COMPLETE_NO_DIGIT" <<'EOF'
-{"type":"assistant","message":"[STAGE_COMPLETE: some text without digit after colon]"}
-{"type":"assistant","message":"about to commit"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"[STAGE_COMPLETE: some text without digit after colon]"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"about to commit"}]}}
 EOF
 run_case "[STAGE_COMPLETE: without digit does not block (silent)" \
   "silent" \


### PR DESCRIPTION
## Problem

`block-sciomc-finding-commit` read the **raw transcript tail as text** and grepped for finding markers (`[FINDING:`, `[CONFLICTS:`, `[STAGE_COMPLETE:N`). Those tokens are also defined as literal example text in sciomc's *own* `SKILL.md` output schema — so whenever that skill (or `codex-review-wrap`) was loaded into context, a benign `git commit` was **false-blocked** even though no sciomc analysis ran. The defect was the *scan corpus* (whole transcript, author-agnostic), not the marker set (already minimized in #429).

## Fix

Replace the raw-text tail scan with **role-aware JSONL parsing**. The finding corpus is now restricted to genuine agent-authored output:

- assistant message `text` blocks
- `Agent`/`Task` subagent `tool_result`s (resolved via `tool_use_id` → tool name across the whole transcript)

and **excludes** the false-positive sources: user-turn text (skill-load doc payloads), system-reminder blocks, and `Read`/`Skill` tool-results (loaded files). The consensus-refetch check still scans the full ordered stream **after** the finding, so a `gh pr view … --json body` recorded as an assistant Bash `tool_use` still satisfies the gate.

## Tests (surface enumeration per the issue)

Rewrote fixtures to the **real** Claude Code transcript schema and added the #573 matrix:

| Marker location | Expected |
|---|---|
| assistant message text | **block** (true positive) |
| Agent/Task subagent result | **block** (true positive) |
| user-turn skill-load (SKILL.md doc) | pass |
| system-reminder block | pass |
| Read tool-result (SKILL.md body) | pass |

Plus a **design-flip false-negative guard** (assistant emits `[CONFLICTS:]` then commits → still blocks). **59/59 pass** (was 53). Spec updated; `build-plugin-manifests.py` idempotent; `check-plugin-manifests.py` OK.

Closes #573

https://claude.ai/code/session_01RVVt9MRWjf18YNicYnh6wS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVVt9MRWjf18YNicYnh6wS)_