### PR TITLE
fix(skills): dedupe restore-sessions trigger

### DIFF
--- a/skills/cmux-resume-sessions/SKILL.md
+++ b/skills/cmux-resume-sessions/SKILL.md
@@ -6,7 +6,7 @@ description: >
   Crash routing override: if the request mentions a crash, power loss, OOM, or "살려야",
   route to cmux-recover-sessions instead — even when the user also mentions a snapshot,
   because the snapshot may be stale and .jsonl scanning reflects the real latest state.
-  Triggers on "resume sessions", "session resume", "session restore", "restore sessions", "cmux resume", "restore from snapshot", "rehydrate sessions", "세션 복원", "스냅샷 복구", "스냅샷 복원".
+  Triggers on "resume sessions", "session resume", "session restore", "cmux resume", "restore from snapshot", "rehydrate sessions", "세션 복원", "스냅샷 복구", "스냅샷 복원".
 verified-against-runtime: true
 runtime-verified-at: 2026-05-28
 runtime-verified-note: "jq 1.x // empty + bash hostname (cmux 1.x snapshot schema: top-level .hostname) — silent-proceed on missing field / null / empty string; emits real value when present; matches against $(hostname). 4 synthetic + 1 real-snapshot cases probed."
@@ -42,7 +42,7 @@ It does NOT restore runtime state of previously running commands or sessions.
 - Restore a workspace layout from a `cmux-save-sessions` snapshot
 - Rehydrate yesterday's working set at the start of a new day
 - Move a session layout to another machine (snapshot → transfer → resume)
-- Triggers: "resume sessions", "session restore", "session resume", "cmux resume", "restore sessions"
+- Triggers: "resume sessions", "session restore", "session resume", "cmux resume"
 
 > **Not for crash recovery** — after a power loss, use `cmux-recover-sessions` (scans `.jsonl` files directly).
 


### PR DESCRIPTION
## 요약

bare trigger `"restore sessions"`가 `recover-sessions`(tmux 크래시 복구)와 `cmux-resume-sessions`(스냅샷 복원) 양쪽에 중복 선언돼 라우팅 collision을 일으켰다. 이 PR은 consensus 결정에 따라 **`cmux-resume-sessions`에서만 제거**하고 `recover-sessions`(generic tmux recovery owner)에는 유지한다.

## 변경

`skills/cmux-resume-sessions/SKILL.md` 2곳에서 bare `"restore sessions"`만 제거:
- frontmatter `description` Triggers 목록(line 9)
- in-body `- Triggers:` bullet(line 45)

`"session restore"`(다른 문구)·`"restore from snapshot"`·`"resume sessions"`·`"cmux resume"`·한국어 trigger는 모두 유지 → restore 의도 커버리지 손실 없음. `recover-sessions`·README·CLI 변경 없음.

## 검증

- `grep -c 'restore sessions' skills/cmux-resume-sessions/SKILL.md` → 0
- `grep -c 'restore sessions' skills/recover-sessions/SKILL.md` → 2 (유지)
- `grep -c 'session restore\|restore from snapshot' skills/cmux-resume-sessions/SKILL.md` → 3 (intent 유지)
- frontmatter YAML `yaml.safe_load` 파싱 OK(5 키 보존)
- `bash scripts/run-tests.sh` → ALL TESTS PASSED; `check-plugin-manifests.py` → OK
- 리뷰: `omc:code-reviewer` APPROVE(블로커 0, LOW 1 — line 51 헤더 산문 substring, trigger 아님), `codex-review-wrap` 결함 없음

Pre-commit verified: bash scripts/run-tests.sh → ALL TESTS PASSED; check-plugin-manifests.py → OK

Caller chain verified: docs-only 변경(SKILL.md trigger 선언 2곳) — trigger SoT는 frontmatter 자체이고 generated manifest는 per-skill trigger를 담지 않음(build-plugin-manifests.py는 base plugin description만 주입). 호출자/파생 사본 없음.

## 영향 범위

문서 trigger 선언 2줄. 런타임/CLI/테스트 동작 불변. 같은 파일 3-PR 직렬: M6(머지됨) → **M5** → B1. B1(Triggers bullet 구조 개편)은 M5 머지 후 rebase.

Closes #587
