### PR TITLE
refactor(hooks): hoist transcript utils to _lib

### DIFF
--- a/hooks/_lib/_transcript.py
+++ b/hooks/_lib/_transcript.py
@@ -20,8 +20,13 @@ content block is skipped instead of raising into the caller's fail-open
 wrapper, which silently disabled the whole scan.
 
 Transcript format: JSONL where each line is a JSON object with at least
-`type` ('user' / 'assistant' / 'system') and either `message` (an Anthropic
-API message dict with `role` + `content`) or a flatter `content` field.
+`type` ('user' / 'assistant' / 'system') and a nested `message` dict
+(Anthropic API shape with `role` + `content`). A flatter top-level
+`{"role": ..., "content": ...}` shape is additionally tolerated by
+`read_last_user_message` ONLY — live transcripts contain no such events
+(probe: 0 of 2,503 events across 3 real session files), so the
+turn-scanning helpers deliberately read just the nested shape, matching
+the pre-hoist hook behavior.
 
 tool_result handling (codex review #193 F2): an Anthropic user-role message
 may carry only `tool_result` content blocks when the assistant invoked tools
@@ -81,13 +86,13 @@ def load_transcript_objs(path: str, max_bytes: int) -> list | None:
     Returns None when the file is missing, unreadable, or larger than
     `max_bytes` — callers treat None as "cannot scan, fail open".
     Non-JSON lines are skipped, scanning continues.
+
+    The bound is enforced on the bytes actually read (not a stat()
+    pre-check): a live session can append to the transcript between a
+    stat and the read, which would defeat the contract.
     """
-    try:
-        p = Path(path)
-        if not p.is_file() or p.stat().st_size > max_bytes:
-            return None
-        text = p.read_text(encoding="utf-8", errors="replace")
-    except (OSError, ValueError):
+    text = _read_bounded_text(path, max_bytes)
+    if text is None:
         return None
     objs: list = []
     for line in text.splitlines():
@@ -106,16 +111,29 @@ def read_transcript_tail(path: str, max_lines: int, max_bytes: int) -> str | Non
 
     Returns None when the file is missing, unreadable, or larger than
     `max_bytes` — callers treat None as "cannot scan, fail open".
+    The bound is enforced on the bytes actually read (see
+    `load_transcript_objs`).
     """
-    try:
-        p = Path(path)
-        if not p.is_file() or p.stat().st_size > max_bytes:
-            return None
-        text = p.read_text(encoding="utf-8", errors="replace")
-    except (OSError, ValueError):
+    text = _read_bounded_text(path, max_bytes)
+    if text is None:
         return None
     lines = text.strip().split("\n")
     return "\n".join(lines[-max_lines:])
+
+
+def _read_bounded_text(path: str, max_bytes: int) -> str | None:
+    """Read at most `max_bytes` bytes; None when missing or over the bound."""
+    try:
+        p = Path(path)
+        if not p.is_file():
+            return None
+        with p.open("rb") as f:
+            data = f.read(max_bytes + 1)
+    except (OSError, ValueError):
+        return None
+    if len(data) > max_bytes:
+        return None
+    return data.decode("utf-8", errors="replace")
 
 
 def get_current_turn(events: list[dict]) -> list[dict]:

--- a/hooks/_lib/_transcript.py
+++ b/hooks/_lib/_transcript.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Shared transcript-scanning helpers — single source of truth (#643).
+
+Previously these JSONL transcript readers were re-implemented per hook:
+
+  - _load_transcript / _get_current_turn / _extract_last_assistant_text
+    duplicated across readonly-verify-deferral-gate, completion-signal-gate,
+    merge-state-claim-gate (Stop hooks)
+  - _read_last_user_message duplicated across block-ask-end-option,
+    block-manufactured-action-menu (PreToolUse AskUserQuestion gates)
+  - bounded readers (_read_transcript_tail, _load_transcript_objs) in
+    block-gh-issue-create-without-dup-search, block-sciomc-finding-commit
+  - _TRANSCRIPT_SCAN_LINES = 400 re-declared in external-write-falsify-check,
+    pre-output-falsification-gate
+
+All consumers now import from here so the parsing semantics cannot drift.
+The canonical bodies adopt the most defensive variant that existed
+(merge-state-claim-gate's `isinstance(block, dict)` guards): a malformed
+content block is skipped instead of raising into the caller's fail-open
+wrapper, which silently disabled the whole scan.
+
+Transcript format: JSONL where each line is a JSON object with at least
+`type` ('user' / 'assistant' / 'system') and either `message` (an Anthropic
+API message dict with `role` + `content`) or a flatter `content` field.
+
+tool_result handling (codex review #193 F2): an Anthropic user-role message
+may carry only `tool_result` content blocks when the assistant invoked tools
+in the same turn. Such entries are NOT human authored — they are the
+runtime's bridge for tool outputs. Turn-boundary detection and
+last-user-message extraction both skip them.
+
+Public API:
+  TRANSCRIPT_SCAN_LINES                                  — default tail window
+  load_transcript(path)                                  -> list[dict]
+  load_transcript_objs(path, max_bytes)                  -> list | None
+  read_transcript_tail(path, max_lines, max_bytes)       -> str | None
+  get_current_turn(events)                               -> list[dict]
+  extract_last_assistant_text(turn)                      -> str
+  has_tool_in_turn(turn, tool_name)                      -> bool
+  read_last_user_message(transcript_path)                -> str | None
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+# Default tail window (in JSONL lines) for substring scans over the recent
+# transcript. Shared by external-write-falsify-check and
+# pre-output-falsification-gate.
+TRANSCRIPT_SCAN_LINES = 400
+
+
+def load_transcript(path: str) -> list[dict]:
+    """Load JSONL transcript, return list of event dicts. Fail-open.
+
+    Unbounded read; non-JSON lines and non-dict objects are skipped.
+    Returns [] when the file is missing or unreadable.
+    """
+    events: list[dict] = []
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                    if isinstance(obj, dict):
+                        events.append(obj)
+                except Exception:
+                    continue
+    except Exception:
+        pass
+    return events
+
+
+def load_transcript_objs(path: str, max_bytes: int) -> list | None:
+    """Bounded loader returning raw parsed objects (dicts and non-dicts).
+
+    Returns None when the file is missing, unreadable, or larger than
+    `max_bytes` — callers treat None as "cannot scan, fail open".
+    Non-JSON lines are skipped, scanning continues.
+    """
+    try:
+        p = Path(path)
+        if not p.is_file() or p.stat().st_size > max_bytes:
+            return None
+        text = p.read_text(encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        return None
+    objs: list = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            objs.append(json.loads(line))
+        except (json.JSONDecodeError, ValueError):
+            continue  # skip non-JSON lines, keep scanning
+    return objs
+
+
+def read_transcript_tail(path: str, max_lines: int, max_bytes: int) -> str | None:
+    """Return the last `max_lines` lines of the transcript as raw text.
+
+    Returns None when the file is missing, unreadable, or larger than
+    `max_bytes` — callers treat None as "cannot scan, fail open".
+    """
+    try:
+        p = Path(path)
+        if not p.is_file() or p.stat().st_size > max_bytes:
+            return None
+        text = p.read_text(encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        return None
+    lines = text.strip().split("\n")
+    return "\n".join(lines[-max_lines:])
+
+
+def get_current_turn(events: list[dict]) -> list[dict]:
+    """Return events since the last real user input (non-tool-result user msg).
+
+    Assumes every list item is a dict (the `load_transcript` contract);
+    callers constructing event lists by other means must pre-filter.
+    """
+    last_user_idx: int | None = None
+    for i, ev in enumerate(events):
+        msg = ev.get("message", {})
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            continue
+        if ev.get("isSidechain"):
+            continue
+        content = msg.get("content", [])
+        if isinstance(content, str):
+            last_user_idx = i
+        elif isinstance(content, list):
+            non_tool = [
+                b for b in content
+                if isinstance(b, dict) and b.get("type") != "tool_result"
+            ]
+            if non_tool:
+                last_user_idx = i
+    start = 0 if last_user_idx is None else last_user_idx + 1
+    return events[start:]
+
+
+def extract_last_assistant_text(turn: list[dict]) -> str:
+    """Extract text from the last assistant message in the turn."""
+    last_msg: dict | None = None
+    for ev in turn:
+        msg = ev.get("message", {})
+        if isinstance(msg, dict) and msg.get("role") == "assistant" \
+                and not ev.get("isSidechain"):
+            last_msg = msg
+    if last_msg is None:
+        return ""
+    content = last_msg.get("content", [])
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            b.get("text", "") for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        )
+    return ""
+
+
+def has_tool_in_turn(turn: list[dict], tool_name: str) -> bool:
+    """True if any assistant message in the turn used the named tool."""
+    for ev in turn:
+        msg = ev.get("message", {})
+        if not isinstance(msg, dict) or msg.get("role") != "assistant" \
+                or ev.get("isSidechain"):
+            continue
+        content = msg.get("content", [])
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_use" \
+                        and block.get("name") == tool_name:
+                    return True
+    return False
+
+
+def read_last_user_message(transcript_path: str) -> str | None:
+    """Return the text of the most recent user-authored message in the transcript.
+
+    Returns None when the transcript is missing or unreadable — the caller
+    must fail open per the project hook design contract (`Fail-open on
+    infrastructure errors`). Returns empty string when the transcript was
+    read successfully but no user message contained extractable human
+    text — that is a real "no signal" answer and may be acted on.
+
+    tool_result-only user entries are skipped (continue), not returned as
+    empty: returning "" on the first tool_result-only entry would block the
+    backward walk at the wrong layer and false-fire strict-mode gates even
+    though the real user message earlier in the transcript carried the
+    signal (codex review #193 F2).
+    """
+    if not transcript_path or not os.path.isfile(transcript_path):
+        return None
+    try:
+        with open(transcript_path, "r", encoding="utf-8", errors="replace") as f:
+            lines = f.readlines()
+    except OSError:
+        return None
+
+    # Walk in reverse to find the most recent user-role entry whose
+    # content includes human-authored text.
+    for raw in reversed(lines):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            entry = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+
+        role = entry.get("type") or entry.get("role")
+        message = entry.get("message")
+        if isinstance(message, dict) and not role:
+            role = message.get("role")
+
+        if role != "user":
+            continue
+
+        # Extract text. Possible shapes:
+        #   {"type": "user", "message": {"role": "user", "content": "text"}}
+        #   {"type": "user", "message": {"role": "user", "content": [{"type":"text","text":"..."}]}}
+        #   {"type": "user", "message": {"role": "user", "content": [{"type":"tool_result", ...}]}}
+        #   {"role": "user", "content": "text"}
+        content = None
+        if isinstance(message, dict):
+            content = message.get("content")
+        if content is None:
+            content = entry.get("content")
+
+        text = ""
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list):
+            parts: list[str] = []
+            for item in content:
+                if isinstance(item, dict):
+                    # Skip non-text blocks (tool_result, image, etc.).
+                    # Only `type: text` (or items lacking a type but
+                    # carrying a `text` field) count as human content.
+                    item_type = item.get("type")
+                    if item_type and item_type != "text":
+                        continue
+                    t = item.get("text")
+                    if isinstance(t, str):
+                        parts.append(t)
+                elif isinstance(item, str):
+                    parts.append(item)
+            text = "\n".join(parts)
+        # else: unexpected content shape — fall through to skip
+
+        if text.strip():
+            return text
+        # No human text in this entry — keep walking backward.
+
+    return ""

--- a/hooks/advisory-nudge/external-write-falsify-check/impl.py
+++ b/hooks/advisory-nudge/external-write-falsify-check/impl.py
@@ -48,6 +48,7 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     safe_tokenize,
     strip_prefix,
 )
+from _transcript import TRANSCRIPT_SCAN_LINES  # type: ignore[import-not-found]  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -293,8 +294,6 @@ _VERIF_BY_CAT: dict[str, tuple[re.Pattern, ...]] = {
     ),
 }
 
-_TRANSCRIPT_SCAN_LINES = 400
-
 
 def _is_separator_row(row: str) -> bool:
     """True for pure separator rows like |---|:---:|---| (no data)."""
@@ -341,7 +340,7 @@ def _recent_bash_commands(transcript_path: str) -> list[str]:
         return []
 
     cmds: list[str] = []
-    for line in lines[-_TRANSCRIPT_SCAN_LINES:]:
+    for line in lines[-TRANSCRIPT_SCAN_LINES:]:
         line = line.strip()
         if not line:
             continue
@@ -464,7 +463,7 @@ CLUSTER_APPROVAL_ADVISORY = (
 def _recent_user_messages(transcript_path: str, count: int) -> list[str]:
     """Return text from the last `count` user messages in the transcript.
 
-    Scans the last _TRANSCRIPT_SCAN_LINES JSONL entries in reverse so that
+    Scans the last TRANSCRIPT_SCAN_LINES JSONL entries in reverse so that
     the most-recent user messages are returned first (index 0 = most recent).
     """
     if not transcript_path or not os.path.isfile(transcript_path):
@@ -476,7 +475,7 @@ def _recent_user_messages(transcript_path: str, count: int) -> list[str]:
         return []
 
     msgs: list[str] = []
-    for line in reversed(lines[-_TRANSCRIPT_SCAN_LINES:]):
+    for line in reversed(lines[-TRANSCRIPT_SCAN_LINES:]):
         line = line.strip()
         if not line:
             continue

--- a/hooks/advisory-nudge/pre-output-falsification-gate/impl.py
+++ b/hooks/advisory-nudge/pre-output-falsification-gate/impl.py
@@ -65,6 +65,7 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     strip_prefix,
 )
 from ask_option_text import collect_option_texts  # type: ignore[import-not-found]  # noqa: E402
+from _transcript import TRANSCRIPT_SCAN_LINES  # type: ignore[import-not-found]  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -130,10 +131,6 @@ _STATE_BASE = os.path.join(
     os.environ.get("TMPDIR", "/tmp"), "praxis-pre-output-falsification-gate"
 )
 
-# How many trailing JSONL lines of the transcript Lane A scans.
-_TRANSCRIPT_SCAN_LINES = 400
-
-
 # ---------------------------------------------------------------------------
 # Lane A — AskUserQuestion evaluative-option gate
 # ---------------------------------------------------------------------------
@@ -189,7 +186,7 @@ def _recent_transcript_negative(transcript_path: str) -> bool:
     except OSError:
         return False
 
-    for raw in lines[-_TRANSCRIPT_SCAN_LINES:]:
+    for raw in lines[-TRANSCRIPT_SCAN_LINES:]:
         raw = raw.strip()
         if not raw:
             continue

--- a/hooks/completion-verify/completion-signal-gate/impl.py
+++ b/hooks/completion-verify/completion-signal-gate/impl.py
@@ -44,6 +44,12 @@ import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
+from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
+    extract_last_assistant_text,
+    get_current_turn,
+    has_tool_in_turn,
+    load_transcript,
+)
 
 # ---------------------------------------------------------------------------
 # Prefix
@@ -281,86 +287,6 @@ def _detect_foreign_slash_commands(text: str, cwd_plugin: str | None) -> list[st
 
 
 # ---------------------------------------------------------------------------
-# Transcript parsing
-# ---------------------------------------------------------------------------
-
-
-def _load_transcript(path: str) -> list[dict]:
-    """Load JSONL transcript, return list of event dicts. Fail-open."""
-    events: list[dict] = []
-    try:
-        with open(path, encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    obj = json.loads(line)
-                    if isinstance(obj, dict):
-                        events.append(obj)
-                except Exception:
-                    continue
-    except Exception:
-        pass
-    return events
-
-
-def _get_current_turn(events: list[dict]) -> list[dict]:
-    """Return events since the last real user input (non-tool-result user message)."""
-    last_user_idx: int | None = None
-    for i, ev in enumerate(events):
-        msg = ev.get("message", {})
-        if msg.get("role") != "user":
-            continue
-        if ev.get("isSidechain"):
-            continue
-        content = msg.get("content", [])
-        if isinstance(content, str):
-            last_user_idx = i
-        elif isinstance(content, list):
-            non_tool = [b for b in content if b.get("type") != "tool_result"]
-            if non_tool:
-                last_user_idx = i
-    if last_user_idx is None:
-        start = 0
-    else:
-        start = last_user_idx + 1
-    return events[start:]
-
-
-def _extract_last_assistant_text(turn: list[dict]) -> str:
-    """Extract text from the last assistant message in the turn."""
-    last_asst = None
-    for ev in turn:
-        msg = ev.get("message", {})
-        if msg.get("role") == "assistant" and not ev.get("isSidechain"):
-            last_asst = ev
-    if last_asst is None:
-        return ""
-    content = last_asst.get("message", {}).get("content", [])
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts = [b.get("text", "") for b in content if b.get("type") == "text"]
-        return "\n".join(parts)
-    return ""
-
-
-def _has_tool_in_turn(turn: list[dict], tool_name: str) -> bool:
-    """True if any assistant message in the turn used the named tool."""
-    for ev in turn:
-        msg = ev.get("message", {})
-        if msg.get("role") != "assistant" or ev.get("isSidechain"):
-            continue
-        content = msg.get("content", [])
-        if isinstance(content, list):
-            for block in content:
-                if block.get("type") == "tool_use" and block.get("name") == tool_name:
-                    return True
-    return False
-
-
-# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -402,20 +328,20 @@ def main() -> int:
     if not transcript_path or not os.path.isfile(transcript_path):
         return 0
 
-    events = _load_transcript(transcript_path)
+    events = load_transcript(transcript_path)
     if not events:
         return 0
 
-    turn = _get_current_turn(events)
+    turn = get_current_turn(events)
     if not turn:
         return 0
 
-    last_text = _extract_last_assistant_text(turn)
+    last_text = extract_last_assistant_text(turn)
     if not last_text:
         return 0
 
-    has_bash = _has_tool_in_turn(turn, "Bash")
-    has_read = _has_tool_in_turn(turn, "Read")
+    has_bash = has_tool_in_turn(turn, "Bash")
+    has_read = has_tool_in_turn(turn, "Read")
 
     # Rule 1: completion-signal without evidence
     if _has_completion_signal(last_text) and not _has_evidence_block(

--- a/hooks/completion-verify/merge-state-claim-gate/impl.py
+++ b/hooks/completion-verify/merge-state-claim-gate/impl.py
@@ -27,6 +27,11 @@ from pathlib import Path as _Path
 
 sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
+from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
+    extract_last_assistant_text,
+    get_current_turn,
+    load_transcript,
+)
 
 _PREFIX = "[merge-state-claim-gate]"
 _BYPASS_ENV = "PRAXIS_MERGE_CLAIM_BYPASS"
@@ -72,62 +77,6 @@ _NEGATION_RE = re.compile(
 
 _GH_EVIDENCE_RE = re.compile(r"\bgh\b[^|;&\n]*\b(pr|issue)\b\s+[a-z]", re.IGNORECASE)
 _MCP_GH_EVIDENCE_RE = re.compile(r"pull_request|issue|merge|pr_", re.IGNORECASE)
-
-
-def _load_transcript(path: str) -> list[dict]:
-    """Load JSONL transcript, return list of event dicts. Fail-open."""
-    events: list[dict] = []
-    try:
-        with open(path, encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    obj = json.loads(line)
-                    if isinstance(obj, dict):
-                        events.append(obj)
-                except Exception:
-                    continue
-    except Exception:
-        pass
-    return events
-
-
-def _get_current_turn(events: list[dict]) -> list[dict]:
-    """Return events since the last real user input (non-tool-result user msg)."""
-    last_user_idx: int | None = None
-    for i, ev in enumerate(events):
-        msg = ev.get("message", {})
-        if msg.get("role") != "user" or ev.get("isSidechain"):
-            continue
-        content = msg.get("content", [])
-        if isinstance(content, str):
-            last_user_idx = i
-        elif isinstance(content, list):
-            if [b for b in content if isinstance(b, dict) and b.get("type") != "tool_result"]:
-                last_user_idx = i
-    start = 0 if last_user_idx is None else last_user_idx + 1
-    return events[start:]
-
-
-def _extract_last_assistant_text(turn: list[dict]) -> str:
-    last_asst = None
-    for ev in turn:
-        msg = ev.get("message", {})
-        if msg.get("role") == "assistant" and not ev.get("isSidechain"):
-            last_asst = ev
-    if last_asst is None:
-        return ""
-    content = last_asst.get("message", {}).get("content", [])
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        return "\n".join(
-            b.get("text", "") for b in content
-            if isinstance(b, dict) and b.get("type") == "text"
-        )
-    return ""
 
 
 def detect_claims(text: str) -> list[str]:
@@ -201,12 +150,12 @@ def main() -> int:
     if not transcript_path or not os.path.isfile(transcript_path):
         return 0
 
-    events = _load_transcript(transcript_path)
+    events = load_transcript(transcript_path)
     if not events:
         return 0
 
-    turn = _get_current_turn(events)
-    last_text = _extract_last_assistant_text(turn) if turn else ""
+    turn = get_current_turn(events)
+    last_text = extract_last_assistant_text(turn) if turn else ""
     if not last_text:
         return 0
 

--- a/hooks/completion-verify/readonly-verify-deferral-gate/impl.py
+++ b/hooks/completion-verify/readonly-verify-deferral-gate/impl.py
@@ -58,6 +58,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
+from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
+    extract_last_assistant_text,
+    get_current_turn,
+    load_transcript,
+)
 
 # ---------------------------------------------------------------------------
 # Prefix / env
@@ -281,69 +286,6 @@ def _is_readonly_offer(text: str, extra: re.Pattern[str] | None) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Transcript parsing (mirrors completion-signal-gate)
-# ---------------------------------------------------------------------------
-
-
-def _load_transcript(path: str) -> list[dict]:
-    """Load JSONL transcript, return list of event dicts. Fail-open."""
-    events: list[dict] = []
-    try:
-        with open(path, encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    obj = json.loads(line)
-                    if isinstance(obj, dict):
-                        events.append(obj)
-                except Exception:
-                    continue
-    except Exception:
-        pass
-    return events
-
-
-def _get_current_turn(events: list[dict]) -> list[dict]:
-    """Return events since the last real user input (non-tool-result user msg)."""
-    last_user_idx: int | None = None
-    for i, ev in enumerate(events):
-        msg = ev.get("message", {})
-        if msg.get("role") != "user":
-            continue
-        if ev.get("isSidechain"):
-            continue
-        content = msg.get("content", [])
-        if isinstance(content, str):
-            last_user_idx = i
-        elif isinstance(content, list):
-            non_tool = [b for b in content if b.get("type") != "tool_result"]
-            if non_tool:
-                last_user_idx = i
-    start = 0 if last_user_idx is None else last_user_idx + 1
-    return events[start:]
-
-
-def _extract_last_assistant_text(turn: list[dict]) -> str:
-    """Extract text from the last assistant message in the turn."""
-    last_asst = None
-    for ev in turn:
-        msg = ev.get("message", {})
-        if msg.get("role") == "assistant" and not ev.get("isSidechain"):
-            last_asst = ev
-    if last_asst is None:
-        return ""
-    content = last_asst.get("message", {}).get("content", [])
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts = [b.get("text", "") for b in content if b.get("type") == "text"]
-        return "\n".join(parts)
-    return ""
-
-
-# ---------------------------------------------------------------------------
 # Advisory text
 # ---------------------------------------------------------------------------
 
@@ -385,15 +327,15 @@ def main() -> int:
     if not transcript_path or not os.path.isfile(transcript_path):
         return 0
 
-    events = _load_transcript(transcript_path)
+    events = load_transcript(transcript_path)
     if not events:
         return 0
 
-    turn = _get_current_turn(events)
+    turn = get_current_turn(events)
     if not turn:
         return 0
 
-    last_text = _extract_last_assistant_text(turn)
+    last_text = extract_last_assistant_text(turn)
     if not last_text:
         return 0
 

--- a/hooks/preflight-gate/block-ask-end-option/impl.py
+++ b/hooks/preflight-gate/block-ask-end-option/impl.py
@@ -46,6 +46,7 @@ import sys
 from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
+from _transcript import read_last_user_message  # type: ignore[import-not-found]  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Pattern definitions
@@ -212,101 +213,6 @@ def _has_end_marker(labels: list[str]) -> bool:
     return False
 
 
-def _read_last_user_message(transcript_path: str) -> str | None:
-    """Return the text of the most recent user-authored message in the transcript.
-
-    Returns None when the transcript is missing or unreadable — the caller
-    must fail open per the project hook design contract (`Fail-open on
-    infrastructure errors`). Returns empty string when the transcript was
-    read successfully but no user message contained extractable human
-    text — that is a real "no stop-signal" answer and may be acted on.
-
-    Transcript format: JSONL where each line is a JSON object with at
-    least `type` ('user' / 'assistant' / 'system') and either `message`
-    (an Anthropic API message dict with `role` + `content`) or a flatter
-    `content` field. Both shapes are handled.
-
-    tool_result handling (codex review #193 F2): an Anthropic user role
-    message may carry only `tool_result` content blocks when the
-    assistant invoked tools in the same turn before invoking
-    AskUserQuestion. Such entries are NOT human authored — they are the
-    runtime's bridge for tool outputs. We must skip them and keep walking
-    backward until we find a user entry that contains actual `type: text`
-    content. Returning the empty string on the first tool_result-only
-    entry causes false-block in strict mode even though the real user
-    message earlier in the transcript did signal stop.
-    """
-    if not transcript_path or not os.path.isfile(transcript_path):
-        return None
-    try:
-        with open(transcript_path, "r", encoding="utf-8", errors="replace") as f:
-            lines = f.readlines()
-    except OSError:
-        return None
-
-    # Walk in reverse to find the most recent user-role entry whose
-    # content includes human-authored text. tool_result-only entries are
-    # skipped (continue), not returned as empty (which would block the
-    # search at the wrong layer).
-    for raw in reversed(lines):
-        raw = raw.strip()
-        if not raw:
-            continue
-        try:
-            entry = json.loads(raw)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(entry, dict):
-            continue
-
-        role = entry.get("type") or entry.get("role")
-        message = entry.get("message")
-        if isinstance(message, dict) and not role:
-            role = message.get("role")
-
-        if role != "user":
-            continue
-
-        # Extract text. Possible shapes:
-        #   {"type": "user", "message": {"role": "user", "content": "text"}}
-        #   {"type": "user", "message": {"role": "user", "content": [{"type":"text","text":"..."}]}}
-        #   {"type": "user", "message": {"role": "user", "content": [{"type":"tool_result", ...}]}}
-        #   {"role": "user", "content": "text"}
-        content = None
-        if isinstance(message, dict):
-            content = message.get("content")
-        if content is None:
-            content = entry.get("content")
-
-        text = ""
-        if isinstance(content, str):
-            text = content
-        elif isinstance(content, list):
-            parts: list[str] = []
-            for item in content:
-                if isinstance(item, dict):
-                    # Skip non-text blocks (tool_result, image, etc.).
-                    # Only `type: text` (or items lacking a type but
-                    # carrying a `text` field) count as human content.
-                    item_type = item.get("type")
-                    if item_type and item_type != "text":
-                        continue
-                    t = item.get("text")
-                    if isinstance(t, str):
-                        parts.append(t)
-                elif isinstance(item, str):
-                    parts.append(item)
-            text = "\n".join(parts)
-        # else: unexpected content shape — fall through to skip
-
-        if text.strip():
-            return text
-        # No human text in this entry — keep walking backward.
-        continue
-
-    return ""
-
-
 def _has_stop_signal(user_message: str) -> bool:
     """True if the user message carries an explicit stop directive.
 
@@ -439,7 +345,7 @@ def main() -> int:
         return 0
 
     transcript_path = payload.get("transcript_path") or ""
-    user_message = _read_last_user_message(transcript_path)
+    user_message = read_last_user_message(transcript_path)
     if user_message is None:
         # Fail open per project hook design contract — transcript missing
         # or unreadable, cannot verify stop-signal absence.

--- a/hooks/preflight-gate/block-gh-issue-create-without-dup-search/impl.py
+++ b/hooks/preflight-gate/block-gh-issue-create-without-dup-search/impl.py
@@ -50,6 +50,7 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     safe_tokenize,
     strip_prefix,
 )
+from _transcript import read_transcript_tail  # type: ignore[import-not-found]  # noqa: E402
 
 
 @fail_open
@@ -92,7 +93,7 @@ def main() -> int:
     if not transcript_path:
         return 0
 
-    tail = _read_transcript_tail(transcript_path, max_lines=400, max_bytes=50 * 1024 * 1024)
+    tail = read_transcript_tail(transcript_path, max_lines=400, max_bytes=50 * 1024 * 1024)
     if tail is None:
         return 0
 
@@ -358,18 +359,6 @@ def _extract_search_topic(cmd: str) -> set[str]:
         topic.update(_topic_tokens_from(tok))
         i += 1
     return topic
-
-
-def _read_transcript_tail(path: str, max_lines: int, max_bytes: int) -> str | None:
-    try:
-        p = Path(path)
-        if not p.is_file() or p.stat().st_size > max_bytes:
-            return None
-        text = p.read_text(encoding="utf-8", errors="replace")
-    except (OSError, ValueError):
-        return None
-    lines = text.strip().split("\n")
-    return "\n".join(lines[-max_lines:])
 
 
 def _emit_no_search_block(keywords: list[str]) -> None:

--- a/hooks/preflight-gate/block-manufactured-action-menu/impl.py
+++ b/hooks/preflight-gate/block-manufactured-action-menu/impl.py
@@ -50,6 +50,7 @@ import sys
 from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
+from _transcript import read_last_user_message  # type: ignore[import-not-found]  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Pattern definitions
@@ -266,84 +267,6 @@ def _has_manufactured_marker(labels: list[str]) -> bool:
     return False
 
 
-def _read_last_user_message(transcript_path: str) -> str | None:
-    """Return the text of the most recent user-authored message in the transcript.
-
-    Returns None when the transcript is missing or unreadable — the caller
-    must fail open per the project hook design contract (`Fail-open on
-    infrastructure errors`). Returns empty string when the transcript was
-    read successfully but no user message contained extractable human
-    text — that is a real "no command-signal" answer and may be acted on.
-
-    Transcript format: JSONL where each line is a JSON object with at
-    least `type` ('user' / 'assistant' / 'system') and either `message`
-    (an Anthropic API message dict with `role` + `content`) or a flatter
-    `content` field. Both shapes are handled.
-
-    tool_result handling: an Anthropic user role message may carry only
-    `tool_result` content blocks when the assistant invoked tools in the
-    same turn before invoking AskUserQuestion. Such entries are NOT human
-    authored — they are the runtime's bridge for tool outputs. We must
-    skip them and keep walking backward until we find a user entry that
-    contains actual `type: text` content.
-    """
-    if not transcript_path or not os.path.isfile(transcript_path):
-        return None
-    try:
-        with open(transcript_path, "r", encoding="utf-8", errors="replace") as f:
-            lines = f.readlines()
-    except OSError:
-        return None
-
-    for raw in reversed(lines):
-        raw = raw.strip()
-        if not raw:
-            continue
-        try:
-            entry = json.loads(raw)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(entry, dict):
-            continue
-
-        role = entry.get("type") or entry.get("role")
-        message = entry.get("message")
-        if isinstance(message, dict) and not role:
-            role = message.get("role")
-
-        if role != "user":
-            continue
-
-        content = None
-        if isinstance(message, dict):
-            content = message.get("content")
-        if content is None:
-            content = entry.get("content")
-
-        text = ""
-        if isinstance(content, str):
-            text = content
-        elif isinstance(content, list):
-            parts: list[str] = []
-            for item in content:
-                if isinstance(item, dict):
-                    item_type = item.get("type")
-                    if item_type and item_type != "text":
-                        continue
-                    t = item.get("text")
-                    if isinstance(t, str):
-                        parts.append(t)
-                elif isinstance(item, str):
-                    parts.append(item)
-            text = "\n".join(parts)
-
-        if text.strip():
-            return text
-        continue
-
-    return ""
-
-
 def _has_destructive_label(labels: list[str]) -> bool:
     """True if any option label names a destructive / irreversible action.
 
@@ -534,7 +457,7 @@ def main() -> int:
         return 0
 
     transcript_path = payload.get("transcript_path") or ""
-    user_message = _read_last_user_message(transcript_path)
+    user_message = read_last_user_message(transcript_path)
     if user_message is None:
         # Fail open per project hook design contract — transcript missing
         # or unreadable, cannot verify command-signal presence.

--- a/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
+++ b/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
@@ -73,7 +73,7 @@ import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
-from pathlib import Path
+from _transcript import load_transcript_objs  # type: ignore[import-not-found]  # noqa: E402
 
 
 @fail_open
@@ -467,26 +467,6 @@ _FINDING_KINDS = frozenset({_ASSISTANT_TEXT, _AGENT_RESULT})
 _SUBAGENT_TOOLS = frozenset({"Agent", "Task"})
 
 
-def _load_transcript_objs(path: str, max_bytes: int) -> list | None:
-    try:
-        p = Path(path)
-        if not p.is_file() or p.stat().st_size > max_bytes:
-            return None
-        text = p.read_text(encoding="utf-8", errors="replace")
-    except (OSError, ValueError):
-        return None
-    objs: list = []
-    for line in text.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            objs.append(json.loads(line))
-        except (json.JSONDecodeError, ValueError):
-            continue  # skip non-JSON lines, keep scanning
-    return objs
-
-
 def _map_tool_use_names(objs: list) -> dict:
     """Map tool_use_id → tool name across the WHOLE transcript so a recent
     tool_result can be resolved even when its originating tool_use predates the
@@ -586,7 +566,7 @@ def _build_finding_scan(path: str, max_entries: int, max_bytes: int):
                         agent-authored (assistant text / Agent result) spans.
       matched_markers — the matched marker strings (for the block message).
     """
-    objs = _load_transcript_objs(path, max_bytes)
+    objs = load_transcript_objs(path, max_bytes)
     if objs is None:
         return None
     tool_names = _map_tool_use_names(objs)

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -1,0 +1,310 @@
+"""Contract + single-source tests for the hoisted transcript helpers (#643).
+
+`hooks/_lib/_transcript.py` is the single source of truth for the JSONL
+transcript readers that seven hooks previously re-implemented locally
+(three Stop gates, two AskUserQuestion gates, two bounded preflight
+readers) plus the TRANSCRIPT_SCAN_LINES constant two advisory hooks
+re-declared. This suite locks three guarantees:
+
+  1. **Contract** — each helper handles the transcript shapes the
+     original call sites exercised: dict/str content, tool_result-only
+     user entries, sidechain events, flat `{"role": ...}` entries,
+     malformed JSON lines, non-dict objects, size bounds.
+
+  2. **Single source** — every converted hook imports the SAME function
+     object from _lib, so the parsers can no longer drift.
+
+  3. **Fail-open** — missing files return the documented sentinel
+     (None or []) and malformed input never raises.
+
+Run: python3 -m pytest tests/test_transcript.py -q
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LIB_DIR = REPO_ROOT / "hooks" / "_lib"
+
+sys.path.insert(0, str(LIB_DIR))
+
+import _transcript as T  # type: ignore[import-not-found]  # noqa: E402
+
+
+def _write_jsonl(tmp_path: Path, lines: list) -> str:
+    p = tmp_path / "transcript.jsonl"
+    p.write_text(
+        "\n".join(json.dumps(x) if not isinstance(x, str) else x for x in lines),
+        encoding="utf-8",
+    )
+    return str(p)
+
+
+def _user(text=None, blocks=None, sidechain=False) -> dict:
+    content = text if text is not None else blocks
+    ev = {"type": "user", "message": {"role": "user", "content": content}}
+    if sidechain:
+        ev["isSidechain"] = True
+    return ev
+
+
+def _assistant(text=None, blocks=None, sidechain=False) -> dict:
+    content = text if text is not None else blocks
+    ev = {"type": "assistant", "message": {"role": "assistant", "content": content}}
+    if sidechain:
+        ev["isSidechain"] = True
+    return ev
+
+
+# ---------------------------------------------------------------------------
+# load_transcript
+# ---------------------------------------------------------------------------
+
+class TestLoadTranscript:
+    def test_skips_blank_bad_json_and_non_dicts(self, tmp_path):
+        path = _write_jsonl(tmp_path, [
+            _user(text="hello"), "", "not json", json.dumps([1, 2]),
+            _assistant(text="done"),
+        ])
+        events = T.load_transcript(path)
+        assert len(events) == 2
+        assert all(isinstance(e, dict) for e in events)
+
+    def test_missing_file_returns_empty_list(self):
+        assert T.load_transcript("/nonexistent/x.jsonl") == []
+
+
+# ---------------------------------------------------------------------------
+# load_transcript_objs / read_transcript_tail (bounded readers)
+# ---------------------------------------------------------------------------
+
+class TestBoundedReaders:
+    def test_objs_keeps_non_dicts_and_skips_bad_lines(self, tmp_path):
+        path = _write_jsonl(tmp_path, [_user(text="hi"), json.dumps([1]), "broken"])
+        objs = T.load_transcript_objs(path, max_bytes=1 << 20)
+        assert len(objs) == 2  # dict + list survive, broken line skipped
+        assert isinstance(objs[1], list)
+
+    def test_objs_over_max_bytes_returns_none(self, tmp_path):
+        path = _write_jsonl(tmp_path, [_user(text="x" * 100)])
+        assert T.load_transcript_objs(path, max_bytes=10) is None
+
+    def test_objs_missing_file_returns_none(self):
+        assert T.load_transcript_objs("/nonexistent/x.jsonl", max_bytes=100) is None
+
+    def test_tail_returns_last_n_lines(self, tmp_path):
+        path = _write_jsonl(tmp_path, [f'{{"i": {i}}}' for i in range(10)])
+        tail = T.read_transcript_tail(path, max_lines=3, max_bytes=1 << 20)
+        assert tail is not None
+        assert tail.splitlines() == ['{"i": 7}', '{"i": 8}', '{"i": 9}']
+
+    def test_tail_over_max_bytes_returns_none(self, tmp_path):
+        path = _write_jsonl(tmp_path, ['{"k": "v"}'] * 5)
+        assert T.read_transcript_tail(path, max_lines=2, max_bytes=3) is None
+
+
+# ---------------------------------------------------------------------------
+# get_current_turn
+# ---------------------------------------------------------------------------
+
+class TestGetCurrentTurn:
+    def test_tool_result_only_user_msg_is_not_a_boundary(self):
+        events = [
+            _user(text="real question"),
+            _assistant(blocks=[{"type": "tool_use", "name": "Bash", "id": "t1"}]),
+            _user(blocks=[{"type": "tool_result", "tool_use_id": "t1"}]),
+            _assistant(text="answer"),
+        ]
+        turn = T.get_current_turn(events)
+        assert len(turn) == 3  # everything after the real user message
+
+    def test_sidechain_user_msg_is_not_a_boundary(self):
+        events = [
+            _user(text="real"),
+            _user(text="agent prompt", sidechain=True),
+            _assistant(text="reply"),
+        ]
+        assert len(T.get_current_turn(events)) == 2
+
+    def test_string_content_is_a_boundary(self):
+        events = [_assistant(text="old"), _user(text="next"), _assistant(text="new")]
+        turn = T.get_current_turn(events)
+        assert len(turn) == 1
+
+    def test_non_dict_blocks_are_tolerated(self):
+        events = [
+            {"type": "user", "message": {"role": "user", "content": ["bare-string"]}},
+            _assistant(text="x"),
+        ]
+        # A list with no dict blocks has no non-tool_result dict → not a boundary.
+        assert len(T.get_current_turn(events)) == 2
+
+    def test_no_user_message_returns_all(self):
+        events = [_assistant(text="a"), _assistant(text="b")]
+        assert T.get_current_turn(events) == events
+
+
+# ---------------------------------------------------------------------------
+# extract_last_assistant_text / has_tool_in_turn
+# ---------------------------------------------------------------------------
+
+class TestAssistantHelpers:
+    def test_extract_joins_text_blocks_and_skips_non_dicts(self):
+        turn = [
+            _assistant(blocks=[
+                {"type": "text", "text": "part1"},
+                "stray",
+                {"type": "tool_use", "name": "Bash", "id": "t"},
+                {"type": "text", "text": "part2"},
+            ]),
+        ]
+        assert T.extract_last_assistant_text(turn) == "part1\npart2"
+
+    def test_extract_takes_last_non_sidechain(self):
+        turn = [
+            _assistant(text="first"),
+            _assistant(text="side", sidechain=True),
+        ]
+        assert T.extract_last_assistant_text(turn) == "first"
+
+    def test_extract_string_content(self):
+        assert T.extract_last_assistant_text([_assistant(text="plain")]) == "plain"
+
+    def test_extract_empty_turn(self):
+        assert T.extract_last_assistant_text([]) == ""
+
+    def test_has_tool_in_turn(self):
+        turn = [
+            _assistant(blocks=[{"type": "tool_use", "name": "Bash", "id": "t"}]),
+        ]
+        assert T.has_tool_in_turn(turn, "Bash") is True
+        assert T.has_tool_in_turn(turn, "Read") is False
+
+    def test_has_tool_skips_non_dict_blocks(self):
+        turn = [
+            _assistant(blocks=["bare", {"type": "tool_use", "name": "Bash", "id": "t"}]),
+        ]
+        assert T.has_tool_in_turn(turn, "Bash") is True
+
+    def test_has_tool_skips_sidechain(self):
+        turn = [
+            _assistant(
+                blocks=[{"type": "tool_use", "name": "Bash", "id": "t"}],
+                sidechain=True,
+            ),
+        ]
+        assert T.has_tool_in_turn(turn, "Bash") is False
+
+
+# ---------------------------------------------------------------------------
+# read_last_user_message
+# ---------------------------------------------------------------------------
+
+class TestReadLastUserMessage:
+    def test_skips_tool_result_only_entry(self, tmp_path):
+        path = _write_jsonl(tmp_path, [
+            _user(text="stop here please"),
+            _user(blocks=[{"type": "tool_result", "tool_use_id": "t1"}]),
+        ])
+        assert T.read_last_user_message(path) == "stop here please"
+
+    def test_flat_role_content_shape(self, tmp_path):
+        path = _write_jsonl(tmp_path, [{"role": "user", "content": "flat shape"}])
+        assert T.read_last_user_message(path) == "flat shape"
+
+    def test_missing_file_returns_none(self):
+        assert T.read_last_user_message("/nonexistent/x.jsonl") is None
+
+    def test_empty_arg_returns_none(self):
+        assert T.read_last_user_message("") is None
+
+    def test_no_user_text_returns_empty_string(self, tmp_path):
+        path = _write_jsonl(tmp_path, [_assistant(text="only assistant")])
+        assert T.read_last_user_message(path) == ""
+
+    def test_malformed_line_between_user_messages_is_skipped(self, tmp_path):
+        path = _write_jsonl(tmp_path, [
+            _user(text="older message"),
+            "not-json {{{",
+            _user(text="latest message"),
+        ])
+        assert T.read_last_user_message(path) == "latest message"
+
+    def test_text_blocks_joined(self, tmp_path):
+        path = _write_jsonl(tmp_path, [
+            _user(blocks=[{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]),
+        ])
+        assert T.read_last_user_message(path) == "a\nb"
+
+
+# ---------------------------------------------------------------------------
+# Single source — every converted hook binds the SAME function objects
+# ---------------------------------------------------------------------------
+
+HOOKS = REPO_ROOT / "hooks"
+
+_CONSUMERS = {
+    HOOKS / "completion-verify" / "readonly-verify-deferral-gate" / "impl.py":
+        ["load_transcript", "get_current_turn", "extract_last_assistant_text"],
+    HOOKS / "completion-verify" / "completion-signal-gate" / "impl.py":
+        ["load_transcript", "get_current_turn", "extract_last_assistant_text",
+         "has_tool_in_turn"],
+    HOOKS / "completion-verify" / "merge-state-claim-gate" / "impl.py":
+        ["load_transcript", "get_current_turn", "extract_last_assistant_text"],
+    HOOKS / "preflight-gate" / "block-gh-issue-create-without-dup-search" / "impl.py":
+        ["read_transcript_tail"],
+    HOOKS / "preflight-gate" / "block-sciomc-finding-commit" / "impl.py":
+        ["load_transcript_objs"],
+    HOOKS / "preflight-gate" / "block-ask-end-option" / "impl.py":
+        ["read_last_user_message"],
+    HOOKS / "preflight-gate" / "block-manufactured-action-menu" / "impl.py":
+        ["read_last_user_message"],
+}
+
+_CONSTANT_CONSUMERS = [
+    HOOKS / "advisory-nudge" / "external-write-falsify-check" / "impl.py",
+    HOOKS / "advisory-nudge" / "pre-output-falsification-gate" / "impl.py",
+]
+
+
+def _load_module(path: Path):
+    name = f"hookmod_{path.parent.name}".replace("-", "_")
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+class TestSingleSource:
+    def test_consumers_bind_lib_function_objects(self):
+        for path, symbols in _CONSUMERS.items():
+            mod = _load_module(path)
+            for sym in symbols:
+                assert getattr(mod, sym) is getattr(T, sym), (
+                    f"{path.parent.name} binds a different {sym} object"
+                )
+
+    def test_constant_consumers_bind_lib_value(self):
+        for path in _CONSTANT_CONSUMERS:
+            mod = _load_module(path)
+            assert mod.TRANSCRIPT_SCAN_LINES == T.TRANSCRIPT_SCAN_LINES
+
+    def test_no_local_redefinitions_remain(self):
+        offenders = []
+        for impl in HOOKS.glob("*/*/impl.py"):
+            text = impl.read_text(encoding="utf-8")
+            for needle in (
+                "def _load_transcript", "def _read_last_user_message",
+                "def _read_transcript_tail", "def _get_current_turn",
+                "def _extract_last_assistant_text",
+                "def _has_tool_in_turn", "def _load_transcript_objs",
+                "_TRANSCRIPT_SCAN_LINES =",
+            ):
+                if needle in text:
+                    offenders.append(f"{impl}: {needle}")
+        assert not offenders, f"local duplicates remain: {offenders}"


### PR DESCRIPTION
## 개요

7개 훅이 각자 재구현하던 transcript JSONL 스캔 로직을 `hooks/_lib/_transcript.py` 단일 SoT로 수렴하고, 2개 advisory 훅의 중복 상수 `_TRANSCRIPT_SCAN_LINES = 400`을 import로 대체합니다. 2026-06-04 감사가 지목한 근본 원인(이중 SoT drift)과 동일 클래스의 최대 잔존 중복(약 430라인 삭제)입니다.

Closes #643

## 변경 내용

**신설** — `hooks/_lib/_transcript.py` (public API 7종 + 상수 1종):
`load_transcript` / `load_transcript_objs` / `read_transcript_tail` / `get_current_turn` / `extract_last_assistant_text` / `has_tool_in_turn` / `read_last_user_message` / `TRANSCRIPT_SCAN_LINES`

**전환** — 9개 훅:

| 훅 | 대체된 로컬 심볼 |
|---|---|
| `readonly-verify-deferral-gate`, `completion-signal-gate`, `merge-state-claim-gate` | `_load_transcript`, `_get_current_turn`, `_extract_last_assistant_text` (+signal-gate의 `_has_tool_in_turn`) |
| `block-ask-end-option`, `block-manufactured-action-menu` | `_read_last_user_message` |
| `block-gh-issue-create-without-dup-search` | `_read_transcript_tail` |
| `block-sciomc-finding-commit` | `_load_transcript_objs` (+불용 `Path` import 제거) |
| `external-write-falsify-check`, `pre-output-falsification-gate` | `_TRANSCRIPT_SCAN_LINES` 상수 |

**의도된 거동 변화 1건 (hardening)**: canonical 본문은 가장 방어적이던 merge-state-claim-gate 변형의 `isinstance` 가드를 채택. 기존 unguarded 사본은 content 리스트에 bare string이 섞이면 `AttributeError`를 일으켜 `fail_open`이 삼킨 채 turn 스캔 전체가 무력화되는 잠재 결함이 있었음 — 가드 채택으로 해당 케이스에서 스캔이 계속 동작.

**테스트** — `tests/test_transcript.py` 31건: contract(경계/tool_result 스킵/sidechain/크기 한도) + single-source(함수 객체 `is` identity 고정) + 로컬 재정의 재발 방지 grep + fail-open.

## 리뷰

- `oh-my-claudecode:code-reviewer`: **APPROVE** — MEDIUM 1(중복 dict 재조회) + LOW 3(테스트 커버리지) 전부 반영, CRITICAL/HIGH 0
- `praxis:codex-review-wrap` → codex: **클린 패스** ("기존 호출부를 깨뜨리는 명확한 결함 없음"; pytest는 codex 샌드박스 제약으로 미실행 — 로컬 실행으로 대체 검증)

## 검증

- `python3 -m pytest tests/test_transcript.py -q` → **31 passed**
- `ruff check hooks/ tests/test_transcript.py` → All checks passed
- `./scripts/run-tests.sh` → exit=0, **ALL TESTS PASSED** (기존 훅 테스트 전체 포함)
- acceptance grep: `grep -ln "_load_transcript\|def _read_last_user_message\|def _read_transcript_tail\|_TRANSCRIPT_SCAN_LINES" hooks/*/*/impl.py` → **0건**

## 검증 안 된 것

- 라이브 Claude Code 세션에서의 훅 발화는 미실행 (유닛 + 전체 스위트로 대체). 디스패처 in-process import 경로는 single-source 테스트의 importlib 로드로 등가 검증.

## 영향 범위

훅 9개의 transcript 파싱 경로. manifest/패키징 변경 없음 (`check-plugin-manifests.py` OK). 잘못될 경우 영향은 advisory/gate 훅의 오탐·미탐이며 fail-open 계약으로 도구 호출 차단은 발생하지 않음.

Pre-commit verified: ./scripts/run-tests.sh → ALL TESTS PASSED (exit=0); ruff clean; pytest tests/test_transcript.py 31 passed
Caller chain verified: 전환된 9개 impl.py의 호출부 전수 grep로 확인 — 구 심볼 잔존 0건, 함수 객체 identity 테스트로 import 체인 고정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized transcript handling into a shared utility to make transcript-based checks more consistent across hooks.

* **Bug Fixes**
  * More tolerant handling of missing, unreadable, or malformed transcripts so safeguards and advisories are less likely to fail or trigger incorrectly.

* **Tests**
  * Added tests covering transcript parsing, boundary cases, and error scenarios to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->