### PR TITLE
refactor(hooks): share option-text via _lib

### DIFF
--- a/hooks/_lib/ask_option_text.py
+++ b/hooks/_lib/ask_option_text.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Shared AskUserQuestion option-text collector (B3, #599).
+
+`collect_option_texts` was duplicated byte-for-byte (modulo one docstring
+line) in two advisory-nudge hooks:
+  - output-block-falsify-advisory/impl.py  (T2 confidence-anchoring scan)
+  - pre-output-falsification-gate/impl.py  (Lane A evaluative-marker scan)
+
+Both now import from here so the option-flattening logic cannot drift across
+the two gates.
+
+Scope note (B3 minimal, #599): ONLY this collector is shared. The
+`(Recommended)`/`Falsified:` token taxonomies stay per-hook — output-block T1
+hard-`deny`s on a literal `(Recommended)` label, while pre-output Lane A is
+stderr-advisory only. Unifying those token sets would blur the deny-vs-advisory
+boundary and is intentionally NOT done here. The `_has_falsified_line` helper
+likewise stays in output-block: it has a single consumer (pre-output uses a
+different `if .* wrong` regex gate, not a `Falsified:` exact-prefix check), so
+hoisting it would be premature abstraction.
+"""
+from __future__ import annotations
+
+
+def collect_option_texts(options: list) -> list[str]:
+    """Collect each option's label + description into a single text list.
+
+    Non-dict entries are skipped; only string label/description values are
+    included. Order is label-then-description, per option, in input order.
+    """
+    texts: list[str] = []
+    for o in options:
+        if not isinstance(o, dict):
+            continue
+        label = o.get("label")
+        if isinstance(label, str):
+            texts.append(label)
+        desc = o.get("description")
+        if isinstance(desc, str):
+            texts.append(desc)
+    return texts

--- a/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
@@ -54,6 +54,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
+from ask_option_text import collect_option_texts  # type: ignore[import-not-found]  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Messages
@@ -204,25 +205,6 @@ def _has_confidence_anchoring(texts: list[str]) -> bool:
     return False
 
 
-def _collect_option_texts(options: list) -> list[str]:
-    """Collect option.label + option.description into a single text list.
-
-    Used by T2 (confidence-anchoring) detection only — T1 (exact marker)
-    still scans labels only via _has_exact_recommended_marker().
-    """
-    texts: list[str] = []
-    for o in options:
-        if not isinstance(o, dict):
-            continue
-        label = o.get("label")
-        if isinstance(label, str):
-            texts.append(label)
-        desc = o.get("description")
-        if isinstance(desc, str):
-            texts.append(desc)
-    return texts
-
-
 def _emit_ask(message: str) -> None:
     """T2 path: soft gate. (decision must be "ask"/"deny" — "allow" is never
     emitted; silent-pass is signaled by no JSON output.)"""
@@ -335,7 +317,7 @@ def main() -> int:
                     tier_decision = "deny"
                     msg_to_emit = ASK_MSG
                     break  # T1 deny is final — overrides any prior T2 ask
-            elif _has_confidence_anchoring(_collect_option_texts(options)):
+            elif _has_confidence_anchoring(collect_option_texts(options)):
                 # T2 (issue #369): confidence-anchoring framing token in
                 # label OR description. Soft gate — false-positive risk
                 # higher than T1's literal marker. Record but keep scanning

--- a/hooks/advisory-nudge/pre-output-falsification-gate/impl.py
+++ b/hooks/advisory-nudge/pre-output-falsification-gate/impl.py
@@ -64,6 +64,7 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     safe_tokenize,
     strip_prefix,
 )
+from ask_option_text import collect_option_texts  # type: ignore[import-not-found]  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -136,21 +137,6 @@ _TRANSCRIPT_SCAN_LINES = 400
 # ---------------------------------------------------------------------------
 # Lane A — AskUserQuestion evaluative-option gate
 # ---------------------------------------------------------------------------
-
-def _collect_option_texts(options: list) -> list[str]:
-    """Collect option.label + option.description into a single text list."""
-    texts: list[str] = []
-    for o in options:
-        if not isinstance(o, dict):
-            continue
-        label = o.get("label")
-        if isinstance(label, str):
-            texts.append(label)
-        desc = o.get("description")
-        if isinstance(desc, str):
-            texts.append(desc)
-    return texts
-
 
 def _has_evaluative_marker(texts: list[str]) -> bool:
     """A1: any text contains an evaluative marker (EN regex or KO substring)."""
@@ -261,7 +247,7 @@ def _lane_a(tool_input: dict, transcript_path: str) -> bool:
             continue
         options = q.get("options")
         if isinstance(options, list):
-            option_texts.extend(_collect_option_texts(options))
+            option_texts.extend(collect_option_texts(options))
         q_body = q.get("question")
         if isinstance(q_body, str):
             body_texts.append(q_body)

--- a/tests/test_ask_option_text.py
+++ b/tests/test_ask_option_text.py
@@ -1,0 +1,242 @@
+"""Differential + contract tests for the hoisted option-text collector (B3, #599).
+
+`hooks/_lib/ask_option_text.py` is the single source of truth for
+`collect_option_texts`, previously duplicated byte-for-byte (modulo one
+docstring line) in two advisory-nudge hooks:
+  - output-block-falsify-advisory  (T2 confidence-anchoring scan)
+  - pre-output-falsification-gate  (Lane A evaluative-marker scan)
+
+This suite locks:
+
+  1. **Contract** — `collect_option_texts()` flattens option label+description,
+     skips non-dict entries and non-string values, preserves order.
+
+  2. **Single source** — both hooks import the SAME function object from _lib,
+     so the collector can no longer drift across the two gates.
+
+  3. **Behavior preservation (differential)** — invoking the real hooks via
+     stdin payloads still yields identical decisions after the extraction:
+       - (Recommended) label + NO `Falsified:` line  → output-block emits
+         `permissionDecision: deny` (T1 hard gate, issue #393).
+       - same payload WITH a `Falsified:` line in the question body → silent pass.
+       - malformed `questions` (non-list) → both hooks exit 0 (fail-open).
+
+The AskUserQuestion payload shape is mirrored from the working oracle baseline
+`tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh`
+(`make_ask_payload`), NOT from the hook under test, per the self-mocking guard.
+
+Run: python3 -m pytest tests/test_ask_option_text.py -q
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LIB_DIR = REPO_ROOT / "hooks" / "_lib"
+NUDGE_DIR = REPO_ROOT / "hooks" / "advisory-nudge"
+OUTPUT_BLOCK = NUDGE_DIR / "output-block-falsify-advisory" / "impl.py"
+PRE_OUTPUT = NUDGE_DIR / "pre-output-falsification-gate" / "impl.py"
+
+sys.path.insert(0, str(LIB_DIR))
+
+
+def _load(mod_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+# Load the canonical module first so the two impl modules' `from
+# ask_option_text import collect_option_texts` resolves to this exact object.
+aot = _load("ask_option_text", LIB_DIR / "ask_option_text.py")
+collect_option_texts = aot.collect_option_texts
+
+
+# ---------------------------------------------------------------------------
+# 1. Contract
+# ---------------------------------------------------------------------------
+
+def test_collects_label_then_description_in_order():
+    options = [
+        {"label": "A", "description": "desc-a"},
+        {"label": "B", "description": "desc-b"},
+    ]
+    assert collect_option_texts(options) == ["A", "desc-a", "B", "desc-b"]
+
+
+def test_label_only_and_description_only():
+    options = [{"label": "only-label"}, {"description": "only-desc"}]
+    assert collect_option_texts(options) == ["only-label", "only-desc"]
+
+
+def test_non_dict_entries_skipped():
+    options = ["not-a-dict", 42, None, {"label": "kept"}]
+    assert collect_option_texts(options) == ["kept"]
+
+
+def test_non_string_label_and_description_skipped():
+    options = [{"label": 123, "description": ["x"]}, {"label": "ok", "description": 9}]
+    assert collect_option_texts(options) == ["ok"]
+
+
+def test_empty_options_returns_empty():
+    assert collect_option_texts([]) == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Single source of truth — both gates import the SAME object
+# ---------------------------------------------------------------------------
+
+def test_both_hooks_share_one_collector_object():
+    ob = _load("impl_output_block", OUTPUT_BLOCK)
+    po = _load("impl_pre_output", PRE_OUTPUT)
+    assert ob.collect_option_texts is collect_option_texts
+    assert po.collect_option_texts is collect_option_texts
+
+
+# ---------------------------------------------------------------------------
+# 3. Behavior preservation — real hook invocation via stdin
+# ---------------------------------------------------------------------------
+
+def _make_ask_payload(option_labels: list[str], question: str = "What should we do?") -> str:
+    """Mirror of the oracle baseline make_ask_payload (option labels only)."""
+    payload = {
+        "session_id": "test-session",
+        "tool_name": "AskUserQuestion",
+        "tool_input": {
+            "questions": [
+                {
+                    "question": question,
+                    "options": [{"label": label} for label in option_labels],
+                }
+            ]
+        },
+        "cwd": "/tmp",
+    }
+    return json.dumps(payload)
+
+
+def _run_hook(hook_path: Path, payload: str) -> subprocess.CompletedProcess:
+    # Clear the falsification-gate bypass so an inherited env var cannot mask a
+    # Lane-A advisory; everything else inherits.
+    env = {**os.environ}
+    env.pop("PRAXIS_FALSIFY_GATE_BYPASS", None)
+    return subprocess.run(
+        [sys.executable, str(hook_path)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _decision(stdout: str) -> str | None:
+    if not stdout.strip():
+        return None
+    obj = json.loads(stdout)
+    return obj.get("hookSpecificOutput", {}).get("permissionDecision")
+
+
+def test_output_block_recommended_without_falsified_denies():
+    payload = _make_ask_payload(["Option A (Recommended)", "Option B"])
+    proc = _run_hook(OUTPUT_BLOCK, payload)
+    assert proc.returncode == 0
+    assert _decision(proc.stdout) == "deny"
+
+
+def test_output_block_recommended_with_falsified_line_silent():
+    payload = _make_ask_payload(
+        ["Option A (Recommended)", "Option B"],
+        question="What should we do?\nFalsified: ran the disconfirming test — no divergence.",
+    )
+    proc = _run_hook(OUTPUT_BLOCK, payload)
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""  # silent pass
+
+
+def test_malformed_questions_non_list_both_hooks_exit_zero():
+    bad_payload = json.dumps({
+        "session_id": "test-session",
+        "tool_name": "AskUserQuestion",
+        "tool_input": {"questions": "not-a-list"},
+        "cwd": "/tmp",
+    })
+    for hook in (OUTPUT_BLOCK, PRE_OUTPUT):
+        proc = _run_hook(hook, bad_payload)
+        assert proc.returncode == 0, f"{hook.parent.name} should fail-open on malformed questions"
+
+
+# ---------------------------------------------------------------------------
+# 4. Differential coverage of the extracted function's REAL consumers
+# ---------------------------------------------------------------------------
+# The (Recommended)-label tests above fire the output-block T1 marker path,
+# which short-circuits BEFORE the `elif _has_confidence_anchoring(
+# collect_option_texts(options))` branch — so they do not route through the
+# extracted collector on the output-block side. The two cases below drive each
+# hook's actual collector consumer: output-block T2 (confidence-anchoring) and
+# pre-output Lane A (evaluative marker + negative transcript).
+
+
+def test_output_block_t2_anchoring_routes_through_collector():
+    """KO confidence-anchoring '안전한' (no literal (Recommended), no Falsified:)
+    → T1 misses, the `elif` evaluates collect_option_texts(options) and T2 emits
+    'ask'. This is the output-block path that actually exercises the collector.
+    Anchoring token mirrored from the oracle T2 baseline ('가장 안전한')."""
+    payload = _make_ask_payload(["가장 안전한 1회 변경", "Faster but more scope"])
+    proc = _run_hook(OUTPUT_BLOCK, payload)
+    assert proc.returncode == 0
+    assert _decision(proc.stdout) == "ask"
+
+
+def _write_transcript(tmp_path, tool_result_text: str) -> Path:
+    """3-line JSONL ending in a user tool_result block carrying the given text.
+    Mirrors the oracle baseline `build_transcript_tool_result`."""
+    p = tmp_path / "transcript.jsonl"
+    lines = [
+        {"type": "user", "message": {"role": "user", "content": "do the work"}},
+        {"type": "assistant", "message": {"role": "assistant",
+         "content": [{"type": "text", "text": "running"}]}},
+        {"type": "user", "message": {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "abc123", "content": tool_result_text}
+        ]}},
+    ]
+    p.write_text("\n".join(json.dumps(line) for line in lines) + "\n", encoding="utf-8")
+    return p
+
+
+def test_pre_output_lane_a_positive_routes_through_collector(tmp_path):
+    """Lane A fires: (Recommended) evaluative marker (A1) + negative transcript
+    evidence (A2) + NO falsify phrase (A3 false) → stderr advisory, exit 0. The
+    option texts are gathered via collect_option_texts inside _lane_a. Payload
+    shape + negative-evidence text mirrored from the oracle baseline."""
+    transcript = _write_transcript(tmp_path, "query returned 0 rows and a timeout error")
+    payload = json.dumps({
+        "session_id": "test-session-A",
+        "transcript_path": str(transcript),
+        "tool_name": "AskUserQuestion",
+        "tool_input": {
+            "questions": [
+                {
+                    "question": "What should we do?",
+                    "header": "Next",
+                    "multiSelect": False,
+                    "options": [
+                        {"label": "Option A (Recommended)", "description": "the safer path"},
+                        {"label": "Option B"},
+                    ],
+                }
+            ]
+        },
+        "cwd": "/tmp",
+    })
+    proc = _run_hook(PRE_OUTPUT, payload)
+    assert proc.returncode == 0
+    assert "falsification-gate" in proc.stderr  # Lane A advisory fired


### PR DESCRIPTION
## 무엇을 바꿨나

`output-block-falsify-advisory` 와 `pre-output-falsification-gate` 두 advisory-nudge 훅이
AskUserQuestion 옵션 텍스트 수집기 `_collect_option_texts` 를 **동일 body 로 중복**(docstring
한 줄 외 byte-identical) 보유하고 있었다. 한쪽만 고치면 옵션 수집 로직이 drift 한다.

공유 함수를 single source of truth 로 hoist:

- **신규** `hooks/_lib/ask_option_text.py` — `collect_option_texts(options)` (pure 함수,
  `_lib` 의존 없음).
- 두 훅은 로컬 정의를 제거하고 `_lib` 에서 import.

### minimal extraction (plan 전제 수정 — author-exempt verification trap)

consensus plan 은 `_collect_option_texts` **와** `has_falsified_line` 둘 다 공유라고
명시했으나, 라이브 코드 probe 결과 **`_has_falsified_line` 은 output-block 훅에만 존재**한다
(`grep 'Falsified\|splitlines\|startswith' pre-output.../impl.py` → 0건; pre-output 은
A3-alt 에서 `_has_falsify_phrase` regex 를 **다른 게이트**로 사용 — C3 경계상 의도된 분리).
따라서 `_has_falsified_line` 은 단일 consumer 이며 `_lib` 이동 시 premature abstraction 이
되므로 output-block 에 그대로 둔다. (사용자 승인: A minimal.)

### C3 불변 — token taxonomy 통일 금지

`output-block` T1 = literal `(Recommended)` 에 hard-`deny`, `pre-output` Lane A = stderr
advisory only. 두 훅의 token 집합은 **per-hook 유지** — 통일 금지(deny vs advisory 경계 보존).

## 검증한 것 (evidence)

- **두 oracle suite UNMODIFIED PASS** — `test_output_block_falsify_advisory.sh` 42/0,
  `test_pre_output_falsification_gate.sh` 25/0. `git diff origin/main...HEAD` 상 oracle 변경 0줄.
- **신규 differential 테스트 11 passed** — collector 계약(5), 두 훅 single-source **객체
  동일성**(`is`), behavior 차등((Recommended) no-Falsified → `deny` / `Falsified:` → silent /
  malformed `questions` → 두 훅 exit 0), 그리고 **추출 함수의 실제 consumer 경로 차등**
  (output-block T2 anchoring → `ask` / pre-output Lane-A positive → advisory).
- `scripts/run-tests.sh` → **ALL TESTS PASSED**; `check-plugin-manifests.py` → OK; ruff clean.
- **omc:code-reviewer** → APPROVE (0 blocking). LOW-1(리터럴 `(Recommended)` 는 T1
  short-circuit 으로 collector 미호출) 반영 → output-block T2 + pre-output Lane-A 차등 추가.
  **codex-review-wrap** → blocking finding 0건.

Pre-commit verified: run-tests.sh (pytest+shell+manifest) exit 0 / ALL TESTS PASSED, ruff clean, two oracle suites unmodified pass (42/0, 25/0), 11-case differential suite pass, both mandatory reviews no-blocking
Caller chain verified: 2 _collect_option_texts consumers enumerated via grep — both advisory-nudge hooks now import collect_option_texts from _lib; _has_falsified_line left in output-block (single consumer; pre-output uses a disjoint `if .* wrong` regex gate, not a Falsified: prefix check)

## 검증 안 한 것 / caveat

- CI 미실행(PR 직후 watch 예정).
- NIT(`options: list` 타입 더 구체화)는 byte-identity refactor 원칙상 의도적 미반영(reviewer 동의).

## 영향 범위 (blast radius)

advisory/enforcement-hook logic. collector 회귀 시 두 falsification 게이트의 옵션 스캔이
바뀔 수 있어 token taxonomy 를 per-hook 으로 보존(C3)하고, 행동 동일성을 미수정 oracle 67-case
+ 차등 11-case 로 입증.

Closes #599


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicated option text collection logic into a shared utility module to improve code consistency across hooks.

* **Tests**
  * Added comprehensive test suite verifying option text collection behavior, including edge cases and cross-hook validation to ensure consistent and reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->