### PR TITLE
test(scripts): add install/verify behavior tests

### DIFF
--- a/tests/test_cli_scripts_behavior.sh
+++ b/tests/test_cli_scripts_behavior.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# test_cli_scripts_behavior.sh — behavioral coverage for install.sh and
+# verify-symlinks.sh (issue #647 F6).
+#
+# The sibling test_cli_scripts_parity.sh guards the shared CLI_SCRIPTS list
+# and runs a happy-path smoke; this suite exercises the *detection and
+# conflict paths* that smoke never reaches: MISSING / NOT-A-LINK / DANGLING /
+# DRIFT / NOT-EXEC on the verify side, and REFUSE / --force BACKUP+REBIND /
+# idempotent re-run / missing-source / bad-args on the install side.
+#
+# Isolation: the real scripts are copied into a throwaway mini-clone whose
+# cli-scripts.sh tracks a single fixture CLI. This keeps every path (source
+# file, bin dir, link target) inside mktemp space — the user's ~/.local/bin
+# and this repo's permission bits are never touched.
+#
+# Usage: bash tests/test_cli_scripts_behavior.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+run_case() {
+  local name="$1" result="$2" expected="$3"
+  if [ "$result" = "$expected" ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expected=$expected got=$result"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+echo "test_cli_scripts_behavior"
+
+# ---------------------------------------------------------------------------
+# Fixture: mini-clone with one tracked CLI ("foo"), fresh bin dir per stanza.
+# ---------------------------------------------------------------------------
+
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+CLONE="$TMP_ROOT/clone"
+mkdir -p "$CLONE/scripts" "$CLONE/skills/foo"
+cp "$ROOT_DIR/scripts/install.sh" "$CLONE/scripts/install.sh"
+cp "$ROOT_DIR/scripts/verify-symlinks.sh" "$CLONE/scripts/verify-symlinks.sh"
+cat > "$CLONE/scripts/cli-scripts.sh" <<'EOF'
+# shellcheck disable=SC2034
+CLI_SCRIPTS=(
+  "skills/foo/foo"
+)
+EOF
+printf '#!/bin/sh\necho foo\n' > "$CLONE/skills/foo/foo"
+chmod +x "$CLONE/skills/foo/foo"
+
+fresh_bin() {
+  BIN="$TMP_ROOT/bin-$RANDOM$RANDOM"
+  mkdir -p "$BIN"
+}
+
+install_sh() { PRAXIS_BIN_DIR="$BIN" bash "$CLONE/scripts/install.sh" "$@" 2>&1; }
+verify_sh()  { PRAXIS_BIN_DIR="$BIN" bash "$CLONE/scripts/verify-symlinks.sh" 2>&1; }
+
+# ---------------------------------------------------------------------------
+# install.sh — fresh install, idempotency
+# ---------------------------------------------------------------------------
+
+fresh_bin
+out=$(install_sh); rc=$?
+run_case "install: fresh run exits 0" "$rc" "0"
+echo "$out" | grep -q "^LINK     foo" ; run_case "install: fresh run reports LINK" "$?" "0"
+run_case "install: symlink created" "$([ -L "$BIN/foo" ] && echo yes || echo no)" "yes"
+
+out=$(install_sh); rc=$?
+run_case "install: re-run exits 0 (idempotent)" "$rc" "0"
+echo "$out" | grep -q "^OK       foo"; run_case "install: re-run reports OK" "$?" "0"
+echo "$out" | grep -q "already=1"; run_case "install: re-run counts already=1" "$?" "0"
+
+out=$(verify_sh); rc=$?
+run_case "verify: clean install passes" "$rc" "0"
+echo "$out" | grep -q "^OK         foo"; run_case "verify: clean install reports OK" "$?" "0"
+
+# ---------------------------------------------------------------------------
+# install.sh — conflict refuse (default) vs --force backup + overwrite
+# ---------------------------------------------------------------------------
+
+fresh_bin
+echo "precious user binary" > "$BIN/foo"
+out=$(install_sh); rc=$?
+run_case "install: regular-file conflict exits 1" "$rc" "1"
+echo "$out" | grep -q "^REFUSE   foo"; run_case "install: conflict reports REFUSE" "$?" "0"
+run_case "install: refused file left untouched" \
+  "$([ "$(cat "$BIN/foo")" = "precious user binary" ] && echo yes || echo no)" "yes"
+
+out=$(install_sh --force); rc=$?
+run_case "install: --force on regular file exits 0" "$rc" "0"
+echo "$out" | grep -q "^BACKUP   foo -> "; run_case "install: --force reports BACKUP" "$?" "0"
+run_case "install: --force replaced file with symlink" \
+  "$([ -L "$BIN/foo" ] && echo yes || echo no)" "yes"
+bak=$(find "$BIN" -name 'foo.bak.*' | head -1)
+run_case "install: .bak preserves original content" \
+  "$([ -n "$bak" ] && [ "$(cat "$bak")" = "precious user binary" ] && echo yes || echo no)" "yes"
+
+# ---------------------------------------------------------------------------
+# install.sh — --force REBIND of a symlink pointing at another clone
+# ---------------------------------------------------------------------------
+
+fresh_bin
+OTHER="$TMP_ROOT/other-clone-foo"
+printf '#!/bin/sh\necho other\n' > "$OTHER"; chmod +x "$OTHER"
+ln -s "$OTHER" "$BIN/foo"
+out=$(install_sh --force); rc=$?
+run_case "install: --force rebind exits 0" "$rc" "0"
+echo "$out" | grep -q "^REBIND   foo: $OTHER -> "; run_case "install: rebind logs old target" "$?" "0"
+bak=$(find "$BIN" -name 'foo.bak.*' | head -1)
+run_case "install: rebind backup preserves the link itself" \
+  "$([ -L "$bak" ] && [ "$(readlink "$bak")" = "$OTHER" ] && echo yes || echo no)" "yes"
+run_case "install: rebind points dst at this clone" \
+  "$([ "$(readlink "$BIN/foo")" = "$CLONE/skills/foo/foo" ] && echo yes || echo no)" "yes"
+
+# ---------------------------------------------------------------------------
+# install.sh — missing source, bad arguments
+# ---------------------------------------------------------------------------
+
+fresh_bin
+mv "$CLONE/skills/foo/foo" "$CLONE/skills/foo/foo.hidden"
+out=$(install_sh); rc=$?
+run_case "install: missing source exits 1" "$rc" "1"
+echo "$out" | grep -q "^MISSING  foo"; run_case "install: missing source reports MISSING" "$?" "0"
+mv "$CLONE/skills/foo/foo.hidden" "$CLONE/skills/foo/foo"
+
+install_sh --no-such-flag >/dev/null 2>&1
+run_case "install: unknown option exits 2" "$?" "2"
+
+# ---------------------------------------------------------------------------
+# verify-symlinks.sh — each drift class
+# ---------------------------------------------------------------------------
+
+fresh_bin
+out=$(verify_sh); rc=$?
+run_case "verify: missing link exits 1" "$rc" "1"
+echo "$out" | grep -q "^MISSING    foo"; run_case "verify: reports MISSING" "$?" "0"
+
+fresh_bin
+echo "not a link" > "$BIN/foo"
+out=$(verify_sh); rc=$?
+run_case "verify: regular file exits 1" "$rc" "1"
+echo "$out" | grep -q "^NOT-A-LINK foo"; run_case "verify: reports NOT-A-LINK" "$?" "0"
+
+fresh_bin
+ln -s "$TMP_ROOT/does-not-exist" "$BIN/foo"
+out=$(verify_sh); rc=$?
+run_case "verify: dangling link exits 1" "$rc" "1"
+echo "$out" | grep -q "^DANGLING   foo"; run_case "verify: reports DANGLING" "$?" "0"
+
+fresh_bin
+# Precondition: DRIFT is only meaningful if $OTHER canonicalizes to a different
+# file than the tracked source — guard explicitly so a fixture refactor that
+# moves $OTHER under the clone can't silently turn DRIFT into OK. Canonicalize
+# via python3 like the scripts themselves (BSD/GNU realpath flags differ).
+canon() { /usr/bin/env python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$1"; }
+run_case "verify: drift fixture resolves outside the clone source" \
+  "$([ "$(canon "$OTHER")" != "$(canon "$CLONE/skills/foo/foo")" ] && echo yes || echo no)" "yes"
+ln -s "$OTHER" "$BIN/foo"   # resolves fine, but to a different file
+out=$(verify_sh); rc=$?
+run_case "verify: foreign target exits 1" "$rc" "1"
+echo "$out" | grep -q "^DRIFT      foo"; run_case "verify: reports DRIFT" "$?" "0"
+
+fresh_bin
+ln -s "$CLONE/skills/foo/foo" "$BIN/foo"
+chmod -x "$CLONE/skills/foo/foo"
+out=$(verify_sh); rc=$?
+run_case "verify: non-executable target exits 1" "$rc" "1"
+echo "$out" | grep -q "^NOT-EXEC   foo"; run_case "verify: reports NOT-EXEC" "$?" "0"
+chmod +x "$CLONE/skills/foo/foo"
+
+fresh_bin
+rm -rf "$CLONE/skills/foo"
+out=$(verify_sh); rc=$?
+run_case "verify: absent source exits 1" "$rc" "1"
+echo "$out" | grep -q "^NO-SOURCE  foo"; run_case "verify: reports NO-SOURCE" "$?" "0"
+
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== summary ==="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "Failed cases:"
+  for n in "${FAILED_NAMES[@]}"; do echo "  - $n"; done
+  exit 1
+fi
+exit 0

--- a/tests/test_cli_scripts_behavior.sh
+++ b/tests/test_cli_scripts_behavior.sh
@@ -60,8 +60,7 @@ printf '#!/bin/sh\necho foo\n' > "$CLONE/skills/foo/foo"
 chmod +x "$CLONE/skills/foo/foo"
 
 fresh_bin() {
-  BIN="$TMP_ROOT/bin-$RANDOM$RANDOM"
-  mkdir -p "$BIN"
+  BIN=$(mktemp -d "$TMP_ROOT/bin.XXXXXX")
 }
 
 install_sh() { PRAXIS_BIN_DIR="$BIN" bash "$CLONE/scripts/install.sh" "$@" 2>&1; }
@@ -160,14 +159,16 @@ run_case "verify: dangling link exits 1" "$rc" "1"
 echo "$out" | grep -q "^DANGLING   foo"; run_case "verify: reports DANGLING" "$?" "0"
 
 fresh_bin
-# Precondition: DRIFT is only meaningful if $OTHER canonicalizes to a different
-# file than the tracked source — guard explicitly so a fixture refactor that
-# moves $OTHER under the clone can't silently turn DRIFT into OK. Canonicalize
-# via python3 like the scripts themselves (BSD/GNU realpath flags differ).
+DRIFT_TARGET="$TMP_ROOT/drift-target-foo"   # own fixture — independent of the REBIND stanza
+printf '#!/bin/sh\necho drift\n' > "$DRIFT_TARGET"; chmod +x "$DRIFT_TARGET"
+# Precondition: DRIFT is only meaningful if the target canonicalizes to a
+# different file than the tracked source — guard explicitly so a fixture
+# refactor that moves it under the clone can't silently turn DRIFT into OK.
+# Canonicalize via python3 like the scripts themselves (BSD/GNU realpath differ).
 canon() { /usr/bin/env python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$1"; }
 run_case "verify: drift fixture resolves outside the clone source" \
-  "$([ "$(canon "$OTHER")" != "$(canon "$CLONE/skills/foo/foo")" ] && echo yes || echo no)" "yes"
-ln -s "$OTHER" "$BIN/foo"   # resolves fine, but to a different file
+  "$([ "$(canon "$DRIFT_TARGET")" != "$(canon "$CLONE/skills/foo/foo")" ] && echo yes || echo no)" "yes"
+ln -s "$DRIFT_TARGET" "$BIN/foo"   # resolves fine, but to a different file
 out=$(verify_sh); rc=$?
 run_case "verify: foreign target exits 1" "$rc" "1"
 echo "$out" | grep -q "^DRIFT      foo"; run_case "verify: reports DRIFT" "$?" "0"


### PR DESCRIPTION
## 개요

#647 F6 — `scripts/install.sh` / `scripts/verify-symlinks.sh`의 행동 테스트 추가. 기존 `tests/test_cli_scripts_parity.sh`는 CLI_SCRIPTS 목록 패리티 + happy-path smoke만 커버 — 본 스위트는 smoke가 도달하지 않는 **탐지·충돌 경로 전 분기**를 검증합니다 (35 cases).

Refs #647 (F6 — 마지막 잔존 항목)

## 변경 내용

신규 파일 1개: `tests/test_cli_scripts_behavior.sh` (201줄)

| 대상 | 커버 분기 |
|---|---|
| install.sh | fresh LINK / idempotent OK+already=1 / REFUSE(기본, 원본 무손상) / --force BACKUP(.bak 내용 보존) / --force REBIND(백업이 링크 자체 보존 + 새 타깃 검증) / MISSING source / unknown-option exit 2 |
| verify-symlinks.sh | MISSING / NOT-A-LINK / DANGLING / DRIFT / NOT-EXEC / NO-SOURCE — 각 분기 exit 1 + 고정폭 토큰 verbatim 단언 |

**격리 설계**: 실제 스크립트를 mktemp mini-clone으로 복사 + 단일 fixture CLI(`skills/foo/foo`) + `PRAXIS_BIN_DIR` override + 케이스별 fresh bin dir — 사용자 `~/.local/bin`과 레포 권한 비트를 일절 건드리지 않음 (chmod -x는 clone 사본에만, 즉시 복원). 출력 토큰은 install 9칸 / verify 11칸 고정폭을 verbatim 추적.

## 리뷰

- `oh-my-claudecode:code-reviewer`: **APPROVE** (LOW 3건). 독립 검증: 전 분기 재현 + 토큰 verbatim 일치 + 격리 확인(실 bin/권한 비트 무손상) + mutation 복원 순서 확인. LOW 2(DRIFT 전제 가드) 수용 — 1줄 가드 추가; LOW 1(요약 포맷)은 run-tests.sh가 exit code 기준이라 비이슈 거부; LOW 3(다중 .bak 시 head -1)은 케이스별 fresh bin 구조상 해당 없음.
- `praxis:codex-review-wrap` → codex: **P2 1건 수용** — DRIFT 가드의 bare `realpath`가 스크립트 본체가 의도적으로 회피한 의존성(install.sh:58 주석: BSD/GNU realpath 차이로 python3 사용)을 재도입 → python3 canonicalization으로 교체. 전제 검증: 스크립트 소스 직접 grep으로 확인.

## 검증

- `PATH=pyenv-shims ./scripts/run-tests.sh` → exit 0, **ALL TESTS PASSED** (최종 상태 fresh run, 신규 스위트 수집 확인 — log line 2477)
- 신규 스위트 단독 실행 35/35 PASS
- `shellcheck tests/test_cli_scripts_behavior.sh` clean (SC2319/SC2012 수정 — sibling의 `$(... && echo yes || echo no)` 컨벤션 채택)
- 격리 검증: 실 `~/.local/bin`에 foo/foo.bak.* 누출 0, 레포 `scripts/*.sh` 권한 비트 무변경 (code-reviewer 독립 확인)

## 검증 안 된 것

- CI(ubuntu) 환경 실행 — PR CI에서 확인 (macOS 로컬은 green)

## 영향 범위

테스트 추가만 — 프로덕션 스크립트·훅·스킬 무변경. 잘못될 경우 영향은 CI 테스트 시간 소폭 증가 수준.

Pre-commit verified: PATH=pyenv-shims ./scripts/run-tests.sh → exit 0 ALL TESTS PASSED; 신규 스위트 35/35; shellcheck clean
Caller chain verified: 신규 파일은 run-tests.sh의 tests/test_*.sh glob으로만 수집(line 52 직접 확인), 다른 호출자 없음; 프로덕션 코드 무변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive behavioral test harness for the CLI installer and verifier, exercising installer scenarios (fresh install, idempotent re-run, conflicts, force/overwrite/retarget behaviors, missing source, unknown options) and verifier scenarios (missing link, non-link file, dangling link, drift, non-executable target, absent source). Prints PASS/FAIL summary and exits non-zero on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->