### PR TITLE
fix(check): detect runtime signals in references

### DIFF
--- a/scripts/check-plugin-manifests.py
+++ b/scripts/check-plugin-manifests.py
@@ -412,28 +412,43 @@ def _skill_runtime_verification_reasons(skill_dir: Path) -> list[str]:
 
       - `AskUserQuestion(...)` appears in the spec (interactive runtime call)
       - `Skill(...)` appears in the spec (delegation runtime call)
-      - the skill wraps external CLI command templates in SKILL.md
+      - the skill wraps external CLI command templates in SKILL.md or references/*.md
       - the skill ships an executable helper beside SKILL.md (wrapper/runtime
         surface the prose depends on)
 
+    Scanning includes SKILL.md and all references/*.md so that operative signals
+    that live exclusively in reference files are not missed (false negative).
     This keeps the gate conservative for prose-only docs skills while still
     catching the repo's current runtime-sensitive surfaces.
     """
     skill_path = skill_dir / "SKILL.md"
     try:
-        text = skill_path.read_text()
+        skill_text = skill_path.read_text()
     except OSError:
         return []
 
+    # Collect reference texts (references/*.md alongside SKILL.md)
+    ref_texts: list[str] = []
+    refs_dir = skill_dir / "references"
+    if refs_dir.is_dir():
+        for ref_path in sorted(refs_dir.glob("*.md")):
+            try:
+                ref_texts.append(ref_path.read_text())
+            except OSError:
+                pass
+
+    # Combined text for signal detection across all prose files
+    all_texts = [skill_text] + ref_texts
+
     reasons: list[str] = []
-    if _skill_has_operative_ask_user_question(text):
+    if any(_skill_has_operative_ask_user_question(t) for t in all_texts):
         reasons.append("AskUserQuestion")
-    if SKILL_CALL_RE.search(text):
+    if any(SKILL_CALL_RE.search(t) for t in all_texts):
         reasons.append("Skill(...)")
     if (
         skill_dir.name in EXTERNAL_CLI_WRAPPER_SKILLS
-        or _skill_has_external_cli_template(text)
-        or _skill_has_inline_external_cli(text)
+        or any(_skill_has_external_cli_template(t) for t in all_texts)
+        or any(_skill_has_inline_external_cli(t) for t in all_texts)
     ):
         reasons.append("external-cli-wrapper")
     if _skill_has_helper_executable(skill_dir):

--- a/scripts/check-plugin-manifests.py
+++ b/scripts/check-plugin-manifests.py
@@ -422,18 +422,24 @@ def _skill_runtime_verification_reasons(skill_dir: Path) -> list[str]:
     catching the repo's current runtime-sensitive surfaces.
     """
     skill_path = skill_dir / "SKILL.md"
+    # Read with errors="replace": a non-UTF-8 byte is replaced, never raises.
+    # This is deliberate over `except UnicodeError: return []` — swallowing a
+    # decode failure on SKILL.md would exclude the skill from the gate entirely
+    # (helper-executable / missing-metadata skills would pass undetected). With
+    # replacement the file is still scanned, so ASCII signals survive and the
+    # gate is never silently bypassed. OSError (truly unreadable) still skips.
     try:
-        skill_text = skill_path.read_text()
+        skill_text = skill_path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return []
 
-    # Collect reference texts (references/*.md alongside SKILL.md)
+    # Collect reference texts (references/*.md alongside SKILL.md).
     ref_texts: list[str] = []
     refs_dir = skill_dir / "references"
     if refs_dir.is_dir():
         for ref_path in sorted(refs_dir.glob("*.md")):
             try:
-                ref_texts.append(ref_path.read_text())
+                ref_texts.append(ref_path.read_text(encoding="utf-8", errors="replace"))
             except OSError:
                 pass
 

--- a/tests/test_skill_runtime_metadata.py
+++ b/tests/test_skill_runtime_metadata.py
@@ -523,6 +523,35 @@ def test_references_only_operative_ask_user_question_is_detected(tmp_path):
     assert check._skill_runtime_verification_reasons(skill_dir) == ["AskUserQuestion"]
 
 
+def test_non_utf8_reference_file_does_not_crash(tmp_path):
+    """A non-UTF-8 references/*.md is read with replacement, never crashes (#685)."""
+    skill_dir = tmp_path / "refs-bad-encoding"
+    _write_skill(
+        skill_dir,
+        body="# Skill\n\nAsk the user via `AskUserQuestion(...)` before continuing.\n",
+    )
+    refs_dir = skill_dir / "references"
+    refs_dir.mkdir()
+    # Invalid UTF-8 — a strict decode would raise UnicodeDecodeError.
+    (refs_dir / "bad.md").write_bytes(b"\xff\xfe\x00bad bytes")
+    # The reference is read with replacement; the SKILL.md signal still detected.
+    assert check._skill_runtime_verification_reasons(skill_dir) == ["AskUserQuestion"]
+
+
+def test_non_utf8_skill_md_is_still_scanned_not_bypassed(tmp_path):
+    """A non-UTF-8 SKILL.md must still be scanned, not silently excluded from the
+    gate — a decode-failure return [] would let a runtime-sensitive skill pass
+    undetected (#685, Codex P2)."""
+    skill_dir = tmp_path / "skill-bad-encoding"
+    skill_dir.mkdir()
+    # SKILL.md with a valid ASCII operative signal followed by an invalid byte.
+    frontmatter = '---\nname: fixture-skill\ndescription: "fixture"\n---\n\n'
+    body = "# Skill\n\nSurface choices via `AskUserQuestion(...)` first.\n"
+    (skill_dir / "SKILL.md").write_bytes(frontmatter.encode() + body.encode() + b"\xff\xfe")
+    # ASCII signal survives replacement → gate is NOT bypassed.
+    assert check._skill_runtime_verification_reasons(skill_dir) == ["AskUserQuestion"]
+
+
 def test_multiple_runtime_signals_are_all_reported(tmp_path):
     skill_dir = tmp_path / "multi-signal"
     _write_skill(

--- a/tests/test_skill_runtime_metadata.py
+++ b/tests/test_skill_runtime_metadata.py
@@ -507,6 +507,22 @@ def test_runtime_note_chomping_block_scalar_is_rejected(tmp_path):
     assert any("block scalar" in drift for drift in drifts), drifts
 
 
+def test_references_only_operative_ask_user_question_is_detected(tmp_path):
+    """Operative AskUserQuestion in references/*.md alone must trigger the gate."""
+    skill_dir = tmp_path / "refs-only-ask"
+    _write_skill(
+        skill_dir,
+        body="# Skill\n\nThis skill delegates work to sub-steps defined in references.\n",
+    )
+    refs_dir = skill_dir / "references"
+    refs_dir.mkdir()
+    (refs_dir / "step1.md").write_text(
+        "# Step 1\n\nSurface the choices via `AskUserQuestion(...)` before proceeding.\n",
+        encoding="utf-8",
+    )
+    assert check._skill_runtime_verification_reasons(skill_dir) == ["AskUserQuestion"]
+
+
 def test_multiple_runtime_signals_are_all_reported(tmp_path):
     skill_dir = tmp_path / "multi-signal"
     _write_skill(
@@ -560,7 +576,7 @@ def test_current_repo_runtime_sensitive_skill_set_is_stable():
             "external-cli-wrapper",
             "helper-executable",
         ),
-        "retrospect": ("external-cli-wrapper",),
+        "retrospect": ("AskUserQuestion", "external-cli-wrapper"),
         "writing-praxis-skill": (
             "AskUserQuestion",
             "Skill(...)",


### PR DESCRIPTION
## 배경

런타임 메타데이터 게이트(#676/#678)의 `_skill_runtime_verification_reasons`가
`SKILL.md` 본문만 스캔하고 `references/*.md`는 보지 않아, operative 런타임 신호
(`AskUserQuestion`/`Skill(...)`/외부 CLI/helper)를 references로만 배치한 prose-only
스킬이 게이트를 통째로 우회할 수 있는 false-negative가 있었습니다.

## 변경

- `scripts/check-plugin-manifests.py`: `_skill_runtime_verification_reasons`가
  `SKILL.md` + `references/*.md`를 합쳐(`all_texts`) 모든 검출 함수에 통과시키도록 확장.
  operative vs non-operative 구분(부정문맥 regex)은 파일별로 동일 적용 — 새 코드경로 없음.
- `tests/test_skill_runtime_metadata.py`: references-only operative `AskUserQuestion`
  fixture 검출 테스트 추가. 스냅샷 갱신 — retrospect가 `('AskUserQuestion','external-cli-wrapper')`로 복귀.

## 검증

- `./scripts/build-plugin-manifests.py` → clean
- `./scripts/check-plugin-manifests.py` → OK
- `./scripts/run-tests.sh` → 343 passed

Caller chain verified: grep found 1 production caller (scripts/check-plugin-manifests.py:446) + test callsites; signature unchanged (skill_dir)
Pre-commit verified: ./scripts/run-tests.sh -> 343 passed

Closes #685


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for runtime metadata detection across reference documentation files.

* **Chores**
  * Enhanced metadata verification to scan skill reference files alongside primary documentation for improved completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->