### PR TITLE
fix(skills): demote bypass-review skill to CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 | **Full** | + all cmux-* skills | + cmux |
 | **Multi-provider** | + codex/gemini routing in cmux-* | + codex-cli, gemini-cli |
 
-## Skills (15)
+## Skills (14)
 
 > **Invocation**: praxis entries are *skills*, not subagents. Always call them
 > via `Skill(skill="praxis:<name>")` — `Agent(subagent_type="praxis:<name>")`
@@ -48,7 +48,6 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 
 | Skill | Purpose |
 |-------|---------|
-| `bypass-review` | Review bypass-telemetry event logs written by the bypass-telemetry hook — aggregate and inspect JSONL records |
 | `strike` | Declare a rule violation — session-scoped counter, escalating signal (1진 warning → 2진 review → 3진 Stop-hook block) |
 | `strikes` | Show current strike count + recorded violation reasons for the active session |
 | `reset-strikes` | Reset the session strike counter to 0 after a 3진 block (required to unblock responses) |
@@ -124,6 +123,7 @@ They are not AI skills — they have no `SKILL.md` and cannot be invoked as `/pr
 
 | Binary | Source | Purpose |
 |--------|--------|---------|
+| `bypass-review` | `skills/bypass-review/bypass-review` | Review bypass-telemetry event logs written by the bypass-telemetry hook — aggregate and inspect JSONL records (no `SKILL.md`; not invocable as `/praxis:*`) |
 | `cmux-browser` | `skills/cmux-browser/cmux-browser` | Pass-through for `cmux browser`; intercepts selector-missing errors and adds subcommand-specific usage hints |
 
 ### Install / refresh CLI symlinks

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Development workflow skills for Claude Code — disciplined, fast, resilient.
 
 | Skill | Trigger keywords | When to use | Example invocation |
 |-------|-----------------|-------------|-------------------|
-| `bypass-review` | `bypass review`, `bypass telemetry`, `우회 이벤트 확인`, `bypass log` | bypass-telemetry hook이 기록한 JSONL 이벤트 로그를 집계·검토할 때 | `/praxis:bypass-review` |
 | `strike` | `/strike`, `/praxis:strike`, `strike 1/2/3`, `삼진` | 규칙 위반 발생 시 명시적으로 기록할 때 (colloquial "strike a balance" 등은 제외) | `/praxis:strike <위반 이유>` |
 | `strikes` | `/strikes`, `strike status`, `몇 진`, `check strikes` | 현재 세션의 strike 횟수와 위반 내역을 확인할 때 | `/praxis:strikes` |
 | `reset-strikes` | `/reset-strikes`, `strike 초기화`, `clear strikes` | 3진 블록 후 카운터를 초기화해 응답을 재개할 때 | `/praxis:reset-strikes` |

--- a/scripts/check-plugin-manifests.py
+++ b/scripts/check-plugin-manifests.py
@@ -56,6 +56,11 @@ def _skill_dirs() -> list[Path]:
 
     Mirrors `_hook_dirs()` convention: files (SKILL.md.tmpl) and underscore-
     prefixed entries (future internal layout) are excluded automatically.
+
+    A directory counts as a skill only if it carries a `SKILL.md`. Binary-only
+    dirs (e.g. `bypass-review`, which ships a CLI under `skills/` but has no
+    `SKILL.md` and cannot be invoked as `/praxis:*`) are excluded so they are
+    not double-counted against the skill surface (issue #582).
     """
     skills_root = REPO_ROOT / "skills"
     dirs: list[Path] = []
@@ -65,6 +70,8 @@ def _skill_dirs() -> list[Path]:
         if not entry.is_dir():
             continue
         if entry.name.startswith("_") or entry.name == "__pycache__":
+            continue
+        if not (entry / "SKILL.md").exists():
             continue
         dirs.append(entry)
     return dirs

--- a/scripts/cli-scripts.sh
+++ b/scripts/cli-scripts.sh
@@ -5,8 +5,10 @@
 #   - scripts/install.sh         (symlink each into ~/.local/bin)
 #   - scripts/verify-symlinks.sh (drift check those same symlinks)
 #
-# Add a new entry here when a skill ships an executable — both consumers
-# pick it up automatically, so the two lists can never drift apart again.
+# Add a new entry here when a skills/ directory ships an executable CLI
+# (whether or not it is also a skill — e.g. bypass-review is CLI-only, no
+# SKILL.md) — both consumers pick it up automatically, so the two lists can
+# never drift apart again.
 #
 # This file is meant to be *sourced*, not executed. It defines the
 # CLI_SCRIPTS array (repo-relative paths) and nothing else.

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -41,7 +41,6 @@ OPT_IN_HOOKS: dict[str, str] = {
 # silent skill proliferation; every intentional surface change is paired
 # with an explicit declaration here.
 EXPECTED_SKILLS: frozenset[str] = frozenset({
-    "bypass-review",
     "cmux-browser",
     "cmux-delegate",
     "cmux-recover-sessions",

--- a/tests/test_skill_surface_freeze.sh
+++ b/tests/test_skill_surface_freeze.sh
@@ -2,7 +2,7 @@
 # test_skill_surface_freeze.sh — verify check-plugin-manifests.py Rule 11 (#465)
 #
 # Asserts:
-#   1. Current seed (15 skills) passes
+#   1. Current seed (14 skills) passes
 #   2. Unexpected skill dir triggers non-zero exit + UNEXPECTED SKILL message
 #   3. Removed (declared-but-missing) skill triggers non-zero exit + REMOVED SKILL message
 #   4. SKILL.md.tmpl (file, not dir) and underscore-prefixed dirs are excluded
@@ -30,8 +30,9 @@ BACKUP="$BACKUP_DIR/strikes"
 
 cleanup() {
   # Idempotent restore: handles interruption (SIGINT/TERM) mid-fixture.
-  [ -d "$GHOST" ] && rmdir "$GHOST" 2>/dev/null
-  [ -d "$GHOST_UNDERSCORE" ] && rmdir "$GHOST_UNDERSCORE" 2>/dev/null
+  # GHOST now carries a SKILL.md (see Case 2), so rm -rf — not rmdir.
+  [ -d "$GHOST" ] && rm -rf "$GHOST" 2>/dev/null
+  [ -d "$GHOST_UNDERSCORE" ] && rm -rf "$GHOST_UNDERSCORE" 2>/dev/null
   if [ -d "$BACKUP" ] && [ ! -d "$ROOT_DIR/skills/strikes" ]; then
     mv "$BACKUP" "$ROOT_DIR/skills/strikes"
   fi
@@ -63,23 +64,30 @@ run_case() {
   fi
 }
 
-# Case 1: current 15-skill seed passes
-run_case "seed-15-passes" "python3 \"$CHECK\"" 0 "plugin-manifest check OK"
+# Case 1: current 14-skill seed passes (bypass-review demoted to CLI, #582)
+run_case "seed-14-passes" "python3 \"$CHECK\"" 0 "plugin-manifest check OK"
 
 # Case 2: unexpected skill dir triggers UNEXPECTED SKILL
+# Since #582, a dir counts as a skill only if it has a SKILL.md, so the
+# fixture must carry one to be detected as a genuine unexpected skill.
 mkdir -p "$GHOST"
+: > "$GHOST/SKILL.md"
 run_case "unexpected-skill-fails" "python3 \"$CHECK\"" 1 "UNEXPECTED SKILL(S).*ghost-skill-fixture"
-rmdir "$GHOST"
+rm -rf "$GHOST"
 
 # Case 3: removed (declared-but-missing) skill triggers REMOVED SKILL
 mv "$ROOT_DIR/skills/strikes" "$BACKUP"
 run_case "removed-skill-fails" "python3 \"$CHECK\"" 1 "REMOVED SKILL(S).*strikes"
 mv "$BACKUP" "$ROOT_DIR/skills/strikes"
 
-# Case 4: SKILL.md.tmpl (file) and _-prefixed dirs are excluded
+# Case 4: SKILL.md.tmpl (file) and _-prefixed dirs are excluded.
+# The fixture carries a SKILL.md so this isolates the underscore rule: with a
+# SKILL.md present, the only reason it stays excluded is the leading underscore
+# (not the #582 SKILL.md filter, which would otherwise mask a regression here).
 mkdir -p "$GHOST_UNDERSCORE"
+: > "$GHOST_UNDERSCORE/SKILL.md"
 run_case "underscore-prefix-excluded" "python3 \"$CHECK\"" 0 "plugin-manifest check OK"
-rmdir "$GHOST_UNDERSCORE"
+rm -rf "$GHOST_UNDERSCORE"
 
 # Case 5: post-restore returns to passing state
 run_case "post-restore-passes" "python3 \"$CHECK\"" 0 "plugin-manifest check OK"


### PR DESCRIPTION
## 요약

`skills/bypass-review/`는 Python CLI(`bypass-review`)만 담은 **binary-only 디렉터리**로 `SKILL.md`가 없어 `/praxis:*`로 호출 불가하다. 그런데도 "스킬 15개" surface에 집계되고 스킬 표에 노출돼 있었다. 나머지 14개 `skills/*/`는 전부 `SKILL.md`를 가진다. 이 PR은 `bypass-review`를 CLI 도구로 재분류한다.

## 변경 (4개 mutually-atomic sub-change)

`check-plugin-manifests.py`의 스킬 개수 불변식(Rule 11/12)이 부분 적용 시 CI를 red로 만들기 때문에 4개는 분리 불가한 단일 commit이다.

1. **`scripts/check-plugin-manifests.py` `_skill_dirs()`** — `SKILL.md` 존재 필터 추가. binary-only 디렉터리를 스킬로 집계하지 않는다(`cmux-browser`는 `SKILL.md`가 있어 스킬로 유지 → 14).
2. **`scripts/constants.py` `EXPECTED_SKILLS`** — `bypass-review` 제거(frozenset 14개).
3. **docs** — `AGENTS.md` 헤더 `Skills (15)`→`(14)` + `bypass-review` 행을 "CLI tools (not skills)" 표로 이동; `README.md` 스킬 표에서 `bypass-review` 행 제거(`CLAUDE.md`→`AGENTS.md` 심볼릭); `cli-scripts.sh` 주석을 "skill"이 아닌 "CLI" 기준으로 정정(omc:code-reviewer LOW #1).
4. **`tests/test_skill_surface_freeze.sh`** — seed 15→14; 새 필터가 Case 2(UNEXPECTED)·Case 4(underscore) oracle을 마스킹하지 않도록 fixture가 `SKILL.md`를 생성하도록 강화(cleanup `rmdir`→`rm -rf`).

`skills/using-praxis/SKILL.md`는 변경하지 않음 — 이미 `bypass-review`를 스킬로 나열하지 않으므로 데모트 의도가 충족돼 있다.

## 검증

- `find skills -name SKILL.md | wc -l` → 14
- `grep -rn 'Skills (15)' AGENTS.md README.md` → 0
- `python3 scripts/check-plugin-manifests.py` → plugin-manifest check OK
- `bash tests/test_skill_surface_freeze.sh` → 5/5 pass
- `bash tests/test_bypass_review.sh` → 23/23 pass (CLI 동작 불변)
- `bash scripts/run-tests.sh` → ALL TESTS PASSED
- `ruff check` clean; `shellcheck --severity=warning`(CI 게이트 레벨) clean. (SC2329 info는 `cleanup()` trap 간접호출에 대한 false-positive로 HEAD에도 존재하던 pre-existing이며 CI warning 게이트 미만이라 영향 없음)
- 리뷰: `omc:code-reviewer` APPROVE(블로커 0, LOW 2 — #1 수정·#2 의도된 위임), `codex-review-wrap` correctness 문제 없음

Pre-commit verified: bash scripts/run-tests.sh → ALL TESTS PASSED; check-plugin-manifests.py → OK; test_skill_surface_freeze 5/5; test_bypass_review 23/23

Caller chain verified: `_skill_dirs()`의 호출자는 check-plugin-manifests.py Rule 11(on_disk_skills)뿐; `EXPECTED_SKILLS`의 consumer는 check-plugin-manifests.py Rule 11/12 한 곳뿐(build-plugin-manifests.py는 skills/ 디렉터리를 통째로 symlink할 뿐 개별 스킬을 열거/집계하지 않음 — code-reviewer 확인). 따라서 4개 sub-change 외 downstream 영향 없음.

## 영향 범위

scripts + docs + 1개 test 한정. CLI 바이너리(`skills/bypass-review/bypass-review`) 경로·동작 불변(B4에서 이미 `cli-scripts.sh`에 등재, symlink/install/verify 영향 없음). 생성 manifest 재생성 불필요.

## 선행 조건

B4(#580) 머지 완료.

Closes #582
