### PR TITLE
refactor(hooks): unify stop-hook signal on json

### DIFF
--- a/docs/hook/INDEX.md
+++ b/docs/hook/INDEX.md
@@ -104,6 +104,12 @@ finalized. Run sequentially: `completion-verify` → `retrospect-mix-check` →
 `merge-state-claim-gate` → `strike-counter stop`.
 Also includes session-lifecycle enforcement.
 
+Signal convention (issue #647 H3): every hook in this role emits stdout JSON —
+advisory tier `{"systemMessage": ...}` (shown to the user, does not block),
+block tier `{"decision": "block", "reason": ...}` (blocks the stop; reason is
+fed to the model). Exit code is 0 in both tiers; stderr is never the signal
+channel.
+
 | Hook | Trigger | Purpose |
 |------|---------|---------|
 | [completion-verify](../../hooks/completion-verify/completion-verify/spec.md) | Stop | Block "done / 완료" claims without same-turn Bash verification evidence |

--- a/hooks/_lib/_hook_io.py
+++ b/hooks/_lib/_hook_io.py
@@ -1,4 +1,7 @@
-"""Standard decision-emit format for praxis PreToolUse hooks (issue #470).
+"""Standard decision-emit format for praxis PreToolUse and Stop hooks.
+
+PreToolUse `permissionDecision` shape: issue #470. Stop advisory/block
+shapes: issue #647 H3 (see the Stop-event emitters section below).
 
 13 PreToolUse hooks each hand-rolled the identical `permissionDecision` JSON
 dump to stdout — `json.dump({"hookSpecificOutput": {"hookEventName":
@@ -73,4 +76,49 @@ def emit_decision(
     """
     out = stream if stream is not None else sys.stdout
     json.dump(format_decision(decision, reason, event_name), out)
+    out.write("\n")
+
+
+# --- Stop-event emitters (issue #647 H3) ------------------------------------
+#
+# completion-verify Stop hooks signal in two tiers, both as stdout JSON so the
+# whole role shares one mechanism (the shell hooks already emit
+# `{decision: "block", reason}` via jq):
+#
+#   advisory  → `{"systemMessage": ...}` + exit 0. Shown to the user in the
+#               transcript; does NOT block the stop and is NOT fed to the
+#               model. (stderr with exit 0 only reaches the debug log, so the
+#               pre-#647 stderr advisories were effectively invisible.)
+#   block     → `{"decision": "block", "reason": ...}` + exit 0. Blocks the
+#               stop; `reason` is fed to the model so it can self-correct.
+#
+# Callers own the exit code (always 0 for both shapes — blocking is carried by
+# the JSON `decision` field, not the exit code).
+
+
+def format_stop_advisory(message: str) -> dict:
+    """Return the non-blocking Stop advisory dict (no I/O)."""
+    return {"systemMessage": message}
+
+
+def format_stop_block(reason: str) -> dict:
+    """Return the blocking Stop decision dict (no I/O).
+
+    Key order matches the shell siblings' `jq -n '{decision: ..., reason: ...}'`
+    output for cross-implementation consistency.
+    """
+    return {"decision": "block", "reason": reason}
+
+
+def emit_stop_advisory(message: str, stream: Optional[TextIO] = None) -> None:
+    """Write the Stop `systemMessage` JSON to stdout (+ trailing newline)."""
+    out = stream if stream is not None else sys.stdout
+    json.dump(format_stop_advisory(message), out)
+    out.write("\n")
+
+
+def emit_stop_block(reason: str, stream: Optional[TextIO] = None) -> None:
+    """Write the Stop `{decision: block}` JSON to stdout (+ trailing newline)."""
+    out = stream if stream is not None else sys.stdout
+    json.dump(format_stop_block(reason), out)
     out.write("\n")

--- a/hooks/completion-verify/completion-signal-gate/impl.py
+++ b/hooks/completion-verify/completion-signal-gate/impl.py
@@ -15,7 +15,7 @@ Two detection rules:
   Rule 1 — completion-signal without evidence-block:
     Scan the last assistant turn for completion-signal tokens (EN/KR).
     If found AND the turn has no evidence-block indicators (Bash tool call,
-    Read tool call, cited `$ ... → output` lines), emit advisory to stderr.
+    Read tool call, cited `$ ... → output` lines), emit the advisory.
 
   Rule 2 — plugin-context anchoring (Event 2):
     Scan the last assistant message text for /command patterns.
@@ -23,9 +23,11 @@ Two detection rules:
     .claude-plugin/marketplace.json or git remote slug).
     If mismatch detected, emit advisory.
 
-Tier: advisory (stderr only, no decision JSON, exit 0).
-Advisory is a system-reminder signal; Claude will see it as additional context
-in the next turn. No blocking until tier promotion (follow-up issue).
+Tier: advisory (stdout `{"systemMessage": ...}` JSON, exit 0 — issue #647 H3
+standardized the completion-verify role on stdout JSON; the old stderr form
+only reached the debug log). No block tier — this hook never blocks.
+The systemMessage is shown to the user in the transcript only — it does NOT
+enter the model's context. No blocking until tier promotion (follow-up issue).
 
 Fail-open contract:
   - Malformed / missing stdin JSON → exit 0
@@ -43,6 +45,7 @@ import subprocess
 import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_io import emit_stop_advisory  # type: ignore[import-not-found]  # noqa: E402
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
     extract_last_assistant_text,
@@ -343,11 +346,13 @@ def main() -> int:
     has_bash = has_tool_in_turn(turn, "Bash")
     has_read = has_tool_in_turn(turn, "Read")
 
+    messages: list[str] = []
+
     # Rule 1: completion-signal without evidence
     if _has_completion_signal(last_text) and not _has_evidence_block(
         last_text, has_bash, has_read
     ):
-        sys.stderr.write(ADVISORY_RULE1 + "\n")
+        messages.append(ADVISORY_RULE1)
 
     # Rule 2: plugin-context anchoring
     cwd_plugin = _get_cwd_plugin_name() or _get_cwd_git_slug()
@@ -355,10 +360,15 @@ def main() -> int:
         foreign = _detect_foreign_slash_commands(last_text, cwd_plugin)
         if foreign:
             cmds_str = ", ".join(foreign)
-            msg = ADVISORY_RULE2.replace("{cmds}", cmds_str).replace(
-                "{plugin}", cwd_plugin
+            messages.append(
+                ADVISORY_RULE2.replace("{cmds}", cmds_str).replace(
+                    "{plugin}", cwd_plugin
+                )
             )
-            sys.stderr.write(msg + "\n")
+
+    if messages:
+        # Single JSON object per invocation — both rules can fire in one stop.
+        emit_stop_advisory("\n".join(messages))
 
     return 0
 

--- a/hooks/completion-verify/completion-signal-gate/spec.md
+++ b/hooks/completion-verify/completion-signal-gate/spec.md
@@ -3,7 +3,7 @@
 Supported hosts: all
 
 `hooks/completion-signal-gate.py` fires on every `Stop` event and emits an
-advisory to stderr when the last assistant turn contains a completion-signal
+advisory (stdout `{"systemMessage": ...}` JSON) when the last assistant turn contains a completion-signal
 phrase without an evidence-block indicator in the same turn, or when a
 cross-plugin slash command is surfaced in the wrong repo context.
 
@@ -107,10 +107,13 @@ Fires in either of two forms when the cwd's active plugin is `praxis`
 
 ### Response
 
-Both rules emit advisory text to **stderr only**. No JSON is written to
+Both rules emit a single stdout `{"systemMessage": ...}` JSON object per
+invocation (messages joined with a newline when both rules fire; issue #647
+H3 standardized the completion-verify role on stdout JSON — stderr with exit
+0 only reached the debug log). No `decision` field is written to
 stdout. The hook always exits 0 — it never blocks.
 
-**Rule 1 advisory (stderr):**
+**Rule 1 advisory (systemMessage body):**
 
 ```
 [praxis:completion-signal-gate] completion-signal phrase detected in last turn without an evidence-block (Bash tool result, Read tool call, or cited '$ command → output' line).
@@ -118,7 +121,7 @@ stdout. The hook always exits 0 — it never blocks.
 [praxis:completion-signal-gate] Trigger: matched completion-signal token in last assistant turn. Add evidence or remove the completion phrase to suppress this advisory.
 ```
 
-**Rule 2 advisory (stderr):**
+**Rule 2 advisory (systemMessage body):**
 
 ```
 [praxis:completion-signal-gate] cross-plugin slash command(s) /laplace-dev-hub:close-hub-issue surfaced while cwd plugin is 'praxis'.
@@ -179,7 +182,7 @@ triple gate). This hook is complementary:
 - **Weaker evidence gate** — any Bash or Read tool call suppresses this hook;
   `completion-verify.sh` additionally requires the evidence span to be pasted
   verbatim in the message (L2).
-- **Advisory vs block** — this hook emits stderr advisory only; the sibling
+- **Advisory vs block** — this hook emits a `systemMessage` advisory only; the sibling
   hard-blocks. Both fire on the same Stop event, independently.
 
 ### Tests

--- a/hooks/completion-verify/merge-state-claim-gate/impl.py
+++ b/hooks/completion-verify/merge-state-claim-gate/impl.py
@@ -13,9 +13,12 @@ This hook scans the final assistant message for a *completed* merge / PR / issue
 / worktree state assertion and, if no fresh state query
 (`gh pr|issue view/list/merge`, or a GitHub MCP pull_request/issue/merge read)
 appears in the recent transcript, emits an advisory. It is advisory by default
-(exit 0 + stderr; the model has already stopped, so the note reaches the user);
-`PRAXIS_MERGE_CLAIM_STRICT=1` escalates to exit 2 (re-prompts the model to
-verify). Fully fail-open; bypass with `PRAXIS_MERGE_CLAIM_BYPASS=1`.
+(stdout `{"systemMessage": ...}` JSON + exit 0 — shown to the user in the
+transcript; issue #647 H3 standardized the completion-verify role on stdout
+JSON, replacing the old stderr form that only reached the debug log);
+`PRAXIS_MERGE_CLAIM_STRICT=1` escalates to `{"decision": "block", "reason":
+...}` (re-prompts the model to verify). Fully fail-open; bypass with
+`PRAXIS_MERGE_CLAIM_BYPASS=1`.
 """
 from __future__ import annotations
 
@@ -26,6 +29,10 @@ import sys
 from pathlib import Path as _Path
 
 sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_io import (  # type: ignore[import-not-found]  # noqa: E402
+    emit_stop_advisory,
+    emit_stop_block,
+)
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
     extract_last_assistant_text,
@@ -166,8 +173,11 @@ def main() -> int:
     if has_fresh_state_query(events):
         return 0  # claim is backed by a recent state query
 
-    sys.stderr.write(_advisory(kinds))
-    return 2 if os.environ.get(_STRICT_ENV, "").strip() == "1" else 0
+    if os.environ.get(_STRICT_ENV, "").strip() == "1":
+        emit_stop_block(_advisory(kinds))
+    else:
+        emit_stop_advisory(_advisory(kinds))
+    return 0
 
 
 if __name__ == "__main__":

--- a/hooks/completion-verify/merge-state-claim-gate/spec.md
+++ b/hooks/completion-verify/merge-state-claim-gate/spec.md
@@ -5,7 +5,7 @@ Supported hosts: all
 `hooks/completion-verify/merge-state-claim-gate/impl.py` runs on the `Stop`
 event. It scans the **final assistant message** for a completed merge / PR /
 issue / worktree state assertion and, when no fresh state query appears in the
-recent transcript, emits a **stderr advisory**.
+recent transcript, emits a **stdout `{"systemMessage": ...}` JSON advisory**.
 
 ### Why this exists
 
@@ -23,9 +23,12 @@ did.
 
 ### What is emitted
 
-Advisory by default — exit 0 + stderr. The model has already stopped, so the
-note reaches the user (and the next turn's context). `PRAXIS_MERGE_CLAIM_STRICT=1`
-escalates to exit 2, which re-prompts the model to verify before stopping.
+Advisory by default — exit 0 + stdout `{"systemMessage": ...}` JSON (issue #647
+H3; the old exit-0 stderr form only reached the debug log). The model has
+already stopped, so the note reaches the user (transcript-visible; not fed to
+the model). `PRAXIS_MERGE_CLAIM_STRICT=1`
+escalates to a `{"decision": "block", "reason": ...}` JSON, which re-prompts
+the model to verify before stopping.
 
 | Condition | Result |
 |-----------|--------|
@@ -87,6 +90,6 @@ bash tests/hooks/completion-verify/test_merge_state_claim_gate.sh
 
 13 cases: English/Korean claim without evidence (advisory), claim with `gh`
 evidence / GitHub MCP evidence (silent), neutral message (silent), negated claim
-(silent), future intent (silent), strict mode (exit 2), bypass (silent),
+(silent), future intent (silent), strict mode (decision: block), bypass (silent),
 `stop_hook_active` loop guard (silent), worktree-cleanup claim (advisory),
 missing transcript (fail-open), malformed JSON (fail-open).

--- a/hooks/completion-verify/readonly-verify-deferral-gate/impl.py
+++ b/hooks/completion-verify/readonly-verify-deferral-gate/impl.py
@@ -33,9 +33,12 @@ A project that wants to recognise its own read-only CLIs sets
 PRAXIS_READONLY_VERIFY_SIGNALS to an extra regex (alternation) — no
 project-specific token is hard-coded in this file.
 
-Tier: advisory (stderr only, exit 0). PRAXIS_READONLY_VERIFY_STRICT=1 escalates
-to exit 2 (Stop is blocked and stderr is shown to the model so it re-runs the
-read). PRAXIS_READONLY_VERIFY_BYPASS=1 silences the hook entirely.
+Tier: advisory (stdout `{"systemMessage": ...}` JSON, exit 0 — issue #647 H3
+standardized the completion-verify role on stdout JSON; the old stderr form
+only reached the debug log). PRAXIS_READONLY_VERIFY_STRICT=1 escalates to
+`{"decision": "block", "reason": ...}` (Stop is blocked and the reason is fed
+to the model so it re-runs the read). PRAXIS_READONLY_VERIFY_BYPASS=1 silences
+the hook entirely.
 
 KNOWN LIMITATION (see spec.md): this is an output-scan proxy. It polices the
 *articulation* of a deferral, not the behaviour — it misses a vague offer that
@@ -57,6 +60,10 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "_lib"))
+from _hook_io import (  # type: ignore[import-not-found]  # noqa: E402
+    emit_stop_advisory,
+    emit_stop_block,
+)
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
     extract_last_assistant_text,
@@ -300,7 +307,7 @@ ADVISORY = (
     "send/deploy).\n"
     f"{PREFIX} If the deferred action is actually a mutation, name it explicitly "
     "so the carve-out recognises it. Bypass: " + _BYPASS_ENV + "=1; "
-    "strict (exit 2): " + _STRICT_ENV + "=1."
+    "strict (decision: block): " + _STRICT_ENV + "=1."
 )
 
 
@@ -344,8 +351,11 @@ def main() -> int:
     if not _is_readonly_offer(last_text, extra):
         return 0
 
-    sys.stderr.write(ADVISORY + "\n")
-    return 2 if os.environ.get(_STRICT_ENV, "").strip() == "1" else 0
+    if os.environ.get(_STRICT_ENV, "").strip() == "1":
+        emit_stop_block(ADVISORY)
+    else:
+        emit_stop_advisory(ADVISORY)
+    return 0
 
 
 if __name__ == "__main__":

--- a/hooks/completion-verify/readonly-verify-deferral-gate/spec.md
+++ b/hooks/completion-verify/readonly-verify-deferral-gate/spec.md
@@ -3,7 +3,7 @@
 Supported hosts: all
 
 `hooks/readonly-verify-deferral-gate.sh` fires on every `Stop` event and emits
-an advisory to stderr when the last assistant turn **offers** to run a
+a stdout `{"systemMessage": ...}` JSON advisory when the last assistant turn **offers** to run a
 read-only verification ("should I check ...?", "진행할까요?") instead of just
 running it and pasting the result.
 
@@ -117,25 +117,27 @@ still warn; the offer sentence for B carries no past-run cue, so it does
 
 ## Response
 
-Advisory text to **stderr only**; no JSON on stdout.
+Advisory arrives as a single stdout `{"systemMessage": ...}` JSON object
+(issue #647 H3); stderr stays empty.
 
 ```text
 [praxis:readonly-verify-deferral-gate] a read-only verification was OFFERED instead of run: the last turn names a read-only command (SELECT…FROM, kubectl get/describe/logs, git status, --dry-run, …) and defers it to the user ('should I check?', '진행할까요?').
 [praxis:readonly-verify-deferral-gate] Rule: CLAUDE.md 'Read-only calls auto-proceed' — a read carries no mutation risk, so just run it and paste the result. Do NOT hand it back as an option. Deferral is reserved for mutations (write/push/merge/delete/send/deploy).
-[praxis:readonly-verify-deferral-gate] If the deferred action is actually a mutation, name it explicitly so the carve-out recognises it. Bypass: PRAXIS_READONLY_VERIFY_BYPASS=1; strict (exit 2): PRAXIS_READONLY_VERIFY_STRICT=1.
+[praxis:readonly-verify-deferral-gate] If the deferred action is actually a mutation, name it explicitly so the carve-out recognises it. Bypass: PRAXIS_READONLY_VERIFY_BYPASS=1; strict (decision: block): PRAXIS_READONLY_VERIFY_STRICT=1.
 ```
 
 ## Tiers / env vars
 
 | Env var | Effect |
 |---------|--------|
-| (default) | Advisory: stderr + exit 0. Never blocks. |
-| `PRAXIS_READONLY_VERIFY_STRICT=1` | Escalate to exit 2 — Stop is blocked and stderr is shown to the model so it re-runs the read. |
+| (default) | Advisory: stdout `{"systemMessage": ...}` JSON + exit 0. Never blocks. |
+| `PRAXIS_READONLY_VERIFY_STRICT=1` | Escalate to `{"decision": "block", "reason": ...}` — Stop is blocked and the reason is fed to the model so it re-runs the read. |
 | `PRAXIS_READONLY_VERIFY_BYPASS=1` | Silence the hook entirely (exit 0, no scan). |
 | `PRAXIS_READONLY_VERIFY_SIGNALS=<regex>` | OR-ed into Signal A to recognise project-specific read-only CLIs. |
 
 Exit-2-on-Stop semantics match the sibling `merge-state-claim-gate`: Claude Code
-treats a Stop hook exit 2 as "block the stop and show stderr to the model".
+treats a Stop hook `{"decision": "block"}` as "block the stop and feed the
+reason to the model" (equivalent to the exit-2 stderr form, but structured).
 
 ## KNOWN LIMITATION — output-scan proxy
 

--- a/tests/hooks/completion-verify/test_completion_signal_gate.py
+++ b/tests/hooks/completion-verify/test_completion_signal_gate.py
@@ -50,6 +50,18 @@ spec.loader.exec_module(csg)  # type: ignore[union-attr]
 # ---------------------------------------------------------------------------
 
 
+
+def _msg(stdout: str) -> str:
+    """Extract the systemMessage from the hook's stdout JSON.
+
+    Issue #647 H3: advisories arrive as `{"systemMessage": ...}` on stdout
+    (stderr stays empty). Empty stdout (silent pass) maps to "".
+    """
+    if not stdout.strip():
+        return ""
+    return json.loads(stdout)["systemMessage"]
+
+
 def mk_user(text: str) -> dict[str, Any]:
     return {
         "type": "user",
@@ -158,9 +170,9 @@ def test_rule1_triggers_on_phrase(phrase: str, tmp_path: Path) -> None:
     tp = write_jsonl(events, tmp_path)
     stdout, stderr, rc = run_hook(tp)
     assert rc == 0, f"hook must exit 0 (advisory); got {rc}"
-    assert stdout == "", f"advisory hook must produce no stdout; got: {stdout!r}"
-    assert "[praxis:completion-signal-gate]" in stderr, (
-        f"advisory not emitted for phrase {phrase!r}; stderr={stderr!r}"
+    assert stderr == "", f"advisory hook must keep stderr empty; got: {stderr!r}"
+    assert "[praxis:completion-signal-gate]" in _msg(stdout), (
+        f"advisory not emitted for phrase {phrase!r}; stdout={stdout!r}"
     )
 
 
@@ -180,10 +192,10 @@ def test_rule1_suppressed_by_bash_tool(tmp_path: Path) -> None:
         mk_assistant("5 tests passed. 완료."),
     ]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp)
+    stdout, stderr, rc = run_hook(tp)
     assert rc == 0
-    assert "[praxis:completion-signal-gate]" not in stderr, (
-        f"must not trigger when Bash tool is present; stderr={stderr!r}"
+    assert stdout == "", (
+        f"must not trigger when Bash tool is present; stdout={stdout!r}"
     )
 
 
@@ -196,10 +208,10 @@ def test_rule1_suppressed_by_read_tool(tmp_path: Path) -> None:
         mk_assistant("파일 확인 완료. 이상 없음."),
     ]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp)
+    stdout, stderr, rc = run_hook(tp)
     assert rc == 0
-    assert "[praxis:completion-signal-gate]" not in stderr, (
-        f"must not trigger when Read tool is present; stderr={stderr!r}"
+    assert stdout == "", (
+        f"must not trigger when Read tool is present; stdout={stdout!r}"
     )
 
 
@@ -212,10 +224,10 @@ def test_rule1_suppressed_by_cited_output_line(tmp_path: Path) -> None:
         ),
     ]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp)
+    stdout, stderr, rc = run_hook(tp)
     assert rc == 0
-    assert "[praxis:completion-signal-gate]" not in stderr, (
-        f"must not trigger with cited output; stderr={stderr!r}"
+    assert stdout == "", (
+        f"must not trigger with cited output; stdout={stdout!r}"
     )
 
 
@@ -235,9 +247,9 @@ def test_fp1_bash_evidence_complete(tmp_path: Path) -> None:
         mk_assistant("15 tests passed in 1.2s. 완료."),
     ]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp)
+    stdout, stderr, rc = run_hook(tp)
     assert rc == 0
-    assert "[praxis:completion-signal-gate]" not in stderr, f"FP1 false-positive: {stderr!r}"
+    assert stdout == "", f"FP1 false-positive: {stderr!r}"
 
 
 def test_fp2_no_completion_phrase(tmp_path: Path) -> None:
@@ -247,9 +259,9 @@ def test_fp2_no_completion_phrase(tmp_path: Path) -> None:
         mk_assistant("다음 단계는 PR 생성입니다. 브랜치를 먼저 확인하겠습니다."),
     ]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp)
+    stdout, stderr, rc = run_hook(tp)
     assert rc == 0
-    assert "[praxis:completion-signal-gate]" not in stderr, f"FP2 false-positive: {stderr!r}"
+    assert stdout == "", f"FP2 false-positive: {stderr!r}"
 
 
 def test_fp3_read_tool_with_completion_phrase(tmp_path: Path) -> None:
@@ -263,9 +275,9 @@ def test_fp3_read_tool_with_completion_phrase(tmp_path: Path) -> None:
         mk_assistant("hooks.json 확인 완료. 이상 없음."),
     ]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp)
+    stdout, stderr, rc = run_hook(tp)
     assert rc == 0
-    assert "[praxis:completion-signal-gate]" not in stderr, f"FP3 false-positive: {stderr!r}"
+    assert stdout == "", f"FP3 false-positive: {stderr!r}"
 
 
 def test_fp4_bash_lint_clean(tmp_path: Path) -> None:
@@ -279,9 +291,9 @@ def test_fp4_bash_lint_clean(tmp_path: Path) -> None:
         mk_assistant("0 errors. All done."),
     ]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp)
+    stdout, stderr, rc = run_hook(tp)
     assert rc == 0
-    assert "[praxis:completion-signal-gate]" not in stderr, f"FP4 false-positive: {stderr!r}"
+    assert stdout == "", f"FP4 false-positive: {stderr!r}"
 
 
 def test_fp5_assistant_in_progress(tmp_path: Path) -> None:
@@ -295,9 +307,9 @@ def test_fp5_assistant_in_progress(tmp_path: Path) -> None:
         mk_assistant("브랜치 상태 확인됨. 다음으로 PR을 생성하겠습니다."),
     ]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp)
+    stdout, stderr, rc = run_hook(tp)
     assert rc == 0
-    assert "[praxis:completion-signal-gate]" not in stderr, f"FP5 false-positive: {stderr!r}"
+    assert stdout == "", f"FP5 false-positive: {stderr!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -314,10 +326,11 @@ def test_event1_exact_quote(tmp_path: Path) -> None:
         ),
     ]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp)
+    stdout, stderr, rc = run_hook(tp)
     assert rc == 0
-    assert "[praxis:completion-signal-gate]" in stderr, (
-        f"Event 1 quote must trigger advisory; stderr={stderr!r}"
+    assert stderr == "", f"firing path must keep stderr empty; got {stderr!r}"
+    assert "[praxis:completion-signal-gate]" in _msg(stdout), (
+        f"Event 1 quote must trigger advisory; stdout={stdout!r}"
     )
 
 
@@ -350,8 +363,9 @@ def test_rule2_foreign_plugin_command(tmp_path: Path) -> None:
     )
     assert result.returncode == 0
     # Should emit advisory about foreign namespace
-    assert "[praxis:completion-signal-gate]" in result.stderr, (
-        f"Rule 2 must fire for foreign plugin command; stderr={result.stderr!r}"
+    assert result.stderr == "", f"firing path must keep stderr empty; got {result.stderr!r}"
+    assert "[praxis:completion-signal-gate]" in _msg(result.stdout), (
+        f"Rule 2 must fire for foreign plugin command; stdout={result.stdout!r}"
     )
 
 
@@ -374,8 +388,9 @@ def test_rule2_bare_foreign_skill(tmp_path: Path) -> None:
         cwd=str(REPO_ROOT),
     )
     assert result.returncode == 0
-    assert "[praxis:completion-signal-gate]" in result.stderr, (
-        f"Rule 2 must fire for bare foreign skill `/release`; stderr={result.stderr!r}"
+    assert result.stderr == "", f"firing path must keep stderr empty; got {result.stderr!r}"
+    assert "[praxis:completion-signal-gate]" in _msg(result.stdout), (
+        f"Rule 2 must fire for bare foreign skill `/release`; stdout={result.stdout!r}"
     )
 
 
@@ -398,8 +413,8 @@ def test_rule2_bare_unknown_command_silent(tmp_path: Path) -> None:
         cwd=str(REPO_ROOT),
     )
     assert result.returncode == 0
-    assert "[praxis:completion-signal-gate]" not in result.stderr, (
-        f"Rule 2 must NOT fire for unknown bare commands; stderr={result.stderr!r}"
+    assert result.stdout == "", (
+        f"Rule 2 must NOT fire for unknown bare commands; stdout={result.stdout!r}"
     )
 
 
@@ -439,8 +454,8 @@ def test_rule2_namespaced_foreign_silent_in_non_praxis_cwd(tmp_path: Path) -> No
         cwd=str(tmp_path),  # laplace-dev-hub cwd, NOT praxis
     )
     assert result.returncode == 0
-    assert "[praxis:completion-signal-gate]" not in result.stderr, (
-        f"Rule 2 must NOT fire in non-praxis cwd; stderr={result.stderr!r}"
+    assert result.stdout == "", (
+        f"Rule 2 must NOT fire in non-praxis cwd; stdout={result.stdout!r}"
     )
 
 
@@ -480,6 +495,7 @@ def test_failsafe_stop_hook_active(tmp_path: Path) -> None:
         timeout=5,
     )
     assert result.returncode == 0
+    assert result.stdout == ""
     assert result.stderr == ""
 
 
@@ -500,6 +516,7 @@ def test_failsafe_missing_transcript() -> None:
         timeout=5,
     )
     assert result.returncode == 0
+    assert result.stdout == ""
     assert result.stderr == ""
 
 
@@ -518,6 +535,7 @@ def test_failsafe_empty_transcript(tmp_path: Path) -> None:
         timeout=5,
     )
     assert result.returncode == 0
+    assert result.stdout == ""
     assert result.stderr == ""
 
 
@@ -630,10 +648,10 @@ def test_negated_completion_no_advisory_end_to_end(tmp_path: Path) -> None:
         mk_assistant("아직 작업이 완료되지 않았습니다. 다음 단계가 남아 있습니다."),
     ]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp)
+    stdout, stderr, rc = run_hook(tp)
     assert rc == 0
-    assert "[praxis:completion-signal-gate]" not in stderr, (
-        f"negated completion must not trigger Rule 1 advisory; stderr={stderr!r}"
+    assert stdout == "", (
+        f"negated completion must not trigger Rule 1 advisory; stdout={stdout!r}"
     )
 
 
@@ -644,10 +662,10 @@ def test_negated_completion_en_no_advisory_end_to_end(tmp_path: Path) -> None:
         mk_assistant("The refactor is not done yet — two modules remain."),
     ]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp)
+    stdout, stderr, rc = run_hook(tp)
     assert rc == 0
-    assert "[praxis:completion-signal-gate]" not in stderr, (
-        f"negated EN completion must not trigger advisory; stderr={stderr!r}"
+    assert stdout == "", (
+        f"negated EN completion must not trigger advisory; stdout={stdout!r}"
     )
 
 

--- a/tests/hooks/completion-verify/test_merge_state_claim_gate.sh
+++ b/tests/hooks/completion-verify/test_merge_state_claim_gate.sh
@@ -45,26 +45,43 @@ run_case() {
 p={"transcript_path":sys.argv[1]}
 p.update(json.loads(sys.argv[2]))
 print(json.dumps(p))' "$TRANSCRIPT" "$extra")
-  err=$(printf '%s' "$payload" | env "$@" python3 "$HOOK" 2>&1 1>/dev/null)
+  # issue #647 H3: advisory/block both arrive as stdout JSON (exit always 0);
+  # stderr must stay empty in every case.
+  local out
+  out=$(printf '%s' "$payload" | env "$@" python3 "$HOOK" 2>/tmp/msc-stderr.$$)
   rc=$?
+  err=$(cat /tmp/msc-stderr.$$ 2>/dev/null; rm -f /tmp/msc-stderr.$$)
   case "$expected" in
     advisory)
       [ "$rc" -eq 0 ] || ok=0
-      printf '%s' "$err" | grep -q "\[merge-state-claim-gate\]" || ok=0
+      [ -z "$err" ] || ok=0
+      printf '%s' "$out" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+assert "[merge-state-claim-gate]" in d["systemMessage"]
+assert "decision" not in d
+' || ok=0
       ;;
     advisory-strict)
-      [ "$rc" -eq 2 ] || ok=0
-      printf '%s' "$err" | grep -q "\[merge-state-claim-gate\]" || ok=0
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$err" ] || ok=0
+      printf '%s' "$out" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+assert d["decision"] == "block"
+assert "[merge-state-claim-gate]" in d["reason"]
+' || ok=0
       ;;
     silent)
       [ "$rc" -eq 0 ] || ok=0
       [ -z "$err" ] || ok=0
+      [ -z "$out" ] || ok=0
       ;;
   esac
   if [ "$ok" -eq 1 ]; then
     echo "PASS  [$name]"; PASS=$((PASS + 1))
   else
-    echo "FAIL  [$name] expected=$expected rc=$rc err=<$err>"; FAIL=$((FAIL + 1))
+    echo "FAIL  [$name] expected=$expected rc=$rc out=<$out> err=<$err>"; FAIL=$((FAIL + 1))
   fi
 }
 
@@ -96,7 +113,7 @@ run_case silent "negated-claim" '{}'
 build_transcript "Next I will create a PR and then merge it." none
 run_case silent "future-intent" '{}'
 
-# --- strict mode -> exit 2 ------------------------------------------------
+# --- strict mode -> decision:block JSON ------------------------------------------------
 build_transcript "PR #543 created and merged." none
 run_case advisory-strict "strict-mode" '{}' PRAXIS_MERGE_CLAIM_STRICT=1
 

--- a/tests/hooks/completion-verify/test_readonly_verify_deferral_gate.py
+++ b/tests/hooks/completion-verify/test_readonly_verify_deferral_gate.py
@@ -53,6 +53,18 @@ PREFIX = "[praxis:readonly-verify-deferral-gate]"
 # ---------------------------------------------------------------------------
 
 
+
+def _msg(stdout: str) -> str:
+    """Extract the systemMessage from the hook's stdout JSON.
+
+    Issue #647 H3: advisories arrive as `{"systemMessage": ...}` on stdout
+    (stderr stays empty). Empty stdout (silent pass) maps to "".
+    """
+    if not stdout.strip():
+        return ""
+    return json.loads(stdout)["systemMessage"]
+
+
 def mk_user(text: str) -> dict[str, Any]:
     return {
         "type": "user",
@@ -163,8 +175,8 @@ def test_triggers_on_readonly_offer(text: str, tmp_path: Path) -> None:
     tp = write_jsonl(events, tmp_path)
     stdout, stderr, rc = run_hook(tp)
     assert rc == 0, f"advisory mode must exit 0; got {rc}"
-    assert stdout == "", f"advisory hook must produce no stdout; got {stdout!r}"
-    assert PREFIX in stderr, f"advisory not emitted for {text!r}; stderr={stderr!r}"
+    assert stderr == "", f"advisory hook must keep stderr empty; got {stderr!r}"
+    assert PREFIX in _msg(stdout), f"advisory not emitted for {text!r}; stdout={stdout!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -189,9 +201,9 @@ def test_mutation_carveout_suppresses(text: str, tmp_path: Path) -> None:
     """Mutation present → asking is legitimate → no advisory."""
     events = [mk_user("진행 방법"), mk_assistant(text)]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp)
+    stdout, stderr, rc = run_hook(tp)
     assert rc == 0
-    assert PREFIX not in stderr, f"mutation carve-out failed: {text!r}; stderr={stderr!r}"
+    assert stdout == "", f"mutation carve-out failed: {text!r}; stdout={stdout!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -213,9 +225,9 @@ def test_already_ran_cue_suppresses(text: str, tmp_path: Path) -> None:
     """An offer sentence carrying a past-tense run cue → read already ran → no warn."""
     events = [mk_user("상태"), mk_assistant(text)]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp)
+    stdout, stderr, rc = run_hook(tp)
     assert rc == 0
-    assert PREFIX not in stderr, f"already-ran cue must suppress: {text!r}; stderr={stderr!r}"
+    assert stdout == "", f"already-ran cue must suppress: {text!r}; stdout={stdout!r}"
 
 
 def test_declarative_report_then_courtesy_no_advisory(tmp_path: Path) -> None:
@@ -233,9 +245,9 @@ def test_declarative_report_then_courtesy_no_advisory(tmp_path: Path) -> None:
         mk_assistant("`git status` 확인했습니다. 추가로 진행할까요?"),
     ]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp)
+    stdout, stderr, rc = run_hook(tp)
     assert rc == 0
-    assert PREFIX not in stderr, f"declarative report must not warn; stderr={stderr!r}"
+    assert stdout == "", f"declarative report must not warn; stdout={stdout!r}"
 
 
 def test_mixed_turn_offered_read_differs_from_run_read_warns(tmp_path: Path) -> None:
@@ -254,10 +266,10 @@ def test_mixed_turn_offered_read_differs_from_run_read_warns(tmp_path: Path) -> 
         mk_assistant("Should I run `SELECT count(*) FROM orders` next?"),
     ]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp)
+    stdout, stderr, rc = run_hook(tp)
     assert rc == 0
-    assert PREFIX in stderr, (
-        f"mixed turn (offered read != run read) must warn; stderr={stderr!r}"
+    assert PREFIX in _msg(stdout), (
+        f"mixed turn (offered read != run read) must warn; stdout={stdout!r}"
     )
 
 
@@ -273,9 +285,9 @@ def test_read_without_deferral_no_advisory(tmp_path: Path) -> None:
         mk_assistant("`SELECT count(*) FROM orders` 결과는 1,024건입니다."),
     ]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp)
+    stdout, stderr, rc = run_hook(tp)
     assert rc == 0
-    assert PREFIX not in stderr, f"read-without-deferral false positive: {stderr!r}"
+    assert stdout == "", f"read-without-deferral false positive: {stderr!r}"
 
 
 def test_deferral_without_read_no_advisory(tmp_path: Path) -> None:
@@ -285,9 +297,9 @@ def test_deferral_without_read_no_advisory(tmp_path: Path) -> None:
         mk_assistant("다음 단계를 진행할까요? 설계 방향을 먼저 정해야 합니다."),
     ]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp)
+    stdout, stderr, rc = run_hook(tp)
     assert rc == 0
-    assert PREFIX not in stderr, f"deferral-without-read false positive: {stderr!r}"
+    assert stdout == "", f"deferral-without-read false positive: {stderr!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -314,9 +326,9 @@ def test_cross_sentence_read_and_deferral_no_advisory(text: str, tmp_path: Path)
     """Read and deferral in different sentences → not an offer → no advisory."""
     events = [mk_user("상태 보고"), mk_assistant(text)]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp)
+    stdout, stderr, rc = run_hook(tp)
     assert rc == 0
-    assert PREFIX not in stderr, f"cross-sentence false positive: {text!r}; stderr={stderr!r}"
+    assert stdout == "", f"cross-sentence false positive: {text!r}; stdout={stdout!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -332,14 +344,14 @@ def test_signals_env_extends_read_detection(tmp_path: Path) -> None:
     ]
     tp = write_jsonl(events, tmp_path)
     # Without the env var, no built-in pattern matches → no advisory.
-    _, stderr_off, _ = run_hook(tp)
-    assert PREFIX not in stderr_off, f"unexpected match w/o env: {stderr_off!r}"
+    stdout_off, _, _ = run_hook(tp)
+    assert PREFIX not in _msg(stdout_off), f"unexpected match w/o env: {stdout_off!r}"
     # With the env var, the project read CLI matches → advisory.
-    _, stderr_on, rc = run_hook(
+    stdout_on, _, rc = run_hook(
         tp, env_extra={"PRAXIS_READONLY_VERIFY_SIGNALS": r"\bmycli\s+inspect\b"}
     )
     assert rc == 0
-    assert PREFIX in stderr_on, f"SIGNALS env did not extend detection; stderr={stderr_on!r}"
+    assert PREFIX in _msg(stdout_on), f"SIGNALS env did not extend detection; stdout={stdout_on!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -347,16 +359,19 @@ def test_signals_env_extends_read_detection(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_strict_mode_exits_2(tmp_path: Path) -> None:
-    """STRICT=1 escalates a real offer to exit 2 (blocks Stop)."""
+def test_strict_mode_blocks(tmp_path: Path) -> None:
+    """STRICT=1 escalates a real offer to a {decision: block} JSON (blocks Stop)."""
     events = [
         mk_user("확인"),
         mk_assistant("should I run `SELECT 1 FROM dual` to verify?"),
     ]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp, env_extra={"PRAXIS_READONLY_VERIFY_STRICT": "1"})
-    assert rc == 2, f"STRICT must exit 2; got {rc}"
-    assert PREFIX in stderr
+    stdout, stderr, rc = run_hook(tp, env_extra={"PRAXIS_READONLY_VERIFY_STRICT": "1"})
+    assert rc == 0, f"STRICT must exit 0 (block is carried by JSON); got {rc}"
+    assert stderr == "", f"strict path must keep stderr empty; got {stderr!r}"
+    decision = json.loads(stdout)
+    assert decision["decision"] == "block"
+    assert PREFIX in decision["reason"]
 
 
 def test_bypass_silences(tmp_path: Path) -> None:
@@ -366,9 +381,9 @@ def test_bypass_silences(tmp_path: Path) -> None:
         mk_assistant("should I run `SELECT 1 FROM dual` to verify?"),
     ]
     tp = write_jsonl(events, tmp_path)
-    _, stderr, rc = run_hook(tp, env_extra={"PRAXIS_READONLY_VERIFY_BYPASS": "1"})
+    stdout, stderr, rc = run_hook(tp, env_extra={"PRAXIS_READONLY_VERIFY_BYPASS": "1"})
     assert rc == 0
-    assert stderr == "", f"BYPASS must silence; stderr={stderr!r}"
+    assert stdout == "" and stderr == "", f"BYPASS must silence; stdout={stdout!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -408,8 +423,9 @@ def test_failsafe_missing_transcript() -> None:
 def test_failsafe_empty_transcript(tmp_path: Path) -> None:
     tp = str(tmp_path / "empty.jsonl")
     Path(tp).write_text("")
-    _, stderr, rc = run_hook(tp)
+    stdout, stderr, rc = run_hook(tp)
     assert rc == 0
+    assert stdout == ""
     assert stderr == ""
 
 


### PR DESCRIPTION
## 개요

#647 H3 — completion-verify(Stop) 역할 내 시그널 메커니즘 이원화 해소. shell 훅 3개는 `{decision: "block", reason}` JSON, python advisory 훅 3개는 stderr+exit 0(advisory)/exit 2(strict)로 갈라져 있던 것을 **stdout JSON 단일 컨벤션**으로 통일합니다.

Refs #647 (H3 — F6는 후속 PR)

## 설계 (전제 검증 완료)

공식 Claude Code hooks 문서로 사전 검증: Stop 훅에서 **exit 0 + stderr는 debug log 전용**(사용자 비가시), `systemMessage` JSON은 transcript에 사용자 가시 표시(모델 컨텍스트 미진입), `{decision: "block"}`은 exit 2와 등가의 block이되 structured. 즉 이번 전환은 advisory 가시성을 **개선**합니다 (기존 stderr advisory는 사실상 보이지 않았음).

| Tier | 변경 전 | 변경 후 |
|---|---|---|
| advisory | stderr + exit 0 (debug-only) | `{"systemMessage": ...}` + exit 0 (사용자 가시) |
| strict/block | exit 2 + stderr | `{"decision": "block", "reason": ...}` + exit 0 (shell sibling과 동일 shape) |

## 변경 내용

1. **`hooks/_lib/_hook_io.py`**: `format/emit_stop_advisory` + `format/emit_stop_block` 추가 — 기존 `emit_decision`(#470) 추출 패턴 미러(format/emit 분리, injectable stream). block shape의 키 순서는 shell sibling의 jq 출력과 일치.
2. **python 훅 3개 전환**: `completion-signal-gate`(두 rule이 한 stop에서 동시 발화 시 단일 JSON으로 join — 연결 JSON 무효 함정 회피), `merge-state-claim-gate`, `readonly-verify-deferral-gate`(strict 모드 exit 2 → decision block).
3. **spec.md 3개 + `docs/hook/INDEX.md`** completion-verify 역할 헤더에 시그널 컨벤션 명문화.
4. **테스트 3개 스위트** 새 계약으로 갱신: stdout JSON 파싱 단언, 발화 경로 stderr 빈 것, silent 경로 stdout 빈 것, fail-open 경로 stdout 오염 없음.

## 리뷰

- `oh-my-claudecode:code-reviewer`: **APPROVE** (LOW 5건 — 문서 정확성 2 + 테스트 강화 3, 전부 수정 후 amend). 독립 검증: 양 tier live smoke, 두 rule 동시 발화 시 단일 JSON(`json.load` clean), 잔존 `sys.stderr.write`/`exit 2` grep 0건, fail-open 경로 partial-JSON 윈도우 없음(emit이 main 말미 단일 호출).
- `praxis:codex-review-wrap` → codex: **finding 0건**.

## 검증

- `PATH=pyenv-shims ./scripts/run-tests.sh` → **ALL TESTS PASSED** (amend 후 fresh run)
- pytest completion-verify 165/165 + shell 22/22, `ruff check` clean
- **실 subprocess 기능 smoke 5/5**: 훅 3개 × 양 tier — `keys=['systemMessage']` / `keys=['decision','reason']`, rc=0, stderr empty (실행 출력 확인)

## 검증 안 된 것

- 라이브 Claude Code Stop 이벤트 발화는 미실행 (실 payload subprocess smoke로 대체)

## 영향 범위

completion-verify advisory 3개의 사용자 가시 surface 변경 — 기존 비가시 stderr → transcript systemMessage (Scope-risk: moderate, 의도된 개선). strict 모드 block 거동은 등가(exit 2 → decision JSON). 다른 역할·훅 무영향.

Pre-commit verified: PATH=pyenv-shims ./scripts/run-tests.sh → ALL TESTS PASSED; ruff clean; pytest 165/165 + shell 22/22; live subprocess smoke 5/5 both tiers
Caller chain verified: 3개 훅 모두 wrapper .sh → impl.py main() 단일 경로(manifest standalone 엔트리)이며 emit은 main 말미 단일 호출 — double-emit 경로 없음(code-reviewer 독립 grep 확인); _hook_io 신규 헬퍼의 기존 호출자 0(신규 API)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Specs updated to document a stdout JSON signal convention for completion-verify hooks (advisory via systemMessage; blocking via decision: "block"; exit code 0).

* **Improvements**
  * Standardized hooks to emit structured JSON on stdout for advisory and blocking tiers, always exiting 0; stderr is not used for signals.

* **Tests**
  * Tests updated to parse/validate JSON on stdout, assert stderr is empty, and verify advisory vs. block behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->