### PR TITLE
fix(hooks): add subprocess timeout to rename-sweep

### DIFF
--- a/hooks/preflight-gate/block-rename-sweep-survivors/impl.py
+++ b/hooks/preflight-gate/block-rename-sweep-survivors/impl.py
@@ -184,6 +184,7 @@ def _survivors(token: str) -> list[str]:
         ["git", "grep", "-n", "--fixed-strings", token],
         capture_output=True,
         text=True,
+        timeout=5,
     )
     if result.returncode != 0:
         return []
@@ -256,6 +257,7 @@ def main() -> int:
         ["git", "diff", "--cached", "--unified=0"],
         capture_output=True,
         text=True,
+        timeout=5,
     ).stdout
 
     if not diff.strip():

--- a/tests/hooks/preflight-gate/test_block_rename_sweep_survivors_timeout.py
+++ b/tests/hooks/preflight-gate/test_block_rename_sweep_survivors_timeout.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import subprocess
-import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/hooks/preflight-gate/test_block_rename_sweep_survivors_timeout.py
+++ b/tests/hooks/preflight-gate/test_block_rename_sweep_survivors_timeout.py
@@ -1,0 +1,103 @@
+"""Unit tests for TimeoutExpired handling in block-rename-sweep-survivors.
+
+Verifies that a hung subprocess.run call (git grep or git diff) raises
+subprocess.TimeoutExpired and that @fail_open converts it to exit 0.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the hook module directly for unit coverage
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+HOOK_PATH = (
+    REPO_ROOT
+    / "hooks"
+    / "preflight-gate"
+    / "block-rename-sweep-survivors"
+    / "impl.py"
+)
+
+spec = importlib.util.spec_from_file_location("block_rename_sweep_survivors", HOOK_PATH)
+assert spec is not None and spec.loader is not None
+brs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(brs)  # type: ignore[union-attr]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_COMMIT_PAYLOAD = json.dumps(
+    {"tool_name": "Bash", "tool_input": {"command": "git commit -m test"}}
+)
+
+
+def _run_main(payload: str, monkeypatch: pytest.MonkeyPatch) -> int:
+    monkeypatch.setattr("sys.stdin", __import__("io").StringIO(payload))
+    return brs.main()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_expired_on_git_diff_returns_0(monkeypatch: pytest.MonkeyPatch) -> None:
+    """git diff --cached hanging raises TimeoutExpired; @fail_open returns 0."""
+
+    def _raise_timeout(*args: object, **kwargs: object) -> None:
+        cmd = args[0] if args else []
+        if "diff" in cmd:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=5)
+        # git grep should not be reached when git diff raises
+        raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+    monkeypatch.setattr("subprocess.run", _raise_timeout)
+    result = _run_main(_COMMIT_PAYLOAD, monkeypatch)
+    assert result == 0
+
+
+def test_timeout_expired_on_git_grep_returns_0(monkeypatch: pytest.MonkeyPatch) -> None:
+    """git grep hanging raises TimeoutExpired; @fail_open returns 0."""
+
+    # Simulate: git diff succeeds (returns diff with a sweep), git grep hangs.
+    # We need a diff that contains a sweep so _survivors() is actually called.
+    _sweep_diff = (
+        "diff --git a/f1.py b/f1.py\n"
+        "--- a/f1.py\n"
+        "+++ b/f1.py\n"
+        "@@ -1,3 +1,3 @@\n"
+        "-lifecycle_stage = 1\n"
+        "-lifecycle_stage = 2\n"
+        "-lifecycle_stage = 3\n"
+        "+lifecycle_phase = 1\n"
+        "+lifecycle_phase = 2\n"
+        "+lifecycle_phase = 3\n"
+    )
+
+    call_count = {"n": 0}
+
+    def _side_effect(*args: object, **kwargs: object) -> object:
+        cmd = args[0] if args else []
+        call_count["n"] += 1
+        if "diff" in cmd:
+            # Return a fake CompletedProcess with the sweep diff
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=_sweep_diff, stderr="")
+        if "grep" in cmd:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=5)
+        raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+    monkeypatch.setattr("subprocess.run", _side_effect)
+    result = _run_main(_COMMIT_PAYLOAD, monkeypatch)
+    assert result == 0
+    # Both diff and grep were attempted
+    assert call_count["n"] >= 2


### PR DESCRIPTION
## 변경 내용

`hooks/preflight-gate/block-rename-sweep-survivors/impl.py`의 두 `subprocess.run` 호출에 `timeout=5` 추가:

1. **`git grep` 호출** (~line 183, `_survivors()` 함수): `timeout=5` 추가
2. **`git diff --cached` 호출** (~line 255, `main()` 함수): `timeout=5` 추가

### 동기

기존 코드에서 두 subprocess 호출에 timeout이 없어 git 프로세스가 hang할 경우 외부 10초 훅 kill까지 블록됐습니다. `timeout=5`를 추가하면 hung 서브프로세스가 `subprocess.TimeoutExpired`를 raise하고, 기존 `@fail_open` 데코레이터가 이를 exit 0으로 변환합니다(fail-open 시맨틱 보존).

### @fail_open 불변식 유지

`_hook_runtime.py:112-120`의 `@fail_open` 래퍼가 모든 `Exception`을 잡아 exit 0을 반환합니다. `TimeoutExpired`는 `Exception` 서브클래스이므로 별도 `try/except TimeoutExpired` 불필요 — 형제 hook 컨벤션과 일치합니다.

### timeout 값 근거

`timeout=5`는 형제 hook들의 지배적 컨벤션입니다:
- `hooks/advisory-nudge/external-write-path-existence-check/impl.py:154`
- `hooks/advisory-nudge/path-probe-gate/impl.py:156`
- `hooks/preflight-gate/worktree-edit-gate/impl.py:121`
- `hooks/preflight-gate/pre-edit-protected-branch-guard/impl.py:147`

## 검증 결과

```
$ grep -n 'timeout=' hooks/preflight-gate/block-rename-sweep-survivors/impl.py
187:        timeout=5,
260:        timeout=5,

$ grep -n 'fail_open\|def main' hooks/preflight-gate/block-rename-sweep-survivors/impl.py
45:from _hook_runtime import fail_open
234:@fail_open
235:def main() -> int:
```

### TimeoutExpired 유닛 테스트

```
$ python3 -m pytest tests/hooks/preflight-gate/test_block_rename_sweep_survivors_timeout.py -v
tests/...::test_timeout_expired_on_git_diff_returns_0 PASSED
tests/...::test_timeout_expired_on_git_grep_returns_0 PASSED
2 passed in 0.02s
```

### 기존 rename-sweep 쉘 테스트

```
Results: 11 passed, 0 failed
```

### 전체 pytest 스위트

```
135 passed in 2.62s
```

Pre-commit verified: pytest 135 passed, shell rename-sweep 11 passed
Caller chain verified: N/A -- hook impl internal change, no Python callers of _survivors() or main() outside this file

Closes #603


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 5-second timeout to preflight hook git operations to prevent indefinite hangs; the hook now returns cleanly when underlying git commands exceed this limit.

* **Tests**
  * Added unit tests verifying timeout scenarios and the hook's fail-open behavior, ensuring it exits successfully if git operations time out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->