### PR TITLE
fix(askuserquestion): enforce falsified line pre-authoring

### DIFF
--- a/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
@@ -71,7 +71,16 @@ ADVISORY_MSG = (
 ASK_MSG = (
     "(Recommended) 라벨이 있으나 question body 에 "
     "'Falsified: <disconfirming test 결과>' 가 없음. "
-    "CLAUDE.md Self-Falsify Before Recommendation Lock 룰. 추가 후 재시도. "
+    "CLAUDE.md Self-Falsify Before Recommendation Lock 룰. "
+    # Template-level guidance (issue #682): the problem is not only this call —
+    # the AskUserQuestion compose template is missing the field. Bake a
+    # column-0 `Falsified:` line into every future (Recommended) compose BEFORE
+    # the tool call is formed, not just when the hook fires.
+    "[pre-author-template] "
+    "이번 호출뿐 아니라 앞으로 (Recommended) 라벨을 붙일 때마다 "
+    "AskUserQuestion 작성 직전(도구 호출 전) 에 "
+    "첫 칼럼 시작 'Falsified: <검증 결과>' 줄을 템플릿에 포함하라 — "
+    "인스턴스 수정이 아닌 템플릿 수정이 필요하다. "
     "'Falsified:' 는 자기 줄 첫 칼럼에서 시작해야 한다 (startswith 검사) — "
     "질문문 중간/불릿/코드펜스 내부 배치는 미검출."
 )
@@ -81,7 +90,15 @@ ANCHORING_ASK_MSG = (
     "natural/obvious/clearly/default/prefer/recommend/안전한/자연스러운/"
     "당연히/분명히/추천/기본값) 이 있으나 question body 에 "
     "'Falsified: <disconfirming test 결과>' 가 없음. "
-    "CLAUDE.md Output-Block-Level Falsification Gate. 추가 후 재시도. "
+    "CLAUDE.md Output-Block-Level Falsification Gate. "
+    # Template-level guidance (issue #682): bake the Falsified: line into the
+    # AskUserQuestion compose template for every anchoring-framed option, not
+    # just the current call.
+    "[pre-author-template] "
+    "이번 호출뿐 아니라 앞으로 confidence-anchoring 토큰을 옵션 라벨/설명에 쓸 때마다 "
+    "AskUserQuestion 작성 직전(도구 호출 전) 에 "
+    "첫 칼럼 시작 'Falsified: <검증 결과>' 줄을 템플릿에 포함하라 — "
+    "인스턴스 수정이 아닌 템플릿 수정이 필요하다. "
     "'Falsified:' 는 자기 줄 첫 칼럼에서 시작해야 한다 (startswith 검사) — "
     "질문문 중간/불릿/코드펜스 내부 배치는 미검출."
 )

--- a/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
@@ -38,7 +38,7 @@ References: issue [#221](https://github.com/devseunggwan/praxis/issues/221) (adv
 
 | Tool | Trigger condition | Decision |
 |------|-----------------|----------|
-| `AskUserQuestion` (T1) | Option `label` contains exact `(Recommended)` or `(추천)` AND question body has no `Falsified:` line | `permissionDecision: ask` (ASK_MSG) |
+| `AskUserQuestion` (T1) | Option `label` contains exact `(Recommended)` or `(추천)` AND question body has no `Falsified:` line | `permissionDecision: deny` (ASK_MSG) |
 | `AskUserQuestion` (T1) | Option `label` contains exact `(Recommended)` or `(추천)` AND question body has `Falsified:` line | Silent pass |
 | `AskUserQuestion` (T2, issue #369) | Option `label` OR `description` contains a confidence-anchoring framing token AND question body has no `Falsified:` line | `permissionDecision: ask` (ANCHORING_ASK_MSG) |
 | `AskUserQuestion` (T2) | Same as above + `Falsified:` present | Silent pass |
@@ -57,7 +57,7 @@ self-authored proposal block about to be surfaced. When these exact tokens
 
 - **`Falsified:` present** → silent pass. The model has provided verifiable
   evidence of a disconfirming test.
-- **`Falsified:` absent** → `permissionDecision: ask` with ASK_MSG. The model
+- **`Falsified:` absent** → `permissionDecision: deny` with ASK_MSG (hard block — issue #393). The model
   must add the falsification line and retry.
 
 T1 scans `options[].label` ONLY — description is scanned by T2 (below).
@@ -108,16 +108,22 @@ matched; read-only commands (`git log --all`, `gh pr list`) do not fire.
 
 ### Response shape
 
-#### T1 Ask-escalation (AskUserQuestion with exact `(Recommended)` / `(추천)`, no `Falsified:`)
+#### T1 Deny-escalation (AskUserQuestion with exact `(Recommended)` / `(추천)`, no `Falsified:`) — issue #393
 
 **JSON to stdout** (message constant: `ASK_MSG`):
+
+> Issue #682: message upgraded from instance-level ("add Falsified: and retry")
+> to template-level — instructs Claude to bake the `Falsified:` line into the
+> AskUserQuestion compose template for every future `(Recommended)` call, not
+> just fix the current instance. Identified by the `[pre-author-template]` ASCII
+> marker in the message body.
 
 ```json
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "ask",
-    "permissionDecisionReason": "(Recommended) 라벨이 있으나 question body 에 'Falsified: <disconfirming test 결과>' 가 없음. CLAUDE.md Self-Falsify Before Recommendation Lock 룰. 추가 후 재시도. 'Falsified:' 는 자기 줄 첫 칼럼에서 시작해야 한다 (startswith 검사) — 질문문 중간/불릿/코드펜스 내부 배치는 미검출."
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "(Recommended) 라벨이 있으나 question body 에 'Falsified: <disconfirming test 결과>' 가 없음. CLAUDE.md Self-Falsify Before Recommendation Lock 룰. [pre-author-template] 이번 호출뿐 아니라 앞으로 (Recommended) 라벨을 붙일 때마다 AskUserQuestion 작성 직전(도구 호출 전) 에 첫 칼럼 시작 'Falsified: <검증 결과>' 줄을 템플릿에 포함하라 — 인스턴스 수정이 아닌 템플릿 수정이 필요하다. 'Falsified:' 는 자기 줄 첫 칼럼에서 시작해야 한다 (startswith 검사) — 질문문 중간/불릿/코드펜스 내부 배치는 미검출."
   }
 }
 ```
@@ -126,12 +132,15 @@ matched; read-only commands (`git log --all`, `gh pr list`) do not fire.
 
 **JSON to stdout** (message constant: `ANCHORING_ASK_MSG`):
 
+> Issue #682: same template-level upgrade as T1. The `[pre-author-template]`
+> marker identifies this as template-level guidance (not instance-level).
+
 ```json
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "permissionDecision": "ask",
-    "permissionDecisionReason": "옵션 라벨/설명에 confidence-anchoring framing 토큰 (safer/safest/natural/obvious/clearly/default/prefer/recommend/안전한/자연스러운/당연히/분명히/추천/기본값) 이 있으나 question body 에 'Falsified: <disconfirming test 결과>' 가 없음. CLAUDE.md Output-Block-Level Falsification Gate. 추가 후 재시도. 'Falsified:' 는 자기 줄 첫 칼럼에서 시작해야 한다 (startswith 검사) — 질문문 중간/불릿/코드펜스 내부 배치는 미검출."
+    "permissionDecisionReason": "옵션 라벨/설명에 confidence-anchoring framing 토큰 (safer/safest/natural/obvious/clearly/default/prefer/recommend/안전한/자연스러운/당연히/분명히/추천/기본값) 이 있으나 question body 에 'Falsified: <disconfirming test 결과>' 가 없음. CLAUDE.md Output-Block-Level Falsification Gate. [pre-author-template] 이번 호출뿐 아니라 앞으로 confidence-anchoring 토큰을 옵션 라벨/설명에 쓸 때마다 AskUserQuestion 작성 직전(도구 호출 전) 에 첫 칼럼 시작 'Falsified: <검증 결과>' 줄을 템플릿에 포함하라 — 인스턴스 수정이 아닌 템플릿 수정이 필요하다. 'Falsified:' 는 자기 줄 첫 칼럼에서 시작해야 한다 (startswith 검사) — 질문문 중간/불릿/코드펜스 내부 배치는 미검출."
   }
 }
 ```
@@ -174,14 +183,14 @@ All parsing is done with the Python standard library only.
 ### Tests
 
 ```bash
-bash tests/test_output_block_falsify_advisory.sh
+bash tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
 ```
 
-Covers 40 cases:
+Covers 47 cases (44 pre-#682 + 3 new):
 
-**T1 ask-escalation (AskUserQuestion, issue #290):**
-- Option label `(Recommended)` + no `Falsified:` in question body → `permissionDecision: ask` (ASK_MSG)
-- Option label `(추천)` + no `Falsified:` → `permissionDecision: ask`
+**T1 deny-escalation (AskUserQuestion, issue #290/#393):**
+- Option label `(Recommended)` + no `Falsified:` in question body → `permissionDecision: deny` (ASK_MSG)
+- Option label `(추천)` + no `Falsified:` → `permissionDecision: deny`
 - Option label `(Recommended)` + `Falsified:` line present → silent pass
 - Non-recommended option labels → silent pass
 
@@ -192,7 +201,7 @@ Covers 40 cases:
 - Mixed Hangul/ASCII (`prefer this 옵션`) → `ask` — word-boundary regression
 - `(Recommended)` in description-only (no marker in label) → `ask` (replaces former false-positive-guard pass)
 - T2 anchoring + `Falsified:` line → silent pass
-- T1 precedence: literal `(Recommended)` + anchoring description → ASK_MSG (T1 wins)
+- T1 precedence: literal `(Recommended)` + anchoring description → `deny` with ASK_MSG (T1 wins, issue #393)
 
 **T2 negative cases (must not fire):**
 - `preferential treatment` (no token in set) → pass
@@ -217,3 +226,8 @@ Covers 40 cases:
 - Empty payload → exit 0, silent pass
 - Unknown tool name → exit 0, silent pass
 - Non-string command (int / null) → exit 0, silent pass
+
+**Template-level message cases (issue #682):**
+- `(Recommended)` + no `Falsified:` → deny message contains `pre-author-template` ASCII marker
+- confidence-anchoring (`safer`) + no `Falsified:` → ask message contains `pre-author-template` ASCII marker
+- `(Recommended)` + column-0 `Falsified:` present → silent pass (regression — template-level message change must not break satisfaction)

--- a/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
@@ -189,6 +189,7 @@ bash tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
 Covers 47 cases (44 pre-#682 + 3 new):
 
 **T1 deny-escalation (AskUserQuestion, issue #290/#393):**
+
 - Option label `(Recommended)` + no `Falsified:` in question body → `permissionDecision: deny` (ASK_MSG)
 - Option label `(추천)` + no `Falsified:` → `permissionDecision: deny`
 - Option label `(Recommended)` + `Falsified:` line present → silent pass
@@ -204,6 +205,7 @@ Covers 47 cases (44 pre-#682 + 3 new):
 - T1 precedence: literal `(Recommended)` + anchoring description → `deny` with ASK_MSG (T1 wins, issue #393)
 
 **T2 negative cases (must not fire):**
+
 - `preferential treatment` (no token in set) → pass
 - Bare `safe` (only `safer`/`safest` in set) → pass
 - `unsafer` (word-boundary regression) → pass
@@ -228,6 +230,7 @@ Covers 47 cases (44 pre-#682 + 3 new):
 - Non-string command (int / null) → exit 0, silent pass
 
 **Template-level message cases (issue #682):**
+
 - `(Recommended)` + no `Falsified:` → deny message contains `pre-author-template` ASCII marker
 - confidence-anchoring (`safer`) + no `Falsified:` → ask message contains `pre-author-template` ASCII marker
 - `(Recommended)` + column-0 `Falsified:` present → silent pass (regression — template-level message change must not break satisfaction)

--- a/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
@@ -546,6 +546,32 @@ run_case "T2: Falsified: mid-line does not satisfy startswith check — still as
       "단계별로 진행. Falsified: no duplicate PR found. 어떻게 할까요?")"
 
 # ---------------------------------------------------------------------------
+# Template-level guidance cases — issue #682
+# ---------------------------------------------------------------------------
+
+# T1: (Recommended) without Falsified: → deny message must contain the
+# [pre-author-template] marker, proving the message is template-level
+# (instructs Claude to fix the compose template, not just this instance).
+run_case "T1 (issue #682): (Recommended) + no Falsified: → deny contains pre-author-template" \
+  "deny:pre-author-template" \
+  "$(make_ask_payload '["Option A (Recommended)", "Option B"]')"
+
+# T2: confidence-anchoring without Falsified: → ask message must contain the
+# [pre-author-template] marker for the same template-level reason.
+run_case "T2 (issue #682): safer label + no Falsified: → ask contains pre-author-template" \
+  "ask:pre-author-template" \
+  "$(make_ask_payload '["A safer rollout", "B aggressive"]')"
+
+# Regression: a compliant call (Recommended) + column-0 Falsified: — must
+# still silent-pass (the template-level message change must not break this).
+run_case "T1 (issue #682): (Recommended) + column-0 Falsified: → silent pass (regression)" \
+  pass \
+  "$(make_ask_payload_with_question \
+      '["Option A (Recommended)", "Option B"]' \
+      "Falsified: checked existing PRs — none found.
+What should we do?")"
+
+# ---------------------------------------------------------------------------
 # @fail_open structural assertion
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 배경

AskUserQuestion self-falsify 훅은 `(Recommended)` 옵션 + column-0 `Falsified:` 라인
누락 시 호출을 차단합니다(post-authoring 반응형). 매 차단은 그 호출만 국소 교정될 뿐
다음 compose의 생성 템플릿은 갱신되지 않아, 한 세션에서 4회 반복·메모리 fold로도
cross-session 재발이 막히지 않았습니다(#682 escalation).

## 변경

- `hooks/advisory-nudge/output-block-falsify-advisory/impl.py`: `ASK_MSG`(T1 deny),
  `ANCHORING_ASK_MSG`(T2 ask)를 instance-level → **template-level** 가이드로 격상.
  `[pre-author-template]` 마커 + "이 호출만이 아니라 향후 모든 `(Recommended)` compose
  템플릿에 column-0 `Falsified:` 라인을 baked-in 하라"는 지시 추가.
  column-0 `startswith` 구조 검사 및 deny/ask tier 판정은 **불변**(게이트 약화 없음).
- `spec.md`: 기존 T1 `ask`→`deny` 불일치(#393에서 deny로 격상됐으나 spec 미반영) 동반 수정.
- 훅 test: T1/T2가 `pre-author-template` 마커를 emit하는지 + column-0 compliant는
  silent-pass 회귀 케이스 3건 추가.

## 비고

별도 pre-authoring prose/skill 표면은 이 repo에 존재하지 않아(가이드가 전부 훅 메시지에 상주),
제안 2(prose 표면 지시)는 비해당. 제안 1(메시지 격상)으로 의도 충족.

## 검증

- 훅 test: 47 passed
- `python3 -m pytest tests/ -q` → 342 passed
- `./scripts/run-tests.sh` → ALL PASSED

Caller chain verified: N/A -- hook invoked by Claude Code runtime (hooks/manifest.json), message-string constants only
Pre-commit verified: ./scripts/run-tests.sh -> ALL PASSED (hook test 47, pytest 342)

Closes #682
