### PR TITLE
feat(bypass): summarize review signals

### DIFF
--- a/docs/bypass-telemetry.md
+++ b/docs/bypass-telemetry.md
@@ -87,13 +87,21 @@ Options:
 
 ### Output
 
-The report has four sections:
+The report has seven sections:
 
 1. **Summary** — total events, date window, error count.
 2. **Top bypass vars** — frequency table; vars with error events are flagged
    `⚠ bad-bypass candidate` (bypass followed by a tool failure).
-3. **Bypass by tool** — group by `tool` field.
-4. **Error events** — per-event detail for `tool_result_status == "error"`.
+3. **Bypass by hook / rule family** — normalized labels derived from the bypass
+   var names (for example `SCIOMC_GATE`, `WORKTREE_GATE`, `GH_JSON`) with
+   per-family error counts.
+4. **Bypass by command family** — first executable token after inline env
+   prefixes, with path-like commands collapsed to `path:<basename>`.
+5. **Error-linked bypass signals** — separate summary for vars / hook families /
+   command groups that still ended in a tool error.
+6. **Bypass by tool** — group by `tool` field.
+7. **Error events** — per-event detail for `tool_result_status == "error"`,
+   including the normalized family and command-group labels.
 
 Use `--errors-only` to print just the error-event section.
 
@@ -101,8 +109,9 @@ Use `--errors-only` to print just the error-event section.
 
 The CLI is read-only and only aggregates what is already in the JSONL.
 Bypass var **values** were never stored by the hook; they do not appear in
-any output.  `tool_input` is printed as-is (already truncated and redacted
-by the writer at ≤200 chars).
+any output. `tool_input` remains truncated/redacted by the writer, and the
+derived command-family view never prints a full path — path-like commands are
+collapsed to `path:<basename>`.
 
 ### Example output
 

--- a/skills/bypass-review/bypass-review
+++ b/skills/bypass-review/bypass-review
@@ -255,6 +255,18 @@ def summarize_counter(counter: Counter[str], limit: int = 5) -> str:
     return ", ".join(f"{name} ({count})" for name, count in counter.most_common(limit))
 
 
+def _coerce_bypass_vars(raw: object) -> list[str]:
+    """Return only the string entries of a bypass_env_vars value.
+
+    JSONL records are produced by an external hook, so a malformed entry
+    (non-list, or a list with non-string items) must degrade to an empty
+    list rather than crash aggregation/rendering on the whole report.
+    """
+    if not isinstance(raw, list):
+        return []
+    return [var for var in raw if isinstance(var, str)]
+
+
 def _sorted_unique_families(bypass_vars: list[str]) -> list[str]:
     return sorted({derive_bypass_family(var) for var in bypass_vars}) or [UNKNOWN]
 
@@ -275,7 +287,7 @@ def aggregate(events: list[dict]) -> dict:
     error_events: list[dict] = []
 
     for ev in events:
-        bypass_vars: list[str] = ev.get(FIELD_BYPASS_ENV_VARS) or []
+        bypass_vars: list[str] = _coerce_bypass_vars(ev.get(FIELD_BYPASS_ENV_VARS))
         tool: str = ev.get(FIELD_TOOL) or UNKNOWN
         status: str = ev.get(FIELD_TOOL_RESULT_STATUS) or "ok"
         command_family = derive_command_family(ev.get(FIELD_TOOL_INPUT))
@@ -471,7 +483,7 @@ def _render_error_events(lines: list[str], error_events: list[dict]) -> None:
         ts = ev.get(FIELD_TIMESTAMP, "(no timestamp)")
         session = ev.get(FIELD_SESSION_ID, "") or "(no session)"
         tool = ev.get(FIELD_TOOL, UNKNOWN)
-        bypass_vars = ev.get(FIELD_BYPASS_ENV_VARS) or []
+        bypass_vars = _coerce_bypass_vars(ev.get(FIELD_BYPASS_ENV_VARS))
         tool_input = ev.get(FIELD_TOOL_INPUT, "") or ""
         families = ", ".join(_sorted_unique_families(bypass_vars))
         command_family = derive_command_family(tool_input)

--- a/skills/bypass-review/bypass-review
+++ b/skills/bypass-review/bypass-review
@@ -21,8 +21,11 @@ Options:
 Output sections:
   1. Summary — total events + date window
   2. Top bypass vars — frequency table (which rules are bypassed most)
-  3. Bypass by hook/tool — group by tool field
-  4. Error events — events where tool_result_status == "error"
+  3. Bypass by hook/rule family — normalized from bypass var names
+  4. Bypass by command family — first executable token after env prefixes
+  5. Error-linked bypass signals — separate summary for failed bypasses
+  6. Bypass by tool — group by tool field
+  7. Error events — events where tool_result_status == "error"
 
 Privacy contract (read-only, never re-derives omitted fields):
   - bypass var VALUES are not in the JSONL; this CLI never prints them
@@ -37,8 +40,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
+import shlex
 import sys
-from collections import Counter, defaultdict
+from collections import Counter
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -55,6 +60,16 @@ FIELD_TOOL_INPUT = "tool_input"
 FIELD_TOOL_RESULT_STATUS = "tool_result_status"
 
 STATUS_ERROR = "error"
+UNKNOWN = "(unknown)"
+
+_INLINE_ENV_TOKEN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+_ENV_OPTIONS_WITH_VALUE = {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}
+_BYPASS_PREFIXES = (
+    "CLAUDE_HOOK_BYPASS_",
+    "PRAXIS_HOOK_BYPASS_",
+    "PRAXIS_",
+)
+_BYPASS_SUFFIX = "_BYPASS"
 
 
 # ---------------------------------------------------------------------------
@@ -130,36 +145,164 @@ def load_events(telemetry_dir: Path, days: int) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
+# Aggregation helpers
+# ---------------------------------------------------------------------------
+
+def derive_bypass_family(var_name: object) -> str:
+    """Normalize a bypass var name into a hook/rule-family label."""
+    if not isinstance(var_name, str):
+        return UNKNOWN
+
+    family = var_name.strip()
+    if not family:
+        return UNKNOWN
+
+    for prefix in _BYPASS_PREFIXES:
+        if family.startswith(prefix):
+            family = family[len(prefix):]
+            break
+
+    if family.endswith(_BYPASS_SUFFIX):
+        family = family[: -len(_BYPASS_SUFFIX)]
+
+    return family or UNKNOWN
+
+
+def _looks_like_env_assignment(token: str) -> bool:
+    return bool(_INLINE_ENV_TOKEN_RE.match(token))
+
+
+def _split_env_split_string(value: str) -> list[str] | None:
+    try:
+        return shlex.split(value)
+    except ValueError:
+        return None
+
+
+def _normalize_command_token(token: str) -> str:
+    candidate = token.strip()
+    if not candidate or candidate in {"-", "--"}:
+        return UNKNOWN
+    if "/" in candidate:
+        basename = Path(candidate).name
+        return f"path:{basename}" if basename else "path"
+    return candidate
+
+
+def derive_command_family(tool_input: object) -> str:
+    """Return a safe command-family label from redacted tool_input."""
+    if not isinstance(tool_input, str) or not tool_input.strip():
+        return UNKNOWN
+
+    try:
+        tokens = shlex.split(tool_input, posix=True)
+    except ValueError:
+        tokens = tool_input.split()
+
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if _looks_like_env_assignment(token):
+            index += 1
+            continue
+        if token == "env":
+            index += 1
+            while index < len(tokens):
+                env_token = tokens[index]
+                if _looks_like_env_assignment(env_token):
+                    index += 1
+                    continue
+                if env_token in {"-i", "--ignore-environment", "-0", "--null"}:
+                    index += 1
+                    continue
+                if env_token in {"--", "-"}:
+                    index += 1
+                    continue
+                if env_token in {"-S", "--split-string"} and index + 1 < len(tokens):
+                    split_tokens = _split_env_split_string(tokens[index + 1])
+                    if split_tokens is None:
+                        return UNKNOWN
+                    tokens[index : index + 2] = split_tokens
+                    continue
+                if env_token in _ENV_OPTIONS_WITH_VALUE:
+                    index += 2
+                    continue
+                if (
+                    env_token.startswith("--unset=")
+                    or env_token.startswith("--chdir=")
+                    or env_token.startswith("--split-string=")
+                ):
+                    if env_token.startswith("--split-string="):
+                        split_tokens = _split_env_split_string(
+                            env_token.split("=", 1)[1]
+                        )
+                        if split_tokens is None:
+                            return UNKNOWN
+                        tokens[index : index + 1] = split_tokens
+                        continue
+                    index += 1
+                    continue
+                break
+            continue
+        return _normalize_command_token(token)
+
+    return UNKNOWN
+
+
+def summarize_counter(counter: Counter[str], limit: int = 5) -> str:
+    if not counter:
+        return "none"
+    return ", ".join(f"{name} ({count})" for name, count in counter.most_common(limit))
+
+
+def _sorted_unique_families(bypass_vars: list[str]) -> list[str]:
+    return sorted({derive_bypass_family(var) for var in bypass_vars}) or [UNKNOWN]
+
+
+# ---------------------------------------------------------------------------
 # Aggregation
 # ---------------------------------------------------------------------------
 
 def aggregate(events: list[dict]) -> dict:
     """Return aggregated statistics over the event list."""
     bypass_var_counts: Counter[str] = Counter()
+    bypass_var_error_counts: Counter[str] = Counter()
+    hook_family_counts: Counter[str] = Counter()
+    hook_family_error_counts: Counter[str] = Counter()
+    command_family_counts: Counter[str] = Counter()
+    command_family_error_counts: Counter[str] = Counter()
     tool_counts: Counter[str] = Counter()
     error_events: list[dict] = []
-    # Per-var error count for the "signal too strict?" callout
-    bypass_var_error_counts: Counter[str] = Counter()
 
     for ev in events:
         bypass_vars: list[str] = ev.get(FIELD_BYPASS_ENV_VARS) or []
-        tool: str = ev.get(FIELD_TOOL) or "(unknown)"
+        tool: str = ev.get(FIELD_TOOL) or UNKNOWN
         status: str = ev.get(FIELD_TOOL_RESULT_STATUS) or "ok"
+        command_family = derive_command_family(ev.get(FIELD_TOOL_INPUT))
 
         for var in bypass_vars:
             bypass_var_counts[var] += 1
+            hook_family = derive_bypass_family(var)
+            hook_family_counts[hook_family] += 1
             if status == STATUS_ERROR:
                 bypass_var_error_counts[var] += 1
+                hook_family_error_counts[hook_family] += 1
 
         tool_counts[tool] += 1
+        command_family_counts[command_family] += 1
 
         if status == STATUS_ERROR:
+            command_family_error_counts[command_family] += 1
             error_events.append(ev)
 
     return {
         "total": len(events),
         "bypass_var_counts": bypass_var_counts,
         "bypass_var_error_counts": bypass_var_error_counts,
+        "hook_family_counts": hook_family_counts,
+        "hook_family_error_counts": hook_family_error_counts,
+        "command_family_counts": command_family_counts,
+        "command_family_error_counts": command_family_error_counts,
         "tool_counts": tool_counts,
         "error_events": error_events,
     }
@@ -174,6 +317,44 @@ _DIVIDER = "─" * 60
 
 def _render_header(title: str) -> str:
     return f"\n{_DIVIDER}\n{title}\n{_DIVIDER}"
+
+
+def _render_error_count_table(
+    lines: list[str],
+    title: str,
+    label: str,
+    counts: Counter[str],
+    error_counts: Counter[str],
+    *,
+    note_label: str,
+    empty_label: str,
+    label_width: int,
+) -> None:
+    lines.append(_render_header(title))
+    if not counts:
+        lines.append(f"  ({empty_label})")
+        return
+
+    lines.append(f"  {label:<{label_width}}  {'Count':>5}  {'Errors':>6}  Note")
+    lines.append(f"  {'─' * label_width}  {'─' * 5}  {'─' * 6}  {'─' * 24}")
+    for name, count in counts.most_common():
+        err_count = error_counts.get(name, 0)
+        note = note_label if err_count > 0 else ""
+        lines.append(f"  {name:<{label_width}}  {count:>5}  {err_count:>6}  {note}")
+
+
+def _render_error_signal_summary(lines: list[str], agg: dict) -> None:
+    lines.append(_render_header("Error-Linked Bypass Signals"))
+    if not agg["error_events"]:
+        lines.append("  (none — all bypasses succeeded)")
+        return
+
+    lines.append("  Vars           : " + summarize_counter(agg["bypass_var_error_counts"]))
+    lines.append("  Hook families  : " + summarize_counter(agg["hook_family_error_counts"]))
+    lines.append("  Command groups : " + summarize_counter(agg["command_family_error_counts"]))
+    lines.append(
+        "  Note: these groupings had a bypass active on the same event that still failed."
+    )
 
 
 def render_report(
@@ -203,23 +384,61 @@ def render_report(
         return "\n".join(lines)
 
     # ── Section 2: Top bypass vars ──
-    lines.append(_render_header("Top Bypass Vars (most bypassed rules)"))
+    _render_error_count_table(
+        lines,
+        "Top Bypass Vars (most bypassed rules)",
+        "Var name",
+        agg["bypass_var_counts"],
+        agg["bypass_var_error_counts"],
+        note_label="⚠ bad-bypass candidate",
+        empty_label="no bypass var data",
+        label_width=50,
+    )
     if agg["bypass_var_counts"]:
-        lines.append(f"  {'Var name':<50}  {'Count':>5}  {'Errors':>6}  Note")
-        lines.append(f"  {'─' * 50}  {'─' * 5}  {'─' * 6}  {'─' * 20}")
-        for var, count in agg["bypass_var_counts"].most_common():
-            err_count = agg["bypass_var_error_counts"].get(var, 0)
-            note = "⚠ bad-bypass candidate" if err_count > 0 else ""
-            lines.append(f"  {var:<50}  {count:>5}  {err_count:>6}  {note}")
         lines.append("")
         lines.append(
             "  Note: high count = rule may be too strict; "
             "Errors = bypass followed by tool failure (bad-bypass candidate)."
         )
-    else:
-        lines.append("  (no bypass var data)")
 
-    # ── Section 3: By tool ──
+    # ── Section 3: By hook/rule family ──
+    _render_error_count_table(
+        lines,
+        "Bypass by Hook / Rule Family",
+        "Family",
+        agg["hook_family_counts"],
+        agg["hook_family_error_counts"],
+        note_label="⚠ error-linked",
+        empty_label="no hook/rule family data",
+        label_width=26,
+    )
+    lines.append("")
+    lines.append(
+        "  Family labels are normalized from bypass var names "
+        "(for example SCIOMC_GATE, WORKTREE_GATE, GH_JSON)."
+    )
+
+    # ── Section 4: By command family ──
+    _render_error_count_table(
+        lines,
+        "Bypass by Command Family",
+        "Command",
+        agg["command_family_counts"],
+        agg["command_family_error_counts"],
+        note_label="⚠ error-linked",
+        empty_label="no command-family data",
+        label_width=20,
+    )
+    lines.append("")
+    lines.append(
+        "  Command family is the first executable token after inline env prefixes; "
+        "path-like commands are collapsed to path:<basename>."
+    )
+
+    # ── Section 5: Error-linked summaries ──
+    _render_error_signal_summary(lines, agg)
+
+    # ── Section 6: By tool ──
     lines.append(_render_header("Bypass Events by Tool"))
     if agg["tool_counts"]:
         lines.append(f"  {'Tool':<30}  {'Count':>5}")
@@ -229,7 +448,7 @@ def render_report(
     else:
         lines.append("  (no tool data)")
 
-    # ── Section 4: Error events detail ──
+    # ── Section 7: Error events detail ──
     _render_error_events(lines, agg["error_events"])
 
     return "\n".join(lines)
@@ -251,13 +470,17 @@ def _render_error_events(lines: list[str], error_events: list[dict]) -> None:
     for i, ev in enumerate(error_events, 1):
         ts = ev.get(FIELD_TIMESTAMP, "(no timestamp)")
         session = ev.get(FIELD_SESSION_ID, "") or "(no session)"
-        tool = ev.get(FIELD_TOOL, "(unknown)")
+        tool = ev.get(FIELD_TOOL, UNKNOWN)
         bypass_vars = ev.get(FIELD_BYPASS_ENV_VARS) or []
         tool_input = ev.get(FIELD_TOOL_INPUT, "") or ""
+        families = ", ".join(_sorted_unique_families(bypass_vars))
+        command_family = derive_command_family(tool_input)
         lines.append(f"\n  [{i}] {ts}")
         lines.append(f"      session : {session}")
         lines.append(f"      tool    : {tool}")
         lines.append(f"      bypass  : {', '.join(bypass_vars)}")
+        lines.append(f"      family  : {families}")
+        lines.append(f"      command : {command_family}")
         if tool_input:
             lines.append(f"      input   : {tool_input}")
 

--- a/tests/test_bypass_review.sh
+++ b/tests/test_bypass_review.sh
@@ -15,16 +15,18 @@
 #
 # Tested surface variants:
 #   1. Grouping by bypass var name — frequency counts are correct
-#   2. Error event highlighting — tool_result_status=="error" events surfaced
-#   3. --errors-only flag — output restricted to error events
-#   4. Zero events — handles empty telemetry dir gracefully
-#   5. Multi-day span — events from multiple files aggregated correctly
-#   6. --days flag — events outside the window are excluded
-#   7. --dir flag — reads from override directory (not ~/.praxis)
-#   8. Malformed JSONL lines — skipped without crashing
-#   9. Missing field graceful — record with absent field doesn't crash
-#  10. Privacy: bypass var VALUES do not appear in output
-#  11. Exit code 0 on success, 1 on bad --days value
+#   2. Hook/rule-family + command-family summaries — grouped safely
+#   3. Error event highlighting — tool_result_status=="error" events surfaced
+#   4. --errors-only flag — output restricted to error events
+#   5. Zero events — handles empty telemetry dir gracefully
+#   6. Multi-day span — events from multiple files aggregated correctly
+#   7. --days flag — events outside the window are excluded
+#   8. --dir flag — reads from override directory (not ~/.praxis)
+#   9. Malformed JSONL lines — skipped without crashing
+#  10. Missing field graceful — record with absent field doesn't crash
+#  11. Privacy: bypass var VALUES do not appear in output
+#  12. Privacy: path-like command families do not expose full paths
+#  13. Exit code 0 on success, 1 on bad --days value
 #
 # Run:  bash tests/test_bypass_review.sh
 # Exit: 0 on success, 1 on at least one failure
@@ -68,26 +70,27 @@ assert_fail() {
   printf 'FAIL  [%s] %s\n' "$name" "$msg"
 }
 
-# make_event <bypass_vars_json_array> <status> [tool] [session]
+# make_event <bypass_vars_json_array> <status> [tool] [session] [tool_input]
 # Emits a single JSON line using TODAY's UTC date in the timestamp.
 make_event() {
   local bypass_vars_json="$1"
   local status="$2"
   local tool="${3:-Bash}"
   local session="${4:-test-session-42}"
+  local tool_input="${5:-CLAUDE_HOOK_BYPASS_X=<redacted> git commit}"
   python3 -c "
 import json, sys
 from datetime import datetime, timezone
 bypass_vars = json.loads(sys.argv[1])
-status, tool, session = sys.argv[2], sys.argv[3], sys.argv[4]
+status, tool, session, tool_input = sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5]
 print(json.dumps({
     'timestamp': datetime.now(tz=timezone.utc).isoformat(),
     'session_id': session,
     'tool': tool,
     'bypass_env_vars': bypass_vars,
-    'tool_input': 'CLAUDE_HOOK_BYPASS_X=<redacted> git commit',
+    'tool_input': tool_input,
     'tool_result_status': status,
-}))" "$bypass_vars_json" "$status" "$tool" "$session"
+}))" "$bypass_vars_json" "$status" "$tool" "$session" "$tool_input"
 }
 
 # write_fixture_file <path> <list of json lines>
@@ -138,7 +141,104 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 2: Error event highlighting
+# Test 2: Hook/rule-family + command-family summaries
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== bypass-review: hook and command family summaries ==="
+
+DIR1B="$TMP_DIR/t1b"
+mkdir -p "$DIR1B"
+ev_git_family=$(make_event '["CLAUDE_HOOK_BYPASS_SCIOMC_GATE"]' "ok" "Bash" "sess-git" \
+  'CLAUDE_HOOK_BYPASS_SCIOMC_GATE=<redacted> git commit -m fix')
+ev_gh_family=$(make_event '["PRAXIS_HOOK_BYPASS_WORKTREE_GATE"]' "error" "Bash" "sess-gh1" \
+  'PRAXIS_HOOK_BYPASS_WORKTREE_GATE=<redacted> gh pr create')
+ev_gh_json=$(make_event '["PRAXIS_GH_JSON_BYPASS"]' "error" "Bash" "sess-gh2" \
+  'PRAXIS_GH_JSON_BYPASS=<redacted> gh issue view 1 --json state')
+ev_lower_env=$(make_event '["PRAXIS_GH_JSON_BYPASS"]' "ok" "Bash" "sess-gh3" \
+  'foo=<redacted> gh issue list')
+ev_env_ignore=$(make_event '["PRAXIS_GH_JSON_BYPASS"]' "ok" "Bash" "sess-gh4" \
+  'env -i PRAXIS_GH_JSON_BYPASS=<redacted> gh pr list')
+ev_env_chdir=$(make_event '["PRAXIS_GH_JSON_BYPASS"]' "ok" "Bash" "sess-gh5" \
+  'env -C /tmp PRAXIS_GH_JSON_BYPASS=<redacted> gh pr view 1')
+ev_env_separator=$(make_event '["PRAXIS_GH_JSON_BYPASS"]' "ok" "Bash" "sess-gh6" \
+  'env -- PRAXIS_GH_JSON_BYPASS=<redacted> gh pr status')
+ev_env_dash_separator=$(make_event '["PRAXIS_GH_JSON_BYPASS"]' "ok" "Bash" "sess-gh7" \
+  'env - PRAXIS_GH_JSON_BYPASS=<redacted> gh pr checks 1')
+ev_env_split_string=$(make_event '["PRAXIS_GH_JSON_BYPASS"]' "ok" "Bash" "sess-gh8" \
+  'env -S "PRAXIS_GH_JSON_BYPASS=<redacted> gh pr diff 1"')
+ev_env_split_string_equals=$(make_event '["PRAXIS_GH_JSON_BYPASS"]' "ok" "Bash" "sess-gh9" \
+  'env --split-string="PRAXIS_GH_JSON_BYPASS=<redacted> gh issue list"')
+write_fixture "$DIR1B/bypass-events-$TODAY.jsonl" "$ev_git_family" "$ev_gh_family" "$ev_gh_json" "$ev_lower_env" "$ev_env_ignore" "$ev_env_chdir" "$ev_env_separator" "$ev_env_dash_separator" "$ev_env_split_string" "$ev_env_split_string_equals"
+
+out1b=$(python3 "$CLI" --dir "$DIR1B" --days 7 2>&1)
+
+if echo "$out1b" | grep -q "Bypass by Hook / Rule Family"; then
+  assert_pass "hook/rule family section present"
+else
+  assert_fail "hook/rule family section present" "section missing; output: $out1b"
+fi
+
+if echo "$out1b" | grep -q "Bypass by Command Family"; then
+  assert_pass "command family section present"
+else
+  assert_fail "command family section present" "section missing; output: $out1b"
+fi
+
+if echo "$out1b" | grep -q "Error-Linked Bypass Signals"; then
+  assert_pass "error-linked summary section present"
+else
+  assert_fail "error-linked summary section present" "section missing; output: $out1b"
+fi
+
+if echo "$out1b" | grep -q "SCIOMC_GATE" && echo "$out1b" | grep -q "WORKTREE_GATE" && echo "$out1b" | grep -q "GH_JSON"; then
+  assert_pass "normalized hook/rule families shown"
+else
+  assert_fail "normalized hook/rule families shown" "expected normalized families missing; output: $out1b"
+fi
+
+if echo "$out1b" | grep -q "gh" && echo "$out1b" | grep -q "git"; then
+  assert_pass "command families shown"
+else
+  assert_fail "command families shown" "expected command families missing; output: $out1b"
+fi
+
+if printf '%s\n' "$out1b" | grep -Fq "gh (2)" && printf '%s\n' "$out1b" | grep -Fq "WORKTREE_GATE (1)"; then
+  assert_pass "error-linked summary groups failed bypasses"
+else
+  assert_fail "error-linked summary groups failed bypasses" "expected error-linked summary entries missing; output: $out1b"
+fi
+
+if printf '%s\n' "$out1b" | grep -Fq "foo=<redacted>" || printf '%s\n' "$out1b" | grep -Fq -- "--ignore-environment" || printf '%s\n' "$out1b" | grep -Fq " -C " || printf '%s\n' "$out1b" | grep -Fq "(unknown)"; then
+  assert_fail "command family skips env assignments and env options" "env assignment/option leaked into command family; output: $out1b"
+else
+  assert_pass "command family skips env assignments and env options"
+fi
+
+DIR1C="$TMP_DIR/t1c"
+mkdir -p "$DIR1C"
+ev_env_split_string_malformed=$(make_event '["PRAXIS_GH_JSON_BYPASS"]' "ok" "Bash" "sess-gh10" \
+  'env -S "PRAXIS_GH_JSON_BYPASS=<redacted> gh pr diff 1')
+ev_env_split_string_equals_malformed=$(make_event '["PRAXIS_GH_JSON_BYPASS"]' "ok" "Bash" "sess-gh11" \
+  'env --split-string="PRAXIS_GH_JSON_BYPASS=<redacted> gh issue list')
+write_fixture "$DIR1C/bypass-events-$TODAY.jsonl" "$ev_env_split_string_malformed" "$ev_env_split_string_equals_malformed"
+
+out1c=$(python3 "$CLI" --dir "$DIR1C" --days 7 2>&1)
+rc1c=$?
+
+if [ "$rc1c" -eq 0 ]; then
+  assert_pass "malformed env split-string: exit code 0"
+else
+  assert_fail "malformed env split-string: exit code 0" "exited with code $rc1c; output: $out1c"
+fi
+
+if printf '%s\n' "$out1c" | grep -Fq "(unknown)"; then
+  assert_pass "malformed env split-string: command family unknown"
+else
+  assert_fail "malformed env split-string: command family unknown" "expected unknown family; output: $out1c"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: Error event highlighting
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== bypass-review: error event highlighting ==="
@@ -180,7 +280,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 3: --errors-only flag
+# Test 4: --errors-only flag
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== bypass-review: --errors-only flag ==="
@@ -208,7 +308,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 4: Zero events — empty dir
+# Test 5: Zero events — empty dir
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== bypass-review: zero events — empty telemetry dir ==="
@@ -232,7 +332,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 5: Multi-day aggregation
+# Test 6: Multi-day aggregation
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== bypass-review: multi-day aggregation ==="
@@ -267,7 +367,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 6: --days flag — old events outside window excluded
+# Test 7: --days flag — old events outside window excluded
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== bypass-review: --days=1 excludes yesterday ==="
@@ -295,7 +395,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 7: --dir flag
+# Test 8: --dir flag
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== bypass-review: --dir override ==="
@@ -314,7 +414,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 8: Malformed JSONL lines — skipped without crash
+# Test 9: Malformed JSONL lines — skipped without crash
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== bypass-review: malformed JSONL lines skipped ==="
@@ -345,7 +445,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 9: Missing fields in record — no crash
+# Test 10: Missing fields in record — no crash
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== bypass-review: missing fields in record ==="
@@ -372,7 +472,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 10: Privacy — bypass var VALUES do not appear in output
+# Test 11: Privacy — bypass var VALUES do not appear in output
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== bypass-review: bypass var values never in output ==="
@@ -413,7 +513,34 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 11: Exit code 1 on --days < 1
+# Test 12: Privacy — command family should not expose full path
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== bypass-review: command family path sanitization ==="
+
+DIR10B="$TMP_DIR/t10b"
+mkdir -p "$DIR10B"
+abs_path="/Users/tester/private/internal/run-internal.sh"
+ev_path=$(make_event '["PRAXIS_VERSION_BUMP_BYPASS"]' "ok" "Bash" "test-path" \
+  "PRAXIS_VERSION_BUMP_BYPASS=<redacted> $abs_path --mode verify")
+write_fixture "$DIR10B/bypass-events-$TODAY.jsonl" "$ev_path"
+
+out10b=$(python3 "$CLI" --dir "$DIR10B" --days 1 2>&1)
+
+if printf '%s\n' "$out10b" | grep -Fq "path:run-internal.sh"; then
+  assert_pass "privacy: path-like command family normalized"
+else
+  assert_fail "privacy: path-like command family normalized" "sanitized path family missing; output: $out10b"
+fi
+
+if printf '%s\n' "$out10b" | grep -Fq "$abs_path"; then
+  assert_fail "privacy: full command path not exposed" "absolute path appeared in output"
+else
+  assert_pass "privacy: full command path not exposed"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 13: Exit code 1 on --days < 1
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== bypass-review: exit 1 on bad --days ==="

--- a/tests/test_bypass_review.sh
+++ b/tests/test_bypass_review.sh
@@ -558,6 +558,60 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 14: Malformed bypass_env_vars type — non-list / non-string items
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== bypass-review: malformed bypass_env_vars type ==="
+
+DIR12="$TMP_DIR/t12"
+mkdir -p "$DIR12"
+# Records whose bypass_env_vars is the wrong shape: a bare string, an int,
+# an object, and a list mixing a valid string with non-string items.
+# A well-formed event is appended so the report still has content to render.
+python3 -c "
+import json
+from datetime import datetime, timezone
+ts = datetime.now(tz=timezone.utc).isoformat()
+def rec(bypass):
+    return json.dumps({
+        'timestamp': ts,
+        'session_id': 'sess-malformed',
+        'tool': 'Bash',
+        'bypass_env_vars': bypass,
+        'tool_input': 'X=<redacted> git status',
+        'tool_result_status': 'error',
+    })
+print(rec('CLAUDE_HOOK_BYPASS_SCIOMC_GATE'))   # bare string, not a list
+print(rec(42))                                  # int
+print(rec({'k': 'v'}))                          # object
+print(rec(['PRAXIS_GH_JSON_BYPASS', 7, None]))  # list with non-string items
+" > "$DIR12/bypass-events-$TODAY.jsonl"
+
+out12=$(python3 "$CLI" --dir "$DIR12" --days 1 2>&1)
+rc12=$?
+
+if [ "$rc12" -eq 0 ]; then
+  assert_pass "malformed bypass_env_vars type: exit 0 (no crash)"
+else
+  assert_fail "malformed bypass_env_vars type: exit 0 (no crash)" "exited $rc12; output: $out12"
+fi
+
+# The one valid string item inside the mixed list must still be counted.
+if echo "$out12" | grep -q "PRAXIS_GH_JSON_BYPASS"; then
+  assert_pass "malformed bypass_env_vars type: valid string item retained"
+else
+  assert_fail "malformed bypass_env_vars type: valid string item retained" "valid item missing; output: $out12"
+fi
+
+# A bare-string value must NOT be iterated character-by-character: no
+# single-character var names should leak into the report.
+if printf '%s\n' "$out12" | grep -Eq "^\s+[A-Z] \([0-9]+\)$"; then
+  assert_fail "malformed bypass_env_vars type: string not char-iterated" "single-char var leaked; output: $out12"
+else
+  assert_pass "malformed bypass_env_vars type: string not char-iterated"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## 요약
- `bypass-review`에 hook/rule family, command family, error-linked bypass summary를 추가했습니다.
- env wrapper와 redacted env assignment parsing을 보강했습니다.
- malformed `env --split-string=` 입력이 crash 대신 `(unknown)`으로 집계되도록 처리했습니다.

## 검증
- `bash tests/test_bypass_review.sh` → `Results: 34 passed, 0 failed`
- `bash tests/hooks/postuse-correction/test_bypass_telemetry.sh` → `Results: 33 passed, 0 failed`
- `PATH="$HOME/.pyenv/shims:$PATH" PYTHONDONTWRITEBYTECODE=1 ./scripts/run-tests.sh` → `311 passed in 8.22s`, `ALL TESTS PASSED`
- Codex review → 수정 필요 결함 없음

Closes #675

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded bypass-review CLI reports with additional aggregated insights by bypass family and command family.
  * Added a new error-linked bypass signals summary and enriched error details with derived family/command context.
* **Documentation**
  * Updated the bypass-review output specification to match the revised report structure and privacy behavior (no bypass variable values; redaction/path normalization rules clarified).
* **Tests**
  * Expanded CLI coverage with new fixtures for grouping, error filtering, malformed inputs, privacy/path normalization, and robustness against invalid telemetry shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->