### PR TITLE
fix(skills): correct cmux-resume Iron Law

### DIFF
--- a/skills/cmux-resume-sessions/SKILL.md
+++ b/skills/cmux-resume-sessions/SKILL.md
@@ -34,7 +34,7 @@ Restores workspace structure (name, cwd) and continues Claude Code conversations
 RESUME RESTORES STRUCTURE AND CONTINUES CONVERSATIONS.
 ```
 
-Resume restores workspace structure (name, cwd) and runs `claude --continue` to pick up the most recent conversation in each directory.
+Resume restores workspace structure (name, cwd) and, per session, runs `claude --resume <session-id>` when the snapshot carries a session id — falling back to `claude --continue` (the cwd's most recent conversation) when it does not — to pick up the prior conversation in each directory.
 It does NOT restore runtime state of previously running commands or sessions.
 
 ## When to Use


### PR DESCRIPTION
## 요약

`skills/cmux-resume-sessions/SKILL.md`의 Iron Law(line 37)가 `claude --continue`만 명시해 `claude --resume <session-id>` primary 경로를 누락했다. 이 PR은 line 37을 실제 CLI 동작에 맞춰 정정한다(문서를 구현에 정합).

## 결함 vs 실제 동작

- **line 37 (수정 전)**: "runs `claude --continue`" — fallback만 서술
- **CLI 소스** `skills/cmux-resume-sessions/cmux-resume-sessions:93-99`: `session_id`가 있으면 `claude --resume $session_id`(primary), 없으면 `claude --continue`(fallback)
- **line 96 / 113-121**: 이미 primary/fallback 둘 다 정확히 서술 → line 37만 모순

## 변경

`skills/cmux-resume-sessions/SKILL.md` line 37 한 줄: `--resume <session-id>` primary + `--continue` fallback을 모두 반영. 슬로건(line 34)·다른 섹션·CLI 동작 변경 없음.

## 검증

- `bash scripts/run-tests.sh` → ALL TESTS PASSED
- `python3 scripts/check-plugin-manifests.py` → plugin-manifest check OK
- CLI 분기 로직 grep 확인(`cmux-resume-sessions:96-99`)
- 리뷰: `omc:code-reviewer` APPROVE(블로커 0, LOW 2 — `--no-claude` 전제·문장 가독성, 둘 다 pre-existing/스타일로 #584 scope 밖), `codex-review-wrap` 정확성/유지보수성 문제 없음

Pre-commit verified: bash scripts/run-tests.sh → ALL TESTS PASSED; check-plugin-manifests.py → OK

Caller chain verified: docs-only 변경(SKILL.md 산문 1줄) — 코드 심볼·CLI 동작 미변경, 호출자 없음. 문서를 기존 구현(`cmux-resume-sessions:96-99`)에 정합시킨 것.

## 영향 범위

문서 1줄. 런타임/CLI/테스트 동작 불변. M5(restore-sessions trigger) → B1(Triggers bullet)이 같은 파일을 후속 편집하므로 M6를 먼저 머지(serialize: M6 → M5 → B1).

Closes #584
