### PR TITLE
docs(agents): include review comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,13 @@ to catch "patch landed in the wrong clone" before it bites a future session.
 
 ## Issue & PR Conventions
 
+- **PR comment retrieval scope**: When asked to check PR comments,
+  inspect both surfaces: Conversation comments (`gh pr view --json comments`)
+  and inline review comments/discussions (`gh api
+  repos/{owner}/{repo}/pulls/<PR>/comments --paginate` or the GraphQL review
+  thread equivalent). Links containing `#discussion_r...` are inline review
+  comments, not Conversation comments; do not report "no comments" or "only one
+  comment" until both surfaces have been checked.
 - **Partial-scope PR**: When a PR addresses only a subset of an issue's body
   (e.g., "items 1-3 implemented, P-redesign deferred to follow-up"), use
   `Refs #N` (or `Addresses #N (items X, Y; Z deferred)`) in the PR body


### PR DESCRIPTION
## 요약
- AGENTS.md에 PR comment 확인 범위를 명시했습니다.
- `gh pr view --json comments`의 Conversation comments와 `pulls/<PR>/comments`의 inline review comments/discussions를 모두 확인하도록 규칙을 추가했습니다.
- `#discussion_r...` 링크는 inline review comment라는 판별 기준을 추가했습니다.

## 검증
- `rg -n "review comment|inline comment|discussion_r|pulls/.*/comments|review discussion|PR review comment|comments" AGENTS.md` → 기존 관련 규칙 없음 확인
- `gh api repos/devseunggwan/praxis/pulls/673/comments --paginate --jq ...` → `discussion_r3421243134`가 `pull_request_review_id`, `path`, `line`을 가진 pull request review comment로 확인됨
- `git diff --check origin/main...HEAD` → 출력 없음, whitespace clean
- `rg -n "PR comment retrieval scope|discussion_r|pulls/<PR>/comments|gh pr view --json comments" AGENTS.md` → 새 규칙 위치 확인
- Codex review → 기존 지침과 충돌하거나 실행 경로를 깨뜨리는 문제 없음

## 미검증
- AGENTS.md 문서 1개 변경이라 full suite는 실행하지 않았습니다.

Closes #680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified PR comment retrieval procedures in developer guidelines to include inspection of both conversation comments and inline review threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->