### PR TITLE
fix(retrospect): gate-7 scans exit-0 content errors

### DIFF
--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -457,8 +457,10 @@ if grep -Eq '(^|[^\\])"isCompactSummary"[[:space:]]*:[[:space:]]*true' "$TRANSCR
     # overwriting a more specific error).
     #
     # Canonical derivation commands (from skills/retrospect/references/report-template.md):
-    #   is_error_count  ← grep -c '"is_error":true' {transcript_path}
-    #   user_turn_count ← grep -c '"role":"user"'  {transcript_path}
+    #   is_error_count      ← grep -c '"is_error":true' {transcript_path}
+    #   user_turn_count     ← grep -c '"role":"user"'  {transcript_path}
+    #   content_error_count ← tool_result lines | grep -cE '<calibrated error syntax>'
+    #                         (floor-only: declared 0 while live>tol is laundering)
     # interrupt_count has no canonical grep command in the spec; skip re-derivation.
     #
     # Tolerance: 1 line off-by-one is accepted to account for live-append races
@@ -475,6 +477,13 @@ if grep -Eq '(^|[^\\])"isCompactSummary"[[:space:]]*:[[:space:]]*true' "$TRANSCR
       # Re-derive user_turn_count (role:user covers both literal JSON forms).
       live_ut_count=$(grep -c '"role":"user"' "$TRANSCRIPT_PATH" 2>/dev/null || true)
       live_ut_count=${live_ut_count:-0}
+      # Re-derive content_error_count [issue #670], scoped to tool_result-bearing
+      # lines so the calibrated regex matches errors embedded in exit-0 tool_result
+      # CONTENT, not the agent's own analysis prose or the Stage-3 report (those
+      # live in assistant/text lines, never carry "type":"tool_result").
+      live_ce_count=$(grep '"type":"tool_result"' "$TRANSCRIPT_PATH" 2>/dev/null \
+        | grep -cE 'Exit code [1-9]|command terminated|js_error|FATAL|No such file|denied|BLOCKED|Usage: ' 2>/dev/null || true)
+      live_ce_count=${live_ce_count:-0}
 
       # Parse declared user_turn_count from the receipt body.
       # The declared line is: is_error_count: N | user_turn_count: N | interrupt_count: N
@@ -507,6 +516,17 @@ if grep -Eq '(^|[^\\])"isCompactSummary"[[:space:]]*:[[:space:]]*true' "$TRANSCR
 
       if [ "$ie_mismatch" = "1" ] || [ "$ut_mismatch" = "1" ]; then
         GATE7_VIOLATION="post-compaction receipt declares counts that do not match a live grep of the transcript (tolerance=$GATE7_VALUE_TOLERANCE): declared is_error_count=$declared_ie vs live=$live_ie_count; declared user_turn_count=${declared_ut:-(unparseable)} vs live=$live_ut_count — re-run grep -c '\"is_error\":true' and grep -c '\"role\":\"user\"' against the transcript this turn and paste the REAL output in the receipt fence before Stage 3"
+      fi
+
+      # Content-error floor [issue #670]: the structural block above accepts a
+      # declared content_error_count of 0 without requiring an enum. But a declared
+      # 0 while the transcript's tool_result content carries real error signals is
+      # the same laundering #671 closes for is_error_count — the leading signal (the
+      # content scan) was never run. Re-derive and block when declared 0 but live
+      # signals exceed tolerance. Only fires when no earlier violation is set.
+      if [ -z "$GATE7_VIOLATION" ] && [ "${ce_count:-0}" -eq 0 ] 2>/dev/null \
+         && [ "$live_ce_count" -gt "$GATE7_VALUE_TOLERANCE" ]; then
+        GATE7_VIOLATION="post-compaction receipt declares content_error_count=0 but a live scan of the transcript's tool_result content finds $live_ce_count error signal(s) (tolerance=$GATE7_VALUE_TOLERANCE) — exit-0 tool_result content (e.g. 'Exit code 1', 'FATAL', 'js_error') is not flagged by is_error:true; re-run: grep '\"type\":\"tool_result\"' \"\$transcript\" | grep -cE 'Exit code [1-9]|command terminated|js_error|FATAL|No such file|denied|BLOCKED|Usage: ' — paste the REAL count and enumerate each signal in a content_error_enum block before Stage 3"
       fi
     fi
   fi

--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -339,6 +339,8 @@ if grep -Eq '(^|[^\\])"isCompactSummary"[[:space:]]*:[[:space:]]*true' "$TRANSCR
   re_rs='^[[:space:]]*<!--[[:space:]]*retrospect:transcript_receipt_skipped:.*-->[[:space:]]*$'
   re_ib='^[[:space:]]*<!--[[:space:]]*retrospect:is_error_enum begin[[:space:]]*-->[[:space:]]*$'
   re_ie='^[[:space:]]*<!--[[:space:]]*retrospect:is_error_enum end[[:space:]]*-->[[:space:]]*$'
+  re_cb='^[[:space:]]*<!--[[:space:]]*retrospect:content_error_enum begin[[:space:]]*-->[[:space:]]*$'
+  re_ce='^[[:space:]]*<!--[[:space:]]*retrospect:content_error_enum end[[:space:]]*-->[[:space:]]*$'
   rcpt_begin=$(printf '%s\n' "$MOST_RECENT_BLOCK" | grep -cE "$re_rb")
   rcpt_skipped=$(printf '%s\n' "$MOST_RECENT_BLOCK" | grep -cE "$re_rs")
   # Marker COUNTS cannot detect a malformed fence: a balanced begin==end count
@@ -408,6 +410,42 @@ if grep -Eq '(^|[^\\])"isCompactSummary"[[:space:]]*:[[:space:]]*true' "$TRANSCR
         END { print c+0 }')
       if [ "$ie_begin" -lt 1 ] || [ "$ie_end" -lt 1 ] || [ "$ie_rows" -lt 1 ]; then
         GATE7_VIOLATION="post-compaction receipt declares is_error_count=$ie_count but has no complete '<!-- retrospect:is_error_enum begin/end -->' block with per-event disposition rows inside the receipt fence (found begin=$ie_begin end=$ie_end disposition_rows=$ie_rows) — a count proves a scan ran, not that the errors were read; enumerate each is_error inside the fence with a promote/note/dismiss disposition before Stage 3"
+      fi
+    fi
+    # Content-error-signal check [issue #670]: errors embedded in exit-0
+    # tool_result CONTENT are not flagged by is_error:true — they appear in the
+    # text body of a successful tool_result (e.g. "Exit code 1", "FATAL:",
+    # "js_error:"). A separate scan anchored to error SYNTAX (not the bare word
+    # "error", which produces false positives on field names like "is_error":false)
+    # catches these. Calibrated regex: 'Exit code [1-9]|command terminated|
+    # js_error|FATAL|No such file|denied|BLOCKED|Usage: '.
+    # When the receipt declares content_error_count > 0, require a per-signal
+    # 'retrospect:content_error_enum' block — same structure as is_error_enum.
+    # An absent content_error_count field blocks (mirrors is_error_count absent).
+    if [ -z "$GATE7_VIOLATION" ]; then
+      # content_error_count sits on the pipe-delimited count line (not its own line),
+      # so do NOT anchor with '^'. Use a word-boundary-style guard: require the field
+      # to be preceded by a non-digit non-letter char (pipe/space) or start of string
+      # to resist injection via enum rows that could quote 'content_error_count: 99'.
+      # Pick the first match (head -1) to be consistent with ie_count extraction.
+      ce_count=$(printf '%s\n' "$RECEIPT_BLOCK" \
+        | grep -oE '[^a-zA-Z0-9_]content_error_count:[[:space:]]*[0-9]+|^[[:space:]]*content_error_count:[[:space:]]*[0-9]+' \
+        | grep -oE 'content_error_count:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -1)
+      if [ -z "$ce_count" ]; then
+        GATE7_VIOLATION="post-compaction transcript_receipt fence carries no parseable 'content_error_count: N' line inside the fence — run grep -cE 'Exit code [1-9]|command terminated|js_error|FATAL|No such file|denied|BLOCKED|Usage: ' against the transcript content and paste the REAL count in the receipt before Stage 3"
+      elif [ "$ce_count" -gt 0 ] 2>/dev/null; then
+        # Require begin+end markers AND >= 1 disposition row inside the fence,
+        # mirroring the is_error_enum enforcement exactly.
+        ce_begin=$(printf '%s\n' "$RECEIPT_BLOCK" | grep -cE "$re_cb")
+        ce_end=$(printf '%s\n' "$RECEIPT_BLOCK" | grep -cE "$re_ce")
+        ce_rows=$(printf '%s\n' "$RECEIPT_BLOCK" | awk -v cb="$re_cb" -v ce="$re_ce" '
+          $0 ~ cb { inblock=1; next }
+          $0 ~ ce { inblock=0 }
+          inblock && /disposition:[[:space:]]*(promote|note|dismiss)/ { c++ }
+          END { print c+0 }')
+        if [ "$ce_begin" -lt 1 ] || [ "$ce_end" -lt 1 ] || [ "$ce_rows" -lt 1 ]; then
+          GATE7_VIOLATION="post-compaction receipt declares content_error_count=$ce_count but has no complete '<!-- retrospect:content_error_enum begin/end -->' block with per-signal disposition rows inside the receipt fence (found begin=$ce_begin end=$ce_end disposition_rows=$ce_rows) — a count proves a scan ran, not that the signals were read; enumerate each content-error signal inside the fence with a promote/note/dismiss disposition before Stage 3"
+        fi
       fi
     fi
     # Gate-7 VALUE check [issue #671]: presence + structural validity alone do not
@@ -553,7 +591,7 @@ if [ "$should_block" = "true" ]; then
     fi
   done
 
-  full_reason="Retrospect mix-check gate triggered. ${reason}. Fix guide: Gate-1 → relabel finding category via skills/retrospect/references/stage1-2-analysis.md; Gate-2 → supply either (a) 5-line 'not <action>: <reason>' rationale (Schema A) or (b) 1-2 'not-others: <dim-tags>' lines (Schema B, issue #285) in Stage 2.5; Gate-3 verdict → return to skills/retrospect/references/stage2.5-audit.md and re-evaluate evidence robustness for 2-action findings; Gate-3 backing_repo → return to skills/retrospect/references/stage1-2-analysis.md action assignment (step 7) and add 'backing_repo: <owner/repo>' to Rationale cell; Gate-4 → return to skills/retrospect/references/stage2.5-audit.md Gate-4 and re-run external-repo classification; ensure gate_4_verdict is emitted in the distribution card; Gate-7 → post-compaction session: emit a '<!-- retrospect:transcript_receipt begin/end -->' fence with the real full-transcript scan output (or the 'retrospect:transcript_receipt_skipped: transcript unreachable' line when the jsonl is genuinely unreachable). See skills/retrospect/references/stage2.5-audit.md and skills/retrospect/references/stage3-reporting.md."
+  full_reason="Retrospect mix-check gate triggered. ${reason}. Fix guide: Gate-1 → relabel finding category via skills/retrospect/references/stage1-2-analysis.md; Gate-2 → supply either (a) 5-line 'not <action>: <reason>' rationale (Schema A) or (b) 1-2 'not-others: <dim-tags>' lines (Schema B, issue #285) in Stage 2.5; Gate-3 verdict → return to skills/retrospect/references/stage2.5-audit.md and re-evaluate evidence robustness for 2-action findings; Gate-3 backing_repo → return to skills/retrospect/references/stage1-2-analysis.md action assignment (step 7) and add 'backing_repo: <owner/repo>' to Rationale cell; Gate-4 → return to skills/retrospect/references/stage2.5-audit.md Gate-4 and re-run external-repo classification; ensure gate_4_verdict is emitted in the distribution card; Gate-7 → post-compaction session: emit a '<!-- retrospect:transcript_receipt begin/end -->' fence with the real full-transcript scan output (or the 'retrospect:transcript_receipt_skipped: transcript unreachable' line when the jsonl is genuinely unreachable); include both 'is_error_count: N' and 'content_error_count: N' fields; when content_error_count > 0 add a '<!-- retrospect:content_error_enum begin/end -->' block with per-signal promote/note/dismiss disposition rows (issue #670). See skills/retrospect/references/stage2.5-audit.md and skills/retrospect/references/stage3-reporting.md."
   jq -n --arg r "$full_reason" '{decision: "block", reason: $r}'
   exit 0
 fi

--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -418,7 +418,9 @@ if grep -Eq '(^|[^\\])"isCompactSummary"[[:space:]]*:[[:space:]]*true' "$TRANSCR
     # "js_error:"). A separate scan anchored to error SYNTAX (not the bare word
     # "error", which produces false positives on field names like "is_error":false)
     # catches these. Calibrated regex: 'Exit code [1-9]|command terminated|
-    # js_error|FATAL|No such file|denied|BLOCKED|Usage: '.
+    # js_error|FATAL|No such file|denied|BLOCKED|Usage:([[:space:]]|$)'
+    # (the Usage: alternation matches a trailing space OR end-of-line so bare
+    # usage banners without a trailing space are not undercounted).
     # When the receipt declares content_error_count > 0, require a per-signal
     # 'retrospect:content_error_enum' block — same structure as is_error_enum.
     # An absent content_error_count field blocks (mirrors is_error_count absent).
@@ -432,7 +434,7 @@ if grep -Eq '(^|[^\\])"isCompactSummary"[[:space:]]*:[[:space:]]*true' "$TRANSCR
         | grep -oE '[^a-zA-Z0-9_]content_error_count:[[:space:]]*[0-9]+|^[[:space:]]*content_error_count:[[:space:]]*[0-9]+' \
         | grep -oE 'content_error_count:[[:space:]]*[0-9]+' | grep -oE '[0-9]+' | head -1)
       if [ -z "$ce_count" ]; then
-        GATE7_VIOLATION="post-compaction transcript_receipt fence carries no parseable 'content_error_count: N' line inside the fence — run grep -cE 'Exit code [1-9]|command terminated|js_error|FATAL|No such file|denied|BLOCKED|Usage: ' against the transcript content and paste the REAL count in the receipt before Stage 3"
+        GATE7_VIOLATION="post-compaction transcript_receipt fence carries no parseable 'content_error_count: N' line inside the fence — run: grep '\"type\":\"tool_result\"' \"\$transcript\" | grep -cE 'Exit code [1-9]|command terminated|js_error|FATAL|No such file|denied|BLOCKED|Usage:([[:space:]]|\$)' and paste the REAL count in the receipt before Stage 3"
       elif [ "$ce_count" -gt 0 ] 2>/dev/null; then
         # Require begin+end markers AND >= 1 disposition row inside the fence,
         # mirroring the is_error_enum enforcement exactly.
@@ -482,7 +484,7 @@ if grep -Eq '(^|[^\\])"isCompactSummary"[[:space:]]*:[[:space:]]*true' "$TRANSCR
       # CONTENT, not the agent's own analysis prose or the Stage-3 report (those
       # live in assistant/text lines, never carry "type":"tool_result").
       live_ce_count=$(grep '"type":"tool_result"' "$TRANSCRIPT_PATH" 2>/dev/null \
-        | grep -cE 'Exit code [1-9]|command terminated|js_error|FATAL|No such file|denied|BLOCKED|Usage: ' 2>/dev/null || true)
+        | grep -cE 'Exit code [1-9]|command terminated|js_error|FATAL|No such file|denied|BLOCKED|Usage:([[:space:]]|$)' 2>/dev/null || true)
       live_ce_count=${live_ce_count:-0}
 
       # Parse declared user_turn_count from the receipt body.
@@ -526,7 +528,7 @@ if grep -Eq '(^|[^\\])"isCompactSummary"[[:space:]]*:[[:space:]]*true' "$TRANSCR
       # signals exceed tolerance. Only fires when no earlier violation is set.
       if [ -z "$GATE7_VIOLATION" ] && [ "${ce_count:-0}" -eq 0 ] 2>/dev/null \
          && [ "$live_ce_count" -gt "$GATE7_VALUE_TOLERANCE" ]; then
-        GATE7_VIOLATION="post-compaction receipt declares content_error_count=0 but a live scan of the transcript's tool_result content finds $live_ce_count error signal(s) (tolerance=$GATE7_VALUE_TOLERANCE) — exit-0 tool_result content (e.g. 'Exit code 1', 'FATAL', 'js_error') is not flagged by is_error:true; re-run: grep '\"type\":\"tool_result\"' \"\$transcript\" | grep -cE 'Exit code [1-9]|command terminated|js_error|FATAL|No such file|denied|BLOCKED|Usage: ' — paste the REAL count and enumerate each signal in a content_error_enum block before Stage 3"
+        GATE7_VIOLATION="post-compaction receipt declares content_error_count=0 but a live scan of the transcript's tool_result content finds $live_ce_count error signal(s) (tolerance=$GATE7_VALUE_TOLERANCE) — exit-0 tool_result content (e.g. 'Exit code 1', 'FATAL', 'js_error') is not flagged by is_error:true; re-run: grep '\"type\":\"tool_result\"' \"\$transcript\" | grep -cE 'Exit code [1-9]|command terminated|js_error|FATAL|No such file|denied|BLOCKED|Usage:([[:space:]]|\$)' — paste the REAL count and enumerate each signal in a content_error_enum block before Stage 3"
       fi
     fi
   fi

--- a/hooks/completion-verify/retrospect-mix-check/spec.md
+++ b/hooks/completion-verify/retrospect-mix-check/spec.md
@@ -59,12 +59,24 @@ summary's pre-formatted numbers is structurally identical to a fresh one and pas
 The value check re-derives `is_error_count` and `user_turn_count` from the transcript
 independently and compares them against the declared values:
 
-| Field | Canonical derivation command |
-|-------|------------------------------|
-| `is_error_count` | `grep -c '"is_error":true' {transcript_path}` |
-| `user_turn_count` | `grep -c '"role":"user"' {transcript_path}` |
+| Field | Canonical derivation command | Semantics |
+|-------|------------------------------|-----------|
+| `is_error_count` | `grep -c '"is_error":true' {transcript_path}` | exact (±tolerance) |
+| `user_turn_count` | `grep -c '"role":"user"' {transcript_path}` | exact (±tolerance) |
+| `content_error_count` (issue #670) | `grep '"type":"tool_result"' {transcript_path} \| grep -cE '<calibrated error syntax>'` | floor only |
 
 `interrupt_count` is not re-derived (no canonical grep command in the spec).
+
+**`content_error_count` floor (issue #670):** the structural block accepts a
+declared `content_error_count: 0` without requiring an enum. The floor re-derives
+the count from **tool_result content only** (the grep is scoped to lines bearing
+`"type":"tool_result"` so the calibrated error-syntax regex never matches the
+agent's own analysis prose or the Stage-3 report, which live in assistant/text
+lines). When the receipt declares `0` but the live tool_result scan finds more
+than `tolerance` signals, Stage 3 is blocked — a declared `0` that launders away
+real exit-0 errors is the same gap #671 closed for `is_error_count`. The check is
+a floor, not exact equality: the agent may dismiss matches via the
+`content_error_enum` disposition rows, but cannot claim zero signals existed.
 
 **Tolerance:** a delta of ≤ 1 line is accepted to account for live-append races (the
 transcript is appended while the Stop hook runs; the final line may be partially
@@ -78,10 +90,10 @@ scan this turn and blocks Stage 3.
 - A structural violation was already set: value check is skipped (more specific error wins)
 - `transcript_path` is missing or unreadable: value check is skipped
 
-**Note:** `interrupt_count` value-checking is deferred because no canonical grep
-command is specified in the skill's stage reference files. Issue #670 will extend
-Gate-7 with a content-error-signal scan; that PR may also define and add
-`interrupt_count` re-derivation.
+**Note:** `interrupt_count` value-checking remains deferred because no canonical
+grep command is specified in the skill's stage reference files. Issue #670 added
+the content-error-signal scan and its floor re-derivation (above); `interrupt_count`
+re-derivation is still open.
 
 ### Issue #666 — retrospect-active Stage-3 fence-omission gate
 

--- a/tests/hooks/completion-verify/test_retrospect_mix_check.sh
+++ b/tests/hooks/completion-verify/test_retrospect_mix_check.sh
@@ -913,6 +913,19 @@ mk_is_error() {
   }'
 }
 
+# Emit a JSONL record simulating an exit-0 tool_result whose CONTENT carries an
+# error signal (is_error:false). Used to exercise the issue #670 content-error
+# floor: the calibrated regex must catch the signal from tool_result content even
+# though the envelope flag is false. The line bears "type":"tool_result" so the
+# hook's scoped re-derivation counts it.
+mk_content_error() {
+  jq -nc --arg msg "$1" '{
+    type: "tool_result",
+    "is_error": false,
+    message: {role: "tool", content: [{type: "text", text: $msg}]}
+  }'
+}
+
 # Emit a JSONL record for a non-compaction user turn.
 # Used to add real user turns so hook's grep -c '"role":"user"' matches declared count.
 # Note: mk_compaction() already contributes 1 user turn to the count.
@@ -1531,6 +1544,49 @@ else
   echo "PASS  [CE7_calibration_regex_matches_all_error_signals]"
   PASS=$((PASS + 1))
 fi
+
+# CE_FLOOR tests [issue #670] — independent re-derivation floor. The structural
+# block accepts a declared content_error_count: 0 without an enum; the floor
+# re-derives from tool_result content and blocks a declared 0 that launders away
+# real exit-0 errors (the same gap #671 closed for is_error_count).
+
+# CE_FLOOR1: block — receipt declares content_error_count: 0 but two tool_result
+# bodies carry exit-0 error signals (live=2 > tolerance=1).
+CE_FLOOR1_RECEIPT='<!-- retrospect:transcript_receipt begin -->
+is_error_count: 0 | user_turn_count: 1 | interrupt_count: 0 | content_error_count: 0
+<!-- retrospect:transcript_receipt end -->'
+CE_FLOOR1_REPORT="$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+${CE_FLOOR1_RECEIPT}"
+CE_FLOOR1_TRANSCRIPT="$(mk_compaction)
+$(mk_content_error "Exit code 1: build failed")
+$(mk_content_error "FATAL: connection refused")
+$(mk_assistant "$CE_FLOOR1_REPORT")"
+run_case "CE_FLOOR1_block_declared_zero_while_live_content_errors_exist" "block" "$CE_FLOOR1_TRANSCRIPT"
+
+# CE_FLOOR2: pass — the error syntax appears only in an assistant/text line (the
+# agent's own prose), NOT in a tool_result line. Scoping excludes it, so the
+# floor does not fire on a declared 0.
+CE_FLOOR2_RECEIPT='<!-- retrospect:transcript_receipt begin -->
+is_error_count: 0 | user_turn_count: 1 | interrupt_count: 0 | content_error_count: 0
+<!-- retrospect:transcript_receipt end -->'
+CE_FLOOR2_REPORT="$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+The narrative mentions Exit code 1 and FATAL in prose but no tool actually failed.
+${CE_FLOOR2_RECEIPT}"
+CE_FLOOR2_TRANSCRIPT="$(mk_compaction)
+$(mk_assistant "$CE_FLOOR2_REPORT")"
+run_case "CE_FLOOR2_pass_error_syntax_only_in_assistant_prose_scoped_out" "pass" "$CE_FLOOR2_TRANSCRIPT"
+
+# CE_FLOOR3: pass — a single tool_result error signal is within tolerance (1),
+# so a declared 0 is not blocked (mirrors the is_error/user_turn off-by-one rule).
+CE_FLOOR3_RECEIPT='<!-- retrospect:transcript_receipt begin -->
+is_error_count: 0 | user_turn_count: 1 | interrupt_count: 0 | content_error_count: 0
+<!-- retrospect:transcript_receipt end -->'
+CE_FLOOR3_REPORT="$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+${CE_FLOOR3_RECEIPT}"
+CE_FLOOR3_TRANSCRIPT="$(mk_compaction)
+$(mk_content_error "Exit code 1: single transient failure")
+$(mk_assistant "$CE_FLOOR3_REPORT")"
+run_case "CE_FLOOR3_pass_single_content_error_within_tolerance" "pass" "$CE_FLOOR3_TRANSCRIPT"
 
 # Synthetic regression fixtures (AC-R1~R4) ----------------------------------
 # Each fixture pairs a .jsonl transcript with a .expected.json sidecar:

--- a/tests/hooks/completion-verify/test_retrospect_mix_check.sh
+++ b/tests/hooks/completion-verify/test_retrospect_mix_check.sh
@@ -927,7 +927,7 @@ mk_user_turn() {
 # [issue #664] is_error_count > 0 requires a nested retrospect:is_error_enum block
 # (count proves a scan ran, not that the errors were read).
 G_RECEIPT_FENCE='<!-- retrospect:transcript_receipt begin -->
-is_error_count: 3 | user_turn_count: 5 | interrupt_count: 0
+is_error_count: 3 | user_turn_count: 5 | interrupt_count: 0 | content_error_count: 0
 <!-- retrospect:is_error_enum begin -->
 - [1] hook advisory fire | disposition: dismiss (negative-list: expected enforcement)
 - [2] transient timeout | disposition: note (retried, resolved)
@@ -940,7 +940,7 @@ is_error_count: 3 | user_turn_count: 5 | interrupt_count: 0
 <!-- retrospect:transcript_receipt end -->'
 # Zero-error receipt — no enum block required (nothing to enumerate).
 G_RECEIPT_ZERO='<!-- retrospect:transcript_receipt begin -->
-is_error_count: 0 | user_turn_count: 5 | interrupt_count: 0
+is_error_count: 0 | user_turn_count: 5 | interrupt_count: 0 | content_error_count: 0
 <!-- retrospect:transcript_receipt end -->'
 # Enum bypass #1: only the begin marker (no end, no disposition rows). A bare
 # substring check on 'retrospect:is_error_enum' would pass this; the strengthened
@@ -1015,7 +1015,7 @@ is_error_count: 3 | user_turn_count: 5 | interrupt_count: 0'
 # the report passes — a retrospect OF a session about these markers (e.g. this
 # change) must not be false-positive blocked [Codex round 5].
 G_RECEIPT_VALID_MARKER_MENTIONS='<!-- retrospect:transcript_receipt begin -->
-is_error_count: 2 | user_turn_count: 5 | interrupt_count: 0
+is_error_count: 2 | user_turn_count: 5 | interrupt_count: 0 | content_error_count: 0
 <!-- retrospect:is_error_enum begin -->
 - [1] hook discussed <!-- retrospect:transcript_receipt begin --> marker handling | disposition: note (meta-mention)
 - [2] error citing retrospect:is_error_enum begin and transcript_receipt end in prose | disposition: dismiss (negative-list)
@@ -1347,7 +1347,7 @@ run_case "V1_block_stale_is_error_count_from_compaction_summary" "block" "$V1_TR
 # Transcript: 1 compaction (user turn), 2 is_error events, 1 assistant.
 # Live: is_error_count=2, user_turn_count=1.
 V2_RECEIPT='<!-- retrospect:transcript_receipt begin -->
-is_error_count: 2 | user_turn_count: 1 | interrupt_count: 0
+is_error_count: 2 | user_turn_count: 1 | interrupt_count: 0 | content_error_count: 0
 <!-- retrospect:is_error_enum begin -->
 - [1] hook block | disposition: dismiss (expected enforcement)
 - [2] timeout | disposition: note (retried, resolved)
@@ -1366,7 +1366,7 @@ run_case "V2_pass_receipt_counts_match_live_transcript" "pass" "$V2_TRANSCRIPT"
 # Live: is_error_count=3, user_turn_count=1.
 # Declared: is_error_count=2 — delta=1 == tolerance=1 → pass.
 V3_RECEIPT='<!-- retrospect:transcript_receipt begin -->
-is_error_count: 2 | user_turn_count: 1 | interrupt_count: 0
+is_error_count: 2 | user_turn_count: 1 | interrupt_count: 0 | content_error_count: 0
 <!-- retrospect:is_error_enum begin -->
 - [1] hook block | disposition: dismiss (expected enforcement)
 - [2] timeout | disposition: note (retried, resolved)
@@ -1422,6 +1422,115 @@ run_case "V5b_block_absent_user_turn_count_field" "block" "$V5B_TRANSCRIPT"
 # receipt counts diverge (though there is no receipt here anyway).
 V6_TRANSCRIPT="$(mk_assistant "$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")")"
 run_case "V6_pass_no_compaction_gate7_dormant" "pass" "$V6_TRANSCRIPT"
+
+# Content-error-signal enum cases — issue #670 --------------------------------
+# The is_error:true flag only fires when the tool CALL itself fails.  Errors
+# embedded in exit-0 tool_result CONTENT (non-zero exit text, js_error, FATAL,
+# etc.) are missed by the existing is_error scan. Gate-7 now also requires a
+# 'content_error_count: N' line in the receipt and, when N > 0, a
+# '<!-- retrospect:content_error_enum begin/end -->' block with per-signal
+# disposition rows — mirroring the is_error_enum enforcement exactly.
+#
+# Calibrated regex: 'Exit code [1-9]|command terminated|js_error|FATAL|
+#   No such file|denied|BLOCKED|Usage: '
+# This matches error SYNTAX, NOT the bare word "error", which appears in
+# benign JSON field names (e.g. "is_error":false) and agent prose.
+
+# CE1: block — receipt declares content_error_count=2 but NO enum block.
+# A count alone proves a scan ran, not that the signals were read.
+CE1_RECEIPT='<!-- retrospect:transcript_receipt begin -->
+is_error_count: 0 | user_turn_count: 1 | interrupt_count: 0 | content_error_count: 2
+<!-- retrospect:transcript_receipt end -->'
+CE1_REPORT="$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+${CE1_RECEIPT}"
+CE1_TRANSCRIPT="$(mk_compaction)
+$(mk_assistant "$CE1_REPORT")"
+run_case "CE1_block_content_error_count_no_enum" "block" "$CE1_TRANSCRIPT"
+
+# CE2: pass — receipt declares content_error_count=2 AND complete enum block
+# with two per-signal disposition rows. Real error signals in the transcript
+# body (is_error:false envelope containing "Exit code 1" text).
+CE2_RECEIPT='<!-- retrospect:transcript_receipt begin -->
+is_error_count: 0 | user_turn_count: 1 | interrupt_count: 0 | content_error_count: 2
+<!-- retrospect:content_error_enum begin -->
+- [1] bash Exit code 1 (npm test) | disposition: note (retried with fix, resolved)
+- [2] FATAL: database connection refused | disposition: promote (finding #2)
+<!-- retrospect:content_error_enum end -->
+<!-- retrospect:transcript_receipt end -->'
+CE2_REPORT="$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+${CE2_RECEIPT}"
+CE2_TRANSCRIPT="$(mk_compaction)
+$(mk_assistant "$CE2_REPORT")"
+run_case "CE2_pass_content_error_count_with_enum" "pass" "$CE2_TRANSCRIPT"
+
+# CE3: pass — receipt declares content_error_count=0. No enum block required.
+CE3_RECEIPT='<!-- retrospect:transcript_receipt begin -->
+is_error_count: 0 | user_turn_count: 1 | interrupt_count: 0 | content_error_count: 0
+<!-- retrospect:transcript_receipt end -->'
+CE3_REPORT="$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+${CE3_RECEIPT}"
+CE3_TRANSCRIPT="$(mk_compaction)
+$(mk_assistant "$CE3_REPORT")"
+run_case "CE3_pass_content_error_count_zero_no_enum_needed" "pass" "$CE3_TRANSCRIPT"
+
+# CE4: block — receipt carries NO content_error_count field at all.
+# An absent field is a mismatch; the agent must run the calibrated regex and
+# paste the real count. Mirrors the is_error_count absent enforcement.
+CE4_RECEIPT='<!-- retrospect:transcript_receipt begin -->
+is_error_count: 0 | user_turn_count: 1 | interrupt_count: 0
+<!-- retrospect:transcript_receipt end -->'
+CE4_REPORT="$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+${CE4_RECEIPT}"
+CE4_TRANSCRIPT="$(mk_compaction)
+$(mk_assistant "$CE4_REPORT")"
+run_case "CE4_block_absent_content_error_count_field" "block" "$CE4_TRANSCRIPT"
+
+# CE5: block — content_error_count=1 with enum begin/end fence but NO
+# disposition rows inside. Empty enum is the same count-not-content gap.
+CE5_RECEIPT='<!-- retrospect:transcript_receipt begin -->
+is_error_count: 0 | user_turn_count: 1 | interrupt_count: 0 | content_error_count: 1
+<!-- retrospect:content_error_enum begin -->
+<!-- retrospect:content_error_enum end -->
+<!-- retrospect:transcript_receipt end -->'
+CE5_REPORT="$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+${CE5_RECEIPT}"
+CE5_TRANSCRIPT="$(mk_compaction)
+$(mk_assistant "$CE5_REPORT")"
+run_case "CE5_block_content_error_enum_fence_empty_no_rows" "block" "$CE5_TRANSCRIPT"
+
+# CE6: pass — benign content containing "is_error":false and field names with
+# "error" in them does NOT produce a positive content_error_count. The
+# calibrated regex matches error SYNTAX, not the bare word "error". The agent
+# runs the regex, gets 0, declares content_error_count: 0, and no enum is needed.
+# (Functional verification: 'grep -cE ...' on the fixture text returns 0.)
+CE6_RECEIPT='<!-- retrospect:transcript_receipt begin -->
+is_error_count: 0 | user_turn_count: 1 | interrupt_count: 0 | content_error_count: 0
+<!-- retrospect:transcript_receipt end -->'
+CE6_REPORT="$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+${CE6_RECEIPT}"
+CE6_TRANSCRIPT="$(mk_compaction)
+$(mk_assistant "$CE6_REPORT")"
+# Verify the calibrated regex indeed yields 0 on benign content
+_ce6_benign='{"type":"tool_result","is_error":false,"content":[{"type":"text","text":"error_code: 0, is_error: false, status: ok"}]}'
+_ce6_live_count=$(printf '%s\n' "$_ce6_benign" | grep -cE 'Exit code [1-9]|command terminated|js_error|FATAL|No such file|denied|BLOCKED|Usage: ' || true)
+if [ "${_ce6_live_count:-0}" -ne 0 ]; then
+  echo "FAIL  [CE6_calibration] calibrated regex matched benign content (count=$_ce6_live_count) — regex needs recalibration"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("CE6_calibration")
+fi
+run_case "CE6_pass_benign_error_field_names_no_false_positive" "pass" "$CE6_TRANSCRIPT"
+
+# CE7: calibration check — verify the calibrated regex DOES match real error
+# syntax signals that should be caught (exit-0 content-embedded errors).
+_ce7_errors='Exit code 1\ncommand terminated\njs_error: TypeError\nFATAL: connection refused\nNo such file or directory\nPermission denied\nBLOCKED by hook\nUsage: gh pr create [flags]'
+_ce7_live_count=$(printf '%b\n' "$_ce7_errors" | grep -cE 'Exit code [1-9]|command terminated|js_error|FATAL|No such file|denied|BLOCKED|Usage: ' || true)
+_ce7_expected=8
+if [ "${_ce7_live_count:-0}" -ne "$_ce7_expected" ]; then
+  echo "FAIL  [CE7_calibration] calibrated regex matched $_ce7_live_count/${_ce7_expected} expected error signals — regex needs recalibration"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("CE7_calibration")
+else
+  echo "PASS  [CE7_calibration_regex_matches_all_error_signals]"
+  PASS=$((PASS + 1))
+fi
 
 # Synthetic regression fixtures (AC-R1~R4) ----------------------------------
 # Each fixture pairs a .jsonl transcript with a .expected.json sidecar:

--- a/tests/hooks/completion-verify/test_retrospect_mix_check.sh
+++ b/tests/hooks/completion-verify/test_retrospect_mix_check.sh
@@ -1445,7 +1445,7 @@ run_case "V6_pass_no_compaction_gate7_dormant" "pass" "$V6_TRANSCRIPT"
 # disposition rows — mirroring the is_error_enum enforcement exactly.
 #
 # Calibrated regex: 'Exit code [1-9]|command terminated|js_error|FATAL|
-#   No such file|denied|BLOCKED|Usage: '
+#   No such file|denied|BLOCKED|Usage:([[:space:]]|$)'
 # This matches error SYNTAX, NOT the bare word "error", which appears in
 # benign JSON field names (e.g. "is_error":false) and agent prose.
 
@@ -1525,7 +1525,7 @@ CE6_TRANSCRIPT="$(mk_compaction)
 $(mk_assistant "$CE6_REPORT")"
 # Verify the calibrated regex indeed yields 0 on benign content
 _ce6_benign='{"type":"tool_result","is_error":false,"content":[{"type":"text","text":"error_code: 0, is_error: false, status: ok"}]}'
-_ce6_live_count=$(printf '%s\n' "$_ce6_benign" | grep -cE 'Exit code [1-9]|command terminated|js_error|FATAL|No such file|denied|BLOCKED|Usage: ' || true)
+_ce6_live_count=$(printf '%s\n' "$_ce6_benign" | grep -cE 'Exit code [1-9]|command terminated|js_error|FATAL|No such file|denied|BLOCKED|Usage:([[:space:]]|$)' || true)
 if [ "${_ce6_live_count:-0}" -ne 0 ]; then
   echo "FAIL  [CE6_calibration] calibrated regex matched benign content (count=$_ce6_live_count) — regex needs recalibration"
   FAIL=$((FAIL + 1)); FAILED_NAMES+=("CE6_calibration")
@@ -1534,9 +1534,11 @@ run_case "CE6_pass_benign_error_field_names_no_false_positive" "pass" "$CE6_TRAN
 
 # CE7: calibration check — verify the calibrated regex DOES match real error
 # syntax signals that should be caught (exit-0 content-embedded errors).
-_ce7_errors='Exit code 1\ncommand terminated\njs_error: TypeError\nFATAL: connection refused\nNo such file or directory\nPermission denied\nBLOCKED by hook\nUsage: gh pr create [flags]'
-_ce7_live_count=$(printf '%b\n' "$_ce7_errors" | grep -cE 'Exit code [1-9]|command terminated|js_error|FATAL|No such file|denied|BLOCKED|Usage: ' || true)
-_ce7_expected=8
+# Last line is a BARE usage banner ("Usage:" with no trailing space / at EOL) —
+# locks the CodeRabbit #693 fix: the Usage: alternation must match end-of-line.
+_ce7_errors='Exit code 1\ncommand terminated\njs_error: TypeError\nFATAL: connection refused\nNo such file or directory\nPermission denied\nBLOCKED by hook\nUsage: gh pr create [flags]\nUsage:'
+_ce7_live_count=$(printf '%b\n' "$_ce7_errors" | grep -cE 'Exit code [1-9]|command terminated|js_error|FATAL|No such file|denied|BLOCKED|Usage:([[:space:]]|$)' || true)
+_ce7_expected=9
 if [ "${_ce7_live_count:-0}" -ne "$_ce7_expected" ]; then
   echo "FAIL  [CE7_calibration] calibrated regex matched $_ce7_live_count/${_ce7_expected} expected error signals — regex needs recalibration"
   FAIL=$((FAIL + 1)); FAILED_NAMES+=("CE7_calibration")


### PR DESCRIPTION
## 배경

Stage-2 friction 열거와 Gate-7 receipt는 `grep -c '"is_error":true'`에 앵커링됩니다.
harness는 **도구 호출 자체**가 실패할 때만 `is_error:true`를 세팅하므로, exit-0
`tool_result` **content**에 박힌 에러(비-0 종료 Bash의 "Exit code 1", 래퍼 exit-0
"Usage:"·"FATAL", 브라우저/MCP의 "js_error:")는 구조적으로 누락됩니다.

## 변경

`hooks/completion-verify/retrospect-mix-check/`:

1. **content-error-signal 스캔 + per-signal disposition enum** (구조 검사)
   - receipt에 `content_error_count: N` 필드 요구. 부재 시 block.
   - `> 0`이면 `retrospect:content_error_enum` 블록(promote|note|dismiss disposition 행)을
     요구 — count만으로는 통과 불가 (#664 is_error_enum 미러).
   - 캘리브레이션 regex(에러 **구문** 매칭, bare word "error" 아님 → `*_error`·`"is_error":false`
     false positive 회피): `Exit code [1-9]|command terminated|js_error|FATAL|No such file|denied|BLOCKED|Usage: `

2. **floor 재도출** (#671 value-check 확장) — declared 0 laundering 차단
   - hook이 transcript에서 직접 재도출하되 `"type":"tool_result"` 라인에 **한정**
     (assistant 산문·Stage-3 리포트는 그 라인이 아니라 배제 → over-block 방지).
   - declared `content_error_count: 0`인데 live tool_result 스캔이 tolerance 초과면 block.
   - exact equality 아닌 floor: disposition으로 dismiss는 가능하나 신호가 있는데 0 주장은 불가.

## 검증

- `tests/hooks/completion-verify/test_retrospect_mix_check.sh` → **84 cases / 11 fixtures passed**
  - 신규: CE1~CE7(구조·캘리브레이션) + CE_FLOOR1~3(floor: declared-0+live errors→block,
    prose-only→pass(scoped out), 1신호→pass(tolerance))
- `./scripts/run-tests.sh` → **ALL TESTS PASSED** (345 pytest 포함)

Caller chain verified: N/A -- hook invoked by Claude Code runtime (hooks/manifest.json)
Pre-commit verified: ./scripts/run-tests.sh -> ALL TESTS PASSED (84 hook cases, 11 fixtures, 345 pytest)

Closes #670


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transcript error validation to detect and properly track embedded tool errors missed by previous checks, with stricter enforcement of error declarations and corresponding documentation requirements.

* **Tests**
  * Added comprehensive test coverage for content error detection and validation scenarios, including edge cases and tolerance threshold validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->