### PR TITLE
chore(check): assert opt-in wrapper byte-identity

### DIFF
--- a/scripts/check-plugin-manifests.py
+++ b/scripts/check-plugin-manifests.py
@@ -16,7 +16,9 @@ Phase 2 (ADR-0001) invariants:
   6. Generated runtime wrappers under hooks/*.sh are byte-identical to
      the generator output (Phase 2 strict diff replaces Phase 1's exec-
      target parity check). Dispatch-only members carry NO wrapper and are
-     asserted absent from disk (Rule 6b, ADR-0002 Phase 4 / #618).
+     asserted absent from disk (Rule 6b, ADR-0002 Phase 4 / #618). Opt-in
+     wrappers (OPT_IN_HOOKS, not in the manifest) are byte-identity checked
+     too (Rule 6c, #605).
   7. INDEX.md ↔ manifest entry cross-check.
   8. Spec `Supported hosts:` ↔ manifest `hosts` cross-check.
   9. Version consistency across versioned artifacts.
@@ -281,6 +283,20 @@ def main() -> int:
     # the manifest hook loop (it has no manifest entry), so add it here or a
     # stale/missing hooks/_dispatch.sh slips through CI.
     expected_wrappers[_build.DISPATCH_WRAPPER_NAME] = _build.WRAPPER_DISPATCH_TEMPLATE
+
+    # Rule 6c — opt-in hooks (#605): not in the manifest, but emit_wrappers still
+    # generates hooks/<name>.sh for their documented invocation path
+    # (OPT_IN_HOOKS). Mirror that emit so the existence + byte-identity loop below
+    # covers the opt-in wrapper class too — otherwise a stale/missing opt-in
+    # wrapper slips through CI (Rule 6 derived expected_wrappers only from manifest
+    # entries). A manifest entry of the same name wins (matches emit_wrappers).
+    for opt_in_name, opt_in_role in _build.OPT_IN_HOOKS.items():
+        fname = f"{opt_in_name}.sh"
+        if fname in expected_wrappers:
+            continue
+        expected_wrappers[fname] = _build.WRAPPER_PY_TEMPLATE.format(
+            role=opt_in_role, name=opt_in_name, baked_args=""
+        )
 
     for fname, expected_body in expected_wrappers.items():
         wrapper_path = _build.HOOKS_DIR / fname

--- a/tests/test_check_opt_in_wrapper.sh
+++ b/tests/test_check_opt_in_wrapper.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# test_check_opt_in_wrapper.sh — verify check-plugin-manifests.py Rule 6c now
+# covers the OPT_IN_HOOKS wrapper class (#605).
+#
+# Guards M1: Rule 6 derived expected_wrappers only from manifest hook entries,
+# so an opt-in wrapper (e.g. hooks/external-write-falsify-check.sh — emitted by
+# emit_wrappers' separate OPT_IN_HOOKS loop, NOT a manifest entry) had its
+# byte-identity unchecked. A stale or missing opt-in wrapper slipped through CI.
+#
+# Usage: bash tests/test_check_opt_in_wrapper.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK="$ROOT_DIR/scripts/check-plugin-manifests.py"
+# The sole OPT_IN_HOOKS member (scripts/constants.py). Mirrors the dispatch
+# wrapper test's hardcoded _dispatch.sh — same coupling to the build constants.
+WRAPPER="$ROOT_DIR/hooks/external-write-falsify-check.sh"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+run_case() {
+  local name="$1" result="$2" expected="$3"
+  if [ "$result" = "$expected" ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expected=$expected got=$result"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+echo "test_check_opt_in_wrapper"
+
+# Fail fast if the wrapper is absent — otherwise the EXIT trap below would
+# write an empty backup back over $WRAPPER and corrupt it.
+if [ ! -f "$WRAPPER" ]; then
+  echo "FAIL  [wrapper_exists] expected=yes got=no"
+  exit 1
+fi
+
+# Preserve the wrapper and always restore it, even on early exit.
+BACKUP="$(mktemp)"
+cp "$WRAPPER" "$BACKUP"
+restore() { cp "$BACKUP" "$WRAPPER"; chmod 755 "$WRAPPER"; }
+trap 'restore; rm -f "$BACKUP"' EXIT
+
+# 1. The wrapper exists (guarded above) and the baseline check is clean.
+run_case "wrapper_exists" "yes" "yes"
+python3 "$CHECK" >/dev/null 2>&1
+run_case "baseline_check_clean" "$?" "0"
+
+# 2. Tampering the wrapper makes the check FAIL and name the opt-in wrapper.
+printf '\n# tampered by test\n' >> "$WRAPPER"
+OUT="$(python3 "$CHECK" 2>&1)"
+CODE="$?"
+run_case "tampered_check_nonzero" "$CODE" "1"
+echo "$OUT" | grep -q "WRAPPER DRIFT hooks/external-write-falsify-check.sh"
+run_case "tampered_names_opt_in_wrapper" "$?" "0"
+
+# 3. Restoring makes the check clean again.
+restore
+python3 "$CHECK" >/dev/null 2>&1
+run_case "restored_check_clean" "$?" "0"
+
+# 4. Deleting the wrapper makes the check FAIL with a MISSING (not DRIFT) signal.
+rm -f "$WRAPPER"
+OUT="$(python3 "$CHECK" 2>&1)"
+CODE="$?"
+run_case "missing_check_nonzero" "$CODE" "1"
+echo "$OUT" | grep -q "WRAPPER MISSING hooks/external-write-falsify-check.sh"
+run_case "missing_names_opt_in_wrapper" "$?" "0"
+
+# 5. Restoring (again) makes the check clean.
+restore
+trap - EXIT
+rm -f "$BACKUP"
+python3 "$CHECK" >/dev/null 2>&1
+run_case "restored_check_clean_2" "$?" "0"
+
+echo "---"
+echo "PASS=$PASS FAIL=$FAIL"
+if [ "$FAIL" -ne 0 ]; then
+  printf 'FAILED: %s\n' "${FAILED_NAMES[*]}"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 요약

deep-dive 감사 spec Cluster MEDIUM **M1** (#605). `OPT_IN_HOOKS` wrapper
(`hooks/external-write-falsify-check.sh`)는 manifest 에 없고 `emit_wrappers`
의 **별도 opt-in 루프**로 생성된다. 그런데 `check-plugin-manifests.py` Rule 6
는 `expected_wrappers` 를 `manifest["hooks"]` 에서만 도출하므로 opt-in wrapper
클래스의 byte-identity 가 **검증되지 않았다** — stale/missing opt-in wrapper 가
CI 를 통과했다.

## 변경

| 항목 | 변경 |
|------|------|
| `scripts/check-plugin-manifests.py` | **Rule 6c** 추가. `emit_wrappers` 의 opt-in 루프를 mirror — `WRAPPER_PY_TEMPLATE.format(role, name, baked_args="")`, 파일명 `{name}.sh`, manifest 이름 충돌 시 manifest 우선 — 하여 `OPT_IN_HOOKS` wrapper 를 `expected_wrappers` 에 fold-in. 기존 존재/byte-identity 루프가 opt-in 클래스도 커버. 모듈 docstring rule 6 갱신 |
| `tests/test_check_opt_in_wrapper.sh` | 신규. `test_check_dispatch_wrapper.sh` 구조 mirror — baseline clean → tamper(`WRAPPER DRIFT` 발화) → restore → delete(`WRAPPER MISSING` 발화) → restore. 8 케이스 |

런타임 동작 변경 없음 — 누락된 CI invariant 추가.

## 검증

- **Rule 6c falsification** (live): baseline `plugin-manifest check OK`(exit 0)
  → opt-in wrapper tamper → `WRAPPER DRIFT hooks/external-write-falsify-check.sh`
  (exit 1) → delete → `WRAPPER MISSING ...`(exit 1) → restore → OK. 두 failure
  mode 모두 발화.
- **mirror fidelity**: in-process 로 `emit_wrappers` written set 과 check
  `expected_wrappers` set 재현 → keyset 동일·body diff 0·opt-in expected body 가
  on-disk wrapper 와 byte-match (리뷰어 라인별 대조 확인). 정상 빌드 트리에서
  false-positive 없음.
- **신규 테스트**: `bash tests/test_check_opt_in_wrapper.sh` → 8/8 PASS.
- **전체 테스트**: clean-env `scripts/run-tests.sh` → `ALL TESTS PASSED`
  (exit 0, 실 FAIL 0건; `plugin-manifest check OK` 포함).
- **build**: `clean — no changes` (build 스크립트 미변경). **check**: OK.
- **ruff** `ruff check .` → All checks passed. **shellcheck** 신규 테스트 → exit 0.
- **code review**: `oh-my-claudecode:code-reviewer` 2-stage 라이브 검증 →
  **APPROVE** (0 material, 1 optional Nit). codex 비가용 → omc 단독 패스.

미검증: opt-in↔manifest 이름 충돌 분기 (현재 `OPT_IN_HOOKS` 이름이 manifest
엔트리와 충돌하지 않음 — 분기는 build 의 검증된 collision 규칙을 mirror).

## 의존성

감사 M-시퀀스상 **M8(#606)** 이 이 PR(M1)에 의존 — `scripts/check-plugin-manifests.py`
공유. 본 PR 머지 후 #606 은 rebase 필요.

Pre-commit verified: clean-env `scripts/run-tests.sh` → ALL TESTS PASSED (exit 0, plugin-manifest check OK); `build` → clean no-diff; `check` → plugin-manifest check OK; `ruff check .` → All checks passed; shellcheck new test → exit 0
Caller chain verified: Rule 6c 는 check `main()` 내부에서만 동작(CI 전용, 신규 런타임 caller 0); `_build.OPT_IN_HOOKS`(data) + `_build.WRAPPER_PY_TEMPLATE`(build 의 emit_wrappers 가 쓰는 동일 템플릿)를 읽어 `expected_wrappers` 에 채우고 기존 존재/byte-identity assert 루프가 소비 — emit 경로와 단일 SOT 공유로 drift 불가

Closes #605

[skip-codex-review] codex 비가용 세션 — omc:code-reviewer 단독 APPROVE 로 대체


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage validating plugin wrapper compliance, including detection of wrapper drift and missing opt-in hook wrappers across multiple test cases.

* **Chores**
  * Enhanced plugin manifest validation tooling to strengthen CI compliance checks, ensuring opt-in hook wrappers remain present and consistent with generated outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->