### PR TITLE
ci: add reviewdog inline static review actions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,37 @@
+name: actionlint
+
+# reviewdog posts inline review comments, which only works in PR context — so
+# unlike the lint/shellcheck gates this runs on pull_request only, not push.
+on:
+  pull_request:
+    branches: ["**"]
+
+# A newer push to the same PR ref cancels the in-flight run.
+concurrency:
+  group: actionlint-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: read the workflows; reviewdog needs pull-requests:write to
+# post the inline review comments.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # Pinned to the latest release. The existing workflows already pass
+      # actionlint cleanly (issue #585 baseline), so error-level gating starts
+      # from green — any failure is a real workflow bug introduced by the PR.
+      - uses: reviewdog/action-actionlint@v1.72.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          # Workflow YAML errors (bad expressions, shell injection, deprecated
+          # patterns) are real bugs, not style — gate at error.
+          fail_level: error

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,41 @@
+name: markdownlint
+
+# reviewdog posts inline review comments, which only works in PR context — so
+# unlike the lint/shellcheck gates this runs on pull_request only, not push.
+on:
+  pull_request:
+    branches: ["**"]
+
+# A newer push to the same PR ref cancels the in-flight run.
+concurrency:
+  group: markdownlint-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: read the docs; reviewdog needs pull-requests:write to post
+# the inline review comments.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # Pinned so a future action release can't widen rules and turn CI noisy
+      # without an explicit bump. Rule config lives in .markdownlint.yaml.
+      - uses: reviewdog/action-markdownlint@v0.26.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Inline review comments on the PR diff.
+          reporter: github-pr-review
+          # Only flag lines the PR actually changed; the repo's large existing
+          # backlog (issue #585 scan: 1740 MD013, 1318 MD060) stays untouched.
+          filter_mode: added
+          # Advisory rollout: surface suggestions as warnings without ever
+          # failing the check. Raise to error once the docs backlog settles.
+          level: warning
+          fail_level: none

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,41 @@
+# markdownlint config for the reviewdog markdownlint CI (issue #585).
+#
+# Counts below are from a full-tree scan with markdownlint-cli@0.41.0 — the
+# exact version reviewdog/action-markdownlint@v0.26.2 bundles, which depends
+# on markdownlint 0.34.x. (Verified: the action's Dockerfile pins
+# MARKDOWNLINT_CLI_VERSION=v0.41.0, and v0.26.2 is the latest action release.)
+# Counts MUST be re-derived under the pinned version, not a newer local
+# markdownlint — rule sets differ between versions (see the MD060 note below).
+#
+# Only rules the repo intentionally and pervasively diverges from are
+# disabled; everything else stays at markdownlint defaults. plugins/ (a
+# symlink mirror of the repo root) is excluded from the scan.
+#
+# markdownlint-cli auto-discovers this file at the repo root, so the
+# reviewdog action needs no explicit --config flag.
+
+default: true
+
+# 1706 violations — docs (tables, prose, rule text) use long lines by design.
+# An 80-column cap would churn nearly every file with no readability gain.
+MD013: false
+
+# 88 — spec.md / SKILL.md files repeat section headings (## 작업, ## 검증)
+# by template. Duplicate headings are structural here, not a mistake.
+MD024: false
+
+# 52 — some docs open with a non-heading line (frontmatter, intro sentence)
+# rather than a top-level heading.
+MD041: false
+
+# 6 — a few docs use intentional inline HTML (<details>, <br>, alignment).
+MD033: false
+
+# NOTE: MD060 (table-column-style) is intentionally NOT listed. It was added
+# in markdownlint 0.39.0, but the pinned action bundles 0.34.x, so the rule
+# does not exist in CI and disabling it would be dead config (a no-op).
+# This repo's tables are not column-aligned (~1300 cells), so when
+# action-markdownlint is eventually bumped to a release bundling markdownlint
+# >=0.39, MD060 will activate and surface a large warning backlog — add
+# `MD060: false` here at that time, and re-derive every count above under the
+# new bundled version.


### PR DESCRIPTION
## 요약

CI 에 reviewdog 기반 인라인 정적 리뷰 2종을 추가한다. 기존 6종
(codeql/ruff/shellcheck/gitleaks/pytest/lychee)이 비우던 "PR diff 인라인
코멘트" 영역을 채운다. 모두 러너 안에서 `GITHUB_TOKEN` 만으로 동작하며
외부 App 권한·LLM 키가 필요 없다 — 기존 least-privilege 컨벤션과 일치.

## 변경

| 파일 | 내용 |
|------|------|
| `.github/workflows/actionlint.yml` | 워크플로우 YAML 린트 (action-actionlint@v1.72.0), `fail_level: error` |
| `.github/workflows/markdownlint.yml` | md 린트 (action-markdownlint@v0.26.2), `filter_mode: added`, advisory(`fail_level: none`) |
| `.markdownlint.yaml` | 레포 스타일에 맞춘 룰 config (MD013/MD024/MD041/MD033 OFF) |

## 이슈 작업 항목 상태

- [x] reviewdog/action-markdownlint
- [x] reviewdog/action-actionlint
- [ ] ~~reviewdog/action-bandit~~ — **제외 결정**. reviewdog org 에 bandit
  인라인 액션이 존재하지 않고(probe 로 404 확인), `hooks/` `scripts/` 실제
  스캔 결과 bandit findings 가 전부 의도된 설계 패턴(fail-open try/except,
  `/tmp` staging, gh/git subprocess, 비보안 SHA1)이라 CI 게이트화 시 순수
  노이즈. Python 실보안은 기존 CodeQL 이 이미 커버.

## 검증

Pre-commit verified: actionlint exit 0 (전체 8개 워크플로우) + markdownlint-cli@0.41.0 (CI 번들 버전) config 적용 시 MD013/MD024/MD041/MD033 위반 목록에서 제거 확인.
Caller chain verified: N/A -- CI 워크플로우/config 파일만 변경, 코드 호출자 없음.
[skip-codex-review] -- codex-review-wrap 으로 이미 리뷰 완료 (clean).

- **actionlint**: 기존 워크플로우 6개 + 신규 2개 모두 `exit 0` (무위반 베이스라인)
- **markdownlint**: CI 가 실제 번들하는 버전(`markdownlint-cli@0.41.0` /
  markdownlint 0.34.x)으로 config 적용 검증 — OFF 한 4개 룰 모두 위반 목록에서
  제거됨. 남은 위반은 전부 기존 파일이라 `filter_mode: added` 로 CI 비노출
- **code-review**: HIGH finding(MD060 버전 미스매치 — 로컬 cli2 vs CI 번들
  룰셋 차이로 `MD060: false` 가 dead config)을 직접 probe 로 confirm 후 config
  정직화(MD060 제거 + 미래 maintainer 경고 노트, 카운트 재산출)
- **codex review**: clean (기능 버그 없음)

## 미검증 / 리스크

- 실제 PR 에서 reviewdog 인라인 코멘트 렌더링은 이 PR 머지 후 첫 PR 에서만
  확인 가능 (CI 환경 의존, 로컬 재현 불가)
- markdownlint 는 `fail_level: none` advisory 로 시작 — 어떤 PR 도 차단하지
  않음. 안정화 후 `error` 로 승급 가능
- fork PR 에서는 read-only 토큰이라 인라인 코멘트 미게시(fail-open).
  `pull_request_target` 은 토큰 탈취 위험으로 의도적 미사용

## blast radius

- 신규 워크플로우는 `pull_request` 트리거 only — 기존 push 게이트 무영향
- markdownlint advisory 라 어떤 PR 도 차단하지 않음
- actionlint 는 워크플로우 YAML 오류 시에만 차단(무위반 베이스라인에서 시작)

Closes #585
