### PR TITLE
docs(architecture): add architectural shape

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5,6 +5,36 @@ manifests relate. Values come from [`ETHOS.md`](ETHOS.md); implementation
 mechanisms come from [`DESIGN.md`](DESIGN.md). This file describes the
 *wiring*.
 
+## Architectural shape
+
+Four architectural patterns, one per layer — a reading map for the sections
+below.
+
+- **Microkernel (plugin) core.** A small shared kernel (`hooks/_lib/` — the
+  fail-open runtime, the dispatcher, and shared helpers) hosts the hook suite
+  and the skills as independent plugins. Extending praxis at the kernel level
+  means adding one hook directory plus one manifest entry
+  ([`CONTRIBUTING.md`](CONTRIBUTING.md) walks the full checklist); the kernel
+  only executes, isolates, and aggregates. Counts live in the
+  [Hook index](#hook-index) and [`AGENTS.md`](AGENTS.md), not here.
+- **Interceptor chain, most-restrictive-wins.** Hooks intercept the host's
+  lifecycle (PreToolUse → PostToolUse → Stop, plus UserPromptSubmit and
+  SessionStart). Unlike a classic chain-of-responsibility, every member runs
+  and decisions aggregate `deny > ask > allow`
+  ([§Single-process dispatch](#single-process-dispatch-adr-0002)), with each
+  member fail-open isolated.
+- **Ports-and-adapters packaging.** The runtime core (`skills/`, `hooks/`,
+  `scripts/`) knows nothing about platforms; per-platform artifacts are
+  build-time adapters generated from `manifests/`
+  ([§Multi-Platform Packaging](#multi-platform-packaging)). Adding a platform
+  is one manifest file plus one build run.
+- **Declared state + drift gate.** Generated artifacts are committed, and
+  `scripts/check-plugin-manifests.py` invariants enforce manifest ↔ output
+  parity in CI — the same reconciliation model infrastructure-as-code uses.
+
+The structure is self-similar: to its hosts praxis is a plugin; inside, it is
+a microkernel made of plugins.
+
 ## Provider Routing
 
 Skills that dispatch external CLI workers (`cmux-delegate`) can route tasks to multiple AI providers. When only `claude` is installed, the system behaves exactly as before — no errors, no degradation.


### PR DESCRIPTION
## 개요

ARCHITECTURE.md 서두(인트로 직후)에 `## Architectural shape` 절을 추가합니다. 배선(wiring) 디테일은 이미 문서화되어 있으나 전체 형상을 패턴 어휘로 묶는 프레이밍이 없어, 처음 접하는 독자가 형상을 역추론해야 하는 문제를 해소합니다.

Closes #648

## 변경 내용

4개 패턴을 각 1불릿으로 명명하고 기존 절로 앵커 링크:

| 패턴 | 앵커 대상 |
|---|---|
| Microkernel (plugin) core | `#hook-index`, `AGENTS.md`, `CONTRIBUTING.md` |
| Interceptor chain, most-restrictive-wins | `#single-process-dispatch-adr-0002` |
| Ports-and-adapters packaging | `#multi-platform-packaging` |
| Declared state + drift gate | `scripts/check-plugin-manifests.py` |

이슈 요구사항 준수: 절 내 수치(훅/스킬 개수) 0건 — 개수는 Hook index와 AGENTS.md에 위임. 자기유사 구조(호스트에게는 플러그인, 내부는 마이크로커널) 한 줄 포함.

## 리뷰

- `oh-my-claudecode:code-reviewer` (sonnet): MEDIUM 2 + LOW 3 → **5건 전부 반영** (lifecycle 이벤트 보강 — UserPromptSubmit/SessionStart 추가, `_lib` 설명 일반화, kernel-level 한정어 추가, "classic" 표현 제거, `deny > ask > allow` 코드 스팬 처리)
- `praxis:codex-review-wrap` → codex review: **클린 패스** (finding 0건). Step 5h SoT 감사: inline 전사 없음(참조 링크만) → truncation 없음

## 검증

- `./scripts/run-tests.sh` → `ALL TESTS PASSED`
- `python3 scripts/check-plugin-manifests.py` → `plugin-manifest check OK`
- 앵커 3건 모두 실제 heading 과 대조 확인 (`grep -n "^## Hook index\|^### Single-process dispatch\|^## Multi-Platform Packaging"` → 117/181/246행)

Pre-commit verified: ./scripts/run-tests.sh → ALL TESTS PASSED; python3 scripts/check-plugin-manifests.py → plugin-manifest check OK
Caller chain verified: n/a (docs-only — 코드 심볼 변경 없음, ARCHITECTURE.md 단일 파일 +30행)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced ARCHITECTURE.md with detailed description of the system's architectural patterns, design principles, core structure, and state management approach across system layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->