### PR TITLE
refactor(retrospect): split skill spec

### DIFF
--- a/hooks/advisory-nudge/memory-hint/spec.md
+++ b/hooks/advisory-nudge/memory-hint/spec.md
@@ -46,7 +46,7 @@ hookEvents: [Bash, Edit, AskUserQuestion]       # event whitelist (default [Bash
 
 ### Authoring
 
-The fields above are not authored by hand in the typical flow. The `retrospect` skill emits them at memory-write time. See [`skills/retrospect/SKILL.md`](../../../skills/retrospect/SKILL.md) Stage 4 Action 1 — specifically the "Frontmatter contract — `memory-hint` opt-in" subsection — for the per-category `hookable` default matrix and `hookKeywords` selection rules. This file specifies the **runtime parser contract** (what the hook accepts); the SKILL.md section specifies the **authoring decision** (which memories should opt in, which keywords to pick).
+The fields above are not authored by hand in the typical flow. The `retrospect` skill emits them at memory-write time. See [`skills/retrospect/references/stage4-execution.md`](../../../skills/retrospect/references/stage4-execution.md) Stage 4 Action 1 — specifically the "Frontmatter contract — `memory-hint` opt-in" subsection — for the per-category `hookable` default matrix and `hookKeywords` selection rules. This file specifies the **runtime parser contract** (what the hook accepts); the Stage 4 reference specifies the **authoring decision** (which memories should opt in, which keywords to pick).
 
 ### Per-event tokenization
 

--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -106,7 +106,7 @@ if [ "$RETRO_ACTIVE" = "true" ]; then
     mkdir -p "${PRAXIS_HOME:-$HOME/.praxis}/scope-confirm" || true
     echo "$(date -Iseconds) session=$SESSION_ID blocked_retrospect_fence_omission" \
       >> "${PRAXIS_HOME:-$HOME/.praxis}/scope-confirm/retrospect-mix-blocked.log" || true
-    fence_reason="Retrospect Stage 3 distribution fence missing (issue #666). This is a retrospect-active session (the retrospect skill was invoked this turn) presenting a findings table, but the assistant message carries no '<!-- retrospect:distribution begin -->' fence and no '## Actions Executed' marker. A free-form or localized Stage 3 report bypasses every mix-check gate (Gate-1..7) because the gates key on the canonical output schema. Re-emit the Stage 3 output per the Output Schema Contract in skills/retrospect/SKILL.md: '## Retrospect Report' header -> audit fences -> '<!-- retrospect:distribution begin/end -->' card -> unified findings table."
+    fence_reason="Retrospect Stage 3 distribution fence missing (issue #666). This is a retrospect-active session (the retrospect skill was invoked this turn) presenting a findings table, but the assistant message carries no '<!-- retrospect:distribution begin -->' fence and no '## Actions Executed' marker. A free-form or localized Stage 3 report bypasses every mix-check gate (Gate-1..7) because the gates key on the canonical output schema. Re-emit the Stage 3 output per the Output Schema Contract in skills/retrospect/references/stage3-reporting.md: '## Retrospect Report' header -> audit fences -> '<!-- retrospect:distribution begin/end -->' card -> unified findings table."
     jq -n --arg r "$fence_reason" '{decision: "block", reason: $r}'
     exit 0
   fi
@@ -285,7 +285,7 @@ while IFS= read -r row; do
 
   # Gate-3 (backing_repo): rows whose Proposed Actions contain upstream_feedback
   # or issue MUST declare backing_repo: <owner/repo> in the Rationale cell.
-  # Stage 2 step 8 documents this as MUST; Stage 4 Action 4 step 0 aborts on absence.
+  # Stage 2 step 7 documents this as MUST; Stage 4 Action 4 step 0 aborts on absence.
   has_routed_action=false
   for tok in "${unique_actions[@]}"; do
     case "$tok" in
@@ -295,7 +295,7 @@ while IFS= read -r row; do
   if [ "$has_routed_action" = "true" ]; then
     normalized_r3=$(printf '%s' "$rationale" | sed 's/<br *\/*>/\n/g')
     if ! printf '%s\n' "$normalized_r3" | grep -qE '^[[:space:]]*backing_repo: [A-Za-z0-9_][A-Za-z0-9_.-]*/[A-Za-z0-9_][A-Za-z0-9_.-]*'; then
-      GATE3_VIOLATIONS+=("finding #${finding_num}: Proposed Actions contains upstream_feedback or issue but Rationale missing backing_repo: <owner/repo> — return to Stage 2 step 8")
+      GATE3_VIOLATIONS+=("finding #${finding_num}: Proposed Actions contains upstream_feedback or issue but Rationale missing backing_repo: <owner/repo> — return to Stage 2 step 7")
     fi
   fi
 done <<< "$TABLE_LINES"
@@ -492,7 +492,7 @@ if [ "$should_block" = "true" ]; then
     fi
   done
 
-  full_reason="Retrospect mix-check gate triggered. ${reason}. Fix guide: Gate-1 → relabel finding category; Gate-2 → supply either (a) 5-line 'not <action>: <reason>' rationale (Schema A) or (b) 1-2 'not-others: <dim-tags>' lines (Schema B, issue #285) in Stage 2.5; Gate-3 verdict → return to Stage 2.5 and re-evaluate evidence robustness for 2-action findings; Gate-3 backing_repo → return to Stage 2 step 8 and add 'backing_repo: <owner/repo>' to Rationale cell; Gate-4 → return to Stage 2.5 Gate-4 and re-run external-repo classification; ensure gate_4_verdict is emitted in the distribution card; Gate-7 → post-compaction session: emit a '<!-- retrospect:transcript_receipt begin/end -->' fence with the real full-transcript scan output (or the 'retrospect:transcript_receipt_skipped: transcript unreachable' line when the jsonl is genuinely unreachable). See skills/retrospect/SKILL.md."
+  full_reason="Retrospect mix-check gate triggered. ${reason}. Fix guide: Gate-1 → relabel finding category via skills/retrospect/references/stage1-2-analysis.md; Gate-2 → supply either (a) 5-line 'not <action>: <reason>' rationale (Schema A) or (b) 1-2 'not-others: <dim-tags>' lines (Schema B, issue #285) in Stage 2.5; Gate-3 verdict → return to skills/retrospect/references/stage2.5-audit.md and re-evaluate evidence robustness for 2-action findings; Gate-3 backing_repo → return to skills/retrospect/references/stage1-2-analysis.md action assignment (step 7) and add 'backing_repo: <owner/repo>' to Rationale cell; Gate-4 → return to skills/retrospect/references/stage2.5-audit.md Gate-4 and re-run external-repo classification; ensure gate_4_verdict is emitted in the distribution card; Gate-7 → post-compaction session: emit a '<!-- retrospect:transcript_receipt begin/end -->' fence with the real full-transcript scan output (or the 'retrospect:transcript_receipt_skipped: transcript unreachable' line when the jsonl is genuinely unreachable). See skills/retrospect/references/stage2.5-audit.md and skills/retrospect/references/stage3-reporting.md."
   jq -n --arg r "$full_reason" '{decision: "block", reason: $r}'
   exit 0
 fi

--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -24,6 +24,7 @@ Symptom-level fixes miss the underlying pattern.
 `Agent(subagent_type="oh-my-claudecode:...")`
 
 **Reference map:**
+
 - Stage 1 / 1.5 / 2 / 2.7 details: [`references/stage1-2-analysis.md`](references/stage1-2-analysis.md)
 - Stage 2.5 gate procedures: [`references/stage2.5-audit.md`](references/stage2.5-audit.md)
 - Stage 3 output contract and approval flow: [`references/stage3-reporting.md`](references/stage3-reporting.md)

--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -15,11 +15,21 @@ description: >
 Repeated friction wastes cycles across sessions. Unexamined pain stays unresolved.
 
 **Core principle:** ALWAYS analyze root cause before proposing any action.
-Symptom-level fixes (e.g., "remember to do X") miss the underlying pattern.
+Symptom-level fixes miss the underlying pattern.
 
-**Pipeline:** `Load → Analyze → Report/Approve → Execute` (4 stages)
+**Pipeline:** `Load -> Hygiene -> Analyze -> Audit -> Report/Approve -> Execute`
 
-**Delegates to:** `oh-my-claudecode:tracer` agent (causal pattern analysis), `oh-my-claudecode:analyst` agent (pattern clustering) — invoked via `Agent(subagent_type="oh-my-claudecode:…")`
+**Delegates to:** `oh-my-claudecode:tracer` agent (causal pattern analysis),
+`oh-my-claudecode:analyst` agent (pattern clustering) — invoked via
+`Agent(subagent_type="oh-my-claudecode:...")`
+
+**Reference map:**
+- Stage 1 / 1.5 / 2 / 2.7 details: [`references/stage1-2-analysis.md`](references/stage1-2-analysis.md)
+- Stage 2.5 gate procedures: [`references/stage2.5-audit.md`](references/stage2.5-audit.md)
+- Stage 3 output contract and approval flow: [`references/stage3-reporting.md`](references/stage3-reporting.md)
+- Stage 3 worked examples: [`references/report-template.md`](references/report-template.md)
+- Stage 4 execution procedures: [`references/stage4-execution.md`](references/stage4-execution.md)
+- Rationalization catalog / red flags / full failure matrix: [`references/appendices.md`](references/appendices.md)
 
 ## The Iron Law
 
@@ -30,1266 +40,328 @@ REPEATED PATTERN + MEMORY = FAILED REMEDY. ESCALATE.
 TRACER + ANALYST CALLS ARE MANDATORY, NOT OPTIONAL.
 ```
 
-If you haven't completed Stage 2 (Analyze), you cannot propose actions.
-"It happened because X" is a symptom. "X happened because of missing rule Y / unclear trigger Z / absent skill W" is a root cause.
+If you have not completed Stage 2 (Analyze), you cannot propose actions.
 
 ## When to Use
 
 Use at the END of a working session to extract learnings:
 
 - Session had repeated tool retries or direction changes
-- User gave corrections mid-session ("no, don't do that")
+- User gave corrections mid-session
 - A task took significantly longer than expected
 - Workflow steps were skipped or out of order
 - User expressed frustration or redirected multiple times
 
-**Use this ESPECIALLY when:**
-- The same mistake happened more than once in the session
-- You feel "I should have done that differently"
-- A rule in global `~/.claude/CLAUDE.md` was violated — even once
-- A new workflow pattern emerged that isn't captured anywhere
+Use this especially when the same mistake happened more than once, when you
+feel "I should have done that differently", or when a new workflow pattern
+emerged that is not captured anywhere.
 
-## The Four Stages
+## The Stages
 
 You MUST complete each stage before proceeding to the next.
 
+1. **Stage 1: Load Calibration Standard**
+Read the governing rule files and turn them into concrete scan questions.
+
+2. **Stage 1.5: MEMORY.md Hygiene Pass (Detect-only)**
+Run the bounded hygiene scan before the conversation analysis. It is
+unconditional.
+
+3. **Stage 2: Analyze Conversation**
+Run the symmetric pre-scan lanes, derive root causes, and assign preliminary
+actions.
+
+4. **Stage 2.5: Action Distribution Audit**
+Run the gate suite before any Stage 3 output.
+
+5. **Stage 3: Report + Approval**
+Emit the canonical report shape, carry caveats forward, run the pre-output
+falsification gate, then ask for per-finding approval.
+
+6. **Stage 4: Execute**
+Run only approved actions, then verify the resulting artifacts.
+
 ### Stage 1: Load Calibration Standard
 
-**Before scanning the conversation:**
+Before scanning the conversation:
 
-1. **Read global and project rule files** — load all rules, behavioral guidelines, and workflow requirements
-   - Global: `$CLAUDE_CONFIG_DIR/CLAUDE.md` (i.e., `~/.claude/CLAUDE.md`)
-   - Project: `AGENTS.md` in cwd (if exists; in praxis, `AGENTS.md` is canonical — the project symlink in cwd points to it)
-   - Key sections: Mandatory Rules, Behavioral Rules, Workflow rules
+1. Read global and project rule files.
+2. Identify the rule categories you will scan against.
+3. Turn each category into a calibration question.
 
-2. **Identify rule categories** to scan against:
-   - Workflow discipline (Issue-Driven Workflow, Planning Before Implementation)
-   - Evidence-Based Delivery (No "Trust Me" completions)
-   - Atomic Commits + PR Lifecycle
-   - Mandatory Testing (unit + functional)
-   - Code Review Before Commit
-   - Error Recovery Before Asking
-   - Communication conventions
-
-3. **Set the calibration frame**: For each rule category, form a question — e.g.,
-   "Did the session violate 'Planning Before Implementation'? Were there 3+ step tasks that skipped plan mode?"
+Use [`references/stage1-2-analysis.md`](references/stage1-2-analysis.md)
+before doing the actual scan. That reference is the full procedure for Stage 1,
+Stage 1.5, Stage 2, and Stage 2.7.
 
 ### Stage 1.5: MEMORY.md Hygiene Pass (Detect-only)
 
-Stage 1.5 runs unconditionally between Stage 1 (Load) and Stage 2 (Analyze). Its purpose is to surface latent defects in MEMORY.md itself — defects that the session-scoped friction scanner (Stage 2) cannot see because they accumulate across sessions. Findings produced here flow into the same downstream pipeline (Stage 2 categorization → Stage 2.5 gates → Stage 3 approval → Stage 4 execution). Stage 1.5 itself does NOT mutate MEMORY.md.
+Stage 1.5 runs unconditionally between Stage 1 and Stage 2. It surfaces latent
+MEMORY.md defects that the session-scoped friction scan cannot see.
 
-**Scope:** scan MEMORY.md index + a bounded subset of `feedback_*.md` files.
+**Mandatory shape:**
 
-**Cap (mandatory):** scan up to **5 feedback files per invocation**. Persist a cursor at `.omc/state/retrospect-hygiene-cursor.json` recording (a) the timestamp of the last successful pass, (b) the list of file paths scanned (referred to as `scanned_recent_batch` on subsequent reads), (c) the next-batch pointer (`next_batch_pointer` — path of the next un-scanned feedback file in sorted order), (d) the per-signal pairwise-check trail for the batch (`signal_2_contradiction` / `signal_3_merge_candidate`, each `checked: yes|no, matches: N`), and (e) a `note` field holding the previous cycle's signal 1/2/3 findings (one line per finding — keep terse, e.g., `signal 1: feedback_promoted_section.md L5-17 — 12 markdown links to backing files ABSENT`). Field (d) is the home for the zero-match proof — a clean batch emits no finding, so the negative result is recorded here in the scan trail, not in a (non-existent) per-finding block. Field (e) is the carry-forward home — findings that did not complete a Stage 4 resolution in their original cycle live here until they do. Subsequent retrospects resume from the cursor — full corpus coverage amortizes across multiple sessions. When the full corpus has been scanned once, rotate the cursor to restart from the most-recently-modified entries.
+- Scan up to **5 feedback files per invocation**
+- Persist progress at `.omc/state/retrospect-hygiene-cursor.json`
+- Emit findings with `category: memory_hygiene`
+- Never mutate MEMORY.md here — Stage 1.5 is detect-only
 
-**Cursor read mandate (entry — MUST run first).** If `.omc/state/retrospect-hygiene-cursor.json` exists, before scanning ANY feedback file:
+**Five detection signals:**
 
-- (a) **Use `next_batch_pointer` to choose the batch start** — do NOT make an ad-hoc sort/filter decision (e.g., "scan the 5 most recently modified" / "scan the 5 alphabetically first"). The cursor IS the schedule; overriding it silently re-scans files Stage 1.5 already passed over in the prior cycle and starves the un-scanned tail of the corpus.
-- (b) **Exclude files listed in `scanned_recent_batch` from this batch** — avoid re-scan of the immediately prior batch even if `next_batch_pointer` would otherwise fall inside it (defends against a corrupt or stale pointer).
-- (c) **Carry forward findings stored in the cursor's `note` field** (signals 1/2/3 from the previous cycle) into Stage 3 input. The carried findings flow through Stage 2.5 gates and Stage 3 emit alongside any new findings produced by this batch's scan; they are NOT silently dropped just because the file containing the finding falls outside the current batch's 5-file window. See Stage 3 "Carry-forward integration" for the emit-side contract.
+1. stale reference
+2. contradiction
+3. merge candidate
+4. size threshold
+5. missing oracle annotation
 
-Silent skip of the cursor read (entry without honoring (a)/(b)/(c)) is a Red Flag — it is the structural enabler of the failure mode where a prior cycle's hygiene finding gets contradicted by the current cycle without falsification.
+**Cursor read mandate (entry — MUST run first):**
 
-**Cursor write mandate (exit — read-modify-write union under concurrency, MUST).** The cursor is shared mutable state, and running `/retrospect` from two sessions concurrently or interleaved is a common multi-session workflow. A plain Write at exit clobbers a sibling session's just-persisted `note` (field (e)) and scan trail (field (d)): both sessions read the same cursor at entry, both advance `next_batch_pointer` to the same batch, and the last writer silently drops the first writer's findings and carry-forward. Before persisting the cursor at the end of Stage 1.5, **re-read** the on-disk `.omc/state/retrospect-hygiene-cursor.json` and compare it against the values observed at the entry read (Cursor read mandate above):
+- Use `next_batch_pointer` to choose the batch start
+- Exclude `scanned_recent_batch`
+- Carry forward the cursor `note` into Stage 3 input
 
-Field (a) is re-stamped with a fresh write-time timestamp on *every* persist, so `on-disk (a) != entry-read (a)` is the **primary** concurrent-advance discriminator — it is the one field guaranteed to differ when a sibling persisted, including the headline #568 case where both sessions advanced to the *same* batch and therefore wrote an identical `next_batch_pointer` / `scanned_recent_batch`. Do NOT rely on (c)/(b) alone to detect concurrency: in the same-batch case they match this session's own intended values and would miss the sibling write.
+**Cursor write mandate (exit — read-modify-write union under concurrency, MUST).**
+This is the cross-session complement of the single-session falsification gate.
 
-- (a) **No concurrent advance** — the on-disk last-pass timestamp (field (a)) equals the entry-read value AND `next_batch_pointer` is unchanged: write the new cursor normally. Plain overwrite is safe because no other actor touched the file in this window.
-- (b) **Concurrent advance detected** — the on-disk last-pass timestamp (field (a)) differs from the entry-read value, OR `next_batch_pointer` / `scanned_recent_batch` differ from it: a sibling session persisted between this session's entry read and exit write. Do NOT overwrite — UNION-merge the on-disk cursor with this cycle's result before writing:
-  - **`note` (field (e))**: concatenate the on-disk `note` lines with this cycle's `note` lines, then drop byte-identical duplicate lines. Both sessions' carry-forward findings survive.
-  - **scan trail (field (d))**: union the `signal_2_contradiction` / `signal_3_merge_candidate` records keyed by batch — records for *distinct* batches are BOTH retained, because each batch's pairwise-proof (including a zero-match proof) must survive for downstream audit and a different batch's count is not a substitute proof. Only when both sides recorded the same signal for the *same* batch do they conflict; resolve that conflict by keeping the higher `matches` count (a confirmed match is strictly more informative than a zero).
-  - **`next_batch_pointer` (field (c))**: advance to the FURTHER of the two pointers (the later position in sorted order) so neither session re-scans a batch the other already passed — never rewind to this session's older value.
-  - **`scanned_recent_batch` (field (b))**: union the two file lists.
-- (c) **Record the reconciliation** — when (b) fired, add one line to the Stage 3 Hygiene Scan Trail: `Cursor write: concurrent advance detected — union-merged note (<n_self> self + <n_disk> on-disk lines) + advanced pointer to <pointer>`. This makes the merge auditable by the next cycle.
+- **re-read** the on-disk cursor before persisting
+- If **Concurrent advance detected**, do not overwrite
+- **UNION-merge the on-disk cursor** instead of plain write
+- **concatenate the on-disk `note` lines** with this cycle's lines
+- Advance `next_batch_pointer` to the **FURTHER of the two pointers**
+- Record the Stage 3 trail line:
+  `concurrent advance detected — union-merged note`
+- **Silent overwrite of a concurrently-advanced cursor** is a Red Flag
 
-Silent overwrite of a concurrently-advanced cursor (exit without honoring (a)/(b)/(c)) is a Red Flag. This write mandate is the cross-session complement of the single-session "Falsification gate before invalidating a carried finding" below: the falsification gate stops a session from *semantically* dropping a carried finding without a probe; this write mandate stops a session from *mechanically* clobbering a sibling session's findings via a stale-snapshot overwrite. Both protect field (e); neither subsumes the other.
+If Stage 1.5 finds hygiene defects but Stage 2 finds zero friction events, take
+the hygiene-only path rather than the "No patterns found" early exit.
 
-**Five detection signals (each becomes a finding with `category: memory_hygiene`):**
-
-1. **Stale reference** — the entry cites an artifact that no longer matches reality:
-   - File path absent: entry references `<path>` that does not exist (verify with `test -e`)
-   - CLI flag absent: entry cites `<binary> --<flag>` but `<binary> --help` no longer documents it
-   - CLAUDE.md line shifted: entry cites `~/.claude/CLAUDE.md` line `N` whose content no longer matches the quoted excerpt (verify with `grep -n` of the cited excerpt)
-   - Skill / hook removed: entry references a skill name or hook path that no longer exists in the plugin manifest
-
-   Detection method: parse the entry's body for `\bgrep -n\b`-able tokens (file paths, CLI flag patterns `--[a-z-]+`, CLAUDE.md line citations); run the verification command; record failures as stale.
-
-   **Probe guideline — multi-path enumerate before concluding stale (MUST):** a single-path not-found result (e.g., `test -e <path>` returns false, `grep -n <excerpt> <file>` returns 0 matches) is insufficient to conclude the entry is stale — the target may have been renamed or moved rather than removed. Before recording a stale finding, try at least one additional verification path:
-   - File path absent: also try `find . -name "$(basename <path>)"` to detect **moves** (same filename, new location). This does not catch a true rename (basename changed) — for that, grep a unique symbol / quoted excerpt from the entry across the tree (`grep -rn "<unique token>" .`) before concluding stale.
-   - CLI flag absent: also try `<binary> help <subcommand>` or `man <binary>` to catch flag aliases or nested help pages that `--help` alone does not print.
-   - CLAUDE.md line shifted: also try `grep -n` with a shorter unique substring of the cited excerpt (the full excerpt may span lines that were reformatted).
-   - Skill / hook removed: also try searching the manifest's alias or `name` field, not only the file path.
-   Only when all attempted paths fail does the entry qualify as a confirmed stale finding. Record both the primary probe command and the secondary probe(s) in the finding's evidence block.
-
-   **Probe guideline — stored-value oracle match (MUST):** when the stale-looking citation is a **stored measurement / numeric value** (not a file path, CLI flag, or line citation), concluding it stale additionally requires same-oracle confirmation per Stage 2 step 7h — a probe run under a different matching basis / cohort / unit measures a different quantity and cannot mark the stored value stale. If the entry body does not state its originating oracle, DEFER falsification and propose an entry-annotation update instead (route as `memory`, Stage 4 update path). See step 7h for the full rule and `oracle_match` ledger format.
-
-2. **Contradiction** — two entries provide semantically opposed guidance under overlapping triggers:
-   - Entry A says "always X under trigger T"; Entry B says "never X under trigger T" — same T, opposite directive.
-   - Detection method: concept-level pairwise comparison restricted to entries whose `hookKeywords` (or trigger tokens) overlap. Use LLM judgment for semantic opposition (no regex shortcut). Cap pairwise comparisons to the cursor-batch's 5 files × full-index check.
-
-   **Pairwise-proof requirement (MUST):** record pairwise check metadata in the format `checked: yes, matches: N` where N is the count of contradiction pairs found. "0 across batch" alone is INELIGIBLE — stating a zero count without explicitly confirming that the pairwise comparison was executed is indistinguishable from skipping the check. Placement depends on N: when **N ≥ 1**, record it in each emitted contradiction finding's evidence block; when **N = 0**, no finding is emitted, so record `signal_2_contradiction: checked: yes, matches: 0` in the Stage 1.5 cursor scan trail (field (d) above) — never fabricate a finding just to carry the proof. This requirement exists so downstream retrospects can audit whether Signal 2 ran or was silently elided.
-
-3. **Merge candidate** — two or more entries share a root-cause family but have not been merged:
-   - Same principle restated with different examples (the merge-first policy at Stage 4 Action 1d should have collapsed them).
-   - Detection method: read each entry's `description` field and root-cause prose; group by concept-level matching (same heuristic as Stage 4 Action 1 duplicate-check). When N ≥ 2 entries share a family AND none has been merged, emit a merge-candidate finding.
-
-   **Pairwise-proof requirement (MUST):** record pairwise check metadata in the format `checked: yes, matches: N` where N is the count of merge-candidate groups found. "0 across batch" alone is INELIGIBLE — stating a zero count without confirming the pairwise comparison was executed is indistinguishable from skipping the check. Placement depends on N: when **N ≥ 1**, record it in each emitted merge-candidate finding's evidence block; when **N = 0**, no finding is emitted, so record `signal_3_merge_candidate: checked: yes, matches: 0` in the Stage 1.5 cursor scan trail (field (d) above) — never fabricate a finding just to carry the proof. Same audit rationale as Signal 2.
-
-4. **Size threshold** — the MEMORY.md **index file itself** has grown past a configurable threshold, increasing the risk that the index is silently truncated at load time and that downstream Stage 1 compaction restoration is incomplete (the upstream structural enabler called out by praxis issue #387). Triggered when ANY of these conditions fires:
-   - Index line count ≥ `PRAXIS_RETROSPECT_INDEX_LINE_THRESHOLD` (default `200`)
-   - Index byte size ≥ `PRAXIS_RETROSPECT_INDEX_BYTE_THRESHOLD` (default `24000` — below the ~24.4 KB MEMORY.md load budget observed on at least one host. The prior `30720` / 30 KB default sat *above* common host load budgets, so the index could grow past the real budget and be silently truncated *before* this signal ever fired — the size guard was calibrated above the failure it exists to catch.)
-   - An **observed host truncation warning** for the MEMORY.md index in the session-start context (e.g. a host reminder that the index exceeded its load budget and "only part was loaded") — this fires regardless of the numeric thresholds above. The host's actual load budget can be lower than the configured byte threshold and can drift between hosts / versions, so an event-driven trigger catches the truncation that a static numeric threshold misses.
-
-   Detection method: single `wc -l` + `stat -c %s` (or equivalent) on the index file, **plus** a scan of the session-start context for a host MEMORY.md truncation warning. Signal 4 is **index-scoped (one file)** and unrelated to the per-batch `feedback_*.md` cursor — it fires on every Stage 1.5 invocation when any condition is met, not on a cursor schedule. Threshold env vars that fail to parse as positive integers silently fall back to defaults.
-
-   **Link-detection helper (link-convention-agnostic)** — subsignals 4a and 4b both consume a single shared link scanner. The scanner recognizes a reference from index entry A to artifact B when B appears inside A's body in ANY of three forms:
-
-   - **Wikilink**: `[[B]]` or `[[path/B]]` (Obsidian-style)
-   - **Markdown link**: `[text](path)` where `path` resolves to B (relative or absolute), allowed extensions `.md` / `.txt` / `.json` / `.py` / `.sh`
-   - **Bare basename mention**: a single-token `<B>.<ext>` (≥4 chars, allowed extensions above) appearing as plain text outside code fences
-
-   This contract MUST hold for ANY user's MEMORY.md regardless of their personal link convention. A scan failure on one form falls through to the next; only when all three forms fail to match does the entry count as backlink-zero. The scanner has no user-environment assumption beyond "MEMORY.md is markdown".
-
-   **Subsignals (each routed via Stage 4):**
-
-   a. **Promoted-pointer compression** — an index entry whose body has been promoted to a parent rule file (`~/.claude/CLAUDE.md`, a SKILL.md, a hook spec) should collapse to a single-line pointer. "Promoted" is recognized when the entry body contains at least one outbound reference (via the helper above) to a file under `~/.claude/`, `<plugin_root>/skills/`, `<plugin_root>/hooks/`, or `<plugin_root>/docs/` that actually exists. Routed as `memory` (Stage 4 Action 1 update path) per matched entry; the rewrite replaces the body with a single-line link to the promotion target.
-
-   b. **Backlink-zero archive** — an index entry that NO other index entry references (via the helper above) after a grace period is a candidate for archive. Backlink counting iterates every other entry's body once per scan; entries with `incoming_refs == 0` AND `age_in_sessions ≥ PRAXIS_RETROSPECT_BACKLINK_ZERO_GRACE_SESSIONS` (default `5`) become candidates. Routed as `issue` (Stage 4 Action 2 — human-confirmed archive move; never auto-delete).
-
-   c. **New-entry length cap** — enforce ≤ `PRAXIS_RETROSPECT_INDEX_LINE_CAP` (default `150`) chars per index line at write time. Routed as a write-time guard recorded in the entry's Proposed Actions; Stage 4 Action 1 applies the cap before the write (truncation with `…` marker + detail body file is the canonical pattern).
-
-   **Self-applicability** — Signal 4 catches the retrospect skill's own monotonic-growth pattern: each retrospect adds memory entries, but without a hygiene loop the index outgrows its load-time budget. Signal 4 closes this loop by surfacing the size threshold as an actionable finding, not just an emitted warning.
-
-5. **Missing oracle annotation** — a memory entry stores a numeric / measurement / comparison value (latency delta, row count, comparison sum, count) whose body does NOT state the **oracle** (matching basis, cohort, unit) that produced the value. Such an entry cannot be falsified later: a future cycle has no way to know which oracle to re-probe with, so any correction risks the multi-oracle mismatch that Stage 2 step 7h / Gate-6 guard against.
-
-   Detection method: parse the entry body for stored numeric tokens (a number paired with a comparison or measurement verb — `is N faster`, `count = N`, `sum = N`, `N rows`, `Nh`, `Nms`); for each, check whether the body also states a matching basis / cohort / unit. Detect-only — no value is re-measured at Stage 1.5.
-
-   Routed as `memory` (Stage 4 Action 1 update path): the rewrite adds an explicit oracle/unit annotation to the entry body so a future cycle can falsify with a known basis. This is the defer-and-annotate fallback referenced by step 7h step (1).
-
-**Output — emit per-defect findings into the Stage 2 friction-event lane.**
-
-Each Stage 1.5 finding has:
-- `category[]: [memory_hygiene]` — single category at Stage 1.5; downstream gates may add tool/workflow when defect originates from a tool layer (e.g., manifest staleness from a removed hook).
-- `Tool Layer: —` (default for memory_hygiene; the Stage 2 Layer E composition matrix carves out a `—` row for memory_hygiene the same way it does for behavioral).
-- `Proposed Actions` (provisional, finalized at Stage 2.5):
-  - Stale reference → `memory` (update entry inline) OR `claude_md_draft` (when the stale citation is itself a CLAUDE.md rule line that needs updating)
-  - Contradiction → `memory + issue` (surface both entries via an issue for human resolution; merge in Stage 4 only after explicit decision)
-  - Merge candidate → `memory` (route through Stage 4 Action 1 merge path; the merge IS the action)
-  - Size threshold / 4a promoted-pointer compression → `memory` (Stage 4 Action 1 update path; body collapses to a single-line link to the promotion target)
-  - Size threshold / 4b backlink-zero archive → `issue` (Stage 4 Action 2 — human-confirmed archive move; never auto-delete)
-  - Size threshold / 4c length cap → `memory` (Stage 4 Action 1 with the cap as a write-time guard; truncate + spill detail body to a separate file)
-  - Missing oracle annotation (signal 5) → `memory` (Stage 4 Action 1 update path; add an explicit oracle/unit annotation to the entry body)
-
-**0-friction hygiene-only retrospect path** — when Stage 2 pre-scan finds zero friction events but Stage 1.5 produced ≥1 hygiene finding, the skill does NOT take the "No patterns found ✅" early-exit (Stage 2 line). Instead, proceed to Stage 2.5 → Stage 3 with the hygiene findings as the sole input. Emit a banner in Stage 3 report: `Hygiene-only retrospect — no friction events this session.`
-
-**Stage 3 banner for signal 4 (size_threshold)** — when signal 4 fires (regardless of whether the 0-friction hygiene-only path is also active), emit ONE additional banner line in the Stage 3 report immediately under the section header:
-
-`Index size threshold tripped — {lines} lines / {bytes} bytes (limit: {line_threshold} / {byte_threshold}). Cleanup actions queued: {n_4a}× promoted-pointer compression, {n_4b}× backlink-zero archive, {n_4c}× length-cap write-guard.`
-
-When signal 4 does NOT fire, the line is omitted entirely (no empty banner). This banner is informational and counted under `memory_hygiene` in the distribution card — it does not introduce a new fence parser key.
-
-**Stage 3 emit — Hygiene Scan Trail (carry-forward integration).** The Hygiene Scan Trail block in the Stage 3 report carries TWO lines whenever the cursor's `note` field (field (e)) was non-empty on entry:
-
-```
-Hygiene Scan Trail
-- Current cycle: signal 1/2/3/4 = <one-line summary per signal that fired this cycle, or `none` if the signal produced no finding>
-- Carried from previous cycle (cursor note): signal 1 = <verbatim copy of the carried finding(s)>; signal 2 = ...; signal 3 = ...
-```
-
-The two lines are separate by construction — current-cycle findings and carried findings MUST NOT be merged into a single line, even when the same signal number appears on both sides. Reviewers (and the next cycle's Stage 1.5) read the second line to decide whether the carried finding is still outstanding.
-
-**Falsification gate before invalidating a carried finding (MUST).** When the current cycle's conclusion contradicts a carried finding (e.g., current cycle says "Promoted section self-managed" while carried `note` says "12 markdown links to backing files ABSENT"), the contradiction is NOT a license to silently overwrite the carried finding. Before the carried finding may be dropped, marked resolved, or replaced by the new conclusion, the skill MUST run an explicit falsification — re-execute the carried finding's original probe (path existence test, grep, manifest lookup) against the *current* tree and record the probe command + observed output in the Hygiene Scan Trail as a third line:
-
-```
-- Falsification of carried finding (signal N): probe=`<command>` output=`<observed>` → carried finding RESOLVED|STILL_OUTSTANDING
-```
-
-If the probe shows the carried finding is genuinely resolved (e.g., the previously-absent files now exist), drop it from the next cycle's `note` field. If the probe re-confirms the finding (still absent / still contradictory / still merge-candidate), the carried finding REMAINS in the cursor `note` for the next cycle regardless of any new-cycle conclusion that disagrees with it. Silent overwrite — emitting a current-cycle conclusion that disagrees with the carried finding without running the falsification probe — is a Red Flag (this is the exact failure mode the issue protecting this section was filed against).
-
-When the carried finding is a **stored-value correction** (a numeric measurement / comparison sum / count, not a path / flag / merge-candidate), the re-executed falsification probe MUST satisfy step 7h oracle-match — i.e. it MUST use the SAME oracle (matching basis, cohort, unit) as the stored value — before the carried finding may be marked RESOLVED; a different-oracle probe is not valid falsification and leaves the carried finding STILL_OUTSTANDING.
-
-**`probe-unrunnable` branch (#574).** The falsification gate above assumes the original probe can be re-run. Two cases break that assumption: (a) **access-blocked** — the probe target is no longer reachable (out of scope, requires a system/credential not available this cycle); (b) **rule-conflicted** — re-executing the probe would itself violate a higher rule (e.g. the probe reaches into a personal asset that the host's asset-boundary protection forbids touching). With no branch for these, the gate fails BOTH ways: a finding that can never be falsified carries **forever** (infinite carry), or it gets **silently dropped** without falsification — the two failures the gate exists to prevent. The branch:
-
-- When the probe is access-blocked or rule-conflicted, do NOT silently drop and do NOT silently retain. Record the reason explicitly in the Hygiene Scan Trail as the third line, using `UNRUNNABLE` in place of a probe result:
-
-```
-- carried finding (signal N): probe=UNRUNNABLE (<reason: access-blocked <what> | rule-conflict <which rule>>) → retained|dropped (<rule applied · cycle count>)
-```
-
-- **Retain by default.** A `probe-unrunnable` finding REMAINS in the cursor `note` for the next cycle — same as a STILL_OUTSTANDING result — so it is not silently lost.
-- **Bounded-drop escape (anti-infinite-carry).** Dropping is permitted ONLY when BOTH hold: the probe has been `probe-unrunnable` for **`PRAXIS_RETROSPECT_UNRUNNABLE_DROP_CYCLES` (default 3)** consecutive cycles AND the unrunnability is a **rule-conflict** (case b) — i.e. re-running would keep violating a higher rule, so the finding is structurally un-falsifiable here, not merely inaccessible this once. On drop, the trail line MUST record the conflicting rule and the cycle count (`→ dropped (rule-conflict <rule>; 3rd consecutive unrunnable cycle)`). Access-blocked-only findings (case a) never auto-drop — they are retained until the probe becomes runnable (access may return), and the consecutive-cycle counter resets the moment a runnable falsification succeeds. The consecutive-cycle counter lives in the carried `note` text (e.g. `unrunnable_cycles: 2`) so it survives across cycles without a new cursor field.
-- Emitting a drop without recording the conflicting rule + cycle count, or auto-dropping an access-blocked-only finding, is a Red Flag (it re-opens the silent-drop failure this branch closes).
-
-**Self-conflict detection (optional, advisory).** Before Stage 3 emit, perform a lightweight keyword-overlap check between the cursor `note` text and the current cycle's signal-1/2/3 conclusion text. When ≥1 shared content noun overlaps (file path, section name, or unique identifier) AND the two predicates are opposite (`absent` vs `self-managed`, `stale` vs `fresh`, `contradictory` vs `consistent`, `merge candidate` vs `distinct`), STOP-surface to the user with the trail of both texts and ask whether the carried finding should be retained, falsified, or revised. This advisory check is a defense-in-depth layer above the falsification gate; the gate remains MANDATORY whether or not this check fires.
-
-**Stage 1.5 failure modes:**
-- MEMORY.md not accessible → skip Stage 1.5 entirely; emit `<!-- retrospect:hygiene_skipped: index not accessible -->` trail line; proceed to Stage 2.
-- Cursor file corrupt → reset cursor to most-recently-modified 5 files; log reset in completion report.
-- Per-file scan failure (one of N files unreadable) → continue with remaining files; record per-file failure in the Hygiene Scan Trail section of Stage 3 report.
-- Index file unreadable for size measurement → skip signal 4 only (signals 1-3 proceed normally); emit `<!-- retrospect:hygiene_size_threshold_skipped: index unreadable -->` trail line in Stage 3 report.
-- Threshold / cap env var malformed (non-integer, negative) → fall back to documented default silently; no Stage 1.5 failure.
-- Promotion-target candidate paths unresolvable (plugin root not in scope, custom MEMORY.md layout) → subsignal 4a downgrades to a no-op for that entry (no finding emitted) rather than blocking signal 4.
-
-**Detect-only contract** — Stage 1.5 never writes to MEMORY.md, never deletes a feedback file, never edits the MEMORY.md index. All mutations route through Stage 4: Action 1 merge path (merge candidates), Action 1 update path (stale references / promoted-pointer compression / length-cap rewrites), Action 2 issue creation (contradictions / backlink-zero archive proposals). Inline mutation at Stage 1.5 is a Red Flag.
+Read the full rules, signal definitions, failure modes, and carry-forward logic
+in [`references/stage1-2-analysis.md`](references/stage1-2-analysis.md).
 
 ### Stage 2: Analyze Conversation
 
-**Pre-scan: Symmetric scan (friction + successful + tool usage + user correction + self correction)** — scan the conversation BEFORE calling agents. Produces five lanes:
-
-- **friction_events**: up to 5 friction events (user corrections, retries, skipped steps, stalls). This provides the input for agent calls.
-- **successful_patterns**: up to 3 patterns that worked well this session. Each entry MUST include:
-  - `pattern`: one line (e.g., "deep-dive 3-lane trace identified cross-lane contradiction via direct grep")
-  - `evidence`: specific turn or artifact citation (mandatory — abstract reinforcement like "was helpful" or "responded fast" is FORBIDDEN)
-  - `reinforce_action`: `memory` (capture as MEMORY.md entry; counted in Stage 2.5 distribution card `memory` total — see Stage 4 Action 1 for the origin-prefix convention) or `visualize_only` (display in Stage 3 Reinforced Patterns section, no persistent action)
-- **tool_census**: deterministic inventory of EVERY tool invoked in the scope window (same window as Stage 2 / Stage 2.7: last 50 turns or last session boundary). Unlike `friction_events` (narrative-driven, operator-interpreted), this lane is machine-derived from the transcript so a tool that ran cleanly is still inventoried — closing the blind spot where only tools that *surfaced pain* get examined. It REUSES the Stage 2.7 transcript-scan MECHANISM but broadens its coverage on two axes so the "EVERY tool" promise actually holds: (a) **tool-call types** — Stage 2.7 scanned only Bash invocations + a write-artifact MCP allowlist; the census scans EVERY `tool_use` entry in the transcript: Bash, **all builtin tools** (`Read` / `Edit` / `Write` / `Grep` / `Glob` / `NotebookEdit` / etc.), MCP, and `Agent` dispatches; (b) the write-artifact allowlist is dropped (all tools, not just writes). Axis (a) is load-bearing: without scanning builtin calls, a `builtin`-layer design defect such as Read/Grep output truncation could never be inventoried and the builtin-truncation promotion rule (step 4b Q1) would be permanently dead. The census feeds **step 4b** (which iterates the inventory, not just friction events — see step 4b "Census-driven lane"). The **promotion decision** (which inventory rows clear the step 4b thresholds + dedup + cap) is deterministic and is computed HERE during pre-scan — before the Stage 2 Early-exit decision — so the Early-exit "Census carve-out" can observe the promoted set (see that carve-out's Ordering invariant). step 4b later consumes this same decision; it does not re-decide. Per-tool inventory row:
-
-  ```
-  <!-- retrospect:tool_census begin -->
-  - tool_name: <e.g. "gh", "Bash", "mcp__<server>__<tool>", "Read", "<skill-name>">
-    layer: mcp | cli | builtin | skill
-    call_count: N
-    error_count: N             # calls that returned an error / non-zero exit / exception
-    retry_count: N             # same tool+params RE-ISSUED after a FAILED/errored/unexpected-output prior call. Failure-driven only — intentional polling / repeated status reads / background-output re-reads (e.g. write_stdin polls, airflow_*_progress polling, Read of a growing log) are NOT retries and MUST NOT increment this counter even when consecutive.
-    workaround_marker: true|false   # "fallback"/"manual"/"우회"/"workaround" within 2 turns of the call
-    surfaced_in_friction: true|false  # dedup flag — true ONLY when the friction-driven lane already emitted a TOOL-DEFECT finding for THIS tool_name (a friction event with `tool` ∈ category[] AND same tool_name). A tool merely appearing in a behavioral/workflow friction event (not itself a tool-defect finding) does NOT set this true — that event is a different finding and must not suppress a distinct census tool-defect signal for the same tool. See step 4b "Census dedup".
-    signal: none | <objective-signal summary>   # promotion key; see step 4b thresholds
-  <!-- retrospect:tool_census end -->
-  ```
-
-  `signal` is the promotion key: a row becomes a `tool` finding ONLY when `signal != none` (step 4b). Rows with `signal: none` stay in the trail (audit), never a finding — a cleanly-used tool is evidence the tool worked, not a defect. This mirrors `dismissed_candidates` (full audit log, selective promotion) and prevents MEMORY.md inflation. The census trail fence is informational — the Stop hook's awk parser (`hooks/completion-verify/retrospect-mix-check/impl.sh`) captures only the distribution-card fence + unified table, so the trail is ignored.
-
-- **user_correction**: deterministic candidate scan of USER turns in the same scope window (last 50 turns or last session boundary) for correction / redirect signals, followed by per-candidate LLM judgment. This lane closes the **user-facing** analogue of the blind spot `tool_census` closed for tools. Today a user correction lands ONLY in `friction_events`, which is *narrative-driven, operator-interpreted* — the very agent that disappointed the user is the sole interpreter of whether an utterance "counts", capped at 5, with NO deterministic enumeration source for user-correction utterances (the Pre-scan Checklist's deterministic sources cover review-bot findings / workflow divergence / retried commands — never user turns). The highest-value retrospect signal (the user directly stating what was wrong) is thus routed through the least-deterministic lane. The marker scan provides a machine-derived candidate floor the agent cannot self-servingly omit; the LLM judge provides precision; dropped candidates are audited.
-
-  **Two-stage detection (marker-gated LLM):**
-  1. **Deterministic marker scan** of user turns generates candidates. Marker taxonomy = **Core 3** classes — the recall floor (a correction class with no marker is never even seen as a candidate, so the LLM judge can never recover it):
-     - **negation / stop** (ledger `marker_class: negation`): `아니` · `그거 아니야` · `하지 마` · `그거 말고` · `no` · `don't` · `stop`
-     - **redirect / re-instruction** (ledger `marker_class: redirect`): `~라니까` · `~하라고 했잖아` · `그게 아니라` · `내 말은` · `다시` · `I said X` · `not that`
-     - **mismatch-callout** (did-X-not-Y; ledger `marker_class: mismatch`): `~하라니까 ~하고 있네?` · `왜 X 안 하고 Y?` · `왜 ~했어` · `that's not what I asked`
-     - Implementation note (input-surface enumeration — global `~/.claude/CLAUDE.md` "Regex in Korean/English mixed text"): Python `re.\w` / `\b` is Unicode-aware and places NO boundary between Hangul and ASCII; when an ASCII boundary is the intent in mixed KO/EN text, use `(?<![a-z])foo(?![a-z])` and verify on real mixed input before relying on the pattern. repeat-complaint / undo-request / frustration-tone classes are OUT of v1 scope (lower precision).
-  2. **Per-candidate LLM judgment**: each marker-matched candidate is judged genuine-correction vs false-positive (a benign "no" answering a yes/no question, a quoted string, a hypothetical, a correction aimed at a third party rather than the agent).
-
-  **Routing of the two outcomes:**
-  - **genuine** → emitted as a **behavioral** friction event (`category: [behavioral]`, `origin: user_correction`), flowing through the standard pipeline like any other friction event: step 4 (behavioral correction — what Claude should have done differently), step 5 (root cause), step 6 (cluster), step 7 (MEMORY.md scan), step 8 (action) → Stage 2.5 gates → Stage 3. Because it is a friction event (NOT a separate inventory like census), **step 6 clustering automatically de-dups it** against any narrative-lane friction event of the same root cause — so NO census-style `surfaced_in_friction` dedup flag is needed. The asymmetry with census is principled: census rows bypass clustering (step 4b promotes them straight into the unified table, hence they need the explicit flag), while user_correction rows travel the friction-event clustering path.
-    - **Cap priority (MUST)**: `friction_events` is bounded at 5 (lane 1) — the pre-existing limit on how many events feed the agent calls (a scan-stop, per "Stop after identifying 5 distinct friction events" below). A genuine user_correction is the **highest-value** retrospect signal (the user directly stating what was wrong), so when more than 5 friction events exist this session, genuine user_corrections take priority for the retained slots — a narrative event yields, not the user_correction. This lane changes only the *priority* of which events the existing 5-event bound keeps; it does NOT change the bound, and it does NOT claim events beyond the bound are preserved elsewhere (the >5 limitation predates this lane). Without this priority rule the cap would silently re-open the exact recall gap the lane closes — the highest-value signal would be the one crowded out.
-  - **false-positive (dropped)** → recorded in the `user_correction` ledger (below) with reason + cite, NEVER silently dropped. The judge's drops are audited so a self-serving omission at the judgment step is structurally visible — the same guarantee the `dismissed_candidates` Red Flag ("Silent dismissal ... is BLOCKED") gives the rule-violation ledger. (This is what keeps the marker-gated-LLM choice from re-opening, at the judgment step, the very self-serving blind spot the lane exists to close.)
-
-  Per-drop ledger row:
-  ```
-  <!-- retrospect:user_correction begin -->
-  - candidate: "<verbatim user-turn excerpt>" | marker_class: negation|redirect|mismatch | reason: <why judged not-a-correction> | cite: <turn ref / quoted context>
-  <!-- retrospect:user_correction end -->
-  ```
-  The ledger fence is informational — it lives OUTSIDE the `retrospect:distribution` fence, so the Stop hook's awk parser (distribution card + unified table only) ignores it, exactly like the `tool_census` trail. Empty body when zero candidates were dropped; when the transcript is unreachable, replace the body with a single `<!-- retrospect:user_correction_skipped: transcript unreachable -->` line.
-
-  **Early-exit interaction (intrinsic, not a separate predicate):** unlike the Census carve-out — which needs an explicit early-exit override because an inventory row is not a friction event — a genuine user_correction IS a friction event, added to `friction_events` during pre-scan. So the existing "1+ friction events → mandatory tracer/analyst calls" path fires and the 0-friction early-exit cannot trigger when a genuine correction exists. The lane's highest-value case (the narrative pre-scan surfaced 0 friction events, but the marker scan + judge catches a correction the agent did not narrate) is handled by the SAME mechanism: the marker scan runs as part of pre-scan and contributes the genuine correction to `friction_events` BEFORE the early-exit decision is taken. No separate carve-out clause is required.
-
-- **self_correction**: deterministic candidate scan of the scope window (last 50 turns or last session boundary) for **self-correction signatures**, followed by per-candidate LLM judgment. This lane closes the **agent-facing** analogue of the blind spot `user_correction` closed for user turns. A self-correction is a mistake the agent caught and fixed *itself*, mid-session — and that is exactly the event the narrative pre-scan is most likely to self-servingly omit, because an unconscious filter ("I already fixed it on the spot, so it isn't friction") fires hardest on the agent's own corrected errors. The paradox: the more cleanly a mistake was self-corrected, the more likely it drops out of the retrospect — so the corrected pattern never reaches MEMORY.md and recurs next session. The existing deterministic lanes do not catch it: lane 3 `tool_census.retry_count` is **failure-driven and same-command** (a command re-issued after an error/non-zero exit), whereas a self-correction is a command re-issued **with a different command/tool/parameters to correct a WRONG RESULT** — the prior call *succeeded* (no error), it just answered the wrong question (oracle mismatch / wrong measurement target / wrong basis). The marker scan provides a machine-derived candidate floor the agent cannot self-servingly omit; the LLM judge provides precision; dropped candidates are audited.
-
-  **Self-correction signature (distinguishes from retry and from progressive refinement):** a candidate pair `(prior_call, corrective_call)` within the window where ALL hold:
-  1. **Same intent** — both calls pursue the same goal (measuring the same quantity, locating the same artifact, answering the same question).
-  2. **Changed oracle/target/basis** — the corrective call changes WHAT is measured or HOW (different tool, different path/scope, different flag, different cohort/unit) — NOT merely a re-run of the identical command (that is a lane-3 retry) and NOT merely broadening a search that returned too little (progressive refinement).
-  3. **Prior result was wrong, not merely errored** — the prior call returned a result that was subsequently treated as incorrect/superseded (the agent's own narration says so — `실제로는` / `정정` / `wrong basis` / `that measured the wrong thing` / `should have measured` — OR the prior output value is discarded and not used downstream while the corrective value is). A prior call that *errored* (non-zero exit, exception, timeout) is a lane-3 retry, not a self-correction.
-
-  **Two-stage detection (marker-gated LLM):**
-  1. **Deterministic signature scan** generates candidate `(prior, corrective)` pairs from the window per the three-part signature above. Recall floor: a corrective sequence with no signature is never seen as a candidate.
-  2. **Per-candidate LLM judgment**: each candidate is judged genuine-self-correction vs false-positive (progressive refinement that broadened a correct-but-incomplete result; an unrelated re-run with coincidentally similar parameters; an intentional A/B comparison where BOTH results are kept and used).
-
-  **Routing of the two outcomes:**
-  - **genuine** → emitted as a friction event (`origin: self_correction`), flowing through the standard pipeline (step 4 → 5 → 6 → 7 → 8 → Stage 2.5 → Stage 3). Category follows the **honest dual-nature rule** (see Pre-scan Categorization): a wrong-oracle measurement is `behavioral` by default, and ALSO carries `tool` when the wrong result was caused by a tool defect (e.g., a flag that silently changed the measurement basis). Do NOT narrow to a single convenient label. step 6 clustering de-dups it against any narrative-lane or lane-3 finding of the same root cause, so no census-style `surfaced_in_friction` flag is needed.
-    - **Cap priority (MUST)**: `friction_events` is bounded at 5 (lane 1). Genuine user_corrections rank first for the retained slots (the user directly stating what was wrong is the highest-value signal); genuine self_corrections rank **next**, ahead of narrative-only events — a narrative event yields before a self_correction is dropped. This changes only the *priority* of which events the existing 5-event bound keeps; it does not change the bound.
-  - **false-positive (dropped)** → recorded in the `self_correction` ledger (below) with reason + cite, NEVER silently dropped — the same audit guarantee the `user_correction` and `dismissed_candidates` ledgers give, applied at the self-correction judgment step (the most self-serving step, since the agent is judging its own corrected mistakes).
-
-  Per-drop ledger row:
-  ```
-  <!-- retrospect:self_correction begin -->
-  - corrective: "<verbatim corrective-call excerpt>" | prior: "<verbatim prior-call excerpt>" | signature: oracle-mismatch|wrong-target|basis-change | reason: <why judged not-a-self-correction> | cite: <turn ref>
-  <!-- retrospect:self_correction end -->
-  ```
-  The ledger fence is informational — it lives OUTSIDE the `retrospect:distribution` fence, so the Stop hook's awk parser (distribution card + unified table only) ignores it, exactly like the `tool_census` and `user_correction` fences. Empty body when zero candidates were dropped; when the transcript is unreachable, replace the body with a single `<!-- retrospect:self_correction_skipped: transcript unreachable -->` line.
-
-  **Early-exit interaction (intrinsic, not a separate predicate):** like a genuine user_correction, a genuine self_correction IS a friction event added to `friction_events` during pre-scan, so the 0-friction early-exit cannot fire when one exists — the blocking is intrinsic, no separate carve-out clause is required. This is the structural fix for #572's exact failure: an oracle-mismatch the agent fixed on the spot is enumerated deterministically and reaches the unified findings table instead of being filtered out as "not friction, I already fixed it."
-
-**Pre-scan Categorization (Mandatory)** — every friction event identified in pre-scan MUST be tagged with `category[]: string[]` containing ≥1 of these enumerated values. Stage 2 progression to step 3 is BLOCKED until every event has at least one category label.
-
-| Category | Signal examples (≥2 each) | Required `Tool Layer` (composition with step 4b) |
-|----------|---------------------------|--------------------------------------------------|
-| `behavioral` | "Claude가 확인 없이 결론 도출" / "한 PR에 여러 concern bundle" / "user가 동일 지적 반복" / "user가 '~하라니까 ~하고 있네?' 로 교정" (user_correction lane origin) / "잘못된 oracle 로 측정 후 self-correct" (self_correction lane origin — genuine self-corrections enter here, dual-labeled `tool` when a tool defect caused the wrong result) | none (Tool Layer = `—`) |
-| `tool` | "gh CLI `--state all` 부재" / "MCP 응답 지연" / "Read 출력 truncation" / "kubectl flag 부재" | **mandatory**: one of `mcp` / `cli` / `builtin` / `skill` |
-| `workflow` | "test 안 돌리고 PR" / "verify 단계 건너뜀" / "issue 안 만들고 브랜치" / "code review 생략" | optional: `skill` (when defect originates inside a skill's stage flow) |
-| `spec-gap` | "이 상황을 다루는 규칙 부재" / "SKILL.md trigger 모호" / "global `~/.claude/CLAUDE.md`에 명시되지 않은 행동" | optional: `skill` (when rule gap is in a SKILL.md) |
-| `memory_hygiene` | "stale 파일경로 / CLI flag / CLAUDE.md 라인 인용" / "두 entry가 동일 trigger 에서 contradict" / "merge candidates 미수렴" (Stage 1.5 origin) | none (Tool Layer = `—` by default; `skill` only when the stale citation references a specific skill/hook artifact) |
-| `output_quality` | "PR review-rounds ≥3" / "sub-agent stream-killed + output<100ch used downstream" / "external comment with hypothesis markers, no falsification trace" (Stage 2.7 origin) | **mandatory** when PR/external-write artifact present: `cli` (gh-related) or `skill` (sub-agent); `—` only when MCP-via-behavioral path applies |
-
-**Layer E ↔ step 4b composition matrix** (normative — referenced by step 4b and Stage 3 unified table):
-
-- A friction event MAY carry multiple categories (e.g., `[workflow, tool]` when a workflow step skip was caused by a tool flag bug).
-- When `tool` ∈ `category[]`, the event MUST also be classified into one of the 4 step-4b layers (`mcp` / `cli` / `builtin` / `skill`); the `Tool Layer` cell of the unified table cannot remain `—`.
-- For `behavioral` only events, `Tool Layer` = `—`.
-- For `workflow` or `spec-gap` events without a tool root cause, `Tool Layer` = `—`; if the workflow defect or rule gap originates within a skill, `Tool Layer` MAY be set to `skill` to enable step 4b downstream routing.
-- For `memory_hygiene` events (Stage 1.5 origin), `Tool Layer` = `—` by default. When the stale citation points to a specific skill/hook artifact (e.g., a renamed hook script), `Tool Layer` MAY be set to `skill` so the finding compounds with a `skill` step-4b lane. `memory_hygiene` events do NOT require the mandatory `mcp/cli/builtin/skill` classification that `tool` events do.
-- For `output_quality` events (Stage 2.7 origin), `Tool Layer` follows the audited surface: `cli` for `gh pr|issue` audits, `skill` for sub-agent substance audits, `—` for MCP-via-behavioral path (e.g., Slack `*_send_message` audit where the surface is the action discipline, not the MCP itself). Unlike the strict `tool` category, `output_quality` does not require the layer to be `mcp/cli/builtin/skill` when the audit surface is behavioral (evidence discipline in a comment body).
-
-**Pre-scan Checklist (Mandatory)** — after categorization, emit a deterministic per-category checklist that enumerates rule-violation candidates from machine-checkable sources. Pre-scan is otherwise narrative-driven (operator-interpreted), which lets rule-violation events slip through reframings like "downstream caught it, not friction". The checklist forces an explicit per-category accounting before the 0-friction early exit can fire.
-
-For every rule category identified in Stage 1 (Pre-merge Worktree Precondition / Pre-PR rebase MANDATORY / Caller chain verified / Mandatory Testing / etc.), emit ONE of:
-
-```
-- {category_name}: violations: none
-- {category_name}: violations:
-  - {one-line candidate} | spec_cite: {file:line or section name}
-```
-
-**Deterministic enumeration sources** (candidates MUST come from these — operator narrative is NOT a source):
-- Every codex/review-bot finding produced in this session transcript (Codex, BugBot, Cursor, oh-my-claudecode reviewers)
-- Every workflow step in project `AGENTS.md` / global `~/.claude/CLAUDE.md` where the session took a different path (e.g., merge-from-non-base worktree, force-push instead of fixup, omitted caller-chain line caught by a hook)
-- Every retried command in the session — same command issued ≥2 times (including diagnostic retries)
-
-**Gate behavior** — the Early exit below is valid ONLY when every category's `violations:` line resolves to `none`. A category with a non-`none` line BLOCKS the 0-friction exit; the blocked candidate MUST be either:
-- **Promoted** to a friction event (carries through Stage 2 step 3+ and Stage 2.5 gates), or
-- **Demoted** to the `dismissed_candidates` ledger (note-only, see below) with explicit rationale + spec cite. Demotion does NOT silence the audit trail — it records the dismissal reason for follow-up retrospects to surface dismissed-candidate patterns.
-
-**Mandate scope (narrow — rule violations only)** — the checklist gate's capture mandate applies to **rule violations** (workflow steps in `AGENTS.md` / `~/.claude/CLAUDE.md` / hook denials / spec-cited divergence) and NOT to general codex/review-bot findings. A refactor suggestion, style nit, or defensible alternative implementation from a review bot is NOT subject to the dismissal-to-silence ban — those may be acknowledged or ignored without a checklist entry. This narrowing exists to prevent MEMORY.md from inflating into a review-bot mirror over time.
-
-**Negative list (NOT rule violations — do NOT record in `dismissed_candidates`)** — the following signal classes are explicitly out of mandate scope. Recording them in `dismissed_candidates` is over-capture and silently dilutes the leading-signal value of the ledger (cross-session "same candidate dismissed N times" pattern detection):
-
-- **Builtin tool contract violation** (e.g., Edit on un-Read file, Read on non-existent path, Write-before-Read guard firing, NotebookEdit on a non-notebook) — a simple builtin-API constraint resolved by the documented recovery procedure (Read first, then Edit). This is a tool-protocol error, NOT a workflow / AGENTS.md / `~/.claude/CLAUDE.md` rule violation.
-- **Expected hook / tool API enforcement firing** (e.g., `--state all` blocked by the praxis `gh`-flag advisory hook, external-write-falsify-check nudging on a hypothesis marker, destructive-bash guard asking on `rm -rf`) — the hook is *doing its job* by design. The fire itself is the enforcement working, not a violation against the operator.
-- **Network / transient failure** (timeout, 5xx, MCP server unavailable, `gh` API rate-limit) — environmental noise resolved by retry. Not a rule violation against the operator and not a stable cross-session signal.
-- **Signal naturally resolved by time / state mutation** (e.g., a race that another actor cleaned up, a stale lock that cleared on retry, a CI run that flipped from red to green on rerun) — a *signal*, not a violation. The candidate disappeared without operator action because the world changed underneath it.
-
-**Pre-emit self-check (recommended)** — before appending a `dismissed_candidates` line, verify that the candidate's `spec_cite` actually points to a concrete line / section in `AGENTS.md`, `~/.claude/CLAUDE.md`, a hook script under `hooks/`, or a `SKILL.md`. If the `spec_cite` resolves to none of those (or you find yourself writing `spec_cite: n/a` / `spec_cite: builtin tool contract`), the candidate likely belongs to the Negative list above — drop it from the ledger entirely rather than recording a placeholder. The `dismissed_candidates` ledger's value as a cross-session leading signal degrades quickly if it accumulates non-rule-violation entries.
-
-For a rule-violation candidate, the operator's only dismissal path is:
-- **Demote to `dismissed_candidates` ledger** (note-only) with explicit rationale + spec cite. Silent dismissal — refusing to record the candidate at all — is BLOCKED by the Red Flag in this skill.
-- **Escape hatch via existing resolution** — when `repeat=true AND resolved=true` (a prior session's issue/hook already resolves the same violation pattern; see Stage 2 step 7 escape hatch at the `note only` clause), demotion is permitted with a one-sentence cross-reference to the existing resolution recorded in the dismissal rationale.
-
-**`dismissed_candidates` ledger** — for every checklist candidate that was reviewed and dismissed (i.e., kept off the unified findings table), append one line to the ledger block emitted alongside the checklist:
-
-```
-<!-- retrospect:dismissed_candidates begin -->
-- {one-line candidate} | reason: {dismissal rationale} | spec_cite: {section name or file:line}
-<!-- retrospect:dismissed_candidates end -->
-```
-
-This is a pure audit log, not a gate. It exists so a follow-up retrospect can surface patterns like "the same candidate has been dismissed N times across sessions" — a leading signal that the dismissal rationale itself needs scrutiny. Empty ledger (zero dismissals) still emits the fenced block with no inner lines.
-
-Both the checklist block and the dismissed_candidates block live in Stage 3 output between the report header and the distribution card (see Stage 3 Output Schema Contract). They are informational-only — the Stop hook's awk parser silently ignores them.
-
-**Early exit**: If pre-scan finds 0 friction events AND the Pre-scan Checklist has zero unresolved violations (every category's `violations:` line is `none` OR demoted to `dismissed_candidates`), skip agent calls and route to Stage 3's "No patterns found ✅" minimal output path — which still emits the header, the `pre_scan_checklist` fence, the `dismissed_candidates` fence (with any demoted candidates from this session), the `tool_census` trail (full inventory), the `user_correction` ledger (per-drop audit; empty body when zero drops), the `self_correction` ledger (per-drop audit; empty body when zero drops), and the distribution card (counts = 0, verdicts = NA). The audit-trail fences MUST be emitted in this path so demoted candidates, the tool inventory, and dropped correction candidates are not silently lost. Skipping Stage 3 output entirely is a Red Flag — "exit" here means "skip agent calls + Stage 2.5 gates", not "skip Stage 3 output". **Exception (Stage 1.5 carve-out)**: when Stage 1.5 produced ≥1 `memory_hygiene` finding, the early exit does NOT fire — proceed to Stage 2.5 → Stage 3 with the hygiene findings as the sole input, and emit the Stage 1.5 hygiene-only banner (see Stage 1.5 "0-friction hygiene-only retrospect path"). **Exception (Stage 2.7 carve-out)**: when the session transcript contains ≥1 Stage 2.7 audit trigger (PR / issue / Slack / Notion write — see Stage 2.7 trigger list), the early exit does NOT fire — Stage 2.7 must execute its post-hoc artifact audit so silent-pass quality failures (the exact case Stage 2.7 was designed to catch) are not skipped. If Stage 2.7 produces ≥1 `output_quality` finding, proceed to Stage 2.5 → Stage 3 with those findings as input; if Stage 2.7 silently skips (0 triggers detected after the carve-out check), fall through to the normal 0-friction "No patterns found" exit. **Exception (Checklist carve-out)**: when the Pre-scan Checklist has ≥1 unresolved violation (a category line non-`none` AND not yet demoted to `dismissed_candidates`), the early exit does NOT fire — that candidate must be promoted to a friction event or demoted before Stage 3 can present "No patterns found". **Exception (Census carve-out)**: when the `tool_census` lane (pre-scan lane 3) **promoted ≥1 census finding** (a row that survived the step 4b promotion pipeline — objective signal AND post-dedup AND post-cap), the early exit does NOT fire — instead the promoted census findings flow through the **remaining Stage 2 steps like any other finding**: step 4b (emit), step 5 (root cause), step 6 (cluster), step 7 (MEMORY.md 2-hop scan + `memory_scan` recording), step 8 (action assignment via the category-default `tool` row) → Stage 2.5 gates → Stage 3. The friction-only **tracer/analyst agent calls are skipped** when there are no friction events (they take friction events as input); the census path is deterministic and does not need them. Do NOT shortcut census findings straight to Stage 2.5 — that would skip root-cause/MEMORY-scan/action-assignment and emit under-specified findings or miss required gates. **Ordering invariant (MUST):** the census promotion pass is evaluated **during pre-scan, before this early-exit decision is taken** — NOT deferred to step 4b's position later in the document. This is safe because the promotion decision is **deterministic** and needs only inputs already available at pre-scan time: the lane-3 inventory and the `friction_events` (for the `surfaced_in_friction` dedup — the sole dedup input). It does NOT require the tracer/analyst agent calls. step 4b's thresholds **define** the decision; step 4b later **consumes** the same pre-computed result to emit the findings into the unified table — it does not re-decide. Were promotion deferred to step 4b's textual position, a 0-friction session would take this early exit first and skip step 4b entirely, so the carve-out could never observe a promoted finding and the whole census-driven path would be dead — the exact coverage gap this change closes. This is the structural fix for that gap: a 0-friction session with a latent tool defect (used cleanly but with `error_count`/`retry`/`workaround` signal) still produces a finding instead of silently exiting. The trigger keys on **promoted findings**, not the raw `signal != none` row property: a row that has a signal but is deduped (`surfaced_in_friction == true` — the sole suppression rule) or capped out does NOT count toward the carve-out. Note a retry-only row (`retry_count >= 2`) is NOT suppressed by also appearing in the Pre-scan Checklist (that ledger holds rule violations, not tool-defect findings — see step 4b "Census dedup"); such a row promotes and fires this carve-out. If zero census findings promoted, this exception does not fire and the normal 0-friction exit applies — but the census trail fence (full inventory) is still emitted in Stage 3 output (audit completeness). **No separate User-correction or Self-correction carve-out exists by design**: a genuine user_correction (pre-scan lane 4) or self_correction (pre-scan lane 5) is emitted as a friction event during pre-scan, so it makes `friction_events` non-empty and the 0-friction early-exit simply cannot fire — the blocking is intrinsic, not a predicate added here (see lane 4 / lane 5 "Early-exit interaction"). The `user_correction` and `self_correction` ledger fences (per-drop audit) are still emitted in Stage 3 output even on the 0-friction exit, parallel to the census trail.
-
-**Pre-agent artifact probe (One-Probe-Before-Action — MANDATORY pre-step, #574).** Before the tracer call, for each friction event whose root cause points at a **named, directly-readable artifact** — a file path, a hook script (`hooks/.../impl.py`/`impl.sh`), a config/manifest, or a specific log line — read that artifact **once** and fold the **confirmed fact** into the tracer briefing. This internalizes the global One-Probe-Before-Action principle as a skill-local step so it is actually retrieved during a meta-task (the principle is domain-agnostic, but its usual triggers — tool retry / data mutation / identifier guess — do not fire the association on a retrospect). The strong tracer mandate below otherwise makes "identify friction → immediately call agent" a bound reflex that skips a cheap read even when the root cause sits in an artifact you could just open — so the agent reports an *avoidable* "implementation unverified" as a critical unknown, costing tokens and accuracy.
-
-- **Probe when** the event names a concrete, readable artifact. Emit one briefing line per probed event: `probed artifact: <path/identifier> → <confirmed fact>`. Deferring to "the agent will figure out the implementation" instead of a cheap local read is a Red Flag.
-- **Skip when** the probe cost exceeds the agent cost — the artifact is not directly readable (out of scope / requires a live system / behavior-pattern analysis is the actual question, not a static fact). This skip condition is identical to the global One-Probe skip; record `probe skipped: <reason>` in the briefing so the omission is auditable, not silent.
-- The probe gives the agent **confirmed facts instead of estimates** → avoids critical-unknown churn and saves the tokens the agent would spend re-deriving what one read settles.
-
-**MANDATORY AGENT CALLS — when pre-scan finds 1+ friction events, MUST call sequentially (analyst depends on tracer output):**
-
-1. **tracer agent** (causal chain analysis) — call FIRST:
-   `Agent(subagent_type="oh-my-claudecode:tracer", model="sonnet")`
-   - Input: friction events identified from pre-scan **plus the Pre-agent artifact probe briefing lines** (`probed artifact: <path> → <confirmed fact>` / `probe skipped: <reason>`). When a friction event points at a file / hook / CLI and the briefing carries no probe line for it, that is a Red Flag — go back and probe before calling.
-   - Output: causal chains with confidence scores
-   - Do NOT skip this call. "I can analyze this myself" is a Red Flag. (Note: the artifact probe above is NOT "analyzing it myself" in place of the agent — it is supplying the agent confirmed facts; the agent call still runs.)
-
-2. **analyst agent** (pattern clustering) — call AFTER tracer completes:
-   `Agent(subagent_type="oh-my-claudecode:analyst", model="sonnet")`
-   - Input: friction events + tracer causal chains (from step 1)
-   - Output: clustered patterns with root causes
-
-**Then refine using agent outputs:**
-
-> **Scope:** Scan the most recent 50 turns, or back to the last session boundary.
-> Stop after identifying 5 distinct friction events — clustering (step 6) handles de-duplication.
-> If session history is not accessible, use the user's verbal summary as input to steps 3–8.
->
-> **Compaction + readable transcript (MUST):** When a compaction summary is present in context AND the session transcript jsonl is also readable on disk, the friction pre-scan MUST full-enumerate the transcript — same mechanism as the `tool_census` / Stage 2.7 scan (last 50 turns or last session boundary) — counting is_error occurrences, user-turn interrupts, and retried commands. It MUST NOT default to the compaction summary's salient narrative. The "not accessible → verbal summary" fallback applies ONLY when the transcript is genuinely unreachable (jsonl absent or unreadable). Treating a compaction summary as "accessible history" that substitutes for the transcript is the meta-process trap this skill exists to prevent.
->
-> **Receipt requirement (Gate-7, MUST — structural enforcement of the line above).** Prose alone proved insufficient: this MUST recurred as a salient-window default *after* it shipped (rule exists ≠ retrieval). So the enumeration must leave a machine-checkable trace. When a compaction marker is present and the transcript is readable, the Stage 3 report MUST emit a `retrospect:transcript_receipt` fence (Stage 3 output §3e) containing the **actual scan commands and their real stdout** — not a self-authored block (a hand-written count re-introduces the author-exempt trap). The Stop hook `retrospect-mix-check` enforces the fence's presence and blocks Stage 3 when it is absent in a post-compaction session. When the transcript is genuinely unreachable, emit the `retrospect:transcript_receipt_skipped: transcript unreachable` line instead (the same fallback the census / user_correction / self_correction lanes use). **Count alone is insufficient [issue #664]:** a `grep -c` proves a scan ran, not that the errors were read — so when `is_error_count > 0` the receipt MUST also carry a nested `retrospect:is_error_enum` block enumerating each `is_error` event's content with a `promote`/`note`/`dismiss` disposition (Stage 3 output §3e); the Stop hook blocks Stage 3 when that block is absent. This closes the gap where a count-only receipt let a salient-window pass survive the gate and the most adverse error was silently dropped.
-
-3. **Refine friction events with agent outputs** — merge pre-scan events with tracer/analyst results:
-   - Add any new friction events the agents identified that pre-scan missed
-   - Update causal chains using tracer confidence scores
-   - Drop false positives that agents ruled out
-   - Final list: up to 5 distinct friction events with causal chains attached
-
-4. **Map each event to a global `~/.claude/CLAUDE.md` rule** (or gap):
-   - Read the event's `category[]` from pre-scan and feed it into rule-mapping
-   - Which rule was applicable?
-   - Was it followed, violated, or simply absent?
-   - Quote or paraphrase the specific moment
-   - If `category[]` includes `spec-gap`, this map step often resolves as "rule absent" — fold that signal into step 5 root cause
-
-4b. **Tool Friction Pass** — independently analyze tool/feature-level friction (cross-referenced by Layer E composition matrix above):
-
-   This pass runs SEPARATELY from step 4. A friction event may match a rule violation (step 4) AND a tool defect (step 4b) — both are recorded. Per the Layer E composition matrix, every event with `tool` ∈ `category[]` MUST be classified into one of the 4 layers below; the unified-table `Tool Layer` cell of such an event cannot remain `—`.
-
-   **This pass has TWO input lanes (usage-gated, not friction-gated):**
-   - **Friction-driven lane** — the `friction_events` with `tool` ∈ `category[]` (the historical input). Each is analyzed per "For each tool friction event, record" below.
-   - **Census-driven lane** — iterate the `tool_census` inventory (pre-scan lane 3). The promotion decision (which rows clear the objective-signal thresholds below + dedup + cap) was already computed during pre-scan so the Early-exit Census carve-out could observe it (see pre-scan lane 3 + the carve-out's Ordering invariant); this lane **consumes** that decision and emits each promoted row as a finding — the thresholds below are the definition of that decision, not a second evaluation. This lane is what makes 4b examine tools that ran *without* surfacing friction — the coverage gap this pass was extended to close. The census-driven lane runs EVEN when `friction_events` is empty (see Stage 2 Early-exit "Census carve-out"). A **promoted** census row becomes a finding that enters the standard downstream pipeline like any other finding — step 5 (root cause), step 7 (MEMORY.md 2-hop scan + `memory_scan` recording, which Gate-5 verifies only when the resolved action is a memory action), step 8 (action assignment), and the Stage 2.5 gates.
-
-   **Census promotion thresholds (objective signals — noise suppression):** an inventory row promotes to a `tool` finding when `surfaced_in_friction == false` AND ANY of:
-   - `error_count >= 1` AND the error was not resolved by a documented recovery on retry AND the error is **tool-attributable** (see gate below)
-   - `retry_count >= PRAXIS_RETROSPECT_CENSUS_RETRY_THRESHOLD` (default `2`) AND the retries are **tool-attributable** (see gate below)
-   - `workaround_marker == true` AND the workaround is **tool-attributable** (see gate below) — the marker is a loose text-proximity heuristic (`manual` / `fallback` / `우회` / `workaround` near the call), so a generic "manual" workflow note or an operator workaround unrelated to tool design does NOT promote
-   - output truncated/discarded then re-fetched (builtin Read/Grep over-cap pattern)
-
-   **Tool-attribution gate (MUST — applies to the `error_count`, `retry_count`, and `workaround_marker` signals):** a failure / retry / workaround promotes ONLY when it is attributable to the **tool's own design or reliability** — timeout, schema mismatch, malformed tool output, crash, a missing flag/option, an undocumented behavior the tool should have handled. A signal caused by **operator input** (a malformed argument the agent supplied, then corrected on retry), **repo / working-tree state** (merge conflict, a file the agent should have created first), **permission / auth** (401 / 403, sandbox denial), an **expected environment outcome** (a `grep` exit=1 no-match, a probe deliberately expected to fail), or a **workaround unrelated to a tool defect** (a "manual" process note, an operator-chosen alternative path) is NOT a tool defect and MUST NOT promote — even when the numeric threshold or text marker is met. When attribution is ambiguous, default to NOT promoting: a false `tool` finding routes to noisy upstream feedback, whereas a missed one is recoverable next session. The threshold / marker firing is therefore **necessary but not sufficient** — the attribution gate is the second required condition. (Only the truncation-refetch signal is inherently tool-attributable — it is a concrete builtin design defect by construction — and does not need this gate.)
-
-   Rows with no signal (`signal: none`) stay in the census trail only — never a finding.
-
-   **Q1 — builtin-layer promotion scope (Negative-list alignment):** a `builtin`-layer census row promotes ONLY for a **design-defect** signal (e.g., output truncation forcing a re-fetch). A builtin **protocol error** (Edit on un-Read file, Read on a non-existent path, Write-before-Read guard firing) is EXCLUDED from promotion — it is a tool-protocol error resolved by the documented recovery, explicitly carved out by the Stage 2 Pre-scan Checklist Negative list ("Builtin tool contract violation"). Promoting it would contradict that carve-out.
-
-   **Census dedup (the ONLY dedup that suppresses a census finding):**
-   - `surfaced_in_friction == true` → the friction-driven lane already emitted the SAME tool-defect finding for this tool; the census-driven lane does NOT double-emit (the census row records the cross-ref only). This is the sole suppression rule.
-   - **NOT a dedup — retry_count vs the Pre-scan Checklist:** a `retry_count >= 2` row may ALSO appear as a "retried command" candidate in the Pre-scan Checklist, but that does NOT suppress the census finding. The Checklist is a **rule-violation** ledger (behavioral / workflow — "Claude should not have retried without a diagnostic step"); the census finding is a **tool-defect** finding (the tool *required* N retries — a reliability signal). These are two distinct findings about one event, recorded in BOTH places per the step 4 vs step 4b dedup rule below ("record it in BOTH places"). Suppressing the census tool-defect finding because the Checklist flagged the same retry would delete exactly the latent-tool-defect signal the Census carve-out exists to catch — in a 0-friction session a retry-only census row is often the ONLY promoted finding, so suppressing it re-opens the coverage gap. The Checklist never promotes a tool-defect finding, so there is no genuine double-emit to dedup against.
-
-   **Census finding cap:** promote at most `PRAXIS_RETROSPECT_CENSUS_FINDING_CAP` (default `5`, matching the friction-event cap) findings, ranked by signal severity. When more signal-rows exist, emit the top-N AND record the dropped count in the trail (`<!-- retrospect:census_findings_capped: dropped=K -->`) per the no-silent-cap rule. The full inventory is never capped — only promoted findings are.
-
-   **Env vars** (mirror the `PRAXIS_RETROSPECT_*` convention; malformed non-integer/negative → silent fallback to the documented default):
-   - `PRAXIS_RETROSPECT_CENSUS_RETRY_THRESHOLD` (default `2`) — retry_count promotion threshold
-   - `PRAXIS_RETROSPECT_CENSUS_FINDING_CAP` (default `5`) — max promoted census findings
-
-   **Tool layers to scan (all 4):**
-
-   | Layer | Examples | Friction signals |
-   |-------|----------|-----------------|
-   | `mcp` | any custom or third-party MCP server (data warehouse, observability, chat, infra, etc.) | Slow response, missing field, schema mismatch, timeout |
-   | `cli` | `gh`, `kubectl`, `git`, plus project-specific CLIs | Missing flag/option, undocumented behavior, workaround needed |
-   | `builtin` | Read/Edit/Bash/Grep/Glob, Agent, hooks | Environmental constraint, permission issue, output truncation |
-   | `skill` | praxis / OMC / project-specific skills and subagents | Stage boundary unclear, trigger mismatch, prompt defect, wrong routing |
-
-   **For each tool friction event OR promoted census row, record:**
-   - `tool_name`: specific tool (e.g., "gh CLI", "<plugin-name> MCP", "<skill-name> skill")
-   - `layer`: mcp / cli / builtin / skill
-   - `origin`: `friction` (friction-driven lane) | `census` (census-driven lane) — internal lane-routing state distinguishing the two input lanes during step 4b processing (not a surfaced table column; census-origin is already implied by the row's presence in the tool_census trail)
-   - `friction_type`: missing feature, design defect, documentation gap, performance issue, integration mismatch
-   - `evidence`: the specific moment (quote or paraphrase); for `origin: census`, cite the inventory row's `signal` summary + the call site
-   - `expected_behavior`: what should have happened
-   - `proposed_fix_direction`: brief suggestion for upstream improvement
-
-   **Representative friction examples (for calibration):**
-   1. "gh CLI의 `--state all` 플래그가 없어서 open/closed를 각각 호출해야 했다" → layer: `cli`, friction_type: missing feature
-   2. "MCP 응답 지연으로 3회 재시도 후 fallback 전략을 수동 구성했다" → layer: `mcp`, friction_type: performance issue
-   3. "skill의 Stage 경계가 불명확해서 step을 건너뛰고 다음 stage로 넘어갔다" → layer: `skill`, friction_type: design defect
-   4. "codex exec의 permission mode가 달라 파일 쓰기에 실패했다" → layer: `cli`, friction_type: integration mismatch
-   5. "Read 도구의 출력 truncation으로 파일 끝부분을 놓쳤다" → layer: `builtin`, friction_type: design defect
-
-   **Dedup rule (step 4 vs step 4b):**
-   - If a friction event has BOTH a rule violation (step 4) AND a tool defect (step 4b), record it in BOTH places
-   - Step 4 finding addresses the behavioral correction (what Claude should have done differently)
-   - Step 4b finding addresses the tool improvement (what the tool should do differently)
-   - The two findings may have different action types (e.g., step 4 → memory, step 4b → upstream feedback)
-
-5. **Find root cause** for each pattern:
-
-   ```
-   Symptom:   "Claude retried the same tool 3 times"
-   Pattern:   "Error recovery loop"
-   Root cause: "No diagnostic step between retries — violated Error Recovery Before Asking rule"
-
-   Symptom:   "Implementation started before plan was approved"
-   Pattern:   "Premature execution"
-   Root cause: "Task had 4 steps but plan mode was not entered — violated Planning Before Implementation"
-   ```
-
-6. **Cluster patterns** — are multiple events the same root cause?
-   If 3+ events share a root cause → HIGH priority
-
-6b. **Cluster fold-back** — propagate cluster-level repeat signal to member events.
-
-   Execute this pass AFTER step 7 completes (step 7 sets `event.repeat_count`; this step then computes `event.effective_repeat`):
-
-   ```
-   for each cluster (from step 6):
-     cluster_event_count  = number of events in this cluster
-     cluster_repeat_count = max(event.repeat_count for event in cluster) + (cluster_event_count - 1)
-     # max MEMORY.md hit across cluster members + extra in-session occurrences beyond the first
-   for each event in cluster:
-     event.effective_repeat = max(event.repeat_count, cluster_repeat_count)
-   ```
-
-   For events that belong to no cluster (singleton): `event.effective_repeat = event.repeat_count`.
-
-   **Why this matters**: step 7's MEMORY.md scan is event-level and independent per event. An event with no direct MEMORY.md match (repeat_count=0) that is clustered with repeat events inherits the cluster's accumulated signal — ensuring that all members of the same root-cause family receive a consistent action tier in step 8.
-
-   **Example** (from the session that motivated this step): Cluster with 3 events; 2 have repeat_count=1, 1 has repeat_count=0.
-   - `cluster_repeat_count = max(1, 1, 0) + (3-1) = 3`
-   - Event with repeat_count=0 → `effective_repeat = max(0, 3) = 3` → escalates to "hook or skill", not "memory"
-
-7. **Scan MEMORY.md for repeat patterns** (2-hop deterministic scan — MANDATORY, not skippable):
-
-   This step is required for EVERY finding. Skipping it (e.g., "probably not in MEMORY.md", "I'd remember if I saw this before") is a Red Flag. Each finding MUST record a `memory_scan` field capturing the scan evidence before the finding can advance to step 8.
-
-   a. Read MEMORY.md index (single file read) — extract all feedback entry titles and file paths
-   b. For each finding's root cause, identify candidate matches from index titles (concept-level, not keyword)
-   c. Read each candidate feedback file to confirm semantic match (same root cause, not just similar keywords)
-   d. Only mark `repeat=true` if root cause is semantically identical
-      - Example: "workflow skip" in index + "workflow violation" in finding = match
-      - Example: "commit" matching both "atomic commit" and "pre-commit hook" = NOT auto-match, read file to confirm
-   e. `repeat_count` = number of distinct feedback files with matching root cause
-   f. If match found with existing resolution action (issue/hook already created): mark as `resolved=true`
-   g. **Record `memory_scan` on every finding** — this field is load-bearing for Gate-5 (below).
-
-      **Recording location**: emit the `memory_scan` block as an HTML comment immediately after the unified findings table in the Stage 3 report (one comment per finding, keyed by `finding #N:`). This pin keeps the field auditable by reviewers and parseable by downstream tooling without polluting the human-readable table.
-
-      **Format**:
-
-      ```
-      <!-- memory_scan finding #1:
-        scanned: true
-        candidates_reviewed: [<file1.md>, <file2.md>, ...]   # empty list if index is empty
-        matched: [<matched_file.md>]                          # empty list if no match
-        repeat: true|false
-        repeat_count: N
-        resolved: true|false                                  # optional; omit if no resolution action found
-      -->
-      ```
-
-      **Field requirements** — Gate-5 (Stage 2.5 Step 2) verifies only the **load-bearing** fields below; the rest are documentation-only metadata for human reviewers:
-      - `scanned: true` — **Gate-5 verified** (proves step was executed, not skipped)
-      - `candidates_reviewed` — **Gate-5 verified** (presence required; empty list = index was empty or 0 candidates after concept-level filter)
-      - `repeat` and `repeat_count` — **Gate-5 verified** (presence required; values reflect step (e) results)
-      - `matched` — documentation-only; SHOULD list every file confirmed in step (d) for human review, but Gate-5 does NOT verify its presence (the `repeat`/`repeat_count` pair already encodes this signal at the type level)
-      - `resolved` — **optional** and NOT verified by Gate-5; emit only when `repeat=true` AND existing resolution action found in step (f)
-      - When proposed action ∈ {`memory_create`, `memory_update`}: `memory_scan` MUST be populated — Gate-5 (Stage 2.5) will block Stage 3 if absent
-
-   h. **Stored-value falsification — multi-oracle completeness (MUST)**. This sub-step applies ONLY to a finding whose probe targets a **stored fact VALUE** held in a memory entry — a numeric measurement, a comparison sum, or a count (e.g., "X is 9h faster than Y", "row count = 4.2M", "criteo sum = N"). It does NOT apply to `DESCRIBE` / `SHOW` enumerate results, where the oracle is unambiguous (the catalog itself) and outside this gate.
-
-      An **oracle** is the specific measurement basis that produced the stored value — the matching basis (e.g., warehouse partition key vs FK rowid), the cohort, and the unit. A probe that re-measures the same fact under a *different* oracle measures a *different* quantity; it cannot falsify the stored value, only surface a separate cohort-shift observation.
-
-      Three-step rule:
-
-      1. **Confirm the originating oracle from the entry body.** Read the entry to identify which oracle produced the stored value (matching basis, cohort, unit). If the entry body does NOT state its oracle → **DEFER falsification**: do not attempt to correct the stored value this cycle. Instead propose an entry-annotation update (route as `memory`, Stage 4 update path) that adds the missing oracle/unit annotation, so a future cycle can falsify with a known basis.
-      2. **Probe first with the SAME oracle.** The first falsification probe MUST use the same matching basis, cohort, and unit as the originating oracle. Only a same-oracle probe can confirm or falsify the stored value.
-      3. **Different-oracle results are NOT falsification evidence.** A probe run under a different matching basis / cohort / unit does not invalidate the entry. It MAY be emitted as a *separate* cohort-shift finding (its own row), but it MUST NOT drop, overwrite, or mark-resolved the stored value in the original entry.
-
-      **Ledger fields** (mirror the `memory_scan` HTML-comment format above) — emit one comment per stored-value finding, keyed by `finding #N:`:
-
-      ```
-      <!-- oracle_match finding #N:
-        stored_value_oracle: <matching basis / cohort / unit from entry body, or `absent`>
-        falsification_oracle: <matching basis / cohort / unit of the probe run, or `deferred`>
-        oracle_match: true|false
-      -->
-      ```
-
-      **Invariant**: falsification of a stored value applies ONLY when `oracle_match: true`. When `oracle_match: false`, the probe is a cohort-shift observation, not falsification.
-
-      **Oracle-match confirmation is required before any commit that corrects a stored value.** A value-correcting commit whose finding carries `oracle_match: false` (or absent) is a Red Flag (see Red Flags section).
-
-8. **Auto-assign action type** based on escalation ladder. Use `event.effective_repeat` (from step 6b; equals `event.repeat_count` for singleton events) as the repeat signal for the Repeat-based rows below. Apply Repeat-based rows first; then apply Category-default rows below to override or compound when the event's `category[]` (from pre-scan, step 4) makes memory-only inappropriate even on first occurrence:
-
-   | Condition | Action Type | Rationale |
-   |-----------|-------------|-----------|
-   | New pattern (structural root cause, likely to recur) | memory | First occurrence — capture for future reference |
-   | Repeat (in MEMORY.md, 1-2x) | GitHub issue | Memory alone failed — need systemic fix |
-   | Repeat (3x+) | hook or skill | Multiple memory entries = enforcement gap |
-   | Missing rule (new) | global `~/.claude/CLAUDE.md` draft | No rule exists for this pattern |
-   | Missing rule + Repeat | global `~/.claude/CLAUDE.md` draft + GitHub issue | Missing rule caused repeat — add rule + compliance issue |
-   | Tool friction (step 4b finding) | upstream feedback | Tool improvement needed — issue in the tool's **backing repo** (resolve via Stage 4 Action 4 routing table; not always praxis) |
-   | One-off mistake (situational cause, unlikely to recur) | note only | No persistent action needed |
-   | **Category default — `tool`** | upstream feedback (compound with memory only when behavioral co-label exists) | step 4b backing-repo resolution; tool defect is not a Claude behavior issue, memory alone insufficient |
-   | **Category default — `workflow`** | hook code OR skill idea (memory-alone NOT allowed even on first occurrence) | enforcement gap detected — workflow steps that get skipped need structural enforcement, not memo |
-   | **Category default — `spec-gap`** | global `~/.claude/CLAUDE.md` draft OR skill idea (memory-alone NOT allowed) | rule absent — gaps are filled with rules, not memos |
-   | **Category default — `behavioral`** | memory (default; compound with skill_idea or global `~/.claude/CLAUDE.md` draft when structural) | only category where memory-alone is acceptable; still subject to Gate-2 rationale schema in Stage 2.5 |
-
-   **Distinguishing "New pattern" vs "One-off mistake":**
-   - **New pattern**: root cause is structural (missing rule, absent skill, unclear workflow) → likely to recur in future sessions
-   - **One-off mistake**: root cause is situational (context loss, typo, unusual edge case) → unlikely to recur under normal conditions
-   - When uncertain, default to `memory` (safer to capture than to miss)
-
-   ⚠️ **BLOCKED unless justified**: If `repeat=true`, the action type CANNOT be `memory`.
-
-   **Escape hatch**: If `repeat=true` AND `resolved=true` (existing issue/hook resolution already exists for this feedback), `note only` is allowed. In this case, include a sentence in the report confirming that the existing resolution is still effective.
-
-   ⚠️ **MUST — backing_repo declaration for upstream_feedback rows**: When `Proposed Actions` contains `upstream_feedback` (single or compound), the row's `Rationale` cell MUST include a `backing_repo: <owner/repo>` line resolved per Stage 4 Action 4's resolution table. The declaration is **load-bearing** — Stage 4 re-reads it as the routing decision and aborts on divergence.
-
-   - Resolution source-of-truth (in priority order): plugin manifest `repository` field → MCP server git remote → dotfiles backing repo via symlink chain → project `AGENTS.md` feature-to-repo mapping.
-   - Format: literal line `backing_repo: <owner>/<repo>` embedded in the Rationale cell via `<br>` separators. Example: `Rationale: tool defect in praxis distribution<br>backing_repo: <resolved-praxis-repo>`.
-   - Unresolvable layer (`builtin`, or no upstream reachable per the Action 4 resolution table's `builtin` row): **remove `upstream_feedback` from the row's `Proposed Actions` set entirely**. If the row had compound actions (e.g., `memory, upstream_feedback`), retain the remaining ones (e.g., keep `memory` alone). If `upstream_feedback` was the sole action, re-derive the action via Stage 2 step 8's category-default rows (typically `skill_idea` for `tool` category, or `memory` if behavioral co-label exists). The escape-hatch state `note only` (from `repeat=true AND resolved=true`) is a separate construct and is NOT used here. Do NOT emit a placeholder `backing_repo`.
-   - Ambiguous layer (resolution table's `Other / ambiguous` row): keep `upstream_feedback` but surface to user immediately at Stage 2; the user-supplied repo becomes the declared `backing_repo`. Stage 4 step 0 then re-resolves and may still divergence-prompt if the live re-resolution differs.
-   - Hook-parsing safety: this is not a memory-only row, so the Stage 2.5 Gate-2 5-line schema does not apply. The `backing_repo:` line lives alongside the human rationale text without conflicting with the Gate-2 regex.
+Run the symmetric pre-scan before agent calls. The full mechanics live in
+[`references/stage1-2-analysis.md`](references/stage1-2-analysis.md).
+
+**Pre-scan lanes (all deterministic inputs, then judgment where required):**
+
+- `friction_events`
+- `successful_patterns`
+- `tool_census`
+- `user_correction`
+- `self_correction`
+
+**Mandatory categorization:**
+
+Every emitted finding must carry at least one of:
+
+- `behavioral`
+- `tool`
+- `workflow`
+- `spec-gap`
+- `memory_hygiene`
+- `output_quality`
+
+If `tool` is present, `Tool Layer` must be one of `mcp`, `cli`, `builtin`, or
+`skill`.
+
+**Core flow:**
+
+1. Pre-scan the transcript and produce the five lanes
+2. Run tracer / analyst where the friction path requires them
+3. Derive root causes rather than symptoms
+4. Cluster overlaps
+5. Run the MEMORY.md scan
+6. Assign preliminary actions
+7. Run Stage 2.7 when the artifact-audit triggers are present
+8. Hand findings to Stage 2.5
+
+**Early exit only when all are true:**
+
+- zero friction events
+- zero unresolved Pre-scan Checklist violations
+- zero promoted census findings
+- zero Stage 1.5 hygiene findings
+- zero Stage 2.7 audit findings
+
+**Compaction rule:** post-compaction sessions require the
+`retrospect:transcript_receipt` fence in Stage 3.
 
 ### Stage 2.7: Adaptive Post-hoc Artifact Audit
 
-Stage 2.7 runs between Stage 2 (Analyze) and Stage 2.5 (Distribution Audit). Its purpose is to surface output-quality defects in artifacts the session produced — defects that the friction-event scanner (Stage 2) cannot see because they are *silent-pass* failures (no observable session friction).
+Stage 2.7 is part of Stage 2 and fires only when the session includes artifact
+writes such as PR / issue / Slack / Notion actions.
 
-**Scope window** — same as Stage 2: scan the most recent 50 turns, or back to the last session boundary (whichever is narrower). The window is intentionally identical so that trigger detection (below) and friction-event analysis operate over the same transcript slice — divergent windows would make `output_quality` findings non-deterministic across invocations and could surface artifacts whose context is no longer visible to Stage 2. If the transcript is unreachable post-compaction, fall through to the `transcript unreachable` failure-mode rule below (skip with `<!-- retrospect:audit_skipped: transcript unreachable -->`).
-
-**Adaptive trigger** — Stage 2.7 fires ONLY when the session transcript (within the Scope window above) contains at least one of these artifact-write signals. With zero triggers, Stage 2.7 silently skips.
-
-Trigger detection (scan the session's Bash invocations + MCP tool calls):
-- `gh pr create | edit | merge | comment` Bash invocations
-- `gh issue create | edit | comment | close | reopen` Bash invocations
-- Slack MCP `*_send_message` / `*_update_message` tool calls
-- Notion MCP `*_create_*` / `*_update_*` tool calls
-- `external-write-falsify-check.mjs` PreToolUse hook fired AND the user approved the write (i.e., the write actually proceeded)
-
-**0-trigger silent skip** — when scan finds zero triggers, Stage 2.7 emits a single trail line and exits:
-
-```
-<!-- retrospect:audit_skipped: no artifacts -->
-```
-
-The trail line is mandatory: it documents that Stage 2.7 ran and chose to skip, distinguishing "skipped intentionally" from "stage forgotten." Distribution card emits `output_quality: 0`.
-
-**≥1-trigger audit fires** — execute three sub-audits in parallel; each may produce 0–N findings.
-
-**Sub-audit 1 — PR mergeability** (Tool Layer: `cli`):
-
-For each PR touched by `gh pr {create,edit,merge,comment}` in this session:
-- Run `gh pr view <number-or-url> --json reviewRequests,reviews,state,mergeable,mergedAt`
-- Emit a finding when ANY of:
-  - `state == "CLOSED"` AND `mergedAt == null` (closed without merge — likely abandoned or rejected)
-  - `len([r for r in reviews if r.state == "CHANGES_REQUESTED"]) >= 2` (≥2 CHANGES_REQUESTED submissions — each forces a revision cycle, so ≥2 signals genuine high revision cost). The unfiltered `reviews` array counts individual submissions (APPROVED / COMMENTED / DISMISSED included), not revision rounds — three one-time approvals would meet `len(reviews) >= 3` despite zero rework. Filter on `CHANGES_REQUESTED` to measure what the heuristic intends.
-  - `mergeable == "CONFLICTING"` (stale branch left in conflict state)
-
-Finding template:
-- `category[]: [output_quality]` — single category; the `cli` surface is captured by `Tool Layer` below. Compounding with `tool` would trigger Gate-1 (Stage 2.5) which forbids `memory`-single for `tool` findings; output_quality first-occurrence is appropriately memory-single, so the `tool` co-category is omitted here. (Tool Layer still carries the surface signal.)
-- `Tool Layer: cli`
-- `Proposed Actions`: `memory` (single occurrence) or `memory, claude_md_draft` (when repeat ≥2; rule-gap on review-quality bar)
-
-**Sub-audit 2 — Sub-agent output substance** (Tool Layer: `skill`):
-
-For each sub-agent dispatch in the session (Agent tool calls):
-- Scan the parent's continuation context for stream-killed indicators (`agentId`, `internal ID`, abrupt-output truncation marker, "status=completed" without a result body)
-- Compute output length from the agent's final reported result
-- Flag when ALL of:
-  - Stream-killed indicator present OR output length < 100 characters
-  - Parent agent invoked downstream tooling that referenced the sub-agent's output (i.e., the sub-output was actually *used*, not just discarded)
-
-Finding template:
-- `category[]: [output_quality]` — single category; the `skill` surface is captured by `Tool Layer`. Same rationale as Sub-audit 1: Gate-1 would reject `memory`-single for a `tool`-co-labeled finding, but first-occurrence sub-agent substance is correctly memory-single (a downstream-reliability lesson). Tool Layer below preserves the surface signal.
-- `Tool Layer: skill`
-- `Proposed Actions`: `memory` (capture as a downstream-reliability lesson) or `memory, skill_idea` (when repeat ≥2; sketch a verifier helper)
-
-This sub-audit cross-references `feedback_agent_completion_verify_substance.md` — if a finding here matches that memory entry's family, the action MUST escalate per Stage 2.5 Gate-1 (repeat=true blocks memory-single).
-
-**Sub-audit 3 — External comment evidence** (Tool Layer: `cli`):
-
-For each external comment write — covers both create and update variants (`gh issue comment`, `gh pr comment`, Slack `*_send_message` / `*_update_message`, Notion `*_create_comment` / `*_update_*`). Update variants are included because edited comments can still introduce or retain hypothesis-language markers; auditing only creates would silently miss the same defect class in trigger sessions that only update prior content:
-- Re-use the regex from `hooks/external-write-falsify-check.mjs` to scan the comment body POST-write
-- Hypothesis-language markers without falsification trace: `might`, `could be`, `potential`, `is failing`, `아마`, `~인 듯` etc.
-- Emit a finding when the comment body contains a hypothesis marker AND lacks any of:
-  - `Falsification:` line
-  - `Probe:` line with command + output
-  - Direct evidence citation (file path + line number + quoted excerpt)
-
-Finding template:
-- `category[]: [output_quality, behavioral]` (behavioral because evidence discipline)
-- `Tool Layer: cli` (gh-related) or `—` (Slack/Notion via MCP — Layer E composition matrix's `behavioral` row applies)
-- `Proposed Actions`: `memory` (first occurrence) or `memory, hook_code` (when repeat ≥2; hook-level enforcement consideration)
-
-**Distribution card field** — Stage 3 emits `- output_quality: N` where N counts findings whose `category[]` includes `output_quality`. Like `memory_hygiene`, this is a **category count**, not an action key; the underlying actions still fall under the 6 action-type slots.
-
-**Stage 2.7 failure modes:**
-- Transcript not accessible (jsonl absent or unreadable — NOT the same as a compaction summary being present in context; see Scope block above) → Stage 2.7 emits `<!-- retrospect:audit_skipped: transcript unreadable -->` and skips. When a compaction summary is present but the transcript is also readable on disk, Stage 2.7 MUST full-enumerate the transcript rather than defaulting to the summary's salient narrative.
-- `gh pr view` API failure for a specific PR → log per-PR error in Stage 3 report Audit Trail section; continue with remaining PRs
-- Hypothesis-marker regex import failure (hook file missing or unreadable) → fallback to a built-in minimal regex (`(might|could|potential|아마)`) AND log the fallback in the report
-
-**Detect-only contract** — Stage 2.7 never re-edits PRs, never deletes comments, never re-runs the offending tool. All mutations route through Stage 4 (Action 1 for memory entries, Action 2 for issues, Action 6 for hook code). Inline mutation at Stage 2.7 is a Red Flag.
+It exists to catch silent-pass quality defects that a friction-only scan can
+miss. Use the full trigger list, audit surfaces, and trail rules in
+[`references/stage1-2-analysis.md`](references/stage1-2-analysis.md).
 
 ### Stage 2.5: Action Distribution Audit
 
-After Stage 2 completes (all findings have `category[]` labels and provisional `Proposed Actions`) and BEFORE Stage 3 begins, run the three gate checks below. Each finding has its own per-finding gate counter, reset at Stage 2.5 entry.
+Stage 2.5 is the last gate before Stage 3 output. Run the complete gate suite
+from [`references/stage2.5-audit.md`](references/stage2.5-audit.md).
 
-**Gate-1 (Categorical)** — for each finding whose `category[]` intersects {`tool`, `workflow`, `spec-gap`}, verify `Proposed Actions` ≠ `memory` (single, not compound).
+**Required gates:**
 
-If `memory` is the *only* action for such a finding → return that finding to Stage 2 step 4 (re-evaluate label correctness — Gate-1 violations are most often *mislabeling*: the event was actually behavioral but got tagged tool/workflow/spec-gap, or vice versa) AND step 8 (re-derive action with category-default rows applied).
+- Gate-1: categorical integrity
+- Gate-2: memory-only rationale schema
+- Gate-3: evidence robustness for compound actions
+- Gate-4: external-repo authorization pre-check for `upstream_feedback`
+- Gate-5: `memory_scan` completeness
+- Gate-6: oracle-match completeness for stored-value corrections
 
-**Gate-2 (Procedural)** — for each finding with `Proposed Actions = memory` (single, not compound, regardless of category), verify the `Rationale` cell matches **one** of the two accepted schemas (mixing is not allowed):
+**Output:** a distribution card with action counts plus gate verdicts.
 
-- **Schema A** (verbose): EXACTLY 5 lines, each matching `^not (issue|claude_md_draft|skill_idea|hook_code|upstream_feedback): .+$`. The 5 lines MUST cover all 5 non-memory action types (no duplicates, no missing keys).
-- **Schema B** (dimension-tag, issue #285): 1–2 lines, each matching `^not-others: .+$`. The line(s) MUST encode why all non-memory actions were skipped via dimension tags (e.g., `not-others: repeat=0, rule_exists=yes, gateable=no, tool_defect=no`). No Schema A lines may appear alongside Schema B lines.
-
-If absent or incomplete → return that finding to Stage 2 step 8 (re-evaluate with explicit per-action rationale enforcement).
-
-**Gate-3 (Evidence Robustness)** — for each finding with `Proposed Actions` count = 2 (compound), verify three sub-conditions. Gate-1 and Gate-2 check whether the *form* of action assignment is correct; Gate-3 checks whether the *evidence* underneath each action is robust enough to justify it. Without this gate, category-default form-filling can produce a second action whose only purpose is to ask a question the first action already answered — pure structural redundancy that costs an upstream issue or a global `~/.claude/CLAUDE.md` draft.
-
-Sub-conditions (all three must hold):
-
-(a) **Per-action evidence pointer** — each of the 2 actions cites ≥1 explicit friction-event observation that supports it. Citations live as a sub-bullet inside the Rationale cell or as an inline `(observed: <event-id or one-line>)` reference. Form-filling actions with no concrete observation behind them are not justifiable on their own.
-
-(b) **Sibling decision-coupling check** — if action B's outcome decides a question that action A's existence already presupposes (i.e., A applied option X, and B's purpose is to ask which of {X, Y} is correct), the actions are decision-coupled. The two actions cannot both be justified at the same time — applying A while B is still "asking" produces a contradiction. Resolution: keep the stronger-evidence action; demote the weaker to a **trigger condition** line in Stage 3 ("file new issue if observation Z appears"). Do not execute both.
-
-(c) **Single-observation downgrade** — for each action backed by exactly 1 observation AND `repeat=false` (Stage 2 step 7 result), downgrade one tier per this table:
-
-| Original action (in compound row) | Downgraded to | Rationale |
-|-----------------------------------|---------------|-----------|
-| `upstream_feedback` | `memory` | Single observation against an external party doesn't justify upstream-write cost; capture locally first |
-| `issue` | `memory` | Single observation without repeat doesn't justify systemic-fix tracking; capture pattern first |
-| `hook_code` | `skill_idea` | Single observation doesn't justify enforcement-code investment; sketch as a skill idea first |
-| `claude_md_draft` (single-observation in this row) | `memory` | Single-observation rule additions risk over-fitting; capture as memory first, escalate if the pattern recurs. Note: a *compound* `memory, claude_md_draft` row where `claude_md_draft` is the action being evaluated still downgrades to `memory`, collapsing the row to single `memory`. |
-| `skill_idea` | `memory` | Single observation doesn't justify a skill artifact; capture pattern first |
-| `memory` | (no downgrade) | Already the lowest tier |
-
-If sub-condition (a) fails → return finding to Stage 2 step 8 with prompt to add observation citations.
-If sub-condition (b) fails → keep the stronger-evidence action, mark the weaker for trigger-condition emission in Stage 3, log the coupling reason in Actions Executed report.
-If sub-condition (c) fires → apply the downgrade; if the resulting action set is now memory-only on a `tool`/`workflow`/`spec-gap`-labeled finding, this re-triggers Gate-1 (per-finding loop cap applies). Cap accounting: the downgrade itself does NOT consume a re-entry — only the resulting Gate-1 re-evaluation does. A single Gate-3 (c) → Gate-1 cascade counts as one re-entry, not two.
-
-**Out of scope** — each sub-condition (a) / (b) / (c) has its own skip rule. A single condition does NOT necessarily disable the whole gate; sub-conditions are evaluated independently per finding:
-
-| Condition on the finding | (a) per-action evidence | (b) decision-coupling | (c) single-observation downgrade |
-|--------------------------|:-----------------------:|:---------------------:|:--------------------------------:|
-| `Proposed Actions` count = 1 (single-action; includes behavioral-only defaults and `note only` rows) | SKIP (gate inapplicable — no sibling) | SKIP | SKIP |
-| Two actions affect different artifacts on different surfaces (e.g., `claude_md_draft` for global `~/.claude/CLAUDE.md` + `skill_idea` for tool-side enhancement) | apply | SKIP — not decision-coupled by construction | apply |
-| `repeat=true` finding | apply (per-action evidence still required) | apply (coupling can still occur even with repeat history) | SKIP — repeat history is multi-observation evidence |
-
-The previous all-or-nothing "Gate-3 does NOT fire" framing produced a bypass: a `claude_md_draft + skill_idea` pair backed by a single non-repeat observation would silently skip (a) and (c) along with (b), defeating the core evidence-robustness intent. This table restores sub-condition granularity.
-
-**Decision-coupling examples for sub-condition (b):**
-
-- **Coupled** (Gate-3 (b) fires): `claude_md_draft` rewrites a rule to assert "behavior X is intentional" + `upstream_feedback` opens an upstream issue asking "is X intentional or oversight?". The first action presupposes the answer the second action exists to ask. Keep the stronger-evidence action; demote the other to a trigger-condition line.
-- **Not coupled** (Gate-3 (b) skips): `claude_md_draft` adds a project-side rule + `skill_idea` sketches a tool-side enhancement on a different surface. Both actions can be executed simultaneously without contradiction; their outcomes are independent.
-
-**Per-finding loop cap** — maximum 2 re-entries per finding (across all three gates combined; not per-gate). Worked example of a worst-case path that hits the cap: Gate-3 (a) fail → step 8 re-derive (re-entry 1) → Gate-3 (c) downgrades action → Gate-1 fail → step 8 re-derive (re-entry 2) → cap reached, surface to user. On the 3rd violation for the same finding, surface to user with explicit prompt:
-
-> "Finding #N의 Gate-1/Gate-2/Gate-3 중 하나가 통과되지 않습니다. 어떻게 진행할까요? [a] rationale/observation을 직접 입력해 우회 / [b] action을 직접 지정 / [c] 이 finding은 note only로 강등."
-
-User-supplied resolution is logged but bypasses the gate(s) for that single finding.
-
-**Behavioral-only safeguard (all-findings)** — if ALL findings ended up labeled `behavioral` only (no tool/workflow/spec-gap anywhere), run a final keyword sanity check on the original pre-scan signal text. If any signal contains `gh ` / `kubectl` / `MCP` / `--state` / `permission denied` / `timeout` / `--help` / `flag`, surface to user:
-
-> "모든 finding이 behavioral로 분류되었으나 pre-scan 신호 텍스트에 도구 키워드(`gh`, `MCP`, ...)가 발견됨. 라벨이 정확한지 재검토 필요."
-
-User confirmation required to proceed; if user confirms, log the keyword set found.
-
-**Per-finding behavioral-label falsification (#574)** — the all-findings safeguard above only fires when *every* finding is behavioral; it misses the case where *some* findings are behavioral-single while their root cause carries spec-gap / tool / workflow signal. That gap opens a **motivated-reasoning path**: pick the convenient exit (`memory`) first, then — to pass Gate-1 (which forbids memory-alone on tool/workflow/spec-gap) — narrow a genuinely dual-nature finding down to a single `behavioral` label (label reverse-engineering). `category[]` is multi-valued precisely so this narrowing is never necessary.
-
-For **each** finding labeled `behavioral`-only (not just the all-behavioral case), scan its **root cause text** for spec-gap/tool/workflow signal keywords: `probe` · `scan scope` · `skill` · `hook` · `missing` · `gap` · `scope` · `미구현` · `누락` · `flag` · `--<opt>` · `spec` · `rule absent`. If any is present, the finding MUST carry one of:
-- a `behavioral-label-justify: <why this is NOT spec-gap/tool/workflow despite the keyword>` line (the falsification — an explicit disconfirmation of the alternative label), OR
-- the additional category itself — a dual-nature finding MUST list **all** applicable categories (`category[]` is an array). Narrowing to a single label for gate convenience is forbidden; the honest dual label is the default.
-
-If neither is present → return the finding to **Gate-1 / step 4** for label re-evaluation (per-finding loop cap applies, same accounting as a Gate-1 mislabel re-entry). This extends the falsification family (#227 falsify-recommendation-premise, #489 oracle-mismatch gate) to the *categorization* step: it forces label → action (forward), blocking action → label (reverse-engineered).
-
-**Gate-4 (External-Repo Authorization Pre-check)** — For each finding whose `Proposed Actions` includes `upstream_feedback`, classify the `backing_repo` owner against the own-org allowlist and mark external findings before Stage 3 renders them.
-
-**Step 1 — Extract owner.** Parse `backing_repo: <owner/repo>` from the finding's Rationale cell. If the declaration is absent → Gate-4 skips this finding (Stage 4 Action 4 step 0's missing-declaration abort is the downstream enforcement).
-
-**Step 2 — Resolve own-org allowlist** (in priority order):
-1. Env var `PRAXIS_OWN_ORGS` (comma-separated handles) — e.g., `PRAXIS_OWN_ORGS="my-handle,my-team"`
-2. Fallback: `gh api user --jq .login` → treat the single returned handle as the only own org
-3. Both absent → treat all `backing_repo` owners as external (conservative default — all `upstream_feedback` rows require per-action approval at Stage 4)
-
-**Step 3 — Classify.** Extract `owner` from `backing_repo: <owner/repo>` (case-insensitive comparison). If `owner` ∉ resolved allowlist → mark the finding `external=true`.
-
-**Step 4 — Mark external findings.** For each `external=true` finding, prepend `⚠ EXTERNAL: per-action approval required at Stage 4` to the Rationale cell (separated from existing text by `<br>`). This prefix is load-bearing: Stage 4 Action 4 step 0a scans the Rationale cell for this exact string to trigger its per-action approval gate.
-
-**Gate-4 verdict:**
-- Zero `external=true` findings → `gate_4_verdict: PASS`
-- ≥1 `external=true` finding → `gate_4_verdict: WARN` (the action is still permitted; per-action approval at Stage 4 Action 4 step 0a is the enforcement control)
-- No `upstream_feedback` findings at all → `gate_4_verdict: NA`
-
-`gate_4_verdict` is informational (parallel to `gate_3_verdict`). The Stop hook silently ignores it; enforcement is procedural inside Stage 4 Action 4 step 0a.
-
-**Gate-5 (Memory-Scan Completeness)** — For every finding whose `Proposed Actions` includes `memory` (i.e., the finding is headed toward a MEMORY.md write at Stage 4 Action 1), verify that the finding carries a populated `memory_scan` field (set by Stage 2 step 7g).
-
-> **Why Gate-5 exists**: Stage 2 step 7 was previously procedural-only and effectively skippable. Without a mandatory call site (unlike tracer/analyst agent invocations), "MEMORY.md scan" was easily elided by claiming knowledge from context. Gate-5 provides the structural enforcement — findings that propose memory writes without showing scan evidence are returned to Stage 2 step 7 to complete it.
-
-**Detection**: For each finding, check whether `memory` ∈ `Proposed Actions`. If yes → verify `memory_scan.scanned == true` is present in the finding's internal record from Stage 2 step 7g.
-
-> **Note on `memory_create` vs `memory_update`**: "memory" in the Proposed Actions column covers both creating a new file and merging into an existing one (Stage 4 Action 1's duplicate-check step distinguishes them). Gate-5 applies to both sub-cases. Findings with `memory` as a compound second action (e.g., `memory, issue`) are subject to Gate-5 equally.
-
-**Step 1 — Identify memory-action findings**: collect all findings where `memory` ∈ `unique_actions`.
-
-**Step 2 — Verify `memory_scan` field**: for each finding from step 1, check that Stage 2 step 7g recorded the load-bearing fields (per step 7g's field requirements):
-- `memory_scan.scanned == true` (proves step was executed, not skipped)
-- `candidates_reviewed` is present (even if empty list — proves index was consulted)
-- `repeat` and `repeat_count` fields are present
-
-`matched` and `resolved` are NOT verified by Gate-5 (`matched` is documentation-only; `resolved` is optional per step 7g).
-
-**Step 3 — Classify violations**: any finding from step 1 that fails step 2 → Gate-5 violation → return that finding to Stage 2 step 7 with instruction to complete the 2-hop scan and record `memory_scan` per step 7g. Cap counter applies (same 2-re-entry cap per finding, shared across all gates for that finding).
-
-**Gate-5 verdict:**
-- All memory-action findings have valid `memory_scan` → `gate_5_verdict: PASS`
-- ≥1 memory-action finding missing `memory_scan` → `gate_5_verdict: FAIL`
-- No memory-action findings exist → `gate_5_verdict: NA`
-
-`gate_5_verdict` is informational (parallel to `gate_3_verdict` and `gate_4_verdict`). The Stop hook silently ignores it; enforcement is procedural inside Stage 2.5. If Gate-5 violations persist after 2 per-finding re-entries, surface to user with 3-way override prompt:
-
-> "Finding #N의 Gate-5 (memory_scan 필드 누락)가 통과되지 않습니다. 어떻게 진행할까요? [a] MEMORY.md index를 직접 읽고 memory_scan 필드를 입력 / [b] action을 직접 지정 / [c] 이 finding은 note only로 강등."
-
-**Gate-6 (Oracle-Match Completeness)** — For every finding whose action would CORRECT a stored value in a memory entry (i.e., the memory action was flagged stored-value-falsification at Stage 2 step 7h), verify the `oracle_match` ledger field is present AND, when the action invalidates/overwrites the stored value, `oracle_match: true`.
-
-> **Why Gate-6 exists**: a stored value can be "falsified" by a probe that measured a *different* quantity (different matching basis / cohort / unit), silently overwriting a correct entry with a cohort-shifted number. Step 7h requires same-oracle confirmation; Gate-6 provides the structural enforcement — value-correcting findings without a matching-oracle probe are returned to step 7h.
-
-**Step 1 — Identify stored-value-correcting findings**: collect all findings flagged at step 7h whose action invalidates / overwrites a stored numeric measurement / comparison sum / count.
-
-**Step 2 — Verify `oracle_match`**: for each finding from step 1, check that the `oracle_match` ledger field (step 7h format) is present. If the action invalidates/overwrites the stored value, require `oracle_match: true`.
-
-**Step 3 — Classify violations**: any finding from step 1 with `oracle_match: false` or absent on a value-correcting action → Gate-6 violation → return that finding to Stage 2 step 7h with instruction to (a) re-probe with the same oracle, or (b) convert to a separate cohort-shift finding (its own row, leaving the stored value untouched), or (c) defer + propose an entry-annotation update when the originating oracle is absent from the entry body. Same 2-re-entry cap per finding, shared across all gates for that finding.
-
-**Gate-6 verdict:**
-- All stored-value-correcting findings have `oracle_match: true` → `gate_6_verdict: PASS`
-- ≥1 stored-value-correcting finding has `oracle_match: false` or absent → `gate_6_verdict: FAIL`
-- No stored-value-correcting findings exist → `gate_6_verdict: NA`
-
-`gate_6_verdict` is informational (parallel to `gate_3_verdict` and `gate_5_verdict`). The Stop hook silently ignores it; enforcement is procedural inside Stage 2.5. If Gate-6 violations persist after 2 per-finding re-entries, surface to user with 3-way override prompt:
-
-> "Finding #N의 Gate-6 (oracle-match 미충족 — 다른 oracle 로 stored value 를 덮어쓰려 함)가 통과되지 않습니다. 어떻게 진행할까요? [a] 같은 oracle 로 재측정 / [b] 별도 cohort-shift finding 으로 전환 (stored value 유지) / [c] originating oracle 이 entry 에 없으니 defer + entry-annotation update 제안."
-
-**Output (on pass)** — Stage 2.5 emits the distribution card per the Output Schema Contract defined in Stage 3, plus per-finding Gate-1, Gate-2, Gate-3, Gate-4, Gate-5, and Gate-6 verdicts:
-
-```
-<!-- retrospect:distribution begin -->
-- memory: {n}
-- issue: {n}
-- claude_md_draft: {n}
-- skill_idea: {n}
-- hook_code: {n}
-- upstream_feedback: {n}
-- memory_hygiene: {n}
-- output_quality: {n}
-- gate_1_verdict: {PASS|FAIL|NA}
-- gate_2_verdict: {PASS|FAIL|NA}
-- gate_3_verdict: {PASS|FAIL|NA}
-- gate_4_verdict: {PASS|WARN|NA}
-- gate_5_verdict: {PASS|FAIL|NA}
-- gate_6_verdict: {PASS|FAIL|NA}
-<!-- retrospect:distribution end -->
-```
-
-`memory` count = (friction-event findings with Proposed Actions = `memory`, single or compound) + (successful_patterns where `reinforce_action = memory`). Stage 4 Action 1 reads the same total but routes per-entry by origin tag.
-
-`memory_hygiene` count = findings produced by Stage 1.5 (i.e., findings whose `category[]` includes `memory_hygiene`). This is a **category count**, not an action key — these findings still emit their underlying action under one of the existing 6 action-type slots (memory / issue / claude_md_draft / ...). The `memory_hygiene` line is informational: it surfaces how much of the report originated from Stage 1.5 vs Stage 2 friction-scan.
-
-`NA` = no findings of the relevant type. Per-gate `NA` semantics:
-- `gate_1_verdict: NA` — zero `tool`/`workflow`/`spec-gap` labeled findings exist
-- `gate_2_verdict: NA` — zero memory-only findings exist
-- `gate_3_verdict: NA` — zero findings have `Proposed Actions` count = 2 (every finding is single-action)
-- `gate_4_verdict: NA` — zero `upstream_feedback` findings exist
-- `gate_5_verdict: NA` — zero `memory`-action findings exist
-- `gate_6_verdict: NA` — zero stored-value-correcting findings exist (no finding flagged at step 7h)
-
-The Stop hook `hooks/completion-verify/retrospect-mix-check/impl.sh` parses `gate_1_verdict`, `gate_2_verdict`, and `gate_4_verdict`; `gate_3_verdict` is emitted for visibility and audit-trail purposes (the hook silently ignores unknown keys). Gate-3 is enforced procedurally inside Stage 2.5; structural Stop-hook enforcement is reserved for a follow-up tightening if procedural compliance proves insufficient. Gate-4 is enforced both procedurally (Stage 4 Action 4 step 0a per-action approval) and structurally by the Stop hook: a `gate_4_verdict: FAIL` in the card blocks Stage 3 output, and an absent `gate_4_verdict` combined with a `⚠ EXTERNAL:` Rationale prefix also blocks (indicating Stage 2.5 Gate-4 was partially skipped). `gate_5_verdict` is informational-only and INTENTIONALLY EXCLUDED from Stop hook parsing — the hook silently ignores it; Gate-5 enforcement is procedural inside Stage 2.5. (Stop hook wiring for Gate-5 is a deferred follow-up similar to Gate-4's progression in PR #340 — file a follow-up issue when procedural compliance proves insufficient.) `gate_6_verdict` is likewise informational-only and INTENTIONALLY EXCLUDED from Stop hook parsing (parallel to `gate_3_verdict` and `gate_5_verdict`) — the hook silently ignores it; Gate-6 enforcement is procedural inside Stage 2.5. **Gate-7 (Transcript-Enumeration Receipt)** is a session-level structural check (NOT a per-finding Stage 2.5 gate): when the transcript contains a compaction marker (`"isCompactSummary":true`), the Stop hook requires the `retrospect:transcript_receipt` fence (Stage 3 output §3e) in the report and blocks Stage 3 when it is absent. Unlike the informational fences below, `transcript_receipt` **IS** parsed by the hook — it is the structural enforcement of the Stage 2 "Compaction + readable transcript (MUST)" prose, added because that prose recurred as a salient-window default after shipping (issue #600 follow-up).
-
-This card and verdict block become Stage 3's input header.
+If a gate still fails after 2 per-finding re-entries, surface the documented
+override prompt rather than silently continuing.
 
 ### Stage 3: Report + Approval
 
-**Output Schema Contract** (normative — Stop hook `hooks/completion-verify/retrospect-mix-check/impl.sh` parses this):
+Stage 3 must follow the canonical report shape from
+[`references/stage3-reporting.md`](references/stage3-reporting.md).
+Worked examples live in
+[`references/report-template.md`](references/report-template.md).
 
-Stage 3 output MUST emit, in this order:
+**Output order:**
 
-1. **Header**: a line matching `^## Retrospect Report` (em-dash or hyphen tail accepted: `## Retrospect Report — {date}` or `## Retrospect Report - {date}`).
-2. **Pre-scan Checklist** between HTML comment fences (Stage 2 Pre-scan Checklist origin) — emitted between header and distribution card:
+1. `## Retrospect Report`
+2. audit fences (`pre_scan_checklist`, `dismissed_candidates`, and the required
+   transcript-derived ledgers)
+3. `<!-- retrospect:distribution begin --> ... end -->`
+4. unified findings table
 
-   ```markdown
-   <!-- retrospect:pre_scan_checklist begin -->
-   - {category_name}: violations: none
-   - {category_name}: violations:
-     - {one-line candidate} | spec_cite: {section}
-   <!-- retrospect:pre_scan_checklist end -->
-   ```
+**Per-finding plan must state:**
 
-3. **`dismissed_candidates` ledger** between HTML comment fences (Stage 2 Pre-scan Checklist origin) — emitted alongside the checklist block; empty body when zero candidates were dismissed:
-
-   ```markdown
-   <!-- retrospect:dismissed_candidates begin -->
-   - {one-line candidate} | reason: {rationale} | spec_cite: {section}
-   <!-- retrospect:dismissed_candidates end -->
-   ```
-
-3b. **`tool_census` trail** between HTML comment fences (Stage 2 pre-scan lane 3 origin) — the full tool inventory; one block, all inventory rows (promoted and non-promoted). Empty body only when zero tool calls occurred in the scope window. When transcript is unreachable, replace the body with a single `<!-- retrospect:census_skipped: transcript unreachable -->` line. Promoted rows (those that survived the step 4b promotion pipeline — signal AND post-dedup AND post-cap) ALSO appear as `tool`-category rows in the unified findings table (#5); the trail is the complete audit log:
-
-   ```markdown
-   <!-- retrospect:tool_census begin -->
-   - tool_name: {tool} | layer: {mcp|cli|builtin|skill} | call_count: N | error_count: N | retry_count: N | workaround_marker: {true|false} | surfaced_in_friction: {true|false} | signal: {none|summary}
-   <!-- retrospect:census_findings_capped: dropped=K -->   # only when promoted findings exceeded the cap
-   <!-- retrospect:tool_census end -->
-   ```
-
-3c. **`user_correction` ledger** between HTML comment fences (Stage 2 pre-scan lane 4 origin) — the per-drop audit log: every marker-matched user-turn candidate the LLM judge ruled a false-positive, one row each, with reason + cite. Empty body when zero candidates were dropped (a session with no user corrections, OR one where every marker-matched candidate was judged genuine and promoted). When the transcript is unreachable, replace the body with a single `<!-- retrospect:user_correction_skipped: transcript unreachable -->` line. Genuine corrections do NOT appear here — they are emitted as `behavioral` friction events in the unified findings table (#5); this ledger records only the drops, so the judge's suppressions stay auditable:
-
-   ```markdown
-   <!-- retrospect:user_correction begin -->
-   - candidate: "{verbatim user-turn excerpt}" | marker_class: {negation|redirect|mismatch} | reason: {why judged not-a-correction} | cite: {turn ref / quoted context}
-   <!-- retrospect:user_correction end -->
-   ```
-
-3d. **`self_correction` ledger** between HTML comment fences (Stage 2 pre-scan lane 5 origin) — the per-drop audit log: every signature-matched self-correction candidate the LLM judge ruled a false-positive (progressive refinement / unrelated re-run / kept-A/B comparison), one row each, with reason + cite. Empty body when zero candidates were dropped (no self-correction signatures, OR every signature-matched candidate was judged genuine and promoted). When the transcript is unreachable, replace the body with a single `<!-- retrospect:self_correction_skipped: transcript unreachable -->` line. Genuine self-corrections do NOT appear here — they are emitted as friction events (`origin: self_correction`, `behavioral` ± `tool`) in the unified findings table (#5); this ledger records only the drops, so the most self-serving judgment step (the agent judging its own corrected mistakes) stays auditable:
-
-   ```markdown
-   <!-- retrospect:self_correction begin -->
-   - corrective: "{verbatim corrective-call excerpt}" | prior: "{verbatim prior-call excerpt}" | signature: {oracle-mismatch|wrong-target|basis-change} | reason: {why judged not-a-self-correction} | cite: {turn ref}
-   <!-- retrospect:self_correction end -->
-   ```
-
-3e. **`transcript_receipt` fence** between HTML comment fences (Stage 2 "Compaction + readable transcript MUST" origin) — **emitted ONLY when a compaction marker is present in the transcript** (otherwise omitted entirely; a non-post-compaction session has no receipt). Unlike the §3/§3b/§3c/§3d fences, this one **IS parsed by the Stop hook** (Gate-7) — its absence in a post-compaction session blocks Stage 3. The body MUST contain the **actual scan commands and their real stdout** (run against the live `transcript_path`), not a self-authored count — a hand-written receipt re-introduces the author-exempt verification trap the gate exists to close. When the transcript is genuinely unreachable, replace the whole fence with the single `<!-- retrospect:transcript_receipt_skipped: transcript unreachable -->` line:
-
-   **Count is necessary but NOT sufficient [issue #664].** A `grep -c` count proves a scan *ran*; it does not prove the errors were *read*. A receipt carrying only counts let a salient-window pass survive the gate — the count satisfied the fence while the error contents went unexamined, and the most adverse error (e.g. a guard-blocked verification-fabrication attempt) was silently dropped, surfaced only by the external user. So when `is_error_count > 0`, the receipt MUST ALSO carry a nested **`retrospect:is_error_enum`** block enumerating **each** `is_error` event's content with an explicit disposition: `promote` (becomes a friction finding), `note` (acknowledged, resolved by a guard / transient), or `dismiss` (negative-list, with reason). No event may be silently absent. This converts invisible silent omission into visible, challengeable mis-disposition — the author can still route an event wrongly, but every error is on the page for the reader to contest. The Stop hook (Gate-7) blocks Stage 3 when `is_error_count > 0` and the `retrospect:is_error_enum` block is absent. When `is_error_count == 0`, the enum block is omitted (nothing to enumerate). Use a real extraction command (e.g. a `jq`/python scan emitting each `tool_result` error body), not a hand-authored list:
-
-   ```markdown
-   <!-- retrospect:transcript_receipt begin -->
-   $ grep -c '"is_error":true' <transcript_path>
-   {real N}
-   $ grep -c '"role":"user"' <transcript_path>   # user-turn / interrupt extraction
-   {real N}
-   is_error_count: {N} | user_turn_count: {N} | interrupt_count: {N}
-   $ python3 -c "...emit each tool_result is_error body..." <transcript_path>
-   <!-- retrospect:is_error_enum begin -->
-   - [1] {error content excerpt} | disposition: dismiss (negative-list: expected hook fire)
-   - [2] {error content excerpt} | disposition: note (transient timeout, retried)
-   - [k] {error content excerpt} | disposition: promote (finding #N)
-   <!-- retrospect:is_error_enum end -->
-   <!-- retrospect:transcript_receipt end -->
-   ```
-
-4. **Distribution card** between HTML comment fences. Action keys are canonical snake_case enum; verdict values are `PASS` / `FAIL` / `NA`:
-
-   ```markdown
-   <!-- AUTHORITATIVE_SCHEMA — Stop hook depends on this. Co-update hooks/completion-verify/retrospect-mix-check/impl.sh + tests/hooks/completion-verify/test_retrospect_mix_check.sh + tests/fixtures/retrospect-synth-*.expected.json on any change to: (1) the fence markers themselves, (2) the action key set (memory/issue/claude_md_draft/skill_idea/hook_code/upstream_feedback), (3) gate_1_verdict / gate_2_verdict keys, or (4) the `retrospect:transcript_receipt` fence marker OR the nested `retrospect:is_error_enum` content-block marker / `is_error_count:` count line (Gate-7 is hook-parsed — renaming any of these, or the count-line key the hook reads to decide whether the enum block is required, silently disables the post-compaction enforcement [issue #664]).
-        Gate-3 carve-out: gate_3_verdict is informational-only and INTENTIONALLY EXCLUDED from this co-update contract. The hook's awk parser keys on gate_1_verdict/gate_2_verdict literals only and silently ignores all other lines (regression-tested by tests T8–T17 + the 4 fixture files which still pass without gate_3_verdict). Adding/removing/renaming gate_3_verdict alone does NOT require hook or test changes.
-        Gate-4 enforcement note: gate_4_verdict IS structurally enforced by the Stop hook (unlike gate_3_verdict which remains informational-only). Changes to gate_4_verdict semantics or its FAIL/WARN/NA/PASS values REQUIRE synchronized edits to hooks/completion-verify/retrospect-mix-check/impl.sh and tests/hooks/completion-verify/test_retrospect_mix_check.sh (T36/T37/T38). Adding/removing gate_4_verdict from the card alone does NOT require fence-marker or action-key changes.
-        Gate-5 carve-out: gate_5_verdict is informational-only and INTENTIONALLY EXCLUDED from this co-update contract (parallel to gate_3_verdict). The hook silently ignores gate_5_verdict. Adding/removing/renaming gate_5_verdict alone does NOT require hook or test changes. (Deferred upgrade trajectory similar to Gate-4 in PR #340 — file a follow-up issue for Stop hook wiring when procedural enforcement proves insufficient.)
-        Gate-6 carve-out: gate_6_verdict is informational-only and INTENTIONALLY EXCLUDED from this co-update contract (parallel to gate_3_verdict and gate_5_verdict). The hook silently ignores gate_6_verdict. Adding/removing/renaming gate_6_verdict alone does NOT require hook or test changes.
-        Category-count carve-out (memory_hygiene / output_quality): these are CATEGORY counts (count of findings with the respective category in category[]) — NOT action keys. They are emitted as sibling lines to the action-type counts but are informational-only and INTENTIONALLY EXCLUDED from Stop hook parsing. Adding/removing/renaming memory_hygiene OR output_quality alone does NOT require fence-marker or action-key changes; the underlying actions of Stage 1.5 / Stage 2.7 findings still fall under one of the 6 action-type keys above. The Stop hook's awk parser silently ignores both lines (same mechanism as gate_3/gate_5 verdicts).
-        Pre-scan-checklist + dismissed_candidates + tool_census + user_correction + self_correction carve-out: the `retrospect:pre_scan_checklist`, `retrospect:dismissed_candidates`, `retrospect:tool_census`, `retrospect:user_correction`, and `retrospect:self_correction` fenced blocks (Stage 2 origin) are informational-only and INTENTIONALLY EXCLUDED from Stop hook parsing. They live OUTSIDE the `retrospect:distribution` fence so the awk parser keyed on `distribution begin/end` ignores them. Promoted census findings still surface as `tool`-category rows in the unified table and fall under the existing 6 action-type keys (typically `upstream_feedback`); genuine user_correction / self_correction findings surface as `behavioral`-category rows under the existing action-type keys (typically `claude_md_draft` / `memory`); the trail/ledger fences themselves add no parser key. Adding/removing/renaming the checklist OR dismissed_candidates OR tool_census OR user_correction OR self_correction blocks alone does NOT require hook or test changes. EXCEPTION — the `retrospect:transcript_receipt` fence (Stage 3 output §3e) is NOT in this carve-out: it IS parsed by the Stop hook (Gate-7), so renaming it DOES require synchronized hook + test edits. -->
-   <!-- retrospect:distribution begin -->
-   - memory: 1
-   - issue: 0
-   - claude_md_draft: 0
-   - skill_idea: 0
-   - hook_code: 0
-   - upstream_feedback: 0
-   - memory_hygiene: 0
-   - output_quality: 0
-   - gate_1_verdict: PASS
-   - gate_2_verdict: PASS
-   - gate_3_verdict: PASS
-   - gate_4_verdict: PASS
-   - gate_5_verdict: PASS
-   - gate_6_verdict: PASS
-   <!-- retrospect:distribution end -->
-   ```
-
-5. **Unified findings table** with literal column headers (no abbreviation, no reordering):
-
-   ```
-   | # | Category | Tool Layer | Pattern | Root Cause | Rule / Gap | Repeat? | Proposed Actions (1~2) | Rationale | Priority |
-   ```
-
-   Column semantics:
-   - `Category`: comma-separated subset of `behavioral`, `tool`, `workflow`, `spec-gap`, `memory_hygiene`, `output_quality` (≥1, see Stage 2 pre-scan categorization; `memory_hygiene` originates from Stage 1.5, `output_quality` originates from Stage 2.7)
-   - `Tool Layer`: one of `mcp`, `cli`, `builtin`, `skill`, or `—` (mandatory non-`—` when `tool` ∈ Category, mandatory non-`—` when `output_quality` ∈ Category AND audit surface is gh-CLI or sub-agent, optional `skill` for `workflow` / `spec-gap` / `memory_hygiene`, `—` for `behavioral` / `memory_hygiene` (default) / `output_quality` (MCP-via-behavioral path))
-   - `Proposed Actions (1~2)`: comma-separated subset of `memory`, `issue`, `claude_md_draft`, `skill_idea`, `hook_code`, `upstream_feedback`; for findings marked `external=true` by Stage 2.5 Gate-4, append ` (external)` suffix to `upstream_feedback` (e.g., `memory, upstream_feedback (external)`)
-   - `Rationale`: free-form one-line for compound or non-memory rows; for **memory-only** rows (single `memory`, not compound), the cell MUST match Schema A or Schema B (see Gate-2 in Stage 2.5): Schema A — exactly 5 lines `^not (issue|claude_md_draft|skill_idea|hook_code|upstream_feedback): .+$`, one per non-memory action type; Schema B — 1-2 lines `^not-others: .+$` with dimension tags (e.g., `not-others: repeat=0, rule_exists=yes, gateable=no, tool_defect=no`). Generic single-sentence rationales are NOT acceptable for memory-only findings. **For rows whose actions include `upstream_feedback`** (single or compound), the cell MUST also contain a literal line `backing_repo: <owner>/<repo>` (embedded via `<br>` for single-line markdown form) — Stage 4 Action 4 step 0 reads this as the routing decision. **Compound case `memory, upstream_feedback`**: the row is NOT memory-only (contains a non-memory action), so the Schema A/B requirement does NOT apply — instead use free-form prose for the human rationale + the `backing_repo:` line. Compound combinations are *additive*: each action-specific Rationale convention applies independently to the row, joined with `<br>`.
-
-The Stop hook parses the distribution-card fence (deterministic) and the table (anchored on the literal column headers shown in the unified-table template at [`references/report-template.md`](references/report-template.md)). Drift in this contract requires synchronized edits to `hooks/completion-verify/retrospect-mix-check/impl.sh`, `tests/hooks/completion-verify/test_retrospect_mix_check.sh`, and `tests/fixtures/retrospect-synth-*.expected.json`.
-
-**Session-level enforcement (issue #666).** Emitting the fence is not optional even if you localize or reshape the header/table: a session-scoped *retrospect-active marker* (written by `hooks/preflight-gate/retrospect-active-marker` when the retrospect skill is invoked) lets the Stop hook detect that a Stage 3 report is owed this turn **independent of your output format**. A Stage 3 report that reaches Stop in a retrospect-active session **presenting a findings table** (a markdown table-separator row) but without the `<!-- retrospect:distribution begin -->` fence (and without `## Actions Executed`) is blocked — you cannot bypass the gates by omitting the fence. The block predicate is deliberately narrow (marker present AND table-shaped AND no fence AND not Stage 4): a retrospect-active stop that surfaces only prose — e.g. a legitimate pre-Stage-3 clarification — is not a report and passes through. The marker clears on Stage 4 (`## Actions Executed`) or on the next non-retrospect user prompt.
-
-**Spec AC-A3 deviation note** — earlier draft asked for "memory-only justification 한 줄" inside the distribution card. v2 relocates that justification into the unified-table `Rationale` column as the structured 5-line `not <action>: <reason>` block: strictly more informative than a single line, single source of truth, eliminates card↔table inconsistency risk.
-
----
-
-**Present findings as a single unified table per the Output Schema Contract
-above.** The full consolidated template (header → audit fences → distribution
-card → unified table, in emit order) lives at
-[`references/report-template.md`](references/report-template.md) — Read it when
-composing the Stage 3 report. The Output Schema Contract above is the normative
-source on any divergence.
-
-#### Trigger Conditions (Gate-3 (b) demotions)
-
-(Non-machine-parsed; emitted for human review only — not parsed by the Stop hook.)
-
-If Stage 2.5 Gate-3 detected sibling decision-coupling and demoted the weaker action,
-emit one bullet per demoted action below. Format: literal `^- Finding #N: file <action>
-when <observation predicate>$`.
-
-- Finding #N: file `<demoted_action>` when `<observation predicate>` (originally proposed alongside `<kept_action>`; demoted because <coupling reason>)
-
-If no Gate-3 (b) demotions occurred, omit this section entirely (do not emit "None.").
-
-No patterns found: emit the **header**, the **`retrospect:pre_scan_checklist` fence**, the **`retrospect:dismissed_candidates` fence** (populated with any dismissals from Stage 2's Pre-scan Checklist; empty body when zero), the **`retrospect:tool_census` fence** (full tool inventory for the session; empty body only when zero tool calls; `census_skipped` line when transcript unreachable), the **`retrospect:user_correction` fence** (per-drop ledger; empty body when zero candidates were dropped; `user_correction_skipped` line when transcript unreachable), the **`retrospect:self_correction` fence** (per-drop ledger; empty body when zero candidates were dropped; `self_correction_skipped` line when transcript unreachable), and the **distribution card** with all counts = 0 and verdicts = NA, plus literal "This session followed all global `~/.claude/CLAUDE.md` rules. ✅". These audit fences MUST be emitted even in the 0-friction case — otherwise the dismissed-candidate, tool-usage, dropped-user-correction, and dropped-self-correction audit trails are silently lost in exactly the path they are most needed (Stage 2 early exit). Note: the 0-friction "No patterns found" path requires that the user_correction AND self_correction scans promoted **zero genuine corrections** — a single genuine correction (user or self) is a friction event, so friction_events is non-empty and this path is not reachable (the populated-table path runs instead). Note: the 0-friction "No patterns found" path is reachable only when the census **promoted zero findings** (no row survived the step 4b pipeline — either no objective signal, or every signal row was deduped / capped out); a single promoted census finding fires the Census carve-out and routes to the populated-table path instead.
-
-**Enumerate-before-empty-fence (MANDATORY in the 0-friction path):** before emitting an empty `dismissed_candidates` fence in the 0-friction exit, MUST run the following deterministic enumeration — an empty fence is permitted only when step (a) surfaces zero **rule-violation** matches (review-bot output that is purely style nits / refactor suggestions does not count as a rule violation and does not block an empty fence):
-
-(a) Scan the session transcript for codex/review-bot finding markers. "Codex/review-bot finding markers" are explicit tool outputs from: Codex CLI reviewer output blocks, BugBot comment bodies, oh-my-claudecode reviewer agent result text, Cursor review annotations. Every match — regardless of whether it constitutes a rule violation — MUST be inspected for rule-violation content. Any match that is a rule violation (workflow step in `AGENTS.md` / `~/.claude/CLAUDE.md` / hook denial / spec-cited divergence) MUST appear as a ledger line in `dismissed_candidates` with rationale (typically the escape-hatch form: `repeat=false AND resolved=true via in-session apply`, or `not a rule violation — style/refactor suggestion only`). Review-bot findings that are purely style nits or refactor suggestions are acknowledged and dismissed inline; they do NOT require a `dismissed_candidates` entry (per the narrow-scope rule at Stage 2 Pre-scan Checklist "Mandate scope").
-
-(b) Every codex/review-bot match that identifies a rule violation MUST appear as a ledger line: `- {one-line candidate} | reason: {dismissal rationale} | spec_cite: {section name or file:line}`. The escape-hatch `repeat=false AND resolved=true via in-session apply` is the standard rationale when the finding was already fixed in the same session.
-
-(c) An empty `dismissed_candidates` fence is ONLY permitted when step (a) enumeration returns zero **rule-violation** matches. The Red Flag is narrow-scoped to rule violations: emitting an empty fence after step (a) surfaced a rule-violation match (instead of recording it as a ledger line) is a Red Flag (see Red Flags section). A transcript whose review-bot output is purely style nits / refactor suggestions — no rule-violation match — correctly permits an empty fence; the mere presence of a review-bot output block does NOT itself force a ledger entry.
-
-#### Reinforced Patterns (this session)
-
-(Emitted only when pre-scan found ≥1 successful_patterns with `reinforce_action: visualize_only`. Omit this section entirely if none — do not emit "None." Rows with `reinforce_action: memory` are NOT listed here — they appear in Stage 4 Actions Executed report alongside friction-origin memory entries, distinguishable by the `Reinforced — ` description prefix.)
-
-- {pattern_1} (evidence: {turn or artifact})
-- {pattern_2} ...
-
-The unified table folds the previous dual-table layout (Pattern + Tool/Feature Findings) into one. Tool-layer information that previously lived in a separate "Tool/Feature Findings" table is now carried in the `Tool Layer` column of every row tagged with `tool` in `Category`. Reviewers see all findings in priority order without cross-referencing two tables.
-
-**Sorting**: rows SHOULD be sorted by `Priority` (HIGH → MED → LOW). Within the same priority, prefer non-memory `Proposed Actions` first so escalations surface above behavioral memos.
-
-**Action type baseline comes from Stage 2 escalation ladder**, but Stage 3 MUST explicitly evaluate all six action types per finding and select 1–2 composite actions.
-
-> **Exception — one-off mistakes**: If Stage 2 classified the finding as `note only` (situational root cause, unlikely to recur), skip the evaluation below entirely. No persistent action is created; the finding appears in the report as acknowledged only.
-
-**For each finding (except one-off), evaluate ALL six action types before selecting:**
-
-| Action Type | When to Choose | Skip If |
-|-------------|---------------|---------|
-| **MEMORY.md feedback** | New pattern (1st occurrence, repeat_count=0), individual learning | repeat=true (memory is BLOCKED) |
-| **GitHub issue** | Systemic fix needed (tool/skill implementation), repeat pattern (1–2×) | One-off mistake, purely local insight |
-| **Global `~/.claude/CLAUDE.md` draft** | Explicit rule gap exists, cross-project scope needed | Existing rule already covers this pattern |
-| **Skill idea note** | Repeat pattern needs enforcement mechanism, manual recall is insufficient | Single memo is sufficient, no recurring trigger |
-| **Hook code** | Repeat (3x+) requiring automated enforcement; manual recall has repeatedly failed | Fewer than 3 repeats; skill idea or rule is sufficient |
-| **Upstream feedback** | Tool/feature-level defect identified in step 4b; improvement needed in the tool itself, not in Claude's behavior | Finding is purely a rule violation with no tool-level root cause |
-
-**Selection matrix — three axes to determine compound vs. single action:**
-
-| Axis | Signal → Action |
-|------|----------------|
-| **Repeat count** | 0× → `memory` (first occurrence); 1–2× → `issue` (memory blocked — repeat=true); 3×+ → `skill` or `hook` (enforcement gap) |
-| **Scope** | Cross-project impact → global `~/.claude/CLAUDE.md` draft; single-project → `MEMORY.md` |
-| **Gap type** | Rule violated → `memory` (reinforce); rule absent → global `~/.claude/CLAUDE.md` draft (fill gap); no enforcement → `skill idea` |
-
-> **Axis precedence: Repeat-count is the highest-priority axis.** When `repeat=true`, the Scope and Gap type axes cannot override to `memory` — the repeat-count constraint (issue / skill / hook) always wins. Apply Scope and Gap type only to determine additional actions alongside the repeat-count result.
-
-**Compound action is the default for HIGH-priority findings.** A single `memory` action is acceptable only when the rationale for skipping all other types is explicitly stated in the `Rationale` column.
-
-**Before approval, explain each action's concrete plan:**
-
-For each finding, present:
-1. **What will be created** (file path, issue title, hook name, or global `~/.claude/CLAUDE.md` rule text)
-2. **Why this action type** (escalation rationale — e.g., "Already recorded 3x in MEMORY.md")
-3. **How it will be verified** (what check confirms it works)
-4. **Stage 2 caveats carried forward** (MANDATORY when any of the following hold) — emit a literal `Stage 2 caveats:` line listing each item that applies to this finding. Omit the entire line only when none of the items apply.
-   - `tracer confidence: LOW|MED` — tracer agent (Stage 2 step 1) returned anything below HIGH on this finding's causal chain
-   - `single observation` — only 1 friction-event citation supports this finding (Stage 2.5 Gate-3 (c) precondition)
-   - `alternative root cause not ruled out: <description>` — tracer/analyst surfaced ≥1 competing root cause that was not falsified
-   - `Gate-3 (c) downgrade applied: <original> → <new>` — Stage 2.5 downgraded the action tier
-   - `Gate-3 (b) sibling demoted to trigger: <demoted_action>` — Stage 2.5 split a decision-coupled pair into kept + trigger
-   - `repeat=true, resolved=true (escape hatch)` — existing resolution covers this; verify before re-acting
-   - `analyst clustered with #N` — analyst agent (Stage 2 step 2) clustered this with another finding whose Proposed Actions differ
-  Stage 3 ranking (including `(Recommended)` selection in the next sub-section) MUST read these caveats. A `(Recommended)` label cannot be applied to an action whose Stage 2 caveats include `tracer confidence: LOW`, `single observation` alone, or `alternative root cause not ruled out` — those caveats must be discharged via the Pre-Output Falsification Gate below before ranking.
+1. what will be created
+2. why this action type
+3. how it will be verified
+4. `Stage 2 caveats: ...` when applicable
+5. `Falsification: ...`
 
 #### Pre-Output Falsification Gate (AskUserQuestion)
 
-This gate fires immediately before each `AskUserQuestion` call emitted by Stage 3 for any finding. It is normative — skipping it for the same finding more than once per Stage 3 turn is a Red Flag.
+This gate fires immediately before each `AskUserQuestion` emitted by Stage 3.
 
-**Trigger detection (scan every option label and surrounding framing):**
+**Trigger detection:**
 
-- Literal `(Recommended)` suffix on any option label
-- Confidence-anchoring framing in option label or description: `safer`, `safest`, `natural fit`, `natural choice`, `obvious choice`, `clearly`, `안전한`, `자연스러운`, `당연히`, `분명히`
-- Synonymous ranking signals: `default to`, `default choice`, `prefer this`, `recommend`, `추천`, `기본값`
+- **Literal `(Recommended)` suffix** on any option label
+- confidence-anchoring phrasing such as `safer`, `natural fit`, `안전한`,
+  `자연스러운`, `추천`, `default to`
 
-If ANY trigger matches → the gate fires. The first option's mere position is NOT a trigger; only labels and framing are.
+**Mandatory question (internal, never omitted):**
 
-**Mandatory pre-output question (internal to the skill, not surfaced to user):**
+> If this proposal's premise is wrong, what observation should be missing from
+> the current evidence? Is that observation actually missing?
 
-> "If this proposal's premise is wrong, what observation should be *missing* from the current evidence? Is that observation actually missing?"
+**Carry forward Stage 2 caveats:**
 
-Concretely, for each `(Recommended)`-labeled option, derive:
-
-1. The proposal's premise in one sentence (e.g., "this friction's root cause is in Claude's behavior, addressable via memory entry")
-2. The disconfirming observation that would make the premise false (e.g., "if upstream tool defect is the real root cause, the friction recurs even when Claude follows the proposed memory rule perfectly")
-3. Whether that disconfirming observation is actually missing in Stage 2 evidence — read the finding's `category[]`, `Tool Layer`, root cause text, and Stage 2 caveats (above) to check
+- `tracer confidence: LOW|MED`
+- `single observation`
+- `alternative root cause not ruled out`
+- `Gate-3 (c) downgrade applied`
+- `Gate-3 (b) sibling demoted to trigger`
+- `repeat=true, resolved=true (escape hatch)`
+- `analyst clustered with #N`
 
 **Outcome rules:**
 
-| Falsification outcome | Action |
-|---|---|
-| Premise survives — disconfirming observation IS missing in Stage 2 evidence | `(Recommended)` label allowed; emit one-line falsification trace in the per-finding plan: `Falsification: premise survived — <disconfirming observation> was not present in Stage 2 evidence (category=<...>, Tool Layer=<...>, root cause=<one-line>)` |
-| Premise fails — disconfirming observation IS present | `(Recommended)` label DISALLOWED; surface the option as unranked alongside siblings; record `Falsification: premise failed — <disconfirming observation> present, surfacing unranked` |
-| Falsification step not run (e.g., skill skipped this gate) | `(Recommended)` label DISALLOWED; ESCALATE to user with open premise: `AskUserQuestion` MUST include a question line asking the user to confirm the premise before any ranked option is offered |
+- **Premise survives** -> `(Recommended)` allowed
+- **Premise fails** -> `(Recommended)` **DISALLOWED**
+- **Falsification step not run** -> `(Recommended)` **DISALLOWED** and
+  **ESCALATE to user with open premise**
 
-**The gate composes with Stage 2 caveats (above):**
+Every ranked option needs a `Falsification:` trace line immediately below
+`Stage 2 caveats:` (or in its place when there are no caveats).
 
-- `tracer confidence: LOW` → falsification cannot mark "premise survives" without explicit disconfirming-observation check (LOW confidence IS itself a present disconfirming signal until shown otherwise)
-- `single observation` + `repeat=false` → falsification must explicitly state whether the single observation is dispositive; if dispositive evidence absent, downgrade to unranked
-- `alternative root cause not ruled out` → premise fails by construction; surface unranked
+**gate-suppressed example:** when a single observation leaves an alternative
+root cause unresolved, surface the option unranked rather than marking it
+`(Recommended)`.
 
-**Skip conditions (gate does NOT fire):**
+**Approval flow:**
 
-- Zero `(Recommended)` labels AND zero confidence-anchoring phrases in the entire Stage 3 output (the trigger scan finds nothing)
-- Stage 3 emits the "No patterns found. ✅" early exit per Stage 2 step 7
-- All findings are `note only` (one-off mistakes — no ranking needed)
+For each finding, ask:
 
-The gate's outcome MUST appear as a `Falsification:` line in the per-finding plan immediately under the `Stage 2 caveats:` line (or replace it when `Stage 2 caveats:` is omitted). Reviewers and downstream parsers anchor on this exact prefix.
+- `✅ Execute now`
+- `⏭ Skip`
+- `🕐 Defer (create note only)`
 
-Worked examples — single action (repeat pattern), compound action (rule gap +
-repeat), and a gate-suppressed `(Recommended)` — live in
-[`references/report-template.md`](references/report-template.md) §Worked
-examples. Read them when calibrating per-finding plans: each shows the
-`Stage 2 caveats:` / `Falsification:` line composition this section mandates.
-
-**Then ask for approval per item using AskUserQuestion:**
-
-```
-For each finding, user selects:
-  ✅ Execute now  |  ⏭ Skip  |  🕐 Defer (create note only)
-```
-
-Do NOT execute any action until user approves.
+Do not execute any action until the user approves it.
 
 ### Stage 4: Execute
 
-**"note only" items require no execution** — they appear in the completion report as acknowledged but need no persistent artifact.
+`note only` items require no execution.
 
-**Before executing ANY approved action, Read
-[`references/stage4-execution.md`](references/stage4-execution.md)** — it holds
-the complete per-action procedures (templates, prompt variants, the backing-repo
-resolution table, the per-artifact verification matrix, and the
-completion-report format). The map below is for orientation only; executing an
-action from the map alone skips the embedded gates and is a Red Flag.
+Before executing any approved action, read
+[`references/stage4-execution.md`](references/stage4-execution.md). It holds
+the full procedures, prompt variants, repo-resolution rules, and artifact
+verification matrix.
 
-| # | Action | Non-negotiable gate (full procedure in the reference) |
-|---|--------|-------------------------------------------------------|
-| 1 | MEMORY.md feedback (friction-event + success-pattern origins) | duplicate-check before create — merge-first; `hookable`/`hookKeywords` frontmatter decision recorded |
-| 2 | GitHub issue | project issue conventions (Conventional Commits title) |
-| 3 | Global `~/.claude/CLAUDE.md` draft | target detection (Global / Project / External) FIRST; Global path = staging file → AskUserQuestion 3-option → apply only on explicit approval — direct Edit is a Red Flag |
-| 4 | Upstream feedback | step 0 backing-repo verification (declared `backing_repo:` vs re-resolved value compare — examples use the `<resolved_backing_repo>` placeholder, never a hardcoded repo) + step 0a external-repo per-action authorization, both BEFORE any `gh issue create` |
-| 5 | Skill idea note | written to `.omc/plans/retrospect-skill-idea-{slug}.md` |
-| 6 | Hook code | protected-branch check → dedicated worktree when needed; user review before `settings.json` registration |
-| 7 | Verification | per-artifact verification matrix — every executed action verified, results in the completion table |
-| 8 | Completion report | `## Actions Executed` table with links/paths + verification trail |
+**Action map:**
+
+| # | Action | Reference-owned gate |
+|---|--------|----------------------|
+| 1 | MEMORY.md feedback | duplicate-check before create; `hookable` / `hookKeywords` decision |
+| 2 | GitHub issue | project issue workflow |
+| 3 | global `~/.claude/CLAUDE.md` draft | target detection + staging + approval |
+| 4 | upstream feedback | backing-repo verification + external approval gate; Stage 3 rationale uses `backing_repo: <resolved_backing_repo>` and praxis-internal routing examples use `<resolved-praxis-repo>` placeholders until live resolution |
+| 5 | skill idea note | local artifact write |
+| 6 | hook code | branch/worktree guard + registration prompt |
 
 ## Rationalization Prevention
 
-| Excuse | Reality |
-|--------|---------|
-| "It was a one-off mistake, not worth capturing" | If it happened once, it can happen again. Capture it. |
-| "I know the root cause, I'll just note the symptom" | Symptoms recur. Root causes get fixed. Write the root cause. |
-| "MEMORY.md is already long, skip this" | Length doesn't matter. Missing the pattern is the cost. |
-| "The session was mostly fine, nothing to retrospect" | Even 1 friction event is worth 2 minutes to capture. |
-| "I'll do this later" | Later never comes. Do it at session end while context is fresh. |
-| "This is a tool issue, not a Claude issue" | Tool + Claude interaction is within scope. Both can be improved. |
-| "Tool issue라서 이번 retrospect scope 밖이다" | Scope 안이다. Step 4b에서 분석하고 `upstream feedback`으로 도구의 backing repo (Stage 4 Action 4 의 routing 표 참고)에 이슈를 남겨야 한다. |
-| "도구 결함이지 내 행동 문제가 아니다" | 둘 다일 수 있다. Step 4 (행동 교정)와 step 4b (도구 개선)에 각각 기록하라. 하나만 선택하지 마라. |
-| "내가 그 자리에서 바로 고쳤으니 friction이 아니다" | 고친 것도 패턴이다. 자가-교정(self-correct)한 실수일수록 회고에서 빠지기 쉽다 (무의식 필터). 잘못된 oracle 로 측정 후 정정한 것도 friction — self_correction lane (pre-scan lane 5)이 결정론적으로 enumerate 하므로 narrative 누락을 보완한다. |
+Do not rationalize past any mandatory gate.
+
+- "small fix", "I already know", "the agent will infer it", and "CI will catch
+  it" are not exemptions
+- When you notice yourself trying to bypass a mandatory step, run the step
+- If you truly need an exemption, ask the user explicitly
+
+The larger rationalization catalog lives in
+[`references/appendices.md`](references/appendices.md).
 
 ## Red Flags — STOP
 
-If you catch yourself:
+STOP and return to the owning stage when any of these happen:
 
-- Proposing actions before completing Stage 2 analysis
-- Writing "root cause: Claude forgot to X" without tracing WHY the forgetting happened
-- Adding a MEMORY.md entry that just repeats the global `~/.claude/CLAUDE.md` rule verbatim (no new insight)
-- Creating a GitHub issue for every minor friction (low-ROI noise)
-- Skipping the approval step and executing actions directly
-- Editing `$CLAUDE_CONFIG_DIR/CLAUDE.md` directly (without the staging → AskUserQuestion 3-option path) — global `~/.claude/CLAUDE.md` requires staging + explicit `apply` approval; direct Edit/Write is blocked by the self-modification classifier and skips user review. Use the Global path flow in Action 3 above.
-- Proposing `memory` for a pattern that already exists in MEMORY.md (MUST escalate instead)
-- Skipping tracer/analyst agent calls ("I can analyze this myself")
-- Generating artifacts without verification ("issue created" without showing URL)
-- Creating a new memory file without checking existing entries for overlap (MUST merge into existing when root cause matches)
-- **Proposing MEMORY.md feedback as the only action when the same rule was violated 3+ times** — this ignores memo's proven limits; enforcement mechanisms (skill, hook, rule) MUST be evaluated alongside memory
-- **Proposing MEMORY.md feedback as the only action when the finding is a rule gap (rule absent)** — gaps are not filled by memos; global `~/.claude/CLAUDE.md` draft or skill idea MUST be considered
-- **Forcing tool friction into only a rule-violation frame** — tool-layer defects from step 4b MUST be carried in the unified findings table with `Tool Layer` set to a non-`—` value and evaluated for `upstream feedback`, not collapsed into rule-violation-only findings
-- **Skipping step 4b entirely** ("no tool issues this session") — step 4b is mandatory. If no tool friction is found, the distribution card MUST emit `upstream_feedback: 0` and the report MUST state "No tool/feature friction detected. ✅" explicitly
-- **Pre-scan에서 friction event에 `category[]` 라벨링을 누락한 채 Stage 2 step 3 이상 진행** — Layer E 강제. 누락은 Stage 2 진입 전 차단되어야 한다.
-- **Pre-scan Checklist 가 식별한 rule-violation 후보를 dismissed_candidates ledger 기록 없이 silent 으로 무시** — 운영자의 dismissal-to-silence 권한은 차단됨. 후보는 (a) friction event 로 promote 하거나 (b) dismissed_candidates 에 explicit rationale + spec cite 와 함께 demote 해야 한다. 일반 codex/review-bot finding (refactor 제안 / style nit) 은 본 mandate 적용 대상 아님 — narrow scope 는 rule violation 사실에만 적용된다 (MEMORY.md 가 review-bot mirror 로 inflate 되는 위험 방지).
-- **Memory-only finding의 `Rationale`이 Gate-2 schema 를 만족하지 않음** — Gate-2 위반. 허용 schema: (a) 5줄 `not <action>: <reason>` 형식 (Schema A) 또는 (b) 1-2줄 `not-others: <dim-tags>` 형식 (Schema B). 일반 한 줄 진술, 3-line `not-others:`, Schema A/B 혼용은 모두 부적격.
-- **Stage 2.5 분포 감사를 명시적으로 건너뛰고 Stage 3로 직행** — distribution card와 Gate-1/Gate-2/Gate-3 verdict 출력은 Stage 3 입력의 mandatory 전제.
-- **`tool` 라벨 finding의 `Tool Layer` 컬럼이 `—`로 비어 있음** — Layer E ↔ step 4b composition matrix 위반. tool 카테고리는 4b layer 중 하나(mcp/cli/builtin/skill)를 반드시 가져야 한다.
-- **`upstream_feedback` 행에 `backing_repo: <owner/repo>` 선언이 없음** — Stage 2 step 8 위반. 선언은 Stage 4 Action 4 step 0의 라우팅 결정 입력이며, 누락 시 Stage 4가 abort 한다.
-- **Stage 4 Action 4에서 step 0 (declared vs re-resolved 비교)을 건너뛰고 바로 `gh issue create` 실행** — 이슈가 잘못된 레포로 라우팅되는 정확한 실패 경로. 선언과 재계산 값을 모두 기록하지 않은 채 진행하면 retrospect 자체가 검증 불가.
-- **`Proposed Actions` count = 2 인데 두 action 이 decision-coupled (한 쪽이 다른 쪽이 묻는 질문을 이미 결정)** — Gate-3 (b) 위반. 둘 다 실행하면 상호 모순 상태가 만들어지며, `upstream_feedback` 측이 외부 레포에 빈 질문을 남기는 노이즈가 발생한다. 강한 evidence 쪽을 유지하고 약한 쪽은 trigger condition으로 강등.
-- **2-action finding 의 각 action 이 ≥1 friction-event observation 을 인용하지 않음** — Gate-3 (a) 위반. Category-default form-filling만으로 만들어진 action 은 evidence-based delivery 원칙과 충돌하며, 첫 번째 action 이 이미 수행한 결정을 두 번째가 반복-질문하는 redundancy 의 전형적 신호.
-- **Surfacing an option as `(Recommended)` or default without running a disconfirming test on the recommendation's own premise** — premise verification at HIGH-confidence lock is mandatory. The user's push-back is a trailing signal; pre-emptive self-falsification is the correct path. (Pairs with the upstream `Falsify Before Fix` global rule.)
-- **Emitting `AskUserQuestion` with a `(Recommended)` label or confidence-anchoring framing (`safer` / `natural fit` / `안전한` / `자연스러운`) without an accompanying `Falsification:` trace line in the per-finding plan** — Stage 3 Pre-Output Falsification Gate violation. The label asserts ranking confidence that wasn't earned; downstream readers (user, hooks, retrospect parsers) cannot tell whether the premise was tested. If the gate didn't run, drop the label and surface the option unranked.
-- **Stage 3 ranking that contradicts Stage 2 caveats** — e.g., `(Recommended)` applied to an action whose Stage 2 row carries `tracer confidence: LOW`, `single observation` alone, or `alternative root cause not ruled out`. Stage 2's caveat is the leading signal; Stage 3 must carry it forward (`Stage 2 caveats:` line) and either discharge it via falsification or suppress the recommendation.
-- **`upstream_feedback` 행의 `backing_repo` owner가 own-org 밖인데 Stage 2.5 Gate-4 마킹(`⚠ EXTERNAL: per-action approval required at Stage 4` prefix) 없이 Stage 3 진입** — Gate-4 가 실행되지 않은 것. Stage 2.5로 돌아가 Gate-4 재실행.
-- **external-marked finding 의 Stage 4 `upstream_feedback` 실행에서 AskUserQuestion per-action 승인(step 0a) 없이 `gh issue create` 직행** — global `~/.claude/CLAUDE.md` zero-exception 룰 위반. STOP, step 0a AskUserQuestion 실행 먼저.
-- **`memory` action 이 있는 finding 에서 `memory_scan` 필드 없이 Stage 2.5 Gate-5 진입** — Stage 2 step 7 스킵 증거. Stage 2 step 7로 돌아가 2-hop 스캔을 완료하고 `memory_scan` 필드를 기록하라. "MEMORY.md를 이미 알고 있어서 스캔이 필요 없다"는 Gate-5 우회 근거로 인정되지 않는다.
-- **Using a different-oracle probe (different matching basis / cohort / unit) to falsify or correct a stored value without same-oracle confirmation** — Stage 2 step 7h / Gate-6 violation. A probe run under a different oracle measures a different quantity; it cannot invalidate the stored value. STOP — re-probe with the originating oracle, or surface the result as a separate cohort-shift finding (leaving the stored value untouched), or defer + propose an entry-annotation update when the entry body does not state its oracle. (e.g., the warehouse-partition-key vs FK-rowid measurement basis yielded a 9h latency shift that was NOT a falsification of the stored value but a cohort-shift artifact.)
-- **Stage 3 "Execute now" 선택을 external-repo write 의 per-action 승인으로 ratify** — Stage 3 승인은 action 카테고리 선택이지, 외부 repo 개별 write 승인이 아님. Stage 4 step 0a 게이트를 반드시 별도로 실행.
-- **Omitting the `Stage 2 caveats:` line on a finding that has any of: tracer confidence below HIGH, single observation, alternative root cause not ruled out, Gate-3 downgrade, analyst cluster overlap, escape-hatch state** — carry-forward is mandatory whenever ANY of these holds. Silent omission lets Stage 3 rank as if Stage 2 returned clean HIGH-confidence evidence.
-- **조사 도구 결과를 completeness 검증 없이 결론에 사용 (premise unverified)** — 다음 두 패턴 모두 "premise falsified" (반증 테스트를 설계한 뒤 통과 → 진행 가능)가 아니라 "premise unverified" (도구 출력 자체의 한계를 검증하지 않은 채 결론에 사용 → STOP) 에 해당한다: (a) `find ... | head -N` 결과로 "파일/모듈 없음" 단정 — **`head` 를 제거한 원 명령 `find ... | wc -l` 을 별도로 실행**해 총 라인 수를 확인하고, cap 초과 시 cap 제거 또는 `grep -rn <token>` narrowing 필요 (`head -N` 파이프 뒤에 `| wc -l` 을 붙이면 cap 으로 잘린 뒤의 라인 수만 세므로 정확히 N개와 cap 초과를 구분할 수 없어 검증이 실패한다); (b) `find <path>` 빈 결과로 "경로/모듈 없음" 단정 — `ls <parent>` 로 path coverage 를 확인하거나 상위 경로로 재시도, 또는 `grep -rn <token>` cross-check 필요.
-- **Stage 1.5 hygiene scan을 "MEMORY.md가 작아서" 또는 "이미 다 안다"는 이유로 건너뜀** — Stage 1.5는 unconditional. 코퍼스 크기와 무관하게 cap-and-cursor 메커니즘으로 비용이 amortized 된다. "내가 이미 안다" 는 author-exempt verification trap 의 변형 — Stage 1.5의 detect-only 책임을 Stage 2 friction-scanner 가 대신할 수 없다 (silent recurrence는 마찰 신호 없이 누적).
-- **Stage 2.7 audit-skip을 trail 라인 없이 silent으로 처리** — `<!-- retrospect:audit_skipped: no artifacts -->` (또는 `transcript unreadable` variant)은 mandatory. trail 라인 부재 시 "Stage 2.7이 실행되었는가" vs "스킵되었는가" vs "잊혀졌는가" 를 retrospective audit이 구분할 수 없다. 0-trigger silent skip path도 trail 라인은 emit 한다.
-- **0-friction exit에서 empty `dismissed_candidates` fence를 emit했으나 step (a) 열거가 rule-violation match를 surface함** — enumerate-before-empty-fence 요건 위반. codex/review-bot output(Codex CLI reviewer, BugBot comment, oh-my-claudecode reviewer result, Cursor annotation) 중 **rule violation에 해당하는** match가 있는데도 `dismissed_candidates` fence가 비어 있으면, 열거 결과를 ledger에 기록하지 않은 증거. STOP, rule-violation match를 모두 ledger 라인으로 기록한 뒤 emit. (style nit / refactor suggestion만 있는 output block은 위반이 아니며 empty fence가 정상 — 단순 output block 존재만으로는 Red Flag 아님.)
-- **`tool_census` lane을 건너뛰고 step 4b를 friction_events 만으로 실행** — usage-gated 전환의 핵심을 무효화. census lane은 결정론적(transcript-derived)이므로 "마찰이 없었으니 점검할 도구가 없다"는 스킵 근거로 인정되지 않는다 — 마찰 없이 깨끗하게 쓰인 도구가 바로 census가 잡으려는 사각지대다. transcript가 닿지 않을 때만 `census_skipped` trail 라인과 함께 스킵 허용. trail 라인 없이 census fence를 통째로 생략하는 것은 "실행했는가 vs 스킵했는가 vs 잊었는가"를 구분 불가하게 만드는 Red Flag.
-- **promoted census finding(step 4b 승격 파이프라인 통과: signal AND post-dedup AND post-cap)이 있는데 0-friction "No patterns found" 경로로 early exit** — Census carve-out 위반. 깨끗하게 쓰였지만 `error_count`/`retry`/`workaround` 신호를 가진 도구는 finding으로 승격되어야 하며, 그 존재가 early exit을 막는다. STOP, Stage 2.5 → Stage 3 populated-table 경로로 진행.
-- **`user_correction` marker scan을 건너뛰고 friction_events를 narrative pre-scan만으로 구성** — usage-gated 탐지의 사용자-대면 축을 무효화. marker scan은 결정론적(user-turn-derived)이므로 "내가 사용자 교정을 다 narrate했다"는 스킵 근거로 인정되지 않는다 — 에이전트가 자발적으로 narrate하지 않은 교정이 바로 이 lane이 잡으려는 사각지대다 (narrative lane은 self-serving). transcript가 닿지 않을 때만 `user_correction_skipped` ledger 라인과 함께 스킵 허용.
-- **marker-매칭 user-turn candidate를 LLM judge가 false-positive로 떨어뜨렸으나 `user_correction` ledger에 기록 없이 silent drop** — judge 단계 self-serving 은폐. dismissed_candidates의 "Silent dismissal ... is BLOCKED" Red Flag와 동일 — 모든 drop은 reason + cite와 함께 ledger 라인으로 기록되어야 한다. STOP, 떨어뜨린 candidate를 ledger에 기록하라.
-- **self-corrected 실수를 "그 자리에서 고쳤으니 friction 아님"으로 friction_events에서 누락** — `self_correction` lane (pre-scan lane 5) 스킵. 자가-교정 이벤트는 narrative lane이 가장 self-servingly 누락하는 부류다 (#572). self-correction signature(동일 의도 + oracle/target/basis 변경 + 이전 결과가 errored가 아니라 wrong)는 결정론적으로 enumerate 되어야 하며, "내가 다 narrate했다"는 스킵 근거로 인정되지 않는다. transcript가 닿지 않을 때만 `self_correction_skipped` ledger 라인과 함께 스킵 허용.
-- **signature-매칭 self_correction candidate를 LLM judge가 false-positive로 떨어뜨렸으나 `self_correction` ledger에 기록 없이 silent drop** — 가장 self-serving한 judge 단계(에이전트가 자신의 교정한 실수를 스스로 판정)의 은폐. 모든 drop은 reason + cite와 함께 ledger 라인으로 기록되어야 한다. STOP, 떨어뜨린 candidate를 ledger에 기록하라.
-- **friction event가 file / hook / CLI 같은 직접 읽을 수 있는 아티팩트를 가리키는데 tracer 호출 전 Pre-agent artifact probe 없이 (briefing에 `probed artifact:` / `probe skipped:` 라인 부재) 바로 agent 호출** — One-Probe-Before-Action 위반 (#574). agent에게 추정 대신 확정 사실을 줘야 한다. "agent가 구현을 알아낼 것"으로 cheap read를 미루는 것은 Red Flag. STOP, 아티팩트를 1회 읽고 briefing에 `probed artifact: <path> → <확정 사실>` 라인을 추가하라 (또는 probe 비용 > agent 비용이면 `probe skipped: <reason>`).
-- **behavioral-단일 라벨 finding의 root cause에 spec-gap/tool/workflow 신호 키워드(`probe`/`scope`/`skill`/`hook`/`missing`/`gap`/`누락`/`미구현`/`flag`/`--<opt>` 등)가 있는데 `behavioral-label-justify:` 라인도, 추가 category도 없이 Stage 3 진입** — per-finding behavioral-label falsification 위반 (#574). gate에 유리한 단일 라벨로 좁히는 label 역산 경로. dual-nature finding은 `category[]`에 모든 해당 category를 표기해야 한다. STOP, Gate-1 / step 4로 돌아가 라벨을 재평가하거나 `behavioral-label-justify:` 한 줄로 대안 라벨을 반증하라.
-- **carried finding의 probe가 unrunnable(접근 불가 / 상위 룰 충돌)인데 Hygiene Scan Trail에 `probe=UNRUNNABLE (...)` 기록 없이 silent retain 또는 silent drop** — carry-forward probe-unrunnable 분기 위반 (#574). 무한 carry와 silent drop 둘 다 차단되어야 한다. access-blocked-only finding을 auto-drop 하거나, drop 시 충돌 룰 + 연속 cycle 카운트를 기록하지 않는 것도 Red Flag. STOP, trail에 명시 라인을 기록하고 retain/bounded-drop 규칙(rule-conflict AND N연속 cycle)을 적용하라.
-- **applied-on-branch claim ("X가 dev/prod/브랜치 Y에 적용됨/배포됨/차단됨", "deployed to prod", "blocked since ...")을 inline `Probe: <command> → <output>` 인용 없이 stage 출력·리포트·타임라인 서사에 기재** — reference-frame collapse (#656). ref A에 존재 = ref B에 적용이 아니다: PR `state=MERGED`는 base가 feature branch(stacked PR)일 수 있고, dev 커밋 날짜는 prod 적용 시점이 아니다. 검증 명령은 `gh pr view <N> --json state,baseRefName`(PR 기반) / `git merge-base --is-ancestor <commit> origin/<target>`(커밋 기반). codex-review-wrap의 critic pre-lock probe와 동일 인용 패턴 — probe 없는 applied claim은 서사가 아니라 가설이다. STOP, reachability probe를 실행하고 출력과 함께 인용하라.
+- Acting from a stage summary without reading its linked reference
+- An `AskUserQuestion` recommendation without an accompanying `Falsification:` trace line
+- Stage 3 ranking that contradicts Stage 2 caveats
+- Omitting the `Stage 2 caveats:` line when caveats apply
+- Silent overwrite of a concurrently-advanced cursor
 
-**ALL of these mean: STOP. Return to Stage 2.**
+The exhaustive Red Flag catalog is in
+[`references/appendices.md`](references/appendices.md).
 
 ## Quick Reference
 
-| Stage | Key Activity | Success Criteria |
-|-------|-------------|-----------------|
-| **1. Load** | Read global `~/.claude/CLAUDE.md`, form scan questions | Rule categories identified |
-| **1.5 Hygiene** | Detect-only MEMORY.md scan — stale references / contradictions / merge candidates (cap 5 files/invocation + cursor carryover) + size threshold (index-scoped, every invocation; subsignals 4a/4b/4c) + missing oracle annotation (signal 5 — stored numeric values lacking matching basis / cohort / unit) | Stage 1.5 findings emitted with `category: memory_hygiene` (or `hygiene_skipped` trail if MEMORY.md unreachable) |
-| **2. Analyze** | Scan conversation (5 pre-scan lanes: friction / successful / tool_census / user_correction / self_correction), map to rules, find root cause; step 4b runs usage-gated (friction-driven + census-driven lanes) | Root cause (not symptom) for each pattern; every event has `category[]`; tool_census trail emitted (every tool inventoried, promoted only on objective signal); user_correction + self_correction ledgers emitted (every judged drop recorded; genuine corrections promoted to friction events) |
-| **2.7 Audit** | Adaptive post-hoc artifact audit — fires only when session contains `gh pr|issue|comment` / Slack-Notion MCP write / approved external-write events; runs 3 sub-audits (PR mergeability, sub-agent substance, external comment evidence) | Stage 2.7 findings emitted with `category: output_quality` (or `audit_skipped` trail if 0 triggers) |
-| **2.5 Audit** | Run Gate-1 (categorical) + Gate-2 (Schema A 5-line or Schema B dimension-tag rationale) + Gate-3 (evidence robustness for 2-action findings) + Gate-4 (external-repo authorization pre-check for upstream_feedback) + Gate-5 (memory-scan completeness for memory-action findings) + Gate-6 (oracle-match completeness for stored-value corrections) | All applicable gates PASS/WARN or per-finding cap reached and surfaced to user |
-| **3. Report** | Present unified table + distribution card, carry Stage 2 caveats forward, run Pre-Output Falsification Gate before each `AskUserQuestion`, collect approval per item | User approved at least 1 item (or confirmed 0 findings); every `(Recommended)` label has a `Falsification:` trace |
-| **4. Execute** | Run approved actions, verify artifacts | Completion report with links/paths + verification results |
+| Stage | Minimum check |
+|-------|---------------|
+| Stage 1 | Load rule files and calibration questions |
+| Stage 1.5 | Cursor schedule honored; detect-only hygiene scan executed |
+| Stage 2 | Five pre-scan lanes + categories + early-exit carve-outs checked |
+| Stage 2.5 | Gates 1-6 evaluated before any Stage 3 output |
+| Stage 3 | Pre-Output Falsification Gate before each `AskUserQuestion` |
+| Stage 4 | Reference procedure read; artifact verified after execution |
+
+Full tables and stage-by-stage failure handling are in
+[`references/appendices.md`](references/appendices.md).
 
 ## Error Handling
 
 | Stage | Failure | Action |
 |-------|---------|--------|
-| Stage 1 (load) | `~/.claude/CLAUDE.md` not found (global) or `AGENTS.md` not found (project) | Proceed with global defaults; flag the missing file in the report |
-| Stage 1.5 (hygiene) | MEMORY.md index not accessible | Skip Stage 1.5 entirely; emit `<!-- retrospect:hygiene_skipped: index not accessible -->` trail line; proceed to Stage 2 |
-| Stage 1.5 (hygiene) | Cursor file (`.omc/state/retrospect-hygiene-cursor.json`) corrupt | Reset cursor to most-recently-modified 5 files; log reset in completion report |
-| Stage 1.5 (hygiene) | Per-file scan failure (one of N files unreadable) | Continue with remaining files; record per-file failure in Stage 3 report Hygiene Scan Trail section |
-| Stage 2 (analyze) | Session history not accessible | Fall back to the user's verbal summary as input to steps 3–8 |
-| Stage 2.7 (audit) | Trigger detection scan failed (e.g., transcript unreadable) | Emit `<!-- retrospect:audit_skipped: transcript unreadable -->` trail line; skip Stage 2.7; proceed to Stage 2.5 |
-| Stage 2.7 (audit) | 0 triggers detected (no PR/external-write artifacts in session) | Silent skip with mandatory trail line `<!-- retrospect:audit_skipped: no artifacts -->` AND `output_quality: 0` in distribution card |
-| Stage 2.7 (audit) | `gh pr view` API failure for a specific PR | Log per-PR error in Stage 3 report Audit Trail section; continue with remaining PRs |
-| Stage 2.7 (audit) | Mid-session artifact deletion (e.g., PR was created then closed by user before retrospect) | Treat as audit signal — closed-without-merge IS a finding (per Sub-audit 1 trigger). If artifact entirely removed (issue/PR deleted), log "artifact no longer accessible" in Audit Trail; do not emit finding for that artifact |
-| Stage 2 (census) | Transcript unreachable for tool inventory (post-compaction) | Skip the census lane; emit `<!-- retrospect:census_skipped: transcript unreachable -->` as the tool_census fence body; the Census carve-out does not fire; proceed with friction-driven 4b only |
-| Stage 2 (census) | A single tool call's name is unparseable | Skip that inventory row; continue with remaining tools; note the skip in the tool_census trail |
-| Stage 2 (census) | Zero tool calls in the scope window (pure-conversation session) | Emit an empty tool_census fence; no findings; Census carve-out does not fire |
-| Stage 2 (census) | `PRAXIS_RETROSPECT_CENSUS_*` env var malformed (non-integer / negative) | Silent fallback to documented default (2 / 5); no Stage 2 failure |
-| Stage 2 (user_correction) | Transcript unreachable for user-turn scan (post-compaction) | Skip the marker scan; emit `<!-- retrospect:user_correction_skipped: transcript unreachable -->` as the ledger fence body; fall back to narrative friction_events only (the user's verbal summary remains an input per the analyze fallback) |
-| Stage 2 (user_correction) | Marker matched but LLM judge cannot classify a candidate (ambiguous) | Default to PROMOTING as a genuine behavioral friction event (a false positive surfaces a benign finding for user dismissal; a false negative silently loses a real correction — the asymmetry favors promotion). Do NOT silently drop. Mark the event `origin: user_correction (ambiguous)` so the disposition stays auditable — promotions are not ledger-recorded (the ledger records drops only), so the origin suffix is the only trace distinguishing a confident-genuine promotion from an ambiguous-default one |
-| Stage 2 (user_correction) | Zero user-turn corrections in the scope window | Emit an empty user_correction ledger fence; no findings; early-exit proceeds normally (no genuine correction to block it) |
-| Stage 2 (self_correction) | Transcript unreachable for the signature scan (post-compaction) | Skip the signature scan; emit `<!-- retrospect:self_correction_skipped: transcript unreachable -->` as the ledger fence body; fall back to narrative friction_events only |
-| Stage 2 (Gate-7 receipt) | Post-compaction marker present, transcript readable, but `retrospect:transcript_receipt` fence absent from the Stage 3 report | Stop hook `retrospect-mix-check` blocks Stage 3 — run the full-transcript friction scan and emit the receipt fence (Stage 3 output §3e) with the real command output before re-presenting |
-| Stage 2 (Gate-7 receipt) | Transcript genuinely unreachable (jsonl absent/unreadable) in a post-compaction session | Emit `<!-- retrospect:transcript_receipt_skipped: transcript unreachable -->` in place of the fence; the Stop hook fail-opens (it cannot read the transcript either, so it exits 0 per the `[ ! -f "$TRANSCRIPT_PATH" ]` guard) |
-| Stage 2 (self_correction) | Signature matched but LLM judge cannot classify a candidate (ambiguous self-correction vs progressive refinement) | Default to PROMOTING as a genuine behavioral friction event (a false positive surfaces a benign finding for user dismissal; a false negative silently loses a self-corrected pattern — the asymmetry favors promotion, since self-corrected events are the #572 blind spot). Mark the event `origin: self_correction (ambiguous)` so the disposition stays auditable |
-| Stage 2 (self_correction) | Zero self-correction signatures in the scope window | Emit an empty self_correction ledger fence; no findings; early-exit proceeds normally |
-| Stage 2 (analyze) | No friction events found | Exit with "No patterns found. ✅" — do not fabricate findings (subject to the Census carve-out: a promoted census finding overrides this exit) |
-| Stage 2 (analyze) | MEMORY.md scan failed (file not accessible) | Treat all findings as new patterns (repeat=false). Flag scan failure in report |
-| Stage 2 (analyze) | MEMORY.md is empty | Normal processing — all findings are new patterns |
-| Stage 2 (analyze) | tracer/analyst call failed | Fall back to manual analysis. Flag agent failure in report. Warn about reduced root cause quality |
-| Stage 2 (analyze) | Pre-scan event missing `category[]` label | Block Stage 2 progression to step 3; instruct LLM to backfill labels per Layer E enumerated values |
-| Stage 2.5 (audit) | Gate-1 violation persists after 2 per-finding re-entries | Surface to user with override prompt; log user-supplied rationale |
-| Stage 2.5 (audit) | Gate-2 violation persists after 2 per-finding re-entries | Surface to user with override prompt; log user-supplied rationale |
-| Stage 2.5 (audit) | Gate-3 violation persists after 2 per-finding re-entries | Surface to user with 3-way override prompt (`[a] rationale 직접 입력 / [b] action 직접 지정 / [c] note only 강등`); log selection |
-| Stage 2.5 (audit) | Gate-3 (c) downgrade collapses action set to memory-only on a tool/workflow/spec-gap finding | Re-trigger Gate-1; counts toward the per-finding loop cap of 2 |
-| Stage 2.5 (audit) | Behavioral-only safeguard triggered (tool keywords detected in pre-scan signals) | Surface to user; require explicit confirmation before proceeding to Stage 3 |
-| Stage 2.5 (audit) | Per-finding behavioral-label falsification — behavioral-only finding's root cause carries a spec-gap/tool/workflow signal keyword with neither a `behavioral-label-justify:` line nor the added category (#574) | Return finding to Gate-1 / step 4 for label re-evaluation; per-finding loop cap applies (same accounting as a Gate-1 mislabel re-entry) |
-| Stage 2 (analyze) | Pre-agent artifact probe — a friction event names a file/hook/CLI but the artifact is not directly readable (out of scope / live system / behavior-pattern question) (#574) | Skip the probe (cost > agent cost); record `probe skipped: <reason>` in the tracer briefing so the omission is auditable; proceed to the agent call |
-| Stage 1.5 (hygiene) | Carried-finding falsification probe is unrunnable — access-blocked or re-running would violate a higher rule (#574) | Record `probe=UNRUNNABLE (<reason>)` in the Hygiene Scan Trail; RETAIN by default. Auto-drop only when rule-conflicted AND unrunnable for `PRAXIS_RETROSPECT_UNRUNNABLE_DROP_CYCLES` (default 3) consecutive cycles, recording the conflicting rule + cycle count; access-blocked-only findings never auto-drop |
-| Stage 1.5 (hygiene) | `PRAXIS_RETROSPECT_UNRUNNABLE_DROP_CYCLES` malformed (non-integer / negative) | Silent fallback to documented default (3); no Stage 1.5 failure |
-| Stage 2.5 (audit) | Gate-4 — `backing_repo` declaration absent (cannot extract owner) | Skip this finding in Gate-4; Stage 4 Action 4 step 0's missing-declaration abort handles it downstream |
-| Stage 2.5 (audit) | Gate-4 — `gh api user --jq .login` fails and `PRAXIS_OWN_ORGS` is unset | Conservative default: treat all `upstream_feedback` findings as external; emit `gate_4_verdict: WARN` |
-| Stage 2.5 (audit) | Gate-5 — memory-action finding missing `memory_scan` field after 2 re-entries | Surface to user with 3-way override prompt (`[a] 직접 MEMORY.md 읽고 memory_scan 입력 / [b] action 직접 지정 / [c] note only 강등`); log selection |
-| Stage 2.5 (audit) | Gate-5 — MEMORY.md index not accessible during step 7 scan | Record `memory_scan: {scanned: true, candidates_reviewed: [], error: "index not accessible"}` and treat all findings as new patterns (repeat=false) |
-| Stage 2.5 (audit) | Gate-6 — stored-value-correcting finding has `oracle_match: false` or absent after 2 re-entries | Surface to user with 3-way override prompt (`[a] 같은 oracle 로 재측정 / [b] 별도 cohort-shift finding 으로 전환 (stored value 유지) / [c] note only 강등`); log selection |
-| Stage 2.5 (audit) | Gate-6 — originating oracle un-determinable (entry body lacks oracle/unit annotation) | Defer falsification; propose an entry-annotation update (`memory`, Stage 4 update path) adding the missing oracle/unit so a future cycle can falsify with a known basis; record `oracle_match: false, falsification_oracle: deferred` |
-| Stage 3 (report) | Pre-Output Falsification Gate triggered but premise cannot be falsified or survives only ambiguously | Drop `(Recommended)` label; surface option unranked; emit explicit premise-confirmation line in `AskUserQuestion` per the gate's "Falsification step not run" row |
-| Stage 3 (report) | Finding lacks Stage 2 caveats line despite tracer confidence below HIGH or single-observation flag | Block Stage 3 emission for that finding; return to Stage 2 step 5 (root cause refinement) or Stage 2.5 Gate-3 (c) (single-observation downgrade) and re-derive |
-| Stage 3 (report) | User rejects all findings | Capture the rejection itself as a feedback signal for future retrospects |
-| Stage 4 (execute) | MEMORY.md write fails | Report the path error; never silently drop the feedback |
-| Stage 4 (execute) | GitHub issue creation fails | Fall back to saving a note in `.omc/plans/` for later manual creation |
-| Stage 4 (execute) | Upstream feedback issue creation fails | Fall back to saving a note in `.omc/plans/tool-friction-{slug}.md` with intended `tool-friction:{layer}` label and issue draft |
-| Stage 4 (execute) | `tool-friction:*` label doesn't exist (and the verified backing repo is the praxis distribution) | Auto-create with `gh label create "tool-friction:{layer}" --repo <verified-praxis-repo>` and retry |
-| Stage 4 (execute) | Action 4 step 0 — `backing_repo` declaration missing from finding row | ABORT this action; return finding to Stage 2 step 8 with prompt to emit declaration; do NOT fall back to project repo |
-| Stage 4 (execute) | Action 4 step 0 — declared vs re-resolved `backing_repo` divergence | ABORT this action; surface `AskUserQuestion` per step 0.4 prompt variants (3-way `[a] declared / [b] re-resolved / [c] skip-upstream_feedback-action`, or 2-way for AMBIGUOUS cases); do NOT auto-pick |
-| Stage 4 (execute) | Action 4 step 0a — external authorization `AskUserQuestion` declined (`[b]` picked) | Remove `upstream_feedback` from finding's action set; log in Actions Executed as skipped with reason |
-| Stage 4 (execute) | Action 4 step 0a — external authorization gate skipped without `AskUserQuestion` | STOP; return to step 0a; never auto-proceed on external-repo writes |
+| Stage 1.5 | MEMORY.md index inaccessible | skip hygiene with the documented trail line; continue to Stage 2 |
+| Stage 2 | transcript unreachable | emit the documented `*_skipped` trail line and continue with the allowed fallback |
+| Stage 3 | Pre-Output Falsification Gate triggered but premise cannot be falsified | drop ranking, surface the option unranked, and ask with open premise |
+| Stage 3 | finding lacks Stage 2 caveats line despite required caveats | block Stage 3 emission and return to Stage 2 / 2.5 |
+| Stage 4 | artifact write fails | report the failure; do not silently drop the action |
+
+The complete failure matrix is in
+[`references/appendices.md`](references/appendices.md).
 
 ## Integration
 
-**Entry point:** End of a working session, or after a particularly rough workflow experience
-**Exit point:** Completion report shown — improvements applied to the next working session
-
-**OMC delegation:**
-- `tracer` agent: causal chain analysis for complex friction patterns
-- `analyst` agent: cluster multiple friction events into root causes
-- Project's issue creation skill: GitHub issue creation in Stage 4
+- The Stop hook parses the Stage 3 distribution card and unified findings table
+- Post-compaction Stage 3 output also needs the `retrospect:transcript_receipt`
+  fence
+- Any schema drift must be co-updated with the hook and tests called out in
+  [`references/stage3-reporting.md`](references/stage3-reporting.md)

--- a/skills/retrospect/references/appendices.md
+++ b/skills/retrospect/references/appendices.md
@@ -1,0 +1,66 @@
+# Retrospect appendices
+
+Supplementary material for [`../SKILL.md`](../SKILL.md). This file holds the
+longer rationalization catalog, red-flag list, quick-reference table, failure
+matrix summary, and integration notes.
+
+## Rationalization prevention
+
+Do not bypass a mandatory step because the task feels small, safe, or familiar.
+
+Invalid rationalizations include:
+
+- "3-line fix"
+- "low blast radius"
+- "I already know this rule"
+- "the agent or CI will catch it"
+
+When you catch yourself thinking that way, run the step instead of arguing past
+it. Only the user can grant an exemption.
+
+## Red Flags — STOP
+
+The following are structural stop signals:
+
+- skipping Stage 1.5 because MEMORY.md is "small enough"
+- skipping the tool census because no tool visibly failed
+- silent dismissal of a `user_correction` or `self_correction` candidate
+- jumping to Stage 3 without reading the linked reference for the active stage
+- a behavioral-only finding whose own root-cause text points at tool/workflow
+  or spec-gap causes
+- silent retain / silent drop of an unrunnable carried-finding probe
+- any applied-on-branch or deployed-on-branch claim without a live probe
+
+## Quick Reference
+
+| Stage | Key activity | Success criteria |
+|-------|--------------|-----------------|
+| Stage 1 | Load rule files and scan questions | categories and questions are explicit |
+| Stage 1.5 | Detect-only MEMORY.md hygiene scan | cursor honored; findings emitted or documented skip trail |
+| Stage 2 | Symmetric pre-scan + analysis | root causes, categories, and audit trails are complete |
+| Stage 2.5 | Gate suite | gates 1-6 have explicit verdicts |
+| Stage 3 | Canonical report + approval | `Stage 2 caveats:` and `Falsification:` lines are present where required |
+| Stage 4 | Approved execution + verification | artifact exists and verification result is reported |
+
+## Error handling summary
+
+| Stage | Failure | Action |
+|-------|---------|--------|
+| Stage 1 | missing rule file | continue with defaults; flag it |
+| Stage 1.5 | MEMORY.md index inaccessible | emit hygiene skipped trail and continue |
+| Stage 1.5 | cursor corrupt | reset bounded batch and log the reset |
+| Stage 2 | transcript unreachable | emit the relevant skipped trail line and use the allowed fallback |
+| Stage 2.5 | gate still fails after 2 re-entries | surface the gate-specific override prompt |
+| Stage 3 | falsification gate cannot clear the premise | drop ranking and ask with open premise |
+| Stage 3 | required caveat line missing | block emission and return to Stage 2 / 2.5 |
+| Stage 4 | write / issue / hook action fails | report the failure; never silently drop it |
+
+## Integration notes
+
+- The Stop hook parses the distribution card and unified findings table
+- Post-compaction sessions also require the `retrospect:transcript_receipt`
+  fence
+- Stage 4 action procedures and artifact verification live in
+  [`stage4-execution.md`](stage4-execution.md)
+- Worked examples live in [`report-template.md`](report-template.md)
+

--- a/skills/retrospect/references/appendices.md
+++ b/skills/retrospect/references/appendices.md
@@ -63,4 +63,3 @@ The following are structural stop signals:
 - Stage 4 action procedures and artifact verification live in
   [`stage4-execution.md`](stage4-execution.md)
 - Worked examples live in [`report-template.md`](report-template.md)
-

--- a/skills/retrospect/references/report-template.md
+++ b/skills/retrospect/references/report-template.md
@@ -1,10 +1,9 @@
 # Stage 3 report template + worked examples (retrospect)
 
-Reference material for [`../SKILL.md`](../SKILL.md) Stage 3. The **Output
-Schema Contract in SKILL.md is the normative source** — on any divergence
-between this template and the contract, the contract wins. Read this file when
-composing the Stage 3 report or calibrating per-finding plans; it carries no
-mandates of its own.
+Reference material for [`../SKILL.md`](../SKILL.md) Stage 3. The **normative
+contract now lives in [`stage3-reporting.md`](stage3-reporting.md)**. Read that
+file first for the canonical emit order, schema rules, and approval gate; use
+this file for the consolidated template and worked examples.
 
 ## Consolidated report template
 
@@ -36,6 +35,12 @@ enumerate).
 <!-- retrospect:dismissed_candidates begin -->
 - {one-line candidate} | reason: {rationale} | spec_cite: {section}
 <!-- retrospect:dismissed_candidates end -->
+
+Hygiene Scan Trail
+- Current cycle: signal 1/2/3/4/5 = {one-line summary per signal, or none}
+- Carried from previous cycle (cursor note): signal N = {verbatim carried finding}
+- Falsification of carried finding (signal N): probe=`{command}` output=`{observed}` -> RESOLVED|STILL_OUTSTANDING|UNRUNNABLE
+- Cursor write: concurrent advance detected — union-merged note ({n_self} self + {n_disk} on-disk lines) + advanced pointer to {pointer}
 
 <!-- retrospect:tool_census begin -->
 - tool_name: {tool} | layer: {mcp|cli|builtin|skill} | call_count: {n} | error_count: {n} | retry_count: {n} | workaround_marker: {true|false} | surfaced_in_friction: {true|false} | signal: {none|summary}
@@ -84,6 +89,13 @@ $ python3 -c "...emit each tool_result is_error body..." {transcript_path}
 |---|----------|------------|---------|------------|------------|---------|------------------------|-----------|----------|
 | 1 | {behavioral|tool|workflow|spec-gap, ...} | {mcp|cli|builtin|skill|—} | {pattern} | {root_cause} | {rule_ref or "gap"} | {Yes(Nx)/No} | {action1[, action2]} | {rationale: 5 `not <action>:` lines for memory-only, or one-line for compound/non-memory} | HIGH/MED/LOW |
 ...
+
+<!-- memory_scan finding #<n>:
+  scanned: true
+  candidates_reviewed: <concrete paths or unreachable marker>
+  repeat: true|false
+  repeat_count: <integer>
+-->
 
 ```
 

--- a/skills/retrospect/references/stage1-2-analysis.md
+++ b/skills/retrospect/references/stage1-2-analysis.md
@@ -1,0 +1,515 @@
+# Stage 1 / 1.5 / 2 / 2.7 procedures (retrospect)
+
+Detailed procedures for the early stages of
+[`../SKILL.md`](../SKILL.md). `SKILL.md` holds the execution spine and routing;
+this file holds the full Stage 1, Stage 1.5, Stage 2, and Stage 2.7 rules.
+
+## Stage 1: Load Calibration Standard
+
+Before scanning the conversation:
+
+1. Read global and project rule files.
+   - Global: `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md`
+   - Project: `AGENTS.md` in cwd
+2. Identify the rule categories you are scanning against.
+   - workflow discipline
+   - evidence-based delivery
+   - atomic commits / PR lifecycle
+   - mandatory testing
+   - code review before commit
+   - error recovery before asking
+   - communication conventions
+3. Turn each category into a calibration question.
+   - Example: "Did this session violate Planning Before Implementation?"
+
+If a rule file is missing, proceed with defaults and flag it in the report.
+
+## Stage 1.5: MEMORY.md Hygiene Pass (Detect-only)
+
+Stage 1.5 runs unconditionally between Stage 1 and Stage 2. It detects latent
+MEMORY.md defects that do not show up as session friction.
+
+### Scope and cursor
+
+- Scan up to **5 feedback files per invocation**
+- Persist progress at `.omc/state/retrospect-hygiene-cursor.json`
+- Cursor fields:
+  - last successful timestamp
+  - `scanned_recent_batch`
+  - `next_batch_pointer`
+  - pairwise-proof trail for signals 2 and 3
+  - carry-forward `note`
+
+### Cursor read mandate (entry)
+
+If the cursor exists, before scanning any feedback file:
+
+1. Use `next_batch_pointer` as the schedule
+2. Exclude `scanned_recent_batch`
+3. Carry the `note` field forward into Stage 3 input
+
+Silent skip of the cursor read is a Red Flag.
+
+### Cursor write mandate (exit — read-modify-write union under concurrency, MUST)
+
+Before persisting the cursor:
+
+1. **re-read** the on-disk cursor
+2. Compare it with the entry snapshot
+   - the write-time timestamp is the primary concurrent-advance discriminator:
+     if the on-disk timestamp differs from the entry-read timestamp, another
+     session persisted, even when `next_batch_pointer` and
+     `scanned_recent_batch` still match
+   - do not rely on pointer/list comparison alone; same-batch concurrent
+     writes can otherwise clobber sibling `note` and scan-trail updates
+3. If no concurrent advance happened, write normally
+4. If **Concurrent advance detected**, **UNION-merge the on-disk cursor**
+   instead of overwriting:
+   - **concatenate the on-disk `note` lines** with this cycle's lines, then
+     de-duplicate byte-identical lines
+   - union the per-batch scan trail
+   - advance `next_batch_pointer` to the **FURTHER of the two pointers**
+   - union `scanned_recent_batch`
+5. Record the Stage 3 trail line:
+   `Cursor write: concurrent advance detected — union-merged note (...)`
+
+This is the cross-session complement of the single-session falsification gate.
+**Silent overwrite of a concurrently-advanced cursor** is a Red Flag.
+
+### Detection signals
+
+1. **Stale reference**
+   - Verify file paths, CLI flags, line citations, and skill/hook references
+   - Use a second probe path before concluding stale
+2. **Contradiction**
+   - Pairwise compare entries with overlapping triggers
+   - Record pairwise proof even when matches = 0
+3. **Merge candidate**
+   - Group entries that restate the same root-cause family
+   - Record pairwise proof even when matches = 0
+4. **Size threshold**
+   - Check index line count, byte size, and observed host truncation warnings
+   - Fire when line count >= `PRAXIS_RETROSPECT_INDEX_LINE_THRESHOLD`
+     (default `200`)
+   - Fire when byte size >= `PRAXIS_RETROSPECT_INDEX_BYTE_THRESHOLD`
+     (default `24000`)
+   - New writes must enforce `PRAXIS_RETROSPECT_INDEX_LINE_CAP`
+     (default `150`) per index line
+   - malformed threshold env vars silently fall back to the documented defaults
+   - Subsignals:
+     - promoted-pointer compression
+     - backlink-zero archive
+     - new-entry length cap
+
+   Link-detection helper (link-convention-agnostic): promoted-pointer
+   compression and backlink-zero archive both consume one shared scanner. The
+   scanner recognizes a reference from index entry A to artifact B when B appears
+   in A's body in any of these forms:
+
+   - `[[wikilink]]` whose target basename equals B
+   - Markdown link `[text](path)` where `path` resolves to B (relative or
+     absolute), with allowed extensions `.md`, `.txt`, `.json`, `.py`, `.sh`
+   - Bare basename mention: a single-token `<B>.<ext>` (minimum 4 chars, allowed
+     extensions above) outside code fences
+
+   A scan failure on one form falls through to the next. Only when all three
+   forms fail to match does an entry count as backlink-zero.
+5. **Missing oracle annotation**
+   - Detect numeric measurements whose oracle / cohort / unit is not recorded
+
+### Output and carry-forward rules
+
+- Emit findings as `category: memory_hygiene`
+- `Tool Layer` is `—` by default; use `skill` only when a skill/hook artifact
+  is directly implicated
+- Set provisional `Proposed Actions` by signal, finalized by Stage 2.5:
+  - stale reference -> `memory`, or `claude_md_draft` when the stale citation
+    is itself a rule line that needs updating
+  - contradiction -> `memory + issue` so both entries are surfaced for human
+    resolution before merge
+  - merge candidate -> `memory` through the Stage 4 merge path
+  - size threshold / promoted-pointer compression -> `memory`
+  - backlink-zero archive -> `issue` for human-confirmed archive movement
+  - new-entry length cap -> `memory` with the cap as a write-time guard
+  - missing oracle annotation -> `memory`
+- Stage 1.5 is detect-only: no inline MEMORY.md mutation
+- If Stage 2 finds zero friction but Stage 1.5 produced findings, use the
+  hygiene-only path instead of the early exit
+
+### Hygiene Scan Trail
+
+When Stage 1.5 runs, Stage 3 must carry:
+
+- current-cycle summary
+- carried findings from the cursor `note`
+- falsification result when the current cycle contradicts a carried finding
+
+If a carried finding's probe is unrunnable:
+
+- record `probe=UNRUNNABLE (...)`
+- retain by default
+- auto-drop only for repeated rule-conflict cases per the bounded-drop rule
+
+Bounded-drop rule:
+
+- a rule-conflict carried finding may be auto-dropped only after
+  `PRAXIS_RETROSPECT_UNRUNNABLE_DROP_CYCLES` consecutive cycles (default `3`)
+  with `probe=UNRUNNABLE` and no fresh supporting evidence
+- access-blocked-only findings are never auto-dropped; retain them until the
+  artifact becomes readable or the user explicitly clears the finding
+- every drop must leave a Stage 3 trail line with the carried finding id,
+  cycle count, and reason
+
+### Failure modes
+
+- MEMORY.md inaccessible -> emit `<!-- retrospect:hygiene_skipped: index not accessible -->`
+- cursor corrupt -> reset to a bounded batch and log the reset
+- unreadable file inside batch -> continue with the remaining files
+- index unreadable for size measurement -> skip signal 4 only
+
+## Stage 2: Analyze Conversation
+
+Stage 2 starts with a symmetric pre-scan before any agent calls.
+
+### Pre-scan lanes
+
+Scope window: scan the current session boundary when available; otherwise scan
+the last 50 turns. Post-compaction sessions must use the available transcript
+jsonl when readable and emit the Stage 3 transcript receipt trail. The same
+scope window applies to `tool_census`, `user_correction`, and
+`self_correction`, so their counts and early-exit decisions share one oracle.
+
+1. **`friction_events`**
+   - up to 5 friction events feeding the friction analysis path
+2. **`successful_patterns`**
+   - up to 3 successful patterns
+   - each needs `pattern`, `evidence`, and `reinforce_action`
+3. **`tool_census`**
+   - deterministic inventory of every tool used in scope
+   - row shape:
+     - `tool_name`
+     - `layer`
+     - `call_count`
+     - `error_count`
+     - `retry_count`
+     - `workaround_marker`
+     - `surfaced_in_friction`
+     - `signal`
+   - `retry_count` is failure-driven only: same tool + parameters re-issued
+     after a failed, errored, or unexpected-output prior call. Intentional
+     polling, repeated status reads, and background-output re-reads (for example
+     `write_stdin` polls, progress polling, or reading a growing log) are not
+     retries and must not increment this counter even when consecutive.
+4. **`user_correction`**
+   - deterministic marker scan of user turns
+   - candidate classes and recall-floor markers:
+     - `negation`: `아니`, `그거 아니야`, `하지 마`, `그거 말고`,
+       `no`, `don't`, `stop`
+     - `redirect`: `~라니까`, `~하라고 했잖아`, `그게 아니라`,
+       `내 말은`, `다시`, `I said X`, `not that`
+     - `mismatch`: `~하라니까 ~하고 있네?`, `왜 X 안 하고 Y?`,
+       `왜 ~했어`, `that's not what I asked`
+   - Python `re.\w` / `\b` is Unicode-aware; for ASCII boundaries in mixed
+     Korean/English text use explicit ASCII guards such as
+     `(?<![a-z])foo(?![a-z])`
+   - cap priority: when more than 5 friction events exist, genuine `user_correction` events rank first for the retained `friction_events` slots; a narrative-only event yields before a user correction is dropped
+   - false-positive drops must be recorded in the ledger
+5. **`self_correction`**
+   - deterministic signature scan of agent self-correction sequences
+   - signature families: `oracle-mismatch`, `wrong-target`, `basis-change`
+   - a candidate requires all three:
+     1. same intent
+     2. changed oracle, target, or basis
+     3. prior result was wrong or superseded, not merely errored
+   - identical command re-runs are retries; broadening a correct-but-incomplete
+     search is progressive refinement, not self-correction
+   - cap priority: genuine self-corrections rank after genuine
+     `user_correction` events and before narrative-only events for retained
+     `friction_events` slots
+   - false-positive drops must be recorded in the ledger
+
+### Categorization
+
+Every emitted finding must carry at least one category:
+
+- `behavioral`
+- `tool`
+- `workflow`
+- `spec-gap`
+- `memory_hygiene`
+- `output_quality`
+
+Rules:
+
+- `tool` requires `Tool Layer = mcp|cli|builtin|skill`
+- `behavioral`-only findings use `Tool Layer = —`
+- `workflow`, `spec-gap`, and `memory_hygiene` may optionally use `skill`
+  when the skill itself is part of the problem surface
+
+### Core Stage 2 sequence
+
+1. Run the pre-scan
+2. Emit the Pre-scan Checklist and dismissed-candidate ledger inputs
+3. Run tracer / analyst on the friction path
+4. Derive root causes
+5. Cluster overlaps
+6. Run the MEMORY.md repeat scan
+7. Assign provisional actions
+8. Run Stage 2.7 when triggered
+
+#### Action assignment (step 7)
+
+Auto-assign provisional `Proposed Actions` from the escalation ladder below.
+Use `event.effective_repeat` from the MEMORY scan as the repeat signal; for
+singleton events it equals `event.repeat_count`. Apply Repeat-based rows first,
+then Category-default rows when `category[]` makes memory-only inappropriate
+even on first occurrence.
+
+For clusters with the same root cause in one session, fold the cluster back
+into repeat escalation before assigning actions:
+
+- compute `cluster_repeat_count = max(repeat_count) + (cluster_event_count - 1)`
+- propagate that value to every cluster member as `event.effective_repeat`
+- use the propagated `event.effective_repeat` for all Repeat-based rows, so a
+  new member of a repeated cluster does not stay at `repeat_count=0`
+
+| Condition | Action Type | Rationale |
+|-----------|-------------|-----------|
+| New pattern with structural root cause | `memory` | First occurrence; capture for future reference |
+| Repeat in MEMORY.md, 1-2x | `issue` | Memory alone failed; needs systemic fix |
+| Repeat 3x+ | `hook_code` or `skill_idea` | Multiple memory entries indicate an enforcement gap |
+| Missing rule, new | `claude_md_draft` | No rule exists for this pattern |
+| Missing rule + repeat | `claude_md_draft`, `issue` | Missing rule caused recurrence |
+| Tool friction from step 4b | `upstream_feedback` | Tool improvement belongs in the tool's backing repo |
+| One-off situational mistake | `note only` | No persistent action needed |
+| Category default — `tool` | `upstream_feedback` (compound with `memory` only when behavioral co-label exists) | Tool defect is not a Claude behavior issue |
+| Category default — `workflow` | `hook_code` or `skill_idea` | Skipped workflow steps need structural enforcement |
+| Category default — `spec-gap` | `claude_md_draft` or `skill_idea` | Rule gaps are filled with rules or skill changes |
+| Category default — `behavioral` | `memory` | Only category where memory-alone is acceptable |
+
+Distinguish "new pattern" from "one-off mistake" by recurrence likelihood:
+structural root causes are new patterns; typo/context-loss edge cases are
+one-off. When uncertain, default to `memory`.
+
+If `repeat=true`, `Proposed Actions` must not be `memory` alone. The only
+escape hatch is `repeat=true AND resolved=true`, where `note only` is allowed
+with a report sentence confirming the existing resolution still works.
+
+For any row whose `Proposed Actions` contains `upstream_feedback` or `issue`,
+the `Rationale` cell must include a literal `backing_repo: <owner>/<repo>` line,
+embedded with `<br>` separators when rendered in the Stage 3 table. The Stop
+hook treats both actions as routed actions, and Stage 4 re-reads this declaration
+as the routing decision before creating either upstream feedback or project issue
+artifacts.
+
+Resolve `backing_repo:` from these sources, in order:
+
+1. Plugin manifest `repository` field
+2. MCP server git remote
+3. Dotfiles backing repo via symlink chain
+4. Project `AGENTS.md` feature-to-repo mapping
+
+If the layer is unresolvable (`builtin`, or no upstream reachable per Stage 4
+Action 4's routing table), remove `upstream_feedback` from the action set and
+re-derive the remaining action from the ladder. Do not emit a placeholder
+`backing_repo`. If the layer is ambiguous, keep `upstream_feedback` only after
+surfacing the repo choice to the user at Stage 2; that user-selected repo
+becomes the declared `backing_repo:`.
+
+#### Tool-friction promotion pass (step 4b)
+
+Run this pass after the behavioral / workflow friction scan and before root
+cause clustering. It promotes objective tool defects into `category: tool`
+findings so they do not disappear behind behavioral memories.
+
+Tool layers to scan:
+
+| Layer | Examples | Friction signals |
+|-------|----------|-----------------|
+| `mcp` | custom or third-party MCP servers | slow response, missing field, schema mismatch, timeout |
+| `cli` | `gh`, `kubectl`, `git`, project CLIs | missing flag/option, undocumented behavior, workaround needed |
+| `builtin` | Read/Edit/Bash/Grep/Glob, Agent, hooks | environmental constraint, permission issue, output truncation |
+| `skill` | praxis / OMC / project-specific skills and subagents | stage boundary unclear, trigger mismatch, prompt defect, wrong routing |
+
+For each tool-friction event or promoted census row, record:
+
+- `tool_name`
+- `layer`
+- `origin`: `friction` or `census`
+- `friction_type`: missing feature, design defect, documentation gap,
+  performance issue, or integration mismatch
+- `evidence`: event citation, or census row `signal` plus call site
+- `expected_behavior`
+- `proposed_fix_direction`
+
+Promotion rule: if the census row carries objective evidence (`error_count > 0`,
+`retry_count > 0`, `workaround_marker`, or a non-empty `signal`) and it is not
+already represented by an equivalent step-4 finding, promote it as a tool
+finding. Cap promoted census-origin findings at
+`PRAXIS_RETROSPECT_CENSUS_FINDING_CAP` (default `5`) and record non-promoted
+rows in the `retrospect:tool_census` trail.
+
+Dedup rule: if a single moment has both a rule violation and a tool defect,
+record both findings. The step-4 finding addresses what the agent should have
+done differently; the step-4b finding addresses what the tool should improve.
+The two findings may have different action types.
+
+Backing-repo signal: for any promoted tool finding likely to become
+`upstream_feedback`, carry the source needed by Stage 2 step 7 / Stage 4 Action
+4 to resolve `backing_repo:`. If the layer is unresolvable, do not fabricate a
+placeholder; let step 7 remove or re-derive `upstream_feedback`.
+
+#### Mandatory tracer / analyst calls
+
+TRACER + ANALYST CALLS ARE MANDATORY, NOT OPTIONAL when
+`friction_events` is non-empty:
+
+- before invoking the tracer, run one cheap artifact probe when the friction
+  event names a directly readable file, hook, skill, CLI, or command output
+- include the probe result in the tracer brief as `probed artifact:`; if the
+  artifact cannot be probed, include `probe skipped:` with the reason
+- the artifact probe informs the tracer; it does not replace the mandatory
+  tracer call
+- invoke the tracer first on the friction path and preserve its hypothesis,
+  evidence, and confidence in Stage 2 caveats
+- invoke the analyst after tracer output to cluster overlap and identify
+  shared root-cause families
+- do not replace either call with a local summary; if an invocation is
+  unavailable, record the failure explicitly and carry the caveat into Stage 3
+
+#### MEMORY.md repeat-scan producer contract
+
+For every finding whose provisional or final action includes `memory`, Stage 2
+must produce the fields consumed by Stage 2.5 Gate-5:
+
+- `memory_scan.scanned`
+- `memory_scan.candidates_reviewed`
+- `repeat`
+- `repeat_count`
+
+The scan must inspect the 2-hop candidate set before deciding repeat status:
+
+1. identify candidate memories/rules from the finding's pattern, tool layer,
+   action type, and root-cause wording
+2. open the candidate files or explicitly record why they were unreachable
+3. set `repeat=true` only when a prior matching pattern exists
+4. set `repeat_count` to the number of matching prior occurrences reviewed
+5. set `memory_scan.candidates_reviewed` to the concrete candidate list, not a
+   self-authored claim that the scan happened
+
+If the index or a candidate file is inaccessible, still emit
+`memory_scan.scanned=true`, record the blocker in
+`memory_scan.candidates_reviewed`, and treat the finding as a new pattern for
+action assignment unless another reachable candidate proves a repeat. This
+keeps Gate-5 passable while preserving the accessibility caveat. Do not
+silently omit the `memory_scan` field.
+
+### Early-exit rules
+
+The "No patterns found" path is allowed only when all are true:
+
+- `friction_events` is empty
+- the Pre-scan Checklist has no unresolved violations
+- Stage 1.5 produced no hygiene findings
+- the census promoted no findings
+- Stage 2.7 produced no findings
+
+Otherwise continue through Stage 2.5 and Stage 3.
+
+### Transcript-derived trail requirements
+
+For post-compaction sessions with a readable JSONL transcript, enumerate the
+transcript before analysis instead of relying only on the compaction summary:
+
+- scan `is_error` tool results and record `is_error_count`
+- scan explicit user corrections and record `user_correction_count`
+- scan self-corrections / retries and record `self_correction_count`
+- if the transcript is unreadable, emit
+  `retrospect:transcript_receipt_skipped: transcript unreachable` and carry the
+  caveat into Stage 3
+
+Stage 3 must carry the appropriate trail/ledger fences:
+
+- `retrospect:tool_census`
+- `retrospect:user_correction`
+- `retrospect:self_correction`
+- `retrospect:transcript_receipt` for post-compaction sessions
+
+These trails are audit surfaces. Silent omission is a Red Flag.
+
+## Stage 2.7: Adaptive Post-hoc Artifact Audit
+
+Stage 2.7 is the artifact-quality audit path.
+
+### Trigger surfaces
+
+Run it when the session transcript contains any of:
+
+- PR / issue / comment writes
+- Slack or Notion writes
+- approved external-write events
+
+### Audit focus
+
+1. **PR and issue quality**
+   - missing evidence
+   - mergeability / blocking-comment blind spots
+2. **Sub-agent substance**
+   - shallow or empty downstream output being used as if it were verified work
+3. **External-write evidence**
+   - hypotheses or unverified claims in comments / messages / reports
+
+### Output
+
+- emit `category: output_quality`
+- set provisional `Proposed Actions` by sub-audit, finalized by Stage 2.5:
+  - PR mergeability -> `memory` for repeated approval-gate drift, or
+    `claude_md_draft` when a user-facing workflow rule needs strengthening
+  - sub-agent substance -> `skill_idea` for prompt/role contract gaps, or
+    `memory` when the issue is a repeated local verification habit
+  - external-comment evidence -> `memory` for repeated claim hygiene drift,
+    `claude_md_draft` for rule gaps, or `hook_code` when an existing hook can
+    enforce the missing evidence trace
+- include the artifact-audit trail line when 0 triggers exist:
+  `<!-- retrospect:audit_skipped: no artifacts -->`
+- if the transcript is unreadable, emit the unreadable variant instead of
+  inventing a result
+
+### Required sub-audits
+
+When at least one trigger surface exists, run all three sub-audits. A sub-audit
+may emit zero findings, but it must not be silently skipped.
+
+#### Sub-audit 1: PR mergeability
+
+For each PR touched by `gh pr {create,edit,merge,comment}` in this session, run:
+
+```bash
+gh pr view <number-or-url> --json reviewRequests,reviews,state,mergeable,mergedAt
+```
+
+Emit an `output_quality` finding with `Tool Layer: cli` when any of these hold:
+
+- `state == "CLOSED"` and `mergedAt == null`
+- two or more `CHANGES_REQUESTED` review submissions are present
+- `mergeable == "CONFLICTING"`
+
+Filter on `CHANGES_REQUESTED`; raw review count alone does not measure revision
+cost.
+
+#### Sub-audit 2: sub-agent substance
+
+For every sub-agent / reviewer result used as evidence downstream, inspect the
+actual returned text. Emit an `output_quality` finding with `Tool Layer: skill`
+when the result is stream-killed, empty, shorter than 100 meaningful characters,
+or contains no concrete file / symbol / command evidence while the parent
+session treated it as verified work.
+
+#### Sub-audit 3: external-comment evidence
+
+For each external/shared-surface comment or message write, scan the emitted body
+for hypothesis markers such as `might`, `could be`, `probably`, `seems like`,
+`가능성`, `추정`, or equivalent unverified framing. If the same body lacks a
+verification trace, falsification trace, or cited command/API output, emit an
+`output_quality` finding. This applies to create and update variants because an
+edited comment can introduce or preserve the same defect.

--- a/skills/retrospect/references/stage1-2-analysis.md
+++ b/skills/retrospect/references/stage1-2-analysis.md
@@ -343,7 +343,8 @@ For each tool-friction event or promoted census row, record:
 - `proposed_fix_direction`
 
 Promotion rule: if the census row carries objective evidence (`error_count > 0`,
-`retry_count > 0`, `workaround_marker`, or a non-empty `signal`) and it is not
+`retry_count >= PRAXIS_RETROSPECT_CENSUS_RETRY_THRESHOLD` (default `2`),
+`workaround_marker`, or a non-empty `signal`) and it is not
 already represented by an equivalent step-4 finding, promote it as a tool
 finding. Cap promoted census-origin findings at
 `PRAXIS_RETROSPECT_CENSUS_FINDING_CAP` (default `5`) and record non-promoted

--- a/skills/retrospect/references/stage2.5-audit.md
+++ b/skills/retrospect/references/stage2.5-audit.md
@@ -1,0 +1,256 @@
+# Stage 2.5 action-distribution audit (retrospect)
+
+Detailed gate procedures for [`../SKILL.md`](../SKILL.md) Stage 2.5.
+`SKILL.md` names the gates; this file defines how each gate passes, fails, and
+hands off to Stage 3.
+
+## Gate sequence
+
+Run the gates in this order for the current finding set:
+
+1. Gate-1 — categorical integrity
+2. Gate-2 — memory-only rationale schema
+3. Gate-3 — evidence robustness for compound actions
+4. Gate-4 — external-repo pre-check for `upstream_feedback`
+5. Gate-5 — `memory_scan` completeness
+6. Gate-6 — oracle-match completeness
+
+Each finding gets at most 2 gate-driven re-entries before you must surface the
+documented override prompt to the user.
+
+### Override prompt after 2 re-entries
+
+When any gate still fails after the per-finding re-entry cap, stop the loop and
+surface the gate-specific 3-way prompt. Do not invent a fourth "continue
+looping" path.
+
+- Gate-1 / Gate-2 / Gate-3:
+  `"Finding #N의 Gate-X가 2회 재진입 후에도 통과되지 않습니다. 어떻게 진행할까요? [a] rationale 직접 입력 / [b] action 직접 지정 / [c] note only 강등."`
+- Gate-5:
+  `"Finding #N의 Gate-5 (memory_scan 필드 누락)가 통과되지 않습니다. 어떻게 진행할까요? [a] MEMORY.md index를 직접 읽고 memory_scan 필드를 입력 / [b] action을 직접 지정 / [c] 이 finding은 note only로 강등."`
+- Gate-6:
+  `"Finding #N의 Gate-6 (oracle_match 누락 또는 불일치)가 통과되지 않습니다. 어떻게 진행할까요? [a] 같은 oracle로 재측정 / [b] 별도 cohort-shift finding으로 전환하고 stored value 유지 / [c] 이 finding은 note only로 강등."`
+
+Record the selected option and the user's supplied rationale in the Stage 3
+trail before proceeding.
+
+## Gate-1: categorical integrity
+
+Purpose: block label backsliding that hides a tool/workflow/spec-gap defect as
+`behavioral` or `memory` only.
+
+Pass when:
+
+- every finding has a valid `category[]`
+- any finding with `tool` has `Tool Layer`
+- the chosen categories match the actual root cause
+
+Fail when:
+
+- a required category is missing
+- a `tool` finding has `Tool Layer = —`
+- a behavioral-only label contradicts the finding's own root-cause evidence
+- any finding whose `category[]` intersects `tool`, `workflow`, or `spec-gap`
+  has `Proposed Actions = memory` as a single, non-compound action
+
+Behavioral-only safeguard (all findings): if all findings are labeled
+`behavioral` only, run a final keyword sanity check on the original pre-scan
+signal text. If any signal contains tool/workflow indicators such as `gh`,
+`kubectl`, `MCP`, `--state`, `permission denied`, `timeout`, `--help`, or
+`flag`, surface the keyword set to the user and require explicit confirmation
+before Stage 3. If the user confirms, log the confirmation with the keyword set.
+
+Per-finding behavioral-label falsification: for each finding labeled
+`behavioral` only, scan its root-cause text for spec-gap/tool/workflow signal
+keywords: `probe`, `scan scope`, `skill`, `hook`, `missing`, `gap`, `scope`,
+`미구현`, `누락`, `flag`, `--<opt>`, `spec`, `rule absent`. If any signal is
+present, the finding must either add the honest second category or include
+`behavioral-label-justify: <why this is NOT spec-gap/tool/workflow despite the keyword>`.
+If neither is present, return the finding to Gate-1 / Stage 2 categorization for
+label re-evaluation; do not let action choice drive category narrowing.
+
+## Gate-2: memory-only rationale schema
+
+Purpose: prevent unsupported `memory`-only resolutions.
+
+This gate applies only to findings whose `Proposed Actions` is exactly
+`memory`.
+
+Accept either:
+
+- **Schema A**: exactly 5 lines of `not <action>: <reason>` covering every
+  non-memory action type
+- **Schema B**: 1-2 lines of `not-others: <dimension tags>`
+
+Generic one-line rationales do not pass Gate-2.
+
+## Gate-3: evidence robustness for compound actions
+
+Purpose: make sure dual-action plans are actually justified. For each finding
+with exactly two `Proposed Actions`, evaluate all three sub-conditions below.
+Single-action findings skip Gate-3.
+
+### Gate-3(a): per-action evidence pointer
+
+Each action must cite at least one explicit friction-event observation that
+supports that action. Citations live in the Rationale cell as a sub-bullet or
+inline `(observed: <event-id or one-line>)` reference. If an action is present
+only because a category default filled the table, return it to Stage 2 step 7
+(action assignment) and add observation citations before re-entering Gate-3.
+
+### Gate-3(b): sibling decision-coupling
+
+If action B's outcome decides a question that action A already presupposes, the
+pair is decision-coupled and both actions cannot be executed together. Keep the
+stronger-evidence action and demote the weaker action to a Stage 3 trigger
+condition line: `Finding #N: file <action> when <observation predicate>`.
+
+Example: a `claude_md_draft` that asserts "behavior X is intentional" coupled
+with `upstream_feedback` asking whether X is intentional is contradictory. Keep
+one; demote the other to a trigger.
+
+### Gate-3(c): single-observation downgrade
+
+For each action backed by exactly one observation and `repeat=false`, downgrade
+one tier:
+
+| Original action | Downgraded to | Rationale |
+|-----------------|---------------|-----------|
+| `upstream_feedback` | `memory` | One observation against an external party does not justify upstream-write cost |
+| `issue` | `memory` | One observation without repeat does not justify systemic tracking |
+| `hook_code` | `skill_idea` | One observation does not justify enforcement code |
+| `claude_md_draft` | `memory` | One-observation rule changes risk over-fitting |
+| `skill_idea` | `memory` | One observation does not justify a skill artifact |
+| `memory` | no downgrade | Already the lowest tier |
+
+If the resulting action set becomes memory-only while the finding still carries
+`tool`, `workflow`, or `spec-gap`, re-run Gate-1. The downgrade itself does not
+consume a re-entry; the resulting Gate-1 re-evaluation does.
+
+### Gate-3 outcomes
+
+- all applicable sub-conditions pass -> keep both actions and emit
+  `gate_3_verdict: PASS`
+- any sub-condition changes the action set -> apply the downgrade/demotion and
+  re-enter the affected gate path
+- no compound findings -> `gate_3_verdict: NA`
+- unresolved violation after the per-finding re-entry cap -> surface the
+  documented 3-way user override prompt
+
+## Gate-4: external-repo authorization pre-check
+
+Purpose: classify `upstream_feedback` findings before Stage 3 ranking so that
+external writes cannot slip through as if they were ordinary internal issues.
+
+For each `upstream_feedback` finding:
+
+1. parse `backing_repo: <owner>/<repo>` from the Rationale cell
+2. resolve the own-org allowlist
+3. classify the owner as internal or external
+4. annotate external findings with the literal Stage 4 warning prefix:
+   `⚠ EXTERNAL: per-action approval required at Stage 4`
+5. emit `gate_4_verdict`
+
+Own-org allowlist resolution, in priority order:
+
+1. `PRAXIS_OWN_ORGS` as comma-separated handles
+2. `gh api user --jq .login` as the single own handle
+3. conservative fallback: treat all `backing_repo` owners as external
+
+Classification: extract `owner` from `backing_repo: <owner>/<repo>` and compare
+case-insensitively against the resolved allowlist. If owner is absent from the
+allowlist, mark the finding `external=true`. If the `backing_repo:` declaration
+is absent, Gate-4 skips that finding here; Stage 4 Action 4 step 0's
+missing-declaration abort is the downstream enforcement.
+
+For external findings, the literal warning prefix must appear in the Stage 3
+Rationale cell for the `upstream_feedback (external)` row. Stage 4 scans that
+exact string before creating/commenting/editing in an external repository; a
+paraphrase disables the per-action approval gate. The same row must also carry
+`backing_repo: <owner>/<repo>` so Stage 4 can route the approval decision to the
+right repository boundary.
+
+Verdicts:
+
+- `PASS` -> zero external findings; all `upstream_feedback` rows are internal
+- `WARN` -> at least one external finding exists, or conservative fallback was
+  required; Stage 4 must require per-action approval for external rows
+- `NA` -> no `upstream_feedback` findings
+
+## Gate-5: memory-scan completeness
+
+Purpose: prove that the MEMORY.md repeat scan actually happened for any finding
+that wants a `memory` action.
+
+For every memory-action finding, require:
+
+- `memory_scan.scanned == true`
+- `memory_scan.candidates_reviewed` present
+- `repeat` present
+- `repeat_count` present
+
+If the scan could not run because the index is inaccessible, record that in the
+`memory_scan` field rather than silently skipping the field.
+
+## Gate-6: oracle-match completeness
+
+Purpose: prevent overwriting stored numeric values with a probe that measured a
+different quantity.
+
+For every stored-value correction finding, require:
+
+- `oracle_match` field present
+- `oracle_match: true` when the action would invalidate or overwrite the stored
+  value
+
+Producer procedure:
+
+1. Read the originating entry's stored oracle: matching basis, cohort, and unit.
+2. Re-probe with the same matching basis / cohort / unit before treating the
+   stored value as stale or wrong.
+3. Record `oracle_match: true` only when the falsification probe used that same
+   oracle.
+4. Treat a different-oracle probe as a cohort-shift observation, not as
+   falsification of the stored value.
+
+If the originating entry did not record its oracle, defer falsification and
+route the work to an annotation update rather than fabricating a correction.
+
+## Distribution card
+
+On pass, Stage 2.5 hands Stage 3 the canonical distribution card:
+
+```markdown
+<!-- retrospect:distribution begin -->
+- memory: {n}
+- issue: {n}
+- claude_md_draft: {n}
+- skill_idea: {n}
+- hook_code: {n}
+- upstream_feedback: {n}
+- memory_hygiene: {n}
+- output_quality: {n}
+- gate_1_verdict: {PASS|FAIL|NA}
+- gate_2_verdict: {PASS|FAIL|NA}
+- gate_3_verdict: {PASS|FAIL|NA}
+- gate_4_verdict: {PASS|WARN|NA}
+- gate_5_verdict: {PASS|FAIL|NA}
+- gate_6_verdict: {PASS|FAIL|NA}
+<!-- retrospect:distribution end -->
+```
+
+Semantics:
+
+- `memory_hygiene` and `output_quality` are category counts, not action keys
+- `gate_1_verdict`, `gate_2_verdict`, and `gate_4_verdict` are structurally
+  relevant to the Stop-hook path
+- `gate_3_verdict`, `gate_5_verdict`, and `gate_6_verdict` are emitted for
+  procedural audit even when the Stop hook does not parse them
+
+## Re-entry and override
+
+If a finding still fails a gate after 2 re-entries:
+
+- do not keep looping
+- surface the documented override prompt for that gate
+- record the user's selection in the report trail

--- a/skills/retrospect/references/stage3-reporting.md
+++ b/skills/retrospect/references/stage3-reporting.md
@@ -65,6 +65,7 @@ auditable memory-scan evidence block near the unified findings table:
 These lines surface the Gate-5 producer fields from Stage 2.5. Keeping them only
 in internal reasoning is a Red Flag because reviewers and downstream hooks cannot
 verify that the MEMORY.md repeat scan actually ran.
+
 - `Proposed Actions (1~2)` is a subset of:
   `memory`, `issue`, `claude_md_draft`, `skill_idea`, `hook_code`,
   `upstream_feedback`

--- a/skills/retrospect/references/stage3-reporting.md
+++ b/skills/retrospect/references/stage3-reporting.md
@@ -1,0 +1,271 @@
+# Stage 3 reporting contract (retrospect)
+
+Normative Stage 3 contract for [`../SKILL.md`](../SKILL.md). `SKILL.md` keeps
+the execution spine; this file defines the canonical Stage 3 report shape, the
+approval flow, and the output-level gates.
+
+## Canonical emit order
+
+Stage 3 output MUST emit, in this order:
+
+1. `## Retrospect Report`
+2. `retrospect:pre_scan_checklist`
+3. `retrospect:dismissed_candidates`
+4. Stage 1.5 Hygiene Scan Trail when hygiene scan emitted carried findings,
+   concurrent cursor merge, probe falsification, or hygiene skip/size-threshold
+   markers
+5. transcript-derived trails / ledgers
+   - `retrospect:tool_census`
+   - `retrospect:user_correction`
+   - `retrospect:self_correction`
+   - `retrospect:transcript_receipt` in post-compaction sessions
+6. Stage 2.7 audit trail or skip marker
+   - `<!-- retrospect:audit_skipped: no artifacts -->`
+   - `<!-- retrospect:audit_skipped: transcript unreadable -->`
+   - per-artifact audit trail lines when triggers were inspected
+7. `<!-- retrospect:distribution begin --> ... end -->`
+8. unified findings table
+9. memory-action evidence blocks for every finding whose proposed action
+   includes `memory`
+
+The `memory` distribution count includes both finding rows whose Proposed
+Actions include `memory` and `successful_patterns` rows whose
+`reinforce_action` is `memory`. A success-pattern memory entry must be surfaced
+for approval in the same Stage 3 approval pass before Stage 4 may write it.
+
+## Unified findings table
+
+The table header is fixed:
+
+```markdown
+| # | Category | Tool Layer | Pattern | Root Cause | Rule / Gap | Repeat? | Proposed Actions (1~2) | Rationale | Priority |
+```
+
+Key column rules:
+
+- `Category` is a comma-separated subset of:
+  `behavioral`, `tool`, `workflow`, `spec-gap`, `memory_hygiene`,
+  `output_quality`
+- `Tool Layer` must be `mcp|cli|builtin|skill|—`
+
+## Memory-Scan Evidence
+
+For every finding whose proposed action includes `memory`, Stage 3 MUST emit an
+auditable memory-scan evidence block near the unified findings table:
+
+```markdown
+<!-- memory_scan finding #<n>:
+  scanned: true
+  candidates_reviewed: <concrete paths or unreachable marker>
+  repeat: true|false
+  repeat_count: <integer>
+-->
+```
+
+These lines surface the Gate-5 producer fields from Stage 2.5. Keeping them only
+in internal reasoning is a Red Flag because reviewers and downstream hooks cannot
+verify that the MEMORY.md repeat scan actually ran.
+- `Proposed Actions (1~2)` is a subset of:
+  `memory`, `issue`, `claude_md_draft`, `skill_idea`, `hook_code`,
+  `upstream_feedback`
+- any row with `upstream_feedback` or `issue` in `Proposed Actions` must declare
+  `backing_repo: <owner>/<repo>` in `Rationale`
+- memory-only rows must use the Stage 2.5 Gate-2 rationale schema
+
+## No-pattern audit path
+
+The 0-friction "No patterns found" path still emits the report header, every
+audit fence in the canonical emit order, and the distribution card with all
+counts = 0 and verdicts = NA. These audit fences are mandatory even when no
+finding survives; otherwise dismissed-candidate and transcript-derived audit
+trails disappear on the path where they are hardest to reconstruct.
+
+### Enumerate-before-empty-fence
+
+Before emitting an empty `retrospect:dismissed_candidates` fence in the
+0-friction path, scan the session transcript for codex/review-bot finding
+markers:
+
+- Codex CLI reviewer output blocks
+- BugBot comment bodies
+- reviewer agent result text
+- Cursor review annotations
+
+Every marker match must be inspected for rule-violation content. Any match that
+is a workflow/spec/hook rule violation must appear as a ledger line:
+
+```markdown
+- {one-line candidate} | reason: {dismissal rationale} | spec_cite: {section name or file:line}
+```
+
+An empty `dismissed_candidates` fence is allowed only when this enumeration
+returns zero rule-violation matches. Pure style nits or refactor suggestions do
+not force a ledger entry.
+
+## Transcript receipt
+
+When the transcript contains a compaction marker, the report must include the
+`retrospect:transcript_receipt` fence with real command output.
+
+When `is_error_count > 0`, the receipt must also include a nested
+`retrospect:is_error_enum` block enumerating each error with a disposition:
+
+- `promote`
+- `note`
+- `dismiss`
+
+The skipped variant is allowed only when the transcript is genuinely
+unreachable.
+
+## Per-finding plan contract
+
+For every non-note-only finding, Stage 3 must explain:
+
+1. what will be created
+2. why this action type was chosen
+3. how it will be verified
+4. `Stage 2 caveats: ...` when caveats apply
+5. `Falsification: ...`
+
+### Trigger Conditions (Gate-3 (b) demotions)
+
+If Stage 2.5 Gate-3 detected sibling decision-coupling and demoted the weaker
+action, emit one bullet per demoted action after the unified findings table.
+This section is for human review only and is not parsed by the Stop hook.
+
+Format: literal `^- Finding #N: file <action> when <observation predicate>$`.
+
+```markdown
+- Finding #N: file `<demoted_action>` when `<observation predicate>` (originally proposed alongside `<kept_action>`; demoted because <coupling reason>)
+```
+
+If no Gate-3 (b) demotions occurred, omit the section entirely.
+
+### Action selection ladder
+
+Action type baseline comes from the Stage 2 escalation ladder, but Stage 3 must
+explicitly evaluate all six action types per non-note-only finding and select
+one or two actions.
+
+| Action Type | When to Choose | Skip If |
+|-------------|---------------|---------|
+| `memory` | New pattern, first occurrence, individual learning | `repeat=true`; memory is blocked |
+| `issue` | Systemic fix needed; repeat pattern at 1-2 prior occurrences | One-off mistake, purely local insight |
+| `claude_md_draft` | Explicit cross-project rule gap exists | Existing rule already covers this pattern |
+| `skill_idea` | Repeat pattern needs enforcement and manual recall is insufficient | Single memo is sufficient |
+| `hook_code` | Repeat pattern at 3+ occurrences requiring automated enforcement | Fewer than 3 repeats |
+| `upstream_feedback` | Tool or feature-level defect belongs upstream | Pure rule violation with no tool-level root cause |
+
+Selection matrix:
+
+| Axis | Signal -> Action |
+|------|------------------|
+| Repeat count | 0x -> `memory`; 1-2x -> `issue`; 3x+ -> `skill_idea` or `hook_code` |
+| Scope | Cross-project -> `claude_md_draft`; single-project -> `memory` |
+| Gap type | Rule violated -> reinforce; rule absent -> draft; no enforcement -> `skill_idea` |
+
+Repeat-count is the highest-priority axis. When `repeat=true`, scope and gap
+type cannot override back to `memory`; use them only to choose additional
+actions alongside the repeat-count result.
+
+Compound action is the default for HIGH-priority findings. A single `memory`
+action is acceptable only when the `Rationale` column explicitly explains why
+all other action types were skipped.
+
+## Reinforced patterns
+
+Emit the reinforced-patterns section only when there are
+`successful_patterns` rows with `reinforce_action: visualize_only`.
+
+For `successful_patterns` rows with `reinforce_action: memory`, emit an approval
+row or prompt item that names the reinforced pattern, its evidence, and the
+MEMORY.md entry that Stage 4 would create. Do not write reinforced memory entries
+from Stage 4 unless that item was explicitly approved in Stage 3.
+
+Do not emit a placeholder "None." section.
+
+## Pre-Output Falsification Gate (AskUserQuestion)
+
+This gate fires immediately before each `AskUserQuestion`.
+
+### Trigger detection
+
+Any of the following triggers the gate:
+
+- Literal `(Recommended)` suffix
+- confidence-anchoring phrasing such as `safer`, `safest`, `natural fit`,
+  `natural choice`, `obvious choice`, `clearly`, `recommend`, `default choice`,
+  `default to`, `prefer this`, `안전한`, `자연스러운`, `추천`, `당연히`, `분명히`
+
+### Mandatory question
+
+Ask internally:
+
+> If this proposal's premise is wrong, what observation should be missing from
+> the current evidence? Is that observation actually missing?
+
+### Caveats that must be read before ranking
+
+- `tracer confidence: LOW|MED`
+- `single observation`
+- `alternative root cause not ruled out`
+- `Gate-3 (c) downgrade applied`
+- `Gate-3 (b) sibling demoted to trigger`
+- `repeat=true, resolved=true (escape hatch)`
+- `analyst clustered with #N`
+
+### Outcomes
+
+- **Premise survives** -> `(Recommended)` allowed
+- **Premise fails** -> `(Recommended)` disallowed; surface unranked
+- **Falsification step not run** -> `(Recommended)` DISALLOWED; ESCALATE to user with open premise
+
+The final Stage 3 output must include a `Falsification:` line for every ranked
+option.
+
+## Red Flags
+
+Stop and return to Stage 2 / Stage 2.5 when any of these are true:
+
+- Emitting `AskUserQuestion` with ranking language without an accompanying `Falsification:` trace line.
+- Stage 3 ranking that contradicts Stage 2 caveats.
+- Omitting the `Stage 2 caveats:` line when caveats apply.
+
+## Quick Reference
+
+Pre-Output Falsification Gate before each `AskUserQuestion`; every ranked
+option needs `Falsification:` evidence.
+
+## Error Handling
+
+| Failure | Action |
+|---|---|
+| Pre-Output Falsification Gate triggered but premise cannot be falsified | Drop ranking and ask with open premise |
+| Finding lacks Stage 2 caveats line despite required caveats | Block Stage 3 emission and return to Stage 2 / 2.5 |
+
+## Approval flow
+
+After the report, ask per finding:
+
+- `✅ Execute now`
+- `⏭ Skip`
+- `🕐 Defer (create note only)`
+
+Do not run Stage 4 until the user explicitly approves the finding.
+
+## Co-update note
+
+Any schema drift here must be co-updated with:
+
+- `hooks/completion-verify/retrospect-mix-check/impl.sh`
+- `tests/hooks/completion-verify/test_retrospect_mix_check.sh`
+- `tests/fixtures/retrospect-synth-*.expected.json`
+
+## Examples
+
+Use [`report-template.md`](report-template.md) for the consolidated template and
+worked examples when composing the final Stage 3 output.
+
+Example classification: `gate-suppressed` means the `(Recommended)` label was
+removed because the disconfirming observation was present or the premise was not
+falsified.

--- a/skills/retrospect/references/stage4-execution.md
+++ b/skills/retrospect/references/stage4-execution.md
@@ -62,10 +62,10 @@ For each approved action:
 
    **Precondition:** This check applies ONLY when the finding's action type is `memory` (new pattern). If Stage 2 already marked `repeat=true` and escalated to issue/hook/global `~/.claude/CLAUDE.md` draft, skip this check — the escalation ladder takes precedence over merge.
 
-   a. Reuse Stage 2 Step 7's repeat scan results — if a finding matched an existing memory but was NOT escalated (i.e., it's a genuinely new sub-pattern), that file is the merge target
+   a. Reuse Stage 2 step 6's repeat scan results — if a finding matched an existing memory but was NOT escalated (i.e., it's a genuinely new sub-pattern), that file is the merge target
    b. If no Stage 2 match: scan MEMORY.md index for entries with overlapping root cause or topic (concept-level, not keyword)
    c. For each candidate, read the existing memory file and compare:
-      - Same root cause / principle → **merge**: append new context (examples, How to apply items) to the existing file. If merge makes this the 2nd+ occurrence, re-evaluate whether action type should escalate per Stage 2 Step 8
+      - Same root cause / principle → **merge**: append new context (examples, How to apply items) to the existing file. If merge makes this the 2nd+ occurrence, re-evaluate whether action type should escalate per Stage 2 step 7
       - Related but distinct principle → **create new file** (genuinely different insight)
    d. **Never create a new file when the insight is a specific instance of an existing general rule** — add it as a numbered sub-item instead
    e. After merge or create, update MEMORY.md index (update description if merged, add new line if created)
@@ -117,7 +117,7 @@ For each approved action:
 
    This gate is the first procedure step for every `upstream_feedback` row, executed **before** any of the resolution-table lookups below. Skipping it means the most salient file path in the executor's local context (often the working project repo) wins the routing decision — which is the exact failure mode this gate prevents.
 
-   1. **Read the declaration.** Parse `backing_repo: <owner/repo>` from the finding's Rationale cell (Stage 2 step 8 makes this MANDATORY for upstream_feedback rows; Stage 3 surfaces it). If the declaration is absent → ABORT this action and return the finding to Stage 2 step 8 with prompt: `"Finding #N upstream_feedback row missing backing_repo declaration — re-run Stage 2 step 8."`
+   1. **Read the declaration.** Parse `backing_repo: <owner/repo>` from the finding's Rationale cell (Stage 2 step 7 makes this MANDATORY for upstream_feedback rows; Stage 3 surfaces it). If the declaration is absent → ABORT this action and return the finding to Stage 2 step 7 with prompt: `"Finding #N upstream_feedback row missing backing_repo declaration — re-run Stage 2 step 7."`
 
    2. **Re-resolve from source-of-truth.** Independently of the declaration, re-resolve the backing repo using the resolution table below. Do NOT use the declared value as the lookup input — use the tool/layer signal from Stage 2 step 4b to derive the repo from scratch. Capture the re-resolved value as `live_backing_repo`. If the resolution table's `Other / ambiguous` row matches the layer (no concrete repo derivable), treat `live_backing_repo = AMBIGUOUS` and skip to step 0.4 with a 2-way prompt instead of 3-way.
 

--- a/tests/test_retrospect_cursor_concurrency.sh
+++ b/tests/test_retrospect_cursor_concurrency.sh
@@ -5,7 +5,7 @@
 # (`.omc/state/retrospect-hygiene-cursor.json`) is shared mutable state. Two
 # sessions running /retrospect concurrently both read the same cursor and the
 # second session's plain Write clobbers the first session's `note` carry-forward.
-# The skill MUST re-read the on-disk cursor before persisting and union-merge on
+# The Stage 1/2 reference MUST re-read the on-disk cursor before persisting and union-merge on
 # a detected concurrent advance instead of overwriting.
 #
 # Like the Stage 3 falsification gate, memory-only enforcement of this rule does
@@ -18,10 +18,10 @@
 set +e
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-SKILL="$REPO_ROOT/skills/retrospect/SKILL.md"
+SPEC="$REPO_ROOT/skills/retrospect/references/stage1-2-analysis.md"
 
-if [ ! -f "$SKILL" ]; then
-  echo "FAIL: SKILL.md not found at $SKILL" >&2
+if [ ! -f "$SPEC" ]; then
+  echo "FAIL: stage1-2-analysis.md not found at $SPEC" >&2
   exit 1
 fi
 
@@ -33,19 +33,19 @@ assert_present() {
   local name="$1"
   local pattern="$2"
   local hits
-  hits=$(grep -c -- "$pattern" "$SKILL" 2>/dev/null)
+  hits=$(grep -c -- "$pattern" "$SPEC" 2>/dev/null)
   hits=${hits:-0}
   if [ "$hits" -gt 0 ]; then
     echo "PASS: $name"
     PASS=$((PASS + 1))
   else
-    echo "FAIL: $name — pattern '$pattern' missing in SKILL.md"
+    echo "FAIL: $name — pattern '$pattern' missing in stage1-2-analysis.md"
     FAIL=$((FAIL + 1))
     FAILED_NAMES+=("$name")
   fi
 }
 
-echo "=== retrospect SKILL.md Stage 1.5 cursor write mandate checks ==="
+echo "=== retrospect Stage 1/2 reference Stage 1.5 cursor write mandate checks ==="
 echo ""
 
 # --- 1. Mandate section header exists ----------------------------------------

--- a/tests/test_retrospect_falsify_recommended.sh
+++ b/tests/test_retrospect_falsify_recommended.sh
@@ -7,7 +7,7 @@
 # per-finding plan.
 #
 # Memory-only enforcement of this rule has failed historically — retrieval at
-# Stage 3 output time does not fire reliably. The skill itself owns the gate;
+# Stage 3 output time does not fire reliably. The Stage 3 reference owns the gate;
 # this test pins the gate's language in place so prompt drift surfaces in CI.
 #
 # Run:  ./tests/test_retrospect_falsify_recommended.sh
@@ -16,10 +16,10 @@
 set +e
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-SKILL="$REPO_ROOT/skills/retrospect/SKILL.md"
+SPEC="$REPO_ROOT/skills/retrospect/references/stage3-reporting.md"
 
-if [ ! -f "$SKILL" ]; then
-  echo "FAIL: SKILL.md not found at $SKILL" >&2
+if [ ! -f "$SPEC" ]; then
+  echo "FAIL: stage3-reporting.md not found at $SPEC" >&2
   exit 1
 fi
 
@@ -31,13 +31,13 @@ assert_present() {
   local name="$1"
   local pattern="$2"
   local hits
-  hits=$(grep -c -- "$pattern" "$SKILL" 2>/dev/null)
+  hits=$(grep -c -- "$pattern" "$SPEC" 2>/dev/null)
   hits=${hits:-0}
   if [ "$hits" -gt 0 ]; then
     echo "PASS: $name"
     PASS=$((PASS + 1))
   else
-    echo "FAIL: $name — pattern '$pattern' missing in SKILL.md"
+    echo "FAIL: $name — pattern '$pattern' missing in stage3-reporting.md"
     FAIL=$((FAIL + 1))
     FAILED_NAMES+=("$name")
   fi
@@ -47,19 +47,19 @@ assert_present_extended() {
   local name="$1"
   local pattern="$2"
   local hits
-  hits=$(grep -E -c -- "$pattern" "$SKILL" 2>/dev/null)
+  hits=$(grep -E -c -- "$pattern" "$SPEC" 2>/dev/null)
   hits=${hits:-0}
   if [ "$hits" -gt 0 ]; then
     echo "PASS: $name"
     PASS=$((PASS + 1))
   else
-    echo "FAIL: $name — extended regex '$pattern' missing in SKILL.md"
+    echo "FAIL: $name — extended regex '$pattern' missing in stage3-reporting.md"
     FAIL=$((FAIL + 1))
     FAILED_NAMES+=("$name")
   fi
 }
 
-echo "=== retrospect SKILL.md Stage 3 falsification gate checks ==="
+echo "=== retrospect Stage 3 reference falsification gate checks ==="
 echo ""
 
 # --- 1. Gate section header exists -------------------------------------------
@@ -145,15 +145,40 @@ assert_present \
   "Gate-3 (c) downgrade applied"
 
 assert_present \
+  "carry-forward — Gate-3 (b) demotion" \
+  "Gate-3 (b) sibling demoted to trigger"
+
+assert_present \
   "carry-forward — analyst cluster overlap" \
   "analyst clustered with"
 
-# --- 7. Composition between caveats and gate (LOW confidence blocks rec) ----
+# --- 7. Stage 3 escalation and no-pattern audit contracts --------------------
+assert_present \
+  "no-pattern audit — enumerate before empty fence" \
+  "Enumerate-before-empty-fence"
+
+assert_present \
+  "no-pattern audit — review-bot marker enumeration" \
+  "codex/review-bot finding"
+
+assert_present \
+  "trigger section — Gate-3 demotion format" \
+  "Finding #N: file"
+
+assert_present \
+  "action ladder — all six action types" \
+  "evaluate all six action types"
+
+assert_present \
+  "action ladder — repeat count precedence" \
+  "Repeat-count is the highest-priority axis"
+
+# --- 8. Composition between caveats and gate (LOW confidence blocks rec) ----
 assert_present \
   "caveat composition — LOW confidence blocks survives" \
   "tracer confidence: LOW"
 
-# --- 8. Red Flag entry exists ------------------------------------------------
+# --- 9. Red Flag entry exists ------------------------------------------------
 assert_present \
   "Red Flag — AskUserQuestion without Falsification trace" \
   "without an accompanying \`Falsification:\` trace line"
@@ -166,12 +191,12 @@ assert_present \
   "Red Flag — omitting Stage 2 caveats line" \
   "Omitting the \`Stage 2 caveats:\` line"
 
-# --- 9. Quick Reference updated ----------------------------------------------
+# --- 10. Quick Reference updated ---------------------------------------------
 assert_present \
   "Quick Reference — Pre-Output Falsification Gate mentioned" \
   "Pre-Output Falsification Gate before each"
 
-# --- 10. Error Handling rows for the gate ------------------------------------
+# --- 11. Error Handling rows for the gate ------------------------------------
 assert_present \
   "Error Handling — gate triggered but premise un-falsifiable" \
   "Pre-Output Falsification Gate triggered but premise cannot be falsified"
@@ -180,7 +205,7 @@ assert_present \
   "Error Handling — missing caveat line blocks Stage 3 emission" \
   "lacks Stage 2 caveats line"
 
-# --- 11. Example block demonstrates suppressed (Recommended) -----------------
+# --- 12. Example block demonstrates suppressed (Recommended) -----------------
 assert_present \
   "example — gate-suppressed (Recommended) demonstration" \
   "gate-suppressed"

--- a/tests/test_retrospect_routing.sh
+++ b/tests/test_retrospect_routing.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# tests/test_retrospect_routing.sh — assert retrospect SKILL.md is repo-agnostic
+# tests/test_retrospect_routing.sh — assert retrospect skill docs are repo-agnostic
 #
 # Regression test for the routing rule: user-specific GitHub org/repo names
 # MUST NOT appear in the retrospect skill. The skill is distributed across
@@ -12,7 +12,8 @@
 set +e
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-SKILL="$REPO_ROOT/skills/retrospect/SKILL.md"
+SKILL_DIR="$REPO_ROOT/skills/retrospect"
+SKILL="$SKILL_DIR/SKILL.md"
 
 if [ ! -f "$SKILL" ]; then
   echo "FAIL: SKILL.md not found at $SKILL" >&2
@@ -42,14 +43,14 @@ run_forbidden_check() {
   local name="$1"
   local pattern="$2"
   local hits
-  hits=$(grep -c -- "$pattern" "$SKILL" 2>/dev/null)
+  hits=$(grep -R -c -- "$pattern" "$SKILL_DIR" 2>/dev/null | awk -F: '{sum += $2} END {print sum + 0}')
   hits=${hits:-0}
   if [ "$hits" -eq 0 ]; then
     echo "PASS: $name"
     PASS=$((PASS + 1))
   else
     echo "FAIL: $name — found $hits occurrence(s) of '$pattern':"
-    grep -n -- "$pattern" "$SKILL" | sed 's/^/    /'
+    grep -R -n -- "$pattern" "$SKILL_DIR" | sed 's/^/    /'
     FAIL=$((FAIL + 1))
     FAILED_NAMES+=("$name")
   fi
@@ -61,19 +62,39 @@ run_placeholder_check() {
   local name="$1"
   local placeholder="$2"
   local hits
-  hits=$(grep -c -- "$placeholder" "$SKILL" 2>/dev/null)
+  hits=$(grep -R -c -- "$placeholder" "$SKILL_DIR" 2>/dev/null | awk -F: '{sum += $2} END {print sum + 0}')
   hits=${hits:-0}
   if [ "$hits" -gt 0 ]; then
     echo "PASS: $name"
     PASS=$((PASS + 1))
   else
-    echo "FAIL: $name — placeholder '$placeholder' missing in SKILL.md"
+    echo "FAIL: $name — placeholder '$placeholder' missing in retrospect docs"
     FAIL=$((FAIL + 1))
     FAILED_NAMES+=("$name")
   fi
 }
 
-echo "=== retrospect SKILL.md repo-agnosticism checks ==="
+run_anchor_check() {
+  local name="$1"
+  local path="$2"
+  local pattern="$3"
+  if [ ! -f "$path" ]; then
+    echo "FAIL: $name — missing file $path"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+    return
+  fi
+  if grep -q -- "$pattern" "$path" 2>/dev/null; then
+    echo "PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name — pattern '$pattern' missing in $path"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+echo "=== retrospect docs repo-agnosticism checks ==="
 echo ""
 
 for pattern in "${FORBIDDEN_PATTERNS[@]}"; do
@@ -83,6 +104,63 @@ done
 echo ""
 run_placeholder_check "uses <resolved_backing_repo> placeholder" "<resolved_backing_repo>"
 run_placeholder_check "uses <resolved-praxis-repo> placeholder" "<resolved-praxis-repo>"
+
+echo ""
+echo "=== retrospect reference split smoke checks ==="
+run_anchor_check "stage1-2 reference exists with cursor write mandate" "$SKILL_DIR/references/stage1-2-analysis.md" "Cursor write mandate"
+run_anchor_check "stage1-2 reference keeps CLAUDE_CONFIG_DIR fallback" "$SKILL_DIR/references/stage1-2-analysis.md" '${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md'
+run_anchor_check "stage1-2 reference keeps timestamp concurrency discriminator" "$SKILL_DIR/references/stage1-2-analysis.md" "write-time timestamp is the primary concurrent-advance discriminator"
+run_anchor_check "stage1-2 reference keeps size threshold env defaults" "$SKILL_DIR/references/stage1-2-analysis.md" "PRAXIS_RETROSPECT_INDEX_LINE_THRESHOLD"
+run_anchor_check "stage1-2 reference keeps size line cap default" "$SKILL_DIR/references/stage1-2-analysis.md" "PRAXIS_RETROSPECT_INDEX_LINE_CAP"
+run_anchor_check "stage1-2 reference keeps user-correction markers" "$SKILL_DIR/references/stage1-2-analysis.md" "that's not what I asked"
+run_anchor_check "stage1-2 reference keeps mixed regex warning" "$SKILL_DIR/references/stage1-2-analysis.md" "explicit ASCII guards"
+run_anchor_check "stage1-2 reference keeps pre-scan scope window" "$SKILL_DIR/references/stage1-2-analysis.md" "last 50 turns"
+run_anchor_check "stage1-2 reference keeps retry_count polling exclusion" "$SKILL_DIR/references/stage1-2-analysis.md" "background-output re-reads"
+run_anchor_check "stage1-2 reference keeps user-correction cap priority" "$SKILL_DIR/references/stage1-2-analysis.md" "genuine \`user_correction\` events rank first"
+run_anchor_check "stage1-2 reference keeps self-correction criteria" "$SKILL_DIR/references/stage1-2-analysis.md" "prior result was wrong or superseded"
+run_anchor_check "stage1-2 reference keeps self-correction cap priority" "$SKILL_DIR/references/stage1-2-analysis.md" "genuine self-corrections rank after"
+run_anchor_check "stage1-2 reference keeps action assignment ladder" "$SKILL_DIR/references/stage1-2-analysis.md" "Action assignment (step 7)"
+run_anchor_check "stage1-2 reference keeps hygiene action mapping" "$SKILL_DIR/references/stage1-2-analysis.md" "stale reference -> \`memory\`"
+run_anchor_check "stage1-2 reference keeps bounded-drop cycle rule" "$SKILL_DIR/references/stage1-2-analysis.md" "PRAXIS_RETROSPECT_UNRUNNABLE_DROP_CYCLES"
+run_anchor_check "stage1-2 reference keeps access-blocked retention" "$SKILL_DIR/references/stage1-2-analysis.md" "access-blocked-only findings are never auto-dropped"
+run_anchor_check "stage1-2 reference keeps cluster repeat propagation" "$SKILL_DIR/references/stage1-2-analysis.md" "cluster_repeat_count = max(repeat_count) + (cluster_event_count - 1)"
+run_anchor_check "stage1-2 reference keeps link scanner wikilink support" "$SKILL_DIR/references/stage1-2-analysis.md" "[[wikilink]]"
+run_anchor_check "stage1-2 reference keeps link scanner bare basename support" "$SKILL_DIR/references/stage1-2-analysis.md" "Bare basename mention"
+run_anchor_check "stage1-2 reference keeps memory-scan fallback passable" "$SKILL_DIR/references/stage1-2-analysis.md" "memory_scan.scanned=true"
+run_anchor_check "stage1-2 reference keeps backing_repo declaration rule" "$SKILL_DIR/references/stage1-2-analysis.md" "backing_repo: <owner>/<repo>"
+run_anchor_check "stage1-2 reference keeps tool-friction step 4b" "$SKILL_DIR/references/stage1-2-analysis.md" "Tool-friction promotion pass"
+run_anchor_check "stage1-2 reference keeps pre-tracer artifact probe" "$SKILL_DIR/references/stage1-2-analysis.md" "probed artifact:"
+run_anchor_check "stage1-2 reference keeps PR mergeability audit" "$SKILL_DIR/references/stage1-2-analysis.md" "Sub-audit 1: PR mergeability"
+run_anchor_check "stage1-2 reference keeps external-comment audit" "$SKILL_DIR/references/stage1-2-analysis.md" "external-comment evidence"
+run_anchor_check "stage1-2 reference keeps audit action templates" "$SKILL_DIR/references/stage1-2-analysis.md" "PR mergeability -> \`memory\`"
+run_anchor_check "stage1-2 reference keeps post-compaction transcript enumeration" "$SKILL_DIR/references/stage1-2-analysis.md" "is_error_count"
+run_anchor_check "stage1-2 reference keeps skipped transcript marker" "$SKILL_DIR/references/stage1-2-analysis.md" "retrospect:transcript_receipt_skipped: transcript unreachable"
+run_anchor_check "stage2.5 reference exists with Gate-1" "$SKILL_DIR/references/stage2.5-audit.md" "Gate-1"
+run_anchor_check "stage2.5 reference blocks non-behavioral memory-only" "$SKILL_DIR/references/stage2.5-audit.md" "Proposed Actions = memory"
+run_anchor_check "stage2.5 reference keeps all-findings behavioral safeguard" "$SKILL_DIR/references/stage2.5-audit.md" "Behavioral-only safeguard (all findings)"
+run_anchor_check "stage2.5 reference keeps behavioral label falsification" "$SKILL_DIR/references/stage2.5-audit.md" "behavioral-label-justify"
+run_anchor_check "stage2.5 reference points Gate-3 repair to step 7" "$SKILL_DIR/references/stage2.5-audit.md" "Stage 2 step 7"
+run_anchor_check "stage2.5 reference keeps Gate-3 downgrade table" "$SKILL_DIR/references/stage2.5-audit.md" "single-observation downgrade"
+run_anchor_check "stage2.5 reference keeps override prompt body" "$SKILL_DIR/references/stage2.5-audit.md" "rationale 직접 입력"
+run_anchor_check "stage2.5 reference keeps Gate-6 override prompt body" "$SKILL_DIR/references/stage2.5-audit.md" "같은 oracle로 재측정"
+run_anchor_check "stage2.5 reference keeps own-org allowlist resolution" "$SKILL_DIR/references/stage2.5-audit.md" "PRAXIS_OWN_ORGS"
+run_anchor_check "stage2.5 reference keeps external WARN verdict" "$SKILL_DIR/references/stage2.5-audit.md" "at least one external finding exists"
+run_anchor_check "stage2.5 reference keeps same-oracle producer" "$SKILL_DIR/references/stage2.5-audit.md" "same matching basis / cohort / unit"
+run_anchor_check "stage3 reference exists with distribution fence" "$SKILL_DIR/references/stage3-reporting.md" "retrospect:distribution begin"
+run_anchor_check "stage3 reference keeps hygiene trail slot" "$SKILL_DIR/references/stage3-reporting.md" "Stage 1.5 Hygiene Scan Trail"
+run_anchor_check "stage3 reference keeps Stage 2.7 audit skipped slot" "$SKILL_DIR/references/stage3-reporting.md" "retrospect:audit_skipped: no artifacts"
+run_anchor_check "stage3 reference counts success-pattern memory" "$SKILL_DIR/references/stage3-reporting.md" "successful_patterns\` rows whose"
+run_anchor_check "stage3 reference gates success-pattern memory approval" "$SKILL_DIR/references/stage3-reporting.md" "explicitly approved in Stage 3"
+run_anchor_check "stage3 reference keeps memory-scan evidence block" "$SKILL_DIR/references/stage3-reporting.md" "memory_scan finding #<n>"
+run_anchor_check "stage3 reference keeps memory-scan HTML comment" "$SKILL_DIR/references/stage3-reporting.md" "<!-- memory_scan finding #<n>:"
+run_anchor_check "stage3 reference scopes backing_repo to routed actions" "$SKILL_DIR/references/stage3-reporting.md" "any row with \`upstream_feedback\` or \`issue\`"
+run_anchor_check "stage3 reference keeps broad falsification triggers" "$SKILL_DIR/references/stage3-reporting.md" "prefer this"
+run_anchor_check "report template includes hygiene trail" "$SKILL_DIR/references/report-template.md" "Hygiene Scan Trail"
+run_anchor_check "report template includes memory-scan evidence block" "$SKILL_DIR/references/report-template.md" "<!-- memory_scan finding #<n>:"
+run_anchor_check "stage4 reference exists with memory-hint contract" "$SKILL_DIR/references/stage4-execution.md" "Frontmatter contract"
+run_anchor_check "stage4 reference reuses repeat scan step 6" "$SKILL_DIR/references/stage4-execution.md" "Stage 2 step 6's repeat scan results"
+run_anchor_check "stage4 reference returns backing_repo misses to step 7" "$SKILL_DIR/references/stage4-execution.md" "re-run Stage 2 step 7"
+run_anchor_check "appendices reference exists with Red Flags" "$SKILL_DIR/references/appendices.md" "Red Flags"
 
 echo ""
 echo "=== summary ==="

--- a/tests/test_retrospect_routing.sh
+++ b/tests/test_retrospect_routing.sh
@@ -122,6 +122,7 @@ run_anchor_check "stage1-2 reference keeps self-correction cap priority" "$SKILL
 run_anchor_check "stage1-2 reference keeps action assignment ladder" "$SKILL_DIR/references/stage1-2-analysis.md" "Action assignment (step 7)"
 run_anchor_check "stage1-2 reference keeps hygiene action mapping" "$SKILL_DIR/references/stage1-2-analysis.md" "stale reference -> \`memory\`"
 run_anchor_check "stage1-2 reference keeps bounded-drop cycle rule" "$SKILL_DIR/references/stage1-2-analysis.md" "PRAXIS_RETROSPECT_UNRUNNABLE_DROP_CYCLES"
+run_anchor_check "stage1-2 reference keeps census retry promotion threshold" "$SKILL_DIR/references/stage1-2-analysis.md" "PRAXIS_RETROSPECT_CENSUS_RETRY_THRESHOLD"
 run_anchor_check "stage1-2 reference keeps access-blocked retention" "$SKILL_DIR/references/stage1-2-analysis.md" "access-blocked-only findings are never auto-dropped"
 run_anchor_check "stage1-2 reference keeps cluster repeat propagation" "$SKILL_DIR/references/stage1-2-analysis.md" "cluster_repeat_count = max(repeat_count) + (cluster_event_count - 1)"
 run_anchor_check "stage1-2 reference keeps link scanner wikilink support" "$SKILL_DIR/references/stage1-2-analysis.md" "[[wikilink]]"


### PR DESCRIPTION
## 요약
- retrospect SKILL.md의 세부 절차를 Stage별 reference 파일로 분리했습니다.
- Stage 2/2.5/3/4의 load-bearing 계약(memory_scan, backing_repo, Gate verdict, hygiene trail, Stage 2.7 audit, success-pattern approval)을 reference와 smoke test에 고정했습니다.
- retrospect mix-check hook의 repair guide를 새 reference 경로와 단계 번호에 맞췄습니다.

## 검증
- `PATH="$HOME/.pyenv/shims:$PATH" PYTHONDONTWRITEBYTECODE=1 ./scripts/run-tests.sh` → `311 passed in 6.45s`, `ALL TESTS PASSED`
- `bash tests/test_retrospect_routing.sh` → `PASS: 59`, `FAIL: 0`
- `bash tests/hooks/completion-verify/test_retrospect_mix_check.sh` → `Cases: 67 passed, 0 failed`, `Fixtures: 11 passed, 0 failed`
- Codex review → 수정 필요 correctness/security/maintainability 이슈 없음

Closes #674

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected Retrospect guide reference links to the proper stage-specific contract pages.
  * Added/expanded Retrospect stage documentation, including Stage 1–2 rules, Stage 2.5 action distribution audit, Stage 3 reporting contract, Stage 4 execution clarifications, plus new appendices and report-template guidance.

* **Bug Fixes**
  * Updated user-facing hook-blocking messages and guidance targets to match the corrected documentation references.

* **Tests**
  * Updated validation scripts to assert against the new stage reference files and strengthened directory-wide documentation reference checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->