### PR TITLE
feat(telemetry): hook fire-rate ROI ledger

### DIFF
--- a/hooks/_lib/_dispatch.py
+++ b/hooks/_lib/_dispatch.py
@@ -147,14 +147,30 @@ def run_one(role: str, name: str, impl: Path, payload_raw: str) -> tuple[int, st
     return rc, out.getvalue(), err.getvalue()
 
 
+def _record_fires(members, results, payload_raw: str) -> None:
+    """Log each member's fire decision (issue #710). Fail-open, never raises.
+
+    Lazily imports `_fire_ledger` so a missing/broken module can never break the
+    dispatcher — fire telemetry is observe-only.
+    """
+    try:
+        import _fire_ledger  # type: ignore[import-not-found]
+        _fire_ledger.record_group_fires(members, results, payload_raw)
+    except Exception:
+        pass
+
+
 def run_group(
     event: str, matcher: str, payload_raw: str, host: Optional[str] = None
 ) -> int:
     """Run the whole (event, matcher) group; emit one decision; return its exit code."""
-    results = [
-        run_one(role, name, impl, payload_raw)
-        for role, name, impl in group_members(event, matcher, host)
-    ]
+    members = group_members(event, matcher, host)
+    results = [run_one(role, name, impl, payload_raw) for role, name, impl in members]
+
+    # Fire telemetry (issue #710): record each member's decision before the
+    # aggregation below. Observe-only and fail-open — the dispatcher's decision
+    # is unaffected.
+    _record_fires(members, results, payload_raw)
 
     # Forward every hook's stderr (advisory nudges and deny reasons alike).
     for _rc, _so, se in results:

--- a/hooks/_lib/_dispatch.py
+++ b/hooks/_lib/_dispatch.py
@@ -164,6 +164,15 @@ def run_group(
     event: str, matcher: str, payload_raw: str, host: Optional[str] = None
 ) -> int:
     """Run the whole (event, matcher) group; emit one decision; return its exit code."""
+    # Mark this process as the dispatcher so the fail_open-level coarse recorder
+    # (issue #710 coverage expansion) skips the Bash-group members run below —
+    # they are recorded richly by _record_fires. Avoids double-counting.
+    try:
+        import _fire_ledger  # type: ignore[import-not-found]
+        _fire_ledger.mark_dispatcher_process()
+    except Exception:
+        pass
+
     members = group_members(event, matcher, host)
     results = [run_one(role, name, impl, payload_raw) for role, name, impl in members]
 

--- a/hooks/_lib/_fire_ledger.py
+++ b/hooks/_lib/_fire_ledger.py
@@ -121,7 +121,17 @@ def record_group_fires(members, results, payload_raw: str) -> None:
             return
         path = resolve_path()
         path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("a", encoding="utf-8") as fh:
-            fh.write("\n".join(lines) + "\n")
+        # Per-line atomic append (not one big write): O_APPEND makes each
+        # write() atomic up to PIPE_BUF, and one fire record (~150-250 B) is far
+        # under PIPE_BUF (>=4096), so concurrent dispatchers can't tear a line.
+        # Whole-line interleaving across processes is harmless — the reader is
+        # line-oriented JSONL. A single joined write of all N members (~5 KB)
+        # WOULD exceed PIPE_BUF and risk torn lines, so we write per line.
+        fd = os.open(path, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+        try:
+            for line in lines:
+                os.write(fd, (line + "\n").encode("utf-8"))
+        finally:
+            os.close(fd)
     except Exception:
         pass  # fail-open — never break the dispatcher

--- a/hooks/_lib/_fire_ledger.py
+++ b/hooks/_lib/_fire_ledger.py
@@ -116,8 +116,15 @@ def _atomic_append(path: Path, lines: list[str]) -> None:
             return  # FIFO / device / socket / symlink — refuse to write
     except FileNotFoundError:
         pass  # absent — created as a regular file below
-    fd = os.open(path, os.O_WRONLY | os.O_APPEND | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0), 0o644)
+    # O_NONBLOCK so opening a FIFO swapped in after the lstat fails fast (ENXIO)
+    # instead of blocking; O_NOFOLLOW rejects a symlinked final component. Then
+    # fstat the OPENED fd to close the lstat→open swap window before writing.
+    flags = (os.O_WRONLY | os.O_APPEND | os.O_CREAT
+             | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0))
+    fd = os.open(path, flags, 0o644)
     try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            return  # target swapped to a non-regular file after the lstat check
         for line in lines:
             os.write(fd, (line + "\n").encode("utf-8"))
     finally:

--- a/hooks/_lib/_fire_ledger.py
+++ b/hooks/_lib/_fire_ledger.py
@@ -1,0 +1,127 @@
+"""Fire-event telemetry: record which hooks fired and their decision (issue #710).
+
+Companion to bypass-telemetry (which logs bypass *events*). This module logs
+hook *fires* from the central PreToolUse(Bash) dispatcher (`_dispatch.py`) — the
+single point that already runs every member of the hot Bash group and captures
+each one's `(exit, stdout, stderr)`. One JSONL line per member per dispatched
+tool call.
+
+CEILING (issue #710, hot-path MVP): only the dispatched PreToolUse(Bash) group
+is instrumented — the group `_dispatch.py` consolidates. Hooks on other events
+(Stop, UserPromptSubmit, PostToolUse, SessionStart) and non-Bash PreToolUse
+matchers run as standalone processes and are NOT recorded here.
+UPGRADE PATH: when another `(event, matcher)` is added to `manifest.json`
+`dispatch_groups`, it flows through `run_group` and is recorded automatically.
+Universal coverage of standalone hooks would instrument
+`_hook_runtime.fail_open` instead — coarser, because that wrapper sees only the
+return code (advise/pass collapse, no stdout) and has no payload (no session_id
+/ tool).
+
+Record fields (JSONL, one line per hook fire):
+  timestamp    UTC ISO-8601
+  session_id   from payload
+  tool         tool_name from payload
+  hook         hook name (manifest `name`)
+  role         hook role (manifest `role`)
+  decision     "block" | "ask" | "advise" | "pass"
+
+Storage:
+  Default:  ~/.praxis/telemetry/fire-events-YYYY-MM-DD.jsonl  (daily rotation)
+  Override: PRAXIS_FIRE_TELEMETRY_FILE (full path, used by tests)
+  Opt-out:  PRAXIS_FIRE_TELEMETRY_DISABLE=1 → no-op
+
+Fail-open: any error → silently no-op. Never raises into the dispatcher.
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+DECISION_BLOCK = "block"
+DECISION_ASK = "ask"
+DECISION_ADVISE = "advise"
+DECISION_PASS = "pass"
+
+# Decision markers — kept in sync with _dispatch.py run_group aggregation.
+# (The invariant canary planned in issue #712 will pin this pairing.)
+_ASK_MARKER = '"permissionDecision": "ask"'
+_DENY_MARKER = '"permissionDecision": "deny"'
+
+
+def classify_decision(rc: int, stdout: str, stderr: str) -> str:
+    """Map a member's `(exit, stdout, stderr)` to a fire decision.
+
+    Mirrors `_dispatch.run_group`'s PER-MEMBER decision precedence (this is one
+    member's own outcome, not the cross-member aggregate the dispatcher emits):
+    deny (exit 2 / deny marker) > ask (ask marker) > advise (any stderr) > pass.
+    """
+    if rc == 2 or _DENY_MARKER in stdout:
+        return DECISION_BLOCK
+    if _ASK_MARKER in stdout:
+        return DECISION_ASK
+    if stderr.strip():
+        return DECISION_ADVISE
+    return DECISION_PASS
+
+
+def _disabled() -> bool:
+    return os.environ.get("PRAXIS_FIRE_TELEMETRY_DISABLE", "").strip() == "1"
+
+
+def resolve_path() -> Path:
+    """Resolve today's fire-events JSONL path (PRAXIS_FIRE_TELEMETRY_FILE wins)."""
+    override = os.environ.get("PRAXIS_FIRE_TELEMETRY_FILE", "").strip()
+    if override:
+        return Path(override)
+    today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+    return Path.home() / ".praxis" / "telemetry" / f"fire-events-{today}.jsonl"
+
+
+def _extract_payload(payload_raw: str) -> tuple[str, str]:
+    """Return `(session_id, tool)` from the raw JSON payload; `("", "")` on error."""
+    try:
+        data = json.loads(payload_raw)
+    except Exception:
+        return "", ""
+    if not isinstance(data, dict):
+        return "", ""
+    sid = data.get("session_id")
+    tool = data.get("tool_name")
+    return (sid if isinstance(sid, str) else ""), (tool if isinstance(tool, str) else "")
+
+
+def record_group_fires(members, results, payload_raw: str) -> None:
+    """Append one fire record per `(member, result)` pair. Fail-open, batched.
+
+    `members`   : list of `(role, name, impl)` from `group_members`.
+    `results`   : list of `(rc, stdout, stderr)` from `run_one`, positionally aligned.
+    `payload_raw`: the raw hook payload JSON (session_id / tool_name source).
+
+    Batched into ONE file open per dispatched tool call (the dispatcher is the
+    hot path — one open for ~N members, not N opens).
+    """
+    if _disabled():
+        return
+    try:
+        session_id, tool = _extract_payload(payload_raw)
+        ts = datetime.now(tz=timezone.utc).isoformat()
+        lines: list[str] = []
+        for (role, name, _impl), (rc, stdout, stderr) in zip(members, results):
+            lines.append(json.dumps({
+                "timestamp": ts,
+                "session_id": session_id,
+                "tool": tool,
+                "hook": name,
+                "role": role,
+                "decision": classify_decision(rc, stdout, stderr),
+            }, ensure_ascii=False))
+        if not lines:
+            return
+        path = resolve_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write("\n".join(lines) + "\n")
+    except Exception:
+        pass  # fail-open — never break the dispatcher

--- a/hooks/_lib/_fire_ledger.py
+++ b/hooks/_lib/_fire_ledger.py
@@ -6,24 +6,32 @@ single point that already runs every member of the hot Bash group and captures
 each one's `(exit, stdout, stderr)`. One JSONL line per member per dispatched
 tool call.
 
-CEILING (issue #710, hot-path MVP): only the dispatched PreToolUse(Bash) group
-is instrumented — the group `_dispatch.py` consolidates. Hooks on other events
-(Stop, UserPromptSubmit, PostToolUse, SessionStart) and non-Bash PreToolUse
-matchers run as standalone processes and are NOT recorded here.
-UPGRADE PATH: when another `(event, matcher)` is added to `manifest.json`
-`dispatch_groups`, it flows through `run_group` and is recorded automatically.
-Universal coverage of standalone hooks would instrument
-`_hook_runtime.fail_open` instead — coarser, because that wrapper sees only the
-return code (advise/pass collapse, no stdout) and has no payload (no session_id
-/ tool).
+COVERAGE (issue #710, two tiers):
+  RICH   — the dispatched PreToolUse(Bash) group, recorded by
+           `record_group_fires` from the dispatcher which captures each member's
+           `(rc, stdout, stderr)` → full block/ask/advise/pass + session_id/tool.
+  COARSE — every other hook that uses the @fail_open decorator (Stop,
+           UserPromptSubmit, PostToolUse, SessionStart, non-Bash PreToolUse),
+           recorded by `record_standalone_fire` from `_hook_runtime.fail_open`.
+           That wrapper sees only the return code (no stdout/stdin capture — it
+           must not interfere with a live hook process), so ask/advise/pass
+           collapse to "pass" and session_id/tool are absent. "block" means
+           exit-code 2 ONLY: Stop/UserPromptSubmit hooks block via a stdout JSON
+           `decision` field while exiting 0, so THEIR blocks are invisible to the
+           coarse path and recorded as "pass" (PreToolUse blocks do exit 2 and
+           are captured). Treat coarse Block as a lower bound.
+CEILING: a hook that does NOT use @fail_open is uninstrumented. The dispatcher
+process marks itself (mark_dispatcher_process) so its Bash-group members are not
+double-counted by the coarse path.
 
 Record fields (JSONL, one line per hook fire):
   timestamp    UTC ISO-8601
-  session_id   from payload
-  tool         tool_name from payload
+  session_id   from payload (rich only; "" for coarse)
+  tool         tool_name from payload (rich only; "" for coarse)
   hook         hook name (manifest `name`)
   role         hook role (manifest `role`)
   decision     "block" | "ask" | "advise" | "pass"
+  granularity  "rich" | "coarse"
 
 Storage:
   Default:  ~/.praxis/telemetry/fire-events-YYYY-MM-DD.jsonl  (daily rotation)
@@ -36,6 +44,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -68,6 +77,51 @@ def classify_decision(rc: int, stdout: str, stderr: str) -> str:
 
 def _disabled() -> bool:
     return os.environ.get("PRAXIS_FIRE_TELEMETRY_DISABLE", "").strip() == "1"
+
+
+# Set True in the dispatcher process so fail_open-level recording skips the
+# Bash-group members — they are already recorded richly by record_group_fires.
+# Process-local: standalone hook processes never import/run the dispatcher.
+_DISPATCHER_PROCESS = False
+
+
+def mark_dispatcher_process() -> None:
+    """Mark the current process as the dispatcher (suppresses coarse recording).
+
+    Intentionally one-way and process-lifetime — there is no unmark. Production
+    is safe because each hook (and the dispatcher) runs in its own fresh process,
+    so the flag never leaks across roles. The only place it must be reset is a
+    single-process test harness running both roles (see test helper).
+    """
+    global _DISPATCHER_PROCESS
+    _DISPATCHER_PROCESS = True
+
+
+def _atomic_append(path: Path, lines: list[str]) -> None:
+    """Append `lines` as JSONL with per-line atomic writes; best-effort safe.
+
+    - Per-line `os.write` under O_APPEND: each record (~150-250 B) is far under
+      PIPE_BUF (>=4096), so concurrent writers can't tear a line (whole-line
+      interleaving is harmless for line-oriented JSONL). A single joined write of
+      all N members (~5 KB) WOULD exceed PIPE_BUF and risk torn lines.
+    - Regular-file guard + O_NOFOLLOW: the universal fail_open path opens this on
+      every hook invocation, so a FIFO/device/symlink at the target (planted, or
+      via PRAXIS_FIRE_TELEMETRY_FILE) must not block or misdirect the guard.
+    """
+    if not lines:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        if not stat.S_ISREG(os.lstat(path).st_mode):
+            return  # FIFO / device / socket / symlink — refuse to write
+    except FileNotFoundError:
+        pass  # absent — created as a regular file below
+    fd = os.open(path, os.O_WRONLY | os.O_APPEND | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0), 0o644)
+    try:
+        for line in lines:
+            os.write(fd, (line + "\n").encode("utf-8"))
+    finally:
+        os.close(fd)
 
 
 def resolve_path() -> Path:
@@ -116,22 +170,46 @@ def record_group_fires(members, results, payload_raw: str) -> None:
                 "hook": name,
                 "role": role,
                 "decision": classify_decision(rc, stdout, stderr),
+                "granularity": "rich",
             }, ensure_ascii=False))
-        if not lines:
-            return
-        path = resolve_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        # Per-line atomic append (not one big write): O_APPEND makes each
-        # write() atomic up to PIPE_BUF, and one fire record (~150-250 B) is far
-        # under PIPE_BUF (>=4096), so concurrent dispatchers can't tear a line.
-        # Whole-line interleaving across processes is harmless — the reader is
-        # line-oriented JSONL. A single joined write of all N members (~5 KB)
-        # WOULD exceed PIPE_BUF and risk torn lines, so we write per line.
-        fd = os.open(path, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
-        try:
-            for line in lines:
-                os.write(fd, (line + "\n").encode("utf-8"))
-        finally:
-            os.close(fd)
+        _atomic_append(resolve_path(), lines)
     except Exception:
         pass  # fail-open — never break the dispatcher
+
+
+def record_standalone_fire(hook: str, role: str, rc: int) -> None:
+    """Append a COARSE fire record for a standalone (non-dispatched) hook.
+
+    Called from `_hook_runtime.fail_open`, the universal decorator every hook's
+    `main()` runs through — so this extends fire coverage to hooks outside the
+    PreToolUse(Bash) dispatch group (Stop, UserPromptSubmit, PostToolUse,
+    non-Bash PreToolUse, SessionStart).
+
+    Deliberately NON-INVASIVE: it does not touch the hook's stdin/stdout/stderr
+    (capturing them could break a live hook process), so the ONLY block signal it
+    sees is the exit code. "block" here means exit-code 2.
+
+    IMPORTANT block-coverage limitation: praxis Stop and UserPromptSubmit hooks
+    block by emitting a `{"decision": "block"}` JSON on stdout while exiting 0
+    (see _hook_io.py — "the caller owns the exit code"). Those blocks are
+    INVISIBLE to this path and are recorded as "pass". PreToolUse standalone
+    hooks do exit 2 on block, so their blocks ARE captured. ask/advise likewise
+    collapse to "pass" (granularity="coarse"); session_id/tool are absent. The
+    Bash group keeps full granularity via record_group_fires; this path is skipped
+    inside the dispatcher process to avoid double-counting those members.
+    """
+    if _disabled() or _DISPATCHER_PROCESS:
+        return
+    try:
+        record = {
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+            "session_id": "",
+            "tool": "",
+            "hook": hook,
+            "role": role,
+            "decision": DECISION_BLOCK if rc == 2 else DECISION_PASS,
+            "granularity": "coarse",
+        }
+        _atomic_append(resolve_path(), [json.dumps(record, ensure_ascii=False)])
+    except Exception:
+        pass  # fail-open — never break the hook

--- a/hooks/_lib/_hook_runtime.py
+++ b/hooks/_lib/_hook_runtime.py
@@ -148,6 +148,12 @@ def fail_open(fn: Callable[[], int]) -> Callable[[], int]:
     def wrapper() -> int:
         try:
             rc = fn()
+        except SystemExit as exc:
+            # sys.exit() inside main() raises SystemExit (a BaseException), which
+            # bypasses the Exception clause below. Record the fire from the exit
+            # code, then re-raise to preserve the hook's exit semantics.
+            _maybe_record_fire(fn, exc.code)
+            raise
         except Exception:
             _record_swallowed_exception(fn)
             rc = 0

--- a/hooks/_lib/_hook_runtime.py
+++ b/hooks/_lib/_hook_runtime.py
@@ -94,6 +94,33 @@ def _hook_identity(fn: Callable[[], int]) -> str:
         return getattr(fn, "__name__", "<unknown>")
 
 
+def _hook_role(fn: Callable[[], int]) -> str:
+    """Hook role = grandparent dir of the entrypoint (hooks/<role>/<name>/impl.py)."""
+    try:
+        return os.path.basename(os.path.dirname(os.path.dirname(fn.__code__.co_filename)))
+    except Exception:
+        return ""
+
+
+def _maybe_record_fire(fn: Callable[[], int], rc: object) -> None:
+    """Record a coarse fire event for a standalone hook (issue #710 coverage).
+
+    Best-effort and isolated: any failure (missing module, I/O) is swallowed so
+    the fail-open guard's contract is never affected. The recorder itself no-ops
+    inside the dispatcher process and when telemetry is disabled.
+    """
+    try:
+        _lib = os.path.dirname(os.path.abspath(__file__))
+        if _lib not in sys.path:
+            sys.path.insert(0, _lib)
+        import _fire_ledger  # type: ignore[import-not-found]
+        _fire_ledger.record_standalone_fire(
+            _hook_identity(fn), _hook_role(fn), rc if isinstance(rc, int) else 0
+        )
+    except Exception:
+        pass
+
+
 def _record_swallowed_exception(fn: Callable[[], int]) -> None:
     """Log a swallowed exception as JSONL. Never raises, never leaks to stderr."""
     try:
@@ -110,13 +137,23 @@ def _record_swallowed_exception(fn: Callable[[], int]) -> None:
 
 
 def fail_open(fn: Callable[[], int]) -> Callable[[], int]:
-    """Return 0 on any uncaught Exception (recording it); else pass through."""
+    """Return 0 on any uncaught Exception (recording it); else pass through.
+
+    Side-effect (issue #710): after `fn()` resolves, records an observe-only
+    coarse fire event via `_maybe_record_fire`. That call never alters the
+    returned rc, never raises (fully swallowed), and never touches the hook's
+    stdin/stdout/stderr — the fail-open contract is unchanged.
+    """
     @functools.wraps(fn)
     def wrapper() -> int:
         try:
-            return fn()
+            rc = fn()
         except Exception:
             _record_swallowed_exception(fn)
-            return 0
+            rc = 0
+        # Coarse fire telemetry (issue #710 coverage). After fn() resolves, never
+        # alters rc or raises. Skipped inside the dispatcher process.
+        _maybe_record_fire(fn, rc)
+        return rc
 
     return wrapper

--- a/skills/bypass-review/bypass-review
+++ b/skills/bypass-review/bypass-review
@@ -83,6 +83,7 @@ F_FIRE_TOOL = "tool"
 F_FIRE_HOOK = "hook"
 F_FIRE_ROLE = "role"
 F_FIRE_DECISION = "decision"
+F_FIRE_GRANULARITY = "granularity"
 
 _FIRE_DECISIONS = ("block", "ask", "advise", "pass")
 
@@ -723,12 +724,14 @@ def aggregate_fires(events: list[dict]) -> dict[str, dict]:
         row = by_hook.setdefault(hook, {
             "role": ev.get(F_FIRE_ROLE) or UNKNOWN,
             "fires": 0, "block": 0, "ask": 0, "advise": 0, "pass": 0,
-            "sessions": set(), "last_seen": "",
+            "sessions": set(), "last_seen": "", "coarse": False,
         })
         row["fires"] += 1
         decision = ev.get(F_FIRE_DECISION)
         if decision in _FIRE_DECISIONS:
             row[decision] += 1
+        if ev.get(F_FIRE_GRANULARITY) == "coarse":
+            row["coarse"] = True
         session = ev.get(F_FIRE_SESSION)
         if isinstance(session, str) and session:
             row["sessions"].add(session)
@@ -745,12 +748,42 @@ def default_manifest_path() -> Path:
     return Path(__file__).resolve().parents[2] / "hooks" / "manifest.json"
 
 
+def roster_split(manifest_path: Path) -> tuple[set[str], set[str]] | None:
+    """Split manifest hook names into (instrumentable, uninstrumentable).
+
+    The fire-ledger can only record hooks that flow through the Python
+    @fail_open decorator (coarse) or the Bash dispatch group (rich). Shell hooks
+    (`body: impl.sh`) have no such chokepoint, so they can NEVER produce a fire
+    event and must be excluded from the 'never fired' set — otherwise a shell
+    hook that runs every session is mislabelled as a dead-prune candidate.
+
+    Proxy: instrumentable == body is not an `.sh` file (Python impl, which the
+    praxis convention wraps in @fail_open); uninstrumentable == `body` ends
+    `.sh`. Returns None if the manifest can't be read.
+    """
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        instrumentable: set[str] = set()
+        uninstrumentable: set[str] = set()
+        for hook in manifest.get("hooks", []):
+            if not isinstance(hook, dict) or not hook.get("name"):
+                continue
+            body = hook.get("body") or ""
+            if isinstance(body, str) and body.endswith(".sh"):
+                uninstrumentable.add(hook["name"])
+            else:
+                instrumentable.add(hook["name"])
+        return instrumentable, uninstrumentable
+    except Exception:
+        return None
+
+
 def bash_group_roster(manifest_path: Path) -> set[str] | None:
     """Return hook names dispatched in the PreToolUse(Bash) group, or None.
 
-    The fire-ledger (issue #710) instruments only that group, so the
-    'never fired' set is computed against this roster — not all 64 hooks.
-    Returns None if the manifest can't be read (never-fired then omitted).
+    These are the hooks recorded at RICH granularity (full block/ask/advise/pass)
+    by the central dispatcher. Hooks outside this group are recorded coarsely via
+    fail_open (issue #710 coverage expansion). Returns None if unreadable.
     """
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -783,63 +816,95 @@ def render_fire_report(
     by_hook: dict[str, dict],
     days: int,
     telemetry_dir: Path,
-    roster: set[str] | None,
+    roster: tuple[set[str], set[str]] | None,
 ) -> str:
     lines: list[str] = []
     today = datetime.now(tz=timezone.utc).date()
     since = today - timedelta(days=days - 1)
 
+    coarse_count = sum(1 for r in by_hook.values() if r.get("coarse"))
     lines.append(_render_header("bypass-review: Hook Fire-Rate Report (issue #710)"))
     lines.append(f"  Period : {since} → {today} (last {days} day{'s' if days != 1 else ''})")
     lines.append(f"  Source : {telemetry_dir}")
-    lines.append(f"  Hooks fired : {len(by_hook)}")
-    lines.append("  Scope  : PreToolUse(Bash) dispatch group only (hot-path MVP ceiling)")
+    lines.append(f"  Hooks fired : {len(by_hook)}  ({coarse_count} coarse)")
+    lines.append("  Scope  : Bash dispatch group = rich (block/ask/advise/pass);")
+    lines.append("           other @fail_open hooks = coarse (block/pass only)")
 
     if not by_hook:
+        # Empty window: nothing fired. Intentionally NOT listing the whole roster
+        # as 'never fired' — zero events means 'no telemetry yet', not 'all dead'.
         lines.append("\n  No fire events found in the selected period.")
         return "\n".join(lines)
 
     lines.append(_render_header("Per-Hook Fire Counts"))
     col = 34
     lines.append(
-        f"  {'Hook':<{col}}  {'Fires':>5}  {'Block':>5}  {'Ask':>4}  "
+        f"  {'Hook':<{col}}  {'G':>1}  {'Fires':>5}  {'Block':>5}  {'Ask':>4}  "
         f"{'Advise':>6}  {'Pass':>5}  {'Sess':>4}  Last Seen"
     )
     lines.append(
-        f"  {'─' * col}  {'─' * 5}  {'─' * 5}  {'─' * 4}  {'─' * 6}  "
+        f"  {'─' * col}  {'─' * 1}  {'─' * 5}  {'─' * 5}  {'─' * 4}  {'─' * 6}  "
         f"{'─' * 5}  {'─' * 4}  {'─' * 10}"
     )
     for hook in sorted(by_hook, key=lambda h: by_hook[h]["fires"], reverse=True):
         r = by_hook[hook]
         last_seen = (r["last_seen"] or "")[:10] or "(unknown)"
+        g = "C" if r.get("coarse") else "R"
         lines.append(
-            f"  {hook:<{col}}  {r['fires']:>5}  {r['block']:>5}  {r['ask']:>4}  "
+            f"  {hook:<{col}}  {g:>1}  {r['fires']:>5}  {r['block']:>5}  {r['ask']:>4}  "
             f"{r['advise']:>6}  {r['pass']:>5}  {len(r['sessions']):>4}  {last_seen}"
         )
+    lines.append("")
+    lines.append(
+        "  G: R=rich (Bash dispatch group — full decision granularity).\n"
+        "     C=coarse (standalone @fail_open hook): Block counts EXIT-CODE-2\n"
+        "     blocks only. Stop / UserPromptSubmit hooks block via a stdout JSON\n"
+        "     `decision` field while exiting 0 — those blocks are invisible here\n"
+        "     and fold into Pass (so coarse Block is a lower bound). ask/advise\n"
+        "     also fold into Pass; session id is absent. A coarse 'Fires' count\n"
+        "     ≈ how often the hook's matcher matched, not how often it engaged."
+    )
 
-    # ── Never-fired set (against the Bash-group roster) ──
-    lines.append(_render_header("Never Fired (Bash-group roster − hooks above)"))
+    # ── Never-fired set (instrumentable roster only) ──
+    lines.append(_render_header("Never Fired (instrumentable roster − hooks above)"))
     if roster is None:
         lines.append("  (manifest unavailable — pass --manifest PATH to compute this set)")
     else:
-        never = sorted(roster - set(by_hook))
+        instrumentable, uninstrumentable = roster
+        never = sorted(instrumentable - set(by_hook))
         if not never:
-            lines.append("  (none — every dispatched Bash-group hook fired in this window)")
+            lines.append("  (none — every instrumentable hook fired in this window)")
         else:
-            lines.append(f"  {len(never)} hook(s) in the group never fired:")
+            lines.append(f"  {len(never)} instrumentable hook(s) never fired:")
             for name in never:
                 lines.append(f"    · {name}")
             lines.append("")
             lines.append(
-                "  Caveat: this roster is host-blind — a hook restricted via the\n"
-                "  manifest `hosts` field never fires on a platform it excludes (by\n"
-                "  design), so on a non-claude install it shows here as a false\n"
-                "  'never fired'. Cross-check `hosts` before treating one as dead.")
+                "  Caveat 1 (host-blind): a hook restricted via the manifest `hosts`\n"
+                "  field never fires on a platform it excludes (by design), so on a\n"
+                "  non-claude install it shows here as a false 'never fired'.\n"
+                "  Caveat 2 (rare-but-critical): a low-base-rate guard (e.g. a\n"
+                "  force-push block) may correctly fire ~never — absence here is NOT\n"
+                "  sufficient grounds to prune. Cross-check `hosts` + intent first.")
+
+        # Uninstrumentable hooks are listed separately — they can NEVER produce a
+        # fire event, so conflating them with 'never fired' would mislabel live
+        # shell hooks as dead-prune candidates (codex #714 P2).
+        if uninstrumentable:
+            lines.append("")
+            lines.append(_render_header("Uninstrumented (shell hooks — never recorded)"))
+            lines.append(
+                f"  {len(uninstrumentable)} shell (.sh) hook(s) have no @fail_open /"
+                " dispatch\n  chokepoint, so they emit NO fire events and are EXCLUDED"
+                " from the\n  never-fired set above. Their activity cannot be judged"
+                " from this report:")
+            for name in sorted(uninstrumentable):
+                lines.append(f"    · {name}")
     lines.append("")
     lines.append(
-        "  Ceiling: only the PreToolUse(Bash) dispatch group is instrumented\n"
-        "  (issue #710 hot-path MVP). Hooks on Stop / UserPromptSubmit /\n"
-        "  PostToolUse / SessionStart run standalone and are not counted here."
+        "  Ceiling: coverage spans every hook that uses the @fail_open decorator\n"
+        "  (the praxis convention) plus the Bash dispatch group. Shell (.sh) hooks\n"
+        "  are uninstrumented and listed separately above."
     )
     return "\n".join(lines)
 
@@ -850,7 +915,7 @@ def run_fire_rate(args: argparse.Namespace, telemetry_dir: Path) -> int:
     manifest_path = (
         Path(args.manifest_path) if args.manifest_path else default_manifest_path()
     )
-    roster = bash_group_roster(manifest_path)
+    roster = roster_split(manifest_path)
     print(render_fire_report(by_hook, args.days, telemetry_dir, roster))
     return 0
 

--- a/skills/bypass-review/bypass-review
+++ b/skills/bypass-review/bypass-review
@@ -73,6 +73,19 @@ FIELD_TOOL_RESULT_STATUS = "tool_result_status"
 STATUS_ERROR = "error"
 UNKNOWN = "(unknown)"
 
+# ---------------------------------------------------------------------------
+# Fire-event field names (issue #710) — cited verbatim from
+# hooks/_lib/_fire_ledger.py record_group_fires()
+# ---------------------------------------------------------------------------
+F_FIRE_TIMESTAMP = "timestamp"
+F_FIRE_SESSION = "session_id"
+F_FIRE_TOOL = "tool"
+F_FIRE_HOOK = "hook"
+F_FIRE_ROLE = "role"
+F_FIRE_DECISION = "decision"
+
+_FIRE_DECISIONS = ("block", "ask", "advise", "pass")
+
 _INLINE_ENV_TOKEN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 _ENV_OPTIONS_WITH_VALUE = {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}
 _BYPASS_PREFIXES = (
@@ -95,6 +108,26 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "Reads ~/.praxis/telemetry/bypass-events-YYYY-MM-DD.jsonl files."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "mode",
+        nargs="?",
+        default="bypass",
+        choices=["bypass", "fire-rate"],
+        help=(
+            "Report mode: 'bypass' (default — bypass-events) or 'fire-rate' "
+            "(hook fire ledger from fire-events, issue #710)"
+        ),
+    )
+    parser.add_argument(
+        "--manifest",
+        dest="manifest_path",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Path to hooks/manifest.json for the 'never fired' roster in "
+            "fire-rate mode (default: resolved relative to this CLI's repo)"
+        ),
     )
     parser.add_argument(
         "-d", "--days",
@@ -649,6 +682,172 @@ def _render_error_events(lines: list[str], error_events: list[dict]) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Fire-rate mode (issue #710) — hook fire ledger from fire-events JSONL
+# ---------------------------------------------------------------------------
+
+def load_fire_events(telemetry_dir: Path, days: int) -> list[dict]:
+    """Load valid JSONL records from the last N days of fire-events files."""
+    events: list[dict] = []
+    for date_str in date_range(days):
+        path = telemetry_dir / f"fire-events-{date_str}.jsonl"
+        if not path.is_file():
+            continue
+        try:
+            with path.open(encoding="utf-8") as fh:
+                for raw_line in fh:
+                    line = raw_line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(record, dict):
+                        events.append(record)
+        except OSError:
+            continue
+    return events
+
+
+def aggregate_fires(events: list[dict]) -> dict[str, dict]:
+    """Per-hook fire aggregation: counts by decision, sessions, last seen.
+
+    Returns dict[hook_name] -> {role, fires, block, ask, advise, pass,
+    sessions: set[str], last_seen: str}.
+    """
+    by_hook: dict[str, dict] = {}
+    for ev in events:
+        hook = ev.get(F_FIRE_HOOK)
+        if not isinstance(hook, str) or not hook:
+            continue
+        row = by_hook.setdefault(hook, {
+            "role": ev.get(F_FIRE_ROLE) or UNKNOWN,
+            "fires": 0, "block": 0, "ask": 0, "advise": 0, "pass": 0,
+            "sessions": set(), "last_seen": "",
+        })
+        row["fires"] += 1
+        decision = ev.get(F_FIRE_DECISION)
+        if decision in _FIRE_DECISIONS:
+            row[decision] += 1
+        session = ev.get(F_FIRE_SESSION)
+        if isinstance(session, str) and session:
+            row["sessions"].add(session)
+        ts = ev.get(F_FIRE_TIMESTAMP)
+        if isinstance(ts, str) and ts > row["last_seen"]:
+            row["last_seen"] = ts
+    return by_hook
+
+
+def default_manifest_path() -> Path:
+    """hooks/manifest.json resolved relative to this CLI's real (de-symlinked) path."""
+    # __file__ is symlinked from ~/.local/bin into the repo's skills/bypass-review/.
+    # resolve() follows the symlink; parents[2] is the repo root.
+    return Path(__file__).resolve().parents[2] / "hooks" / "manifest.json"
+
+
+def bash_group_roster(manifest_path: Path) -> set[str] | None:
+    """Return hook names dispatched in the PreToolUse(Bash) group, or None.
+
+    The fire-ledger (issue #710) instruments only that group, so the
+    'never fired' set is computed against this roster — not all 64 hooks.
+    Returns None if the manifest can't be read (never-fired then omitted).
+    """
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    roster: set[str] = set()
+    for hook in manifest.get("hooks", []):
+        name = hook.get("name")
+        if not name:
+            continue
+        entries = hook.get("entries") or [
+            {"event": hook.get("event"), "matcher": hook.get("matcher")}
+        ]
+        for entry in entries:
+            if entry.get("event") == "PreToolUse" and entry.get("matcher") == "Bash":
+                roster.add(name)
+                break
+    return roster
+
+
+def render_fire_report(
+    by_hook: dict[str, dict],
+    days: int,
+    telemetry_dir: Path,
+    roster: set[str] | None,
+) -> str:
+    lines: list[str] = []
+    today = datetime.now(tz=timezone.utc).date()
+    since = today - timedelta(days=days - 1)
+
+    lines.append(_render_header("bypass-review: Hook Fire-Rate Report (issue #710)"))
+    lines.append(f"  Period : {since} → {today} (last {days} day{'s' if days != 1 else ''})")
+    lines.append(f"  Source : {telemetry_dir}")
+    lines.append(f"  Hooks fired : {len(by_hook)}")
+    lines.append("  Scope  : PreToolUse(Bash) dispatch group only (hot-path MVP ceiling)")
+
+    if not by_hook:
+        lines.append("\n  No fire events found in the selected period.")
+        return "\n".join(lines)
+
+    lines.append(_render_header("Per-Hook Fire Counts"))
+    col = 34
+    lines.append(
+        f"  {'Hook':<{col}}  {'Fires':>5}  {'Block':>5}  {'Ask':>4}  "
+        f"{'Advise':>6}  {'Pass':>5}  {'Sess':>4}  Last Seen"
+    )
+    lines.append(
+        f"  {'─' * col}  {'─' * 5}  {'─' * 5}  {'─' * 4}  {'─' * 6}  "
+        f"{'─' * 5}  {'─' * 4}  {'─' * 10}"
+    )
+    for hook in sorted(by_hook, key=lambda h: by_hook[h]["fires"], reverse=True):
+        r = by_hook[hook]
+        last_seen = (r["last_seen"] or "")[:10] or "(unknown)"
+        lines.append(
+            f"  {hook:<{col}}  {r['fires']:>5}  {r['block']:>5}  {r['ask']:>4}  "
+            f"{r['advise']:>6}  {r['pass']:>5}  {len(r['sessions']):>4}  {last_seen}"
+        )
+
+    # ── Never-fired set (against the Bash-group roster) ──
+    lines.append(_render_header("Never Fired (Bash-group roster − hooks above)"))
+    if roster is None:
+        lines.append("  (manifest unavailable — pass --manifest PATH to compute this set)")
+    else:
+        never = sorted(roster - set(by_hook))
+        if not never:
+            lines.append("  (none — every dispatched Bash-group hook fired in this window)")
+        else:
+            lines.append(f"  {len(never)} hook(s) in the group never fired:")
+            for name in never:
+                lines.append(f"    · {name}")
+            lines.append("")
+            lines.append(
+                "  Caveat: this roster is host-blind — a hook restricted via the\n"
+                "  manifest `hosts` field never fires on a platform it excludes (by\n"
+                "  design), so on a non-claude install it shows here as a false\n"
+                "  'never fired'. Cross-check `hosts` before treating one as dead.")
+    lines.append("")
+    lines.append(
+        "  Ceiling: only the PreToolUse(Bash) dispatch group is instrumented\n"
+        "  (issue #710 hot-path MVP). Hooks on Stop / UserPromptSubmit /\n"
+        "  PostToolUse / SessionStart run standalone and are not counted here."
+    )
+    return "\n".join(lines)
+
+
+def run_fire_rate(args: argparse.Namespace, telemetry_dir: Path) -> int:
+    events = load_fire_events(telemetry_dir, args.days)
+    by_hook = aggregate_fires(events)
+    manifest_path = (
+        Path(args.manifest_path) if args.manifest_path else default_manifest_path()
+    )
+    roster = bash_group_roster(manifest_path)
+    print(render_fire_report(by_hook, args.days, telemetry_dir, roster))
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
@@ -663,6 +862,9 @@ def main(argv: list[str] | None = None) -> int:
         telemetry_dir = Path(args.telemetry_dir)
     else:
         telemetry_dir = Path.home() / ".praxis" / "telemetry"
+
+    if args.mode == "fire-rate":
+        return run_fire_rate(args, telemetry_dir)
 
     events = load_events(telemetry_dir, args.days)
     agg = aggregate(events)

--- a/skills/bypass-review/bypass-review
+++ b/skills/bypass-review/bypass-review
@@ -754,21 +754,29 @@ def bash_group_roster(manifest_path: Path) -> set[str] | None:
     """
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        roster: set[str] = set()
+        # isinstance guards: a valid-JSON-but-misstructured manifest (non-dict
+        # hook, non-list entries) must skip the bad item, not crash fire-rate.
+        for hook in manifest.get("hooks", []):
+            if not isinstance(hook, dict):
+                continue
+            name = hook.get("name")
+            if not name:
+                continue
+            entries = hook.get("entries") or [
+                {"event": hook.get("event"), "matcher": hook.get("matcher")}
+            ]
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if (isinstance(entry, dict)
+                        and entry.get("event") == "PreToolUse"
+                        and entry.get("matcher") == "Bash"):
+                    roster.add(name)
+                    break
+        return roster
     except Exception:
         return None
-    roster: set[str] = set()
-    for hook in manifest.get("hooks", []):
-        name = hook.get("name")
-        if not name:
-            continue
-        entries = hook.get("entries") or [
-            {"event": hook.get("event"), "matcher": hook.get("matcher")}
-        ]
-        for entry in entries:
-            if entry.get("event") == "PreToolUse" and entry.get("matcher") == "Bash":
-                roster.add(name)
-                break
-    return roster
 
 
 def render_fire_report(

--- a/skills/bypass-review/bypass-review
+++ b/skills/bypass-review/bypass-review
@@ -766,13 +766,16 @@ def roster_split(manifest_path: Path) -> tuple[set[str], set[str]] | None:
         instrumentable: set[str] = set()
         uninstrumentable: set[str] = set()
         for hook in manifest.get("hooks", []):
-            if not isinstance(hook, dict) or not hook.get("name"):
+            if not isinstance(hook, dict):
                 continue
+            name = hook.get("name")
+            if not isinstance(name, str) or not name:
+                continue  # non-string name would break sorted() in the report
             body = hook.get("body") or ""
             if isinstance(body, str) and body.endswith(".sh"):
-                uninstrumentable.add(hook["name"])
+                uninstrumentable.add(name)
             else:
-                instrumentable.add(hook["name"])
+                instrumentable.add(name)
         return instrumentable, uninstrumentable
     except Exception:
         return None
@@ -794,7 +797,7 @@ def bash_group_roster(manifest_path: Path) -> set[str] | None:
             if not isinstance(hook, dict):
                 continue
             name = hook.get("name")
-            if not name:
+            if not isinstance(name, str) or not name:
                 continue
             entries = hook.get("entries") or [
                 {"event": hook.get("event"), "matcher": hook.get("matcher")}

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -358,6 +358,35 @@ def test_atomic_append_skips_non_regular_file(tmp_path):
     assert stat.S_ISFIFO(os.lstat(fifo).st_mode)  # untouched, still a FIFO
 
 
+def test_fail_open_records_on_systemexit_and_reraises(tmp_path, monkeypatch):
+    """sys.exit() inside main() raises SystemExit (BaseException) — telemetry must
+    still record (from the exit code) and the exit must propagate (CodeRabbit)."""
+    hr = _load("_hook_runtime_se", _REPO / "hooks" / "_lib" / "_hook_runtime.py")
+    out = tmp_path / "fire.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    _reset_real_dispatcher_flag(monkeypatch)
+
+    @hr.fail_open
+    def exits() -> int:
+        raise SystemExit(2)
+
+    with pytest.raises(SystemExit) as ei:
+        exits()
+    assert ei.value.code == 2  # exit semantics preserved
+    recs = [json.loads(line) for line in out.read_text().splitlines() if line.strip()]
+    assert recs and recs[0]["decision"] == "block"  # exit 2 -> block
+
+
+def test_roster_split_skips_non_string_name(tmp_path):
+    """A non-string `name` must be skipped, else render's sorted() raises (CodeRabbit)."""
+    manifest = {"hooks": [{"name": 1}, {"name": "ok", "event": "Stop"}]}
+    mpath = tmp_path / "m.json"
+    mpath.write_text(json.dumps(manifest))
+    instrumentable, _ = cli.roster_split(mpath)
+    assert instrumentable == {"ok"} and 1 not in instrumentable
+
+
 def test_aggregate_marks_coarse_hooks():
     events = [
         {"hook": "c", "role": "completion-verify", "decision": "pass",

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -1,0 +1,214 @@
+"""Tests for the hook fire-rate ledger (issue #710).
+
+Two surfaces:
+  1. Writer — hooks/_lib/_fire_ledger.py: classify_decision() precedence and
+     record_group_fires() JSONL output / opt-out / fail-open.
+  2. Reader — skills/bypass-review/bypass-review fire-rate mode: aggregate_fires,
+     bash_group_roster, and end-to-end report rendering from synthetic fixtures.
+
+Field names in the fixtures are produced by the writer under test, so the
+reader half is verified against the writer's real output (no SUT-mirrored mock):
+test_writer_reader_roundtrip feeds record_group_fires output straight into the
+CLI loader.
+
+Run: python3 -m pytest tests/test_fire_ledger.py -q
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+from contextlib import redirect_stdout
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+
+
+def _load(modname: str, path: Path):
+    # SourceFileLoader (not spec_from_file_location) so the extensionless
+    # `bypass-review` CLI loads — file-suffix inference returns no loader for it.
+    loader = SourceFileLoader(modname, str(path))
+    spec = importlib.util.spec_from_loader(modname, loader)
+    assert spec
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+fl = _load("_fire_ledger", _REPO / "hooks" / "_lib" / "_fire_ledger.py")
+cli = _load("bypass_review_cli", _REPO / "skills" / "bypass-review" / "bypass-review")
+
+_DENY = '{"hookSpecificOutput": {"permissionDecision": "deny"}}'
+_ASK = '{"hookSpecificOutput": {"permissionDecision": "ask"}}'
+
+
+# ---------------------------------------------------------------------------
+# Writer: classify_decision precedence (the load-bearing logic)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("rc,stdout,stderr,expected", [
+    (2, "", "", "block"),                 # exit 2 -> block
+    (0, _DENY, "", "block"),              # deny marker -> block
+    (2, "", "an advisory nudge", "block"),  # exit 2 wins over stderr
+    (0, _ASK, "", "ask"),                 # ask marker -> ask
+    (0, _ASK, "nudge", "ask"),            # ask wins over advise
+    (0, "", "an advisory nudge", "advise"),  # stderr -> advise
+    (0, "", "", "pass"),                  # silent allow -> pass
+    (0, "", "   \n  ", "pass"),           # whitespace-only stderr -> pass
+])
+def test_classify_decision(rc, stdout, stderr, expected):
+    assert fl.classify_decision(rc, stdout, stderr) == expected
+
+
+def test_block_is_not_misread_as_pass():
+    """Falsification: a blocking hook (exit 2) must NOT record as pass.
+
+    This is the smallest check that fails if the decision precedence regresses
+    to 'exit code ignored' — the whole ledger would then under-count blocks.
+    """
+    assert fl.classify_decision(2, "", "") != "pass"
+
+
+# ---------------------------------------------------------------------------
+# Writer: record_group_fires JSONL output
+# ---------------------------------------------------------------------------
+
+def _payload(session="sess-1", tool="Bash") -> str:
+    return json.dumps({"session_id": session, "tool_name": tool, "tool_input": {"command": "ls"}})
+
+
+def test_record_group_fires_writes_one_line_per_member(tmp_path, monkeypatch):
+    out = tmp_path / "fire-events.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+
+    members = [
+        ("preflight-gate", "block-foo", Path("x")),
+        ("advisory-nudge", "nudge-bar", Path("y")),
+    ]
+    results = [(2, "", ""), (0, "", "a nudge")]
+    fl.record_group_fires(members, results, _payload("sess-9", "Bash"))
+
+    lines = [json.loads(line) for line in out.read_text().splitlines() if line.strip()]
+    assert len(lines) == 2
+    assert lines[0] == {
+        "timestamp": lines[0]["timestamp"],  # opaque; presence checked below
+        "session_id": "sess-9", "tool": "Bash",
+        "hook": "block-foo", "role": "preflight-gate", "decision": "block",
+    }
+    assert lines[0]["timestamp"]  # non-empty ISO timestamp
+    assert lines[1]["hook"] == "nudge-bar"
+    assert lines[1]["decision"] == "advise"
+
+
+def test_opt_out_writes_nothing(tmp_path, monkeypatch):
+    out = tmp_path / "fire-events.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_DISABLE", "1")
+    fl.record_group_fires([("r", "h", Path("x"))], [(0, "", "")], _payload())
+    assert not out.exists()
+
+
+def test_malformed_payload_still_records(tmp_path, monkeypatch):
+    """A non-JSON payload degrades session/tool to '' but still logs the fire."""
+    out = tmp_path / "fire-events.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    fl.record_group_fires([("r", "h", Path("x"))], [(0, "", "")], "not json{")
+    rec = json.loads(out.read_text().splitlines()[0])
+    assert rec["session_id"] == "" and rec["tool"] == "" and rec["hook"] == "h"
+
+
+# ---------------------------------------------------------------------------
+# Reader: aggregate + roster + end-to-end report
+# ---------------------------------------------------------------------------
+
+def test_aggregate_fires_counts_by_decision():
+    events = [
+        {"hook": "a", "role": "preflight-gate", "decision": "block", "session_id": "s1", "timestamp": "2026-06-26T01:00:00+00:00"},
+        {"hook": "a", "role": "preflight-gate", "decision": "pass", "session_id": "s2", "timestamp": "2026-06-26T02:00:00+00:00"},
+        {"hook": "b", "role": "advisory-nudge", "decision": "advise", "session_id": "s1", "timestamp": "2026-06-26T03:00:00+00:00"},
+    ]
+    agg = cli.aggregate_fires(events)
+    assert agg["a"]["fires"] == 2
+    assert agg["a"]["block"] == 1 and agg["a"]["pass"] == 1
+    assert agg["a"]["sessions"] == {"s1", "s2"}
+    assert agg["a"]["last_seen"] == "2026-06-26T02:00:00+00:00"
+    assert agg["b"]["advise"] == 1
+
+
+def test_bash_group_roster_filters_to_pretooluse_bash(tmp_path):
+    manifest = {
+        "hooks": [
+            {"name": "bash-gate", "role": "preflight-gate", "event": "PreToolUse", "matcher": "Bash"},
+            {"name": "stop-gate", "role": "completion-verify", "event": "Stop", "matcher": ""},
+            {"name": "multi", "role": "preflight-gate", "entries": [
+                {"event": "UserPromptSubmit", "matcher": ""},
+                {"event": "PreToolUse", "matcher": "Bash", "file": "impl.py"},
+            ]},
+        ]
+    }
+    mpath = tmp_path / "manifest.json"
+    mpath.write_text(json.dumps(manifest))
+    roster = cli.bash_group_roster(mpath)
+    assert roster == {"bash-gate", "multi"}
+
+
+def test_bash_group_roster_missing_manifest_returns_none(tmp_path):
+    assert cli.bash_group_roster(tmp_path / "nope.json") is None
+
+
+def test_writer_reader_roundtrip(tmp_path, monkeypatch):
+    """End-to-end: writer output -> CLI fire-rate report, no mirrored mock.
+
+    record_group_fires writes today's fire-events file; the CLI loads it via
+    --dir and renders. The 'never fired' set uses a synthetic manifest roster.
+    """
+    today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+    telem_dir = tmp_path / "telemetry"
+    telem_dir.mkdir()
+    out = telem_dir / f"fire-events-{today}.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+
+    members = [
+        ("preflight-gate", "block-foo", Path("x")),
+        ("advisory-nudge", "nudge-bar", Path("y")),
+    ]
+    fl.record_group_fires(members, [(2, "", ""), (0, "", "n")], _payload())
+
+    manifest = {"hooks": [
+        {"name": "block-foo", "role": "preflight-gate", "event": "PreToolUse", "matcher": "Bash"},
+        {"name": "nudge-bar", "role": "advisory-nudge", "event": "PreToolUse", "matcher": "Bash"},
+        {"name": "silent-gate", "role": "preflight-gate", "event": "PreToolUse", "matcher": "Bash"},
+    ]}
+    mpath = tmp_path / "manifest.json"
+    mpath.write_text(json.dumps(manifest))
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = cli.main(["fire-rate", "--dir", str(telem_dir), "--manifest", str(mpath)])
+    report = buf.getvalue()
+
+    assert rc == 0
+    assert "block-foo" in report and "nudge-bar" in report
+    assert "Hooks fired : 2" in report
+    # silent-gate is in the roster but never fired -> appears in Never Fired set
+    assert "silent-gate" in report
+
+
+def test_fire_rate_empty_window(tmp_path, capsys):
+    rc = cli.main(["fire-rate", "--dir", str(tmp_path)])
+    assert rc == 0
+    assert "No fire events found" in capsys.readouterr().out
+
+
+def test_default_mode_still_bypass(tmp_path, capsys):
+    """Back-compat: no positional arg keeps the original bypass report."""
+    rc = cli.main(["--dir", str(tmp_path)])
+    assert rc == 0
+    assert "Bypass Telemetry Report" in capsys.readouterr().out

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -18,6 +18,9 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import os
+import stat
+import sys
 from contextlib import redirect_stdout
 from datetime import datetime, timezone
 from importlib.machinery import SourceFileLoader
@@ -99,6 +102,7 @@ def test_record_group_fires_writes_one_line_per_member(tmp_path, monkeypatch):
         "timestamp": lines[0]["timestamp"],  # opaque; presence checked below
         "session_id": "sess-9", "tool": "Bash",
         "hook": "block-foo", "role": "preflight-gate", "decision": "block",
+        "granularity": "rich",
     }
     assert lines[0]["timestamp"]  # non-empty ISO timestamp
     assert lines[1]["hook"] == "nudge-bar"
@@ -226,3 +230,141 @@ def test_default_mode_still_bypass(tmp_path, capsys):
     rc = cli.main(["--dir", str(tmp_path)])
     assert rc == 0
     assert "Bypass Telemetry Report" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Coverage expansion (issue #710): standalone coarse recording + fail_open wiring
+# ---------------------------------------------------------------------------
+
+def test_record_standalone_fire_writes_coarse(tmp_path, monkeypatch):
+    out = tmp_path / "fire.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    monkeypatch.setattr(fl, "_DISPATCHER_PROCESS", False)
+    fl.record_standalone_fire("stop-gate", "completion-verify", 2)
+    fl.record_standalone_fire("nudge", "advisory-nudge", 0)
+    recs = [json.loads(line) for line in out.read_text().splitlines() if line.strip()]
+    assert len(recs) == 2
+    assert recs[0]["decision"] == "block" and recs[0]["granularity"] == "coarse"
+    assert recs[0]["hook"] == "stop-gate" and recs[0]["session_id"] == ""
+    # rc 0 collapses to pass (coarse cannot distinguish ask/advise/pass)
+    assert recs[1]["decision"] == "pass"
+
+
+def test_record_standalone_fire_skipped_in_dispatcher(tmp_path, monkeypatch):
+    """In the dispatcher process, coarse recording is suppressed (no double-count)."""
+    out = tmp_path / "fire.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.setattr(fl, "_DISPATCHER_PROCESS", True)
+    fl.record_standalone_fire("x", "y", 2)
+    assert not out.exists()
+
+
+def test_record_standalone_fire_opt_out(tmp_path, monkeypatch):
+    out = tmp_path / "fire.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_DISABLE", "1")
+    monkeypatch.setattr(fl, "_DISPATCHER_PROCESS", False)
+    fl.record_standalone_fire("x", "y", 0)
+    assert not out.exists()
+
+
+def test_roster_split_separates_shell_hooks(tmp_path):
+    manifest = {"hooks": [
+        {"name": "a", "event": "PreToolUse", "matcher": "Bash"},   # py (instrumentable)
+        {"name": "b", "event": "Stop"},                            # py (instrumentable)
+        {"name": "sh1", "event": "Stop", "body": "impl.sh"},       # shell (uninstrumentable)
+        "not-a-dict",
+        {"event": "Stop"},  # no name -> skipped
+    ]}
+    mpath = tmp_path / "m.json"
+    mpath.write_text(json.dumps(manifest))
+    instrumentable, uninstrumentable = cli.roster_split(mpath)
+    assert instrumentable == {"a", "b"}
+    assert uninstrumentable == {"sh1"}
+
+
+def _reset_real_dispatcher_flag(monkeypatch):
+    """Reset _DISPATCHER_PROCESS on the SAME _fire_ledger that fail_open imports.
+
+    fail_open's _maybe_record_fire does `import _fire_ledger` (sys.modules), while
+    the test's `fl` is a separate SourceFileLoader instance. In the full suite a
+    sibling test that runs the dispatcher in-process can flip that shared flag to
+    True, suppressing coarse recording here. Reset the real module (auto-restored).
+    """
+    import importlib
+    lib = str(_REPO / "hooks" / "_lib")
+    if lib not in sys.path:
+        sys.path.insert(0, lib)
+    real_fl = importlib.import_module("_fire_ledger")
+    monkeypatch.setattr(real_fl, "_DISPATCHER_PROCESS", False)
+
+
+def test_fail_open_records_coarse_fire_and_preserves_return(tmp_path, monkeypatch):
+    """The universal @fail_open decorator records a coarse fire for a standalone hook."""
+    hr = _load("_hook_runtime", _REPO / "hooks" / "_lib" / "_hook_runtime.py")
+    out = tmp_path / "fire.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    _reset_real_dispatcher_flag(monkeypatch)
+
+    @hr.fail_open
+    def blocking_main() -> int:
+        return 2
+
+    rc = blocking_main()
+    assert rc == 2  # return value unchanged by instrumentation
+    recs = [json.loads(line) for line in out.read_text().splitlines() if line.strip()]
+    assert len(recs) == 1
+    assert recs[0]["decision"] == "block" and recs[0]["granularity"] == "coarse"
+
+
+def test_fail_open_swallows_exception_and_still_records(tmp_path, monkeypatch):
+    hr = _load("_hook_runtime_exc", _REPO / "hooks" / "_lib" / "_hook_runtime.py")
+    out = tmp_path / "fire.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    _reset_real_dispatcher_flag(monkeypatch)
+
+    @hr.fail_open
+    def boom() -> int:
+        raise RuntimeError("kaboom")
+
+    rc = boom()
+    assert rc == 0  # exception -> fail-open 0
+    recs = [json.loads(line) for line in out.read_text().splitlines() if line.strip()]
+    assert recs and recs[0]["decision"] == "pass"  # rc 0 after swallow
+
+
+def test_dispatcher_process_writes_rich_not_coarse(tmp_path, monkeypatch):
+    """In the dispatcher process the rich record persists and the coarse path is
+    suppressed — locks the no-double-count contract at the role boundary."""
+    out = tmp_path / "fire.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    monkeypatch.setattr(fl, "_DISPATCHER_PROCESS", False)
+    fl.mark_dispatcher_process()  # run_group calls this at entry
+    fl.record_group_fires([("preflight-gate", "h", Path("x"))], [(2, "", "")], _payload())
+    fl.record_standalone_fire("h", "preflight-gate", 2)  # member fail_open — suppressed
+    recs = [json.loads(line) for line in out.read_text().splitlines() if line.strip()]
+    assert len(recs) == 1 and recs[0]["granularity"] == "rich"
+
+
+def test_atomic_append_skips_non_regular_file(tmp_path):
+    """Security guard: a FIFO target is skipped, never opened (no block, no raise)."""
+    fifo = tmp_path / "pipe"
+    os.mkfifo(fifo)
+    fl._atomic_append(fifo, ['{"x":1}'])  # must return without blocking/raising
+    assert stat.S_ISFIFO(os.lstat(fifo).st_mode)  # untouched, still a FIFO
+
+
+def test_aggregate_marks_coarse_hooks():
+    events = [
+        {"hook": "c", "role": "completion-verify", "decision": "pass",
+         "granularity": "coarse", "session_id": "", "timestamp": "2026-06-26T01:00:00+00:00"},
+        {"hook": "r", "role": "preflight-gate", "decision": "block",
+         "granularity": "rich", "session_id": "s1", "timestamp": "2026-06-26T02:00:00+00:00"},
+    ]
+    agg = cli.aggregate_fires(events)
+    assert agg["c"]["coarse"] is True
+    assert agg["r"]["coarse"] is False

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -162,6 +162,20 @@ def test_bash_group_roster_missing_manifest_returns_none(tmp_path):
     assert cli.bash_group_roster(tmp_path / "nope.json") is None
 
 
+def test_bash_group_roster_malformed_manifest_does_not_crash(tmp_path):
+    """A valid-JSON-but-misstructured manifest skips bad items, never raises."""
+    manifest = {"hooks": [
+        "not-a-dict",                                       # non-dict hook
+        {"name": "good", "event": "PreToolUse", "matcher": "Bash"},
+        {"name": "bad-entries", "entries": "not-a-list"},   # non-list entries
+        {"name": "bad-entry-item", "entries": ["not-a-dict"]},
+    ]}
+    mpath = tmp_path / "manifest.json"
+    mpath.write_text(json.dumps(manifest))
+    # Skips the three malformed items, keeps the one valid Bash hook.
+    assert cli.bash_group_roster(mpath) == {"good"}
+
+
 def test_writer_reader_roundtrip(tmp_path, monkeypatch):
     """End-to-end: writer output -> CLI fire-rate report, no mirrored mock.
 


### PR DESCRIPTION
## 무엇을 / 왜

ponytail 비교(deep-dive)에서 도출된 P1. praxis는 ~60개 훅을 직관으로 누적했지만 그 훅들이 실제로 마찰을 줄이는지 측정한 적이 없다. 이 PR은 훅 fire-rate를 기록하는 observe-only telemetry 기반을 추가해, praxis가 모든 곳에 요구하는 evidence-based 잣대를 자기 훅에도 처음으로 적용한다. #713(증거 기반 hook prune 감사)의 선행 데이터 기반이다.

## 커버리지 (2-tier)

- **RICH** — 중앙 PreToolUse(Bash) dispatcher(`_dispatch.py`)가 이미 캡처하는 각 멤버의 `(rc, stdout, stderr)`를 `block/ask/advise/pass`로 분류해 full-granularity 기록.
- **COARSE** — 그 외 모든 `@fail_open` standalone 훅(Stop / UserPromptSubmit / PostToolUse / 비-Bash PreToolUse). 유일한 공통 chokepoint인 `@fail_open` 데코레이터를 **비침습적**으로 계측 — `main()` 반환 후 return code만 보고 기록(stdin/stdout/stderr 미접촉, 훅 동작 불변).
  - **block 한계(정직성)**: coarse "block"은 **exit-code 2만** 집계. Stop/UserPromptSubmit 훅은 stdout JSON `decision` 필드로 차단하며 exit 0이라, 그 차단은 coarse에 보이지 않고 "pass"로 기록된다(PreToolUse 차단은 exit 2라 잡힘). docstring·리포트에 명시.
- **이중기록 방지**: dispatcher 프로세스는 `mark_dispatcher_process()`로 자기 표시 → Bash 그룹 멤버는 rich로만 기록, coarse 경로는 skip.
- **shell(.sh) 훅**: `@fail_open`/dispatch chokepoint가 없어 계측 불가 → never-fired roster에서 제외하고 별도 "Uninstrumented" 섹션에 분리(codex #714 P2).

## 변경 (5파일)

- `hooks/_lib/_fire_ledger.py` (신규): observe-only writer. `record_group_fires`(rich, batched) + `record_standalone_fire`(coarse) + `_atomic_append`(per-line `O_APPEND` 원자 추가 + 정규파일 가드/`O_NOFOLLOW`로 FIFO/symlink hang·오도 차단) + granularity 필드. bypass-telemetry 계약(opt-out `PRAXIS_FIRE_TELEMETRY_DISABLE`, override `PRAXIS_FIRE_TELEMETRY_FILE`, fail-open) 미러.
- `hooks/_lib/_hook_runtime.py`: `fail_open`이 `main()` 반환 후 coarse fire 기록(`_maybe_record_fire`). 반환값/예외/I/O 스트림 불변 — fail-open 계약 유지.
- `hooks/_lib/_dispatch.py`: `run_group` 진입 시 dispatcher 프로세스 표시. 결정 로직 불변.
- `skills/bypass-review/bypass-review`: `fire-rate` 모드. per-hook 카운트 + rich/coarse(G) 컬럼 + instrumentable roster 대비 never-fired + uninstrumented(shell) 별도 섹션 + host-blind/rare-but-critical caveat. 기존 호출 back-compat.
- `tests/test_fire_ledger.py`: decision 4종 precedence + standalone coarse 기록 + dispatcher-skip(이중기록 방지) + roster split + fail_open 통합 + FIFO 가드 + writer↔reader roundtrip(SUT-mirror 회피) + back-compat.

## 검증

- 단위 28(파일 단독) / 373(전체 dir) 통과, 전체 스위트(`scripts/run-tests.sh`) **ALL TESTS PASSED**, ruff clean.
- **실제 아티팩트 기능 검증**: 실제 standalone 훅(Stop/PostToolUse) → coarse 기록, 실제 `_dispatch.py` + 32개 Bash-group 훅 → rich 기록, **coarse∩rich 겹침 0**(이중기록 없음). telemetry 파일을 FIFO로 둔 실제 Stop 훅 → **멈춤 없음**(FIFO 가드 동작 확인).
- 3종 독립 리뷰: omc code-reviewer(HIGH 1 = Stop/UPS block-as-pass 정직성 반영, MEDIUM 2 = docstring) + security-reviewer(LOW = FIFO/symlink 가드 반영) + codex(P2 = shell 훅 roster 분리 반영).

## 검증 안 한 것

- 실제 훅의 `ask`/`advise` decision 및 Stop의 stdout-JSON block 경로(coarse는 설계상 미구분 — return code만 관측).
- 병렬 dispatcher 동시 append 부하(원자성은 per-line `O_APPEND`로 설계상 보장, 부하 테스트는 미실시).

## 영향 범위

`@fail_open`은 모든 standalone 훅 + dispatcher의 hot path. 변경은 observe-only·이중 fail-open이며 I/O 스트림·반환값·결정 동작에 영향 없음. telemetry 비활성화 시 무비용 단락.

## Open items (후속)

- 텔레메트리 retention 정책(일별 파일 누적 — reader는 `--days` 윈도).
- coarse의 Stop/UPS block 가시성: stdout 캡처는 훅 간섭 위험으로 의도적 미채택(현재는 정직성 caveat로 처리).

Refs #710 (fire-ledger + 전 훅 fire-rate 리포트 구현; outcome proxy 및 A/B sub-phase는 후속으로 연기 — 이슈 유지)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-hook “fire” telemetry capture and logging (rich for dispatched groups, coarse for standalone hooks).
  * Introduced a new `fire-rate` report mode with decision breakdowns and a “Never Fired” section when manifest data is available.

* **Bug Fixes**
  * Telemetry recording is now fail-open and won’t block dispatch or reporting, including during malformed/edge cases.
  * Coarse standalone recording is suppressed during dispatcher processing to avoid duplicate telemetry.

* **Tests**
  * Expanded coverage for decision classification, telemetry writing/opt-out behavior, report aggregation, and suppression/fail-open semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->