### PR TITLE
ci: disable credential persistence in checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ concurrency:
   cancel-in-progress: true
 
 # Least privilege default: jobs only read the checked-out code. The reviewdog
-# jobs widen to pull-requests:write at the job level.
+# jobs widen to pull-requests:write at the job level. No job pushes back to the
+# repo, so every checkout sets persist-credentials: false — the GITHUB_TOKEN is
+# not left in .git/config for later steps (pip/apt/run-tests.sh) to reach.
 permissions:
   contents: read
 
@@ -27,6 +29,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
@@ -44,6 +48,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       # ubuntu-latest ships shellcheck, but install explicitly so the job
       # doesn't silently depend on the runner image. Rules come from
       # .shellcheckrc at the repo root.
@@ -65,6 +71,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       # Synthetic test secrets are allowlisted in .gitleaks.toml.
       - uses: gitleaks/gitleaks-action@v2
         env:
@@ -78,6 +85,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
@@ -92,6 +101,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       # --offline: only validate local file-path links and in-document
       # fragments. External URLs (mostly github.com) are skipped to avoid
       # unauthenticated 429 false failures. --exclude-path '^plugins/': those
@@ -118,6 +129,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       # Pinned to the latest release; existing workflows pass actionlint
       # cleanly, so error-level gating starts from green.
       - uses: reviewdog/action-actionlint@v1.72.0
@@ -136,6 +149,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       # Rule config lives in .markdownlint.yaml (counts derived under the
       # version this action bundles — see that file's header).
       - uses: reviewdog/action-markdownlint@v0.26.2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,12 @@ jobs:
       security-events: write
 
     steps:
+      # persist-credentials: false — the CodeQL actions use the job's
+      # GITHUB_TOKEN directly, so the checkout token need not stay in
+      # .git/config for later steps.
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       # CodeQL supports Python (the project's hook/script logic). Bash is not a
       # CodeQL language — shellcheck.yml covers the shell sources instead.


### PR DESCRIPTION
## 요약

#592 머지 후 CodeRabbit/zizmor 가 남긴 보안 지적 중 credential persistence 를
처리한다. 모든 checkout 에 `persist-credentials: false` 추가.

## 변경

checkout 은 기본으로 `.git/config` 에 `GITHUB_TOKEN` 을 persist 한다. 이 레포
CI job 은 repo 에 push 하지 않으므로(전부 read-only checks) 불필요 → 후속
스텝(pip/apt/`run-tests.sh`) compromise 시 token 악용 표면을 줄인다.

- `ci.yml` 7개 checkout (ruff/shellcheck/gitleaks/test/link-check/actionlint/markdownlint)
- `codeql.yml` 1개 checkout

SHA 핀(두 번째 지적)은 `dependabot.yml` 의 github-actions tag 관리 정책 +
`codeql.yml` tag 핀과 충돌해 제외(의도된 tag-pin 정책).

## 검증

Pre-commit verified: actionlint exit 0 (ci.yml + codeql.yml).
Caller chain verified: N/A -- CI 워크플로우 설정만 변경, 코드 호출자 없음.
[skip-codex-review] -- codex review 이미 완료 (clean).

- **actionlint**: 무위반 (exit 0)
- **code-review**: APPROVE — gitleaks(env token) / codeql(token default `github.token`) /
  reviewdog(input token) 모두 persist 된 credential 과 무관함을 authoritative source 로
  verified. 8/8 checkout 커버
- **codex review**: clean (CI/CodeQL 동작 깨뜨릴 결함 없음)

## 미검증 / 리스크

- 실제 CI 동작은 이 PR CI 에서 확인 — 특히 gitleaks PR-commit enumeration 과
  codeql SARIF 업로드가 persist=false 로 정상 동작하는지(functional test)
- blast radius narrow: 설정 추가만, 로직 변경 없음. top-level permissions 가 이미
  `contents: read` 라 어떤 job 도 write-git 경로가 없었음

Closes #595


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline security by implementing least-privilege checkout configurations across automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->