### PR TITLE
chore(audit): fix low batch h7 s1 s4 h1

### DIFF
--- a/docs/hook/INDEX.md
+++ b/docs/hook/INDEX.md
@@ -47,8 +47,13 @@ confirmation-prompt layer.
 
 ## advisory-nudge
 
-Pre-tool stderr hints. **Never block** — emit reminders for recurrent patterns
-so the agent can self-correct. Fail-open on infrastructure errors by design.
+Pre-tool stderr hints. **Default: never block** — emit reminders for recurrent
+patterns so the agent can self-correct. Documented exceptions escalate beyond
+stderr: hooks marked "opt-in strict" in the table emit `ask`/`deny`/block only
+when their strict-mode env var is set, and `output-block-falsify-advisory`'s
+T1 tier hard-denies — without any env gate — when the exact `(Recommended)`
+marker appears without an accompanying `Falsified:` line (issue #393).
+Fail-open on infrastructure errors by design.
 
 | Hook | Trigger | Purpose |
 |------|---------|---------|
@@ -60,7 +65,7 @@ so the agent can self-correct. Fail-open on infrastructure errors by design.
 | [memory-hint](../../hooks/advisory-nudge/memory-hint/spec.md) | PreToolUse | Surface hookable memory entries by keyword at decision-construction time |
 | [external-write-falsify-check](../../hooks/advisory-nudge/external-write-falsify-check/spec.md) | PreToolUse (opt-in) | Warn before posting hypothesis-stage text to PR / issue / Slack / Notion |
 | [external-api-literal-trigger](../../hooks/advisory-nudge/external-api-literal-trigger/spec.md) | PreToolUse | Advisory nudge when ALL_CAPS enum candidates or 3-part SQL identifiers are written without prior retrieval verification |
-| [output-block-falsify-advisory](../../hooks/advisory-nudge/output-block-falsify-advisory/spec.md) | PreToolUse | Advisory nudge to run output-block falsification gate before surfacing `(Recommended)` options or bulk-action commands |
+| [output-block-falsify-advisory](../../hooks/advisory-nudge/output-block-falsify-advisory/spec.md) | PreToolUse | Output-block falsification gate before surfacing `(Recommended)` options or bulk-action commands — T1 (exact `(Recommended)` marker without `Falsified:` line) hard-denies; T2 (confidence-anchoring tokens) emits `ask` |
 | [advisory-wrapper-signature-verify](../../hooks/advisory-nudge/advisory-wrapper-signature-verify/spec.md) | PreToolUse | Advisory nudge to verify wrapped function signatures before writing wrapper/client code |
 | [jq-config-empty-dict-advisory](../../hooks/advisory-nudge/jq-config-empty-dict-advisory/spec.md) | PreToolUse | Advisory nudge when `jq` reads a config file (settings.json, hooks.json, ~/.claude/*.json, ~/.codex/*.json) that is empty or invalid JSON |
 | [bash-worktree-existence-advisory](../../hooks/advisory-nudge/bash-worktree-existence-advisory/spec.md) | PreToolUse | Advisory nudge when `cd <path>` targets a path that does not exist on disk |

--- a/hooks/preflight-gate/session-intent/impl.py
+++ b/hooks/preflight-gate/session-intent/impl.py
@@ -73,6 +73,7 @@ import os
 import re
 import sys
 import sys as _sys
+import tempfile
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
@@ -287,8 +288,24 @@ def write_state(path: str, state: dict) -> None:
         parent = os.path.dirname(path)
         if parent and not os.path.isdir(parent):
             os.makedirs(parent, exist_ok=True)
-        with open(path, "w", encoding="utf-8") as fh:
-            json.dump(state, fh)
+        # Atomic write (temp + rename): a crash mid-write must not leave a
+        # truncated JSON file — a concurrent PreToolUse read of partial JSON
+        # would fail to parse and silently fail-open the gate (issue #647 H7).
+        fd, tmp_path = tempfile.mkstemp(
+            dir=parent or ".", prefix=".session-intent-"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(state, fh)
+            os.replace(tmp_path, path)
+        except Exception:
+            # Broad on purpose: json.dump can raise TypeError (not OSError);
+            # any failure before os.replace must unlink the temp file.
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
     except OSError:
         # State write failure is non-fatal — the gate will simply not fire
         # for this session, equivalent to a missing state file.

--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cmux-delegate
-description: Delegate a task to an independent Claude Code session in a new cmux workspace with auto-collected context. Triggers on "delegate", "cmux delegate", "new session", "별도 세션".
+description: Delegate a task to an independent Claude Code session in a new cmux workspace with auto-collected context. Triggers on "cmux delegate", "delegate task", "delegate to new session", "별도 세션", "세션에 위임".
 ---
 
 # cmux-delegate

--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -19,7 +19,7 @@ Symptom-level fixes (e.g., "remember to do X") miss the underlying pattern.
 
 **Pipeline:** `Load → Analyze → Report/Approve → Execute` (4 stages)
 
-**Delegates to:** OMC `tracer` agent (causal pattern analysis), `analyst` agent (pattern clustering)
+**Delegates to:** `oh-my-claudecode:tracer` agent (causal pattern analysis), `oh-my-claudecode:analyst` agent (pattern clustering) — invoked via `Agent(subagent_type="oh-my-claudecode:…")`
 
 ## The Iron Law
 


### PR DESCRIPTION
## 개요

#647 LOW 잔존분 중 batch 처리 승인된 4건(H7·S1·S4·H1)을 관심사별 atomic 커밋 4개로 수정합니다. H3(completion-verify block 시그널 표준화)와 F6(install/verify 행동 테스트)은 별도 PR로 후속 — 본 PR은 이슈의 부분 범위만 다루므로 `Closes`가 아닌 Refs를 사용합니다.

Refs #647 (H7, S1, S4, H1 — H3·F6는 후속 PR)

## 변경 내용 (커밋별)

| 커밋 | Finding | 내용 |
|---|---|---|
| `fix(hooks): atomic state write in session-intent` | H7 | `write_state()`를 `tempfile.mkstemp` + `os.replace` 원자 쓰기로 전환 — crash mid-write 시 truncated JSON이 PreToolUse 읽기에서 silent fail-open되는 표면 제거. cleanup은 `except Exception`(json.dump TypeError 경로 temp 누수 방지, code-reviewer LOW 수용) |
| `fix(skills): narrow cmux-delegate trigger phrases` | S1 | 과일반 bare 트리거 `"delegate"`/`"new session"` 제거 → 복합 구문 5종 (sibling 컨벤션 정합) |
| `docs(skills): qualify retrospect delegate agent names` | S4 | frontmatter `Delegates to`의 bare `tracer`/`analyst` → `oh-my-claudecode:` 정규형 + invocation form 명시 (본문 Stage 2 실제 호출과 일치) |
| `docs(hooks): fix advisory-nudge never-block wording` | H1 | INDEX.md 헤더 "Never block" → 기본 + 예외 2종(opt-in strict env-gate / output-block-falsify-advisory T1의 `(Recommended)`+`Falsified:` 부재 시 deny) 정확화; 해당 훅 행에 T1/T2 tier 분리 기술 |

## 리뷰

- `oh-my-claudecode:code-reviewer`: REQUEST_CHANGES → 2건 모두 수정 후 autosquash. MEDIUM(H1 prose "unconditionally"가 자체 표·impl과 모순 → `Falsified:` 부재 조건 명시로 교체), LOW(H7 cleanup이 OSError만 catch → TypeError 경로 temp 누수 → `except Exception`으로 확장). S1/S4는 사실 정확성 검증 통과(트리거 충돌 0건, invocation form 본문 388/394행과 일치).
- `praxis:codex-review-wrap` → codex: **finding 0건** ("명확한 correctness 문제를 찾지 못했습니다").

## 검증

- `PATH=pyenv-shims ./scripts/run-tests.sh` → **ALL TESTS PASSED** (autosquash 후 fresh run)
- `ruff check hooks/` → All checks passed
- session-intent 기존 스위트 26/26 + 기능 smoke: 원자 쓰기 정상 + temp 잔존 0 + **TypeError 주입 시 temp 누수 0** (falsification 실행 출력 확인)
- retrospect 잠금 테스트 3종 무수정 green
- `check-plugin-manifests.py` OK (SKILL.md description은 생성물에 미복제 확인)

## 검증 안 된 것

- crash-injection mid-write(전원 단절 시점 재현)는 미실행 — `os.replace` 원자성 보장에 의존

## 영향 범위

session-intent 훅의 state 쓰기 경로(거동 동일, 실패 모드만 개선), cmux-delegate 트리거 폭(좁아짐 — 의도), 문서 2건. 잘못될 경우 영향은 cmux-delegate 트리거 미발화(명시 호출로 복구 가능) 수준.

## #647 wontfix 3건 (이 PR에서 코드 무변경, 이슈에 기록됨)

H2(전 spec/impl 대조 mismatch 0건 — 재현 불가), H5(docstring 명세와 일치 — as designed), H6(파서 공유 lib 존재, env 키 차이는 의도적 분리).

Pre-commit verified: PATH=pyenv-shims ./scripts/run-tests.sh → ALL TESTS PASSED; ruff clean; session-intent 26/26 + TypeError-injection no-leak smoke; retrospect lock tests 3/3
Caller chain verified: write_state 호출자는 session-intent impl 내부 1곳뿐(impl.py:446, grep 확인), 시그니처 불변; SKILL.md description 변경은 생성 manifest에 미전파(check-plugin-manifests.py OK)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified hook behavior documentation for advisory notifications, strict handling modes, and error handling
  * Updated skill trigger keywords for improved discoverability
  * Enhanced delegation documentation with explicit agent references

* **Bug Fixes**
  * Improved session state persistence with atomic writes to prevent data corruption during concurrent access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->