### PR TITLE
chore(hooks): finalize dispatch consolidation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -149,6 +149,71 @@ else:
 | `merge-menu-review-options-advisory` | PreToolUse | Advisory (opt-in strict via `PRAXIS_MERGE_MENU_REVIEW_STRICT=1`) on `AskUserQuestion` when a merge-decision menu (an option label names a merge/squash action) offers no review/debate option — nudges the agent to re-author the menu with codex-review-wrap / code-reviewer / critic levers before the merge gate (issue #560) | [hooks/advisory-nudge/merge-menu-review-options-advisory/spec.md](hooks/advisory-nudge/merge-menu-review-options-advisory/spec.md) |
 | `bypass-telemetry` | PostToolUse(Bash) | Observe-only: log bypass-env usage (`CLAUDE_HOOK_BYPASS_*` / `PRAXIS_*BYPASS*`) to daily JSONL (`~/.praxis/telemetry/bypass-events-YYYY-MM-DD.jsonl`) — never blocks (issue #441 Phase 1; Phase 2 review CLI + Phase 3 HTTP deferred) | [hooks/postuse-correction/bypass-telemetry/spec.md](hooks/postuse-correction/bypass-telemetry/spec.md) |
 
+### Single-process dispatch (ADR-0002)
+
+Every `Bash` tool call fires the whole `PreToolUse(Bash)` hook group. Under the
+per-hook model each member is a `.sh` wrapper that `exec python3 .../impl.py`, so
+one `Bash` call cold-started ~33 python3 interpreters — ~99% of the latency is
+interpreter startup, not hook logic. ADR-0002 collapses that group into **one**
+python3 process.
+
+- **Declaration.** `hooks/manifest.json` carries a `dispatch_groups` array of
+  `{event, matcher}` pairs. Only `(PreToolUse, Bash)` is collapsed today: the
+  **33** hooks whose manifest `matcher` is exactly `Bash`. The two multi-tool
+  hooks that also fire on Bash — `memory-hint`
+  (`Bash|Edit|Write|NotebookEdit|AskUserQuestion`) and
+  `external-api-literal-trigger` (`Write|Edit|Bash`) — keep standalone wrappers,
+  because folding them into a Bash-only runner would drop their Edit/Write firing.
+- **Build path.** For each platform, `build-plugin-manifests.py`
+  (`filter_hooks_for_host`) emits, after host filtering, exactly **one** dispatcher
+  node per group — `${CLAUDE_PLUGIN_ROOT}/hooks/_dispatch.sh <event> <matcher>
+  <host>` — instead of one node per member. The platform `host_id` is baked into
+  the command so the runtime applies the same `hosts` filter. The node `timeout`
+  is the max of member timeouts (members run sequentially in one process, so the
+  budget matches the slowest member's per-process budget, not the sum).
+- **Runtime path.** `hooks/_lib/_dispatch.py` reads the payload from stdin once,
+  resolves the ordered member list for `(event, matcher)` from the manifest
+  (host-filtered to match the build), imports each member's `impl.py`
+  in-process — the `if __name__ == "__main__"` guard means importing does **not**
+  run `main()` — re-points `sys.stdin` at a fresh copy of the payload per member,
+  and runs each member's `main()` through the existing `_hook_runtime.fail_open`
+  decorator. Member `impl.py` files are unmodified; the dispatcher adapts around
+  them.
+- **Aggregation (most-restrictive wins).** Decisions are classified
+  role-agnostically by exit code / `permissionDecision` marker: any member
+  `deny` (exit 2 or `"permissionDecision": "deny"`) → propagate `deny`; else any
+  `ask` → propagate `ask`; else allow. Every member's stderr (advisory nudges and
+  deny reasons alike) is always forwarded. Role-agnostic detection is deliberate —
+  some `advisory-nudge` hooks emit `ask`/`deny` under strict modes, so a role-gated
+  split would silently drop their gate decisions.
+- **Fail-open** ([`ETHOS.md`](ETHOS.md)). Each member runs under `fail_open`, and
+  the dispatcher's own `main()` swallows exceptions to a `0` (allow), so a crash
+  in one `impl.py` cannot block the tool call or abort the other members —
+  restoring the isolation process separation gave for free. Import-time failures
+  are forwarded to stderr (visible, not silent) before failing open.
+- **Guard.** `scripts/check-plugin-manifests.py` Rule 13 ties the build and
+  runtime paths together: for every `dispatch_groups` pair, per platform, the
+  committed `hooks.json` must hold exactly one dispatcher node (no leaked member
+  node, no second node, correct host args), and `_dispatch.group_members` must
+  resolve the same member set the build collapsed, with every `impl.py` present
+  on disk. A future manifest or schema edit that breaks the collapse fails CI.
+
+**Measured latency** (`/usr/bin/time -p`, warm caches, no-op `ls -la` payload, 33
+members, claude host):
+
+| Path | Wall-clock |
+|------|-----------|
+| Single-process dispatcher (wired runtime path) | **~0.13s** |
+| Reconstructed per-process model (33 wrappers, spawned in parallel) | ~0.46s |
+
+The dispatcher's measured ~0.13s matches the ADR-0002 §1.2 prototype estimate.
+The per-process baseline above is the parallel wrapper-spawn cost on the same
+bench; the ADR §1.1 figure of 1.87s was measured inside a live, CPU-saturated
+Claude Code session (35 hooks) and reflects a harsher orchestration context.
+Either way, the cost-growth shape is what changed: each hook added to the group
+now costs one in-process `main()` call (~ms) instead of one more cold-started
+process on every `Bash` call.
+
 ## Multi-Platform Packaging
 
 Runtime source (`skills/`, `hooks/`, `scripts/`) is shared. Platform-specific

--- a/scripts/check-plugin-manifests.py
+++ b/scripts/check-plugin-manifests.py
@@ -26,6 +26,11 @@ Phase 2 (ADR-0001) invariants:
   12. AGENTS.md "## Skills (N)" count and per-skill backtick tokens, and
      README.md per-skill backtick tokens, all match EXPECTED_SKILLS
      (issue #498 — doc drift invariant).
+  13. Each manifest `dispatch_groups` (event, matcher) collapses to exactly
+     one dispatcher node per platform hooks.json (no member silently left as
+     its own node, no second dispatcher node), and the runtime resolver
+     `_dispatch.group_members` resolves the same member set the build
+     collapsed (ADR-0002, #617 — ties build path and runtime path together).
 
 CI invokes this; developers can too, via `./scripts/check-plugin-manifests.py`.
 """
@@ -48,7 +53,68 @@ assert _spec and _spec.loader
 _build = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_build)
 
+# ADR-0002 (#617): the runtime dispatch resolver. Rule 13 cross-checks that the
+# build collapse (filter_hooks_for_host → committed hooks.json) and the runtime
+# resolution (group_members) agree on each dispatch group's members.
+_disp_spec = importlib.util.spec_from_file_location(
+    "praxis_dispatch", REPO_ROOT / "hooks" / "_lib" / "_dispatch.py"
+)
+assert _disp_spec and _disp_spec.loader
+_dispatch = importlib.util.module_from_spec(_disp_spec)
+_disp_spec.loader.exec_module(_dispatch)
+
 from constants import EXPECTED_SKILLS, OPT_IN_HOOKS, VALID_ROLES  # noqa: E402
+
+
+def dispatch_node_drifts(
+    hooks_json: dict,
+    event: str,
+    matcher: str | None,
+    host_id: str,
+    expected_members: set[str],
+    dispatch_wrapper_name: str,
+) -> list[str]:
+    """Drift strings for one (event, matcher) group's node shape in a hooks.json.
+
+    Pure function (no I/O) so the node-shape half of Rule 13 is unit-testable in
+    isolation from the runtime resolver. `expected_members` is the host-kept
+    member set: non-empty → the group must hold exactly ONE node and it must be
+    the dispatcher wrapper carrying `event matcher host_id` args; empty (the host
+    filtered every member) → the group must be absent (zero nodes).
+    """
+    groups = [
+        g
+        for g in hooks_json.get("hooks", {}).get(event, [])
+        if g.get("matcher") == matcher
+    ]
+    nodes = [n for g in groups for n in g.get("hooks", [])]
+    dispatch_nodes = [
+        n for n in nodes if dispatch_wrapper_name in n.get("command", "")
+    ]
+    member_nodes = [
+        n for n in nodes if dispatch_wrapper_name not in n.get("command", "")
+    ]
+    out: list[str] = []
+    want = 1 if expected_members else 0
+    if len(dispatch_nodes) != want:
+        out.append(
+            f"DISPATCH NODE COUNT {event}/{matcher} host={host_id}: expected "
+            f"{want} dispatcher node(s), found {len(dispatch_nodes)}"
+        )
+    if member_nodes:
+        out.append(
+            f"DISPATCH MEMBER LEAK {event}/{matcher} host={host_id}: "
+            f"{len(member_nodes)} non-dispatcher node(s) in a collapsed group: "
+            f"{[n.get('command', '') for n in member_nodes]}"
+        )
+    for n in dispatch_nodes:
+        cmd = n.get("command", "")
+        if f"{event} {matcher} {host_id}" not in cmd:
+            out.append(
+                f"DISPATCH ARGS {event}/{matcher} host={host_id}: dispatcher "
+                f"command {cmd!r} missing '{event} {matcher} {host_id}' args"
+            )
+    return out
 
 
 def _skill_dirs() -> list[Path]:
@@ -435,6 +501,96 @@ def main() -> int:
             "EXPECTED_SKILLS but not found as a first-column `backtick` token in a "
             "table row — add them to the skill table"
         )
+
+    # ------------------------------------------------------------------
+    # Rule 13 — dispatch-group ↔ build/runtime consistency (ADR-0002, #617)
+    #
+    # Each (event, matcher) in manifest.dispatch_groups is collapsed by the
+    # build (filter_hooks_for_host) into ONE dispatcher node, and resolved at
+    # runtime by _dispatch.group_members. Those are two independent readers of
+    # the manifest; this rule ties them — and the committed hooks.json artifact —
+    # together so a future manifest/schema edit cannot silently break the
+    # collapse (drop a member, leave a stray per-member node, emit two dispatcher
+    # nodes, or bake the wrong host into the dispatcher command). For every
+    # platform that emits a hooks.json, per host:
+    #   (a) the (event, matcher) group holds exactly ONE node and it is the
+    #       dispatcher wrapper carrying `event matcher host` args when ≥1 member
+    #       survives the host filter; ZERO nodes when the host filters all
+    #       members — verified by dispatch_node_drifts() above;
+    #   (b) group_members(event, matcher, host) equals the manifest-derived
+    #       member set for that host, with no duplicates, and every resolved
+    #       impl.py exists on disk.
+    # ------------------------------------------------------------------
+    def _manifest_members_for(event: str, matcher: str | None, host: str) -> set[str]:
+        names: set[str] = set()
+        for hook in manifest["hooks"]:
+            hosts = hook.get("hosts")
+            if hosts is not None and host not in hosts:
+                continue
+            entries = hook.get("entries") or [
+                {"event": hook.get("event"), "matcher": hook.get("matcher")}
+            ]
+            if any(
+                e.get("event") == event and e.get("matcher") == matcher
+                for e in entries
+            ):
+                names.add(hook["name"])
+        return names
+
+    hooks_outputs: list[tuple[str, Path]] = []
+    for platform_file in sorted(_build.PLATFORMS_DIR.glob("*.json")):
+        platform = json.loads(platform_file.read_text())
+        host_id = platform.get("host_id", platform["platform"])
+        for output in platform["outputs"]:
+            if output["kind"] == "hooks":
+                hooks_outputs.append((host_id, REPO_ROOT / output["path"]))
+
+    for event, matcher in sorted(dispatch_groups, key=lambda em: (em[0], em[1] or "")):
+        for host_id, hooks_path in hooks_outputs:
+            expected = _manifest_members_for(event, matcher, host_id)
+
+            # (b) runtime resolution must match the manifest, with no dup, and
+            #     every resolved impl on disk.
+            resolved = _dispatch.group_members(event, matcher, host_id)
+            resolved_names = [name for _role, name, _impl in resolved]
+            if len(resolved_names) != len(set(resolved_names)):
+                drifts.append(
+                    f"DISPATCH DUP {event}/{matcher} host={host_id}: "
+                    f"group_members resolves a hook more than once "
+                    f"({sorted(resolved_names)})"
+                )
+            if set(resolved_names) != expected:
+                drifts.append(
+                    f"DISPATCH MEMBER DRIFT {event}/{matcher} host={host_id}: "
+                    f"group_members={sorted(set(resolved_names))} != "
+                    f"manifest={sorted(expected)}"
+                )
+            for _role, name, impl in resolved:
+                if not impl.exists():
+                    drifts.append(
+                        f"DISPATCH IMPL MISSING {event}/{matcher} host={host_id}: "
+                        f"{name} -> {impl} does not exist on disk"
+                    )
+
+            # (a) committed hooks.json node shape — exactly one dispatcher node,
+            #     no leaked member node, correct host args.
+            if not hooks_path.exists():
+                drifts.append(
+                    f"DISPATCH HOOKS MISSING {hooks_path}: cannot verify "
+                    f"{event}/{matcher} collapse"
+                )
+                continue
+            hooks_json = json.loads(hooks_path.read_text())
+            drifts.extend(
+                dispatch_node_drifts(
+                    hooks_json,
+                    event,
+                    matcher,
+                    host_id,
+                    expected,
+                    _build.DISPATCH_WRAPPER_NAME,
+                )
+            )
 
     if drifts:
         print("plugin-manifest check FAILED:")

--- a/tests/test_check_dispatch_invariant.py
+++ b/tests/test_check_dispatch_invariant.py
@@ -1,0 +1,142 @@
+"""Rule 13 (ADR-0002, #617): dispatch-group ↔ build/runtime consistency.
+
+Two halves, tested independently:
+
+  - ``dispatch_node_drifts()`` — the pure node-shape checker, exercised with
+    crafted hooks.json fragments (exactly-one-dispatcher, member-leak, node
+    count, wrong-host args, host-filtered-empty);
+  - the runtime cross-check inside ``main()`` — exercised end-to-end by
+    monkeypatching ``_dispatch.group_members`` to drop a resolved member and
+    asserting ``main()`` reports ``DISPATCH MEMBER DRIFT`` while the unmodified
+    tree is otherwise green.
+
+The node-shape half can be checked against a committed-file tamper too, but that
+also trips Rule 5 (drift); these unit tests isolate Rule 13's own signal so a
+regression in the new invariant is unambiguous.
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+from contextlib import redirect_stdout
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_spec = importlib.util.spec_from_file_location(
+    "check_plugin_manifests", REPO_ROOT / "scripts" / "check-plugin-manifests.py"
+)
+assert _spec and _spec.loader
+check = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check)
+
+WRAP = check._build.DISPATCH_WRAPPER_NAME  # "_dispatch.sh"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _hooks_json(nodes: list[dict]) -> dict:
+    return {"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": nodes}]}}
+
+
+def _disp_node(host: str, *, event: str = "PreToolUse", matcher: str = "Bash") -> dict:
+    return {
+        "type": "command",
+        "command": (
+            f"${{CLAUDE_PLUGIN_ROOT}}/hooks/{WRAP} {event} {matcher} {host}"
+        ),
+        "timeout": 15,
+    }
+
+
+def _member_node(name: str) -> dict:
+    return {
+        "type": "command",
+        "command": f"${{CLAUDE_PLUGIN_ROOT}}/hooks/{name}.sh",
+        "timeout": 5,
+    }
+
+
+# ---------------------------------------------------------------------------
+# dispatch_node_drifts — pure node-shape checker
+# ---------------------------------------------------------------------------
+
+def test_one_dispatcher_node_is_clean():
+    hj = _hooks_json([_disp_node("claude")])
+    out = check.dispatch_node_drifts(
+        hj, "PreToolUse", "Bash", "claude", {"side-effect-scan"}, WRAP
+    )
+    assert out == [], out
+
+
+def test_two_dispatcher_nodes_flagged():
+    hj = _hooks_json([_disp_node("claude"), _disp_node("claude")])
+    out = check.dispatch_node_drifts(
+        hj, "PreToolUse", "Bash", "claude", {"x"}, WRAP
+    )
+    assert any("DISPATCH NODE COUNT" in d for d in out), out
+
+
+def test_member_leak_flagged():
+    hj = _hooks_json([_disp_node("claude"), _member_node("side-effect-scan")])
+    out = check.dispatch_node_drifts(
+        hj, "PreToolUse", "Bash", "claude", {"x"}, WRAP
+    )
+    assert any("DISPATCH MEMBER LEAK" in d for d in out), out
+
+
+def test_zero_nodes_with_expected_members_flagged():
+    hj = _hooks_json([])
+    out = check.dispatch_node_drifts(
+        hj, "PreToolUse", "Bash", "claude", {"x"}, WRAP
+    )
+    assert any("DISPATCH NODE COUNT" in d for d in out), out
+
+
+def test_zero_nodes_when_host_filters_all_is_clean():
+    # No member survives the host filter → matcher group absent → no drift.
+    hj = {"hooks": {"PreToolUse": []}}
+    out = check.dispatch_node_drifts(
+        hj, "PreToolUse", "Bash", "codex", set(), WRAP
+    )
+    assert out == [], out
+
+
+def test_wrong_host_args_flagged():
+    # A dispatcher node baked with the codex host, checked under claude.
+    hj = _hooks_json([_disp_node("codex")])
+    out = check.dispatch_node_drifts(
+        hj, "PreToolUse", "Bash", "claude", {"x"}, WRAP
+    )
+    assert any("DISPATCH ARGS" in d for d in out), out
+
+
+# ---------------------------------------------------------------------------
+# Runtime cross-check — full main() with a monkeypatched resolver
+# ---------------------------------------------------------------------------
+
+def _run_main() -> tuple[int, str]:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = check.main()
+    return rc, buf.getvalue()
+
+
+def test_baseline_check_clean():
+    rc, out = _run_main()
+    assert rc == 0, out
+
+
+def test_member_drop_detected(monkeypatch):
+    orig = check._dispatch.group_members
+
+    def fake(event, matcher, host=None):
+        members = orig(event, matcher, host)
+        return members[:-1] if members else members  # drop one resolved member
+
+    monkeypatch.setattr(check._dispatch, "group_members", fake)
+    rc, out = _run_main()
+    assert rc == 1, out
+    assert "DISPATCH MEMBER DRIFT" in out, out


### PR DESCRIPTION
## 요약

ADR-0002 single-process Bash-hook dispatcher 시리즈의 **마지막 Phase 4** (PR4/4).
런타임 동작 변경 없음 — guard + 측정 + 문서화 패스다. dispatcher 자체는 PR3(#616)
에서 이미 4개 플랫폼 `hooks.json` 에 wired 됨.

| 항목 | 변경 |
|------|------|
| `scripts/check-plugin-manifests.py` | **Rule 13** 추가 — 빌드 collapse(`filter_hooks_for_host` → committed `hooks.json`)와 런타임 resolver(`_dispatch.group_members`)를 manifest `dispatch_groups` 기준으로 묶음. 순수 함수 `dispatch_node_drifts()` 분리 |
| `tests/test_check_dispatch_invariant.py` | 신규 — node-shape 순수 케이스 6 + full `main()` 2 (baseline clean / member-drop → `DISPATCH MEMBER DRIFT`) |
| `ARCHITECTURE.md` | `### Single-process dispatch (ADR-0002)` 서브섹션 + 실측 latency 표 |

### Rule 13 이 잡는 것

각 `dispatch_groups` `(event, matcher)` 에 대해 플랫폼 host별로:
- (a) committed `hooks.json` 의 해당 그룹에 dispatcher 노드 **정확히 1개**
  (member 노드 누출 0, 중복 노드 0, `event matcher host` args 일치) — host 필터로
  member 가 0이면 노드도 0;
- (b) `group_members(event, matcher, host)` 가 manifest 재도출 member 집합과 일치
  (중복 없음, 모든 `impl.py` 존재).

→ 향후 manifest/schema 편집이 collapse 를 silent break 하면 CI fail.

## 검증

- **pytest**: `194 passed` (신규 8 포함). clean env 전체 `scripts/run-tests.sh` →
  `ALL TESTS PASSED`, 실제 `FAIL: tests/` 0건.
- **Rule 13 falsification**: baseline clean / 합성 변이 FAIL 확인
  (member-drop → `DISPATCH MEMBER DRIFT`; node-shape 변이 → NODE COUNT / MEMBER
  LEAK / ARGS 각각).
- **manifest check**: `plugin-manifest check OK`.
- **ruff**: `ruff check .` → `All checks passed!` (pin 0.15.8, CI 동일).
- **latency 재측정** (`/usr/bin/time -p`, warm, no-op `ls -la`, 33 members,
  claude host): 단일 프로세스 dispatcher **~0.13s** vs 재구성 per-process 병렬
  baseline **~0.46s** (동일 bench). ~0.13s 는 ADR-0002 §1.2 prototype 추정과 일치.
- **code review**: `oh-my-claudecode:code-reviewer` → APPROVE.

미검증: 실 Claude Code 세션 hook invocation (dispatcher 런타임 경로는 이 PR에서
미변경 — guard/측정/문서만); latency 절대값은 머신 의존(warm, 단일 bench).

## Scope 결정

#617 Scope 4번째 항목(Approach-A orphan Bash wrapper 정리)은 이슈에
`(optional, may split to a follow-up)` 로 명시되어 **#618 로 분리**했다. dispatcher
perf 이득은 PR3 에서 이미 ship 되었고 항목 4는 런타임 미참조 파일 정리라 에픽
종료를 막지 않는다.

Pre-commit verified: clean-env `scripts/run-tests.sh` → ALL TESTS PASSED (pytest 194, shell all, manifest OK); `ruff check .` All checks passed
Caller chain verified: `dispatch_node_drifts()` 는 `main()` 에서만 호출; `_dispatch.group_members` 는 기존 런타임 `run_group` 호출에 더해 check `main()` 의 신규 caller 추가 — import-time side effect(`sys.path` insert + `fail_open` import) 무해함을 standalone check 실행(exit 0)으로 확인

Closes #617
Closes #613

항목 4 → #618


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded architecture documentation describing the single-process dispatch group model and runtime resolution behavior.

* **Tests**
  * Added comprehensive test suite validating consistency between build-time configuration and runtime dispatch execution, including edge cases and error detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->