### PR TITLE
fix(retrospect): gate-7 value check not presence

### DIFF
--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -468,7 +468,7 @@ if grep -Eq '(^|[^\\])"isCompactSummary"[[:space:]]*:[[:space:]]*true' "$TRANSCR
       fi
 
       if [ "$ie_mismatch" = "1" ] || [ "$ut_mismatch" = "1" ]; then
-        GATE7_VIOLATION="post-compaction receipt declares counts that do not match a live grep of the transcript (tolerance=$GATE7_VALUE_TOLERANCE): declared is_error_count=$declared_ie vs live=$live_ie_count; declared user_turn_count=${declared_ut:-(unparseable)} vs live=$live_ut_count — re-run 'grep -c \"is_error\":true' and 'grep -c \"role\":\"user\"' against the transcript this turn and paste the REAL output in the receipt fence before Stage 3"
+        GATE7_VIOLATION="post-compaction receipt declares counts that do not match a live grep of the transcript (tolerance=$GATE7_VALUE_TOLERANCE): declared is_error_count=$declared_ie vs live=$live_ie_count; declared user_turn_count=${declared_ut:-(unparseable)} vs live=$live_ut_count — re-run grep -c '\"is_error\":true' and grep -c '\"role\":\"user\"' against the transcript this turn and paste the REAL output in the receipt fence before Stage 3"
       fi
     fi
   fi

--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -410,6 +410,67 @@ if grep -Eq '(^|[^\\])"isCompactSummary"[[:space:]]*:[[:space:]]*true' "$TRANSCR
         GATE7_VIOLATION="post-compaction receipt declares is_error_count=$ie_count but has no complete '<!-- retrospect:is_error_enum begin/end -->' block with per-event disposition rows inside the receipt fence (found begin=$ie_begin end=$ie_end disposition_rows=$ie_rows) — a count proves a scan ran, not that the errors were read; enumerate each is_error inside the fence with a promote/note/dismiss disposition before Stage 3"
       fi
     fi
+    # Gate-7 VALUE check [issue #671]: presence + structural validity alone do not
+    # prove freshness — a receipt whose counts were transcribed verbatim from the
+    # compaction summary passes every structural check while the declared values
+    # diverge from a live grep of the same transcript. Re-derive is_error_count
+    # and user_turn_count from the transcript and compare against the declared
+    # values. Only runs when no structural violation is already set (no point
+    # overwriting a more specific error).
+    #
+    # Canonical derivation commands (from skills/retrospect/references/report-template.md):
+    #   is_error_count  ← grep -c '"is_error":true' {transcript_path}
+    #   user_turn_count ← grep -c '"role":"user"'  {transcript_path}
+    # interrupt_count has no canonical grep command in the spec; skip re-derivation.
+    #
+    # Tolerance: 1 line off-by-one is accepted to account for live-append races
+    # (the transcript is appended while the Stop hook runs; the final line may be
+    # partially written when grep scans). A delta > GATE7_VALUE_TOLERANCE lines
+    # indicates the count was not derived from a fresh scan this turn.
+    # Exit-code trap: grep -c returns exit code 1 on 0 matches; capture output
+    # into a variable and never put grep -c inside an 'if' condition or '&&' chain.
+    GATE7_VALUE_TOLERANCE=1
+    if [ -z "$GATE7_VIOLATION" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+      # Re-derive is_error_count.
+      live_ie_count=$(grep -c '"is_error":true' "$TRANSCRIPT_PATH" 2>/dev/null || true)
+      live_ie_count=${live_ie_count:-0}
+      # Re-derive user_turn_count (role:user covers both literal JSON forms).
+      live_ut_count=$(grep -c '"role":"user"' "$TRANSCRIPT_PATH" 2>/dev/null || true)
+      live_ut_count=${live_ut_count:-0}
+
+      # Parse declared user_turn_count from the receipt body.
+      # The declared line is: is_error_count: N | user_turn_count: N | interrupt_count: N
+      # Anchor to line-start; pick the first match to resist injection via enum rows.
+      declared_ut=$(printf '%s\n' "$RECEIPT_BLOCK" \
+        | grep -oE '^[[:space:]]*is_error_count:[[:space:]]*[0-9]+[[:space:]]*\|[[:space:]]*user_turn_count:[[:space:]]*[0-9]+' \
+        | grep -oE 'user_turn_count:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -1)
+      # ie_count was already parsed above; reuse it as declared_ie.
+      declared_ie="$ie_count"
+
+      # Numeric comparison helper: abs(a - b) > tol => mismatch.
+      _gate7_mismatch() {
+        local a="$1" b="$2" tol="$3"
+        # Validate both are integers; non-integer means unparseable → treat as mismatch.
+        case "$a$b" in *[!0-9]*) echo 1; return ;; esac
+        local diff=$(( a - b ))
+        [ "$diff" -lt 0 ] && diff=$(( -diff ))
+        [ "$diff" -gt "$tol" ] && echo 1 || echo 0
+      }
+
+      ie_mismatch=$(_gate7_mismatch "$declared_ie" "$live_ie_count" "$GATE7_VALUE_TOLERANCE")
+      # user_turn_count: an absent/unparseable field is always a mismatch.
+      # _gate7_mismatch("", N) silently passes because "" concatenated with a
+      # digit string contains no non-digit chars; guard explicitly instead.
+      if [ -z "$declared_ut" ]; then
+        ut_mismatch=1
+      else
+        ut_mismatch=$(_gate7_mismatch "$declared_ut" "$live_ut_count" "$GATE7_VALUE_TOLERANCE")
+      fi
+
+      if [ "$ie_mismatch" = "1" ] || [ "$ut_mismatch" = "1" ]; then
+        GATE7_VIOLATION="post-compaction receipt declares counts that do not match a live grep of the transcript (tolerance=$GATE7_VALUE_TOLERANCE): declared is_error_count=$declared_ie vs live=$live_ie_count; declared user_turn_count=${declared_ut:-(unparseable)} vs live=$live_ut_count — re-run 'grep -c \"is_error\":true' and 'grep -c \"role\":\"user\"' against the transcript this turn and paste the REAL output in the receipt fence before Stage 3"
+      fi
+    fi
   fi
 fi
 

--- a/hooks/completion-verify/retrospect-mix-check/spec.md
+++ b/hooks/completion-verify/retrospect-mix-check/spec.md
@@ -46,6 +46,42 @@ of the following hold:
 | Any row with `Category` ∈ {tool, workflow, spec-gap} AND `Proposed Actions = memory` (single) | Gate-1 violation detected via independent table parse |
 | Any row with `Proposed Actions = memory` (single) whose `Rationale` lacks exactly 5 lines `^not (issue\|claude_md_draft\|skill_idea\|hook_code\|upstream_feedback): .+$` | Gate-2 violation detected via independent table parse |
 | Any row with `Proposed Actions` containing `upstream_feedback` or `issue` whose `Rationale` lacks a `backing_repo: <owner/repo>` declaration | Gate-3 (backing_repo) violation — Stage 2 step 8 requires this declaration for routing; Stage 4 Action 4 step 0 aborts on absence |
+| Gate-7 value mismatch: `transcript_receipt` fence declares `is_error_count` or `user_turn_count` that diverges from a live grep of the transcript by more than 1 | Receipt was transcribed verbatim from the compaction summary rather than re-derived this turn (presence ≠ freshness) |
+
+### Gate-7 value check (issue #671)
+
+Previous Gate-7 logic verified that the `transcript_receipt` fence was **present** and
+**structurally valid** (begin/end markers, parseable `is_error_count`, enum block when
+count > 0). It did **not** verify that the declared counts were derived from the live
+transcript this turn. A fence with counts transcribed verbatim from the compaction
+summary's pre-formatted numbers is structurally identical to a fresh one and passed.
+
+The value check re-derives `is_error_count` and `user_turn_count` from the transcript
+independently and compares them against the declared values:
+
+| Field | Canonical derivation command |
+|-------|------------------------------|
+| `is_error_count` | `grep -c '"is_error":true' {transcript_path}` |
+| `user_turn_count` | `grep -c '"role":"user"' {transcript_path}` |
+
+`interrupt_count` is not re-derived (no canonical grep command in the spec).
+
+**Tolerance:** a delta of ≤ 1 line is accepted to account for live-append races (the
+transcript is appended while the Stop hook runs; the final line may be partially
+written at scan time). A delta > 1 indicates the count was not derived from a fresh
+scan this turn and blocks Stage 3.
+
+**Non-firing conditions (same as existing Gate-7):**
+
+- `_skipped` variant present and no `begin` fence: value check is skipped (no fence to verify)
+- No compaction marker in transcript: Gate-7 is dormant
+- A structural violation was already set: value check is skipped (more specific error wins)
+- `transcript_path` is missing or unreadable: value check is skipped
+
+**Note:** `interrupt_count` value-checking is deferred because no canonical grep
+command is specified in the skill's stage reference files. Issue #670 will extend
+Gate-7 with a content-error-signal scan; that PR may also define and add
+`interrupt_count` re-derivation.
 
 ### Issue #666 — retrospect-active Stage-3 fence-omission gate
 
@@ -168,8 +204,8 @@ git -C ~/.claude/plugins/.../praxis apply --reverse <patch>
 
 ### Tests
 
-`tests/test_retrospect_mix_check.sh` covers 38 cases plus 8 synthetic
-regression fixtures:
+`tests/hooks/completion-verify/test_retrospect_mix_check.sh` covers 73 cases
+plus 11 synthetic regression fixtures:
 
 - 4 pass scenarios (behavior-only with rationale, escalated tool, escalated
   workflow, compound action)
@@ -195,6 +231,10 @@ regression fixtures:
   pass — parser ignores; T-NEW2 audit_skipped trail line outside fence → pass
   — trail does not interfere with parsing; T-NEW3 output_quality category
   count in card with cli Tool Layer → pass)
+- 6 Gate-7 value check (issue #671): V1 stale is_error_count blocked; V2
+  counts match live transcript → pass; V3 off-by-one within tolerance → pass;
+  V4 stale user_turn_count blocked; V5 _skipped variant bypasses value check →
+  pass; V6 no compaction Gate-7 dormant → pass
 
 ### Category counts (memory_hygiene, output_quality)
 

--- a/tests/hooks/completion-verify/test_retrospect_mix_check.sh
+++ b/tests/hooks/completion-verify/test_retrospect_mix_check.sh
@@ -903,6 +903,26 @@ mk_compaction() {
   }'
 }
 
+# Emit a JSONL record simulating a tool_result with is_error:true.
+# Used to add real is_error events so hook's grep -c matches declared count.
+mk_is_error() {
+  jq -nc --arg msg "$1" '{
+    type: "tool_result",
+    "is_error": true,
+    message: {role: "tool", content: [{type: "text", text: $msg}]}
+  }'
+}
+
+# Emit a JSONL record for a non-compaction user turn.
+# Used to add real user turns so hook's grep -c '"role":"user"' matches declared count.
+# Note: mk_compaction() already contributes 1 user turn to the count.
+mk_user_turn() {
+  jq -nc --arg msg "$1" '{
+    type: "human",
+    message: {role: "user", content: [{type: "text", text: $msg}]}
+  }'
+}
+
 # Receipt fence (real-output form) and the unreachable-skip variant.
 # [issue #664] is_error_count > 0 requires a nested retrospect:is_error_enum block
 # (count proves a scan ran, not that the errors were read).
@@ -1009,9 +1029,18 @@ $(mk_assistant "$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")")"
 run_case "G1_block_postcompaction_no_receipt" "block" "$G1_TRANSCRIPT"
 
 # G2: pass — post-compaction transcript, report WITH the receipt fence.
+# G_RECEIPT_FENCE declares is_error_count: 3 | user_turn_count: 5.
+# Transcript must contain 3 is_error events and 5 user turns (compaction=1 + 4 more).
 G2_REPORT="$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
 ${G_RECEIPT_FENCE}"
 G2_TRANSCRIPT="$(mk_compaction)
+$(mk_user_turn "user message 2")
+$(mk_user_turn "user message 3")
+$(mk_user_turn "user message 4")
+$(mk_user_turn "user message 5")
+$(mk_is_error "hook advisory fire")
+$(mk_is_error "transient timeout")
+$(mk_is_error "classifier blocked a fabrication attempt")
 $(mk_assistant "$G2_REPORT")"
 run_case "G2_pass_postcompaction_with_receipt" "pass" "$G2_TRANSCRIPT"
 
@@ -1052,9 +1081,15 @@ run_case "G6_block_postcompaction_receipt_count_only_no_enum" "block" "$G6_TRANS
 
 # G7: pass — post-compaction, receipt with is_error_count=0. No enum block is
 # required (nothing to enumerate); the content check must NOT fire on zero errors.
+# G_RECEIPT_ZERO declares is_error_count: 0 | user_turn_count: 5.
+# Transcript must contain 0 is_error events and 5 user turns (compaction=1 + 4 more).
 G7_REPORT="$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
 ${G_RECEIPT_ZERO}"
 G7_TRANSCRIPT="$(mk_compaction)
+$(mk_user_turn "user message 2")
+$(mk_user_turn "user message 3")
+$(mk_user_turn "user message 4")
+$(mk_user_turn "user message 5")
 $(mk_assistant "$G7_REPORT")"
 run_case "G7_pass_postcompaction_receipt_zero_errors_no_enum_needed" "pass" "$G7_TRANSCRIPT"
 
@@ -1141,9 +1176,17 @@ run_case "G16_block_postcompaction_single_unterminated_fence" "block" "$G16_TRAN
 # strings inline. Anchored marker matching ignores in-row mentions, so a
 # retrospect of a session about these markers is not false-positive blocked
 # [Codex round 5 — anchor to standalone comment-delimiter lines].
+# G_RECEIPT_VALID_MARKER_MENTIONS declares is_error_count: 2 | user_turn_count: 5.
+# Transcript must contain 2 is_error events and 5 user turns (compaction=1 + 4 more).
 G17_REPORT="$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
 ${G_RECEIPT_VALID_MARKER_MENTIONS}"
 G17_TRANSCRIPT="$(mk_compaction)
+$(mk_user_turn "user message 2")
+$(mk_user_turn "user message 3")
+$(mk_user_turn "user message 4")
+$(mk_user_turn "user message 5")
+$(mk_is_error "hook discussed marker handling")
+$(mk_is_error "error citing is_error_enum marker in prose")
 $(mk_assistant "$G17_REPORT")"
 run_case "G17_pass_postcompaction_valid_receipt_inline_marker_mentions" "pass" "$G17_TRANSCRIPT"
 
@@ -1267,6 +1310,118 @@ EOF
 )
 run_marker_case "F666_7b_block_prose_with_localized_table_no_fence" "block" \
   "$(mk_assistant "$F666_PROSE_TABLE")" "kept"
+
+# Gate-7 VALUE check cases — issue #671 -------------------------------------
+# A receipt with counts transcribed from a stale compaction summary rather than
+# re-derived this turn passes every STRUCTURAL check but may have counts that
+# diverge from a live grep of the same transcript. The value check re-derives
+# is_error_count and user_turn_count and blocks when the delta > tolerance (1).
+#
+# Transcript construction: the fixtures below use real JSONL so the hook's own
+# grep yields deterministic values. mk_compaction() yields 1 "role":"user" line;
+# mk_assistant() yields 0 "role":"user" lines. mk_is_error() and mk_user_turn()
+# are defined near mk_compaction() above.
+
+# V1: block — receipt declares is_error_count=5 but transcript has 0 is_error events.
+# This is the core "stale receipt from compaction summary" scenario.
+V1_RECEIPT='<!-- retrospect:transcript_receipt begin -->
+is_error_count: 5 | user_turn_count: 1 | interrupt_count: 0
+<!-- retrospect:is_error_enum begin -->
+- [1] hook advisory | disposition: dismiss (expected enforcement)
+- [2] timeout | disposition: note (retried)
+- [3] classifier block | disposition: promote (finding #1)
+- [4] network error | disposition: note (transient)
+- [5] parse error | disposition: dismiss (negative-list)
+<!-- retrospect:is_error_enum end -->
+<!-- retrospect:transcript_receipt end -->'
+V1_REPORT="$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+${V1_RECEIPT}"
+# Transcript: 1 compaction (1 user turn), 1 assistant message, 0 is_error events.
+# Live grep: is_error_count=0, user_turn_count=1.
+# Declared: is_error_count=5 — delta=5 > tolerance=1 → block.
+V1_TRANSCRIPT="$(mk_compaction)
+$(mk_assistant "$V1_REPORT")"
+run_case "V1_block_stale_is_error_count_from_compaction_summary" "block" "$V1_TRANSCRIPT"
+
+# V2: pass — receipt declares counts matching live transcript exactly.
+# Transcript: 1 compaction (user turn), 2 is_error events, 1 assistant.
+# Live: is_error_count=2, user_turn_count=1.
+V2_RECEIPT='<!-- retrospect:transcript_receipt begin -->
+is_error_count: 2 | user_turn_count: 1 | interrupt_count: 0
+<!-- retrospect:is_error_enum begin -->
+- [1] hook block | disposition: dismiss (expected enforcement)
+- [2] timeout | disposition: note (retried, resolved)
+<!-- retrospect:is_error_enum end -->
+<!-- retrospect:transcript_receipt end -->'
+V2_REPORT="$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+${V2_RECEIPT}"
+V2_TRANSCRIPT="$(mk_compaction)
+$(mk_is_error "hook advisory fire")
+$(mk_is_error "transient timeout")
+$(mk_assistant "$V2_REPORT")"
+run_case "V2_pass_receipt_counts_match_live_transcript" "pass" "$V2_TRANSCRIPT"
+
+# V3: pass — receipt with is_error_count off by exactly 1 (within tolerance).
+# Transcript: 1 compaction (user turn), 3 is_error events, 1 assistant.
+# Live: is_error_count=3, user_turn_count=1.
+# Declared: is_error_count=2 — delta=1 == tolerance=1 → pass.
+V3_RECEIPT='<!-- retrospect:transcript_receipt begin -->
+is_error_count: 2 | user_turn_count: 1 | interrupt_count: 0
+<!-- retrospect:is_error_enum begin -->
+- [1] hook block | disposition: dismiss (expected enforcement)
+- [2] timeout | disposition: note (retried, resolved)
+<!-- retrospect:is_error_enum end -->
+<!-- retrospect:transcript_receipt end -->'
+V3_REPORT="$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+${V3_RECEIPT}"
+V3_TRANSCRIPT="$(mk_compaction)
+$(mk_is_error "hook advisory fire")
+$(mk_is_error "transient timeout")
+$(mk_is_error "third error during live-append race")
+$(mk_assistant "$V3_REPORT")"
+run_case "V3_pass_is_error_count_off_by_one_within_tolerance" "pass" "$V3_TRANSCRIPT"
+
+# V4: block — user_turn_count declared as 7 but transcript has 1 user turn.
+# Delta = 6 > tolerance = 1 → block.
+# is_error_count=0 so no enum block required.
+V4_RECEIPT='<!-- retrospect:transcript_receipt begin -->
+is_error_count: 0 | user_turn_count: 7 | interrupt_count: 0
+<!-- retrospect:transcript_receipt end -->'
+V4_REPORT="$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+${V4_RECEIPT}"
+# Transcript: 1 compaction (1 user turn), 0 is_error events, 1 assistant.
+# Live: is_error_count=0, user_turn_count=1. Declared: user_turn_count=7 → block.
+V4_TRANSCRIPT="$(mk_compaction)
+$(mk_assistant "$V4_REPORT")"
+run_case "V4_block_stale_user_turn_count_from_compaction_summary" "block" "$V4_TRANSCRIPT"
+
+# V5: pass — _skipped variant bypasses value check (no receipt to verify).
+# Regression: the _skipped path must not fire the value check.
+V5_REPORT="$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+${G_RECEIPT_SKIPPED}"
+V5_TRANSCRIPT="$(mk_compaction)
+$(mk_assistant "$V5_REPORT")"
+run_case "V5_pass_skipped_variant_no_value_check" "pass" "$V5_TRANSCRIPT"
+
+# V5b: block — receipt has is_error_count=0 but no user_turn_count field at all.
+# An absent user_turn_count must be treated as a mismatch, not silently skipped
+# (Codex P2: _gate7_mismatch("", N) returns 0 due to concat digit-only check).
+V5B_RECEIPT='<!-- retrospect:transcript_receipt begin -->
+is_error_count: 0 | interrupt_count: 0
+<!-- retrospect:transcript_receipt end -->'
+V5B_REPORT="$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+${V5B_RECEIPT}"
+# Transcript: 1 compaction, 0 is_error events, 1 assistant. is_error_count=0 matches
+# live, but user_turn_count is absent from receipt → block.
+V5B_TRANSCRIPT="$(mk_compaction)
+$(mk_assistant "$V5B_REPORT")"
+run_case "V5b_block_absent_user_turn_count_field" "block" "$V5B_TRANSCRIPT"
+
+# V6: pass — non-post-compaction session; Gate-7 is dormant.
+# No compaction marker in transcript, so value check never runs even if
+# receipt counts diverge (though there is no receipt here anyway).
+V6_TRANSCRIPT="$(mk_assistant "$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")")"
+run_case "V6_pass_no_compaction_gate7_dormant" "pass" "$V6_TRANSCRIPT"
 
 # Synthetic regression fixtures (AC-R1~R4) ----------------------------------
 # Each fixture pairs a .jsonl transcript with a .expected.json sidecar:


### PR DESCRIPTION
## 배경

Gate-7(#639)은 post-compaction Stage 3 리포트를 `retrospect:transcript_receipt`
fence **존재** 여부로만 차단했습니다. fence 안 수치가 이번 턴 live grep에서 나온 건지는
검증하지 않아, compaction 요약의 선포맷 수치를 그대로 옮겨 적은 stale receipt가
fresh와 구조적으로 동일해 게이트를 통과했습니다(presence != freshness).

## 변경

- `hooks/completion-verify/retrospect-mix-check/impl.sh`: Gate-7을 **value 검사**로 전환.
  구조 검증 통과 후 훅이 transcript에서 직접 재도출:
  - `is_error_count` ← `grep -c '"is_error":true'`
  - `user_turn_count` ← `grep -c '"role":"user"'`
  fence 선언값을 파싱해 `|declared - live| > tolerance(1)` 이면 차단 + guidance에 diff 표기.
  absent/unparseable `user_turn_count`는 무조건 mismatch로 처리
  (`_gate7_mismatch("", N)`가 digit-only concat 때문에 silent pass하던 갭 차단).
- `spec.md`: 재도출 명령·tolerance 근거·비발화 조건·`interrupt_count` 보류를 문서화.
- 훅 test: stale-copied→block / live-correct→pass / presence·`_skipped`·non-post-compaction
  회귀 포함 신규 케이스. transcript fixture는 실제 N개 이벤트를 담아 훅 자체 grep이
  N을 산출하도록 구성(카운트 mock 아님).

## tolerance

**1 line** — Stop 훅 스캔이 마지막 JSONL 라인 append와 경합할 수 있는 최대 race가 ±1.
그 이상 차이는 stale source 신호.

## 검증

- `tests/hooks/completion-verify/test_retrospect_mix_check.sh` → 74 cases / 11 fixtures passed

## 비고

sibling 이슈 #670(content-error-signal oracle)은 orthogonal, 동일 훅 위로 후속 rebase 예정.

Caller chain verified: N/A -- hook invoked by Claude Code runtime (hooks/manifest.json)
Pre-commit verified: tests/hooks/completion-verify/test_retrospect_mix_check.sh -> 74 cases / 11 fixtures passed

Closes #671
