### PR TITLE
feat(praxis): hook bypass observability

### DIFF
--- a/skills/bypass-review/bypass-review
+++ b/skills/bypass-review/bypass-review
@@ -7,6 +7,7 @@ human review.
 
 Phase 2 of issue #456 (Phase 1 = hook that writes the log; Phase 3 = HTTP
 forwarding, deferred).
+Issue #689: per-hook aggregation view + tool-error co-occurrence.
 
 Usage:
   bypass-review [OPTIONS]
@@ -16,16 +17,26 @@ Options:
   --dir PATH             Override the telemetry directory
                          (default: ~/.praxis/telemetry)
   --errors-only          Show only events where tool_result_status = "error"
+  --per-hook FAMILY      Show detailed breakdown for one hook/rule family only
+                         (e.g. --per-hook SCIOMC_GATE).  Family names are
+                         normalized bypass var suffixes — see Section 3 output
+                         for the list of families in the current window.
   -h, --help             Show this message and exit
 
 Output sections:
   1. Summary — total events + date window
   2. Top bypass vars — frequency table (which rules are bypassed most)
-  3. Bypass by hook/rule family — normalized from bypass var names
+  3. Per-hook aggregation — bypass count, error count, error rate %, distinct
+     sessions, last seen timestamp; one row per hook/rule family.  This is the
+     primary observability surface for deciding whether to add a new block gate.
   4. Bypass by command family — first executable token after env prefixes
   5. Error-linked bypass signals — separate summary for failed bypasses
   6. Bypass by tool — group by tool field
   7. Error events — events where tool_result_status == "error"
+
+With --per-hook FAMILY:
+  Shows only events for the named family: per-event detail including session,
+  tool, command, and error status.
 
 Privacy contract (read-only, never re-derives omitted fields):
   - bypass var VALUES are not in the JSONL; this CLI never prints them
@@ -103,6 +114,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--errors-only",
         action="store_true",
         help="Show only events where tool_result_status == 'error'",
+    )
+    parser.add_argument(
+        "--per-hook",
+        dest="per_hook",
+        default=None,
+        metavar="FAMILY",
+        help=(
+            "Show detailed per-event breakdown for one hook/rule family "
+            "(e.g. SCIOMC_GATE). Family names are the normalized suffixes "
+            "shown in the Per-Hook Aggregation section."
+        ),
     )
     return parser.parse_args(argv)
 
@@ -281,6 +303,9 @@ def aggregate(events: list[dict]) -> dict:
     bypass_var_error_counts: Counter[str] = Counter()
     hook_family_counts: Counter[str] = Counter()
     hook_family_error_counts: Counter[str] = Counter()
+    # Per-hook detail: sessions and last-seen per family (for Section 3).
+    # dict[family] -> {"sessions": set[str], "last_seen": str | None}
+    hook_family_detail: dict[str, dict] = {}
     command_family_counts: Counter[str] = Counter()
     command_family_error_counts: Counter[str] = Counter()
     tool_counts: Counter[str] = Counter()
@@ -291,6 +316,8 @@ def aggregate(events: list[dict]) -> dict:
         tool: str = ev.get(FIELD_TOOL) or UNKNOWN
         status: str = ev.get(FIELD_TOOL_RESULT_STATUS) or "ok"
         command_family = derive_command_family(ev.get(FIELD_TOOL_INPUT))
+        session: str = ev.get(FIELD_SESSION_ID) or ""
+        timestamp: str = ev.get(FIELD_TIMESTAMP) or ""
 
         for var in bypass_vars:
             bypass_var_counts[var] += 1
@@ -299,6 +326,15 @@ def aggregate(events: list[dict]) -> dict:
             if status == STATUS_ERROR:
                 bypass_var_error_counts[var] += 1
                 hook_family_error_counts[hook_family] += 1
+
+            # Accumulate per-hook detail: distinct sessions + latest timestamp.
+            detail = hook_family_detail.setdefault(
+                hook_family, {"sessions": set(), "last_seen": None}
+            )
+            if session:
+                detail["sessions"].add(session)
+            if timestamp and (detail["last_seen"] is None or timestamp > detail["last_seen"]):
+                detail["last_seen"] = timestamp
 
         tool_counts[tool] += 1
         command_family_counts[command_family] += 1
@@ -313,6 +349,7 @@ def aggregate(events: list[dict]) -> dict:
         "bypass_var_error_counts": bypass_var_error_counts,
         "hook_family_counts": hook_family_counts,
         "hook_family_error_counts": hook_family_error_counts,
+        "hook_family_detail": hook_family_detail,
         "command_family_counts": command_family_counts,
         "command_family_error_counts": command_family_error_counts,
         "tool_counts": tool_counts,
@@ -369,12 +406,135 @@ def _render_error_signal_summary(lines: list[str], agg: dict) -> None:
     )
 
 
+def _render_per_hook_aggregation(lines: list[str], agg: dict) -> None:
+    """Render Section 3: Per-Hook Aggregation — the primary observability table.
+
+    Columns: hook family | bypass count | error count | error rate % |
+             distinct sessions | last seen (UTC date only for brevity).
+
+    This is the surface maintainers read before adding a new block gate:
+    high bypass count + low error rate = rule may be too strict;
+    high error rate = bypass actively associated with failures.
+    """
+    lines.append(_render_header("Per-Hook Aggregation"))
+    counts = agg["hook_family_counts"]
+    if not counts:
+        lines.append("  (no hook/rule family data)")
+        return
+
+    error_counts = agg["hook_family_error_counts"]
+    detail = agg["hook_family_detail"]
+
+    col_family = 26
+    lines.append(
+        f"  {'Hook / Rule Family':<{col_family}}  {'Bypasses':>8}  "
+        f"{'Errors':>6}  {'Err%':>5}  {'Sessions':>8}  Last Seen"
+    )
+    lines.append(
+        f"  {'─' * col_family}  {'─' * 8}  {'─' * 6}  {'─' * 5}  "
+        f"{'─' * 8}  {'─' * 10}"
+    )
+
+    for family, count in counts.most_common():
+        err_count = error_counts.get(family, 0)
+        err_rate = f"{100 * err_count / count:.0f}%" if count > 0 else " n/a"
+        d = detail.get(family, {})
+        sessions = len(d.get("sessions") or set())
+        last_seen_raw = d.get("last_seen") or ""
+        # Truncate to date portion (YYYY-MM-DD) — microsecond timestamps are noisy here.
+        last_seen = last_seen_raw[:10] if last_seen_raw else "(unknown)"
+        lines.append(
+            f"  {family:<{col_family}}  {count:>8}  {err_count:>6}  "
+            f"{err_rate:>5}  {sessions:>8}  {last_seen}"
+        )
+
+    lines.append("")
+    lines.append(
+        "  Err% = errors / bypasses.  High Err% means the bypass co-occurred with\n"
+        "  tool failures — strong signal for a new block gate.  High Bypasses + low\n"
+        "  Err% means the rule is frequently bypassed without failures — review\n"
+        "  whether the hook is too strict before tightening it."
+    )
+    lines.append(
+        "  Note: 'error co-occurrence' is DERIVED — the telemetry schema records\n"
+        "  tool_result_status per event; it does not causally link the bypass to\n"
+        "  the failure.  Correlation only.  See follow-up issue #689 for causal\n"
+        "  attribution tracking."
+    )
+
+
+def _render_per_hook_detail(
+    lines: list[str], events: list[dict], family: str, errors_only: bool = False
+) -> None:
+    """Render a per-event detail view for a single hook/rule family.
+
+    Used when --per-hook FAMILY is passed.  Shows every event whose
+    bypass_env_vars contains at least one var normalizing to ``family``.
+    When ``errors_only`` is set, the view is restricted to error events so
+    the flag keeps its documented meaning in combination with --per-hook.
+    """
+    matching = [
+        ev for ev in events
+        if any(
+            derive_bypass_family(var) == family
+            for var in _coerce_bypass_vars(ev.get(FIELD_BYPASS_ENV_VARS))
+        )
+    ]
+    if errors_only:
+        matching = [
+            ev for ev in matching
+            if (ev.get(FIELD_TOOL_RESULT_STATUS) or "ok") == STATUS_ERROR
+        ]
+
+    filter_note = " (errors only)" if errors_only else ""
+    lines.append(
+        _render_header(f"Per-Hook Detail: {family}{filter_note}  [{len(matching)} event(s)]")
+    )
+    if not matching:
+        scope = "error events" if errors_only else "events"
+        lines.append(f"  (no {scope} found for family '{family}')")
+        lines.append(
+            "  Tip: family names are normalized bypass var suffixes. "
+            "Run without --per-hook to see available families."
+        )
+        return
+
+    error_count = sum(
+        1 for ev in matching
+        if (ev.get(FIELD_TOOL_RESULT_STATUS) or "ok") == STATUS_ERROR
+    )
+    err_rate = f"{100 * error_count / len(matching):.0f}%" if matching else "n/a"
+    sessions = {(ev.get(FIELD_SESSION_ID) or "") for ev in matching if ev.get(FIELD_SESSION_ID)}
+    lines.append(f"  Total bypasses : {len(matching)}")
+    lines.append(f"  Errors         : {error_count}  ({err_rate})")
+    lines.append(f"  Distinct sessions: {len(sessions)}")
+    lines.append("")
+
+    for i, ev in enumerate(matching, 1):
+        ts = ev.get(FIELD_TIMESTAMP, "(no timestamp)")
+        session = ev.get(FIELD_SESSION_ID, "") or "(no session)"
+        tool = ev.get(FIELD_TOOL, UNKNOWN)
+        bypass_vars = _coerce_bypass_vars(ev.get(FIELD_BYPASS_ENV_VARS))
+        tool_input = ev.get(FIELD_TOOL_INPUT, "") or ""
+        status = ev.get(FIELD_TOOL_RESULT_STATUS, "ok") or "ok"
+        command_family = derive_command_family(tool_input)
+        status_marker = " ⚠ ERROR" if status == STATUS_ERROR else ""
+        lines.append(f"  [{i}] {ts}{status_marker}")
+        lines.append(f"      session : {session}")
+        lines.append(f"      tool    : {tool}")
+        lines.append(f"      bypass  : {', '.join(bypass_vars)}")
+        lines.append(f"      command : {command_family}")
+        if tool_input:
+            lines.append(f"      input   : {tool_input}")
+
+
 def render_report(
     events: list[dict],
     agg: dict,
     days: int,
     telemetry_dir: Path,
     errors_only: bool,
+    per_hook: str | None = None,
 ) -> str:
     lines: list[str] = []
 
@@ -389,6 +549,11 @@ def render_report(
 
     if agg["total"] == 0:
         lines.append("\n  No bypass events found in the selected period.")
+        return "\n".join(lines)
+
+    # ── --per-hook mode: single-family drill-down ──
+    if per_hook is not None:
+        _render_per_hook_detail(lines, events, per_hook, errors_only)
         return "\n".join(lines)
 
     if errors_only:
@@ -413,22 +578,8 @@ def render_report(
             "Errors = bypass followed by tool failure (bad-bypass candidate)."
         )
 
-    # ── Section 3: By hook/rule family ──
-    _render_error_count_table(
-        lines,
-        "Bypass by Hook / Rule Family",
-        "Family",
-        agg["hook_family_counts"],
-        agg["hook_family_error_counts"],
-        note_label="⚠ error-linked",
-        empty_label="no hook/rule family data",
-        label_width=26,
-    )
-    lines.append("")
-    lines.append(
-        "  Family labels are normalized from bypass var names "
-        "(for example SCIOMC_GATE, WORKTREE_GATE, GH_JSON)."
-    )
+    # ── Section 3: Per-Hook Aggregation (primary observability surface) ──
+    _render_per_hook_aggregation(lines, agg)
 
     # ── Section 4: By command family ──
     _render_error_count_table(
@@ -515,7 +666,9 @@ def main(argv: list[str] | None = None) -> int:
 
     events = load_events(telemetry_dir, args.days)
     agg = aggregate(events)
-    report = render_report(events, agg, args.days, telemetry_dir, args.errors_only)
+    report = render_report(
+        events, agg, args.days, telemetry_dir, args.errors_only, args.per_hook
+    )
     print(report)
     return 0
 

--- a/tests/test_bypass_review.sh
+++ b/tests/test_bypass_review.sh
@@ -172,7 +172,7 @@ write_fixture "$DIR1B/bypass-events-$TODAY.jsonl" "$ev_git_family" "$ev_gh_famil
 
 out1b=$(python3 "$CLI" --dir "$DIR1B" --days 7 2>&1)
 
-if echo "$out1b" | grep -q "Bypass by Hook / Rule Family"; then
+if echo "$out1b" | grep -q "Per-Hook Aggregation"; then
   assert_pass "hook/rule family section present"
 else
   assert_fail "hook/rule family section present" "section missing; output: $out1b"
@@ -609,6 +609,192 @@ if printf '%s\n' "$out12" | grep -Eq "^\s+[A-Z] \([0-9]+\)$"; then
   assert_fail "malformed bypass_env_vars type: string not char-iterated" "single-char var leaked; output: $out12"
 else
   assert_pass "malformed bypass_env_vars type: string not char-iterated"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 15: Per-Hook Aggregation section (#689)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== bypass-review: per-hook aggregation section (issue #689) ==="
+
+DIR13="$TMP_DIR/t13"
+mkdir -p "$DIR13"
+ev13_a=$(make_event '["CLAUDE_HOOK_BYPASS_SCIOMC_GATE"]' "ok" "Bash" "sess-a" \
+  'CLAUDE_HOOK_BYPASS_SCIOMC_GATE=<redacted> git commit')
+ev13_b=$(make_event '["CLAUDE_HOOK_BYPASS_SCIOMC_GATE"]' "error" "Bash" "sess-b" \
+  'CLAUDE_HOOK_BYPASS_SCIOMC_GATE=<redacted> git push')
+ev13_c=$(make_event '["PRAXIS_HOOK_BYPASS_WORKTREE_GATE"]' "ok" "Bash" "sess-c" \
+  'PRAXIS_HOOK_BYPASS_WORKTREE_GATE=<redacted> gh pr create')
+write_fixture "$DIR13/bypass-events-$TODAY.jsonl" "$ev13_a" "$ev13_b" "$ev13_c"
+
+out13=$(python3 "$CLI" --dir "$DIR13" --days 1 2>&1)
+
+# Per-Hook Aggregation section header must be present
+if echo "$out13" | grep -q "Per-Hook Aggregation"; then
+  assert_pass "per-hook aggregation: section header present"
+else
+  assert_fail "per-hook aggregation: section header present" "section missing; output: $out13"
+fi
+
+# Both hook families must appear as rows
+if echo "$out13" | grep -q "SCIOMC_GATE" && echo "$out13" | grep -q "WORKTREE_GATE"; then
+  assert_pass "per-hook aggregation: hook families as rows"
+else
+  assert_fail "per-hook aggregation: hook families as rows" "families missing; output: $out13"
+fi
+
+# Err% column must be present (header row check)
+if echo "$out13" | grep -q "Err%"; then
+  assert_pass "per-hook aggregation: Err% column header present"
+else
+  assert_fail "per-hook aggregation: Err% column header present" "Err% missing; output: $out13"
+fi
+
+# Sessions column must be present
+if echo "$out13" | grep -q "Sessions"; then
+  assert_pass "per-hook aggregation: Sessions column header present"
+else
+  assert_fail "per-hook aggregation: Sessions column header present" "Sessions missing; output: $out13"
+fi
+
+# Last Seen column must be present
+if echo "$out13" | grep -q "Last Seen"; then
+  assert_pass "per-hook aggregation: Last Seen column header present"
+else
+  assert_fail "per-hook aggregation: Last Seen column header present" "Last Seen missing; output: $out13"
+fi
+
+# SCIOMC_GATE has 1 error out of 2 bypass events → 50% error rate
+if printf '%s\n' "$out13" | grep -q "SCIOMC_GATE" && printf '%s\n' "$out13" | grep "SCIOMC_GATE" | grep -q "50%"; then
+  assert_pass "per-hook aggregation: SCIOMC_GATE error rate 50%"
+else
+  assert_fail "per-hook aggregation: SCIOMC_GATE error rate 50%" "rate missing; output: $out13"
+fi
+
+# WORKTREE_GATE has 0 errors → 0% error rate
+if printf '%s\n' "$out13" | grep -q "WORKTREE_GATE" && printf '%s\n' "$out13" | grep "WORKTREE_GATE" | grep -q "0%"; then
+  assert_pass "per-hook aggregation: WORKTREE_GATE error rate 0%"
+else
+  assert_fail "per-hook aggregation: WORKTREE_GATE error rate 0%" "rate missing; output: $out13"
+fi
+
+# Distinct sessions: SCIOMC_GATE has 2 sessions (sess-a, sess-b)
+if printf '%s\n' "$out13" | grep "SCIOMC_GATE" | grep -qE "[[:space:]]2[[:space:]]"; then
+  assert_pass "per-hook aggregation: SCIOMC_GATE distinct sessions = 2"
+else
+  assert_fail "per-hook aggregation: SCIOMC_GATE distinct sessions = 2" "session count wrong; output: $out13"
+fi
+
+# Limitation note about derived co-occurrence must appear
+if echo "$out13" | grep -q "DERIVED"; then
+  assert_pass "per-hook aggregation: derived co-occurrence limitation note present"
+else
+  assert_fail "per-hook aggregation: derived co-occurrence limitation note present" "limitation note missing; output: $out13"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 16: --per-hook FAMILY flag (#689)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== bypass-review: --per-hook flag (issue #689) ==="
+
+DIR14="$TMP_DIR/t14"
+mkdir -p "$DIR14"
+ev14_a=$(make_event '["CLAUDE_HOOK_BYPASS_SCIOMC_GATE"]' "ok" "Bash" "sess-ph-a" \
+  'CLAUDE_HOOK_BYPASS_SCIOMC_GATE=<redacted> git log')
+ev14_b=$(make_event '["CLAUDE_HOOK_BYPASS_SCIOMC_GATE"]' "error" "Bash" "sess-ph-b" \
+  'CLAUDE_HOOK_BYPASS_SCIOMC_GATE=<redacted> git push')
+ev14_c=$(make_event '["PRAXIS_HOOK_BYPASS_WORKTREE_GATE"]' "ok" "Bash" "sess-ph-c" \
+  'PRAXIS_HOOK_BYPASS_WORKTREE_GATE=<redacted> gh pr list')
+write_fixture "$DIR14/bypass-events-$TODAY.jsonl" "$ev14_a" "$ev14_b" "$ev14_c"
+
+out14=$(python3 "$CLI" --dir "$DIR14" --days 1 --per-hook SCIOMC_GATE 2>&1)
+
+# Per-Hook Detail section must appear with the correct family name
+if echo "$out14" | grep -q "Per-Hook Detail: SCIOMC_GATE"; then
+  assert_pass "--per-hook: detail section with correct family"
+else
+  assert_fail "--per-hook: detail section with correct family" "section missing; output: $out14"
+fi
+
+# Should show 2 events (only SCIOMC_GATE events, not WORKTREE_GATE)
+if echo "$out14" | grep -q "\[2 event(s)\]"; then
+  assert_pass "--per-hook: correct event count (2)"
+else
+  assert_fail "--per-hook: correct event count (2)" "event count wrong; output: $out14"
+fi
+
+# WORKTREE_GATE events must NOT appear in the output
+if echo "$out14" | grep -q "WORKTREE_GATE"; then
+  assert_fail "--per-hook: other families filtered out" "WORKTREE_GATE leaked into --per-hook output"
+else
+  assert_pass "--per-hook: other families filtered out"
+fi
+
+# Error events must be marked with ⚠ ERROR
+if echo "$out14" | grep -q "ERROR"; then
+  assert_pass "--per-hook: error events marked"
+else
+  assert_fail "--per-hook: error events marked" "ERROR marker missing; output: $out14"
+fi
+
+# Distinct sessions summary must appear
+if echo "$out14" | grep -q "Distinct sessions"; then
+  assert_pass "--per-hook: distinct sessions line present"
+else
+  assert_fail "--per-hook: distinct sessions line present" "sessions line missing; output: $out14"
+fi
+
+# Test --per-hook with non-existent family: graceful no-match message
+out14b=$(python3 "$CLI" --dir "$DIR14" --days 1 --per-hook DOES_NOT_EXIST 2>&1)
+rc14b=$?
+
+if [ "$rc14b" -eq 0 ]; then
+  assert_pass "--per-hook nonexistent family: exit code 0"
+else
+  assert_fail "--per-hook nonexistent family: exit code 0" "exited $rc14b; output: $out14b"
+fi
+
+if echo "$out14b" | grep -q "no events found for family"; then
+  assert_pass "--per-hook nonexistent family: helpful no-match message"
+else
+  assert_fail "--per-hook nonexistent family: helpful no-match message" "message missing; output: $out14b"
+fi
+
+# Top Bypass Vars and Per-Hook Aggregation sections should NOT appear in --per-hook mode
+if echo "$out14" | grep -q "Top Bypass Vars"; then
+  assert_fail "--per-hook: top bypass vars section suppressed" "Top Bypass Vars appeared in --per-hook output"
+else
+  assert_pass "--per-hook: top bypass vars section suppressed"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 17: --per-hook FAMILY + --errors-only honors the error filter (#689, codex P2)
+# DIR14 SCIOMC_GATE = ev14_a(ok) + ev14_b(error); --errors-only must drop the ok event.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== bypass-review: --per-hook + --errors-only (issue #689) ==="
+out17=$(python3 "$CLI" --dir "$DIR14" --days 1 --per-hook SCIOMC_GATE --errors-only 2>&1)
+
+if echo "$out17" | grep -q "(errors only)"; then
+  assert_pass "--per-hook+--errors-only: filter note shown in header"
+else
+  assert_fail "--per-hook+--errors-only: filter note shown in header" "note missing; output: $out17"
+fi
+
+if echo "$out17" | grep -q "\[1 event(s)\]"; then
+  assert_pass "--per-hook+--errors-only: ok event filtered (1 of 2 shown)"
+else
+  assert_fail "--per-hook+--errors-only: ok event filtered (1 of 2 shown)" "expected 1 event; output: $out17"
+fi
+
+# Every listed event must be an error (no ok event leaks through the combination).
+listed=$(echo "$out17" | grep -cE '^[[:space:]]+\[[0-9]+\] ' || true)
+err_marked=$(echo "$out17" | grep -c "⚠ ERROR" || true)
+if [ "$listed" = "1" ] && [ "$err_marked" = "1" ]; then
+  assert_pass "--per-hook+--errors-only: every listed event is an error"
+else
+  assert_fail "--per-hook+--errors-only: every listed event is an error" "listed=$listed err=$err_marked; output: $out17"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 배경

부모 #672(Track 5). 신규 block hook을 추가하기 전에 **실제 bypass evidence**를
먼저 관측할 수 있어야 합니다.

## 변경

기존 `bypass-telemetry` JSONL 위에서 **집계/조회만** 추가 (신규 차단 로직 없음):

- **Per-Hook Aggregation** (기본 관측 surface): hook/rule family별 `Bypasses |
  Errors | Err% | Sessions | Last Seen`. 해석 노트(높은 Err% = block gate 후보,
  높은 Bypasses + 낮은 Err% = 훅이 과도하게 엄격할 수 있음) 포함.
- **`--per-hook FAMILY`** drill-down: 특정 family의 per-event 상세(timestamp,
  ⚠ ERROR 마커, session, tool, bypass vars, command family, input) + 상단 요약.

### Codex review (round 1) — premise 검증 후 적용

- **`--per-hook` + `--errors-only` 조합 honor**: per-hook early-return이
  `errors_only` 분기보다 앞서 실행돼 해당 family의 ok 이벤트까지 출력됐음
  (`--errors-only` help는 error만 표시한다고 명시, 두 옵션 상호배타 아님).
  `_render_per_hook_detail`에 `errors_only`를 전달해 필터 + header에 `(errors
  only)` 표기.

tool-error co-occurrence는 기존 `tool_result_status` 필드에서 **파생**(상관관계,
인과관계 아님)이며 limitation note로 명시 — telemetry 훅은 미수정.

## 검증

- `tests/test_bypass_review.sh` → **57 passed, 0 failed** (신규 Test 17: `--per-hook`+`--errors-only` 조합 — ok 이벤트 필터, `(errors only)` header, 모든 표시 이벤트가 error)
- functional: `bypass-review --per-hook SCIOMC_GATE --errors-only` → `Per-Hook Detail: SCIOMC_GATE (errors only)  [1 event(s)]` (ok 이벤트 제외 확인)
- `./scripts/run-tests.sh` → **ALL TESTS PASSED** (345 pytest 포함)

Caller chain verified: N/A -- bypass-review는 사용자 호출 CLI (telemetry JSONL 소비), 런타임 hook 아님
Pre-commit verified: ./scripts/run-tests.sh -> ALL TESTS PASSED (test_bypass_review 57/57 + 345 pytest)

Closes #689
