### PR TITLE
docs: add missing 6.1.2 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `block-sciomc-finding-commit` hook: the finding-marker scan now parses the transcript **role-aware** (JSONL per-entry) instead of grepping the raw tail as text. The marker corpus is restricted to assistant message `text` blocks and `Agent`/`Task` subagent tool-results; markers inside user turns, system-reminder blocks, or `Read`/`Skill` tool-results that merely *load* a SKILL.md documenting the token schema no longer self-trip the gate. The consensus-refetch check still scans the full ordered stream after the finding, so a `gh pr view … --json body` recorded as an assistant Bash tool_use still satisfies the gate (#573, PR #575)
 - `retrospect`: Stage 1.5 hygiene cursor now guards against multi-session lost-update. A new **Cursor write mandate** re-reads the on-disk `.omc/state/retrospect-hygiene-cursor.json` before persisting and, when a sibling session advanced the cursor since this session's entry read, union-merges the `note` carry-forward + scan trail + batch pointer instead of plain-overwriting. Previously two interleaved `/retrospect` runs clobbered each other's findings — the second session's Write silently dropped the first session's carry-forward, breaking the Stage 1.5 carry-forward guarantee under concurrency (#568)
 
+## [6.1.2] - 2026-06-02
+
+2 PRs since 6.1.1. Fix-only release — no new hooks or skills.
+
+### Fixed
+- `retrospect`: Stage 1.5 hygiene cursor now guards against multi-session lost-update. A new **Cursor write mandate** re-reads the on-disk `.omc/state/retrospect-hygiene-cursor.json` before persisting and, when a sibling session advanced the cursor since this session's entry read, union-merges the `note` carry-forward + scan trail + batch pointer instead of plain-overwriting. Previously two interleaved `/retrospect` runs clobbered each other's findings — the second session's Write silently dropped the first session's carry-forward, breaking the Stage 1.5 carry-forward guarantee under concurrency (#568, PR #569)
+- `commit-title-format-check` hook: `release:` prefix now whitelisted for `gh pr create` titles only. The dev→prod release PR convention `release: Production Deploy (YYYY-MM-DD)` was blocked because `release` is not a Conventional Commits type and the pattern enforces a lowercase description. The whitelist is scoped to `gh pr create` — `git commit -m "release: ..."` and `gh issue create --title "release: ..."` still block (Conventional Commits enforced) (#570, PR #571)
+
 ## [6.1.1] - 2026-06-02
 
 ### Added


### PR DESCRIPTION
## 변경 내용

`CHANGELOG.md`에 누락된 `## [6.1.2]` 섹션을 추가합니다. `## [6.1.3]`과 `## [6.1.1]` 사이에 공백이 있었습니다.

## 6.1.2 내용 재구성 방법

git log로 6.1.1 (9dbe17d)과 6.1.2 (a8cc676) 사이의 커밋을 추적하여 재구성했습니다:

- `fix(retrospect): guard cursor multi-session write` (PR #569, closes #568)
  - Stage 1.5 hygiene cursor 동시 세션 write 충돌 방지를 위한 Cursor write mandate 추가
- `fix(hooks): whitelist release prefix for gh pr create titles` (PR #571, closes #570)
  - `release:` prefix를 gh pr create 타이틀에 한정해 허용 (commit/issue create는 여전히 block)

날짜는 6.1.2 bump commit (a8cc676, 2026-06-02)의 날짜를 기준으로 설정했습니다.
6.1.3 bump commit (9829e64)의 메시지에 "Rejected: retroactive [6.1.2] CHANGELOG section"이 명시되어 있어 이 PR에서 추가합니다.

## 검증 결과

1. `grep -n '## \[6.1.2\]' CHANGELOG.md` → 정확히 1개 (line 20)
2. `grep -nE '## \[6\.1\.[0-9]\]' CHANGELOG.md` → 순서: [6.1.3](line 10) → [6.1.2](line 20) → [6.1.1](line 28) ✓
3. `bash scripts/run-tests.sh` → PASS: 52, FAIL: 0 (ALL 17 PASSED)

Closes #607

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a cursor synchronization issue that could result in lost updates when multiple sessions were running simultaneously. This prevents critical data loss when working with concurrent operations.
  * Updated title validation logic to allow the `release:` prefix when creating pull requests through command-line tools, while maintaining restrictions for other commit-related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->