### PR TITLE
feat(codex-review-wrap): add broker reaper

### DIFF
--- a/skills/codex-review-wrap/LAUNCHD.md
+++ b/skills/codex-review-wrap/LAUNCHD.md
@@ -1,0 +1,79 @@
+# codex-broker-reaper — launchd job (macOS, opt-in)
+
+Periodically reaps openai-codex `app-server-broker.mjs` processes that outlived
+their owning Claude session. This is the **session-independent reclaim path**:
+because it is decoupled from any review session, there is no concurrency hazard
+— each running broker must individually pass the idle-age gate (`broker.log`
+idle longer than `--max-age`, default 30 min) before it is killed, and active
+brokers are skipped.
+
+It complements **Step 6** of `codex-review-wrap`: phase-end reaping keeps the
+broker count down between runs, while this job reclaims orphans whose owning
+session is already gone.
+
+> macOS only. The leak is inherent to launchd reparenting and the
+> `/var/folders` sessionDirs the broker creates.
+
+## Install
+
+```bash
+# 1. Resolve the reaper path from the installed praxis plugin.
+manifest="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/installed_plugins.json"
+plugin_root=$(jq -r '.plugins["praxis@praxis"][0].installPath // empty' "$manifest")
+reaper="$plugin_root/skills/codex-review-wrap/codex-broker-reaper.sh"
+test -x "$reaper" || { echo "reaper not found at $reaper"; exit 1; }
+
+# 2. Render the plist from the template.
+log="$HOME/Library/Logs/codex-broker-reaper.log"
+plist="$HOME/Library/LaunchAgents/com.praxis.codex-broker-reaper.plist"
+sed -e "s#__REAPER_PATH__#$reaper#" -e "s#__LOG_PATH__#$log#" \
+  "$plugin_root/skills/codex-review-wrap/codex-broker-reaper.plist" > "$plist"
+
+# 3. Load it.
+launchctl unload "$plist" 2>/dev/null || true
+launchctl load "$plist"
+launchctl list | grep codex-broker-reaper
+```
+
+## Verify
+
+```bash
+# Force a run now and watch the log.
+launchctl start com.praxis.codex-broker-reaper
+tail -n 20 "$HOME/Library/Logs/codex-broker-reaper.log"
+```
+
+Each run ends with a summary line, e.g.
+`codex-broker-reaper: mode=reap dry_run=false max_age_min=30 scanned=4 reaped=1 gc_dirs=3 skipped=3`.
+
+## Uninstall
+
+```bash
+plist="$HOME/Library/LaunchAgents/com.praxis.codex-broker-reaper.plist"
+launchctl unload "$plist"
+rm -f "$plist"
+```
+
+## Tuning
+
+Edit the rendered `$HOME/Library/LaunchAgents/com.praxis.codex-broker-reaper.plist`:
+
+- `--max-age` argument — minutes a broker must be idle before it is reaped (default 30).
+- `StartInterval` — seconds between runs (default 1800).
+
+Then `launchctl unload` + `launchctl load` to apply.
+
+The job appends to a single log with no rotation. Over the multi-day uptime
+this targets, prune it periodically (or point `StandardOutPath` /
+`StandardErrorPath` at `/dev/null` if you do not need the run history):
+
+```bash
+: > "$HOME/Library/Logs/codex-broker-reaper.log"
+```
+
+## After a praxis plugin update
+
+`installPath` is version-pinned (e.g. `.../praxis/6.3.1`), so the rendered
+plist points at a specific version. After updating the praxis plugin, **re-run
+the Install steps** to re-render the plist against the new path. (The
+phase-end Step 6 reaper resolves its path at runtime and is unaffected.)

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -11,12 +11,16 @@ description: >
   in the session ledger. Step 5f tracks rounds-per-region and surfaces a non-blocking
   diminishing-returns advisory when the same file:region accumulates more than N rounds
   (default 4, configurable via PRAXIS_DIMINISHING_RETURNS_N).
+  At phase end it reaps leaked openai-codex app-server brokers via a co-located
+  idle-gated reaper (GC by default; opt-in running-broker kill via
+  PRAXIS_CODEX_REAP=1) to prevent the kernel_task memory-pressure spike caused
+  by brokers that outlive their owning session.
   Triggers on "codex review", "review codex", "safe review", "/codex-review-wrap",
   "premise verification", "flip detection", "sibling defect", "sibling cross-check",
-  "diminishing returns".
+  "diminishing returns", "broker reap".
 verified-against-runtime: true
 runtime-verified-at: 2026-05-13
-runtime-verified-note: "codex-companion 1.0.4 — ARGUMENTS rejected for non-flag string; AskUserQuestion maxItems:4 blocks worktree list >3 items; Skill() cannot delegate to disable-model-invocation skill. Step 4 hardened to a MUST NOT directive in issue #237 (2026-05-16) — directive-only change, no new runtime claim. Step 5f (PR #329) adds procedural prose only (rounds_per_region ledger + advisory text); no runtime hook code changed — existing verification evidence remains valid."
+runtime-verified-note: "codex-companion 1.0.4 — ARGUMENTS rejected for non-flag string; AskUserQuestion maxItems:4 blocks worktree list >3 items; Skill() cannot delegate to disable-model-invocation skill. Step 4 hardened to a MUST NOT directive in issue #237 (2026-05-16) — directive-only change, no new runtime claim. Step 5f (PR #329) adds procedural prose only (rounds_per_region ledger + advisory text); no runtime hook code changed — existing verification evidence remains valid. Step 6 (issue #683) adds codex-broker-reaper.sh; idle-gate functionally verified 2026-06-18 via synthetic broker — fresh-log SKIP, stale-log REAP, concurrent real brokers untouched (scanned=3 reaped=1 skipped=2)."
 ---
 
 # codex-review-wrap
@@ -44,6 +48,11 @@ have touched each `{file}:{region}` pair and emits a one-time non-blocking
 advisory when the count exceeds the configured threshold (default: 4 rounds,
 env var `PRAXIS_DIMINISHING_RETURNS_N`).
 See **Step 5** for the full gate.
+
+A third responsibility runs at phase end: **Step 6** reaps openai-codex
+app-server brokers that outlived their owning session (a process leak that
+spikes `kernel_task` once accumulated RSS crosses the macOS compressor
+threshold). See **Step 6** for the reaper and its safety gate.
 
 ## Invocation Model
 
@@ -775,6 +784,46 @@ The SoT audit is distinct from the per-finding premise verification in 5b:
 The two steps are complementary: 5b prevents bad fixes; 5h prevents missed
 enumerations from reaching the next reviewer.
 
+### Step 6: Reap leaked codex brokers (phase end)
+
+The openai-codex plugin starts a per-session app-server broker that is
+reparented to launchd (`ppid=1`) and is **not** killed when its owning Claude
+session exits. Across multi-day uptime these accumulate; once cumulative RSS
+crosses the macOS memory-compressor threshold, each idle broker's periodic
+wakeup drives compress/decompress churn that surfaces as `kernel_task` system
+CPU — a non-linear spike, not a linear one.
+
+Run the co-located reaper at the end of every review invocation. It is the
+single source of truth for safe reaping, shared with the launchd job (see
+`LAUNCHD.md`). Resolve it via the plugin root, mirroring the strike-counter
+convention used by the `strike` / `reset-strikes` skills:
+
+**Default — GC only (zero risk).** Removes the stale tmp sessionDirs of brokers
+whose pid is already dead. Never signals a running process.
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/skills/codex-review-wrap/codex-broker-reaper.sh" --gc
+```
+
+**Opt-in — also reap running idle brokers.** When `PRAXIS_CODEX_REAP=1` is set,
+additionally kill running brokers whose `broker.log` has been idle longer than
+`--max-age` minutes (default 30). A broker actively serving a review has a
+freshly-touched log and is skipped by the idle gate, so this stays safe to run
+from inside a session even while sibling sessions hold their own brokers.
+
+```bash
+if [ "${PRAXIS_CODEX_REAP:-0}" = "1" ]; then
+  "${CLAUDE_PLUGIN_ROOT}/skills/codex-review-wrap/codex-broker-reaper.sh" --reap --max-age 30
+fi
+```
+
+**Never** broad-kill (`pkill -f codex`, `pkill node`): sibling Claude sessions
+share the same broker process class, and an unscoped kill aborts their
+in-flight reviews. The reaper's per-broker idle gate is the only sanctioned
+path. The heavy, session-independent reclaim of running orphans belongs to the
+launchd job (`LAUNCHD.md`), not to a per-review phase end — phase end only
+keeps the count below the compressor threshold.
+
 ## Error Handling
 
 | Situation | Action |
@@ -795,6 +844,9 @@ enumerations from reaching the next reviewer.
 | Probe command for 5g returns unexpected output or exits with an error code that signals a command failure (e.g. exit=2 "command not found", permission denied) — distinct from `grep` exit=1 (no match), which is the expected signal for verified absence | Surface probe failure to the user; do not auto-retract the claim — let the user decide |
 | SoT audit (5h) — sibling document not locatable | Emit unresolved advisory; do not block review completion |
 | SoT audit (5h) — parent citation site ambiguous (multiple tables at same heading) | Use all tables at the heading as candidate SoT sources; report each comparison separately |
+| Reaper (Step 6) — running broker has no readable `broker.log` | Idle is indeterminate → broker is KEPT (logged as `SKIP ... no logFile`); never reaped on a guess |
+| Reaper (Step 6) — `CLAUDE_PLUGIN_ROOT` unset (skill run outside plugin context) | Resolve the script via the installed-plugins manifest, same as Step 4a; if still unresolved, skip Step 6 with a one-line note — reaping is best-effort hygiene, not a gate |
+| Reaper (Step 6) — agent considers `pkill -f codex` / `pkill node` | Forbidden: aborts sibling sessions' in-flight reviews. Use only the reaper's per-broker idle gate |
 
 ## Example Flow
 
@@ -935,3 +987,6 @@ user selects: 1
 - Step 5h SoT audit detects truncation only for inline-transcribed enumerations; reference-link citations (sibling SoT referenced but not transcribed) are inherently safe and are not audited
 - Step 5h citation-signal scanning is keyword-based; enumerations that use non-standard labels (e.g., custom matrix row identifiers) may not be detected — when authoring, prefer the standard labels listed in the trigger table
 - Step 5h requires the sibling SoT document to be locally readable; remote-only or external URLs are flagged as unresolved advisories and require manual verification
+- Step 6 reaper is macOS-only (launchd reparenting + `/var/folders` sessionDirs); it is a no-op on other platforms
+- Step 6 idle detection uses `broker.log` mtime as an activity proxy — a broker mid-operation that stays silent longer than `--max-age` could be misjudged idle and reaped; the cost is a benign respawn on the next codex call, never a correctness break
+- Step 6 phase-end reaping keeps the broker count below the compressor threshold but does not reclaim every running orphan; the session-independent launchd job (`LAUNCHD.md`) is what reaps orphans whose owning session is already gone

--- a/skills/codex-review-wrap/codex-broker-reaper.plist
+++ b/skills/codex-review-wrap/codex-broker-reaper.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Template: __REAPER_PATH__ and __LOG_PATH__ are substituted at install time.
+     See LAUNCHD.md for the render/load procedure. -->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.praxis.codex-broker-reaper</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>__REAPER_PATH__</string>
+    <string>--reap</string>
+    <string>--max-age</string>
+    <string>30</string>
+  </array>
+  <key>StartInterval</key>
+  <integer>1800</integer>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>StandardOutPath</key>
+  <string>__LOG_PATH__</string>
+  <key>StandardErrorPath</key>
+  <string>__LOG_PATH__</string>
+</dict>
+</plist>

--- a/skills/codex-review-wrap/codex-broker-reaper.sh
+++ b/skills/codex-review-wrap/codex-broker-reaper.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+# codex-broker-reaper.sh — reap leaked openai-codex app-server brokers.
+#
+# Why this exists:
+#   The openai-codex plugin starts a per-session app-server broker that is meant
+#   to persist for reuse within a session, but it is reparented to launchd
+#   (ppid=1) and is NOT killed when its owning Claude session exits. Over
+#   multi-day uptime these accumulate (observed: 65 broker groups / ~1.37 GB
+#   RSS). Once cumulative RSS crosses the macOS memory-compressor threshold,
+#   every idle broker's periodic wakeup triggers compress/decompress churn that
+#   surfaces as kernel_task sys time — a non-linear spike, not a linear one.
+#
+# Safety model:
+#   - A broker actively serving a review has a freshly-touched broker.log, so
+#     the idle-age gate (--max-age) skips it. We never broad-kill: each running
+#     broker must individually pass the idle gate.
+#   - Worst case for a misjudged reap is a benign respawn on the next codex
+#     call (the broker is stateless infra) — never a correctness break.
+#   - When idleness cannot be determined (no logFile), the broker is KEPT.
+#
+# Modes:
+#   --gc                 GC only: remove stale tmp sessionDirs whose broker pid
+#                        is dead. Zero risk. (default)
+#   --reap [--max-age N] Also kill RUNNING brokers idle > N minutes (default 30),
+#                        then GC. Used by the launchd job and the opt-in
+#                        PRAXIS_CODEX_REAP=1 path in codex-review-wrap.
+#   --dry-run            Print actions without executing.
+#
+# macOS-only: the leak it addresses is inherent to launchd reparenting and the
+# /var/folders sessionDirs the codex broker creates, and the companion launchd
+# plist is macOS-only. BSD stat is used directly (no cross-OS shim).
+
+set -euo pipefail
+
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+STATE_DIR="$CONFIG_DIR/plugins/data/codex-openai-codex/state"
+BROKER_PATTERN='app-server-broker.mjs'
+
+MODE="gc"
+MAX_AGE_MIN=30
+DRY_RUN=false
+
+usage() {
+  cat <<'USAGE'
+Usage: codex-broker-reaper.sh [--gc | --reap] [--max-age MINUTES] [--dry-run]
+
+  --gc            Remove stale tmp sessionDirs of dead brokers (zero risk). Default.
+  --reap          Also kill running brokers idle longer than --max-age, then GC.
+  --max-age N     Idle-minutes threshold for --reap (default: 30).
+  --dry-run       Show what would happen; make no changes.
+  -h, --help      This help.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --gc) MODE="gc" ;;
+    --reap) MODE="reap" ;;
+    --max-age)
+      # Require an explicit numeric value; never consume a following option
+      # (e.g. `--max-age --dry-run` must error, not silently drop --dry-run and
+      # then fall back to a real reap).
+      case "${2:-}" in
+        ''|*[!0-9]*) echo "--max-age requires a positive integer (minutes)" >&2; usage; exit 2 ;;
+      esac
+      MAX_AGE_MIN="$2"; shift ;;
+    --dry-run) DRY_RUN=true ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+  shift
+done
+
+# Validate --max-age is a positive integer; fall back to default otherwise.
+case "$MAX_AGE_MIN" in
+  ''|*[!0-9]*) MAX_AGE_MIN=30 ;;
+esac
+
+now=$(date +%s)
+max_age_sec=$(( MAX_AGE_MIN * 60 ))
+
+scanned=0; reaped=0; gc_dirs=0; skipped=0
+
+# mtime in epoch seconds (BSD/macOS stat). Returns empty on failure (including a
+# file that vanished in a race) WITHOUT propagating a non-zero exit — otherwise
+# the `m="$(mtime ...)"` assignment would trip `set -e` and abort the whole run
+# before the caller's safe-default branch executes. Callers treat empty as
+# "unknown" and KEEP.
+mtime() { stat -f %m "$1" 2>/dev/null || true; }
+
+# Collect a pid and all its descendants (children-first) into a space list.
+# Captured ONCE before signalling so the SIGKILL pass cannot miss a child that
+# SIGTERM reparented to launchd (which would leave it invisible to the next run).
+# The codex broker tree is: app-server-broker.mjs -> node codex app-server ->
+# native codex app-server.
+collect_tree() {
+  local pid="$1" child
+  for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+    collect_tree "$child"
+  done
+  printf '%s ' "$pid"
+}
+
+# Resolve the broker's sessionDir from its command-line endpoint:
+#   ... serve --endpoint unix:/<sessionDir>/broker.sock
+session_dir_of() {
+  ps -o command= -p "$1" 2>/dev/null \
+    | sed -nE 's@.*unix:(.*/cxc-[A-Za-z0-9]+)/broker\.sock.*@\1@p' \
+    | head -1
+}
+
+# Guard before any rm -rf: a sessionDir must be a cxc-* dir under a known temp
+# root. A corrupt broker.json carrying sessionDir="/" or "$HOME" is rejected so
+# the GC pass can never wipe a real tree on malformed input.
+is_safe_session_dir() {
+  local d="$1"
+  case "$(basename "$d")" in cxc-*) ;; *) return 1 ;; esac
+  case "$d" in
+    /var/folders/*|/private/var/folders/*|/tmp/*|/private/tmp/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Best-effort single instance: the opt-in phase-end reaper and the launchd job
+# can otherwise overlap on the same sessionDirs. A stale lock (>5 min — a prior
+# run killed before its EXIT trap) is stolen.
+LOCK="${TMPDIR:-/tmp}/com.praxis.codex-broker-reaper.lock"
+if ! mkdir "$LOCK" 2>/dev/null; then
+  lock_m="$(mtime "$LOCK")"
+  if [[ -n "$lock_m" ]] && (( now - lock_m > 300 )); then
+    rmdir "$LOCK" 2>/dev/null || true
+    mkdir "$LOCK" 2>/dev/null || { echo "codex-broker-reaper: lock contended — exiting"; exit 0; }
+  else
+    echo "codex-broker-reaper: another instance running — exiting"
+    exit 0
+  fi
+fi
+trap 'rmdir "$LOCK" 2>/dev/null || true' EXIT
+
+# --- Pass 1: reap running, idle brokers (only in --reap mode) ---
+if [[ "$MODE" == "reap" ]]; then
+  for pid in $(pgrep -f "$BROKER_PATTERN" 2>/dev/null || true); do
+    scanned=$(( scanned + 1 ))
+    sdir="$(session_dir_of "$pid")"
+    log="$sdir/broker.log"
+
+    if [[ -z "$sdir" || ! -e "$log" ]]; then
+      echo "SKIP   pid=$pid (no logFile — idle indeterminate, kept)"
+      skipped=$(( skipped + 1 )); continue
+    fi
+
+    m="$(mtime "$log")"
+    case "$m" in ''|*[!0-9]*) m=$now ;; esac   # raced/removed → treat as fresh → keep
+    idle=$(( now - m ))
+    if (( idle < max_age_sec )); then
+      echo "SKIP   pid=$pid (active: idle ${idle}s < ${max_age_sec}s gate)"
+      skipped=$(( skipped + 1 )); continue
+    fi
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+      echo "WOULD REAP pid=$pid idle=${idle}s dir=$sdir"
+    else
+      # Re-check right before the kill: if the broker started serving in the
+      # gap its log advanced — skip rather than kill mid-request.
+      now2=$(date +%s); m2="$(mtime "$log")"
+      case "$m2" in ''|*[!0-9]*) m2=$now2 ;; esac
+      if (( now2 - m2 < max_age_sec )); then
+        echo "SKIP   pid=$pid (became active before kill)"
+        skipped=$(( skipped + 1 )); continue
+      fi
+      tree="$(collect_tree "$pid")"
+      for p in $tree; do kill -TERM "$p" 2>/dev/null || true; done
+      sleep 1
+      for p in $tree; do kill -KILL "$p" 2>/dev/null || true; done
+      [[ -n "$sdir" ]] && is_safe_session_dir "$sdir" && [[ -d "$sdir" ]] && rm -rf "$sdir"
+      echo "REAPED pid=$pid idle=${idle}s dir=$sdir"
+    fi
+    reaped=$(( reaped + 1 ))
+  done
+fi
+
+# --- Pass 2: GC stale tmp sessionDirs of dead brokers (both modes) ---
+if [[ -d "$STATE_DIR" ]]; then
+  shopt -s nullglob
+  for bj in "$STATE_DIR"/*/broker.json; do
+    pid="$(jq -r '.pid // empty' "$bj" 2>/dev/null || true)"
+    sdir="$(jq -r '.sessionDir // empty' "$bj" 2>/dev/null || true)"
+    [[ -z "$pid" ]] && continue
+    # Alive brokers are left to the reap pass (idle-gated); GC only dead ones.
+    kill -0 "$pid" 2>/dev/null && continue
+    if [[ -n "$sdir" ]] && is_safe_session_dir "$sdir" && [[ -d "$sdir" ]]; then
+      if [[ "$DRY_RUN" == "true" ]]; then
+        echo "WOULD GC  dir=$sdir (broker pid $pid dead)"
+      else
+        rm -rf "$sdir"
+        echo "GC     dir=$sdir (broker pid $pid dead)"
+      fi
+      gc_dirs=$(( gc_dirs + 1 ))
+    fi
+  done
+fi
+
+echo "codex-broker-reaper: mode=$MODE dry_run=$DRY_RUN max_age_min=$MAX_AGE_MIN scanned=$scanned reaped=$reaped gc_dirs=$gc_dirs skipped=$skipped"

--- a/skills/codex-review-wrap/codex-broker-reaper.sh
+++ b/skills/codex-review-wrap/codex-broker-reaper.sh
@@ -61,8 +61,14 @@ while [[ $# -gt 0 ]]; do
       # (e.g. `--max-age --dry-run` must error, not silently drop --dry-run and
       # then fall back to a real reap).
       case "${2:-}" in
-        ''|*[!0-9]*) echo "--max-age requires a positive integer (minutes)" >&2; usage; exit 2 ;;
+        ''|*[!0-9]*) echo "--max-age requires an integer >= 1 (minutes)" >&2; usage; exit 2 ;;
       esac
+      # All-digits but zero-valued ("0", "00", ...) must also fail: max_age_sec=0
+      # would make the idle gate skip nothing and reap fresh, in-use brokers.
+      # 10# forces base-10 so leading zeros never trip octal evaluation.
+      if (( 10#$2 < 1 )); then
+        echo "--max-age requires an integer >= 1 (minutes)" >&2; usage; exit 2
+      fi
       MAX_AGE_MIN="$2"; shift ;;
     --dry-run) DRY_RUN=true ;;
     -h|--help) usage; exit 0 ;;
@@ -114,6 +120,14 @@ session_dir_of() {
 # the GC pass can never wipe a real tree on malformed input.
 is_safe_session_dir() {
   local d="$1"
+  # Reject anything but a clean absolute path. A traversal-shaped path such as
+  # /tmp/../Users/me/cxc-x string-matches the /tmp/* allowlist below yet resolves
+  # OUTSIDE the temp root, so a downstream rm -rf would escape. Screen the raw
+  # string for relative form and parent-dir / empty segments before allowlisting.
+  [[ "$d" = /* ]] || return 1
+  case "$d" in
+    *"/../"*|*"/.."|*"//"*) return 1 ;;
+  esac
   case "$(basename "$d")" in cxc-*) ;; *) return 1 ;; esac
   case "$d" in
     /var/folders/*|/private/var/folders/*|/tmp/*|/private/tmp/*) return 0 ;;

--- a/tests/test_codex_broker_reaper.sh
+++ b/tests/test_codex_broker_reaper.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# tests/test_codex_broker_reaper.sh — guard the reaper's destructive-op safety gates
+#
+# codex-broker-reaper.sh runs `rm -rf` on broker sessionDirs and SIGKILLs broker
+# trees. Two validation gates protect those destructive ops:
+#   1. --max-age must be an integer >= 1. A zero-valued age makes max_age_sec=0,
+#      so the idle gate skips nothing and fresh, in-use brokers get reaped.
+#   2. is_safe_session_dir() must reject traversal-shaped paths. A path like
+#      /tmp/../Users/me/cxc-x string-matches the /tmp/* allowlist yet resolves
+#      OUTSIDE the temp root, letting rm -rf escape.
+#
+# Run:  ./tests/test_codex_broker_reaper.sh
+# Exit: 0 on success, 1 on first failure (after summary).
+
+set +e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REAPER="$REPO_ROOT/skills/codex-review-wrap/codex-broker-reaper.sh"
+
+if [ ! -f "$REAPER" ]; then
+  echo "FAIL: codex-broker-reaper.sh not found at $REAPER" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+pass() { PASS=$((PASS + 1)); echo "  PASS  $1"; }
+fail() { FAIL=$((FAIL + 1)); FAILED_NAMES+=("$1"); echo "  FAIL  $1" >&2; }
+
+# --- Gate 1: --max-age validation -------------------------------------------
+# Expect exit 2 (rejected) for non-positive / non-numeric values.
+assert_max_age_rejected() {
+  local val="$1"
+  bash "$REAPER" --reap --max-age "$val" --dry-run >/dev/null 2>&1
+  if [ $? -eq 2 ]; then pass "--max-age '$val' rejected"; else fail "--max-age '$val' should be rejected (exit 2)"; fi
+}
+# Expect non-2 (accepted) for positive integers, including leading-zero forms.
+assert_max_age_accepted() {
+  local val="$1"
+  bash "$REAPER" --reap --max-age "$val" --dry-run >/dev/null 2>&1
+  if [ $? -ne 2 ]; then pass "--max-age '$val' accepted"; else fail "--max-age '$val' should be accepted"; fi
+}
+
+for v in 0 00 000 abc "" "1.5" "-1"; do assert_max_age_rejected "$v"; done
+for v in 1 5 30 030; do assert_max_age_accepted "$v"; done
+
+# --- Gate 2: is_safe_session_dir traversal hardening ------------------------
+# Extract the pure function and exercise it in isolation (the script body runs
+# lock acquisition on source, so we lift just the function).
+FN="$(sed -n '/^is_safe_session_dir()/,/^}/p' "$REAPER")"
+if [ -z "$FN" ]; then
+  fail "could not extract is_safe_session_dir() from reaper"
+else
+  safe_rc() { bash -c "$FN"$'\n'"is_safe_session_dir \"\$1\"; echo \$?" _ "$1"; }
+  assert_safe() {
+    local d="$1"
+    if [ "$(safe_rc "$d")" = 0 ]; then pass "safe: '$d'"; else fail "'$d' should be SAFE"; fi
+  }
+  assert_reject() {
+    local d="$1"
+    if [ "$(safe_rc "$d")" != 0 ]; then pass "reject: '$d'"; else fail "'$d' should be REJECTED"; fi
+  }
+
+  # Clean absolute cxc-* dirs under known temp roots → SAFE.
+  assert_safe "/tmp/cxc-abc"
+  assert_safe "/var/folders/xx/cxc-y"
+  assert_safe "/private/tmp/cxc-z"
+  assert_safe "/private/var/folders/aa/cxc-w"
+
+  # Traversal-shaped and out-of-root paths → REJECT.
+  assert_reject "/tmp/../Users/me/cxc-x"      # embedded /../ escapes temp root
+  assert_reject "/tmp/cxc-a/../../../etc"      # climbs out
+  assert_reject "/tmp/cxc-a/.."                # trailing /..
+  assert_reject "//tmp/cxc-a"                  # empty segment
+  assert_reject "relative/cxc-a"               # not absolute
+  assert_reject "/tmp/notcxc"                  # basename not cxc-*
+  assert_reject "/etc/cxc-a"                   # outside allowlist
+fi
+
+echo ""
+echo "=== summary ==="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "Failed cases:"
+  for n in "${FAILED_NAMES[@]}"; do
+    echo "  - $n"
+  done
+  exit 1
+fi
+
+exit 0

--- a/tests/test_skill_runtime_metadata.py
+++ b/tests/test_skill_runtime_metadata.py
@@ -553,6 +553,7 @@ def test_current_repo_runtime_sensitive_skill_set_is_stable():
             "AskUserQuestion",
             "Skill(...)",
             "external-cli-wrapper",
+            "helper-executable",
         ),
         "recover-sessions": (
             "AskUserQuestion",


### PR DESCRIPTION
## 배경

openai-codex 플러그인의 `app-server-broker.mjs`는 세션 종료 시 정리되지 않고 launchd(`ppid=1`)로 재부모화되어 누수됩니다. 6일 가동 환경에서 65개 broker 그룹(199 프로세스, ~1.37GB RSS)까지 누적되어 `kernel_task` 231%/sys 62%의 주원인이 되었고, 누적 RSS가 macOS 메모리 compressor 임계를 넘기면 유휴 broker의 wakeup마다 compress/decompress churn이 발생해 비선형 급증을 유발합니다.

## 변경

reaping 로직을 단일 스크립트에 두고 phase-end(skill)와 launchd가 공유합니다.

- **`codex-broker-reaper.sh`** — `--gc`(죽은 broker의 tmp sessionDir 삭제, 위험 0) / `--reap --max-age N`(실행 중이지만 `broker.log` mtime이 N분 초과 idle인 broker만 SIGTERM→KILL, 기본 30) / `--dry-run`. 실행 중 broker는 `pgrep -f app-server-broker.mjs`로 직접 열거.
- **`codex-review-wrap` SKILL.md Step 6** — phase-end에 `--gc` 항상, `PRAXIS_CODEX_REAP=1`일 때만 `--reap`. broad `pkill` 금지 명시.
- **`codex-broker-reaper.plist` + `LAUNCHD.md`** — 세션과 디커플된 30분 주기 reclaim 잡(자동 load 안 함, 수동 설치).

## 안전 게이트

- `broker.log` mtime 기반 idle 판정 → 진행 중 리뷰 broker는 자동 제외
- kill 직전 freshness 재확인, `cxc-*` shape 가드(`rm -rf` 오삭제 차단), 단일 인스턴스 락
- 오판으로 long-idle 라이브 broker를 reap해도 다음 호출 시 respawn(correctness 무해)

## 검증

- shellcheck clean / bash -n
- 기능 테스트: fresh-log SKIP, stale-log REAP, **동시 실행 중 실제 broker 무사**(scanned=3 reaped=1 skipped=2), GC shape-guard(`/`·non-cxc 거부), 락(held→exit / stale→steal)
- 2회 독립 리뷰: omc:code-reviewer(MEDIUM 4 반영) + Codex(P2 2건 — `set -e` 중단 / `--max-age` dry-run 소실 — 실측 후 수정)
- praxis 전체 테스트 스위트 3회 통과 + plist lint

macOS 전용 (launchd reparenting + `/var/folders` sessionDir).

Closes #683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional macOS broker reaper to clean up leaked Codex broker session artifacts and reduce idle broker accumulation.
  * Introduced a phase-end cleanup step with a safe default (GC-only) and an opt-in mode for additional idle broker reaping based on log age.

* **Documentation**
  * Added end-to-end instructions for installing, validating, tuning, and uninstalling the reaper using a background system job.

* **Tests**
  * Added automated safety-gate checks to ensure reaping respects strict allowlisting and correct `--max-age` validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->