### PR TITLE
chore(hooks): apply fail_open to standalone hooks

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -27,6 +27,25 @@ Design mechanisms shared by all hooks:
 - **Session state via `session_id`.** Per-session memory (intent flags,
   DESCRIBE history) keys on the payload's `session_id` field. PPID is a
   back-compat fallback for direct CLI / test invocation only.
+- **Fail-open via `_hook_runtime.fail_open` (issue #645).** A hook crash
+  must never block a legitimate tool call (ETHOS). Coverage has exactly
+  two paths, by execution mode:
+  - **Dispatched hooks** — members of the `(PreToolUse, Bash)` dispatch
+    group (ADR-0002) run inside `_dispatch.py`, which wraps every member
+    `main()` with `_hook_runtime.fail_open` at runtime. Member `impl.py`
+    files need no decorator of their own; an `impl.py`-level reference is
+    redundant but harmless (double-wrap is a no-op).
+  - **Standalone hooks** — everything invoked through its own
+    `hooks/<name>.sh` wrapper (non-Bash or multi-tool matchers,
+    UserPromptSubmit/PostToolUse/Stop events, opt-in hooks) must apply
+    `@fail_open` to `main()` in `impl.py` directly (argv-style mains wrap
+    a zero-arg `_entry()` instead). Rule 15 in
+    `scripts/check-plugin-manifests.py` enforces this invariant.
+
+  Trade-off, stated explicitly: for *gates*, fail-open means a crashed
+  guard allows the action it would have screened. That is the deliberate
+  ETHOS choice — hook infrastructure failure must degrade to "no hook"
+  rather than "no work".
 - **Compound-Bash cascade advisory (issue #229).** When a PreToolUse(Bash)
   hook rejects (block) or asks-and-may-deny a compound command (`&&`, `||`,
   `;`, `|`, newline) containing a state-changing step (`> file`, `<<EOF >`,

--- a/hooks/advisory-nudge/external-api-literal-trigger/impl.py
+++ b/hooks/advisory-nudge/external-api-literal-trigger/impl.py
@@ -39,6 +39,7 @@ import sys
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import safe_tokenize  # type: ignore[import-not-found]  # noqa: E402
 
 # ---------------------------------------------------------------------------
@@ -252,6 +253,7 @@ def extract_scan_target(tool_name: str, tool_input: dict) -> str | None:
 # Main
 # ---------------------------------------------------------------------------
 
+@fail_open
 def main() -> int:
     try:
         payload = json.load(sys.stdin)

--- a/hooks/advisory-nudge/external-write-falsify-check/impl.py
+++ b/hooks/advisory-nudge/external-write-falsify-check/impl.py
@@ -43,6 +43,7 @@ import sys
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     iter_command_starts,
     safe_tokenize,
@@ -522,6 +523,7 @@ def _is_staging_path(file_path: str) -> bool:
     return any(pat.search(file_path) for pat in STAGING_PATH_PATTERNS)
 
 
+@fail_open
 def main() -> int:
     try:
         payload = json.load(sys.stdin)

--- a/hooks/advisory-nudge/memory-hint/impl.py
+++ b/hooks/advisory-nudge/memory-hint/impl.py
@@ -46,6 +46,7 @@ import sys
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     iter_command_starts,
     safe_tokenize,
@@ -327,6 +328,7 @@ def emit_hits(hits: list[tuple[str, dict, float]]) -> None:
         sys.stderr.write(f"[memory:hookable] ...and {extra} more\n")
 
 
+@fail_open
 def main() -> int:
     try:
         payload = json.load(sys.stdin)

--- a/hooks/advisory-nudge/postcompact-context/impl.py
+++ b/hooks/advisory-nudge/postcompact-context/impl.py
@@ -74,6 +74,7 @@ from pathlib import Path
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _paths import praxis_state_dir, legacy_state_dir  # type: ignore[import-not-found]  # noqa: E402
 
 DEFAULT_TAIL_LINES = 100
@@ -372,6 +373,7 @@ def _tail_lines_setting() -> int:
     return value
 
 
+@fail_open
 def main() -> int:
     if os.environ.get(BYPASS_ENV, "").strip() == "1":
         return 0

--- a/hooks/postuse-correction/builtin-task-postuse/impl.py
+++ b/hooks/postuse-correction/builtin-task-postuse/impl.py
@@ -77,7 +77,7 @@ def main() -> int:
     try:
         payload = json.load(sys.stdin)
     except (json.JSONDecodeError, ValueError, OSError):
-        return 0  # PATH B (malformed input): fail-open, no output
+        return 0  # Early exit (malformed input): fail-open, no output
 
     # Claude Code uses snake_case "tool_name"; camelCase fallback for forward-compat
     tool_name = payload.get("tool_name") or payload.get("toolName") or ""

--- a/hooks/postuse-correction/builtin-task-postuse/impl.py
+++ b/hooks/postuse-correction/builtin-task-postuse/impl.py
@@ -32,6 +32,11 @@ from __future__ import annotations
 import json
 import sys
 
+import sys as _sys
+from pathlib import Path as _Path
+_sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
+
 BUILTIN_TASK_MGMT_TOOLS = frozenset({
     "TaskCreate",
     "TaskUpdate",
@@ -67,11 +72,12 @@ def _emit_correction() -> None:
     sys.stdout.write("\n")
 
 
-def main() -> None:
+@fail_open
+def main() -> int:
     try:
         payload = json.load(sys.stdin)
     except (json.JSONDecodeError, ValueError, OSError):
-        sys.exit(0)  # PATH B (malformed input): fail-open, no output
+        return 0  # PATH B (malformed input): fail-open, no output
 
     # Claude Code uses snake_case "tool_name"; camelCase fallback for forward-compat
     tool_name = payload.get("tool_name") or payload.get("toolName") or ""
@@ -81,13 +87,12 @@ def main() -> None:
         # Early return here ensures PATH B code can never execute for this
         # invocation, eliminating any possibility of dual-message emission.
         _emit_correction()
-        return  # ← explicit gate: nothing below runs for PATH A
+        return 0  # ← explicit gate: nothing below runs for PATH A
 
     # PATH B: not a built-in task management tool — silent pass-through.
-    # sys.exit(0) is used (not plain return) to make the intent unambiguous:
-    # this invocation produces zero output.
-    sys.exit(0)
+    # This invocation produces zero output.
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/hooks/postuse-correction/bypass-telemetry/impl.py
+++ b/hooks/postuse-correction/bypass-telemetry/impl.py
@@ -48,6 +48,11 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+import sys as _sys
+from pathlib import Path as _Path
+_sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
+
 
 # ---------------------------------------------------------------------------
 # Bypass detection
@@ -266,6 +271,7 @@ def run(payload: dict) -> None:
     append_record(record)
 
 
+@fail_open
 def main() -> int:
     # Opt-out gate
     if os.environ.get("PRAXIS_BYPASS_TELEMETRY_DISABLE", "").strip() == "1":

--- a/hooks/postuse-correction/pre-edit-md-escape-advisory/impl.py
+++ b/hooks/postuse-correction/pre-edit-md-escape-advisory/impl.py
@@ -109,6 +109,7 @@ import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -343,5 +344,12 @@ def main(argv: list[str]) -> int:
     return 0
 
 
+@fail_open
+def _entry() -> int:
+    # main(argv) keeps its testable signature; fail_open wraps zero-arg
+    # callables only, so the wrap happens here at the process boundary.
+    return main(sys.argv)
+
+
 if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    sys.exit(_entry())

--- a/hooks/preflight-gate/pre-edit-protected-branch-guard/impl.py
+++ b/hooks/preflight-gate/pre-edit-protected-branch-guard/impl.py
@@ -56,6 +56,7 @@ import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -430,6 +431,7 @@ def _is_inflight_edit(file_path: str, repo_root: str, dirty_files: set[str]) -> 
 # ---------------------------------------------------------------------------
 
 
+@fail_open
 def main() -> int:
     try:
         payload = json.load(sys.stdin)

--- a/hooks/preflight-gate/session-intent/impl.py
+++ b/hooks/preflight-gate/session-intent/impl.py
@@ -76,6 +76,7 @@ import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
+from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     iter_command_starts,
     safe_tokenize,
@@ -488,6 +489,7 @@ def detect_event(payload: dict) -> str:
     return ""
 
 
+@fail_open
 def main() -> int:
     try:
         payload = json.load(sys.stdin)

--- a/scripts/check-plugin-manifests.py
+++ b/scripts/check-plugin-manifests.py
@@ -42,6 +42,7 @@ CI invokes this; developers can too, via `./scripts/check-plugin-manifests.py`.
 """
 from __future__ import annotations
 
+import ast
 import importlib.util
 import json
 import os
@@ -147,6 +148,29 @@ def _skill_dirs() -> list[Path]:
             continue
         dirs.append(entry)
     return dirs
+
+
+def _has_fail_open_decorator(impl_path: Path) -> bool:
+    """True iff some function in impl.py carries an `@fail_open` decorator.
+
+    AST-based on purpose (Rule 15, #645): a substring scan would accept
+    `fail_open` mentioned in a comment/docstring or imported-but-unapplied,
+    none of which actually wraps the entrypoint at runtime. A syntactically
+    invalid impl.py returns False — the hook cannot run at all, and the
+    drift message points at the right file either way.
+    """
+    try:
+        tree = ast.parse(impl_path.read_text())
+    except (OSError, SyntaxError, ValueError):
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for dec in node.decorator_list:
+                if isinstance(dec, ast.Name) and dec.id == "fail_open":
+                    return True
+                if isinstance(dec, ast.Attribute) and dec.attr == "fail_open":
+                    return True
+    return False
 
 
 def _hook_dirs() -> list[Path]:
@@ -664,6 +688,40 @@ def main() -> int:
             drifts.append(
                 f"ORPHAN STUB docs/hook/{stem}.md: no backing hook dir — "
                 "remove it, or add to NON_HOOK_DOCS if it is a real doc"
+            )
+
+    # ------------------------------------------------------------------
+    # Rule 15 — standalone hooks must apply @fail_open (#645)
+    #
+    # Dispatch-group members get `_hook_runtime.fail_open` wrapping at
+    # runtime (`_dispatch.run_one`); every other execution path runs
+    # impl.py bare, so the impl itself must carry an `@fail_open`
+    # decorator (on main(), or on a zero-arg `_entry()` for argv-style
+    # mains). A hook is dispatch-covered iff ALL its manifest entries
+    # are exactly (PreToolUse, Bash); opt-in hooks are standalone by
+    # definition. impl.sh bodies are exempt (no Python entrypoint).
+    # The rule is one-directional: a redundant decorator in a dispatched
+    # member is harmless (double-wrap is a no-op) and not flagged.
+    # Detection is AST-based (decorator on some function), not substring:
+    # `fail_open` appearing only in a comment/docstring, or imported but
+    # never applied, must NOT satisfy the invariant (codex review P2).
+    # ------------------------------------------------------------------
+    for name, role in sorted(_build.hook_identities(manifest).items()):
+        impl_path = _build.HOOKS_DIR / role / name / "impl.py"
+        if not impl_path.exists():
+            continue  # impl.sh body or missing impl — Rule 3 covers the latter
+        if name in OPT_IN_HOOKS:
+            standalone = True
+        else:
+            standalone = any(
+                not (e.get("event") == "PreToolUse" and e.get("matcher") == "Bash")
+                for e in manifest_by_name.get(name, [])
+            )
+        if standalone and not _has_fail_open_decorator(impl_path):
+            drifts.append(
+                f"FAIL-OPEN MISSING hooks/{role}/{name}/impl.py: hook runs "
+                "standalone (not dispatch-wrapped) but no function carries "
+                "the @fail_open decorator — decorate main() (DESIGN.md, #645)"
             )
 
     if drifts:


### PR DESCRIPTION
## 개요

ETHOS fail-open 계약 감사 — `fail_open` 참조가 없던 15개 훅을 실행 경로 기준으로 감별하고, standalone 실행 9개에 `@fail_open`을 적용합니다. 분류·트레이드오프를 DESIGN.md에 문서화하고, 재발 방지 invariant(Rule 15)를 `check-plugin-manifests.py`에 추가합니다.

Closes #645

## 분류 (ground truth: 생성된 `.claude-plugin/hooks/hooks.json` + `_dispatch.group_members`)

| 분류 | 훅 | 조치 |
|---|---|---|
| **디스패치 커버 (6)** — `(PreToolUse, Bash)` 그룹 멤버, 런타임이 member `main()`을 `fail_open`으로 래핑 | `side-effect-scan`, `commit-title-length-check`, `pre-merge-approval-gate`, `external-write-path-existence-check`, `block-personal-asset-leak`, `version-bump-evidence-check` | impl 무변경 (의도적) — DESIGN.md에 문서화 |
| **standalone 실행 (9)** — 자체 wrapper `.sh`로 bare 실행 (멀티툴 matcher, UserPromptSubmit/PostToolUse, opt-in) | `session-intent`*, `postcompact-context`, `memory-hint`, `external-api-literal-trigger`, `pre-edit-protected-branch-guard`, `pre-edit-md-escape-advisory`, `builtin-task-postuse`, `bypass-telemetry`, `external-write-falsify-check`(opt-in) | `@fail_open` 적용 |

\* `session-intent`는 UserPromptSubmit(standalone) + PreToolUse/Bash(dispatched) 혼합 — standalone 엔트리 때문에 적용 대상. 디스패치 경로의 double-wrap은 no-op (검증됨).

## 변경 내용

1. **9개 impl.py**: `from _hook_runtime import fail_open` + `@fail_open`. 변형 2건 — `pre-edit-md-escape-advisory`는 argv형 `main(argv)`이라 zero-arg `_entry()`를 데코레이트, `builtin-task-postuse`는 `-> None`/내부 `sys.exit(0)`을 `-> int` return으로 전환(거동 동일 — A/B로 byte-identical 확인).
2. **DESIGN.md**: "Fail-open via `_hook_runtime.fail_open`" 계약 절 신설 — 두 커버리지 경로 + gate 크래시 시 fail-open 트레이드오프 명시.
3. **check-plugin-manifests.py Rule 15**: standalone 훅(manifest 엔트리 중 하나라도 정확히 `(PreToolUse, Bash)`가 아닌 것, 또는 opt-in)의 impl.py에 `@fail_open` 데코레이터가 있는지 **AST 기반**으로 검증. substring이 아닌 이유: 주석/docstring 언급·import-only는 런타임 래핑이 아니므로 통과시키면 안 됨 (codex 리뷰 P2 수용).

## 리뷰

- `oh-my-claudecode:code-reviewer`: **APPROVE** — CRITICAL/HIGH/MEDIUM 0, LOW 2건 모두 "기존 컨벤션 유지가 옳음, no action". Rule 15 predicate가 dispatch membership oracle과 정확히 일치함을 독립 재구성으로 검증 (MIXED matcher·opt-in 엣지 포함).
- `praxis:codex-review-wrap` → codex: **P2 1건** (substring 검사 약점) — 전제 검증 후 수용, AST 데코레이터 검사로 교체. falsification 6케이스(comment-only/import-only/docstring-only/decorated/attr-decorated/syntax-error) 전부 기대값 일치.

## 검증

- `./scripts/run-tests.sh` → exit=0, **ALL TESTS PASSED** (pytest 전체 + shell 스위트 + manifest check)
- `ruff check hooks/ scripts/ tests/` → All checks passed
- **crash-injection 기능 테스트**: stdin.read가 RuntimeError를 던지도록 주입 → 9개 entrypoint 전부 raise 없이 `rc=0` (fail-open 실동작)
- **정상-경로 A/B**: origin/main vs 본 브랜치, 실제 서브프로세스 호출 10개 payload 조합 → `(exit, stdout, stderr)` 10/10 동일 (거동 보존)
- **Rule 15 negative test**: 훅 1개를 pre-#645 상태로 되돌리면 check FAIL + 정확한 메시지 발화 확인

## 검증 안 된 것

- 라이브 Claude Code 세션에서의 훅 발화는 미실행 (서브프로세스 A/B + crash-injection으로 대체)

## 영향 범위

훅 9개의 크래시 시 exit code 경로(1 → 0)와 check 스크립트. 정상 경로 거동 변화 없음(A/B 검증). 잘못될 경우 영향은 Rule 15 오탐으로 CI red — 훅 런타임 거동에는 영향 없음.

Pre-commit verified: PATH=pyenv-shims ./scripts/run-tests.sh → ALL TESTS PASSED (exit=0); ruff clean; crash-injection 9/9 rc=0; A/B 10/10 identical
Caller chain verified: 9개 훅의 entrypoint(`if __name__`)가 데코레이트된 main/_entry를 호출함을 직접 확인; 디스패치 멤버 double-wrap no-op은 code-reviewer가 독립 검증 (단일 로그라인)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified fail-open hook crash behavior and how gates degrade to “no hook” on infrastructure failures.

* **Improvements**
  * Many hooks now adopt unified fail-open handling so runtime errors fail silently and preserve normal flows.
  * Manifest validation tightened to enforce fail-open decorator presence for standalone hooks, surfacing explicit failures when missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->