### PR TITLE
feat(hook): diagnose --body-file path-not-found

### DIFF
--- a/hooks/preflight-gate/block-pr-without-precommit-evidence/impl.py
+++ b/hooks/preflight-gate/block-pr-without-precommit-evidence/impl.py
@@ -125,8 +125,18 @@ def _path_is_overwritten_in_raw(command: str, path: str) -> bool:
     return any(re.search(p, command) for p in patterns)
 
 
-def _get_effective_body(argv: list[str], hmap: dict[str, str], command: str) -> str:
+def _get_effective_body(
+    argv: list[str], hmap: dict[str, str], command: str
+) -> tuple[str, list[Path]]:
+    """Return (effective_body, missing_body_files).
+
+    missing_body_files is the list of resolved paths that were specified via
+    --body-file but could not be found on disk (and are not stdin or TOCTOU).
+    The caller uses this to emit a path-not-found diagnostic instead of the
+    generic token-missing message.
+    """
     parts: list[str] = []
+    missing: list[Path] = []
     for i, t in enumerate(argv):
         if t in ("--body", "-b") and i + 1 < len(argv):
             parts.append(_resolve_vars(argv[i + 1], hmap))
@@ -141,6 +151,8 @@ def _get_effective_body(argv: list[str], hmap: dict[str, str], command: str) -> 
             p = Path(path).expanduser()
             if p.is_file():
                 parts.append(_safe_read(p))
+            else:
+                missing.append(p)
         elif t.startswith("--body-file="):
             path = t.split("=", 1)[1]
             if path == "-":
@@ -150,7 +162,9 @@ def _get_effective_body(argv: list[str], hmap: dict[str, str], command: str) -> 
             p = Path(path).expanduser()
             if p.is_file():
                 parts.append(_safe_read(p))
-    return "\n".join(parts)
+            else:
+                missing.append(p)
+    return "\n".join(parts), missing
 
 
 def _has_precommit_marker(body: str) -> bool:
@@ -221,6 +235,19 @@ block-pr-without-caller-evidence). The --repo value IS the verification
 target, so bypass would defeat the purpose.
 """
 
+_BODY_FILE_NOT_FOUND_TMPL = """\
+❌ BLOCKED: --body-file not found at {path}
+
+The hook resolves relative paths against its own process cwd, not the PR
+worktree. Use an absolute path so the hook can read the file:
+
+  gh pr create --body-file /absolute/path/to/pr-body.md
+
+Or inline the body directly:
+
+  gh pr create --body "Pre-commit verified: ..."
+"""
+
 
 @fail_open
 def main() -> int:
@@ -249,9 +276,17 @@ def main() -> int:
             continue
         if _uses_template_without_body(argv):
             continue
-        body = _get_effective_body(argv, hmap, command)
+        body, missing_files = _get_effective_body(argv, hmap, command)
         if _has_precommit_marker(_strip_fenced_blocks(body)):
             continue
+        # Emit a distinct diagnostic when a body-file was specified but not
+        # found on disk (relative path resolved against hook cwd, not
+        # PR worktree). This surfaces the real cause instead of letting the
+        # author chase a missing token that was never reachable.
+        if missing_files and not body.strip():
+            msg = _BODY_FILE_NOT_FOUND_TMPL.format(path=missing_files[0].resolve())
+            sys.stderr.write(msg + compound_cascade_hint(command))
+            return 2
         sys.stderr.write(BLOCK_MSG + compound_cascade_hint(command))
         return 2
 

--- a/hooks/preflight-gate/block-pr-without-precommit-evidence/spec.md
+++ b/hooks/preflight-gate/block-pr-without-precommit-evidence/spec.md
@@ -44,7 +44,7 @@ none of the three marker patterns below.
 | `--body` / `-b` value contains any marker | allow |
 | `--body-file <path>` content contains any marker | allow |
 | `--body-file -` (stdin) | block — pipe content is uninspectable at PreToolUse time |
-| `--body-file <path>` with path missing on disk | block — treat as empty body so the marker check fires |
+| `--body-file <path>` with path missing on disk | block — emits a **path-not-found diagnostic** (see below) instead of the generic token-missing message |
 | `--body-file <path>` where the same Bash command redirects to `path` (`> path`, `>> path`, `tee path`) | block — TOCTOU; the file on disk is about to be overwritten |
 | Marker present only inside a fenced code block | block — fenced blocks are stripped before matching |
 | `--repo` / `-R` present | **does NOT bypass** (differs from sibling `block-pr-without-caller-evidence`) |
@@ -79,6 +79,8 @@ stderr+exit-2 rather than the JSON `permissionDecision: "deny"` envelope
 — matches sibling `block-pr-without-caller-evidence` and is the simpler
 choice for unconditional gates with no `ask` / fallback mode.
 
+**Generic token-missing message** (body present but no evidence marker):
+
 ```
 ❌ BLOCKED: `gh pr create` without pre-commit evidence.
 
@@ -89,6 +91,29 @@ Add ONE of these lines to the PR body:
   Pre-commit: n/a (<reason>)
   ...
 ```
+
+**Path-not-found diagnostic** (praxis #608) — emitted when `--body-file` names a
+path that does not exist on disk (and is not stdin or a TOCTOU overwrite).
+The real cause is that the hook resolves relative paths against its own process
+cwd, not the PR worktree, so a relative path like `.omc/pr-123-body.md` that
+exists in the worktree is invisible to the hook:
+
+```
+❌ BLOCKED: --body-file not found at <resolved-path>
+
+The hook resolves relative paths against its own process cwd, not the PR
+worktree. Use an absolute path so the hook can read the file:
+
+  gh pr create --body-file /absolute/path/to/pr-body.md
+
+Or inline the body directly:
+
+  gh pr create --body "Pre-commit verified: ..."
+```
+
+This replaces the generic token-missing message when the body-file is absent
+and no inline body is provided, preventing the author from chasing a missing
+token that was never reachable.
 
 ### Compound cascade advisory
 

--- a/tests/hooks/preflight-gate/test_block_pr_without_precommit_evidence.sh
+++ b/tests/hooks/preflight-gate/test_block_pr_without_precommit_evidence.sh
@@ -234,6 +234,60 @@ run_case "body-file tee-overwritten in same command blocks" block Bash \
 rm -f "$TOCTOU_FILE"
 
 # ---------------------------------------------------------------------------
+# body-file path-not-found diagnostic (praxis #608)
+# ---------------------------------------------------------------------------
+
+# Capture stderr for a given command — mirrors _capture_stderr below but
+# is defined early so these cases can use it inline.
+_capture_stderr_for() {
+  python3 -c '
+import json, sys
+payload = json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {"command": sys.argv[1]},
+})
+sys.stdout.write(payload)
+' "$1" | { python3 "$ROOT_DIR/hooks/preflight-gate/block-pr-without-precommit-evidence/impl.py" >/dev/null; } 2>&1 || true
+}
+
+# path-not-found → DISTINCT diagnostic (not generic token-missing message)
+_missing_path="/tmp/praxis-608-does-not-exist-$$.md"
+_pnf_err=$(_capture_stderr_for "gh pr create --title 'fix: x' --body-file $_missing_path")
+_pnf_rc=0
+# Must be a block (rc=2 handled by run_case above) — here we assert message content
+if printf '%s' "$_pnf_err" | grep -q "body-file not found"; then
+  echo "PASS [pnf-diagnostic] missing body-file emits path-not-found message"; ((PASS++))
+else
+  echo "FAIL [pnf-diagnostic] missing body-file did not emit path-not-found message (stderr: $_pnf_err)"; ((FAIL++))
+  FAILED_NAMES+=("pnf-diagnostic: path-not-found message absent")
+fi
+if printf '%s' "$_pnf_err" | grep -q "absolute path"; then
+  echo "PASS [pnf-diagnostic] path-not-found message advises absolute path"; ((PASS++))
+else
+  echo "FAIL [pnf-diagnostic] path-not-found message missing absolute-path advice (stderr: $_pnf_err)"; ((FAIL++))
+  FAILED_NAMES+=("pnf-diagnostic: absolute-path advice absent")
+fi
+# Must NOT emit the generic token-missing message
+if printf '%s' "$_pnf_err" | grep -q "without pre-commit evidence"; then
+  echo "FAIL [pnf-diagnostic] missing body-file leaked generic token-missing message"; ((FAIL++))
+  FAILED_NAMES+=("pnf-diagnostic: generic message leaked")
+else
+  echo "PASS [pnf-diagnostic] missing body-file does not emit generic token-missing message"; ((PASS++))
+fi
+
+# absolute path + token → PASS (no block, no stderr)
+_abs_body=$(mktemp)
+printf 'Pre-commit verified: ran ruff + tests\n' >"$_abs_body"
+_abs_err=$(_capture_stderr_for "gh pr create --title 'fix: x' --body-file $_abs_body")
+if [ -z "$_abs_err" ]; then
+  echo "PASS [pnf-regression] absolute body-file with token passes (no block)"; ((PASS++))
+else
+  echo "FAIL [pnf-regression] absolute body-file with token was blocked (stderr: $_abs_err)"; ((FAIL++))
+  FAILED_NAMES+=("pnf-regression: absolute body-file with token blocked")
+fi
+rm -f "$_abs_body"
+
+# ---------------------------------------------------------------------------
 # Cascade hint (mirror sibling)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 요약

issue #608 (tool-friction:skill). `block-pr-without-precommit-evidence` 훅이
`--body-file` **상대경로**를 자기 프로세스 cwd 기준으로 해석한다. issue
worktree 에서 `gh pr create --body-file .omc/pr-X.md` 를 호출하면 파일은
worktree 에 실재하지만 훅(별도 프로세스, cwd=main worktree)은 부재로 판정 →
silent 하게 empty body → 일반 "Pre-commit verified 토큰 부재" 메시지로 차단했다.
실제 원인은 "body-file not found" 인데 메시지가 토큰 부재로 오도해, 작성자가
토큰을 추가하려 retry 를 반복했다 (2026-06-04 감사 세션 B2 실제 발생).

## 변경

| 파일 | 변경 |
|------|------|
| `.../block-pr-without-precommit-evidence/impl.py` | `_get_effective_body` 가 `(body, missing_body_files)` 튜플 반환 — `--body-file` 부재(stdin/TOCTOU 제외) 시 resolved path 수집. `main()` 은 `missing_files and not body.strip()` 일 때 path-not-found 진단(절대경로 안내)을 일반 토큰-부재 메시지 대신 emit (exit 2) |
| `.../block-pr-without-precommit-evidence/spec.md` | path-not-found 진단 동작 + body-file 부재 행 갱신 |
| `tests/.../test_block_pr_without_precommit_evidence.sh` | pnf-diagnostic(진단 메시지/절대경로 안내/일반메시지 미누출) + pnf-regression(절대경로+토큰 통과) 4케이스 |

**Scope = priority 1 만**: cwd 기반 상대경로 resolve(priority 2)는 sibling 훅
경로해석 컨벤션 사전 확인이 필요해 의도적으로 제외 — 저위험, 동작 변경 없음
(부재 시 기존에도 차단됐고, 메시지만 정확해짐).

## 검증

- `block_pr_without_precommit_evidence` 테스트: **47 passed, 0 failed** (신규 4케이스 포함).
- clean-env `scripts/run-tests.sh` → `ALL TESTS PASSED` + `plugin-manifest check OK` (exit 0).
- `ruff check .` → All checks passed. shellcheck → 신규 코드 findings 0 (기존 SC2016 info 만).
- 엣지 추적: 절대경로+토큰 → allow(회귀 없음); 부재 상대경로 → 진단; 부재 + inline `--body` → 일반 메시지(body 존재); TOCTOU/stdin → missing 미수집(기존 차단 경로 유지).
- code review: `oh-my-claudecode:code-reviewer` → **APPROVE** (0 material). codex 비가용 → omc 단독.

Pre-commit verified: clean-env scripts/run-tests.sh → ALL TESTS PASSED (exit 0, plugin-manifest check OK); hook 테스트 47/47; ruff check . → All checks passed; shellcheck → 신규 findings 0
Caller chain verified: _get_effective_body (-> tuple[str, list[Path]]) 의 정의(impl.py:128)+호출(impl.py:279, 튜플 언패킹)은 모두 본 파일 내 1:1 쌍, grep 결과 다른 caller 0; sibling block-pr-without-caller-evidence/impl.py:144 의 동명 함수는 별개 파일 독립 함수로 미변경(-> str 유지); from __future__ import annotations 존재 → 제네릭 어노테이션 런타임 안전

Closes #608

[skip-codex-review] codex 비가용 세션 — omc:code-reviewer 단독 APPROVE 로 대체


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when a body file path cannot be found, with specific guidance to use absolute paths instead of the generic pre-commit evidence message.

* **Documentation**
  * Updated specification to clarify handling and messaging for missing body file paths.

* **Tests**
  * Added test coverage for body file path-not-found diagnostic scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->