### PR TITLE
fix(retrospect): scan transcript post-compaction

### DIFF
--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -400,6 +400,8 @@ Both the checklist block and the dismissed_candidates block live in Stage 3 outp
 > **Scope:** Scan the most recent 50 turns, or back to the last session boundary.
 > Stop after identifying 5 distinct friction events — clustering (step 6) handles de-duplication.
 > If session history is not accessible, use the user's verbal summary as input to steps 3–8.
+>
+> **Compaction + readable transcript (MUST):** When a compaction summary is present in context AND the session transcript jsonl is also readable on disk, the friction pre-scan MUST full-enumerate the transcript — same mechanism as the `tool_census` / Stage 2.7 scan (last 50 turns or last session boundary) — counting is_error occurrences, user-turn interrupts, and retried commands. It MUST NOT default to the compaction summary's salient narrative. The "not accessible → verbal summary" fallback applies ONLY when the transcript is genuinely unreachable (jsonl absent or unreadable). Treating a compaction summary as "accessible history" that substitutes for the transcript is the meta-process trap this skill exists to prevent.
 
 3. **Refine friction events with agent outputs** — merge pre-scan events with tracer/analyst results:
    - Add any new friction events the agents identified that pre-scan missed
@@ -678,7 +680,7 @@ Finding template:
 **Distribution card field** — Stage 3 emits `- output_quality: N` where N counts findings whose `category[]` includes `output_quality`. Like `memory_hygiene`, this is a **category count**, not an action key; the underlying actions still fall under the 6 action-type slots.
 
 **Stage 2.7 failure modes:**
-- Transcript not accessible (e.g., session-resume after compaction) → Stage 2.7 emits `<!-- retrospect:audit_skipped: transcript unreadable -->` and skips
+- Transcript not accessible (jsonl absent or unreadable — NOT the same as a compaction summary being present in context; see Scope block above) → Stage 2.7 emits `<!-- retrospect:audit_skipped: transcript unreadable -->` and skips. When a compaction summary is present but the transcript is also readable on disk, Stage 2.7 MUST full-enumerate the transcript rather than defaulting to the summary's salient narrative.
 - `gh pr view` API failure for a specific PR → log per-PR error in Stage 3 report Audit Trail section; continue with remaining PRs
 - Hypothesis-marker regex import failure (hook file missing or unreadable) → fallback to a built-in minimal regex (`(might|could|potential|아마)`) AND log the fallback in the report
 


### PR DESCRIPTION
## 요약

issue #600 (tool-friction:skill). `retrospect` 의 Stage 2 friction pre-scan 이
transcript 접근성을 **binary**(accessible/not)로만 다뤄, **중간 케이스**가
미규정이었다: compaction 요약이 context 에 present(salient)하면서 **동시에**
session transcript jsonl 이 디스크에서 readable 한 경우. 이때 에이전트는 salient
요약을 "접근 가능한 history" 로 인식해 default 하고 더 비싼 full-transcript
열거를 건너뛴다 — global CLAUDE.md 가 경고하는 메타프로세스 함정("enumerate the
full corpus/transcript, NOT the salient/recent window")을 회고 자신이 범한다.

## 변경

`skills/retrospect/SKILL.md` 두 surface 에 명시 clause 추가:

| Surface | 변경 |
|---------|------|
| Stage 2 **Scope 블록** (~L400) | "요약 present + transcript readable → friction pre-scan 은 transcript full-enumerate(is_error/interrupt/retry), 요약 salient 로 default 금지. verbal-summary fallback 은 jsonl 부재/판독불가에만" clause 추가. 기존 `tool_census` / Stage 2.7 transcript-scan mechanism 재사용 |
| Stage 2.7 **error-handling** (~L681) | "not accessible" 를 "jsonl 부재/판독불가(요약 present 와 구별)"로 명확화 + 요약 present·transcript readable 시 full-enumerate 의무. Scope 블록과 cross-reference |

## 검증

- 두 surface 내부 정합성: Scope 블록과 L681 가 상호 cross-reference, 모순 없음.
- mechanism 재사용 정확성: 참조한 census / Stage 2.7 scan mechanism 이 doc 에 실재(L243/L260/L285).
- clean-env `scripts/run-tests.sh` → `ALL TESTS PASSED` + `plugin-manifest check OK` (exit 0; 문서 변경 회귀 없음).
- `ruff check .` → All checks passed.
- code review: `oh-my-claudecode:code-reviewer` → **APPROVE** (0 material). codex 비가용 → omc 단독.

Pre-commit verified: clean-env scripts/run-tests.sh → ALL TESTS PASSED (exit 0, plugin-manifest check OK); ruff check . → All checks passed (문서 변경)
Caller chain verified: 문서(SKILL.md) 변경 — 실행 코드/시그니처 무관, 신규 caller 0; Stage 번호/무관 섹션 불변; 추가 clause 는 기존 transcript-scan mechanism 참조

Closes #600

[skip-codex-review] codex 비가용 세션 — omc:code-reviewer 단독 APPROVE 로 대체


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified transcript-scope handling rules for the retrospect skill, specifying behavior when compaction summaries and readable transcripts coexist, and refined failure-mode documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->