### PR TITLE
refactor(hooks): hoist git-argv parser to _lib

### DIFF
--- a/hooks/_lib/git_commit_titles.py
+++ b/hooks/_lib/git_commit_titles.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Shared git-commit-argv title extraction — single source of truth (B2, #594).
+
+Previously this parser was duplicated byte-for-byte in two preflight gates:
+  - commit-title-format-check/impl.py  (Conventional Commits format gate)
+  - commit-title-length-check/impl.py  (50-char title-length gate)
+
+Both now import from here, so the argv parser cannot silently drift across the
+two gates (the pre-extraction state had already drifted: one copy carried a
+dead `tok.startswith("-") is not False` quirk the other did not).
+
+Public API:
+  GIT_GLOBAL_FLAGS_WITH_ARG, GIT_GLOBAL_BARE_FLAGS, GIT_COMMIT_NO_VALUE_SHORT,
+  MESSAGE_FLAGS, FILE_FLAGS  — constant sets
+  title_from_file(path, base_dir=None)        -> str | None
+  strip_git_global_flags(argv)                -> tuple[list[str], str | None]
+  extract_git_titles(argv)                    -> list[str]
+
+The two gates differ only in WHAT they do with the extracted titles (length
+check vs format check); the extraction itself is identical and lives here.
+"""
+from __future__ import annotations
+
+import os
+import sys as _sys
+from pathlib import Path as _Path
+
+# This module lives in hooks/_lib/ alongside _hook_utils. Consumers already
+# insert this directory onto sys.path before importing us, but inserting it
+# here too keeps the module self-contained (e.g. when imported directly by a
+# differential test) without depending on the importer's path setup.
+_sys.path.insert(0, str(_Path(__file__).resolve().parent))
+from _hook_utils import strip_prefix  # type: ignore[import-not-found]  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Flags that carry the commit message as the next token (or in --flag=value form).
+MESSAGE_FLAGS = frozenset({"-m", "--message"})
+# Flags that carry a file path whose first line is the title.
+FILE_FLAGS = frozenset({"-F", "--file"})
+
+# Git global flags that appear between `git` and the subcommand.
+# These must be stripped before checking argv[1] == "commit".
+# Flags that consume the next token as their argument.
+GIT_GLOBAL_FLAGS_WITH_ARG = frozenset({
+    "-C", "-c",
+    "--git-dir", "--work-tree", "--namespace",
+    "--exec-path", "--super-prefix",
+    "--config-env", "--attr-source",
+    "-L", "--list-cmds",
+})
+# Bare flags (no argument consumed).
+GIT_GLOBAL_BARE_FLAGS = frozenset({
+    "--no-pager", "--paginate", "-p",
+    "--bare", "--no-replace-objects",
+    "--no-lazy-fetch", "--no-optional-locks",
+    "--no-advice", "--literal-pathspecs",
+    "--glob-pathspecs", "--noglob-pathspecs",
+    "--icase-pathspecs",
+    "--help", "--version", "-h", "-v",
+})
+
+# `git commit` short options that take NO value — valid as inner chars of a
+# POSIX combined-short cluster (e.g. -am, -vsm). Excludes value-taking short
+# options like -S (signing key id, optional attached), -F (file), -C (commit
+# ref), -c (commit), -t (template), -u (untracked mode), -m (message).
+GIT_COMMIT_NO_VALUE_SHORT = frozenset("aesvnqzp")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def title_from_file(path: str, base_dir: str | None = None) -> str | None:
+    """Read first line of a file; return None on any error or if stdin placeholder.
+
+    `base_dir` is the working directory git treats as cwd for relative paths
+    (the `-C <dir>` global flag value). When absent, paths are opened
+    relative to the hook's own cwd.
+    """
+    if path == "-":
+        return None  # stdin — acknowledged limitation, silent pass
+    if base_dir and not os.path.isabs(path):
+        path = os.path.join(base_dir, path)
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return fh.readline().rstrip("\n")
+    except OSError:
+        return None  # unreadable — silent pass
+
+
+def strip_git_global_flags(argv: list[str]) -> tuple[list[str], str | None]:
+    """Strip git global flags between 'git' and the subcommand.
+
+    Handles flags-with-arg (-C, -c, --git-dir, etc.) and bare flags
+    (--no-pager, -p, etc.), plus '='-embedded long-form (--git-dir=/path).
+    Returns (argv_at_subcommand, c_dir). The c_dir is the value passed to
+    `-C <dir>` / `-C=<dir>` if present — the working directory git uses for
+    resolving relative paths (notably `-F <file>`). When multiple `-C` flags
+    appear (git supports stacking — each is relative to the previous), they
+    are joined left-to-right, matching git's own behavior.
+    """
+    c_dir: str | None = None
+    i = 1  # skip 'git' at argv[0]
+    while i < len(argv):
+        tok = argv[i]
+        if tok == "--":
+            i += 1
+            break
+        if not tok.startswith("-"):
+            break
+        # Long flag with embedded '=' (e.g. --git-dir=/path) — bare, no next token.
+        if "=" in tok:
+            i += 1
+            continue
+        if tok in GIT_GLOBAL_BARE_FLAGS:
+            i += 1
+            continue
+        if tok in GIT_GLOBAL_FLAGS_WITH_ARG:
+            if tok == "-C" and i + 1 < len(argv):
+                next_dir = argv[i + 1]
+                # git -C stacking: each subsequent -C is relative to prior
+                if c_dir and not os.path.isabs(next_dir):
+                    c_dir = os.path.join(c_dir, next_dir)
+                else:
+                    c_dir = next_dir
+            i += 2  # consume flag + its argument
+            continue
+        # Unknown flag — stop stripping to avoid over-consuming.
+        break
+    return argv[i:], c_dir
+
+
+def extract_git_titles(argv: list[str]) -> list[str]:
+    """Extract commit title candidates from a git-commit argv.
+
+    Only the FIRST -m / --message flag contributes the title; subsequent -m
+    flags are body paragraphs and are ignored (git treats them that way).
+    -F / --file reads the file and takes the first line.
+
+    Handles:
+      git commit -m "title"
+      git commit --message "title"
+      git commit -m="title" / --message="title"
+      git commit -mvalue  (attached short-option, POSIX style)
+      git commit -F /tmp/msg
+      git commit --file /tmp/msg
+      git commit -am "title"   (combined short flag, e.g. -a -m together)
+      git commit --amend -m "title"
+      git -C /path commit -m "title"   (git global flags stripped)
+      git -c key=val commit -m "title" (git global flags stripped)
+    """
+    argv = strip_prefix(argv)
+    if not argv or argv[0] != "git":
+        return []
+
+    # Strip git global flags to find the actual subcommand.
+    sub_argv, c_dir = strip_git_global_flags(argv)
+    if not sub_argv or sub_argv[0] != "commit":
+        return []
+
+    titles: list[str] = []
+    message_seen = False
+    i = 1  # sub_argv[0] is "commit"; start scanning from index 1
+    while i < len(sub_argv):
+        tok = sub_argv[i]
+
+        # Handle --flag=value embedded form.
+        if "=" in tok and tok.startswith("-"):
+            key, _, val = tok.partition("=")
+            if key in MESSAGE_FLAGS and not message_seen:
+                titles.append(val.split("\n")[0])
+                message_seen = True
+                i += 1
+                continue
+            if key in FILE_FLAGS:
+                t = title_from_file(val, base_dir=c_dir)
+                if t is not None:
+                    titles.append(t)
+                i += 1
+                continue
+
+        # Handle attached short-option form: -m<value> parsed as single token.
+        # shlex strips quotes, so `git commit -m"long title"` becomes ['-mlong title'].
+        # This must be checked BEFORE the combined-flag branch to avoid misrouting.
+        if (
+            tok.startswith("-m")
+            and not tok.startswith("--")
+            and len(tok) > 2
+            and not message_seen
+        ):
+            titles.append(tok[2:].split("\n")[0])
+            message_seen = True
+            i += 1
+            continue
+
+        # Handle combined short flags like -am / -vsm (git allows clustered
+        # short options where -m terminates with the next token as value).
+        # Strict whitelist: every preceding char must be a known no-value short
+        # flag from git commit. This excludes `-Smike@example.com` (-S accepts
+        # attached key id; even though `com` ends in `m`, `S/@/.` etc. are not
+        # in the no-value set, so the cluster is rejected). Round-1 heuristic
+        # used "m anywhere in tok[1:]" and was unsafe; round-4 narrows it.
+        if (
+            tok.startswith("-")
+            and not tok.startswith("--")
+            and len(tok) > 2
+            and tok[-1] == "m"
+            and all(c in GIT_COMMIT_NO_VALUE_SHORT for c in tok[1:-1])
+            and not message_seen
+        ):
+            if i + 1 < len(sub_argv):
+                titles.append(sub_argv[i + 1].split("\n")[0])
+                message_seen = True
+                i += 2
+                continue
+
+        # Standard separate-token flags.
+        if tok in MESSAGE_FLAGS and not message_seen:
+            if i + 1 < len(sub_argv):
+                titles.append(sub_argv[i + 1].split("\n")[0])
+                message_seen = True
+                i += 2
+                continue
+            i += 1
+            continue
+
+        if tok in FILE_FLAGS:
+            if i + 1 < len(sub_argv):
+                t = title_from_file(sub_argv[i + 1], base_dir=c_dir)
+                if t is not None:
+                    titles.append(t)
+                i += 2
+                continue
+            i += 1
+            continue
+
+        i += 1
+
+    return titles

--- a/hooks/preflight-gate/commit-title-format-check/impl.py
+++ b/hooks/preflight-gate/commit-title-format-check/impl.py
@@ -54,6 +54,9 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     strip_prefix,
 )
 from block_message import format_block  # type: ignore[import-not-found]  # noqa: E402
+from git_commit_titles import (  # type: ignore[import-not-found]  # noqa: E402
+    extract_git_titles,
+)
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -83,35 +86,6 @@ GH_PR_TITLE_WHITELIST_PREFIXES = (
     "release: ",
 )
 
-# Flags that carry the commit message (separate-token or embedded form).
-MESSAGE_FLAGS = frozenset({"-m", "--message"})
-# Flags that carry a file path whose first line is the title.
-FILE_FLAGS = frozenset({"-F", "--file"})
-
-# git global flags that consume the next token as their argument.
-GIT_GLOBAL_FLAGS_WITH_ARG = frozenset({
-    "-C", "-c",
-    "--git-dir", "--work-tree", "--namespace",
-    "--exec-path", "--super-prefix",
-    "--config-env", "--attr-source",
-    "-L", "--list-cmds",
-})
-# git global bare flags (no argument consumed).
-GIT_GLOBAL_BARE_FLAGS = frozenset({
-    "--no-pager", "--paginate", "-p",
-    "--bare", "--no-replace-objects",
-    "--no-lazy-fetch", "--no-optional-locks",
-    "--no-advice", "--literal-pathspecs",
-    "--glob-pathspecs", "--noglob-pathspecs",
-    "--icase-pathspecs",
-    "--help", "--version", "-h", "-v",
-})
-
-# git commit short options that take NO value — valid inner chars of a combined
-# short cluster (e.g. -am, -vsm). Excludes value-taking short opts like
-# -S, -F, -C, -c, -t, -u, -m.
-GIT_COMMIT_NO_VALUE_SHORT = frozenset("aesvnqzp")
-
 
 # ---------------------------------------------------------------------------
 # Configuration helpers
@@ -138,148 +112,6 @@ def _build_pattern(allowed_types: tuple[str, ...]) -> re.Pattern[str]:
 
 def _is_strict() -> bool:
     return os.environ.get("PRAXIS_COMMIT_TITLE_FORMAT_STRICT", "1") != "0"
-
-
-# ---------------------------------------------------------------------------
-# Git commit message extraction (mirrors commit-title-length-check approach)
-# ---------------------------------------------------------------------------
-
-
-def _title_from_file(path: str, base_dir: str | None = None) -> str | None:
-    """Read first line of a file; return None on any error or if stdin placeholder."""
-    if path == "-":
-        return None  # stdin — acknowledged limitation, silent pass
-    if base_dir and not os.path.isabs(path):
-        path = os.path.join(base_dir, path)
-    try:
-        with open(path, encoding="utf-8") as fh:
-            return fh.readline().rstrip("\n")
-    except OSError:
-        return None  # unreadable — silent pass
-
-
-def _strip_git_global_flags(argv: list[str]) -> tuple[list[str], str | None]:
-    """Strip git global flags; return (argv_at_subcommand, c_dir)."""
-    c_dir: str | None = None
-    i = 1  # skip 'git' at argv[0]
-    while i < len(argv):
-        tok = argv[i]
-        if tok == "--":
-            i += 1
-            break
-        if not tok.startswith("-"):
-            break
-        if "=" in tok:
-            i += 1
-            continue
-        if tok in GIT_GLOBAL_BARE_FLAGS:
-            i += 1
-            continue
-        if tok in GIT_GLOBAL_FLAGS_WITH_ARG:
-            if tok == "-C" and i + 1 < len(argv):
-                next_dir = argv[i + 1]
-                if c_dir and not os.path.isabs(next_dir):
-                    c_dir = os.path.join(c_dir, next_dir)
-                else:
-                    c_dir = next_dir
-            i += 2
-            continue
-        break
-    return argv[i:], c_dir
-
-
-def _extract_git_titles(argv: list[str]) -> list[str]:
-    """Extract commit title candidates from a git-commit argv.
-
-    Only the FIRST -m / --message flag contributes the title.
-    Handles:
-      git commit -m "title"
-      git commit --message "title"
-      git commit -m="title" / --message="title"
-      git commit -mvalue  (attached short-option)
-      git commit -am "title"  (combined short flag)
-      git commit -F /tmp/msg
-      git -C /path commit -m "title"
-    """
-    argv = strip_prefix(argv)
-    if not argv or argv[0] != "git":
-        return []
-
-    sub_argv, c_dir = _strip_git_global_flags(argv)
-    if not sub_argv or sub_argv[0] != "commit":
-        return []
-
-    titles: list[str] = []
-    message_seen = False
-    i = 1  # sub_argv[0] is "commit"
-    while i < len(sub_argv):
-        tok = sub_argv[i]
-
-        # --flag=value embedded form
-        if "=" in tok and tok.startswith("-"):
-            key, _, val = tok.partition("=")
-            if key in MESSAGE_FLAGS and not message_seen:
-                titles.append(val.split("\n")[0])
-                message_seen = True
-                i += 1
-                continue
-            if key in FILE_FLAGS:
-                t = _title_from_file(val, base_dir=c_dir)
-                if t is not None:
-                    titles.append(t)
-                i += 1
-                continue
-
-        # Attached short-option form: -m<value>
-        if (
-            tok.startswith("-m")
-            and not tok.startswith("--")
-            and len(tok) > 2
-            and not message_seen
-        ):
-            titles.append(tok[2:].split("\n")[0])
-            message_seen = True
-            i += 1
-            continue
-
-        # Combined short flags like -am (e.g. -a -m together)
-        if (
-            tok.startswith("-")
-            and not tok.startswith("--")
-            and len(tok) > 2
-            and tok[-1] == "m"
-            and all(c in GIT_COMMIT_NO_VALUE_SHORT for c in tok[1:-1])
-            and not message_seen
-        ):
-            if i + 1 < len(sub_argv):
-                titles.append(sub_argv[i + 1].split("\n")[0])
-                message_seen = True
-                i += 2
-                continue
-
-        # Standard separate-token flags
-        if tok in MESSAGE_FLAGS and not message_seen:
-            if i + 1 < len(sub_argv):
-                titles.append(sub_argv[i + 1].split("\n")[0])
-                message_seen = True
-                i += 2
-                continue
-            i += 1
-            continue
-
-        if tok in FILE_FLAGS:
-            if i + 1 < len(sub_argv):
-                t = _title_from_file(sub_argv[i + 1], base_dir=c_dir)
-                if t is not None:
-                    titles.append(t)
-                i += 2
-                continue
-            i += 1
-            continue
-
-        i += 1
-
-    return titles
 
 
 # ---------------------------------------------------------------------------
@@ -416,7 +248,7 @@ def main() -> int:
 
     for argv in iter_command_starts(tokens):
         # Check git commit titles
-        git_titles = _extract_git_titles(argv)
+        git_titles = extract_git_titles(argv)
         for title in git_titles:
             if _is_whitelisted(title):
                 continue

--- a/hooks/preflight-gate/commit-title-length-check/impl.py
+++ b/hooks/preflight-gate/commit-title-length-check/impl.py
@@ -36,7 +36,9 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     compound_cascade_hint,
     iter_command_starts,
     safe_tokenize,
-    strip_prefix,
+)
+from git_commit_titles import (  # type: ignore[import-not-found]  # noqa: E402
+    extract_git_titles,
 )
 
 # ---------------------------------------------------------------------------
@@ -48,38 +50,6 @@ OPT_OUT_MARKER = "# title-length:ack"
 
 # Prefixes that indicate auto-generated merge/revert commits — skip them.
 SKIP_PREFIXES = ("Merge ", "Revert ")
-
-# Flags that carry the commit message as the next token (or in --flag=value form).
-MESSAGE_FLAGS = frozenset({"-m", "--message"})
-# Flags that carry a file path whose first line is the title.
-FILE_FLAGS = frozenset({"-F", "--file"})
-
-# Git global flags that appear between `git` and the subcommand.
-# These must be stripped before checking argv[1] == "commit".
-# Flags that consume the next token as their argument.
-GIT_GLOBAL_FLAGS_WITH_ARG = frozenset({
-    "-C", "-c",
-    "--git-dir", "--work-tree", "--namespace",
-    "--exec-path", "--super-prefix",
-    "--config-env", "--attr-source",
-    "-L", "--list-cmds",
-})
-# Bare flags (no argument consumed).
-GIT_GLOBAL_BARE_FLAGS = frozenset({
-    "--no-pager", "--paginate", "-p",
-    "--bare", "--no-replace-objects",
-    "--no-lazy-fetch", "--no-optional-locks",
-    "--no-advice", "--literal-pathspecs",
-    "--glob-pathspecs", "--noglob-pathspecs",
-    "--icase-pathspecs",
-    "--help", "--version", "-h", "-v",
-})
-
-# `git commit` short options that take NO value — valid as inner chars of a
-# POSIX combined-short cluster (e.g. -am, -vsm). Excludes value-taking short
-# options like -S (signing key id, optional attached), -F (file), -C (commit
-# ref), -c (commit), -t (template), -u (untracked mode), -m (message).
-GIT_COMMIT_NO_VALUE_SHORT = frozenset("aesvnqzp")
 
 
 # ---------------------------------------------------------------------------
@@ -97,175 +67,6 @@ def _get_max() -> int:
         except ValueError:
             pass
     return DEFAULT_MAX
-
-
-def _title_from_file(path: str, base_dir: str | None = None) -> str | None:
-    """Read first line of a file; return None on any error or if stdin placeholder.
-
-    `base_dir` is the working directory git treats as cwd for relative paths
-    (the `-C <dir>` global flag value). When absent, paths are opened
-    relative to the hook's own cwd.
-    """
-    if path == "-":
-        return None  # stdin — acknowledged limitation, silent pass
-    if base_dir and not os.path.isabs(path):
-        path = os.path.join(base_dir, path)
-    try:
-        with open(path, encoding="utf-8") as fh:
-            return fh.readline().rstrip("\n")
-    except OSError:
-        return None  # unreadable — silent pass
-
-
-def _strip_git_global_flags(argv: list[str]) -> tuple[list[str], str | None]:
-    """Strip git global flags between 'git' and the subcommand.
-
-    Handles flags-with-arg (-C, -c, --git-dir, etc.) and bare flags
-    (--no-pager, -p, etc.), plus '='-embedded long-form (--git-dir=/path).
-    Returns (argv_at_subcommand, c_dir). The c_dir is the value passed to
-    `-C <dir>` / `-C=<dir>` if present — the working directory git uses for
-    resolving relative paths (notably `-F <file>`). When multiple `-C` flags
-    appear (git supports stacking — each is relative to the previous), they
-    are joined left-to-right, matching git's own behavior.
-    """
-    c_dir: str | None = None
-    i = 1  # skip 'git' at argv[0]
-    while i < len(argv):
-        tok = argv[i]
-        if tok == "--":
-            i += 1
-            break
-        if not tok.startswith("-"):
-            break
-        # Long flag with embedded '=' (e.g. --git-dir=/path) — bare, no next token.
-        if "=" in tok:
-            i += 1
-            continue
-        if tok in GIT_GLOBAL_BARE_FLAGS:
-            i += 1
-            continue
-        if tok in GIT_GLOBAL_FLAGS_WITH_ARG:
-            if tok == "-C" and i + 1 < len(argv):
-                next_dir = argv[i + 1]
-                # git -C stacking: each subsequent -C is relative to prior
-                if c_dir and not os.path.isabs(next_dir):
-                    c_dir = os.path.join(c_dir, next_dir)
-                else:
-                    c_dir = next_dir
-            i += 2  # consume flag + its argument
-            continue
-        # Unknown flag — stop stripping to avoid over-consuming.
-        break
-    return argv[i:], c_dir
-
-
-def _extract_titles(argv: list[str]) -> list[str]:
-    """Extract commit title candidates from a git-commit argv.
-
-    Only the FIRST -m / --message flag contributes the title; subsequent -m
-    flags are body paragraphs and are ignored (git treats them that way).
-    -F / --file reads the file and takes the first line.
-
-    Handles:
-      git commit -m "title"
-      git commit --message "title"
-      git commit -m="title" / --message="title"
-      git commit -mvalue  (attached short-option, POSIX style)
-      git commit -F /tmp/msg
-      git commit --file /tmp/msg
-      git commit -am "title"   (combined short flag, e.g. -a -m together)
-      git commit --amend -m "title"
-      git -C /path commit -m "title"   (git global flags stripped)
-      git -c key=val commit -m "title" (git global flags stripped)
-    """
-    argv = strip_prefix(argv)
-    if not argv or argv[0] != "git":
-        return []
-
-    # Strip git global flags to find the actual subcommand.
-    sub_argv, c_dir = _strip_git_global_flags(argv)
-    if not sub_argv or sub_argv[0] != "commit":
-        return []
-
-    titles: list[str] = []
-    message_seen = False
-    i = 1  # sub_argv[0] is "commit"; start scanning from index 1
-    while i < len(sub_argv):
-        tok = sub_argv[i]
-
-        # Handle --flag=value embedded form.
-        if "=" in tok and tok.startswith("-") is not False:
-            key, _, val = tok.partition("=")
-            if key in MESSAGE_FLAGS and not message_seen:
-                titles.append(val.split("\n")[0])
-                message_seen = True
-                i += 1
-                continue
-            if key in FILE_FLAGS:
-                t = _title_from_file(val, base_dir=c_dir)
-                if t is not None:
-                    titles.append(t)
-                i += 1
-                continue
-
-        # Handle attached short-option form: -m<value> parsed as single token.
-        # shlex strips quotes, so `git commit -m"long title"` becomes ['-mlong title'].
-        # This must be checked BEFORE the combined-flag branch to avoid misrouting.
-        if (
-            tok.startswith("-m")
-            and not tok.startswith("--")
-            and len(tok) > 2
-            and not message_seen
-        ):
-            titles.append(tok[2:].split("\n")[0])
-            message_seen = True
-            i += 1
-            continue
-
-        # Handle combined short flags like -am / -vsm (git allows clustered
-        # short options where -m terminates with the next token as value).
-        # Strict whitelist: every preceding char must be a known no-value short
-        # flag from git commit. This excludes `-Smike@example.com` (-S accepts
-        # attached key id; even though `com` ends in `m`, `S/@/.` etc. are not
-        # in the no-value set, so the cluster is rejected). Round-1 heuristic
-        # used "m anywhere in tok[1:]" and was unsafe; round-4 narrows it.
-        if (
-            tok.startswith("-")
-            and not tok.startswith("--")
-            and len(tok) > 2
-            and tok[-1] == "m"
-            and all(c in GIT_COMMIT_NO_VALUE_SHORT for c in tok[1:-1])
-            and not message_seen
-        ):
-            if i + 1 < len(sub_argv):
-                titles.append(sub_argv[i + 1].split("\n")[0])
-                message_seen = True
-                i += 2
-                continue
-
-        # Standard separate-token flags.
-        if tok in MESSAGE_FLAGS and not message_seen:
-            if i + 1 < len(sub_argv):
-                titles.append(sub_argv[i + 1].split("\n")[0])
-                message_seen = True
-                i += 2
-                continue
-            i += 1
-            continue
-
-        if tok in FILE_FLAGS:
-            if i + 1 < len(sub_argv):
-                t = _title_from_file(sub_argv[i + 1], base_dir=c_dir)
-                if t is not None:
-                    titles.append(t)
-                i += 2
-                continue
-            i += 1
-            continue
-
-        i += 1
-
-    return titles
 
 
 # ---------------------------------------------------------------------------
@@ -309,7 +110,7 @@ def main() -> int:
     max_len = _get_max()
 
     for argv in iter_command_starts(tokens):
-        titles = _extract_titles(argv)
+        titles = extract_git_titles(argv)
         for title in titles:
             if any(title.startswith(p) for p in SKIP_PREFIXES):
                 continue

--- a/tests/test_git_commit_titles.py
+++ b/tests/test_git_commit_titles.py
@@ -1,0 +1,179 @@
+"""Differential + contract tests for the hoisted git-argv parser (B2, #594).
+
+`hooks/_lib/git_commit_titles.py` is the single source of truth for the
+commit-title extraction that commit-title-format-check and
+commit-title-length-check previously duplicated byte-for-byte. The two copies
+had already drifted: length-check carried a dead `tok.startswith("-") is not
+False` quirk that format-check did not. This suite locks three guarantees:
+
+  1. **Contract** — `extract_git_titles()` returns the correct title list for
+     the union of every argv shape the two oracle suites exercise
+     (-m / --message / -m= / --message= / -mvalue / -am / -F file / global
+     -C / -c, first-message-only, -S cluster rejection, ...).
+
+  2. **Dead-quirk equivalence** — the `=`-embedded branch (where the two copies
+     differed) behaves identically under the adopted clean form. Because
+     `str.startswith` always returns a bool, `b is not False` ≡ `b`; the
+     embedded `-m=`/`--message=` path is asserted directly so a regression in
+     that exact branch fails here.
+
+  3. **Single source** — both hooks import the SAME function object from _lib,
+     so the parser can no longer drift across the two gates.
+
+  4. **Fail-open** — malformed / dangling / non-git argv returns a list and
+     never raises (the hooks are fail-open by contract).
+
+Run: python3 -m pytest tests/test_git_commit_titles.py -q
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LIB_DIR = REPO_ROOT / "hooks" / "_lib"
+GATE_DIR = REPO_ROOT / "hooks" / "preflight-gate"
+
+# git_commit_titles.py inserts its own dir on sys.path to find _hook_utils, but
+# inserting here too makes the import order-independent.
+sys.path.insert(0, str(LIB_DIR))
+
+
+def _load(mod_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+# Load the canonical module first so the two impl modules' `from
+# git_commit_titles import ...` resolves to this exact object.
+gct = _load("git_commit_titles", LIB_DIR / "git_commit_titles.py")
+extract_git_titles = gct.extract_git_titles
+
+
+# ---------------------------------------------------------------------------
+# 1. Contract — union of oracle-suite argv shapes
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "argv, expected",
+    [
+        # separate-token message forms
+        (["git", "commit", "-m", "hello world"], ["hello world"]),
+        (["git", "commit", "--message", "hello world"], ["hello world"]),
+        # embedded '=' forms (THE branch that carried the dead quirk)
+        (["git", "commit", "-m=hello"], ["hello"]),
+        (["git", "commit", "--message=hello"], ["hello"]),
+        # attached short-option form
+        (["git", "commit", "-mhello"], ["hello"]),
+        # combined short clusters terminating in -m
+        (["git", "commit", "-am", "hello"], ["hello"]),
+        (["git", "commit", "-vsm", "hello"], ["hello"]),
+        # only the FIRST -m contributes the title; later -m are body
+        (["git", "commit", "-m", "title", "-m", "body para"], ["title"]),
+        # --amend before -m
+        (["git", "commit", "--amend", "-m", "hi"], ["hi"]),
+        # git global flags stripped before the subcommand
+        (["git", "-C", "/some/path", "commit", "-m", "hi"], ["hi"]),
+        (["git", "-c", "key=val", "commit", "-m", "hi"], ["hi"]),
+        # -S<keyid> must NOT be misread as a message even though it ends in 'm'
+        (["git", "commit", "-Smike@example.com"], []),
+        # not a git-commit argv
+        (["echo", "hi"], []),
+        (["git", "status"], []),
+        (["git", "commit", "--amend"], []),
+        # a positional containing '=' that does not start with '-' is ignored
+        (["git", "commit", "key=val", "-m", "hi"], ["hi"]),
+    ],
+)
+def test_extract_contract(argv, expected):
+    assert extract_git_titles(argv) == expected
+
+
+# ---------------------------------------------------------------------------
+# 2. Dead-quirk equivalence — embedded `=` branch
+# ---------------------------------------------------------------------------
+
+def test_embedded_message_branch_clean_form():
+    """The `if "=" in tok and tok.startswith("-")` branch (clean form) must
+    accept `-m=`/`--message=` exactly as the old `is not False` quirk did."""
+    assert extract_git_titles(["git", "commit", "-m=quirk path"]) == ["quirk path"]
+    assert extract_git_titles(["git", "commit", "--message=quirk path"]) == ["quirk path"]
+    # a token with '=' but not starting with '-' takes neither branch
+    assert extract_git_titles(["git", "commit", "a=b"]) == []
+
+
+# ---------------------------------------------------------------------------
+# 3. -F / --file forms (first line of the file is the title)
+# ---------------------------------------------------------------------------
+
+def test_file_message_forms(tmp_path):
+    msg = tmp_path / "msg.txt"
+    msg.write_text("feat: from file\n\nbody line\n", encoding="utf-8")
+    assert extract_git_titles(["git", "commit", "-F", str(msg)]) == ["feat: from file"]
+    assert extract_git_titles(["git", "commit", "--file", str(msg)]) == ["feat: from file"]
+    assert extract_git_titles(["git", "commit", f"-F={msg}"]) == ["feat: from file"]
+
+
+def test_file_relative_resolves_against_dash_C(tmp_path):
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    msg = sub / "rel.txt"
+    msg.write_text("fix: relative file\n", encoding="utf-8")
+    argv = ["git", "-C", str(sub), "commit", "-F", "rel.txt"]
+    assert extract_git_titles(argv) == ["fix: relative file"]
+
+
+def test_file_stdin_and_unreadable_are_silent(tmp_path):
+    # `-F -` is stdin → silent (no title)
+    assert extract_git_titles(["git", "commit", "-F", "-"]) == []
+    # unreadable path → silent (no raise, no title)
+    missing = tmp_path / "does-not-exist.txt"
+    assert extract_git_titles(["git", "commit", "-F", str(missing)]) == []
+
+
+# ---------------------------------------------------------------------------
+# 4. Single source of truth — both gates import the SAME object
+# ---------------------------------------------------------------------------
+
+def test_both_hooks_share_one_parser_object():
+    fmt = _load(
+        "impl_format_check",
+        GATE_DIR / "commit-title-format-check" / "impl.py",
+    )
+    length = _load(
+        "impl_length_check",
+        GATE_DIR / "commit-title-length-check" / "impl.py",
+    )
+    # Both modules' `extract_git_titles` must be the very object defined in _lib.
+    assert fmt.extract_git_titles is extract_git_titles
+    assert length.extract_git_titles is extract_git_titles
+
+
+# ---------------------------------------------------------------------------
+# 5. Fail-open — malformed argv returns a list, never raises
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        [],
+        ["git"],
+        ["git", "commit"],
+        ["git", "commit", "-m"],        # dangling -m, no value
+        ["git", "commit", "-F"],        # dangling -F, no value
+        ["git", "commit", "--message"],  # dangling long flag
+        ["git", "-C"],                  # dangling global flag
+        ["git", "commit", "-"],         # lone dash
+        ["git", "commit", "--"],        # end-of-options sentinel
+    ],
+)
+def test_fail_open_returns_list(argv):
+    result = extract_git_titles(argv)
+    assert isinstance(result, list)


### PR DESCRIPTION
## 무엇을 바꿨나

`commit-title-format-check` 와 `commit-title-length-check` 두 preflight-gate hook 이
git-commit-argv 제목 추출 파서를 **byte-identical 로 중복** 보유하고 있었다. 한쪽만
수정하면 두 gate 가 silently drift 한다 — 실제로 `commit-title-length-check` 에만 죽은
`tok.startswith("-") is not False` quirk 가 남아 있어 drift 가 이미 발생한 상태였다.

공유 파서를 single source of truth 로 hoist:

- **신규** `hooks/_lib/git_commit_titles.py` — 상수 5개(`MESSAGE_FLAGS`, `FILE_FLAGS`,
  `GIT_GLOBAL_FLAGS_WITH_ARG`, `GIT_GLOBAL_BARE_FLAGS`, `GIT_COMMIT_NO_VALUE_SHORT`)
  + 함수 3개(`title_from_file`, `strip_git_global_flags`, `extract_git_titles`).
  CLEAN form (`if "=" in tok and tok.startswith("-")`) 채택 — length-check 의
  `is not False` 는 `str.startswith` 가 항상 `bool` 을 반환하므로 증명 가능하게 dead
  (`bool is not False ≡ bool`), 행동 동일.
- 두 gate 는 로컬 정의를 제거하고 `_lib` 에서 `extract_git_titles` 를 import.
  `length-check` 는 `strip_prefix` 를 더 이상 직접 쓰지 않아 import 에서 제거,
  `format-check` 는 `_extract_gh_title` 가 계속 쓰므로 유지.
- **신규** `tests/test_git_commit_titles.py` — 30-case 차등/계약 테스트.

### 범위 밖 (의도적 — silent single-source 주장 아님)

git-argv 상수/파서를 **부분** 참조하는 다른 3개 consumer 는 관심사가 달라 범위 밖:
`branch-name-check`(자체 branch-argv 파서), `verify-commit-flag-override`
(`GIT_COMMIT_NO_VALUE_SHORT` 상수만), `momentum-rule-retrieval-gate`
(`GIT_GLOBAL_FLAGS_WITH_ARG` 상수만 + 인라인). commit-title 파서 전체를 공유하지
않으므로 follow-up 으로 남긴다.

## 검증한 것 (evidence)

- **두 oracle suite UNMODIFIED PASS** — `test_commit_title_format_check.sh` 65/0,
  `test_commit_title_length_check.sh` 47/0. `git diff origin/main...HEAD` 상 두 oracle
  파일 변경 0줄 (행동 변화 신호 없음).
- **신규 differential 테스트 30 passed** — union fixture shapes(`-m`/`--message`/`-m=`/
  `--message=`/`-mvalue`/`-am`/`-F file`/global `-C`·`-c`/first-message-only/`-S` cluster
  rejection), 죽은-quirk 동치(`-m=` 분기), 두 gate single-source **객체 동일성**
  (`fmt.extract_git_titles is extract_git_titles`), fail-open(9개 malformed argv → never raises).
- `scripts/run-tests.sh` → **ALL TESTS PASSED** (pytest+shell+manifest);
  `check-plugin-manifests.py` → OK; `ruff check` clean.
- **omc:code-reviewer** → APPROVE (Critical/High/Medium/Low 0; behavior identity 를 50k-case
  fuzz 로 0 divergence 입증). **codex-review-wrap** → blocking finding 0건.

Pre-commit verified: run-tests.sh (pytest+shell+manifest) exit 0 / ALL TESTS PASSED, ruff clean, two oracle suites unmodified pass (65/0, 47/0), 30-case differential suite pass, both mandatory reviews no-blocking
Caller chain verified: 5 git-argv consumers enumerated via grep; only the 2 commit-title gates share the full parser and now import from _lib; other 3 (branch-name-check / verify-commit-flag-override / momentum-rule-retrieval-gate) use disjoint or constant-only subsets and are intentionally left unchanged

## 검증 안 한 것 / caveat

- CI 미실행 (PR 생성 직후 watch 예정).
- codex 의 sandbox 내 pytest 는 `tmp_path` fixture 의 임시 디렉터리 생성 제한으로 차단
  됐으나, sandbox 외부 `run-tests.sh` exit 0 으로 falsify 됨 (코드 결함 아님).

## 영향 범위 (blast radius)

enforcement-hook logic — 파서 회귀는 사용자 commit/PR/issue 를 mis-block 할 수 있다.
그래서 행동 동일성을 (a) 미수정 oracle suite (b) 차등 테스트 (c) 50k fuzz 로 삼중 입증.
런타임 동작은 두 gate 모두 동일 (length → "ask", format → exit 2 block 경로 유지).

Closes #594


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated git commit title parsing logic into a shared utility module used by multiple hooks.

* **Tests**
  * Added comprehensive test coverage for commit title extraction functionality across various git command formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->