### PR TITLE
feat(hooks): add single-process dispatch runner

### DIFF
--- a/docs/adr/0002-hook-dispatch-consolidation.md
+++ b/docs/adr/0002-hook-dispatch-consolidation.md
@@ -129,9 +129,14 @@ Reproduces the current multi-process semantics:
 | else any `advisory-nudge` stderr/`additionalContext` | accumulate and emit as context, allow |
 | else | exit 0 (transparent pass-through) |
 
-`advisory-nudge` (12 in this group) can only ever contribute to the accumulate
-branch; `preflight-gate` (21) is the only role that can `deny`/`ask`. The `role`
-field already in `manifest.json` makes this split declarative.
+Aggregation is **role-agnostic**: the dispatcher classifies each member's result
+purely by exit code (`2`) or the `permissionDecision` marker on stdout, never by
+`role`. This is deliberate — some `advisory-nudge` hooks DO emit `ask`/`deny`
+(`destructive-bash-guard` calls `emit_decision("ask")` under
+`PRAXIS_DESTRUCTIVE_BASH_STRICT`; `output-block-falsify-advisory` emits both
+`ask` and `deny`), so a role-gated split would silently drop their gate
+decisions. `role` is used only for path/module naming, not for deny/ask
+eligibility.
 
 ### 2.3 Isolation: reuse `fail_open`
 

--- a/docs/adr/0002-hook-dispatch-consolidation.md
+++ b/docs/adr/0002-hook-dispatch-consolidation.md
@@ -28,7 +28,7 @@ group, which fires on **every** `Bash` tool call.
 
 | Metric | Value |
 |--------|-------|
-| `PreToolUse(Bash)` hook entries | 35 (21 `preflight-gate` + 14 `advisory-nudge`) |
+| `PreToolUse(Bash)` hook entries | 35 fire on a `Bash` call: 33 exact-`Bash` (21 `preflight-gate` + 12 `advisory-nudge`) + 2 multi-tool matcher |
 | Per-hook wrapper body | `command -v python3 \|\| exit 0; exec python3 .../impl.py` |
 | 35 hooks, parallel wall-clock | **1.87s** (user 1.44 + sys 1.33 — CPU saturation) |
 | Hook *logic* for a no-op command (`ls -la`) | **2ms** across all 35 |
@@ -104,6 +104,20 @@ A new shared module that:
 Existing `impl.py` files are **not modified**: they keep reading stdin and
 returning an `int` exactly as today. The dispatcher adapts around them.
 
+### 2.1a Scope: exact-`Bash` matcher only
+
+The `PreToolUse(Bash)` group is the **33** hooks whose manifest `matcher` is
+exactly `Bash`. Two `advisory-nudge` hooks carry multi-tool matchers and are
+**not** in this group:
+
+- `memory-hint` (`Bash|Edit|Write|NotebookEdit|AskUserQuestion`)
+- `external-api-literal-trigger` (`Write|Edit|Bash`)
+
+Folding a multi-tool hook into a Bash-only runner would drop its
+Edit/Write/NotebookEdit firing, so both keep their standalone wrappers in this
+phase. Registering such a hook into each of its tool groups is a follow-up.
+Net: 35 hooks fire on a `Bash` call, **33 are consolidated**, 2 stay independent.
+
 ### 2.2 Decision aggregation (most-restrictive wins)
 
 Reproduces the current multi-process semantics:
@@ -115,9 +129,9 @@ Reproduces the current multi-process semantics:
 | else any `advisory-nudge` stderr/`additionalContext` | accumulate and emit as context, allow |
 | else | exit 0 (transparent pass-through) |
 
-`advisory-nudge` (14) can only ever contribute to the accumulate branch;
-`preflight-gate` (21) is the only role that can `deny`/`ask`. The `role` field
-already in `manifest.json` makes this split declarative.
+`advisory-nudge` (12 in this group) can only ever contribute to the accumulate
+branch; `preflight-gate` (21) is the only role that can `deny`/`ask`. The `role`
+field already in `manifest.json` makes this split declarative.
 
 ### 2.3 Isolation: reuse `fail_open`
 
@@ -153,7 +167,7 @@ decision — eager import is already well under the per-process baseline.
 
 | Metric | Before | After |
 |--------|--------|-------|
-| python3 processes per `Bash` call (PreToolUse group) | 35 | 1 |
+| python3 processes per `Bash` call (PreToolUse group) | 35 | 1 (+2 multi-matcher standalone) |
 | `PreToolUse(Bash)` wall-clock (common command) | ~1.87s | ~0.13s |
 | Cost growth per added hook in the group | +1 cold-started process | +1 in-process `main()` call (~ms) |
 

--- a/hooks/_lib/_dispatch.py
+++ b/hooks/_lib/_dispatch.py
@@ -1,0 +1,205 @@
+"""Single-process dispatch runner for same-(event, matcher) hook groups (ADR-0002).
+
+Today each PreToolUse(Bash) hook is a separate `.sh` wrapper that
+`exec python3 .../impl.py`, so one `Bash` tool call cold-starts ~35 python3
+processes. ~99% of the latency is interpreter startup, not hook logic.
+
+This module runs a whole `(event, matcher)` group inside one process:
+
+  1. read the hook payload from stdin ONCE;
+  2. import each member's `impl.py` (the `if __name__ == "__main__"` guard
+     means importing does NOT run `main()`);
+  3. for each member, re-point `sys.stdin` at a fresh `StringIO` of the payload
+     and call its `fail_open`-wrapped `main()`, capturing stdout/stderr/exit;
+  4. aggregate the per-hook results into ONE decision (most-restrictive wins),
+     reproducing the semantics Claude Code applies across independent hook
+     processes.
+
+Member `impl.py` files are NOT modified — they keep reading stdin and returning
+an int exactly as before. The dispatcher adapts around them.
+
+Decision aggregation (ADR-0002 §2.2):
+  - any hook -> deny  (exit 2, or `permissionDecision: "deny"` on stdout) -> deny
+  - else any hook -> ask (`permissionDecision: "ask"` on stdout)          -> ask
+  - else                                                                  -> allow
+  stderr from every hook (advisory nudges AND deny reasons) is always
+  preserved and forwarded.
+
+Fail-open invariant (ETHOS.md): every `main()` runs through `_hook_runtime.fail_open`,
+and the dispatcher's own `main()` swallows exceptions to 0 — a crash here must
+never block a legitimate tool call.
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import traceback
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from typing import Callable, Optional, cast
+
+_HOOKS_DIR = Path(__file__).resolve().parent.parent  # hooks/
+_LIB_DIR = _HOOKS_DIR / "_lib"
+_MANIFEST = _HOOKS_DIR / "manifest.json"
+
+# Member impl.py files do `sys.path.insert(0, .../_lib)` to import _hook_utils etc.
+# Make _lib importable here too so an eager import resolves the same way.
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
+
+_ASK_MARKER = '"permissionDecision": "ask"'
+_DENY_MARKER = '"permissionDecision": "deny"'
+
+
+def group_members(
+    event: str, matcher: str, host: Optional[str] = None
+) -> list[tuple[str, str, Path]]:
+    """Return `(role, name, impl_path)` for manifest entries matching (event, matcher).
+
+    Order follows `manifest.json` array order, which is the declared run order.
+    A multi-event hook contributes the entry whose event/matcher matches.
+
+    `host` mirrors the per-platform filter `build-plugin-manifests.py` applies: a
+    hook is kept iff its `hosts` whitelist is absent OR contains `host`. `host=None`
+    is the canonical (unfiltered) view; the runtime passes its platform host so the
+    dispatcher never re-includes a hook the build stripped for that platform (e.g.
+    a Codex install must not run a `hosts: ["claude"]` guard). See main()/argv[3].
+    """
+    manifest = json.loads(_MANIFEST.read_text())
+    members: list[tuple[str, str, Path]] = []
+    for hook in manifest.get("hooks", []):
+        hosts = hook.get("hosts")
+        if host is not None and hosts is not None and host not in hosts:
+            continue
+        name = hook.get("name")
+        role = hook.get("role")
+        # `or` (not `.get(key, default)`): an explicit "body": null in a future
+        # manifest entry has the key present, so `.get` would return None and
+        # `Path / None` would raise. `or` treats both absent and null as default.
+        body = hook.get("body") or "impl.py"
+        entries = hook.get("entries") or [
+            {"event": hook.get("event"), "matcher": hook.get("matcher"), "file": body}
+        ]
+        for entry in entries:
+            if entry.get("event") == event and entry.get("matcher") == matcher:
+                impl = _HOOKS_DIR / role / name / (entry.get("file") or body)
+                members.append((role, name, impl))
+    # Members are invoked with stdin only (see run_one). A manifest hook that
+    # declares "args" (the per-process runtime forwards those as sys.argv) is NOT
+    # supported in a dispatch group — and the dispatcher's own main() consumes
+    # sys.argv for (event, matcher). None of the current exact-Bash members
+    # declare args; PR3 adds a fail-loud guard when it wires the manifest schema.
+    return members
+
+
+def _load_main(role: str, name: str, impl: Path) -> Optional[Callable[[], int]]:
+    """Import impl.py under a unique module name and return its `main` callable.
+
+    Returns None if the module has no callable `main` (the dispatcher then
+    treats it as a transparent pass). Import errors propagate to the caller,
+    which isolates them per hook.
+    """
+    modname = f"_praxis_dispatch__{role}__{name}".replace("-", "_")
+    spec = importlib.util.spec_from_file_location(modname, impl)
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    fn = getattr(module, "main", None)
+    return cast("Callable[[], int]", fn) if callable(fn) else None
+
+
+def run_one(role: str, name: str, impl: Path, payload_raw: str) -> tuple[int, str, str]:
+    """Run a single member's `main()` in-process. Returns `(exit, stdout, stderr)`.
+
+    `sys.stdin` is re-pointed at a fresh copy of the payload so the unmodified
+    impl.py reads it as if it were the only process. `main()` is wrapped in
+    `fail_open`, so a raising hook is isolated and reported as a pass (exit 0)
+    — double-wrapping an already-`@fail_open` main is harmless.
+    """
+    try:
+        fn = _load_main(role, name, impl)
+    except Exception:
+        # Import-time failure (missing dep, syntax error): fail OPEN — a broken
+        # member must never block the tool — but NOT fail-silent. Forward the
+        # traceback to stderr exactly as the per-process `python3 impl.py` wrapper
+        # would (Python prints it unconditionally), so a disabled guard stays
+        # visible instead of silently allowing.
+        return 0, "", f"[dispatch] {role}/{name} import failed:\n{traceback.format_exc()}"
+    if fn is None:
+        return 0, "", ""
+
+    wrapped = fail_open(fn)
+    out, err = io.StringIO(), io.StringIO()
+    saved_stdin = sys.stdin
+    sys.stdin = io.StringIO(payload_raw)
+    try:
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = wrapped() or 0
+    except SystemExit as exc:  # impl.py may `sys.exit(main())`-style internally
+        rc = exc.code if isinstance(exc.code, int) else 0
+    finally:
+        sys.stdin = saved_stdin
+    return rc, out.getvalue(), err.getvalue()
+
+
+def run_group(
+    event: str, matcher: str, payload_raw: str, host: Optional[str] = None
+) -> int:
+    """Run the whole (event, matcher) group; emit one decision; return its exit code."""
+    results = [
+        run_one(role, name, impl, payload_raw)
+        for role, name, impl in group_members(event, matcher, host)
+    ]
+
+    # Forward every hook's stderr (advisory nudges and deny reasons alike).
+    for _rc, _so, se in results:
+        if se:
+            sys.stderr.write(se)
+
+    # Most-restrictive decision wins: deny > ask > allow. The FIRST deny/ask JSON
+    # on stdout is surfaced — concatenating two decision objects would be invalid
+    # JSON, and Claude Code surfaces one decision anyway. Every member's stderr is
+    # forwarded above regardless, so advisory nudges and later reasons are never
+    # silently dropped. Detection is role-agnostic (exit 2 / marker), since some
+    # advisory-nudge hooks also emit ask/deny — see ADR-0002 §2.2.
+    deny = next(
+        (so for rc, so, _se in results if rc == 2 or _DENY_MARKER in so), None
+    )
+    if deny is not None:
+        if deny:
+            sys.stdout.write(deny)
+        return 2
+
+    ask = next((so for _rc, so, _se in results if _ASK_MARKER in so), None)
+    if ask is not None:
+        sys.stdout.write(ask)
+        return 0
+
+    return 0
+
+
+def main() -> int:
+    """Entrypoint: stdin = hook payload; argv = [event, matcher, host?].
+
+    Defaults to PreToolUse / Bash / no host filter. The build passes the platform
+    host as argv[3] so host-restricted hooks are not re-included (see group_members).
+    Wrapped in a top-level guard so a dispatcher fault fails open (return 0),
+    never blocking the tool call.
+    """
+    try:
+        payload_raw = sys.stdin.read()
+        event = sys.argv[1] if len(sys.argv) > 1 else "PreToolUse"
+        matcher = sys.argv[2] if len(sys.argv) > 2 else "Bash"
+        host = sys.argv[3] if len(sys.argv) > 3 else None
+        return run_group(event, matcher, payload_raw, host)
+    except Exception:
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/hooks/_lib/test_dispatch.py
+++ b/tests/hooks/_lib/test_dispatch.py
@@ -1,0 +1,324 @@
+"""Tests for hooks/_lib/_dispatch.py — single-process group runner (ADR-0002, #613).
+
+Coverage:
+  - group_members: the PreToolUse(Bash) group resolves to the expected count/roles
+  - per-hook equivalence: for a no-op payload, dispatcher `run_one` produces the
+    same (exit, stdout, stderr) as running the hook's impl.py in a fresh
+    subprocess — i.e. stdin reinjection + in-process invocation preserve behaviour
+  - run_group on a no-op payload allows (exit 0, no decision JSON)
+  - aggregation priority (deny > ask > allow) via fake members
+  - crash isolation: a raising member is contained (fail_open) and does not abort
+    the group
+  - latency: the whole group runs well under the 35-process baseline
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LIB = REPO_ROOT / "hooks" / "_lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+import _dispatch  # noqa: E402
+
+# Reuse the dispatcher's own decision markers so the tests track any change to
+# them (single source of truth — see _dispatch._ASK_MARKER / _DENY_MARKER).
+_ASK = _dispatch._ASK_MARKER
+_DENY = _dispatch._DENY_MARKER
+
+
+NOOP_PAYLOAD = json.dumps(
+    {
+        "tool_name": "Bash",
+        "tool_input": {"command": "ls -la"},
+        "cwd": str(REPO_ROOT),
+        "session_id": "test-dispatch",
+    }
+)
+
+
+# --------------------------------------------------------------------------- #
+# group resolution
+# --------------------------------------------------------------------------- #
+
+def test_group_members_count_and_roles():
+    # Exact-`Bash` matcher only. Two advisory hooks (memory-hint,
+    # external-api-literal-trigger) carry multi-tool matchers (Bash|Edit|Write|…)
+    # and are intentionally excluded — see ADR-0002 §2 scope note.
+    members = _dispatch.group_members("PreToolUse", "Bash")
+    assert len(members) == 33, f"expected 33 exact-Bash members, got {len(members)}"
+    # every impl path must exist on disk
+    for role, name, impl in members:
+        assert impl.exists(), f"missing impl for {role}/{name}: {impl}"
+    roles = [role for role, _name, _impl in members]
+    assert roles.count("preflight-gate") == 21
+    assert roles.count("advisory-nudge") == 12
+
+
+def test_group_members_host_filter():
+    # build-plugin-manifests strips host-restricted hooks per platform; the
+    # dispatcher must apply the SAME filter so it never re-includes a hook the
+    # build stripped (a Codex install must not run a hosts:["claude"] guard).
+    def names(ms):
+        return {n for _r, n, _i in ms}
+
+    unfiltered = _dispatch.group_members("PreToolUse", "Bash")
+    claude = _dispatch.group_members("PreToolUse", "Bash", host="claude")
+    codex = _dispatch.group_members("PreToolUse", "Bash", host="codex")
+
+    assert len(unfiltered) == 33  # host=None -> canonical, unfiltered view
+    # the only host-restricted Bash members are the 2 claude-only guards
+    assert names(claude) == names(unfiltered)
+    assert "block-commit-without-codex-review" not in names(codex)
+    assert "block-rename-sweep-survivors" not in names(codex)
+    assert len(codex) == 31
+
+
+# --------------------------------------------------------------------------- #
+# per-hook equivalence: in-process run_one == subprocess impl.py
+# --------------------------------------------------------------------------- #
+
+def _members():
+    return _dispatch.group_members("PreToolUse", "Bash")
+
+
+@pytest.mark.parametrize("member", _members(), ids=lambda m: f"{m[0]}/{m[1]}")
+def test_run_one_matches_subprocess_for_noop(member):
+    role, name, impl = member
+
+    direct = subprocess.run(
+        [sys.executable, str(impl)],
+        input=NOOP_PAYLOAD,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    rc, so, se = _dispatch.run_one(role, name, impl, NOOP_PAYLOAD)
+
+    assert rc == direct.returncode, (
+        f"{role}/{name}: exit mismatch in-process={rc} subprocess={direct.returncode}"
+    )
+    assert so == direct.stdout, f"{role}/{name}: stdout mismatch"
+    assert se == direct.stderr, f"{role}/{name}: stderr mismatch"
+
+
+def test_run_group_noop_allows():
+    rc = _dispatch.run_group("PreToolUse", "Bash", NOOP_PAYLOAD)
+    assert rc == 0
+
+
+# --------------------------------------------------------------------------- #
+# real-impl GATE-FIRING equivalence (ADR-0002 §3.3 / §5.2)
+#
+# The no-op test only exercises the allow path. ADR-0002 mandates
+# dispatcher-vs-subprocess parity for a *gate-firing* payload too, hook by hook,
+# so in-process marker/exit detection is regression-guarded against the REAL
+# impls denying/asking — not just the synthetic fakes below. Firing commands were
+# confirmed empirically (probe 2026-06-05); members inspect the command STRING
+# (they never execute it), so firing is deterministic without real git/gh state.
+# --------------------------------------------------------------------------- #
+
+# `gh search ... --state all` -> block-gh-state-all denies unconditionally (rc 2).
+_FIRING_DENY = "gh search issues foo --state all"
+# `git push --force ...` -> side-effect-scan asks (rc 0 + ask JSON on stdout).
+_FIRING_ASK = "git push --force origin main"
+# Malformed commit title -> commit-title-format-check denies WHILE side-effect-scan
+# + commit-title-length-check ask: exercises deny-beats-ask on REAL impls.
+_FIRING_DENY_OVER_ASK = (
+    'git commit -m "intentionally very long commit title '
+    'exceeding the fifty char limit by a wide margin"'
+)
+
+
+def _payload(command: str) -> str:
+    return json.dumps(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "cwd": str(REPO_ROOT),
+            "session_id": "test-dispatch-firing",
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "command,expected_rc,ask_on_stdout",
+    [
+        (_FIRING_DENY, 2, False),
+        (_FIRING_ASK, 0, True),
+    ],
+    ids=["deny", "ask"],
+)
+def test_run_group_aggregates_real_firing(command, expected_rc, ask_on_stdout, capsys):
+    rc = _dispatch.run_group("PreToolUse", "Bash", _payload(command))
+    out = capsys.readouterr().out
+    assert rc == expected_rc, f"{command!r}: group rc {rc}, expected {expected_rc}"
+    if ask_on_stdout:
+        assert _ASK in out, f"{command!r}: expected ask JSON on stdout"
+    else:
+        # a pure deny must not also surface an ask decision on stdout
+        assert _ASK not in out
+
+
+def test_run_group_deny_beats_ask_on_real_impls(monkeypatch, capsys):
+    # Pin strict so commit-title-format-check denies deterministically regardless
+    # of ambient env; subprocess and in-process both inherit the same value.
+    monkeypatch.setenv("PRAXIS_COMMIT_TITLE_FORMAT_STRICT", "1")
+    rc = _dispatch.run_group("PreToolUse", "Bash", _payload(_FIRING_DENY_OVER_ASK))
+    out = capsys.readouterr().out
+    assert rc == 2, "deny must win over the concurrent asks"
+    assert _ASK not in out, "deny wins; the ask decision must not be surfaced on stdout"
+
+
+def test_run_one_matches_subprocess_for_firing_payload(monkeypatch):
+    # ADR-0002 §3.3: per-hook dispatcher-vs-subprocess parity on a gate-firing
+    # payload. The malformed-commit payload fires 1 deny + 2 ask members on real
+    # impls, so this exercises in-process deny AND ask marker reproduction.
+    monkeypatch.setenv("PRAXIS_COMMIT_TITLE_FORMAT_STRICT", "1")
+    payload = _payload(_FIRING_DENY_OVER_ASK)
+    mismatches: list[str] = []
+    in_proc_denies = 0
+    in_proc_asks = 0
+    for role, name, impl in _dispatch.group_members("PreToolUse", "Bash"):
+        direct = subprocess.run(
+            [sys.executable, str(impl)],
+            input=payload,
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+        rc, so, se = _dispatch.run_one(role, name, impl, payload)
+        if (rc, so, se) != (direct.returncode, direct.stdout, direct.stderr):
+            mismatches.append(
+                f"{role}/{name}: in-proc rc={rc} vs subproc rc={direct.returncode}"
+            )
+        if rc == 2 or _DENY in so:
+            in_proc_denies += 1
+        elif _ASK in so:
+            in_proc_asks += 1
+    assert not mismatches, "firing-payload parity mismatches:\n" + "\n".join(mismatches)
+    assert in_proc_denies >= 1, "deny marker/exit path not exercised in-process"
+    assert in_proc_asks >= 1, "ask marker path not exercised in-process"
+
+
+# --------------------------------------------------------------------------- #
+# aggregation priority via fake members
+# --------------------------------------------------------------------------- #
+
+def _write_fake(tmp_path: Path, name: str, body: str) -> Path:
+    d = tmp_path / name
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / "impl.py"
+    p.write_text(body)
+    return p
+
+
+_FAKE_PASS = "def main():\n    return 0\n"
+_FAKE_DENY_EXIT = "import sys\ndef main():\n    return 2\n"
+_FAKE_ASK = (
+    "import json, sys\n"
+    "def main():\n"
+    "    json.dump({'hookSpecificOutput': {'hookEventName': 'PreToolUse',"
+    " 'permissionDecision': 'ask', 'permissionDecisionReason': 'r'}}, sys.stdout)\n"
+    "    sys.stdout.write('\\n')\n"
+    "    return 0\n"
+)
+_FAKE_ADVISORY = "import sys\ndef main():\n    sys.stderr.write('nudge\\n')\n    return 0\n"
+_FAKE_CRASH = "def main():\n    raise RuntimeError('boom')\n"
+
+
+def _patch_members(monkeypatch, members):
+    # 3-arg signature: run_group calls group_members(event, matcher, host).
+    monkeypatch.setattr(_dispatch, "group_members", lambda _e, _m, _h=None: members)
+
+
+def test_deny_wins_over_ask_and_advisory(tmp_path, monkeypatch, capsys):
+    members = [
+        ("advisory-nudge", "adv", _write_fake(tmp_path, "adv", _FAKE_ADVISORY)),
+        ("preflight-gate", "ask", _write_fake(tmp_path, "ask", _FAKE_ASK)),
+        ("preflight-gate", "deny", _write_fake(tmp_path, "deny", _FAKE_DENY_EXIT)),
+    ]
+    _patch_members(monkeypatch, members)
+    rc = _dispatch.run_group("PreToolUse", "Bash", NOOP_PAYLOAD)
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "nudge" in captured.err  # advisory preserved even under deny
+
+
+def test_ask_when_no_deny(tmp_path, monkeypatch, capsys):
+    members = [
+        ("advisory-nudge", "adv", _write_fake(tmp_path, "adv", _FAKE_ADVISORY)),
+        ("preflight-gate", "ask", _write_fake(tmp_path, "ask", _FAKE_ASK)),
+        ("preflight-gate", "pass", _write_fake(tmp_path, "pass", _FAKE_PASS)),
+    ]
+    _patch_members(monkeypatch, members)
+    rc = _dispatch.run_group("PreToolUse", "Bash", NOOP_PAYLOAD)
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert '"permissionDecision": "ask"' in captured.out
+    assert "nudge" in captured.err
+
+
+def test_all_pass_allows(tmp_path, monkeypatch, capsys):
+    members = [
+        ("preflight-gate", "p1", _write_fake(tmp_path, "p1", _FAKE_PASS)),
+        ("preflight-gate", "p2", _write_fake(tmp_path, "p2", _FAKE_PASS)),
+    ]
+    _patch_members(monkeypatch, members)
+    rc = _dispatch.run_group("PreToolUse", "Bash", NOOP_PAYLOAD)
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == ""
+
+
+def test_crashing_member_is_isolated(tmp_path, monkeypatch):
+    members = [
+        ("preflight-gate", "crash", _write_fake(tmp_path, "crash", _FAKE_CRASH)),
+        ("preflight-gate", "deny", _write_fake(tmp_path, "deny", _FAKE_DENY_EXIT)),
+    ]
+    _patch_members(monkeypatch, members)
+    # crash must NOT abort the group: the later deny still wins.
+    rc = _dispatch.run_group("PreToolUse", "Bash", NOOP_PAYLOAD)
+    assert rc == 2
+
+
+def test_crash_only_fails_open(tmp_path, monkeypatch):
+    members = [
+        ("preflight-gate", "crash", _write_fake(tmp_path, "crash", _FAKE_CRASH)),
+    ]
+    _patch_members(monkeypatch, members)
+    rc = _dispatch.run_group("PreToolUse", "Bash", NOOP_PAYLOAD)
+    assert rc == 0  # a lone crashing hook fails open, never blocks
+
+
+def test_import_error_fails_open_but_not_silent(tmp_path):
+    # A member whose impl.py raises at IMPORT time (missing dep, syntax error)
+    # must fail OPEN (never block) yet surface the traceback — fail-open is not
+    # fail-silent, matching the per-process `python3 impl.py` wrapper.
+    broken = _write_fake(
+        tmp_path, "broken", "import _no_such_module_xyz123\n\n\ndef main():\n    return 0\n"
+    )
+    rc, so, se = _dispatch.run_one("preflight-gate", "broken", broken, NOOP_PAYLOAD)
+    assert rc == 0  # fail OPEN
+    assert so == ""
+    assert "import failed" in se  # NOT fail-silent
+    assert "_no_such_module_xyz123" in se
+
+
+# --------------------------------------------------------------------------- #
+# latency (informational guard, not byte-exact)
+# --------------------------------------------------------------------------- #
+
+def test_group_latency_under_threshold():
+    # one full group pass should be far under the 35-process parallel baseline (~1.87s)
+    t0 = time.time()
+    _dispatch.run_group("PreToolUse", "Bash", NOOP_PAYLOAD)
+    elapsed = time.time() - t0
+    assert elapsed < 1.0, f"group pass took {elapsed*1000:.0f}ms, expected < 1000ms"


### PR DESCRIPTION
## Summary

ADR-0002 Phase 2 of 4: add the single-process dispatch runner + its tests.
**Not wired into the runtime yet — blast-radius 0.** PR3 connects it to the
manifest/build; PR4 adds the invariant guard and re-measures latency.

## What's in this PR

- `hooks/_lib/_dispatch.py` — runs a whole `(event, matcher)` hook group in one
  process: read stdin once, reinject per member via `StringIO`, call each
  `fail_open`-wrapped `main()`, aggregate most-restrictive (deny > ask > allow,
  role-agnostic). Member `impl.py` files are unmodified. Reuses
  `_hook_runtime.fail_open`. Respects the manifest `hosts` whitelist (mirrors
  `build-plugin-manifests.py`) so a host never re-includes a stripped guard;
  import-time member failures fail OPEN but forward the traceback to stderr
  (not fail-silent).
- `tests/hooks/_lib/test_dispatch.py` — 47 tests:
  - 33 per-hook byte-equivalence (`run_one` in-process == `impl.py` subprocess,
    same exit/stdout/stderr) on a no-op payload;
  - gate-firing equivalence on REAL impls (deny / ask / deny-beats-ask) per
    ADR-0002 §3.3;
  - host filter (claude-only guards excluded for a codex host), import-error
    visibility, aggregation priority, crash isolation, lone-crash fail-open,
    latency guard.

## Scope (matches ADR-0002 §2)

The group is the **33 hooks whose manifest matcher is exactly `Bash`** (21
preflight-gate + 12 advisory-nudge). Two advisory hooks (`memory-hint`,
`external-api-literal-trigger`) carry multi-tool matchers (`Bash|Edit|Write|…`)
and stay independent so their non-Bash firing is preserved; multi-group
registration is a follow-up.

## Review

- `oh-my-claudecode:code-reviewer` → COMMENT (0 Critical; recommended fixes
  applied: `body`/`file` None-coercion, decision/args inline invariants).
- Codex round 1 → 2× P2, both verified TRUE and fixed:
  - host filter ignored — the dispatcher read the canonical manifest without the
    `hosts` whitelist, so a codex host would re-include the 2 claude-only Bash
    guards. Fixed by mirroring the build's host filter (`host=None` = canonical;
    runtime passes the platform host via argv[3]).
  - import-time failure was fail-silent — a member with a broken import returned
    allow with no stderr. Fixed to forward the traceback (fail-open, not silent),
    matching the per-process wrapper.
- Codex round 2 → clean (no behavior-breaking bug; ran the suite, exit 0).

## Verification

- `pytest tests/hooks/_lib/test_dispatch.py` — 47 passed
- `pytest tests/` — 182 passed (no regression)
- `ruff check` — All checks passed
- Single-process wall-clock for the 33-hook group on an `ls` payload:
  **~0.2s** (0.18–0.23s) vs the 35-process baseline **1.87s** — ~9x.
  (ADR's ~0.13s was a prototype estimate; the gap is python3 startup +
  33-module `importlib` load. PR4 re-measures on the real runtime path.)

## Not in this PR (later phases)

- PR3: manifest dispatch-group schema + `build-plugin-manifests.py` emits one
  dispatcher entry instead of 33 `.sh`; passes the platform host; generated
  `hooks.json` equivalence; fail-loud guard for an `args`-bearing member.
- PR4: `check-plugin-manifests.py` invariant + latency re-measure + ARCHITECTURE.md.

Refs #613

Pre-commit: n/a (no .pre-commit-config.yaml in repo). Verified instead:
pytest tests/ -> 182 passed; pytest tests/hooks/_lib/test_dispatch.py -> 47
passed (incl. 33 byte-equivalence vs subprocess + gate-firing equivalence on
real impls); ruff check -> clean; codex review 2 rounds (round 1: 2 P2
verified+fixed, round 2: clean). Member impl.py files unmodified; dispatcher
off the runtime path (manifest/hooks.json untouched), so plugin behaviour is
byte-identical until PR3.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined architecture documentation with updated hook consolidation guidance and decision-aggregation rules.
  * Introduced improved hook group dispatching mechanism with enhanced error handling and fail-open protection.
  * Established comprehensive test suite validating dispatcher functionality, aggregation priorities, error isolation, and performance characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->