### PR TITLE
fix(hook): add line-start hint to falsify deny msg

### DIFF
--- a/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
@@ -71,7 +71,9 @@ ADVISORY_MSG = (
 ASK_MSG = (
     "(Recommended) 라벨이 있으나 question body 에 "
     "'Falsified: <disconfirming test 결과>' 가 없음. "
-    "CLAUDE.md Self-Falsify Before Recommendation Lock 룰. 추가 후 재시도."
+    "CLAUDE.md Self-Falsify Before Recommendation Lock 룰. 추가 후 재시도. "
+    "'Falsified:' 는 자기 줄 첫 칼럼에서 시작해야 한다 (startswith 검사) — "
+    "질문문 중간/불릿/코드펜스 내부 배치는 미검출."
 )
 
 ANCHORING_ASK_MSG = (
@@ -79,7 +81,9 @@ ANCHORING_ASK_MSG = (
     "natural/obvious/clearly/default/prefer/recommend/안전한/자연스러운/"
     "당연히/분명히/추천/기본값) 이 있으나 question body 에 "
     "'Falsified: <disconfirming test 결과>' 가 없음. "
-    "CLAUDE.md Output-Block-Level Falsification Gate. 추가 후 재시도."
+    "CLAUDE.md Output-Block-Level Falsification Gate. 추가 후 재시도. "
+    "'Falsified:' 는 자기 줄 첫 칼럼에서 시작해야 한다 (startswith 검사) — "
+    "질문문 중간/불릿/코드펜스 내부 배치는 미검출."
 )
 
 # ---------------------------------------------------------------------------

--- a/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
@@ -117,7 +117,7 @@ matched; read-only commands (`git log --all`, `gh pr list`) do not fire.
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "permissionDecision": "ask",
-    "permissionDecisionReason": "(Recommended) 라벨이 있으나 question body 에 'Falsified: <disconfirming test 결과>' 가 없음. CLAUDE.md Self-Falsify Before Recommendation Lock 룰. 추가 후 재시도."
+    "permissionDecisionReason": "(Recommended) 라벨이 있으나 question body 에 'Falsified: <disconfirming test 결과>' 가 없음. CLAUDE.md Self-Falsify Before Recommendation Lock 룰. 추가 후 재시도. 'Falsified:' 는 자기 줄 첫 칼럼에서 시작해야 한다 (startswith 검사) — 질문문 중간/불릿/코드펜스 내부 배치는 미검출."
   }
 }
 ```
@@ -131,7 +131,7 @@ matched; read-only commands (`git log --all`, `gh pr list`) do not fire.
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "permissionDecision": "ask",
-    "permissionDecisionReason": "옵션 라벨/설명에 confidence-anchoring framing 토큰 (safer/safest/natural/obvious/clearly/default/prefer/recommend/안전한/자연스러운/당연히/분명히/추천/기본값) 이 있으나 question body 에 'Falsified: <disconfirming test 결과>' 가 없음. CLAUDE.md Output-Block-Level Falsification Gate. 추가 후 재시도."
+    "permissionDecisionReason": "옵션 라벨/설명에 confidence-anchoring framing 토큰 (safer/safest/natural/obvious/clearly/default/prefer/recommend/안전한/자연스러운/당연히/분명히/추천/기본값) 이 있으나 question body 에 'Falsified: <disconfirming test 결과>' 가 없음. CLAUDE.md Output-Block-Level Falsification Gate. 추가 후 재시도. 'Falsified:' 는 자기 줄 첫 칼럼에서 시작해야 한다 (startswith 검사) — 질문문 중간/불릿/코드펜스 내부 배치는 미검출."
   }
 }
 ```

--- a/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
@@ -523,6 +523,29 @@ run_case "T2→T1 multi-question: Q1 anchoring, Q2 literal (Recommended) → den
   "$(make_ask_payload_t2_then_t1)"
 
 # ---------------------------------------------------------------------------
+# Line-start hint cases — issue #598
+# ---------------------------------------------------------------------------
+
+# T1: (Recommended) label + Falsified: appears MID-LINE (not at column 0)
+# → hook must still block (deny) AND the message must contain the line-start hint.
+# Needle uses the ASCII word "startswith" which appears literally in the JSON output
+# (Korean is Unicode-escaped by json.dumps, so Korean needle won't match in shell).
+run_case "T1: Falsified: mid-line does not satisfy startswith check — still deny + hint" \
+  "deny:startswith" \
+  "$(make_ask_payload_with_question \
+      '["Option A (Recommended)", "Option B"]' \
+      "이 선택이 A가 B의 선행. Falsified: checked prior PRs — none exist. 계속?")"
+
+# T2: confidence-anchoring label + Falsified: appears MID-LINE
+# → hook must still block (ask) AND the message must contain the line-start hint.
+run_case "T2: Falsified: mid-line does not satisfy startswith check — still ask + hint" \
+  "ask:startswith" \
+  "$(make_ask_payload_with_descriptions \
+      '["S1 only", "S1+S2"]' \
+      '["가장 안전한 1회 변경", "Faster"]' \
+      "단계별로 진행. Falsified: no duplicate PR found. 어떻게 할까요?")"
+
+# ---------------------------------------------------------------------------
 # @fail_open structural assertion
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 요약

issue #598 (tool-friction:skill). `output-block-falsify-advisory` 훅은
`AskUserQuestion` 의 `(Recommended)` / confidence-anchoring 라벨에 대해
question body 의 line-start `Falsified:` 라인을 요구한다 (`impl.py`
`_has_falsified_line` → `line.startswith("Falsified:")`). 그러나 deny/ask
메시지(ASK_MSG / ANCHORING_ASK_MSG)는 line-start 요건을 명시하지 않아,
사용자가 `Falsified:` 를 질문문 **중간**에 이어붙이면 startswith 가 여전히
False → **동일한 opaque 메시지로 ×2 차단**됐다.

## 변경

| 파일 | 변경 |
|------|------|
| `.../output-block-falsify-advisory/impl.py` | ASK_MSG / ANCHORING_ASK_MSG 에 line-start(자기 줄 첫 칼럼, startswith 검사) 요건 1줄 추가 |
| `.../output-block-falsify-advisory/spec.md` | 인용된 permissionDecisionReason 텍스트를 새 메시지와 character-for-character 일치 갱신 |
| `tests/.../test_output_block_falsify_advisory.sh` | T1/T2 mid-line `Falsified:` 픽스처 2케이스 — 여전히 block(deny/ask) + 메시지 line-start 힌트 포함 검증 |

런타임 검출 로직 변경 없음 — 1차 차단 시점에 올바른 포맷을 안내하여 2차 차단을
impossible state 로 전환(memory retrieval 비의존).

## 검증

- `output_block_falsify_advisory` 테스트: **44 passed, 0 failed** (신규 T1/T2 mid-line 포함).
- clean-env `scripts/run-tests.sh` → `ALL TESTS PASSED` + `plugin-manifest check OK` (exit 0).
- `ruff check .` → All checks passed. shellcheck → rc=0.
- code review: `oh-my-claudecode:code-reviewer` → **APPROVE** (0 material). codex 비가용 → omc 단독.

## sibling 점검 (수정 아님 — follow-up 후보)

`block-pr-without-precommit-evidence` / `block-pr-without-caller-evidence` 의
deny 메시지도 동일 line-anchor 정규식(`^Pre-commit verified:` / `^Caller chain verified:`)을
쓰지만, line-start 안내 갭 수정은 본 PR 범위에서 제외 — 해당 파일은 #608 이 동시
수정 중이라 충돌 방지. 별도 follow-up 으로 정리 권장.

Pre-commit verified: clean-env scripts/run-tests.sh → ALL TESTS PASSED (exit 0, plugin-manifest check OK); hook 테스트 44/44; ruff check . → All checks passed; shellcheck → rc=0
Caller chain verified: 메시지 상수 텍스트만 변경 — _has_falsified_line 검출 로직/시그니처 불변, 신규 caller 0; spec.md 는 정적 문서; 테스트는 신규 케이스 추가

Closes #598

[skip-codex-review] codex 비가용 세션 — omc:code-reviewer 단독 APPROVE 로 대체


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified `Falsified:` marker detection behavior—must appear at the start of a line to be recognized.

* **Documentation**
  * Updated messaging to explain that mid-line, bulleted, or code-fence placements won't be detected.

* **Tests**
  * Added regression tests for `Falsified:` marker line-start detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->