### PR TITLE
refactor(scripts): single-source CLI script list

### DIFF
--- a/scripts/cli-scripts.sh
+++ b/scripts/cli-scripts.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# cli-scripts.sh — Canonical list of praxis public CLI scripts.
+#
+# Single source of truth shared by:
+#   - scripts/install.sh         (symlink each into ~/.local/bin)
+#   - scripts/verify-symlinks.sh (drift check those same symlinks)
+#
+# Add a new entry here when a skill ships an executable — both consumers
+# pick it up automatically, so the two lists can never drift apart again.
+#
+# This file is meant to be *sourced*, not executed. It defines the
+# CLI_SCRIPTS array (repo-relative paths) and nothing else.
+
+# shellcheck disable=SC2034  # CLI_SCRIPTS is consumed by the sourcing script
+CLI_SCRIPTS=(
+  "skills/recover-sessions/claude-recover"
+  "skills/recover-sessions/claude-recover-scan"
+  "skills/cmux-resume-sessions/cmux-resume-sessions"
+  "skills/cmux-save-sessions/cmux-save-sessions"
+  "skills/cmux-recover-sessions/cmux-recover-sessions"
+  "skills/cmux-session-manager/cmux-session-status"
+  "skills/cmux-session-manager/cmux-session-cleanup"
+  "skills/cmux-browser/cmux-browser"
+  "skills/bypass-review/bypass-review"
+)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,18 +41,10 @@ done
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BIN_DIR="${PRAXIS_BIN_DIR:-$HOME/.local/bin}"
 
-# Public CLI scripts. Add new entries here when a skill ships an executable.
-CLI_SCRIPTS=(
-  "skills/recover-sessions/claude-recover"
-  "skills/recover-sessions/claude-recover-scan"
-  "skills/cmux-resume-sessions/cmux-resume-sessions"
-  "skills/cmux-save-sessions/cmux-save-sessions"
-  "skills/cmux-recover-sessions/cmux-recover-sessions"
-  "skills/cmux-session-manager/cmux-session-status"
-  "skills/cmux-session-manager/cmux-session-cleanup"
-  "skills/cmux-browser/cmux-browser"
-  "skills/bypass-review/bypass-review"
-)
+# Public CLI scripts — single source of truth, shared with verify-symlinks.sh.
+# Defines the CLI_SCRIPTS array; add a new entry in scripts/cli-scripts.sh.
+# shellcheck source=scripts/cli-scripts.sh
+source "$(dirname "${BASH_SOURCE[0]}")/cli-scripts.sh"
 
 mkdir -p "$BIN_DIR"
 

--- a/scripts/verify-symlinks.sh
+++ b/scripts/verify-symlinks.sh
@@ -12,16 +12,9 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BIN_DIR="${PRAXIS_BIN_DIR:-$HOME/.local/bin}"
 
-CLI_SCRIPTS=(
-  "skills/recover-sessions/claude-recover"
-  "skills/recover-sessions/claude-recover-scan"
-  "skills/cmux-resume-sessions/cmux-resume-sessions"
-  "skills/cmux-save-sessions/cmux-save-sessions"
-  "skills/cmux-recover-sessions/cmux-recover-sessions"
-  "skills/cmux-session-manager/cmux-session-status"
-  "skills/cmux-session-manager/cmux-session-cleanup"
-  "skills/cmux-browser/cmux-browser"
-)
+# Single source of truth, shared with install.sh — see scripts/cli-scripts.sh.
+# shellcheck source=scripts/cli-scripts.sh
+source "$(dirname "${BASH_SOURCE[0]}")/cli-scripts.sh"
 
 drift=0
 for script in "${CLI_SCRIPTS[@]}"; do

--- a/tests/test_cli_scripts_parity.sh
+++ b/tests/test_cli_scripts_parity.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# test_cli_scripts_parity.sh — verify install.sh and verify-symlinks.sh share
+# a single CLI-script source of truth (scripts/cli-scripts.sh).
+#
+# Guards the drift class fixed in issue #580: the two scripts used to hold
+# separate inline CLI_SCRIPTS arrays, and verify-symlinks.sh silently omitted
+# bypass-review. This test fails if either consumer reintroduces an inline
+# array or stops sourcing the canonical list, or if bypass-review falls out.
+#
+# Usage: bash tests/test_cli_scripts_parity.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL="$ROOT_DIR/scripts/install.sh"
+VERIFY="$ROOT_DIR/scripts/verify-symlinks.sh"
+CANONICAL="$ROOT_DIR/scripts/cli-scripts.sh"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+run_case() {
+  local name="$1" result="$2" expected="$3"
+  if [ "$result" = "$expected" ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expected=$expected got=$result"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+echo "test_cli_scripts_parity"
+
+# ---------------------------------------------------------------------------
+# 1. Canonical list exists, is non-empty, and contains bypass-review.
+# ---------------------------------------------------------------------------
+run_case "canonical_exists" "$([ -f "$CANONICAL" ] && echo yes || echo no)" "yes"
+
+# Source the canonical list in a clean subshell and inspect it.
+CANON_COUNT="$(bash -c "source '$CANONICAL'; echo \${#CLI_SCRIPTS[@]}" 2>/dev/null)"
+run_case "canonical_nonempty" "$([ "${CANON_COUNT:-0}" -gt 0 ] && echo yes || echo no)" "yes"
+
+CANON_HAS_BYPASS="$(bash -c "source '$CANONICAL'; printf '%s\n' \"\${CLI_SCRIPTS[@]}\"" 2>/dev/null | grep -c 'skills/bypass-review/bypass-review')"
+run_case "canonical_has_bypass_review" "$CANON_HAS_BYPASS" "1"
+
+# ---------------------------------------------------------------------------
+# 2. Neither consumer declares an inline CLI_SCRIPTS array (single SoT).
+# ---------------------------------------------------------------------------
+INSTALL_INLINE="$(grep -c 'CLI_SCRIPTS=(' "$INSTALL")"
+VERIFY_INLINE="$(grep -c 'CLI_SCRIPTS=(' "$VERIFY")"
+run_case "install_no_inline_array" "$INSTALL_INLINE" "0"
+run_case "verify_no_inline_array"  "$VERIFY_INLINE"  "0"
+
+# ---------------------------------------------------------------------------
+# 3. Both consumers source the canonical list.
+# ---------------------------------------------------------------------------
+INSTALL_SOURCES="$(grep -c 'cli-scripts.sh' "$INSTALL")"
+VERIFY_SOURCES="$(grep -c 'cli-scripts.sh' "$VERIFY")"
+run_case "install_sources_canonical" "$([ "$INSTALL_SOURCES" -ge 1 ] && echo yes || echo no)" "yes"
+run_case "verify_sources_canonical"  "$([ "$VERIFY_SOURCES" -ge 1 ] && echo yes || echo no)" "yes"
+
+# ---------------------------------------------------------------------------
+# 4. Functional parity: install into a temp bin dir, then verify reports OK
+#    for bypass-review (the previously-omitted entry), both exit 0.
+# ---------------------------------------------------------------------------
+TMP_BIN="$(mktemp -d)"
+trap 'rm -rf "$TMP_BIN"' EXIT
+INSTALL_OUT="$(PRAXIS_BIN_DIR="$TMP_BIN" bash "$INSTALL" 2>&1)"
+INSTALL_RC=$?
+VERIFY_OUT="$(PRAXIS_BIN_DIR="$TMP_BIN" bash "$VERIFY" 2>&1)"
+VERIFY_RC=$?
+
+run_case "install_exit_0" "$INSTALL_RC" "0"
+run_case "verify_exit_0"  "$VERIFY_RC"  "0"
+
+# bypass-review must appear as an OK line in the verify output (it would have
+# been silently absent before the single-source fix).
+VERIFY_COVERS_BYPASS="$(printf '%s\n' "$VERIFY_OUT" | grep -cE '^OK +bypass-review$')"
+run_case "verify_covers_bypass_review" "$VERIFY_COVERS_BYPASS" "1"
+
+rm -rf "$TMP_BIN"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+if [ "$FAIL" -eq 0 ]; then
+  echo "ALL $PASS PASSED"
+  exit 0
+else
+  echo "$FAIL FAILED / $PASS PASSED — ${FAILED_NAMES[*]}"
+  exit 1
+fi


### PR DESCRIPTION
## 요약

`scripts/install.sh`와 `scripts/verify-symlinks.sh`가 각각 `CLI_SCRIPTS` 배열을 별도 하드코딩하던 것을 단일 SoT(`scripts/cli-scripts.sh`)로 통합한다. 두 스크립트 모두 이 파일을 source 한다.

부수 효과로 `verify-symlinks.sh`가 누락하던 `bypass-review`를 커버한다 — 기존에는 `bypass-review` symlink이 stale clone을 가리켜도 "All symlinks point at this clone"로 오보했다(false negative).

## 변경

- **신규** `scripts/cli-scripts.sh` — canonical `CLI_SCRIPTS` 배열(sourced-only lib, 9개 항목)
- **수정** `scripts/install.sh` — inline 배열 제거, `cli-scripts.sh` source
- **수정** `scripts/verify-symlinks.sh` — inline 배열 제거, `cli-scripts.sh` source (`bypass-review` 커버)
- **신규** `tests/test_cli_scripts_parity.sh` — 양쪽이 inline 배열 없이 canonical을 source 하는지 + 기능 install→verify가 bypass-review를 커버하는지 검증

## 검증

- `bash tests/test_cli_scripts_parity.sh` → ALL 10 PASSED (순차 20/20 + 동시 8/8, flaky 아님)
- `bash scripts/run-tests.sh` → ALL TESTS PASSED
- `python3 scripts/check-plugin-manifests.py` → plugin-manifest check OK
- `shellcheck` (4파일) → CLEAN
- 리뷰: `omc:code-reviewer` APPROVE(블로커 0), `codex-review-wrap` 버그 없음

codex의 샌드박스 테스트 실행이 exit 1을 낸 것은 read-only 샌드박스가 기능 테스트의 `mktemp` 쓰기를 차단했기 때문이며(기존 `test_build_hosts_filter.sh`와 동일한 mktemp 패턴), unsandboxed 실행은 전부 통과한다.

Pre-commit verified: bash scripts/run-tests.sh → ALL TESTS PASSED; check-plugin-manifests.py → OK; parity 20/20

Caller chain verified: CLI_SCRIPTS의 consumer는 install.sh + verify-symlinks.sh 2곳뿐(grep 확인); 둘 다 cli-scripts.sh를 source 하도록 전환

## 영향 범위

scripts 레이어 한정. install/verify의 8개 공유 항목 동작은 동일하고, 의도된 동작 변경은 verify가 bypass-review를 추가로 검사하는 것 하나뿐. 후속 Cluster A(bypass-review skill→CLI demote)의 verify-symlinks acceptance를 unblock 한다(B4 → A merged-first).

Closes #580
