### PR TITLE
docs: make README prose English, sync CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,39 +11,49 @@ Development workflow skills for Claude Code — disciplined, fast, resilient.
 > returns `Agent type not found` — Agent and Skill resolve disjoint namespaces.
 > See [RUNTIME_CONSTRAINTS.md §3](RUNTIME_CONSTRAINTS.md) for the mapping table.
 
+> **Trigger keywords** mirror each skill's `SKILL.md` `description` field verbatim
+> and are intentionally kept in their source language (some are Korean) so the
+> README stays in sync with what actually triggers the skill — do not translate them.
+
 ### Discovery
 
 | Skill | Trigger keywords | When to use | Example invocation |
 |-------|-----------------|-------------|-------------------|
-| `using-praxis` | `praxis 처음`, `praxis 사용법`, `어떤 skill 부터`, `praxis intro`, `praxis getting started` | 처음 praxis를 접하거나 상황에 맞는 skill을 모를 때 | `/praxis:using-praxis` |
-| `writing-praxis-skill` | `new skill`, `write skill`, `add skill`, `skill template`, `skill spec`, `스킬 작성`, `새 스킬` | 새 SKILL.md를 작성하거나 skill 구조 가이드가 필요할 때 | `/praxis:writing-praxis-skill` |
+| `using-praxis` | `praxis 처음`, `praxis 사용법`, `어떤 skill 부터`, `praxis intro`, `praxis getting started` | To find the right skill when you're new to praxis or unsure which one fits | `/praxis:using-praxis` |
+| `writing-praxis-skill` | `new skill`, `write skill`, `add skill`, `skill template`, `skill spec`, `스킬 작성`, `새 스킬` | To author a new SKILL.md or get a skill-structure guide | `/praxis:writing-praxis-skill` |
 
 ### Development
 
 | Skill | Trigger keywords | When to use | Example invocation |
 |-------|-----------------|-------------|-------------------|
-| `retrospect` | `retrospect`, `what went wrong`, `session review`, `session improvement`, `improve` | 세션 마무리 후 마찰 패턴·근본 원인을 분석하고 개선안을 실행할 때 | `/praxis:retrospect` |
-| `codex-review-wrap` | `codex review`, `review codex`, `safe review`, `premise verification`, `flip detection`, `sibling cross-check` | 다중 worktree 환경에서 `/codex:review`를 전제 검증·flip 탐지와 함께 안전하게 실행할 때 | `/praxis:codex-review-wrap` |
+| `retrospect` | `retrospect`, `what went wrong`, `session review`, `session improvement`, `improve` | To analyze friction patterns / root causes after a session and act on improvements | `/praxis:retrospect` |
+| `codex-review-wrap` | `codex review`, `review codex`, `safe review`, `premise verification`, `flip detection`, `sibling cross-check` | To run `/codex:review` safely in multi-worktree setups, with premise verification and flip detection | `/praxis:codex-review-wrap` |
 
 ### Discipline
 
 | Skill | Trigger keywords | When to use | Example invocation |
 |-------|-----------------|-------------|-------------------|
-| `strike` | `/strike`, `/praxis:strike`, `strike 1/2/3`, `삼진` | 규칙 위반 발생 시 명시적으로 기록할 때 (colloquial "strike a balance" 등은 제외) | `/praxis:strike <위반 이유>` |
-| `strikes` | `/strikes`, `strike status`, `몇 진`, `check strikes` | 현재 세션의 strike 횟수와 위반 내역을 확인할 때 | `/praxis:strikes` |
-| `reset-strikes` | `/reset-strikes`, `strike 초기화`, `clear strikes` | 3진 블록 후 카운터를 초기화해 응답을 재개할 때 | `/praxis:reset-strikes` |
+| `strike` | `/strike`, `/praxis:strike`, `strike 1/2/3`, `삼진` | To explicitly record a rule violation (excludes colloquial uses like "strike a balance") | `/praxis:strike <violation reason>` |
+| `strikes` | `/strikes`, `strike status`, `몇 진`, `check strikes` | To check the current session's strike count and recorded violations | `/praxis:strikes` |
+| `reset-strikes` | `/reset-strikes`, `strike 초기화`, `clear strikes` | To reset the counter and resume responses after a 3-strike block | `/praxis:reset-strikes` |
 
 ### Session Management
 
 | Skill | Trigger keywords | When to use | Example invocation |
 |-------|-----------------|-------------|-------------------|
-| `recover-sessions` | `recover`, `session recovery`, `restore sessions`, `power recovery` | 전원 차단·tmux 크래시 후 세션을 복구할 때 (tmux 백엔드) | `/praxis:recover-sessions` |
-| `cmux-recover-sessions` | `터졌다`, `크래시 복구`, `OOM 복구`, `세션 살려야`, `crash recovery`, `power loss recovery`, `cmux session recovery` | crash·power loss·OOM 후 cmux 세션 다수를 긴급 복구할 때 (`.jsonl` 스캔 기반) | `/praxis:cmux-recover-sessions` |
-| `cmux-save-sessions` | `save sessions`, `session save`, `session snapshot`, `cmux save`, `snapshot list` | 현재 cmux 세션 목록을 JSON으로 저장해 나중에 복원할 때 | `/praxis:cmux-save-sessions` |
-| `cmux-resume-sessions` | `resume sessions`, `restore from snapshot`, `rehydrate sessions`, `세션 복원`, `스냅샷 복원` | 이전에 저장한 스냅샷으로 워크스페이스를 복원할 때 (크래시 복구는 `cmux-recover-sessions`) | `/praxis:cmux-resume-sessions` |
-| `cmux-session-manager` | `cmux session`, `session management`, `session cleanup`, `cmux status`, `cmux tidy` | 일상적인 세션 정리·상태 대시보드가 필요할 때 | `/praxis:cmux-session-manager` |
-| `cmux-delegate` | `delegate`, `cmux delegate`, `new session` | 현재 작업의 맥락을 보존한 채 독립 세션에 위임할 때 (리뷰·디버깅·구현 분리) | `/praxis:cmux-delegate` |
-| `cmux-browser` | `cmux browser`, `cmux 브라우저` | cmux browser CLI로 SPA hydration 대기 포함 E2E 테스트를 실행할 때 | `/praxis:cmux-browser` |
+| `recover-sessions` | `recover`, `session recovery`, `restore sessions`, `power recovery` | To recover sessions after power loss or a tmux crash (tmux backend) | `/praxis:recover-sessions` |
+| `cmux-recover-sessions` | `터졌다`, `크래시 복구`, `OOM 복구`, `세션 살려야`, `crash recovery`, `power loss recovery`, `cmux session recovery` | To emergency-recover many cmux sessions after a crash / power loss / OOM (`.jsonl` scan based) | `/praxis:cmux-recover-sessions` |
+| `cmux-save-sessions` | `save sessions`, `session save`, `session snapshot`, `cmux save`, `snapshot list` | To save the current cmux session list as JSON for later restore | `/praxis:cmux-save-sessions` |
+| `cmux-resume-sessions` | `resume sessions`, `restore from snapshot`, `rehydrate sessions`, `세션 복원`, `스냅샷 복원` | To restore workspaces from a saved snapshot (for crash recovery, use `cmux-recover-sessions`) | `/praxis:cmux-resume-sessions` |
+| `cmux-session-manager` | `cmux session`, `session management`, `session cleanup`, `cmux status`, `cmux tidy` | To run routine session cleanup or view a status dashboard | `/praxis:cmux-session-manager` |
+| `cmux-delegate` | `delegate`, `cmux delegate`, `new session` | To delegate to an independent session while preserving the current task's context (split review / debugging / implementation) | `/praxis:cmux-delegate` |
+| `cmux-browser` | `cmux browser`, `cmux 브라우저` | To run E2E tests via the cmux browser CLI, including SPA hydration waits | `/praxis:cmux-browser` |
+
+> **CLI tools (not skills):** praxis also ships `bypass-review`, a shell wrapper
+> with no `SKILL.md` — it is **not** invocable as `/praxis:*` and is absent from
+> the skills above. It inspects the review bypass-telemetry event logs.
+> See [AGENTS.md → Local Development](AGENTS.md#local-development) for the full
+> list of shipped CLI wrappers.
 
 ## Hooks
 


### PR DESCRIPTION
## 요약

`README.md`를 전면 영어 산문으로 정리하고 repo drift를 동기화한다. deep-interview → omc-plan consensus로 범위·접근을 확정했다.

## 변경 내용

- Skills 테이블 `When to use` 한국어 산문 + `<violation reason>` 플레이스홀더 → 영어. 열 전체를 "To &lt;verb&gt;" voice로 통일.
- `Trigger keywords` 한국어 셀은 **보존** (각 SKILL.md `description`을 verbatim 미러하는 실제 트리거) + 보존 근거 1줄 노트 추가.
- `bypass-review`를 non-skill CLI 도구(SKILL.md 없음, `/praxis:*` 비호출)로 문서화.
- hook 이벤트 목록은 4-event 유지 — README만 5-event로 바꾸면 README↔AGENTS.md drift 발생(둘 다 동일 4-event 라인). 5-event 정확도는 세 문서를 함께 손대는 별도 후속.

## 검증

- `grep -P '[가-힣]' README.md` → 한국어가 `Trigger keywords` 셀에만 잔존(산문 0건).
- 참조 문서 링크 7개(`ARCHITECTURE/DESIGN/RUNTIME_CONSTRAINTS/AGENTS/SECURITY/PRIVACY/docs/hook/INDEX`) 모두 resolve.
- `bypass-review` 노트가 `AGENTS.md:126` / `CLAUDE.md:126` 원문과 일치(앵커 `AGENTS.md#local-development` 존재).
- `omc:code-reviewer`: **APPROVE** (CRITICAL/HIGH/MEDIUM 0, LOW 1건=voice 혼용 → 본 PR에서 해소).
- diff: `README.md` 한정 (24 ins / 14 del).

## 리뷰 노트

consensus(architect)와 `omc:code-reviewer` 모두 deliverable 유실 버그(oh-my-claudecode#3215)로 terse 사인오프만 반환 → agent transcript에서 전체 리뷰를 회수해 반영했다. 해당 버그는 별도 OMC 이슈로 보고함.

Closes #636

Pre-commit verified: grep으로 Korean 격리 / 링크 7개 resolve / bypass-review 노트 AGENTS.md:126 대조 / code-reviewer APPROVE.
Caller chain verified: N/A (docs-only, 코드 호출자 없음).
[skip-codex-review]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Skills section in README with clarifications on trigger keywords and their alignment with skill descriptions.
  * Translated skill usage explanations to English for better accessibility.
  * Added clarification distinguishing CLI tools from invocable skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->