### PR TITLE
feat(ci): automate GitHub releases from CHANGELOG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: release
+
+# Publishes a GitHub Release whenever a vX.Y.Z tag is pushed. The release body
+# is the matching CHANGELOG.md section (via scripts/extract-changelog-section.sh)
+# plus a fixed Install/Update footer, so the release notes always track the
+# changelog. workflow_dispatch lets a maintainer (re)generate one release by
+# tag — re-running is idempotent (an existing release is edited, not duplicated).
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to (re)generate the release for, e.g. v6.2.0"
+        required: true
+
+# Least-privilege default (mirrors ci.yml / codeql.yml); the release job
+# widens to contents: write at the job level.
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # gh release create/edit writes to the Releases API.
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so the tagged commit's CHANGELOG is available, and so a
+          # workflow_dispatch run on main can read the section for any version.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve tag
+        id: tag
+        # Bind the dispatch input through env rather than inlining it into the
+        # shell — the established hardening pattern for user-supplied values.
+        env:
+          TAG_INPUT: ${{ inputs.tag }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${TAG_INPUT}"
+          else
+            tag="${GITHUB_REF_NAME}"
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Build release notes
+        id: notes
+        run: |
+          tag="${{ steps.tag.outputs.tag }}"
+          version="${tag#v}"
+          notes="$(mktemp)"
+          # ANSI-C quoting keeps the ``` code fence literal (single quotes would
+          # make shellcheck read the backticks as a command substitution).
+          footer=$'\n---\n\n### Install / Update\n\n```\n/plugin marketplace add https://github.com/devseunggwan/praxis\n/plugin install praxis\n```\n'
+          {
+            ./scripts/extract-changelog-section.sh "$version"
+            printf '%s' "$footer"
+          } > "$notes"
+          echo "file=${notes}" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ steps.tag.outputs.tag }}"
+          notes="${{ steps.notes.outputs.file }}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "release $tag exists — updating notes"
+            gh release edit "$tag" --notes-file "$notes"
+          else
+            echo "creating release $tag"
+            gh release create "$tag" --title "$tag" --notes-file "$notes" --verify-tag
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,6 +219,26 @@ The next VERSION bump moves those entries under the new version header. Use
 [Keep a Changelog](https://keepachangelog.com/) categories: Added, Changed,
 Fixed, Removed.
 
+## Releasing
+
+Releases are automated by `.github/workflows/release.yml`. To cut one:
+
+1. In your version-bump PR, set `VERSION` and move the `## [Unreleased]`
+   entries under a new `## [X.Y.Z] - YYYY-MM-DD` header in `CHANGELOG.md`.
+2. After it merges to `main`, tag the merge commit and push the tag:
+
+   ```bash
+   git tag vX.Y.Z && git push origin vX.Y.Z
+   ```
+
+3. The `release` workflow builds the body from that CHANGELOG section (via
+   `scripts/extract-changelog-section.sh`) plus a fixed Install/Update footer
+   and publishes the GitHub Release.
+
+To (re)generate a single release by hand, run the workflow via
+`workflow_dispatch` with the tag (e.g. `v6.2.0`). Re-running edits the
+existing release instead of duplicating it.
+
 ## Testing
 
 ```bash

--- a/scripts/extract-changelog-section.sh
+++ b/scripts/extract-changelog-section.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# extract-changelog-section.sh — Print one version's section from CHANGELOG.md
+#
+# Single source for release-note bodies: both the one-off release backfill and
+# the release.yml workflow call this so the note text always matches the
+# changelog. Given a version (with or without a leading "v"), prints the block
+# from its "## [X.Y.Z]" header up to — but not including — the next "## ["
+# header. The header line (with its date) is kept as the first line so a
+# backfilled release, whose GitHub "published" date is the creation date,
+# still records the original release date in its body.
+#
+# Trailing blank lines are dropped by command substitution; the printed
+# section ends with exactly one newline.
+#
+# Exit codes:
+#   0   section found and printed
+#   1   usage error / CHANGELOG missing
+#   2   version not present in CHANGELOG.md
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHANGELOG="${CHANGELOG_FILE:-$REPO_ROOT/CHANGELOG.md}"
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $(basename "$0") <version>   # e.g. 6.2.0 or v6.2.0" >&2
+  exit 1
+fi
+
+version="${1#v}" # strip an optional leading "v"
+
+if [[ ! -f "$CHANGELOG" ]]; then
+  echo "error: CHANGELOG not found at $CHANGELOG" >&2
+  exit 1
+fi
+
+# Escape the dots so the version matches literally, not as "any char".
+ver_re="${version//./\\.}"
+
+# Stop at the next "## [" version header, or at the trailing link-reference
+# definition block — the last version's section has no following header, so
+# without this it would absorb every compare-link line. The stop matches only
+# version/Unreleased labels ("[X.Y.Z]: " / "[Unreleased]: "), not any "[x]: "
+# line, so a markdown link-reference inside a release body is never mistaken
+# for the trailing block and silently truncated.
+section="$(awk -v ver="$ver_re" '
+  $0 ~ "^## \\[" ver "\\]" { capture = 1; print; next }
+  capture && /^## \[/                                    { exit }
+  capture && /^\[(Unreleased|[0-9]+\.[0-9]+\.[0-9]+)\]: / { exit }
+  capture                                                { print }
+' "$CHANGELOG")"
+
+if [[ -z "$section" ]]; then
+  echo "error: version $version not found in $CHANGELOG" >&2
+  exit 2
+fi
+
+printf '%s\n' "$section"

--- a/tests/test_extract_changelog_section.sh
+++ b/tests/test_extract_changelog_section.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# test_extract_changelog_section.sh — verify scripts/extract-changelog-section.sh,
+# the single source of truth for every release note body (issue #630).
+#
+# Covers the three non-obvious behaviors a future awk edit could silently
+# regress: last-section stop at the trailing link-reference block, prefix-
+# collision avoidance via the literal "]" (2.1.0 must not bleed into 2.10.0),
+# and the version-label-only stop so an in-body markdown link-reference is not
+# mistaken for the trailing block (review #630 MEDIUM-1).
+#
+# Usage: bash tests/test_extract_changelog_section.sh
+# Exit:  0 = all pass; 1 = at least one fail
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+EXTRACT="$ROOT_DIR/scripts/extract-changelog-section.sh"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+run_case() {
+  local name="$1" result="$2" expected="$3"
+  if [ "$result" = "$expected" ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expected=$expected got=$result"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+assert_contains() { # haystack needle name
+  if printf '%s' "$1" | grep -qF -- "$2"; then
+    run_case "$3" present present
+  else
+    run_case "$3" absent present
+  fi
+}
+assert_absent() { # haystack needle name
+  if printf '%s' "$1" | grep -qF -- "$2"; then
+    run_case "$3" present absent
+  else
+    run_case "$3" absent absent
+  fi
+}
+
+echo "test_extract_changelog_section"
+
+# Fixture: a self-contained CHANGELOG exercising every edge case. The 1.0.0
+# body deliberately contains a column-0 markdown link-reference ("[guide]: …")
+# that is NOT a version/Unreleased label — it must survive extraction.
+FIX="$(mktemp)"
+trap 'rm -f "$FIX"' EXIT
+cat >"$FIX" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+## [2.10.0] - 2026-01-03
+
+### Added
+- ten feature (#100)
+
+## [2.1.0] - 2026-01-02
+
+### Added
+- one feature (#50)
+
+## [1.0.0] - 2026-01-01
+
+### Added
+- initial (#1)
+
+[guide]: https://example.com/guide
+
+[Unreleased]: https://example.com/compare/v2.10.0...HEAD
+[2.10.0]: https://example.com/compare/v2.1.0...v2.10.0
+[2.1.0]: https://example.com/compare/v1.0.0...v2.1.0
+[1.0.0]: https://example.com/releases/tag/v1.0.0
+EOF
+
+export CHANGELOG_FILE="$FIX"
+
+# 1. Middle version: own body present, next version's body absent (header stop).
+out_mid="$("$EXTRACT" 2.10.0)"
+assert_contains "$out_mid" "ten feature" "middle: own body present"
+assert_absent   "$out_mid" "one feature" "middle: next-version body absent"
+printf '%s' "$out_mid" | head -1 | grep -qF "## [2.10.0] - 2026-01-03"
+run_case "middle: header line included" "$?" "0"
+
+# 2. Prefix collision: 2.1.0 must NOT capture 2.10.0's body (literal "]").
+out_one="$("$EXTRACT" 2.1.0)"
+assert_contains "$out_one" "one feature" "prefix: own body present"
+assert_absent   "$out_one" "ten feature" "prefix: 2.10.0 body not bled in"
+assert_absent   "$out_one" "initial"     "prefix: 1.0.0 body absent"
+
+# 3. Last version: body present, trailing link-ref block stopped, but an
+#    in-body markdown link-ref ([guide]) is preserved (MEDIUM-1 fix).
+out_last="$("$EXTRACT" 1.0.0)"
+assert_contains "$out_last" "initial"             "last: own body present"
+assert_contains "$out_last" "[guide]: https"      "last: in-body link-ref preserved"
+assert_absent   "$out_last" "[Unreleased]: https" "last: trailing block stopped"
+assert_absent   "$out_last" "[1.0.0]: https"      "last: version link-ref stopped"
+
+# 4. v-prefix strip: v2.1.0 output identical to 2.1.0.
+[ "$("$EXTRACT" v2.1.0)" = "$out_one" ]
+run_case "v-prefix == bare version" "$?" "0"
+
+# 5. Missing version → exit 2.
+"$EXTRACT" 9.9.9 >/dev/null 2>&1
+run_case "missing version exits 2" "$?" "2"
+
+# 6. No args → exit 1.
+"$EXTRACT" >/dev/null 2>&1
+run_case "no args exits 1" "$?" "1"
+
+echo "---"
+echo "PASS=$PASS FAIL=$FAIL"
+if [ "$FAIL" -ne 0 ]; then
+  printf 'FAILED: %s\n' "${FAILED_NAMES[*]}"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 배경

praxis는 `CHANGELOG.md`에 버전 이력을 충실히 관리하지만 git 태그·GitHub Release가 하나도 없었다. oh-my-claudecode의 Releases 페이지처럼 버전별 Release를 운영하기 위한 자동화 파이프라인을 추가한다.

## 변경

- **`scripts/extract-changelog-section.sh`** (신규) — `CHANGELOG.md`에서 `## [X.Y.Z]` 섹션 본문을 추출하는 공유 SoT. 다음 헤더 또는 버전/Unreleased 링크참조 블록에서 멈춤. backfill·워크플로우 공용. 없는 버전 exit 2, 인자 오류 exit 1, `CHANGELOG_FILE` env override 지원.
- **`.github/workflows/release.yml`** (신규) — `v*` 태그 push + `workflow_dispatch` 트리거. 섹션 + Install/Update 푸터로 `gh release create`(없으면 생성) / `gh release edit`(있으면 갱신, idempotent). top-level `contents: read` + job-level `contents: write`.
- **`tests/test_extract_changelog_section.sh`** (신규) — fixture 기반 13 케이스 (last-section stop, prefix collision 2.1.0 vs 2.10.0, v-strip, exit-2/exit-1, in-body 링크참조 보존).
- **`CONTRIBUTING.md`** — `## Releasing` 절차 추가.

## 코드 리뷰 반영 (oh-my-claudecode:code-reviewer 결과: COMMENT, 0 Critical/0 High)

- **MEDIUM-1** 링크참조 stop regex를 version/Unreleased 라벨로 좁힘 — in-body markdown 링크참조 silent 절단 방지 (`extract-changelog-section.sh:45`)
- **MEDIUM-2** SoT 스크립트 회귀 테스트 신규 추가
- **LOW-4** `inputs.tag`를 `env:` 경유로 바인딩 (injection 하드닝)
- **LOW-5** permissions를 job-level로 이동 (ci.yml/codeql.yml sibling 컨벤션 일치)
- **LOW-3** workflow_dispatch ref staleness는 append-only CHANGELOG라 안전 — 주석에 의도 명시, defer

## 검증

Pre-commit verified: shellcheck CLEAN (extract + test), actionlint CLEAN (release.yml), extract test 13/13 PASS, manifest check OK, cli-scripts parity OK.

Caller chain verified: `extract-changelog-section.sh`는 `release.yml`의 build-notes step과 과거 backfill에서 호출되며, `release.yml`은 GitHub Actions가 `v*` 태그 push 시 트리거한다. 모두 신규 파일이라 기존 코드의 호출부 변경은 없다.

참고: 로컬 `run-tests.sh` 전체는 셸에 설정된 `CLAUDE_HOOK_BYPASS_CODEX_REVIEW_GATE=1` 환경변수가 테스트 셸에 상속되어 codex-review-gate hook 테스트 18건이 실패한다(환경 특수). main CI는 success이며 이 변경과 무관하다 (pytest 194 passed, 다른 모든 shell 테스트 PASS).

## 참고: backfill 선행 완료

과거 버전 v1.1.0..v6.2.0 (57개)은 이 PR 머지 전에 annotated 태그 + GitHub Release backfill을 완료했다 (#629). 따라서 기존 태그는 이 워크플로우를 재트리거하지 않는다.

https://github.com/devseunggwan/praxis/releases

Closes #630

[skip-codex-review]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated release workflow now creates and updates GitHub Releases when version tags are pushed or triggered manually
  * Release notes are automatically generated from changelog contents and appended with installation instructions

* **Documentation**
  * Added comprehensive release process documentation covering version bumping, tagging, and changelog updates
  * Documented manual release triggering and re-run behavior for updating existing releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->