### PR TITLE
fix(hooks): route scope-confirm log to praxis_home

### DIFF
--- a/hooks/completion-verify/completion-verify/impl.sh
+++ b/hooks/completion-verify/completion-verify/impl.sh
@@ -113,8 +113,8 @@ else
 fi
 
 if [ -n "$block_reason" ]; then
-  mkdir -p ~/.claude/scope-confirm
-  echo "$(date -Iseconds) session=$SESSION_ID blocked_completion_without_evidence" >> ~/.claude/scope-confirm/stop-triggered.log
+  mkdir -p "${PRAXIS_HOME:-$HOME/.praxis}/scope-confirm" || true
+  echo "$(date -Iseconds) session=$SESSION_ID blocked_completion_without_evidence" >> "${PRAXIS_HOME:-$HOME/.praxis}/scope-confirm/stop-triggered.log" || true
 
   REASON="Completion claim detected without same-turn verification evidence. ${block_reason} See AGENTS.md Verification section."
   jq -n --arg r "$REASON" '{decision: "block", reason: $r}'

--- a/hooks/completion-verify/completion-verify/spec.md
+++ b/hooks/completion-verify/completion-verify/spec.md
@@ -46,7 +46,7 @@ When blocked, the hook emits:
 }
 ```
 
-and appends an entry to `~/.claude/scope-confirm/stop-triggered.log`.
+and appends an entry to `${PRAXIS_HOME:-$HOME/.praxis}/scope-confirm/stop-triggered.log`.
 
 ### Fail-safe paths
 

--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -295,8 +295,8 @@ if [ "${#SHORT_ROW_VIOLATIONS[@]}" -gt 0 ]; then
 fi
 
 if [ "$should_block" = "true" ]; then
-  mkdir -p ~/.claude/scope-confirm
-  echo "$(date -Iseconds) session=$SESSION_ID blocked_retrospect_mix_check" >> ~/.claude/scope-confirm/retrospect-mix-blocked.log
+  mkdir -p "${PRAXIS_HOME:-$HOME/.praxis}/scope-confirm" || true
+  echo "$(date -Iseconds) session=$SESSION_ID blocked_retrospect_mix_check" >> "${PRAXIS_HOME:-$HOME/.praxis}/scope-confirm/retrospect-mix-blocked.log" || true
 
   # Build reason string with ' | ' separator.
   reason=""


### PR DESCRIPTION
## 변경 내용

두 completion-verify 훅이 scope-confirm 로그를 `~/.claude/scope-confirm`에 하드코딩하고 있었습니다. praxis는 `~/.claude`(호스트/플러그인 경로)를 소유하지 않으므로, `_lib/_paths.py`의 정식 `praxis_home()` resolver 및 `strike-counter` sibling 컨벤션과 일치하도록 `${PRAXIS_HOME:-$HOME/.praxis}/scope-confirm`로 라우팅합니다.

- `hooks/completion-verify/completion-verify/impl.sh:116-117`
- `hooks/completion-verify/retrospect-mix-check/impl.sh:298-299`
- `hooks/completion-verify/completion-verify/spec.md:49` (impl과 doc 동기화)

쓰기는 best-effort 유지(`mkdir … || true`, append `… || true`) — 잘못되거나 read-only인 경로가 훅의 exit status를 절대 바꾸지 않습니다. 변수 확장은 완전 double-quote 처리하여 bare `~/.claude` 형태에 있던 space-in-path 잠재 결함도 함께 해소했습니다.

## 검증 (실제 실행 출력)

- `grep -rn '\.claude/scope' <두 impl.sh>` → 0 (잔존 없음)
- PRAXIS_HOME override 기능 테스트: `PRAXIS_HOME=$(mktemp -d)` → 로그가 override 디렉터리(`$TMP/scope-confirm/stop-triggered.log`)에 적재됨 확인
- read-only `PRAXIS_HOME` fixture (`chmod 555`) → mkdir/append 실패하지만 `|| true` 가드로 **exit 0** 유지 확인
- `bash scripts/run-tests.sh` → 전 그룹 0 failed (pytest 133 passed + shell 그룹 전부 PASS), exit code 0
- 독립 리뷰: `oh-my-claudecode:code-reviewer` (codex usage-limit fallback) → **APPROVE**, Critical/High/Medium 0건. LOW doc-drift 1건(spec.md:49) 본 커밋에 반영.

## 리스크 / blast radius

enforcement 훅의 진단 로그 *목적지* 변경뿐. 로직/제어흐름/차단 동작 불변. `scope-confirm` 로그는 write-only 진단이며 레포 어디에서도 programmatic reader가 없음(`grep -rn 'scope-confirm' .`로 확인) — 런타임 파손 없음.

Caller chain verified: grep -rn 'scope-confirm' found 0 programmatic readers (write-only diagnostic log; only the two writer hooks touch the path)

Pre-commit verified: bash scripts/run-tests.sh → exit 0, all groups 0 failed (pytest 133 passed + shell groups all PASS)

Closes #604


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging resilience by making log directory creation and output more fault-tolerant.

* **Chores**
  * Updated log file storage locations to use configurable Praxis home directory settings instead of hardcoded paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->