### PR TITLE
refactor(retrospect): split skill into references

### DIFF
--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -967,62 +967,20 @@ Stage 3 output MUST emit, in this order:
    - `Proposed Actions (1~2)`: comma-separated subset of `memory`, `issue`, `claude_md_draft`, `skill_idea`, `hook_code`, `upstream_feedback`; for findings marked `external=true` by Stage 2.5 Gate-4, append ` (external)` suffix to `upstream_feedback` (e.g., `memory, upstream_feedback (external)`)
    - `Rationale`: free-form one-line for compound or non-memory rows; for **memory-only** rows (single `memory`, not compound), the cell MUST match Schema A or Schema B (see Gate-2 in Stage 2.5): Schema A — exactly 5 lines `^not (issue|claude_md_draft|skill_idea|hook_code|upstream_feedback): .+$`, one per non-memory action type; Schema B — 1-2 lines `^not-others: .+$` with dimension tags (e.g., `not-others: repeat=0, rule_exists=yes, gateable=no, tool_defect=no`). Generic single-sentence rationales are NOT acceptable for memory-only findings. **For rows whose actions include `upstream_feedback`** (single or compound), the cell MUST also contain a literal line `backing_repo: <owner>/<repo>` (embedded via `<br>` for single-line markdown form) — Stage 4 Action 4 step 0 reads this as the routing decision. **Compound case `memory, upstream_feedback`**: the row is NOT memory-only (contains a non-memory action), so the Schema A/B requirement does NOT apply — instead use free-form prose for the human rationale + the `backing_repo:` line. Compound combinations are *additive*: each action-specific Rationale convention applies independently to the row, joined with `<br>`.
 
-The Stop hook parses the distribution-card fence (deterministic) and the table (anchored on these literal column headers). Drift in this contract requires synchronized edits to `hooks/completion-verify/retrospect-mix-check/impl.sh`, `tests/hooks/completion-verify/test_retrospect_mix_check.sh`, and `tests/fixtures/retrospect-synth-*.expected.json`.
+The Stop hook parses the distribution-card fence (deterministic) and the table (anchored on the literal column headers shown in the unified-table template at [`references/report-template.md`](references/report-template.md)). Drift in this contract requires synchronized edits to `hooks/completion-verify/retrospect-mix-check/impl.sh`, `tests/hooks/completion-verify/test_retrospect_mix_check.sh`, and `tests/fixtures/retrospect-synth-*.expected.json`.
 
 **Spec AC-A3 deviation note** — earlier draft asked for "memory-only justification 한 줄" inside the distribution card. v2 relocates that justification into the unified-table `Rationale` column as the structured 5-line `not <action>: <reason>` block: strictly more informative than a single line, single source of truth, eliminates card↔table inconsistency risk.
 
 ---
 
-**Present findings as a single unified table per the Output Schema Contract above:**
+**Present findings as a single unified table per the Output Schema Contract
+above.** The full consolidated template (header → audit fences → distribution
+card → unified table, in emit order) lives at
+[`references/report-template.md`](references/report-template.md) — Read it when
+composing the Stage 3 report. The Output Schema Contract above is the normative
+source on any divergence.
 
-```
-## Retrospect Report — {session_date}
-
-<!-- retrospect:pre_scan_checklist begin -->
-- {category_name}: violations: none
-- {category_name}: violations:
-  - {one-line candidate} | spec_cite: {section}
-<!-- retrospect:pre_scan_checklist end -->
-
-<!-- retrospect:dismissed_candidates begin -->
-- {one-line candidate} | reason: {rationale} | spec_cite: {section}
-<!-- retrospect:dismissed_candidates end -->
-
-<!-- retrospect:tool_census begin -->
-- tool_name: {tool} | layer: {mcp|cli|builtin|skill} | call_count: {n} | error_count: {n} | retry_count: {n} | workaround_marker: {true|false} | surfaced_in_friction: {true|false} | signal: {none|summary}
-<!-- retrospect:tool_census end -->
-
-<!-- retrospect:user_correction begin -->
-- candidate: "{verbatim user-turn excerpt}" | marker_class: {negation|redirect|mismatch} | reason: {why judged not-a-correction} | cite: {turn ref / quoted context}
-<!-- retrospect:user_correction end -->
-
-<!-- retrospect:self_correction begin -->
-- corrective: "{verbatim corrective-call excerpt}" | prior: "{verbatim prior-call excerpt}" | signature: {oracle-mismatch|wrong-target|basis-change} | reason: {why judged not-a-self-correction} | cite: {turn ref}
-<!-- retrospect:self_correction end -->
-
-<!-- retrospect:distribution begin -->
-- memory: {n}
-- issue: {n}
-- claude_md_draft: {n}
-- skill_idea: {n}
-- hook_code: {n}
-- upstream_feedback: {n}
-- memory_hygiene: {n}
-- output_quality: {n}
-- gate_1_verdict: {PASS|FAIL|NA}
-- gate_2_verdict: {PASS|FAIL|NA}
-- gate_3_verdict: {PASS|FAIL|NA}
-- gate_4_verdict: {PASS|WARN|NA}
-- gate_5_verdict: {PASS|FAIL|NA}
-- gate_6_verdict: {PASS|FAIL|NA}
-<!-- retrospect:distribution end -->
-
-| # | Category | Tool Layer | Pattern | Root Cause | Rule / Gap | Repeat? | Proposed Actions (1~2) | Rationale | Priority |
-|---|----------|------------|---------|------------|------------|---------|------------------------|-----------|----------|
-| 1 | {behavioral|tool|workflow|spec-gap, ...} | {mcp|cli|builtin|skill|—} | {pattern} | {root_cause} | {rule_ref or "gap"} | {Yes(Nx)/No} | {action1[, action2]} | {rationale: 5 `not <action>:` lines for memory-only, or one-line for compound/non-memory} | HIGH/MED/LOW |
-...
-
-### Trigger Conditions (Gate-3 (b) demotions)
+#### Trigger Conditions (Gate-3 (b) demotions)
 
 (Non-machine-parsed; emitted for human review only — not parsed by the Stop hook.)
 
@@ -1044,13 +1002,12 @@ No patterns found: emit the **header**, the **`retrospect:pre_scan_checklist` fe
 
 (c) An empty `dismissed_candidates` fence is ONLY permitted when step (a) enumeration returns zero **rule-violation** matches. The Red Flag is narrow-scoped to rule violations: emitting an empty fence after step (a) surfaced a rule-violation match (instead of recording it as a ledger line) is a Red Flag (see Red Flags section). A transcript whose review-bot output is purely style nits / refactor suggestions — no rule-violation match — correctly permits an empty fence; the mere presence of a review-bot output block does NOT itself force a ledger entry.
 
-### Reinforced Patterns (this session)
+#### Reinforced Patterns (this session)
 
 (Emitted only when pre-scan found ≥1 successful_patterns with `reinforce_action: visualize_only`. Omit this section entirely if none — do not emit "None." Rows with `reinforce_action: memory` are NOT listed here — they appear in Stage 4 Actions Executed report alongside friction-origin memory entries, distinguishable by the `Reinforced — ` description prefix.)
 
 - {pattern_1} (evidence: {turn or artifact})
 - {pattern_2} ...
-```
 
 The unified table folds the previous dual-table layout (Pattern + Tool/Feature Findings) into one. Tool-layer information that previously lived in a separate "Tool/Feature Findings" table is now carried in the `Tool Layer` column of every row tagged with `tool` in `Category`. Reviewers see all findings in priority order without cross-referencing two tables.
 
@@ -1143,34 +1100,11 @@ Concretely, for each `(Recommended)`-labeled option, derive:
 
 The gate's outcome MUST appear as a `Falsification:` line in the per-finding plan immediately under the `Stage 2 caveats:` line (or replace it when `Stage 2 caveats:` is omitted). Reviewers and downstream parsers anchor on this exact prefix.
 
-Example (single action — repeat pattern):
-> Finding #2: Workflow step skipped (4th occurrence)
-> - **Proposed Actions**: GitHub issue
-> - **Rationale**: Already recorded 3x in MEMORY.md. Memory alone has failed. Structural fix required.
-> - **What will be created**: issue — `feat(hook): add external-repo commit guard`
-> - **Verify**: issue URL returned + `gh issue view` confirms existence
-> - **Stage 2 caveats**: (none — tracer confidence HIGH, repeat=true with 4 observations)
-> - **Falsification**: premise survived — disconfirming observation would be "memory rule prevented step skip in ≥1 prior session"; Stage 2 MEMORY.md scan found no such evidence in any of the 3 prior memory entries
-
-Example (compound action — rule gap + repeat):
-> Finding #1 (HIGH): Hasty interpretation without verification (ambiguous signal → worst-case conclusion, 3 occurrences)
-> - **Proposed Actions**: global `~/.claude/CLAUDE.md` draft + `GitHub issue`
-> - **Rationale**: Rule absent + 3× repeat → fill the rule gap (global `~/.claude/CLAUDE.md` draft) and track enforcement compliance (GitHub issue); matches Stage 2 ladder: "Missing rule + Repeat"
-> - **What will be created**:
->   - global `~/.claude/CLAUDE.md` draft: new rule requiring a disconfirmation check before concluding from ambiguous signals
->   - issue — `feat(retrospect): enforce falsify-first check on ambiguous signal interpretation`
-> - **Verify**: global `~/.claude/CLAUDE.md` draft shown to user for approval + issue URL returned
-> - **Stage 2 caveats**: analyst clustered with Finding #4 (same root cause family); evaluate combined fix scope before executing
-> - **Falsification**: premise survived for `global ~/.claude/CLAUDE.md draft` — if the rule already existed in another section, the 3× repeat would show citations to that rule rather than rule-absent rationale; Stage 2 step 4 confirmed no applicable rule (category=spec-gap)
-
-Example (gate-suppressed `(Recommended)`):
-> Finding #3 (MED): MCP timeout caused 3 retries (single occurrence in this session)
-> - **Proposed Actions**: `upstream_feedback`
-> - **Rationale**: Tool defect surfaced at step 4b — performance issue.<br>backing_repo: `<resolved_backing_repo>`
-> - **What will be created**: issue in the resolved backing repo — `perf(<plugin>): reduce MCP timeout on <op>`
-> - **Verify**: `gh issue view {url}` succeeds + URL repo matches resolved backing repo
-> - **Stage 2 caveats**: `single observation`; `tracer confidence: MED`; `alternative root cause not ruled out: transient network blip`
-> - **Falsification**: premise failed — `(Recommended)` label suppressed. Disconfirming observation IS present (single timeout indistinguishable from transient blip without a second sample). Option surfaced unranked; AskUserQuestion includes premise-confirmation line: "이 timeout이 패턴인지 단발 blip인지 추가 관찰 전에 upstream 이슈를 열까요?"
+Worked examples — single action (repeat pattern), compound action (rule gap +
+repeat), and a gate-suppressed `(Recommended)` — live in
+[`references/report-template.md`](references/report-template.md) §Worked
+examples. Read them when calibrating per-finding plans: each shows the
+`Stage 2 caveats:` / `Falsification:` line composition this section mandates.
 
 **Then ask for approval per item using AskUserQuestion:**
 
@@ -1185,266 +1119,23 @@ Do NOT execute any action until user approves.
 
 **"note only" items require no execution** — they appear in the completion report as acknowledged but need no persistent artifact.
 
-For each approved action:
+**Before executing ANY approved action, Read
+[`references/stage4-execution.md`](references/stage4-execution.md)** — it holds
+the complete per-action procedures (templates, prompt variants, the backing-repo
+resolution table, the per-artifact verification matrix, and the
+completion-report format). The map below is for orientation only; executing an
+action from the map alone skips the embedded gates and is a Red Flag.
 
-1. **MEMORY.md feedback** → Write to `$CLAUDE_CONFIG_DIR/projects/.../memory/` with proper frontmatter. This action processes two input streams:
-
-   **Friction-event origin** (existing behavior): finding row with `memory` in Proposed Actions. Write MEMORY.md entry per existing convention (Type: `feedback`, include: rule, why, how to apply). Description uses the standard feedback format.
-
-   **Success-pattern origin** (new): `successful_patterns` row where `reinforce_action: memory`. Write MEMORY.md entry with:
-   - Type: `feedback`
-   - Description MUST start with `Reinforced — <pattern>` (the `Reinforced — ` prefix distinguishes positive reinforcement entries from friction entries in future retrospect scans)
-   - Evidence: from the `successful_patterns.evidence` field
-   - How to apply: describe how to intentionally replicate the successful pattern
-
-   Per-entry workflow:
-   1. For each finding with `memory` action → write MEMORY.md entry per existing convention.
-   2. For each `successful_patterns` row with `reinforce_action: memory` → write MEMORY.md entry with description starting `Reinforced — <pattern>`, evidence link from the `successful_patterns.evidence` field.
-
-   - Update `MEMORY.md` index (for both origins)
-
-   **Frontmatter contract — `memory-hint` opt-in (mandatory consideration)**
-
-   In addition to standard fields (`name`, `description`, `type`), every new memory MUST evaluate whether to include the `memory-hint` opt-in fields — `hookable` and `hookKeywords`. The full field spec (parser semantics, matching rules, fail-open contract) lives in `hooks/advisory-nudge/memory-hint/spec.md`; this section defines the authoring-time decision. Use top-level `type:` (consistent with `hooks/advisory-nudge/memory-hint/spec.md` example and existing on-disk memory files); do **not** nest under `metadata:`.
-
-   ```yaml
-   ---
-   name: my-memory
-   description: Short rule statement
-   type: feedback
-   hookable: true                           # opt into PreToolUse surface
-   hookKeywords: [keyword1, keyword2]       # whole-token match (case-sensitive)
-   ---
-   ```
-
-   **Category-based default (apply unless rationale documented):**
-
-   | Category | `hookable` default | Rationale |
-   |---|---|---|
-   | behavioral retrieval-critical (silent-recurrence likely; failure mode is "Loaded ≠ Retrieved") | `true` | hook is the only structural enforcement; skill/memory alone fails retrieval at action time |
-   | success-pattern reinforcement (`Reinforced — ` prefix) where intentional replication needs same retrieval surface | `true` | same "retrieve at action time" need applies in reverse |
-   | abstract / meta / cross-cutting principle (no concrete action signal) | `false` | keyword match would be noisy across unrelated commands |
-   | author-generated rule (belongs in `~/.claude/CLAUDE.md` draft) or upstream-feedback note | `false` | not action-gateable; memory is a holding pen, not the enforcement surface |
-
-   When uncertain → default `hookable: false` (safer to omit than to add noise) AND record the uncertainty in the Actions Executed report so a future retrospect can re-evaluate.
-
-   **`hookKeywords` selection rules:**
-   - Choose tokens that appear in the *action* the memory is meant to gate — CLI subcommand (`merge`, `close`), tool name (`Edit`, `cmux-delegate`), distinctive flag (`--force`), or domain identifier (`Closes`, `Recommended`).
-   - Whole-token, case-sensitive matching only (per `hooks/advisory-nudge/memory-hint/spec.md`). List multiple casings explicitly if needed (`[Edit, edit]`).
-   - 1–4 keywords typical; >5 raises false-positive risk linearly.
-   - **Avoid generic English words** (`add`, `run`, `test`, `update`) — they fire on unrelated commands and erode the hint signal.
-   - When the memory targets a non-Bash event (Edit, Write, AskUserQuestion, etc.), the current `memory-hint.py` only fires on Bash — record the intent in the description so a future event-coverage expansion can surface it.
-
-   **⚠️ MANDATORY: Duplicate check before creating any memory file:**
-
-   **Precondition:** This check applies ONLY when the finding's action type is `memory` (new pattern). If Stage 2 already marked `repeat=true` and escalated to issue/hook/global `~/.claude/CLAUDE.md` draft, skip this check — the escalation ladder takes precedence over merge.
-
-   a. Reuse Stage 2 Step 7's repeat scan results — if a finding matched an existing memory but was NOT escalated (i.e., it's a genuinely new sub-pattern), that file is the merge target
-   b. If no Stage 2 match: scan MEMORY.md index for entries with overlapping root cause or topic (concept-level, not keyword)
-   c. For each candidate, read the existing memory file and compare:
-      - Same root cause / principle → **merge**: append new context (examples, How to apply items) to the existing file. If merge makes this the 2nd+ occurrence, re-evaluate whether action type should escalate per Stage 2 Step 8
-      - Related but distinct principle → **create new file** (genuinely different insight)
-   d. **Never create a new file when the insight is a specific instance of an existing general rule** — add it as a numbered sub-item instead
-   e. After merge or create, update MEMORY.md index (update description if merged, add new line if created)
-
-2. **GitHub issue** → Use project's issue creation skill or `gh issue create`
-   - Title: Conventional Commits format (per project convention)
-   - Body: per project convention, with background + task list
-
-3. **Global `~/.claude/CLAUDE.md` draft** → Write proposed rule addition as a markdown block, routed by target
-
-   **Step 0 — Target detection (MUST run first):**
-   Classification is two-stage:
-   1. **Global check uses either the input path OR `realpath` equivalence to the canonical config path**. A dotfiles-symlinked `~/.claude/CLAUDE.md` whose `realpath` resolves outside `~/.claude/` is still the user's own global config — and a finding that directly declares the resolved dotfiles backing path must still route to the Global flow.
-   2. **Project vs External uses `realpath`** of the input. This correctly routes both `AGENTS.md` (regular file) and project-local symlinks such as praxis's own `CLAUDE.md → AGENTS.md` (whose `realpath` lands on a file inside cwd) to the Project path.
-
-   | Target | Detection | Execution path |
-   |--------|-----------|---------------|
-   | **Global `~/.claude/CLAUDE.md`** | EITHER the input path equals `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md` (after `$HOME`/`~` expansion) OR `realpath <input>` equals `realpath ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md` (i.e., the finding declared the resolved dotfiles backing file path directly — still the user's own global config, must take the Global flow). | Staging → AskUserQuestion → apply only on explicit approval (see Global path below) |
-   | **Project `AGENTS.md`** | Not Global AND `realpath <path>` resolves inside cwd. Covers `AGENTS.md` directly and project-local symlinks like `CLAUDE.md → AGENTS.md`. | Direct Edit (see Project path below) |
-   | **External-repo rule file** | Not Global AND `realpath <path>` resolves outside cwd AND outside `~/.claude/` | Same as external-repo gate — do NOT edit; surface to user with resolved path |
-
-   **Project path** (input is project `AGENTS.md`):
-   - Present the draft diff to the user inline
-   - Apply with explicit approval ("yes, add this rule") → Direct Edit
-
-   **Global path** (input equals `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md`):
-   ⚠️ Global scope — changes affect every project. Claude Code's self-modification classifier blocks direct Edit/Write without explicit approval.
-
-   a. **Stage draft**: write the proposed rule block to `/tmp/claude-md-draft-{slug}.md` (use `.omc/plans/claude-md-draft-{slug}.md` as fallback when `/tmp/` is not writable). Present the full draft content inline before showing the prompt.
-
-   b. **AskUserQuestion — 3-option prompt**:
-      ```
-      options:
-        apply  — 승인. 지금 바로 적용합니다.
-        수정   — 변경할 내용을 free-text로 입력하면 재작성 후 다시 이 단계로 돌아옵니다.
-        보류   — 이번 세션은 적용하지 않습니다. 스테이징 파일을 남겨둡니다.
-      ```
-      - `수정` 선택 시: "무엇을 바꿀까요?" 입력 받음 → re-draft → 다시 (b) 단계로 복귀.
-        Cap: 최대 3 라운드. 3 라운드 초과 시: "3회 재작성을 초과했습니다. 수동 편집을 권장합니다: `{staging_path}`" 후 보류 처리.
-      - `보류` 선택 시: Edit 호출 없이 staging 파일 경로를 completion report에 기록하고 종료.
-
-   c. **`apply` 선택 시**: Resolve the actual Edit target via `edit_target="$(realpath "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md")"` first — the builtin `Edit` tool refuses to write through a symlink, so the resolved path is the only writable target in symlinked dotfiles environments. Edit `$edit_target` to insert the approved rule at the indicated position. Show the resulting diff as verification.
-
-4. **Upstream feedback** → Resolve the tool's **backing repo first** (do NOT hardcode any specific repo), then create a labeled issue there. Hardcoding misroutes plugin defects, custom MCP defects, dotfiles defects across user environments.
-
-   ### Step 0 — Backing-repo verification gate (MUST run before any mutation)
-
-   This gate is the first procedure step for every `upstream_feedback` row, executed **before** any of the resolution-table lookups below. Skipping it means the most salient file path in the executor's local context (often the working project repo) wins the routing decision — which is the exact failure mode this gate prevents.
-
-   1. **Read the declaration.** Parse `backing_repo: <owner/repo>` from the finding's Rationale cell (Stage 2 step 8 makes this MANDATORY for upstream_feedback rows; Stage 3 surfaces it). If the declaration is absent → ABORT this action and return the finding to Stage 2 step 8 with prompt: `"Finding #N upstream_feedback row missing backing_repo declaration — re-run Stage 2 step 8."`
-
-   2. **Re-resolve from source-of-truth.** Independently of the declaration, re-resolve the backing repo using the resolution table below. Do NOT use the declared value as the lookup input — use the tool/layer signal from Stage 2 step 4b to derive the repo from scratch. Capture the re-resolved value as `live_backing_repo`. If the resolution table's `Other / ambiguous` row matches the layer (no concrete repo derivable), treat `live_backing_repo = AMBIGUOUS` and skip to step 0.4 with a 2-way prompt instead of 3-way.
-
-   3. **Compare.** If `live_backing_repo == declared backing_repo` → proceed to the rest of Action 4. Normalization rules for equality (apply both sides):
-      - Strip leading/trailing whitespace
-      - Strip trailing `.git`
-      - Treat all of these as equivalent forms of the same repo: `owner/repo`, `https://github.com/owner/repo`, `git@github.com:owner/repo`, `ssh://git@github.com/owner/repo`
-      - Case-insensitive on `owner` and `repo` (GitHub treats them case-insensitively for routing)
-
-   4. **Divergence / ambiguity handling.** If `live_backing_repo != declared backing_repo` (after normalization) → ABORT and surface to user via `AskUserQuestion`. Two prompt variants:
-
-      **(i) Both sides concrete repos — 3-way prompt:**
-      ```
-      ⚠ Backing-repo divergence on Finding #N:
-         Stage 2/3 declared:    {declared}
-         Stage 4 re-resolved:   {live}
-
-      어느 쪽이 정확합니까?
-      [a] declared ({declared}) 으로 진행
-      [b] re-resolved ({live}) 으로 진행 (Stage 2 declaration 정정)
-      [c] 이 finding 은 skip — upstream_feedback 액션 제거
-      ```
-
-      **(ii) Re-resolution returned `AMBIGUOUS` (declared is concrete) — 2-way prompt:**
-      ```
-      ⚠ Backing-repo re-resolution ambiguous on Finding #N:
-         Stage 2/3 declared:    {declared}
-         Stage 4 re-resolved:   AMBIGUOUS (resolution table's `Other / ambiguous` row)
-
-      어느 쪽으로 진행할까요?
-      [a] declared ({declared}) 으로 진행 (사용자가 Stage 2에서 결정한 값을 신뢰)
-      [b] 이 finding 은 skip — upstream_feedback 액션 제거
-      ```
-
-      **(iii) Declared was `AMBIGUOUS` but re-resolution found a concrete value — 2-way prompt:** mirror of (ii) with `[a]` = use re-resolved, `[b]` = skip.
-
-      Do NOT proceed without an explicit pick. `[b]` (in variant i) requires updating the declared `backing_repo` line — record the corrected value in the Actions Executed report's verification trail rather than re-emitting the entire Stage 3 report (the report is append-only post-Stage-3; corrections live in step 0.5's trail). The skip path removes `upstream_feedback` from the row's action set and logs the divergence reason in the Actions Executed section.
-
-   5. **Verification trail.** Record both values + the chosen path in the Actions Executed report (e.g., `Finding #N: backing_repo verified (declared=live=<resolved-praxis-repo>)` or `Finding #N: divergence resolved via [b] — switched declared <X> → re-resolved <Y>`). This trail is the defense against silent misrouting in retrospective analysis.
-
-   ### Backing repo resolution (used by step 0.2 and as reference)
-
-   | Tool name / layer pattern | Backing repo resolution |
-   |---|---|
-   | `mcp__<plugin>__*` from a Claude Code plugin | Read `repository` field from that plugin's `.claude-plugin/plugin.json` (or equivalent manifest) |
-   | `mcp__<service>-*` from a custom/team MCP server | The MCP server's source repo — `git remote -v` of the server's directory, or read its package manifest |
-   | Skill within the praxis distribution itself | The praxis source repo this skill was installed from — read `repository` field in praxis's own plugin manifest |
-   | Hook in `~/.claude/hooks/` or a globally symlinked `~/.claude/CLAUDE.md`/`AGENTS.md` | The user's dotfiles backing repo — resolve via `ls -la` symlink chain, then `git remote -v` of the target dir |
-   | CLI tool (e.g., `gh`, `kubectl`) | The CLI's open-source upstream if accessible; otherwise `note only` |
-   | Builtin tool (Read/Edit/Bash/Grep) | Typically not actionable — `note only` |
-   | Other / ambiguous | Ask the user; do NOT fall back to a hardcoded repo |
-
-   If the active project's `AGENTS.md` provides a feature-to-repo mapping, consult it before deciding a repo.
-
-   ### Step 0a — External-repo authorization gate (MUST run before `gh issue create` for external findings)
-
-   This gate fires for every `upstream_feedback` row where the finding's Rationale cell contains `⚠ EXTERNAL: per-action approval required at Stage 4` (set by Stage 2.5 Gate-4). It fires **even when** the user selected "✅ Execute now" in Stage 3 — Stage 3 approval authorizes the action category, not the specific external-org write.
-
-   **Detection:** scan the Rationale cell (already verified in step 0) for the literal prefix `⚠ EXTERNAL: per-action approval required at Stage 4`. If present → this gate fires. If absent → skip to "Then create the issue."
-
-   **Mandatory `AskUserQuestion` prompt (do NOT proceed without explicit `[a]` pick):**
-
-   ```
-   ⚠ External-repo write authorization required — Finding #N
-
-   Proposed: create GitHub issue in {backing_repo} (classified external by Stage 2.5 Gate-4)
-   Title: {proposed_issue_title}
-   Evidence: {one-line friction event summary}
-
-   Per global `~/.claude/CLAUDE.md` "External / third-party repo content isolation (MUST)", this requires
-   explicit per-action approval. Stage 3 "Execute now" does not satisfy this gate.
-   Auto-mode override, batch approval, and "prior selection ratifies this" inferences
-   are all invalid — only an explicit [a] pick here allows proceeding.
-
-   어느 쪽으로 진행할까요?
-   [a] 승인 — {backing_repo}에 이슈 생성 진행
-   [b] Skip — upstream_feedback 액션 제거 (이 finding의 action set에서 제외)
-   [c] Issue draft를 먼저 검토한 뒤 결정 (draft를 보여준 뒤 재질문)
-   ```
-
-   - If `[b]` → remove `upstream_feedback` from this finding's action set; log reason in Actions Executed report
-   - If `[c]` → show the draft issue body (title, labels, full body text) and re-issue this AskUserQuestion
-   - Only `[a]` → proceed to `gh issue create`
-
-   **Then create the issue (using the verified backing_repo from step 0):**
-   - Title: `{type}({tool_layer}): {friction description}` (Conventional Commits format)
-   - Label: `tool-friction:{layer}` is praxis's own convention. Apply it ONLY when the verified backing repo is the praxis distribution itself. For any other backing repo, use that repo's existing label conventions (e.g., `bug`, `enhancement`); do NOT auto-create praxis-style labels in unrelated repos.
-   - If `tool-friction:*` is needed and missing in the praxis repo: `gh label create "tool-friction:{layer}" --repo <verified-praxis-repo>`
-   - Body: include evidence, expected behavior, proposed fix direction from step 4b finding
-   - Command: `gh issue create --repo <verified_backing_repo> --title "$TITLE" --label "$LABEL" --body "$BODY"` — substitute the verified repo, never hardcode
-   - **Verification (mandatory):** issue URL is returned, `gh issue view {url}` succeeds, AND the URL's repo matches the verified backing repo (catches misrouting)
-
-5. **Skill idea note** → Write to `{current_project}/.omc/plans/retrospect-skill-idea-{slug}.md`
-   - `{current_project}` = `$CLAUDE_PROJECT_DIR` or `git rev-parse --show-toplevel`
-   - Include: problem, proposed skill trigger, pipeline sketch
-
-6. **Hook code** → For enforcement-level actions (repeat 3x+):
-   a. **Write the hook script.** First resolve the target repo (the project's
-      `.claude/hooks/`, or a personal-config / dotfiles repo when the hook backs
-      `~/.claude/`) and check its current branch: `git -C <repo> branch --show-current`.
-      - **On a protected branch (`main` / `dev` / `prod` / `master`)**: an inline
-        `Write` here is blocked by `pre-edit-protected-branch-guard` (it guards
-        Edit/Write on protected branches — both the dirty-tree and the clean-tree
-        PR-workflow-signal paths). Create a dedicated worktree on a new branch and
-        write the hook inside it:
-        ```
-        git -C <repo> worktree add -b retrospect-hook-{slug} \
-            <repo-parent>/<repo-name>.retrospect-hook-{slug} <protected-branch>
-        ```
-        Surface the worktree path to the user for the commit / PR decision —
-        retrospect does NOT auto-commit or auto-PR the hook; its contract ends at
-        the file write.
-      - **Already on a feature branch**: write the hook directly to
-        `.claude/hooks/` or the appropriate location.
-   b. Present the hook code to user for review
-   c. Explain how to register in `.claude/settings.json` (show the exact JSON entry)
-   d. Use AskUserQuestion: "Hook을 settings.json에 등록할까요?" (✅ 등록 / ⏭ 파일만 유지 / 🕐 나중에)
-   e. If approved: Edit `.claude/settings.json` to register the hook (inside the
-      step-(a) worktree when one was created — `settings.json` shares the same
-      protected-branch repo as the hook file)
-   f. If skipped/deferred: leave the hook file in place and provide manual registration instructions
-
-7. **Verification** — For each executed action, verify the artifact:
-
-   | Artifact | Verification |
-   |----------|-------------|
-   | MEMORY.md feedback (new) | File exists + MEMORY.md index updated + `hookable`/`hookKeywords` frontmatter decision recorded (true with keywords, OR false with rationale in Actions Executed report) |
-   | MEMORY.md feedback (merged) | Existing file updated (diff shown) + MEMORY.md index description updated if needed + if existing entry had `hookable: false` **or the field is missing entirely** and merged context now meets the retrieval-critical default, re-evaluate and add/update frontmatter (most pre-existing memories lack `hookable` — missing field is the dominant case, not false) |
-   | GitHub issue | `gh issue view {url}` returns valid data |
-   | Upstream feedback | `gh issue view {url}` returns valid data + URL repo matches `verified_backing_repo` from step 0 + label convention is correct for the verified repo (`tool-friction:{layer}` ONLY when verified repo is the praxis distribution; otherwise the repo's own convention label per Action 4's label rule) |
-   | Hook code | Script file exists + settings.json registration confirmed (dry-run varies by hook type — no generic check). If Action 6 step (a) created a worktree, report the worktree path and confirm the file exists there. |
-   | Global `~/.claude/CLAUDE.md` draft | **Project target (`AGENTS.md`)**: Diff shown + explicit approval received + Edit applied. **Global target (`~/.claude/CLAUDE.md`)**: Staging file created at `/tmp/claude-md-draft-{slug}.md` → AskUserQuestion 3-option presented → `apply`: Edit applied + diff shown; `보류`: staging file path logged in completion report. |
-   | Skill idea note | File exists in `.omc/plans/` |
-
-   Report verification results in the completion table.
-
-8. **Completion report:**
-
-```
-## Actions Executed
-
-| # | Action | Result |
-|---|--------|--------|
-| 1 | MEMORY.md feedback added | ✅ {file_path} |
-| 2 | GitHub issue created | ✅ {url} |
-| 3 | Upstream feedback (Finding #N) | ✅ {url} (backing_repo verified: declared=live={owner/repo}) |
-| 4 | Upstream feedback (Finding #M) | ⚠ aborted at step 0 — declared {X} ≠ re-resolved {Y}; user picked [b], re-issued at {url} |
-| 5 | Upstream feedback (Finding #P) | ⊘ skipped at step 0 — divergence; user picked [c], action removed; reason: declared {X} not reachable, re-resolved {Y} unfamiliar to user |
-...
-
-Session learnings captured. Next session will benefit from these improvements.
-```
+| # | Action | Non-negotiable gate (full procedure in the reference) |
+|---|--------|-------------------------------------------------------|
+| 1 | MEMORY.md feedback (friction-event + success-pattern origins) | duplicate-check before create — merge-first; `hookable`/`hookKeywords` frontmatter decision recorded |
+| 2 | GitHub issue | project issue conventions (Conventional Commits title) |
+| 3 | Global `~/.claude/CLAUDE.md` draft | target detection (Global / Project / External) FIRST; Global path = staging file → AskUserQuestion 3-option → apply only on explicit approval — direct Edit is a Red Flag |
+| 4 | Upstream feedback | step 0 backing-repo verification (declared `backing_repo:` vs re-resolved value compare — examples use the `<resolved_backing_repo>` placeholder, never a hardcoded repo) + step 0a external-repo per-action authorization, both BEFORE any `gh issue create` |
+| 5 | Skill idea note | written to `.omc/plans/retrospect-skill-idea-{slug}.md` |
+| 6 | Hook code | protected-branch check → dedicated worktree when needed; user review before `settings.json` registration |
+| 7 | Verification | per-artifact verification matrix — every executed action verified, results in the completion table |
+| 8 | Completion report | `## Actions Executed` table with links/paths + verification trail |
 
 ## Rationalization Prevention
 

--- a/skills/retrospect/references/report-template.md
+++ b/skills/retrospect/references/report-template.md
@@ -19,7 +19,7 @@ hand-written. If the transcript is genuinely unreachable, replace the fence
 with the single line
 `<!-- retrospect:transcript_receipt_skipped: transcript unreachable -->`.
 
-```
+```markdown
 ## Retrospect Report — {session_date}
 
 <!-- retrospect:pre_scan_checklist begin -->
@@ -80,6 +80,7 @@ is_error_count: {N} | user_turn_count: {N} | interrupt_count: {N}
 
 Example (single action — repeat pattern):
 > Finding #2: Workflow step skipped (4th occurrence)
+>
 > - **Proposed Actions**: GitHub issue
 > - **Rationale**: Already recorded 3x in MEMORY.md. Memory alone has failed. Structural fix required.
 > - **What will be created**: issue — `feat(hook): add external-repo commit guard`
@@ -89,6 +90,7 @@ Example (single action — repeat pattern):
 
 Example (compound action — rule gap + repeat):
 > Finding #1 (HIGH): Hasty interpretation without verification (ambiguous signal → worst-case conclusion, 3 occurrences)
+>
 > - **Proposed Actions**: global `~/.claude/CLAUDE.md` draft + `GitHub issue`
 > - **Rationale**: Rule absent + 3× repeat → fill the rule gap (global `~/.claude/CLAUDE.md` draft) and track enforcement compliance (GitHub issue); matches Stage 2 ladder: "Missing rule + Repeat"
 > - **What will be created**:
@@ -100,6 +102,7 @@ Example (compound action — rule gap + repeat):
 
 Example (gate-suppressed `(Recommended)`):
 > Finding #3 (MED): MCP timeout caused 3 retries (single occurrence in this session)
+>
 > - **Proposed Actions**: `upstream_feedback`
 > - **Rationale**: Tool defect surfaced at step 4b — performance issue.<br>backing_repo: `<resolved_backing_repo>`
 > - **What will be created**: issue in the resolved backing repo — `perf(<plugin>): reduce MCP timeout on <op>`

--- a/skills/retrospect/references/report-template.md
+++ b/skills/retrospect/references/report-template.md
@@ -1,0 +1,108 @@
+# Stage 3 report template + worked examples (retrospect)
+
+Reference material for [`../SKILL.md`](../SKILL.md) Stage 3. The **Output
+Schema Contract in SKILL.md is the normative source** — on any divergence
+between this template and the contract, the contract wins. Read this file when
+composing the Stage 3 report or calibrating per-finding plans; it carries no
+mandates of its own.
+
+## Consolidated report template
+
+Emit order and fence markers per the Output Schema Contract.
+
+The `retrospect:transcript_receipt` fence (§3e) is **post-compaction sessions
+only** — omit the whole block when the transcript has no compaction marker.
+Unlike the other Stage 2 fences it **IS parsed by the Stop hook (Gate-7)**:
+its absence in a post-compaction session blocks Stage 3. The body must be
+real command output run against the live `transcript_path`, never
+hand-written. If the transcript is genuinely unreachable, replace the fence
+with the single line
+`<!-- retrospect:transcript_receipt_skipped: transcript unreachable -->`.
+
+```
+## Retrospect Report — {session_date}
+
+<!-- retrospect:pre_scan_checklist begin -->
+- {category_name}: violations: none
+- {category_name}: violations:
+  - {one-line candidate} | spec_cite: {section}
+<!-- retrospect:pre_scan_checklist end -->
+
+<!-- retrospect:dismissed_candidates begin -->
+- {one-line candidate} | reason: {rationale} | spec_cite: {section}
+<!-- retrospect:dismissed_candidates end -->
+
+<!-- retrospect:tool_census begin -->
+- tool_name: {tool} | layer: {mcp|cli|builtin|skill} | call_count: {n} | error_count: {n} | retry_count: {n} | workaround_marker: {true|false} | surfaced_in_friction: {true|false} | signal: {none|summary}
+<!-- retrospect:tool_census end -->
+
+<!-- retrospect:user_correction begin -->
+- candidate: "{verbatim user-turn excerpt}" | marker_class: {negation|redirect|mismatch} | reason: {why judged not-a-correction} | cite: {turn ref / quoted context}
+<!-- retrospect:user_correction end -->
+
+<!-- retrospect:self_correction begin -->
+- corrective: "{verbatim corrective-call excerpt}" | prior: "{verbatim prior-call excerpt}" | signature: {oracle-mismatch|wrong-target|basis-change} | reason: {why judged not-a-self-correction} | cite: {turn ref}
+<!-- retrospect:self_correction end -->
+
+<!-- retrospect:transcript_receipt begin -->
+$ grep -c '"is_error":true' {transcript_path}
+{real N}
+$ grep -c '"role":"user"' {transcript_path}
+{real N}
+is_error_count: {N} | user_turn_count: {N} | interrupt_count: {N}
+<!-- retrospect:transcript_receipt end -->
+
+<!-- retrospect:distribution begin -->
+- memory: {n}
+- issue: {n}
+- claude_md_draft: {n}
+- skill_idea: {n}
+- hook_code: {n}
+- upstream_feedback: {n}
+- memory_hygiene: {n}
+- output_quality: {n}
+- gate_1_verdict: {PASS|FAIL|NA}
+- gate_2_verdict: {PASS|FAIL|NA}
+- gate_3_verdict: {PASS|FAIL|NA}
+- gate_4_verdict: {PASS|WARN|NA}
+- gate_5_verdict: {PASS|FAIL|NA}
+- gate_6_verdict: {PASS|FAIL|NA}
+<!-- retrospect:distribution end -->
+
+| # | Category | Tool Layer | Pattern | Root Cause | Rule / Gap | Repeat? | Proposed Actions (1~2) | Rationale | Priority |
+|---|----------|------------|---------|------------|------------|---------|------------------------|-----------|----------|
+| 1 | {behavioral|tool|workflow|spec-gap, ...} | {mcp|cli|builtin|skill|—} | {pattern} | {root_cause} | {rule_ref or "gap"} | {Yes(Nx)/No} | {action1[, action2]} | {rationale: 5 `not <action>:` lines for memory-only, or one-line for compound/non-memory} | HIGH/MED/LOW |
+...
+
+```
+
+## Worked examples (per-finding plan calibration)
+
+Example (single action — repeat pattern):
+> Finding #2: Workflow step skipped (4th occurrence)
+> - **Proposed Actions**: GitHub issue
+> - **Rationale**: Already recorded 3x in MEMORY.md. Memory alone has failed. Structural fix required.
+> - **What will be created**: issue — `feat(hook): add external-repo commit guard`
+> - **Verify**: issue URL returned + `gh issue view` confirms existence
+> - **Stage 2 caveats**: (none — tracer confidence HIGH, repeat=true with 4 observations)
+> - **Falsification**: premise survived — disconfirming observation would be "memory rule prevented step skip in ≥1 prior session"; Stage 2 MEMORY.md scan found no such evidence in any of the 3 prior memory entries
+
+Example (compound action — rule gap + repeat):
+> Finding #1 (HIGH): Hasty interpretation without verification (ambiguous signal → worst-case conclusion, 3 occurrences)
+> - **Proposed Actions**: global `~/.claude/CLAUDE.md` draft + `GitHub issue`
+> - **Rationale**: Rule absent + 3× repeat → fill the rule gap (global `~/.claude/CLAUDE.md` draft) and track enforcement compliance (GitHub issue); matches Stage 2 ladder: "Missing rule + Repeat"
+> - **What will be created**:
+>   - global `~/.claude/CLAUDE.md` draft: new rule requiring a disconfirmation check before concluding from ambiguous signals
+>   - issue — `feat(retrospect): enforce falsify-first check on ambiguous signal interpretation`
+> - **Verify**: global `~/.claude/CLAUDE.md` draft shown to user for approval + issue URL returned
+> - **Stage 2 caveats**: analyst clustered with Finding #4 (same root cause family); evaluate combined fix scope before executing
+> - **Falsification**: premise survived for `global ~/.claude/CLAUDE.md draft` — if the rule already existed in another section, the 3× repeat would show citations to that rule rather than rule-absent rationale; Stage 2 step 4 confirmed no applicable rule (category=spec-gap)
+
+Example (gate-suppressed `(Recommended)`):
+> Finding #3 (MED): MCP timeout caused 3 retries (single occurrence in this session)
+> - **Proposed Actions**: `upstream_feedback`
+> - **Rationale**: Tool defect surfaced at step 4b — performance issue.<br>backing_repo: `<resolved_backing_repo>`
+> - **What will be created**: issue in the resolved backing repo — `perf(<plugin>): reduce MCP timeout on <op>`
+> - **Verify**: `gh issue view {url}` succeeds + URL repo matches resolved backing repo
+> - **Stage 2 caveats**: `single observation`; `tracer confidence: MED`; `alternative root cause not ruled out: transient network blip`
+> - **Falsification**: premise failed — `(Recommended)` label suppressed. Disconfirming observation IS present (single timeout indistinguishable from transient blip without a second sample). Option surfaced unranked; AskUserQuestion includes premise-confirmation line: "이 timeout이 패턴인지 단발 blip인지 추가 관찰 전에 upstream 이슈를 열까요?"

--- a/skills/retrospect/references/stage4-execution.md
+++ b/skills/retrospect/references/stage4-execution.md
@@ -1,0 +1,270 @@
+# Stage 4 execution procedures (retrospect)
+
+Full per-action procedures for [`../SKILL.md`](../SKILL.md) Stage 4. SKILL.md
+holds the action map and the non-negotiable gates; this file holds the
+complete procedure text — templates, prompt variants, resolution tables, the
+per-artifact verification matrix, and the completion-report format. **Read
+this file before executing any approved action** — the embedded gates
+(Action 1 duplicate-check, Action 3 Global-path staging, Action 4 step 0 /
+step 0a) live here in full.
+
+For each approved action:
+
+1. **MEMORY.md feedback** → Write to `$CLAUDE_CONFIG_DIR/projects/.../memory/` with proper frontmatter. This action processes two input streams:
+
+   **Friction-event origin** (existing behavior): finding row with `memory` in Proposed Actions. Write MEMORY.md entry per existing convention (Type: `feedback`, include: rule, why, how to apply). Description uses the standard feedback format.
+
+   **Success-pattern origin** (new): `successful_patterns` row where `reinforce_action: memory`. Write MEMORY.md entry with:
+   - Type: `feedback`
+   - Description MUST start with `Reinforced — <pattern>` (the `Reinforced — ` prefix distinguishes positive reinforcement entries from friction entries in future retrospect scans)
+   - Evidence: from the `successful_patterns.evidence` field
+   - How to apply: describe how to intentionally replicate the successful pattern
+
+   Per-entry workflow:
+   1. For each finding with `memory` action → write MEMORY.md entry per existing convention.
+   2. For each `successful_patterns` row with `reinforce_action: memory` → write MEMORY.md entry with description starting `Reinforced — <pattern>`, evidence link from the `successful_patterns.evidence` field.
+
+   - Update `MEMORY.md` index (for both origins)
+
+   **Frontmatter contract — `memory-hint` opt-in (mandatory consideration)**
+
+   In addition to standard fields (`name`, `description`, `type`), every new memory MUST evaluate whether to include the `memory-hint` opt-in fields — `hookable` and `hookKeywords`. The full field spec (parser semantics, matching rules, fail-open contract) lives in `hooks/advisory-nudge/memory-hint/spec.md`; this section defines the authoring-time decision. Use top-level `type:` (consistent with `hooks/advisory-nudge/memory-hint/spec.md` example and existing on-disk memory files); do **not** nest under `metadata:`.
+
+   ```yaml
+   ---
+   name: my-memory
+   description: Short rule statement
+   type: feedback
+   hookable: true                           # opt into PreToolUse surface
+   hookKeywords: [keyword1, keyword2]       # whole-token match (case-sensitive)
+   ---
+   ```
+
+   **Category-based default (apply unless rationale documented):**
+
+   | Category | `hookable` default | Rationale |
+   |---|---|---|
+   | behavioral retrieval-critical (silent-recurrence likely; failure mode is "Loaded ≠ Retrieved") | `true` | hook is the only structural enforcement; skill/memory alone fails retrieval at action time |
+   | success-pattern reinforcement (`Reinforced — ` prefix) where intentional replication needs same retrieval surface | `true` | same "retrieve at action time" need applies in reverse |
+   | abstract / meta / cross-cutting principle (no concrete action signal) | `false` | keyword match would be noisy across unrelated commands |
+   | author-generated rule (belongs in `~/.claude/CLAUDE.md` draft) or upstream-feedback note | `false` | not action-gateable; memory is a holding pen, not the enforcement surface |
+
+   When uncertain → default `hookable: false` (safer to omit than to add noise) AND record the uncertainty in the Actions Executed report so a future retrospect can re-evaluate.
+
+   **`hookKeywords` selection rules:**
+   - Choose tokens that appear in the *action* the memory is meant to gate — CLI subcommand (`merge`, `close`), tool name (`Edit`, `cmux-delegate`), distinctive flag (`--force`), or domain identifier (`Closes`, `Recommended`).
+   - Whole-token, case-sensitive matching only (per `hooks/advisory-nudge/memory-hint/spec.md`). List multiple casings explicitly if needed (`[Edit, edit]`).
+   - 1–4 keywords typical; >5 raises false-positive risk linearly.
+   - **Avoid generic English words** (`add`, `run`, `test`, `update`) — they fire on unrelated commands and erode the hint signal.
+   - When the memory targets a non-Bash event (Edit, Write, AskUserQuestion, etc.), the current `memory-hint.py` only fires on Bash — record the intent in the description so a future event-coverage expansion can surface it.
+
+   **⚠️ MANDATORY: Duplicate check before creating any memory file:**
+
+   **Precondition:** This check applies ONLY when the finding's action type is `memory` (new pattern). If Stage 2 already marked `repeat=true` and escalated to issue/hook/global `~/.claude/CLAUDE.md` draft, skip this check — the escalation ladder takes precedence over merge.
+
+   a. Reuse Stage 2 Step 7's repeat scan results — if a finding matched an existing memory but was NOT escalated (i.e., it's a genuinely new sub-pattern), that file is the merge target
+   b. If no Stage 2 match: scan MEMORY.md index for entries with overlapping root cause or topic (concept-level, not keyword)
+   c. For each candidate, read the existing memory file and compare:
+      - Same root cause / principle → **merge**: append new context (examples, How to apply items) to the existing file. If merge makes this the 2nd+ occurrence, re-evaluate whether action type should escalate per Stage 2 Step 8
+      - Related but distinct principle → **create new file** (genuinely different insight)
+   d. **Never create a new file when the insight is a specific instance of an existing general rule** — add it as a numbered sub-item instead
+   e. After merge or create, update MEMORY.md index (update description if merged, add new line if created)
+
+2. **GitHub issue** → Use project's issue creation skill or `gh issue create`
+   - Title: Conventional Commits format (per project convention)
+   - Body: per project convention, with background + task list
+
+3. **Global `~/.claude/CLAUDE.md` draft** → Write proposed rule addition as a markdown block, routed by target
+
+   **Step 0 — Target detection (MUST run first):**
+   Classification is two-stage:
+   1. **Global check uses either the input path OR `realpath` equivalence to the canonical config path**. A dotfiles-symlinked `~/.claude/CLAUDE.md` whose `realpath` resolves outside `~/.claude/` is still the user's own global config — and a finding that directly declares the resolved dotfiles backing path must still route to the Global flow.
+   2. **Project vs External uses `realpath`** of the input. This correctly routes both `AGENTS.md` (regular file) and project-local symlinks such as praxis's own `CLAUDE.md → AGENTS.md` (whose `realpath` lands on a file inside cwd) to the Project path.
+
+   | Target | Detection | Execution path |
+   |--------|-----------|---------------|
+   | **Global `~/.claude/CLAUDE.md`** | EITHER the input path equals `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md` (after `$HOME`/`~` expansion) OR `realpath <input>` equals `realpath ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md` (i.e., the finding declared the resolved dotfiles backing file path directly — still the user's own global config, must take the Global flow). | Staging → AskUserQuestion → apply only on explicit approval (see Global path below) |
+   | **Project `AGENTS.md`** | Not Global AND `realpath <path>` resolves inside cwd. Covers `AGENTS.md` directly and project-local symlinks like `CLAUDE.md → AGENTS.md`. | Direct Edit (see Project path below) |
+   | **External-repo rule file** | Not Global AND `realpath <path>` resolves outside cwd AND outside `~/.claude/` | Same as external-repo gate — do NOT edit; surface to user with resolved path |
+
+   **Project path** (input is project `AGENTS.md`):
+   - Present the draft diff to the user inline
+   - Apply with explicit approval ("yes, add this rule") → Direct Edit
+
+   **Global path** (input equals `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md`):
+   ⚠️ Global scope — changes affect every project. Claude Code's self-modification classifier blocks direct Edit/Write without explicit approval.
+
+   a. **Stage draft**: write the proposed rule block to `/tmp/claude-md-draft-{slug}.md` (use `.omc/plans/claude-md-draft-{slug}.md` as fallback when `/tmp/` is not writable). Present the full draft content inline before showing the prompt.
+
+   b. **AskUserQuestion — 3-option prompt**:
+      ```
+      options:
+        apply  — 승인. 지금 바로 적용합니다.
+        수정   — 변경할 내용을 free-text로 입력하면 재작성 후 다시 이 단계로 돌아옵니다.
+        보류   — 이번 세션은 적용하지 않습니다. 스테이징 파일을 남겨둡니다.
+      ```
+      - `수정` 선택 시: "무엇을 바꿀까요?" 입력 받음 → re-draft → 다시 (b) 단계로 복귀.
+        Cap: 최대 3 라운드. 3 라운드 초과 시: "3회 재작성을 초과했습니다. 수동 편집을 권장합니다: `{staging_path}`" 후 보류 처리.
+      - `보류` 선택 시: Edit 호출 없이 staging 파일 경로를 completion report에 기록하고 종료.
+
+   c. **`apply` 선택 시**: Resolve the actual Edit target via `edit_target="$(realpath "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md")"` first — the builtin `Edit` tool refuses to write through a symlink, so the resolved path is the only writable target in symlinked dotfiles environments. Edit `$edit_target` to insert the approved rule at the indicated position. Show the resulting diff as verification.
+
+4. **Upstream feedback** → Resolve the tool's **backing repo first** (do NOT hardcode any specific repo), then create a labeled issue there. Hardcoding misroutes plugin defects, custom MCP defects, dotfiles defects across user environments.
+
+   ### Step 0 — Backing-repo verification gate (MUST run before any mutation)
+
+   This gate is the first procedure step for every `upstream_feedback` row, executed **before** any of the resolution-table lookups below. Skipping it means the most salient file path in the executor's local context (often the working project repo) wins the routing decision — which is the exact failure mode this gate prevents.
+
+   1. **Read the declaration.** Parse `backing_repo: <owner/repo>` from the finding's Rationale cell (Stage 2 step 8 makes this MANDATORY for upstream_feedback rows; Stage 3 surfaces it). If the declaration is absent → ABORT this action and return the finding to Stage 2 step 8 with prompt: `"Finding #N upstream_feedback row missing backing_repo declaration — re-run Stage 2 step 8."`
+
+   2. **Re-resolve from source-of-truth.** Independently of the declaration, re-resolve the backing repo using the resolution table below. Do NOT use the declared value as the lookup input — use the tool/layer signal from Stage 2 step 4b to derive the repo from scratch. Capture the re-resolved value as `live_backing_repo`. If the resolution table's `Other / ambiguous` row matches the layer (no concrete repo derivable), treat `live_backing_repo = AMBIGUOUS` and skip to step 0.4 with a 2-way prompt instead of 3-way.
+
+   3. **Compare.** If `live_backing_repo == declared backing_repo` → proceed to the rest of Action 4. Normalization rules for equality (apply both sides):
+      - Strip leading/trailing whitespace
+      - Strip trailing `.git`
+      - Treat all of these as equivalent forms of the same repo: `owner/repo`, `https://github.com/owner/repo`, `git@github.com:owner/repo`, `ssh://git@github.com/owner/repo`
+      - Case-insensitive on `owner` and `repo` (GitHub treats them case-insensitively for routing)
+
+   4. **Divergence / ambiguity handling.** If `live_backing_repo != declared backing_repo` (after normalization) → ABORT and surface to user via `AskUserQuestion`. Two prompt variants:
+
+      **(i) Both sides concrete repos — 3-way prompt:**
+      ```
+      ⚠ Backing-repo divergence on Finding #N:
+         Stage 2/3 declared:    {declared}
+         Stage 4 re-resolved:   {live}
+
+      어느 쪽이 정확합니까?
+      [a] declared ({declared}) 으로 진행
+      [b] re-resolved ({live}) 으로 진행 (Stage 2 declaration 정정)
+      [c] 이 finding 은 skip — upstream_feedback 액션 제거
+      ```
+
+      **(ii) Re-resolution returned `AMBIGUOUS` (declared is concrete) — 2-way prompt:**
+      ```
+      ⚠ Backing-repo re-resolution ambiguous on Finding #N:
+         Stage 2/3 declared:    {declared}
+         Stage 4 re-resolved:   AMBIGUOUS (resolution table's `Other / ambiguous` row)
+
+      어느 쪽으로 진행할까요?
+      [a] declared ({declared}) 으로 진행 (사용자가 Stage 2에서 결정한 값을 신뢰)
+      [b] 이 finding 은 skip — upstream_feedback 액션 제거
+      ```
+
+      **(iii) Declared was `AMBIGUOUS` but re-resolution found a concrete value — 2-way prompt:** mirror of (ii) with `[a]` = use re-resolved, `[b]` = skip.
+
+      Do NOT proceed without an explicit pick. `[b]` (in variant i) requires updating the declared `backing_repo` line — record the corrected value in the Actions Executed report's verification trail rather than re-emitting the entire Stage 3 report (the report is append-only post-Stage-3; corrections live in step 0.5's trail). The skip path removes `upstream_feedback` from the row's action set and logs the divergence reason in the Actions Executed section.
+
+   5. **Verification trail.** Record both values + the chosen path in the Actions Executed report (e.g., `Finding #N: backing_repo verified (declared=live=<resolved-praxis-repo>)` or `Finding #N: divergence resolved via [b] — switched declared <X> → re-resolved <Y>`). This trail is the defense against silent misrouting in retrospective analysis.
+
+   ### Backing repo resolution (used by step 0.2 and as reference)
+
+   | Tool name / layer pattern | Backing repo resolution |
+   |---|---|
+   | `mcp__<plugin>__*` from a Claude Code plugin | Read `repository` field from that plugin's `.claude-plugin/plugin.json` (or equivalent manifest) |
+   | `mcp__<service>-*` from a custom/team MCP server | The MCP server's source repo — `git remote -v` of the server's directory, or read its package manifest |
+   | Skill within the praxis distribution itself | The praxis source repo this skill was installed from — read `repository` field in praxis's own plugin manifest |
+   | Hook in `~/.claude/hooks/` or a globally symlinked `~/.claude/CLAUDE.md`/`AGENTS.md` | The user's dotfiles backing repo — resolve via `ls -la` symlink chain, then `git remote -v` of the target dir |
+   | CLI tool (e.g., `gh`, `kubectl`) | The CLI's open-source upstream if accessible; otherwise `note only` |
+   | Builtin tool (Read/Edit/Bash/Grep) | Typically not actionable — `note only` |
+   | Other / ambiguous | Ask the user; do NOT fall back to a hardcoded repo |
+
+   If the active project's `AGENTS.md` provides a feature-to-repo mapping, consult it before deciding a repo.
+
+   ### Step 0a — External-repo authorization gate (MUST run before `gh issue create` for external findings)
+
+   This gate fires for every `upstream_feedback` row where the finding's Rationale cell contains `⚠ EXTERNAL: per-action approval required at Stage 4` (set by Stage 2.5 Gate-4). It fires **even when** the user selected "✅ Execute now" in Stage 3 — Stage 3 approval authorizes the action category, not the specific external-org write.
+
+   **Detection:** scan the Rationale cell (already verified in step 0) for the literal prefix `⚠ EXTERNAL: per-action approval required at Stage 4`. If present → this gate fires. If absent → skip to "Then create the issue."
+
+   **Mandatory `AskUserQuestion` prompt (do NOT proceed without explicit `[a]` pick):**
+
+   ```
+   ⚠ External-repo write authorization required — Finding #N
+
+   Proposed: create GitHub issue in {backing_repo} (classified external by Stage 2.5 Gate-4)
+   Title: {proposed_issue_title}
+   Evidence: {one-line friction event summary}
+
+   Per global `~/.claude/CLAUDE.md` "External / third-party repo content isolation (MUST)", this requires
+   explicit per-action approval. Stage 3 "Execute now" does not satisfy this gate.
+   Auto-mode override, batch approval, and "prior selection ratifies this" inferences
+   are all invalid — only an explicit [a] pick here allows proceeding.
+
+   어느 쪽으로 진행할까요?
+   [a] 승인 — {backing_repo}에 이슈 생성 진행
+   [b] Skip — upstream_feedback 액션 제거 (이 finding의 action set에서 제외)
+   [c] Issue draft를 먼저 검토한 뒤 결정 (draft를 보여준 뒤 재질문)
+   ```
+
+   - If `[b]` → remove `upstream_feedback` from this finding's action set; log reason in Actions Executed report
+   - If `[c]` → show the draft issue body (title, labels, full body text) and re-issue this AskUserQuestion
+   - Only `[a]` → proceed to `gh issue create`
+
+   **Then create the issue (using the verified backing_repo from step 0):**
+   - Title: `{type}({tool_layer}): {friction description}` (Conventional Commits format)
+   - Label: `tool-friction:{layer}` is praxis's own convention. Apply it ONLY when the verified backing repo is the praxis distribution itself. For any other backing repo, use that repo's existing label conventions (e.g., `bug`, `enhancement`); do NOT auto-create praxis-style labels in unrelated repos.
+   - If `tool-friction:*` is needed and missing in the praxis repo: `gh label create "tool-friction:{layer}" --repo <verified-praxis-repo>`
+   - Body: include evidence, expected behavior, proposed fix direction from step 4b finding
+   - Command: `gh issue create --repo <verified_backing_repo> --title "$TITLE" --label "$LABEL" --body "$BODY"` — substitute the verified repo, never hardcode
+   - **Verification (mandatory):** issue URL is returned, `gh issue view {url}` succeeds, AND the URL's repo matches the verified backing repo (catches misrouting)
+
+5. **Skill idea note** → Write to `{current_project}/.omc/plans/retrospect-skill-idea-{slug}.md`
+   - `{current_project}` = `$CLAUDE_PROJECT_DIR` or `git rev-parse --show-toplevel`
+   - Include: problem, proposed skill trigger, pipeline sketch
+
+6. **Hook code** → For enforcement-level actions (repeat 3x+):
+   a. **Write the hook script.** First resolve the target repo (the project's
+      `.claude/hooks/`, or a personal-config / dotfiles repo when the hook backs
+      `~/.claude/`) and check its current branch: `git -C <repo> branch --show-current`.
+      - **On a protected branch (`main` / `dev` / `prod` / `master`)**: an inline
+        `Write` here is blocked by `pre-edit-protected-branch-guard` (it guards
+        Edit/Write on protected branches — both the dirty-tree and the clean-tree
+        PR-workflow-signal paths). Create a dedicated worktree on a new branch and
+        write the hook inside it:
+        ```
+        git -C <repo> worktree add -b retrospect-hook-{slug} \
+            <repo-parent>/<repo-name>.retrospect-hook-{slug} <protected-branch>
+        ```
+        Surface the worktree path to the user for the commit / PR decision —
+        retrospect does NOT auto-commit or auto-PR the hook; its contract ends at
+        the file write.
+      - **Already on a feature branch**: write the hook directly to
+        `.claude/hooks/` or the appropriate location.
+   b. Present the hook code to user for review
+   c. Explain how to register in `.claude/settings.json` (show the exact JSON entry)
+   d. Use AskUserQuestion: "Hook을 settings.json에 등록할까요?" (✅ 등록 / ⏭ 파일만 유지 / 🕐 나중에)
+   e. If approved: Edit `.claude/settings.json` to register the hook (inside the
+      step-(a) worktree when one was created — `settings.json` shares the same
+      protected-branch repo as the hook file)
+   f. If skipped/deferred: leave the hook file in place and provide manual registration instructions
+
+7. **Verification** — For each executed action, verify the artifact:
+
+   | Artifact | Verification |
+   |----------|-------------|
+   | MEMORY.md feedback (new) | File exists + MEMORY.md index updated + `hookable`/`hookKeywords` frontmatter decision recorded (true with keywords, OR false with rationale in Actions Executed report) |
+   | MEMORY.md feedback (merged) | Existing file updated (diff shown) + MEMORY.md index description updated if needed + if existing entry had `hookable: false` **or the field is missing entirely** and merged context now meets the retrieval-critical default, re-evaluate and add/update frontmatter (most pre-existing memories lack `hookable` — missing field is the dominant case, not false) |
+   | GitHub issue | `gh issue view {url}` returns valid data |
+   | Upstream feedback | `gh issue view {url}` returns valid data + URL repo matches `verified_backing_repo` from step 0 + label convention is correct for the verified repo (`tool-friction:{layer}` ONLY when verified repo is the praxis distribution; otherwise the repo's own convention label per Action 4's label rule) |
+   | Hook code | Script file exists + settings.json registration confirmed (dry-run varies by hook type — no generic check). If Action 6 step (a) created a worktree, report the worktree path and confirm the file exists there. |
+   | Global `~/.claude/CLAUDE.md` draft | **Project target (`AGENTS.md`)**: Diff shown + explicit approval received + Edit applied. **Global target (`~/.claude/CLAUDE.md`)**: Staging file created at `/tmp/claude-md-draft-{slug}.md` → AskUserQuestion 3-option presented → `apply`: Edit applied + diff shown; `보류`: staging file path logged in completion report. |
+   | Skill idea note | File exists in `.omc/plans/` |
+
+   Report verification results in the completion table.
+
+8. **Completion report:**
+
+```
+## Actions Executed
+
+| # | Action | Result |
+|---|--------|--------|
+| 1 | MEMORY.md feedback added | ✅ {file_path} |
+| 2 | GitHub issue created | ✅ {url} |
+| 3 | Upstream feedback (Finding #N) | ✅ {url} (backing_repo verified: declared=live={owner/repo}) |
+| 4 | Upstream feedback (Finding #M) | ⚠ aborted at step 0 — declared {X} ≠ re-resolved {Y}; user picked [b], re-issued at {url} |
+| 5 | Upstream feedback (Finding #P) | ⊘ skipped at step 0 — divergence; user picked [c], action removed; reason: declared {X} not reachable, re-resolved {Y} unfamiliar to user |
+...
+
+Session learnings captured. Next session will benefit from these improvements.
+```

--- a/skills/retrospect/references/stage4-execution.md
+++ b/skills/retrospect/references/stage4-execution.md
@@ -97,12 +97,14 @@ For each approved action:
    a. **Stage draft**: write the proposed rule block to `/tmp/claude-md-draft-{slug}.md` (use `.omc/plans/claude-md-draft-{slug}.md` as fallback when `/tmp/` is not writable). Present the full draft content inline before showing the prompt.
 
    b. **AskUserQuestion — 3-option prompt**:
-      ```
+
+      ```text
       options:
         apply  — 승인. 지금 바로 적용합니다.
         수정   — 변경할 내용을 free-text로 입력하면 재작성 후 다시 이 단계로 돌아옵니다.
         보류   — 이번 세션은 적용하지 않습니다. 스테이징 파일을 남겨둡니다.
       ```
+
       - `수정` 선택 시: "무엇을 바꿀까요?" 입력 받음 → re-draft → 다시 (b) 단계로 복귀.
         Cap: 최대 3 라운드. 3 라운드 초과 시: "3회 재작성을 초과했습니다. 수동 편집을 권장합니다: `{staging_path}`" 후 보류 처리.
       - `보류` 선택 시: Edit 호출 없이 staging 파일 경로를 completion report에 기록하고 종료.
@@ -128,7 +130,8 @@ For each approved action:
    4. **Divergence / ambiguity handling.** If `live_backing_repo != declared backing_repo` (after normalization) → ABORT and surface to user via `AskUserQuestion`. Two prompt variants:
 
       **(i) Both sides concrete repos — 3-way prompt:**
-      ```
+
+      ```text
       ⚠ Backing-repo divergence on Finding #N:
          Stage 2/3 declared:    {declared}
          Stage 4 re-resolved:   {live}
@@ -140,7 +143,8 @@ For each approved action:
       ```
 
       **(ii) Re-resolution returned `AMBIGUOUS` (declared is concrete) — 2-way prompt:**
-      ```
+
+      ```text
       ⚠ Backing-repo re-resolution ambiguous on Finding #N:
          Stage 2/3 declared:    {declared}
          Stage 4 re-resolved:   AMBIGUOUS (resolution table's `Other / ambiguous` row)
@@ -178,7 +182,7 @@ For each approved action:
 
    **Mandatory `AskUserQuestion` prompt (do NOT proceed without explicit `[a]` pick):**
 
-   ```
+   ```text
    ⚠ External-repo write authorization required — Finding #N
 
    Proposed: create GitHub issue in {backing_repo} (classified external by Stage 2.5 Gate-4)
@@ -221,10 +225,12 @@ For each approved action:
         Edit/Write on protected branches — both the dirty-tree and the clean-tree
         PR-workflow-signal paths). Create a dedicated worktree on a new branch and
         write the hook inside it:
-        ```
+
+        ```bash
         git -C <repo> worktree add -b retrospect-hook-{slug} \
             <repo-parent>/<repo-name>.retrospect-hook-{slug} <protected-branch>
         ```
+
         Surface the worktree path to the user for the commit / PR decision —
         retrospect does NOT auto-commit or auto-PR the hook; its contract ends at
         the file write.
@@ -254,7 +260,7 @@ For each approved action:
 
 8. **Completion report:**
 
-```
+```markdown
 ## Actions Executed
 
 | # | Action | Result |


### PR DESCRIPTION
## 개요

`skills/retrospect/SKILL.md` 1,592줄 → **1,283줄** 구조 분리. 런타임에 항상 필요한 normative 본문은 유지하고, 참조 시점에만 필요한 상세를 `skills/retrospect/references/`로 이동합니다.

Closes #646

## 분리 결과 (이슈 검증 기준: 본문 줄 수 + 분리 문서 목록)

| 파일 | 줄 수 | 내용 |
|---|---|---|
| `skills/retrospect/SKILL.md` | **1,283** (기존 1,592) | normative 본문 전체 잔존 |
| `skills/retrospect/references/report-template.md` | 105 (신규) | Stage 3 통합 리포트 템플릿 + worked examples 3종 |
| `skills/retrospect/references/stage4-execution.md` | 270 (신규) | Stage 4 Action 1~8 전체 절차 (템플릿/프롬프트/resolution table/검증 매트릭스/완료 리포트 형식) |

## 분리 경계 설계

- **frontmatter trigger SoT 불변** — description 영역 diff 없음 (origin/main 대비 검증).
- **Output Schema Contract(hook-parsed) 전체 본문 잔존** — Stop hook `retrospect-mix-check`가 파싱하는 fence 마커, AUTHORITATIVE_SCHEMA 주석, distribution-card 키 셋 모두 SKILL.md에 유지.
- 기존 템플릿 fence **안에** 있던 normative 절 4개(Trigger Conditions / No patterns found / Enumerate-before-empty-fence / Reinforced Patterns)는 본문으로 **승격** (verbatim, 헤딩 ###→####).
- Stage 4 상세는 "**Before executing ANY approved action, Read the reference**" MUST 지시 + 8행 게이트 요약표로 대체 — 요약표는 각 action의 non-negotiable gate(Action 3 staging→AskUserQuestion→명시 승인, Action 4 step 0/0a 등)를 보존.
- 테스트 잠금 패턴(`<resolved_backing_repo>` 등)은 본문에 잔존하도록 경계 조정 — `test_retrospect_*.sh` 3종은 **무수정** green.

## codex-review-wrap/SKILL.md (937줄) 적용 여부 판단 — 이슈 체크박스 4

**적용 보류 (이번 PR 범위에서 제외).** 근거: Step 1~5(5a~5h)가 전부 매 라운드 실행 순서에 들어가는 런타임 게이트 절차라 "참조 시점에만 필요한 상세"와의 경계가 약함. 분리 가능 영역은 Example Flow(~120줄)+5g worked examples 수준으로 효익이 작고, Step 5 게이트 분리는 게이트 skip 리스크를 증가시킴. 필요 시 별도 follow-up 이슈로 진행.

## 리뷰

- `oh-my-claudecode:code-reviewer`: REQUEST_CHANGES → 3건 전부 수정 완료. MEDIUM(stage4-execution.md 닫는 펜스 누락 — 추출 경계가 원본 라인 1447 펜스를 제외), LOW(SKILL.md 본문의 "these literal column headers" dangling 참조 → 템플릿 링크로 교체), LOW(references 미staging → 커밋에 포함, `git diff --cached --diff-filter=A`로 2개 검증).
- `praxis:codex-review-wrap` → codex: **P2 1건 수용** — 분리된 템플릿에 hook-parsed `retrospect:transcript_receipt`(Gate-7) 슬롯 부재. 전제 검증 결과 원본 템플릿에도 슬롯이 없던 pre-existing 상태(회귀 아님)지만, 분리로 누락 위험이 증폭되므로 §3e 조건부 슬롯 + post-compaction-only 안내문 추가.

## 검증

- `PATH=pyenv-shims ./scripts/run-tests.sh` → **ALL TESTS PASSED** (수정 후 fresh run)
- 잠금 테스트 무수정 green: `test_retrospect_cursor_concurrency.sh` 10/10, `test_retrospect_falsify_recommended.sh` 28/28, `test_retrospect_routing.sh` 5/5
- **전수 손실 감사**: 원본 1,129 non-trivial 라인 전부가 (새 SKILL.md + references 2개)에 존재 — 의도적으로 재작성한 intro 1문장만 예외
- **콘텐츠 보존**: 이동 4블록(템플릿/승격절/예시/Stage 4) 추출 원본과 set-inclusion 일치
- 코드펜스 균형: SKILL.md 48 / report-template.md 2 / stage4-execution.md 14 — 전부 짝수
- 상대 링크 `references/*.md` 2개 실파일 resolve 확인

## 검증 안 된 것

- 라이브 `/retrospect` 호출에서 references Read 거동은 미실행 (문서-only 변경; 테스트 잠금 + 전수 손실 감사로 대체)

## 영향 범위

retrospect 스킬 문서 구조만 변경. hook/테스트/코드 무변경. 잘못될 경우 영향은 retrospect 세션의 참조 누락 — Stop hook 잠금(mix-check)은 본문 contract 기준이라 그대로 동작.

Pre-commit verified: PATH=pyenv-shims ./scripts/run-tests.sh → ALL TESTS PASSED; lock tests 10/10+28/28+5/5 unmodified; exhaustive line-loss audit 1 intentional rewrite only
Caller chain verified: SKILL.md의 references/ 상대 링크 2개가 skill 디렉토리 내 실파일로 resolve; Stop hook retrospect-mix-check는 SKILL.md가 아닌 emitted report를 파싱하므로 분리 무영향 (impl.sh:265 직접 확인)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Tightened Stage 3 output schema and Stop-hook parsing expectations; clarified where structured rationale belongs.
  * Consolidated worked examples for single/compound/gate-suppressed cases to aid calibration.
  * Cleaned up reinforced patterns formatting for clearer placeholders.
  * Moved detailed Stage 4 execution procedures into a dedicated playbook and reduced the in-file Stage 4 content to a gate-focused orientation.
  * Added comprehensive per-action execution guidance, verification gates, and completion reporting templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->