### PR TITLE
test(skills): check runtime metadata

### DIFF
--- a/scripts/check-plugin-manifests.py
+++ b/scripts/check-plugin-manifests.py
@@ -24,17 +24,20 @@ Phase 2 (ADR-0001) invariants:
   9. Version consistency across versioned artifacts.
   10. spec.md exists at hooks/<role>/<name>/spec.md for every registered
       hook (Phase 3, ADR-0001 §5.3 — specs collocated with impl).
-  11. skills/<skill-name>/ on disk matches the EXPECTED_SKILLS frozen set
+  11. Runtime-sensitive skills carry runtime verification frontmatter
+      (`verified-against-runtime`, `runtime-verified-at`,
+      `runtime-verified-note`).
+  12. skills/<skill-name>/ on disk matches the EXPECTED_SKILLS frozen set
      (issue #465 — surface freeze gate against silent skill proliferation).
-  12. AGENTS.md "## Skills (N)" count and per-skill backtick tokens, and
+  13. AGENTS.md "## Skills (N)" count and per-skill backtick tokens, and
      README.md per-skill backtick tokens, all match EXPECTED_SKILLS
      (issue #498 — doc drift invariant).
-  13. Each manifest `dispatch_groups` (event, matcher) collapses to exactly
+  14. Each manifest `dispatch_groups` (event, matcher) collapses to exactly
      one dispatcher node per platform hooks.json (no member silently left as
      its own node, no second dispatcher node), and the runtime resolver
      `_dispatch.group_members` resolves the same member set the build
      collapsed (ADR-0002, #617 — ties build path and runtime path together).
-  14. docs/hook/<name>.md redirect-stub parity (#606): every hook dir owns a
+  15. docs/hook/<name>.md redirect-stub parity (#606): every hook dir owns a
       byte-identical 1-line stub, and no orphan stub survives (INDEX.md and the
       hand-written NON_HOOK_DOCS allowlist excepted).
   16. docs/hook-operating-matrix.md parity: generated hook operating surface
@@ -48,6 +51,7 @@ import ast
 import importlib.util
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -73,6 +77,120 @@ _dispatch = importlib.util.module_from_spec(_disp_spec)
 _disp_spec.loader.exec_module(_dispatch)
 
 from constants import EXPECTED_SKILLS, OPT_IN_HOOKS, VALID_ROLES  # noqa: E402
+
+
+RUNTIME_METADATA_REQUIRED_FIELDS = (
+    "verified-against-runtime",
+    "runtime-verified-at",
+    "runtime-verified-note",
+)
+RUNTIME_METADATA_PLACEHOLDERS = {
+    "runtime-verified-at": {"YYYY-MM-DD"},
+    "runtime-verified-note": {
+        "<cli-name> <version> — one-line observed behavior",
+        '"<cli-name> <version> — one-line observed behavior"',
+    },
+}
+RUNTIME_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+SKILL_CALL_RE = re.compile(r"\bSkill\(\s*(?:(?:\"|')|skill\s*=)")
+ASK_USER_QUESTION_CALL_RE = re.compile(
+    r"\bAskUserQuestion\s*\("
+    r"|AskUserQuestion:"
+    r"|(?:ask|call|use|offer|confirm|show|surface|present|emit)"
+    r"[^.\n]{0,80}`?AskUserQuestion`?",
+    re.IGNORECASE,
+)
+NEGATED_ASK_USER_QUESTION_RE = re.compile(
+    r"\b(?:do\s+not|don't|never|must\s+not|should\s+not|cannot|can't|avoid)"
+    r"\s+(?:ask|call|use|offer|confirm|show|surface|present|emit)?"
+    r"[^.\n]{0,80}`?AskUserQuestion`?",
+    re.IGNORECASE,
+)
+INLINE_EXECUTION_CONTEXT_RE = re.compile(
+    r"(?:^|\b)(?:run|execute|call|invoke|use|start|launch)"
+    r"(?:\s+(?:(?:the|this)\s+)?(?:command|template|snippet))?"
+    r"\s*:?\s+$",
+    re.IGNORECASE,
+)
+SHELL_COMMAND_TOKEN_RE = re.compile(
+    r"(?:^|[|;&(]\s*|\$\(\s*)"
+    r"(?:[$#]\s+)?"
+    r"(?:(?:if|while|until|elif|then|do|command|exec)\s+)?"
+    r"(?:(?:[A-Za-z_][A-Za-z0-9_]*=\S+)\s+)*"
+    r"(?:\{[a-zA-Z_][a-zA-Z0-9_]*\}\s+)?"
+    r"(?:(?:/|\.{1,2}/|~/)?(?:[A-Za-z0-9_.+-]+/)*)"
+    r"([A-Za-z_][A-Za-z0-9_.+-]*)(?=\s|$)"
+)
+ROOT_PROMPT_COMMAND_RE = re.compile(
+    r"^(?:(?:[A-Za-z_][A-Za-z0-9_]*=\S+)\s+)*"
+    r"(?:(?:/|\.{1,2}/|~/)?(?:[A-Za-z0-9_.+-]+/)*)"
+    r"([A-Za-z_][A-Za-z0-9_.+-]*)(?=\s|$)"
+)
+KNOWN_EXTERNAL_CLI_COMMANDS = {
+    "airflow",
+    "aws",
+    "claude",
+    "cmux",
+    "codex",
+    "curl",
+    "docker",
+    "gemini",
+    "gh",
+    "git",
+    "jq",
+    "kubectl",
+    "node",
+    "npm",
+    "pnpm",
+    "python",
+    "python3",
+    "wget",
+    "yarn",
+}
+SHELL_NON_EXTERNAL_COMMANDS = {
+    "alias",
+    "break",
+    "case",
+    "cd",
+    "command",
+    "continue",
+    "declare",
+    "do",
+    "done",
+    "echo",
+    "elif",
+    "else",
+    "esac",
+    "eval",
+    "exec",
+    "exit",
+    "export",
+    "fi",
+    "for",
+    "function",
+    "if",
+    "local",
+    "popd",
+    "printf",
+    "pushd",
+    "read",
+    "readonly",
+    "return",
+    "set",
+    "shift",
+    "source",
+    "then",
+    "trap",
+    "type",
+    "typeset",
+    "unset",
+    "while",
+}
+EXTERNAL_CLI_WRAPPER_SKILLS = {
+    # Backstop for wrappers whose runtime-sensitive command templates are not
+    # visible to the static fenced-shell scan.
+    "cmux-delegate",
+}
 
 
 def dispatch_node_drifts(
@@ -150,6 +268,237 @@ def _skill_dirs() -> list[Path]:
             continue
         dirs.append(entry)
     return dirs
+
+
+def _parse_skill_frontmatter(skill_path: Path) -> dict[str, object]:
+    """Best-effort parse of the top-level SKILL.md frontmatter.
+
+    The skill spec frontmatter is intentionally simple: top-level scalar keys
+    plus YAML folded/literal blocks for `description`. We only need scalar
+    extraction for the runtime-verification fields, so this parser ignores
+    nested YAML and continuation lines once it has recorded the parent key.
+    """
+    try:
+        text = skill_path.read_text()
+    except OSError:
+        return {}
+    lines = text.splitlines()
+    if len(lines) < 3 or lines[0].strip() != "---":
+        return {}
+
+    data: dict[str, object] = {}
+    i = 1
+    while i < len(lines):
+        raw = lines[i]
+        stripped = raw.strip()
+        if stripped == "---":
+            return data
+        if not raw or raw[0].isspace() or ":" not in raw:
+            i += 1
+            continue
+        key, value = raw.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if re.fullmatch(r"[>|][+-]?", value):
+            data[key] = value
+            i += 1
+            while i < len(lines):
+                cont = lines[i]
+                if cont.strip() == "---":
+                    return data
+                if cont and not cont[0].isspace():
+                    break
+                i += 1
+            continue
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        if value.lower() == "true":
+            data[key] = True
+        elif value.lower() == "false":
+            data[key] = False
+        else:
+            data[key] = value
+        i += 1
+    return {}
+
+
+def _skill_has_helper_executable(skill_dir: Path) -> bool:
+    """True iff the skill ships a runtime helper binary/script beside SKILL.md."""
+    for entry in skill_dir.iterdir():
+        if entry.name == "SKILL.md" or not entry.is_file():
+            continue
+        if entry.name.startswith("."):
+            continue
+        if os.access(entry, os.X_OK):
+            return True
+    return False
+
+
+def _skill_has_external_cli_template(text: str) -> bool:
+    """Return True when fenced shell templates invoke external CLI binaries."""
+    in_shell_fence = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            language = stripped[3:].strip().lower()
+            if in_shell_fence:
+                in_shell_fence = False
+            else:
+                in_shell_fence = language in {"", "bash", "sh", "shell", "zsh"}
+            continue
+        if not in_shell_fence or not stripped:
+            continue
+        line_to_scan = stripped
+        if stripped.startswith("#"):
+            prompt_body = stripped[1:].lstrip()
+            if not _looks_like_external_cli_invocation(prompt_body):
+                continue
+            line_to_scan = prompt_body
+        for match in SHELL_COMMAND_TOKEN_RE.finditer(line_to_scan):
+            command = match.group(1)
+            if command not in SHELL_NON_EXTERNAL_COMMANDS:
+                return True
+    return False
+
+
+def _looks_like_external_cli_invocation(
+    snippet: str, *, allow_unknown: bool = False
+) -> bool:
+    """Heuristic for prompt-prefixed or inline command snippets."""
+    stripped = snippet.strip()
+    if " " not in stripped:
+        return False
+    match = ROOT_PROMPT_COMMAND_RE.match(stripped)
+    if not match:
+        return False
+    command = match.group(1)
+    first_token = stripped.split()[0]
+    if command in SHELL_NON_EXTERNAL_COMMANDS:
+        return False
+    return (
+        command in KNOWN_EXTERNAL_CLI_COMMANDS
+        or "/" in first_token
+        or re.search(r"(^|\s)--[A-Za-z0-9][A-Za-z0-9_-]*", stripped) is not None
+        or allow_unknown
+    )
+
+
+def _skill_has_inline_external_cli(text: str) -> bool:
+    """Return True when inline code snippets show external CLI invocations."""
+    for match in re.finditer(r"`([^`\n]+)`", text):
+        context = text[max(0, match.start() - 40) : match.start()]
+        if not INLINE_EXECUTION_CONTEXT_RE.search(context):
+            continue
+        if _looks_like_external_cli_invocation(match.group(1), allow_unknown=True):
+            return True
+    return False
+
+
+def _skill_has_operative_ask_user_question(text: str) -> bool:
+    """True when prose instructs the skill to use AskUserQuestion at runtime."""
+    for match in ASK_USER_QUESTION_CALL_RE.finditer(text):
+        context = text[max(0, match.start() - 80) : match.end()]
+        if NEGATED_ASK_USER_QUESTION_RE.search(context):
+            continue
+        return True
+    return False
+
+
+def _skill_runtime_verification_reasons(skill_dir: Path) -> list[str]:
+    """Return the runtime-sensitive reasons that require frontmatter metadata.
+
+    The rule intentionally prefers low-ambiguity, static signals already
+    codified in CONTRIBUTING.md:
+
+      - `AskUserQuestion(...)` appears in the spec (interactive runtime call)
+      - `Skill(...)` appears in the spec (delegation runtime call)
+      - the skill wraps external CLI command templates in SKILL.md
+      - the skill ships an executable helper beside SKILL.md (wrapper/runtime
+        surface the prose depends on)
+
+    This keeps the gate conservative for prose-only docs skills while still
+    catching the repo's current runtime-sensitive surfaces.
+    """
+    skill_path = skill_dir / "SKILL.md"
+    try:
+        text = skill_path.read_text()
+    except OSError:
+        return []
+
+    reasons: list[str] = []
+    if _skill_has_operative_ask_user_question(text):
+        reasons.append("AskUserQuestion")
+    if SKILL_CALL_RE.search(text):
+        reasons.append("Skill(...)")
+    if (
+        skill_dir.name in EXTERNAL_CLI_WRAPPER_SKILLS
+        or _skill_has_external_cli_template(text)
+        or _skill_has_inline_external_cli(text)
+    ):
+        reasons.append("external-cli-wrapper")
+    if _skill_has_helper_executable(skill_dir):
+        reasons.append("helper-executable")
+    return reasons
+
+
+def _skill_runtime_metadata_drifts(skill_dir: Path) -> list[str]:
+    """Drift strings for one runtime-sensitive skill's verification metadata."""
+    reasons = _skill_runtime_verification_reasons(skill_dir)
+    if not reasons:
+        return []
+
+    skill_path = skill_dir / "SKILL.md"
+    frontmatter = _parse_skill_frontmatter(skill_path)
+    drifts: list[str] = []
+    reason_text = ", ".join(reasons)
+
+    verified = frontmatter.get("verified-against-runtime")
+    if verified is not True:
+        drifts.append(
+            f"SKILL RUNTIME METADATA {skill_dir.name}: runtime-sensitive "
+            f"({reason_text}) but missing `verified-against-runtime: true`"
+        )
+
+    verified_at = frontmatter.get("runtime-verified-at")
+    if not isinstance(verified_at, str) or not verified_at.strip():
+        drifts.append(
+            f"SKILL RUNTIME METADATA {skill_dir.name}: runtime-sensitive "
+            f"({reason_text}) but missing `runtime-verified-at`"
+        )
+    else:
+        normalized = verified_at.strip()
+        if normalized in RUNTIME_METADATA_PLACEHOLDERS["runtime-verified-at"]:
+            drifts.append(
+                f"SKILL RUNTIME METADATA {skill_dir.name}: "
+                "`runtime-verified-at` still carries a template placeholder"
+            )
+        elif not RUNTIME_DATE_RE.fullmatch(normalized):
+            drifts.append(
+                f"SKILL RUNTIME METADATA {skill_dir.name}: "
+                f"`runtime-verified-at` must be YYYY-MM-DD, got {normalized!r}"
+            )
+
+    verified_note = frontmatter.get("runtime-verified-note")
+    if not isinstance(verified_note, str) or not verified_note.strip():
+        drifts.append(
+            f"SKILL RUNTIME METADATA {skill_dir.name}: runtime-sensitive "
+            f"({reason_text}) but missing `runtime-verified-note`"
+        )
+    else:
+        normalized_note = verified_note.strip()
+        if re.fullmatch(r"[>|][+-]?", normalized_note):
+            drifts.append(
+                f"SKILL RUNTIME METADATA {skill_dir.name}: "
+                "`runtime-verified-note` must be an inline verification note, "
+                "not a block scalar"
+            )
+        elif normalized_note in RUNTIME_METADATA_PLACEHOLDERS["runtime-verified-note"]:
+            drifts.append(
+                f"SKILL RUNTIME METADATA {skill_dir.name}: "
+                "`runtime-verified-note` still carries a template placeholder"
+            )
+
+    return drifts
 
 
 def _has_fail_open_decorator(impl_path: Path) -> bool:
@@ -487,7 +836,13 @@ def main() -> int:
         )
 
     # ------------------------------------------------------------------
-    # Rule 11 — Skill surface freeze (#465)
+    # Rule 11 — runtime-sensitive skill metadata
+    # ------------------------------------------------------------------
+    for skill_dir in _skill_dirs():
+        drifts.extend(_skill_runtime_metadata_drifts(skill_dir))
+
+    # ------------------------------------------------------------------
+    # Rule 12 — Skill surface freeze (#465)
     # ------------------------------------------------------------------
     on_disk_skills = {d.name for d in _skill_dirs()}
     unexpected = on_disk_skills - EXPECTED_SKILLS
@@ -506,7 +861,7 @@ def main() -> int:
         )
 
     # ------------------------------------------------------------------
-    # Rule 12 — Doc skill-count invariant (#498)
+    # Rule 13 — Doc skill-count invariant (#498)
     #
     # AGENTS.md carries an explicit "## Skills (N)" header whose count must
     # equal len(EXPECTED_SKILLS).  Both AGENTS.md and README.md embed skill
@@ -525,7 +880,7 @@ def main() -> int:
     agents_text = agents_md_path.read_text()
     readme_text = readme_md_path.read_text()
 
-    # Rule 12a — AGENTS.md "## Skills (N)" count header must match
+    # Rule 13a — AGENTS.md "## Skills (N)" count header must match
     count_match = _re.search(r"^##\s+Skills\s+\((\d+)\)", agents_text, _re.MULTILINE)
     if count_match is None:
         drifts.append(
@@ -541,7 +896,7 @@ def main() -> int:
                 f"EXPECTED_SKILLS has {expected_count} — update the header"
             )
 
-    # Rule 12b — every EXPECTED_SKILLS member appears in AGENTS.md
+    # Rule 13b — every EXPECTED_SKILLS member appears in AGENTS.md
     agents_backtick_skills = set(_re.findall(r"`([^`]+)`", agents_text))
     missing_in_agents = EXPECTED_SKILLS - agents_backtick_skills
     if missing_in_agents:
@@ -551,7 +906,7 @@ def main() -> int:
             "the skill table"
         )
 
-    # Rule 12c — every EXPECTED_SKILLS member appears as the first column of
+    # Rule 13c — every EXPECTED_SKILLS member appears as the first column of
     # a README.md skill table row.  We match `| \`skill-name\` |` so that a
     # skill name mentioned only in a description cell (cross-reference noise)
     # does not satisfy the check.
@@ -567,7 +922,7 @@ def main() -> int:
         )
 
     # ------------------------------------------------------------------
-    # Rule 13 — dispatch-group ↔ build/runtime consistency (ADR-0002, #617)
+    # Rule 14 — dispatch-group ↔ build/runtime consistency (ADR-0002, #617)
     #
     # Each (event, matcher) in manifest.dispatch_groups is collapsed by the
     # build (filter_hooks_for_host) into ONE dispatcher node, and resolved at
@@ -657,7 +1012,7 @@ def main() -> int:
             )
 
     # ------------------------------------------------------------------
-    # Rule 14 — docs/hook stub parity (#606)
+    # Rule 15 — docs/hook stub parity (#606)
     #
     # Every hook dir (manifest entries + OPT_IN_HOOKS) owns a 1-line
     # docs/hook/<name>.md redirect stub (ADR-0001 §337-338), byte-identical to
@@ -693,7 +1048,7 @@ def main() -> int:
             )
 
     # ------------------------------------------------------------------
-    # Rule 15 — standalone hooks must apply @fail_open (#645)
+    # Rule 16 — standalone hooks must apply @fail_open (#645)
     #
     # Dispatch-group members get `_hook_runtime.fail_open` wrapping at
     # runtime (`_dispatch.run_one`); every other execution path runs

--- a/skills/cmux-browser/SKILL.md
+++ b/skills/cmux-browser/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: cmux-browser
 description: "Browser automation E2E testing via cmux browser CLI — navigation, form input, click, state verification with SPA hydration wait. Triggers on \"cmux browser\", \"cmux 브라우저\"."
+verified-against-runtime: true
+runtime-verified-at: 2026-06-16
+runtime-verified-note: "cmux 1.x browser help + tests/test_cmux_browser.sh — surface handles remain mandatory for most subcommands, and selector-required wrapper errors add usage hints while selector paths pass through."
 ---
 
 # cmux Browser E2E Test

--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: cmux-delegate
 description: Delegate a task to an independent Claude Code session in a new cmux workspace with auto-collected context. Triggers on "cmux delegate", "delegate task", "delegate to new session", "별도 세션", "세션에 위임".
+verified-against-runtime: true
+runtime-verified-at: 2026-06-17
+runtime-verified-note: "cmux/gh/claude/codex/gemini --help probe — cmux new-workspace exists, gh exposes pr/issue commands, claude supports --model/--permission-mode, codex exposes exec, and gemini supports -p/--prompt."
 ---
 
 # cmux-delegate

--- a/skills/cmux-recover-sessions/SKILL.md
+++ b/skills/cmux-recover-sessions/SKILL.md
@@ -11,6 +11,9 @@ description: >
   Only defer to cmux-resume-sessions when there is NO crash context and the user
   explicitly wants to rehydrate a saved snapshot.
   Triggers on "터졌다", "크래시 복구", "크래시 복원", "전원 꺼짐 복구", "OOM 복구", "세션 살려야", "recover cmux", "crash recovery", "power loss recovery", "cmux session recovery".
+verified-against-runtime: true
+runtime-verified-at: 2026-06-16
+runtime-verified-note: "cmux-recover-sessions --list --show-uuid (fixture HOME) + help probe — list mode bypasses cmux ping, preserves HOME/UUID columns, and scans compact-summary sessions through the shared recover scanner."
 ---
 
 # Recover Sessions (cmux)

--- a/skills/cmux-save-sessions/SKILL.md
+++ b/skills/cmux-save-sessions/SKILL.md
@@ -4,6 +4,9 @@ description: >
   Save cmux session list as a JSON snapshot. Current session excluded by default.
   Supports save and list commands.
   Triggers on "save sessions", "session save", "session snapshot", "cmux save", "list snapshots", "snapshot list".
+verified-against-runtime: true
+runtime-verified-at: 2026-06-16
+runtime-verified-note: "mock cmux/tmux probe of cmux-save-sessions — default run excludes $CMUX_WORKSPACE_ID, writes top-level hostname + summary, and serializes sibling Claude session_id values into sessions[].session_id."
 ---
 
 # cmux Save Sessions

--- a/skills/cmux-save-sessions/SKILL.md
+++ b/skills/cmux-save-sessions/SKILL.md
@@ -116,7 +116,8 @@ done
       "branch": "main",
       "pr": "none",
       "category": "[DEV]",
-      "cwd": "/path/to/project"
+      "cwd": "/path/to/project",
+      "session_id": "5f3c1e9a-..."
     }
   ]
 }

--- a/skills/cmux-session-manager/SKILL.md
+++ b/skills/cmux-session-manager/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: cmux-session-manager
 description: Automate daily cmux session management. Manual commands for status (dashboard) and cleanup (tidy + reorganize), plus init (hook) and report (schedule) automation. Triggers on "cmux session", "session management", "session cleanup", "cmux status", "cmux cleanup", "cmux tidy".
+verified-against-runtime: true
+runtime-verified-at: 2026-06-16
+runtime-verified-note: "mock cmux/tmux probe of cmux-session-cleanup --dry-run — it emits three JSON phases split by ---PHASE_SEPARATOR---, keeps safe_named orphans report-only, and routes idle workspaces into idle_cleanup/reorganize."
 ---
 
 # cmux Session Manager

--- a/skills/recover-sessions/SKILL.md
+++ b/skills/recover-sessions/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: recover-sessions
 description: Bulk recover Claude Code sessions after power loss or tmux crash. Interactive interview to determine recovery scope, layout, and execution mode. Triggers on "recover", "session recovery", "restore sessions", "power recovery".
+verified-against-runtime: true
+runtime-verified-at: 2026-06-16
+runtime-verified-note: "claude-recover --list (fixture HOME) + tests/test_recover_scan_display_name.sh — list mode prints HOME/PROJECT/FIRST MESSAGE without tmux creation, and the shared scanner prefers compact-summary display names."
 ---
 
 # Recover Sessions

--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -6,6 +6,9 @@ description: >
   actions, then execute after user approval.
   Triggers on "retrospect", "what went wrong", "session review",
   "session improvement", "what was the issue", "improve".
+verified-against-runtime: true
+runtime-verified-at: 2026-06-16
+runtime-verified-note: "tests/test_retrospect_falsify_recommended.sh + test_retrospect_routing.sh + retrospect hook suites — Stage 3 AskUserQuestion recommendations require falsification traces, and the active-marker/report-fence contract stays aligned."
 ---
 
 # Retrospect

--- a/skills/writing-praxis-skill/SKILL.md
+++ b/skills/writing-praxis-skill/SKILL.md
@@ -6,6 +6,9 @@ description: >
   Triggers on "new praxis skill", "write praxis skill", "add praxis skill",
   "skill template", "praxis skill spec", "스킬 작성", "새 스킬".
   Do NOT activate on "add skill section", "skill up", "skill set".
+verified-against-runtime: true
+runtime-verified-at: 2026-06-16
+runtime-verified-note: "claude 1.x --help + current praxis verified-skill survey — the guide's `--model`/`--resume` examples and AskUserQuestion/Skill runtime constraints still match the live Claude CLI surface."
 ---
 
 # writing-praxis-skill

--- a/tests/test_skill_runtime_metadata.py
+++ b/tests/test_skill_runtime_metadata.py
@@ -559,7 +559,7 @@ def test_current_repo_runtime_sensitive_skill_set_is_stable():
             "external-cli-wrapper",
             "helper-executable",
         ),
-        "retrospect": ("AskUserQuestion", "external-cli-wrapper"),
+        "retrospect": ("external-cli-wrapper",),
         "writing-praxis-skill": (
             "AskUserQuestion",
             "Skill(...)",

--- a/tests/test_skill_runtime_metadata.py
+++ b/tests/test_skill_runtime_metadata.py
@@ -34,6 +34,7 @@ def _write_skill(
     verified: bool | None = None,
     verified_at: str | None = None,
     verified_note: str | None = None,
+    quote_verified_note: bool = True,
     helper_name: str | None = None,
     helper_executable: bool = True,
 ) -> Path:
@@ -48,7 +49,10 @@ def _write_skill(
     if verified_at is not None:
         lines.append(f"runtime-verified-at: {verified_at}")
     if verified_note is not None:
-        lines.append(f'runtime-verified-note: "{verified_note}"')
+        if quote_verified_note:
+            lines.append(f'runtime-verified-note: "{verified_note}"')
+        else:
+            lines.append(f"runtime-verified-note: {verified_note}")
     lines.extend(["---", "", body])
     skill_path = skill_dir / "SKILL.md"
     skill_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -412,6 +416,7 @@ def test_unquoted_runtime_note_placeholder_is_rejected(tmp_path):
         verified=True,
         verified_at="2026-06-17",
         verified_note="<cli-name> <version> — one-line observed behavior",
+        quote_verified_note=False,
     )
     drifts = check._skill_runtime_metadata_drifts(skill_dir)
     assert any("template placeholder" in d for d in drifts), drifts

--- a/tests/test_skill_runtime_metadata.py
+++ b/tests/test_skill_runtime_metadata.py
@@ -1,0 +1,563 @@
+"""Rule 11: runtime-sensitive SKILL.md frontmatter metadata gate.
+
+Locks the static signals used by ``check-plugin-manifests.py`` so the merge-time
+gate stays conservative but non-trivial:
+
+  - operative ``AskUserQuestion(...)`` call prose triggers the metadata requirement;
+  - operative ``Skill(...)`` delegation prose triggers it too;
+  - known external CLI wrapper skills trigger even without a helper executable;
+  - executable helper files beside ``SKILL.md`` trigger it for wrapper-backed
+    skills even when the prose itself stays terse;
+  - missing / placeholder metadata fields are reported as drift;
+  - prose-only docs skills without those signals stay out of scope.
+"""
+from __future__ import annotations
+
+import importlib.util
+import stat
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_spec = importlib.util.spec_from_file_location(
+    "check_plugin_manifests", REPO_ROOT / "scripts" / "check-plugin-manifests.py"
+)
+assert _spec and _spec.loader
+check = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check)
+
+
+def _write_skill(
+    skill_dir: Path,
+    *,
+    body: str,
+    verified: bool | None = None,
+    verified_at: str | None = None,
+    verified_note: str | None = None,
+    helper_name: str | None = None,
+    helper_executable: bool = True,
+) -> Path:
+    skill_dir.mkdir()
+    lines = [
+        "---",
+        "name: fixture-skill",
+        'description: "fixture"',
+    ]
+    if verified is not None:
+        lines.append(f"verified-against-runtime: {'true' if verified else 'false'}")
+    if verified_at is not None:
+        lines.append(f"runtime-verified-at: {verified_at}")
+    if verified_note is not None:
+        lines.append(f'runtime-verified-note: "{verified_note}"')
+    lines.extend(["---", "", body])
+    skill_path = skill_dir / "SKILL.md"
+    skill_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    if helper_name is not None:
+        helper = skill_dir / helper_name
+        helper.write_text("#!/bin/sh\necho helper\n", encoding="utf-8")
+        mode = helper.stat().st_mode
+        if helper_executable:
+            helper.chmod(mode | stat.S_IXUSR)
+        else:
+            helper.chmod(mode & ~stat.S_IXUSR)
+    return skill_path
+
+
+def test_docs_only_skill_without_runtime_markers_is_out_of_scope(tmp_path):
+    skill_dir = tmp_path / "docs-only"
+    _write_skill(
+        skill_dir,
+        body="# Guide\n\nThis skill explains conventions only.\n",
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == []
+    assert check._skill_runtime_metadata_drifts(skill_dir) == []
+
+
+def test_ask_user_question_requires_runtime_metadata(tmp_path):
+    skill_dir = tmp_path / "ask-skill"
+    _write_skill(
+        skill_dir,
+        body=(
+            "# Skill\n\n"
+            "Ask the user via `AskUserQuestion(...)` before continuing.\n"
+        ),
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == ["AskUserQuestion"]
+    drifts = check._skill_runtime_metadata_drifts(skill_dir)
+    assert any("verified-against-runtime: true" in d for d in drifts), drifts
+    assert any("runtime-verified-at" in d for d in drifts), drifts
+    assert any("runtime-verified-note" in d for d in drifts), drifts
+
+
+def test_ask_user_question_mention_only_is_out_of_scope(tmp_path):
+    skill_dir = tmp_path / "mention-only"
+    _write_skill(
+        skill_dir,
+        body=(
+            "# Skill\n\n"
+            "This guide explains why AskUserQuestion is different from prose.\n"
+        ),
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == []
+
+
+def test_negated_ask_user_question_mentions_are_out_of_scope(tmp_path):
+    skill_dir = tmp_path / "negated-ask"
+    _write_skill(
+        skill_dir,
+        body=(
+            "# Skill\n\n"
+            "Do not call `AskUserQuestion(...)` for this docs-only flow.\n"
+            "Never use AskUserQuestion when the user already approved.\n"
+        ),
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == []
+
+
+def test_skill_delegation_requires_runtime_metadata(tmp_path):
+    skill_dir = tmp_path / "delegate-skill"
+    _write_skill(
+        skill_dir,
+        body='# Skill\n\nRun `Skill("praxis:other-skill")` next.\n',
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == ["Skill(...)"]
+
+
+def test_skill_keyword_delegation_requires_runtime_metadata(tmp_path):
+    skill_dir = tmp_path / "delegate-keyword-skill"
+    _write_skill(
+        skill_dir,
+        body='# Skill\n\nRun `Skill(skill="praxis:other-skill")` next.\n',
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == ["Skill(...)"]
+
+
+def test_skill_mention_only_is_out_of_scope(tmp_path):
+    skill_dir = tmp_path / "skill-mention-only"
+    _write_skill(
+        skill_dir,
+        body="# Skill\n\nThis guide compares Skill delegation with slash commands.\n",
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == []
+
+
+def test_executable_helper_requires_runtime_metadata(tmp_path):
+    skill_dir = tmp_path / "helper-skill"
+    _write_skill(
+        skill_dir,
+        body="# Skill\n\nThin wrapper around the sibling helper.\n",
+        helper_name="helper-script",
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == [
+        "helper-executable"
+    ]
+
+
+def test_non_executable_helper_does_not_trigger_by_itself(tmp_path):
+    skill_dir = tmp_path / "nonexec-helper"
+    _write_skill(
+        skill_dir,
+        body="# Skill\n\nStatic docs only.\n",
+        helper_name="helper-script",
+        helper_executable=False,
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == []
+
+
+def test_external_cli_wrapper_template_requires_runtime_metadata(tmp_path):
+    skill_dir = tmp_path / "kubectl-wrapper"
+    _write_skill(
+        skill_dir,
+        body=(
+            "# Skill\n\n"
+            "Run the live command template:\n\n"
+            "```bash\n"
+            "kubectl get pods\n"
+            "```\n"
+        ),
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == [
+        "external-cli-wrapper"
+    ]
+
+
+def test_external_cli_wrapper_template_detects_unlisted_binary(tmp_path):
+    skill_dir = tmp_path / "aws-wrapper"
+    _write_skill(
+        skill_dir,
+        body=(
+            "# Skill\n\n"
+            "Run the live command template:\n\n"
+            "```bash\n"
+            "aws sts get-caller-identity\n"
+            "```\n"
+        ),
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == [
+        "external-cli-wrapper"
+    ]
+
+
+def test_external_cli_wrapper_template_detects_shell_prefixes(tmp_path):
+    skill_dir = tmp_path / "prefixed-wrapper"
+    _write_skill(
+        skill_dir,
+        body=(
+            "# Skill\n\n"
+            "Run prefixed command templates:\n\n"
+            "```bash\n"
+            "command gh pr list\n"
+            "exec cmux list-workspaces\n"
+            "if aws sts get-caller-identity; then\n"
+            "  echo ok\n"
+            "fi\n"
+            "```\n"
+        ),
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == [
+        "external-cli-wrapper"
+    ]
+
+
+def test_external_cli_wrapper_template_detects_env_assignments(tmp_path):
+    skill_dir = tmp_path / "env-prefixed-wrapper"
+    _write_skill(
+        skill_dir,
+        body=(
+            "# Skill\n\n"
+            "Run env-prefixed command templates:\n\n"
+            "```bash\n"
+            "AWS_PROFILE=prod aws sts get-caller-identity\n"
+            "CLAUDE_CONFIG_DIR=~/.claude claude --version\n"
+            "```\n"
+        ),
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == [
+        "external-cli-wrapper"
+    ]
+
+
+def test_external_cli_wrapper_template_detects_path_commands(tmp_path):
+    skill_dir = tmp_path / "path-wrapper"
+    _write_skill(
+        skill_dir,
+        body=(
+            "# Skill\n\n"
+            "Run path-qualified command templates:\n\n"
+            "```bash\n"
+            "/usr/local/bin/cmux list-workspaces\n"
+            "./gh pr list\n"
+            "```\n"
+        ),
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == [
+        "external-cli-wrapper"
+    ]
+
+
+def test_external_cli_wrapper_template_detects_prompt_prefix(tmp_path):
+    skill_dir = tmp_path / "prompt-wrapper"
+    _write_skill(
+        skill_dir,
+        body=(
+            "# Skill\n\n"
+            "Run prompt-prefixed command templates:\n\n"
+            "```bash\n"
+            "$ gh pr list\n"
+            "# kubectl get pods\n"
+            "```\n"
+        ),
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == [
+        "external-cli-wrapper"
+    ]
+
+
+def test_external_cli_wrapper_template_detects_root_prompt_only(tmp_path):
+    skill_dir = tmp_path / "root-prompt-wrapper"
+    _write_skill(
+        skill_dir,
+        body=(
+            "# Skill\n\n"
+            "Run root-prompt command templates:\n\n"
+            "```bash\n"
+            "# kubectl get pods\n"
+            "```\n"
+        ),
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == [
+        "external-cli-wrapper"
+    ]
+
+
+def test_external_cli_wrapper_template_detects_custom_root_prompt(tmp_path):
+    skill_dir = tmp_path / "custom-root-prompt-wrapper"
+    _write_skill(
+        skill_dir,
+        body=(
+            "# Skill\n\n"
+            "Run root-prompt command templates:\n\n"
+            "```bash\n"
+            "# mycli --help\n"
+            "```\n"
+        ),
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == [
+        "external-cli-wrapper"
+    ]
+
+
+def test_external_cli_wrapper_template_ignores_shell_comments(tmp_path):
+    skill_dir = tmp_path / "comment-only-shell"
+    _write_skill(
+        skill_dir,
+        body=(
+            "# Skill\n\n"
+            "Document a commented shell snippet:\n\n"
+            "```bash\n"
+            "# install dependencies before continuing\n"
+            "echo done\n"
+            "```\n"
+        ),
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == []
+
+
+def test_inline_external_cli_requires_runtime_metadata(tmp_path):
+    skill_dir = tmp_path / "inline-cli-wrapper"
+    _write_skill(
+        skill_dir,
+        body="# Skill\n\nRun `gh issue create` after preparing the issue body.\n",
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == [
+        "external-cli-wrapper"
+    ]
+
+
+def test_inline_external_cli_detects_command_context(tmp_path):
+    skill_dir = tmp_path / "inline-cli-command-wrapper"
+    _write_skill(
+        skill_dir,
+        body=(
+            "# Skill\n\n"
+            "Run the command `gh issue create` after preparing the issue body.\n"
+            "Execute this command: `kubectl get pods` before reporting status.\n"
+        ),
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == [
+        "external-cli-wrapper"
+    ]
+
+
+def test_inline_external_cli_detects_unknown_command(tmp_path):
+    skill_dir = tmp_path / "inline-cli-unknown-wrapper"
+    _write_skill(
+        skill_dir,
+        body="# Skill\n\nRun `mycli subcommand` against the live environment.\n",
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == [
+        "external-cli-wrapper"
+    ]
+
+
+def test_inline_external_cli_description_is_out_of_scope(tmp_path):
+    skill_dir = tmp_path / "inline-cli-description"
+    _write_skill(
+        skill_dir,
+        body=(
+            "# Skill\n\n"
+            "| Skill | Purpose |\n"
+            "| --- | --- |\n"
+            "| browser | Browser automation via `cmux browser` CLI |\n"
+        ),
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == []
+
+
+def test_external_cli_wrapper_backstop_requires_runtime_metadata(tmp_path):
+    skill_dir = tmp_path / "cmux-delegate"
+    _write_skill(
+        skill_dir,
+        body=(
+            "# Skill\n\n"
+            "Creates a cmux workspace and sends provider command templates.\n"
+        ),
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == [
+        "external-cli-wrapper"
+    ]
+    drifts = check._skill_runtime_metadata_drifts(skill_dir)
+    assert any("external-cli-wrapper" in drift for drift in drifts), drifts
+
+
+def test_placeholder_metadata_is_rejected(tmp_path):
+    skill_dir = tmp_path / "placeholder-skill"
+    _write_skill(
+        skill_dir,
+        body="Ask the user via `AskUserQuestion(...)`.\n",
+        verified=True,
+        verified_at="YYYY-MM-DD",
+        verified_note="<cli-name> <version> — one-line observed behavior",
+    )
+    drifts = check._skill_runtime_metadata_drifts(skill_dir)
+    assert any("template placeholder" in d for d in drifts), drifts
+
+
+def test_unquoted_runtime_note_placeholder_is_rejected(tmp_path):
+    skill_dir = tmp_path / "unquoted-placeholder-skill"
+    _write_skill(
+        skill_dir,
+        body="Ask the user via `AskUserQuestion(...)`.\n",
+        verified=True,
+        verified_at="2026-06-17",
+        verified_note="<cli-name> <version> — one-line observed behavior",
+    )
+    drifts = check._skill_runtime_metadata_drifts(skill_dir)
+    assert any("template placeholder" in d for d in drifts), drifts
+
+
+def test_valid_metadata_clears_runtime_drift(tmp_path):
+    skill_dir = tmp_path / "valid-skill"
+    _write_skill(
+        skill_dir,
+        body="Ask the user via `AskUserQuestion(...)`.\n",
+        verified=True,
+        verified_at="2026-06-16",
+        verified_note="cmux 1.x — prompt rendered with 3 options and cancel",
+    )
+    assert check._skill_runtime_metadata_drifts(skill_dir) == []
+
+
+def test_quoted_runtime_metadata_scalars_are_accepted(tmp_path):
+    skill_dir = tmp_path / "quoted-metadata-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "\n".join(
+            [
+                "---",
+                "name: fixture-skill",
+                'description: "fixture"',
+                'verified-against-runtime: "true"',
+                'runtime-verified-at: "2026-06-17"',
+                'runtime-verified-note: "cmux 1.x — verified"',
+                "---",
+                "",
+                "Ask the user via `AskUserQuestion(...)`.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    assert check._skill_runtime_metadata_drifts(skill_dir) == []
+
+
+def test_runtime_note_block_scalar_is_rejected(tmp_path):
+    skill_dir = tmp_path / "block-note-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "\n".join(
+            [
+                "---",
+                "name: fixture-skill",
+                'description: "fixture"',
+                "verified-against-runtime: true",
+                "runtime-verified-at: 2026-06-17",
+                "runtime-verified-note: >",
+                "  cmux 1.x — verified",
+                "---",
+                "",
+                "Ask the user via `AskUserQuestion(...)`.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    drifts = check._skill_runtime_metadata_drifts(skill_dir)
+    assert any("block scalar" in drift for drift in drifts), drifts
+
+
+def test_runtime_note_chomping_block_scalar_is_rejected(tmp_path):
+    skill_dir = tmp_path / "chomping-block-note-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "\n".join(
+            [
+                "---",
+                "name: fixture-skill",
+                'description: "fixture"',
+                "verified-against-runtime: true",
+                "runtime-verified-at: 2026-06-17",
+                "runtime-verified-note: >-",
+                "  cmux 1.x — verified",
+                "---",
+                "",
+                "Ask the user via `AskUserQuestion(...)`.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    drifts = check._skill_runtime_metadata_drifts(skill_dir)
+    assert any("block scalar" in drift for drift in drifts), drifts
+
+
+def test_multiple_runtime_signals_are_all_reported(tmp_path):
+    skill_dir = tmp_path / "multi-signal"
+    _write_skill(
+        skill_dir,
+        body=(
+            'Run `Skill("praxis:other")` and then ask via `AskUserQuestion(...)`.\n'
+        ),
+        helper_name="runtime-helper",
+    )
+    reasons = check._skill_runtime_verification_reasons(skill_dir)
+    assert reasons == ["AskUserQuestion", "Skill(...)", "helper-executable"]
+
+
+def test_current_repo_runtime_sensitive_skill_set_is_stable():
+    actual = {
+        skill_dir.name: tuple(check._skill_runtime_verification_reasons(skill_dir))
+        for skill_dir in check._skill_dirs()
+        if check._skill_runtime_verification_reasons(skill_dir)
+    }
+    assert actual == {
+        "cmux-browser": ("external-cli-wrapper", "helper-executable"),
+        "cmux-delegate": ("external-cli-wrapper",),
+        "cmux-recover-sessions": (
+            "AskUserQuestion",
+            "external-cli-wrapper",
+            "helper-executable",
+        ),
+        "cmux-resume-sessions": (
+            "AskUserQuestion",
+            "external-cli-wrapper",
+            "helper-executable",
+        ),
+        "cmux-save-sessions": (
+            "AskUserQuestion",
+            "external-cli-wrapper",
+            "helper-executable",
+        ),
+        "cmux-session-manager": (
+            "AskUserQuestion",
+            "external-cli-wrapper",
+            "helper-executable",
+        ),
+        "codex-review-wrap": (
+            "AskUserQuestion",
+            "Skill(...)",
+            "external-cli-wrapper",
+        ),
+        "recover-sessions": (
+            "AskUserQuestion",
+            "external-cli-wrapper",
+            "helper-executable",
+        ),
+        "retrospect": ("AskUserQuestion", "external-cli-wrapper"),
+        "writing-praxis-skill": (
+            "AskUserQuestion",
+            "Skill(...)",
+            "external-cli-wrapper",
+        ),
+    }


### PR DESCRIPTION
## 요약
- runtime-sensitive skill metadata 검사를 `check-plugin-manifests.py`에 추가했습니다.
- AskUserQuestion, Skill delegation, helper executable, external CLI template/inline command 신호를 검출합니다.
- runtime-sensitive skills에 verified runtime metadata를 추가하고 회귀 테스트를 작성했습니다.

## 검증
- `PATH="$HOME/.pyenv/shims:$PATH" PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/test_skill_runtime_metadata.py -q` → `31 passed, 1 warning`
- `PATH="$HOME/.pyenv/shims:$PATH" PYTHONDONTWRITEBYTECODE=1 python3 scripts/check-plugin-manifests.py` → `plugin-manifest check OK`
- `PATH="$HOME/.pyenv/shims:$PATH" PYTHONDONTWRITEBYTECODE=1 ./scripts/run-tests.sh` → `342 passed in 7.10s`, `ALL TESTS PASSED`
- Codex review → 수정 필요 correctness 이슈 없음

Closes #676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CI validation for “runtime-sensitive skills,” enforcing `verified-against-runtime`, `runtime-verified-at` (YYYY-MM-DD), and `runtime-verified-note` formatting.
* **Documentation**
  * Updated multiple `SKILL.md` files to include runtime verification metadata and check notes.
  * Extended the documented JSON snapshot schema to include a per-session `session_id`.
* **Tests**
  * Added pytest coverage to verify runtime-sensitivity detection and drift reporting, including stable expectations for the repo’s runtime-sensitive skill set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->