### PR TITLE
refactor(skills): retire in-body Triggers bullet

### DIFF
--- a/skills/SKILL.md.tmpl
+++ b/skills/SKILL.md.tmpl
@@ -22,7 +22,6 @@ description: >
 
 - <condition or signal that warrants using this skill>
 - <condition 2>
-- Triggers: "<keyword1>", "<keyword2>", "<Korean-keyword>"
 
 ## Process
 

--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cmux-delegate
-description: Delegate a task to an independent Claude Code session in a new cmux workspace with auto-collected context. Triggers on "delegate", "cmux delegate", "new session".
+description: Delegate a task to an independent Claude Code session in a new cmux workspace with auto-collected context. Triggers on "delegate", "cmux delegate", "new session", "별도 세션".
 ---
 
 # cmux-delegate
@@ -19,7 +19,6 @@ description: Delegate a task to an independent Claude Code session in a new cmux
 - 디버깅이나 구현을 별도 세션에 위임할 때
 - 현재 컨텍스트의 편향 없이 fresh eyes가 필요할 때
 - 다중 독립 항목을 병렬로 조사/실행할 때
-- Triggers: "delegate", "cmux delegate", "new session", "별도 세션"
 
 ## Inputs
 

--- a/skills/cmux-recover-sessions/SKILL.md
+++ b/skills/cmux-recover-sessions/SKILL.md
@@ -44,7 +44,6 @@ Recovery reads `.jsonl` files and re-opens them in new cmux workspaces. It must 
 - After a Bun segfault crash that killed a Claude Code session
 - After a Mac power loss when all cmux workspaces are gone
 - After reboot when previous work sessions need to be restored
-- Triggers: "recover cmux", "cmux session recovery", "cmux restore sessions"
 
 ## Prerequisites
 

--- a/skills/cmux-resume-sessions/SKILL.md
+++ b/skills/cmux-resume-sessions/SKILL.md
@@ -42,7 +42,6 @@ It does NOT restore runtime state of previously running commands or sessions.
 - Restore a workspace layout from a `cmux-save-sessions` snapshot
 - Rehydrate yesterday's working set at the start of a new day
 - Move a session layout to another machine (snapshot → transfer → resume)
-- Triggers: "resume sessions", "session restore", "session resume", "cmux resume"
 
 > **Not for crash recovery** — after a power loss, use `cmux-recover-sessions` (scans `.jsonl` files directly).
 

--- a/skills/cmux-save-sessions/SKILL.md
+++ b/skills/cmux-save-sessions/SKILL.md
@@ -34,7 +34,6 @@ The session running this script (the manager session) is excluded by default —
 - Create a shareable snapshot of a multi-workspace setup for another machine
 - Record daily work state for later `cmux-resume-sessions` restore
 - Feed input data to other skills that need a session list
-- Triggers: "save sessions", "session save", "session snapshot", "cmux save", "list snapshots", "snapshot list"
 
 > **Not for crash recovery** — after a power loss, use `cmux-recover-sessions` (reads `.jsonl` files directly).
 

--- a/skills/cmux-session-manager/SKILL.md
+++ b/skills/cmux-session-manager/SKILL.md
@@ -27,7 +27,6 @@ never close or rename sessions without explicit approval, because a still-runnin
 - End-of-day session hygiene (status dashboard, cleanup, reorganize)
 - Too many orphaned or idle sessions accumulated in cmux
 - Before starting new work — verify no stale workspaces are consuming resources
-- Triggers: "cmux session", "session management", "session cleanup", "cmux status", "cmux cleanup", "cmux tidy"
 
 > **Not for crash recovery** — use `cmux-recover-sessions` after a power loss or cmux crash.
 

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -53,7 +53,6 @@ See **Step 5** for the full gate.
 
 - Before calling `/codex:review` from any multi-worktree project
 - When the session cwd differs from the worktree you just finished working in
-- Triggers: "codex review", "review codex", "safe review", "/codex-review-wrap"
 
 ## Inputs
 

--- a/skills/recover-sessions/SKILL.md
+++ b/skills/recover-sessions/SKILL.md
@@ -27,7 +27,6 @@ Recovery reads `.jsonl` files and re-opens them in new tmux panes. It must never
 - After a Mac power loss when all tmux sessions are gone
 - After tmux server crash that killed all running sessions
 - After reboot when previous work sessions need to be restored
-- Triggers: "recover", "session recovery", "restore sessions", "power recovery"
 
 ## Prerequisites
 

--- a/skills/writing-praxis-skill/SKILL.md
+++ b/skills/writing-praxis-skill/SKILL.md
@@ -25,7 +25,6 @@ trigger phrase to describe a second job, split it into two skills.
 - Creating a new praxis skill from scratch
 - Reviewing an existing SKILL.md for structural compliance
 - Onboarding a contributor who will add a skill
-- Triggers: "new praxis skill", "write praxis skill", "add praxis skill", "skill template", "praxis skill spec", "스킬 작성", "새 스킬"
 
 ## Process
 
@@ -54,6 +53,10 @@ description: >
 - `description` should be concise — keep it short enough to scan at a glance.
 - Always end `description` with a `Triggers on "..."` clause so the routing
   table in global `~/.claude/CLAUDE.md` can reference exact keywords.
+- The frontmatter `Triggers on "..."` clause is the **sole** source of trigger
+  keywords. Do NOT duplicate them in an in-body `- Triggers:` bullet — that
+  bullet was retired (#591) because the two copies drifted; frontmatter is the
+  single source of truth.
 - Use multi-line `>` block for descriptions that include trigger keywords; use
   inline text for short single-line descriptions (see `strike/SKILL.md`).
 


### PR DESCRIPTION
## 요약

스킬 trigger가 **두 곳**(frontmatter `Triggers on "..."` SoT + in-body `## When to Use`의 `- Triggers:` bullet)에 선언돼 drift class를 만들었다. `SKILL.md.tmpl`이 in-body bullet을 institutionalize 해 모든 신규 스킬이 중복을 상속한다(M5에서 cmux-resume bullet이 실제 drift했음). 이 PR은 in-body bullet을 전부 제거해 **frontmatter를 sole SoT**로 만든다.

## scope (consensus: broad)

`grep -rn '^\s*-\s*Triggers:' skills/` → 0. 대상 9곳: 템플릿 + 8개 스킬.

## 변경

- `SKILL.md.tmpl` + 7개 스킬(recover-sessions, codex-review-wrap, cmux-resume-sessions, cmux-recover-sessions, cmux-save-sessions, cmux-delegate, cmux-session-manager): in-body `- Triggers:` bullet 제거
- `writing-praxis-skill`: 자체 bullet 제거 + Step 2 Rules에 "frontmatter가 sole trigger SoT, in-body bullet 금지(#591)" note 추가 → 재발 방지
- **`cmux-delegate` frontmatter에 `"별도 세션"` 추가** — 이 한국어 trigger는 in-body bullet에만 있었고 frontmatter엔 없었음(code-reviewer가 silent loss 포착). grep + `git log -S`로 frontmatter 부재 확인 후 sole SoT에 보존.
- `cmux-recover-sessions`의 stale `"cmux restore sessions"`는 frontmatter에 **재추가하지 않음** — #77(2464158)이 crash-recovery가 cmux-resume(restore 소유)와 충돌하지 않도록 frontmatter에서 "restore" 용어를 의도적으로 제거했음(description에 *"NOT for restoring an intentionally saved layout"* 명시). stale bullet 제거가 그 라우팅 결정에 정합.

## 검증

- `grep -rn '^\s*-\s*Triggers:' skills/` → 0
- `grep -rln 'Triggers on' skills/` → 12 (frontmatter SoT 전부 보존)
- 전수 per-skill 키워드 대조(HEAD in-body 키워드 vs 현 frontmatter): cmux-delegate 보존 후 의도치 않은 손실 0 (cmux-recover `"cmux restore sessions"`만 의도적 제외)
- `bash scripts/run-tests.sh` → ALL TESTS PASSED; `check-plugin-manifests.py` → OK
- markdownlint: CI는 `filter_mode: added` + `fail_level: none`(advisory) — added 라인 clean, pre-existing MD040(cmux-delegate:381/409/425, diff 밖)은 scope 외(#585 backlog)
- 리뷰: `omc:code-reviewer` REQUEST_CHANGES(별도 세션 silent loss) → 수정 → clean APPROVE; `codex-review-wrap` 키워드 손실/회귀 없음

Pre-commit verified: bash scripts/run-tests.sh → ALL TESTS PASSED; check-plugin-manifests.py → OK; grep in-body Triggers → 0; per-skill keyword diff → no unintended loss

Caller chain verified: trigger SoT는 frontmatter `description` 절이며 in-body bullet은 문서 표기일 뿐 코드 consumer가 없음(build-plugin-manifests.py는 per-skill trigger를 읽지 않고 base plugin description만 주입). 라우팅은 global routing table이 frontmatter 키워드를 참조 — in-body bullet 제거는 라우팅 동작 불변.

## 영향 범위

스킬 문서 9파일(8 스킬 + 템플릿) + cmux-delegate frontmatter 1키워드 추가. 런타임/CLI/테스트 동작 불변. cmux-resume tri-PR(M6→M5→B1)의 마지막.

Closes #591


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Documentation**
  * Consolidated skill trigger specifications in metadata, removing redundant documentation duplicates for cleaner, more maintainable skill descriptions.
  * Added clarification that session resume functionality is not for crash recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->