### PR TITLE
ci: pin github actions to commit shas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.x"
           # No dependency manifest; hash this workflow (which pins ruff) for a
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       # ubuntu-latest ships shellcheck, but install explicitly so the job
@@ -68,12 +68,12 @@ jobs:
     timeout-minutes: 10
     steps:
       # Full history so gitleaks scans commits, not just the working tree.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           persist-credentials: false
       # Synthetic test secrets are allowlisted in .gitleaks.toml.
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITLEAKS_CONFIG: .gitleaks.toml
           # Required for pull_request scans: the action enumerates the PR's
@@ -84,10 +84,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.x"
           cache: pip
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       # --offline: only validate local file-path links and in-document
@@ -108,7 +108,7 @@ jobs:
       # unauthenticated 429 false failures. --exclude-path '^plugins/': those
       # dirs are symlinks back into the repo root and would re-scan every doc
       # under a plugins/ path where relative links resolve wrong.
-      - uses: lycheeverse/lychee-action@v2
+      - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
           args: >-
             --no-progress
@@ -128,12 +128,12 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       # Pinned to the latest release; existing workflows pass actionlint
       # cleanly, so error-level gating starts from green.
-      - uses: reviewdog/action-actionlint@v1.72.0
+      - uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
@@ -148,12 +148,12 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       # Rule config lives in .markdownlint.yaml (counts derived under the
       # version this action bundles — see that file's header).
-      - uses: reviewdog/action-markdownlint@v0.26.2
+      - uses: reviewdog/action-markdownlint@3667398db9118d7e78f7a63d10e26ce454ba5f58 # v0.26.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,18 +37,18 @@ jobs:
       # persist-credentials: false — the CodeQL actions use the job's
       # GITHUB_TOKEN directly, so the checkout token need not stay in
       # .git/config for later steps.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       # CodeQL supports Python (the project's hook/script logic). Bash is not a
       # CodeQL language — shellcheck.yml covers the shell sources instead.
       - name: initialize codeql
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           languages: python
 
       - name: analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           category: "/language:python"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Full history so the tagged commit's CHANGELOG is available, and so a
           # workflow_dispatch run on main can read the section for any version.


### PR DESCRIPTION
## 배경

CodeRabbit이 PR #631 리뷰에서 `actions/checkout@v6` 같은 floating tag의 supply-chain 위험을 지적했다 (`unpinned-uses`). 레포 전체 일괄 적용 사안이라 별도 이슈(#632)로 분리하여 처리한다.

## 변경

3개 워크플로우(`ci.yml`, `codeql.yml`, `release.yml`)의 모든 `uses: <action>@<tag>` 를 `uses: <action>@<full-commit-sha> # <tag>` 로 변경. tag는 주석으로 병기해 가독성·업데이트 추적을 유지한다. 각 action은 동일 commit을 가리키므로 **동작 변경은 없다** (immutable 고정만).

17개 참조 / 8개 action:

| action | tag | 참조 수 |
|--------|-----|--------|
| actions/checkout | v6 | 9 |
| actions/setup-python | v6 | 2 |
| github/codeql-action/{init,analyze} | v3 | 2 |
| gitleaks/gitleaks-action | v2 | 1 |
| lycheeverse/lychee-action | v2 | 1 |
| reviewdog/action-actionlint | v1.72.0 | 1 |
| reviewdog/action-markdownlint | v0.26.2 | 1 |

## 검증

Pre-commit verified: actionlint CLEAN (3 파일), YAML valid (ruby load), 잔여 tag-pin 0건(`grep @v[0-9]`), 8개 action 전부 파일 SHA == `gh api repos/<repo>/commits/<tag>` 재조회 일치.

Caller chain verified: 워크플로우 YAML만 변경되며 코드 호출부 영향은 없다. 각 action은 동일 commit을 가리키므로 CI 동작은 그대로다.

oh-my-claudecode:code-reviewer 결과: **APPROVE — No issues found**.

Closes #632

[skip-codex-review]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced stability and consistency of automated build and deployment processes by pinning dependency versions to ensure reliable execution across all development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->