### PR TITLE
feat(ci): hook-token invariant canary

### DIFF
--- a/hooks/preflight-gate/block-sciomc-finding-commit/spec.md
+++ b/hooks/preflight-gate/block-sciomc-finding-commit/spec.md
@@ -98,8 +98,8 @@ scope.
 
 ### Escape hatches
 
-- Add `[user-approved]` or `[ratified-by-user]` to the commit message when
-  the user explicitly approved the change in this session.
+- Add `[user-approved]`, `[ratified-by-user]`, or `[user-ratified]` to the
+  commit message when the user explicitly approved the change in this session.
 - Set `CLAUDE_HOOK_BYPASS_SCIOMC_GATE=1` for a deliberate one-off bypass.
 - Missing / unreadable / oversized (`>50MB`) transcript → silent pass
   (cannot enforce). Malformed stdin → silent fail-open.

--- a/hooks/preflight-gate/block-sciomc-finding-commit/spec.md
+++ b/hooks/preflight-gate/block-sciomc-finding-commit/spec.md
@@ -59,8 +59,8 @@ All three conditions must hold for a block (exit 2):
    ratification token. (`user-stated design` is intentionally NOT a re-fetch
    marker — it appears verbatim inside `[CONFLICTS: user-stated design …]`
    payloads and would self-satisfy the check.) The re-fetch scan runs over
-   the full ordered stream (assistant text + assistant Bash tool_use commands
-   + subagent results), so a `gh pr view` recorded as a tool_use still counts.
+   the full ordered stream (assistant text + assistant Bash tool_use commands +
+   subagent results), so a `gh pr view` recorded as a tool_use still counts.
 
 | Situation | Action |
 |-----------|--------|

--- a/scripts/check-hook-token-invariants.py
+++ b/scripts/check-hook-token-invariants.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Invariant canary: load-bearing hook tokens must stay in sync on BOTH sides.
+
+praxis's known root failure mode is dual-SoT drift: a load-bearing token (a
+regex a hook scans for, an env-var family it matches) lives both in the hook
+source that enforces it and in the spec.md that documents it. When one copy is
+reworded the two silently diverge — the doc promises a token the hook no longer
+matches, or vice versa. This canary pins each such token and fails CI when it
+drifts.
+
+Each invariant pins TWO things, one per side, because the two sides carry the
+token in different shapes:
+
+  - ``scan_pattern`` — the enforcing **regex-source fragment** that must appear
+    verbatim in the hook source. This is deliberately the anchored/escaped form
+    (e.g. ``^Pre-commit verified:`` or ``\\[skip-codex-review\\]``) that occurs
+    ONLY on the ``re.compile`` line, not the bare token that also shows up in
+    docstrings, comments, and deny-message strings. Pinning the bare token on
+    the scan side would let a reword of the enforcing line slip through as long
+    as any comment copy survived — so we pin the regex fragment instead.
+  - ``token`` — the human-facing literal the spec documents (and that users copy
+    into commit messages). Pinned by presence in the doc; the doc's contract is
+    "this token is documented", so substring presence is the right strength
+    there.
+
+Scope (issue #712): only tokens a hook actually scans. ``Not-tested:`` /
+``Confidence:`` are commit-trailer conventions no hook scans — out of scope by
+design, so they are deliberately absent from the table below.
+
+The INVARIANTS table itself is the pin point (a third, intentional copy, the
+same model as ponytail's ``check-rule-copies.js``): if a token is renamed on
+both sides at once, the hardcoded literals here stop matching and force the
+canary to be updated in lockstep.
+
+Run standalone or via ``scripts/run-tests.sh``. Exit 0 + a verified count on a
+clean tree; exit 1 listing the offending (token, side, file) on drift.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+# Each invariant pins one load-bearing token across the two files that must
+# stay in sync. ``scan_pattern`` is checked against the hook source (the
+# enforcing regex fragment); ``token`` is checked against the doc (the
+# documented literal). See the module docstring for why the two differ.
+INVARIANTS: list[dict] = [
+    {
+        "token": "Pre-commit verified:",
+        "scan_pattern": "^Pre-commit verified:",
+        "scan": "hooks/preflight-gate/block-pr-without-precommit-evidence/impl.py",
+        "doc": "hooks/preflight-gate/block-pr-without-precommit-evidence/spec.md",
+    },
+    {
+        "token": "Caller chain verified:",
+        "scan_pattern": "^Caller chain verified:",
+        "scan": "hooks/preflight-gate/block-pr-without-caller-evidence/impl.py",
+        "doc": "hooks/preflight-gate/block-pr-without-caller-evidence/spec.md",
+    },
+    {
+        "token": "[skip-codex-review]",
+        "scan_pattern": r"\[skip-codex-review\]",
+        "scan": "hooks/preflight-gate/block-commit-without-codex-review/impl.py",
+        "doc": "hooks/preflight-gate/block-commit-without-codex-review/spec.md",
+    },
+    {
+        "token": "[user-approved]",
+        "scan_pattern": r"\[(?:user-approved|ratified-by-user|user-ratified)\]",
+        "scan": "hooks/preflight-gate/block-sciomc-finding-commit/impl.py",
+        "doc": "hooks/preflight-gate/block-sciomc-finding-commit/spec.md",
+    },
+    {
+        "token": "[ratified-by-user]",
+        "scan_pattern": r"\[(?:user-approved|ratified-by-user|user-ratified)\]",
+        "scan": "hooks/preflight-gate/block-sciomc-finding-commit/impl.py",
+        "doc": "hooks/preflight-gate/block-sciomc-finding-commit/spec.md",
+    },
+    {
+        # The bypass-family detection regex itself — the strongest pin
+        # available. bypass-telemetry's _BYPASS_NAME_RE source must equal the
+        # regex the spec documents, or the telemetry silently stops counting a
+        # renamed bypass family. Here scan_pattern == token: the token *is* the
+        # full regex literal, which appears only at the re.compile line.
+        "token": r"^(?:CLAUDE_HOOK_|PRAXIS_).*BYPASS",
+        "scan_pattern": r"^(?:CLAUDE_HOOK_|PRAXIS_).*BYPASS",
+        "scan": "hooks/postuse-correction/bypass-telemetry/impl.py",
+        "doc": "hooks/postuse-correction/bypass-telemetry/spec.md",
+    },
+]
+
+
+def _read(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        # FileNotFoundError and IsADirectoryError are both OSError subclasses;
+        # a mistyped path is reported as drift below rather than crashing.
+        return None
+
+
+def check(repo: Path = REPO, invariants: list[dict] = INVARIANTS) -> list[str]:
+    """Return a list of drift messages; empty list means every invariant holds."""
+    drifts: list[str] = []
+    for inv in invariants:
+        token = inv["token"]
+
+        # Scan side: the enforcing regex fragment must be present verbatim.
+        scan_text = _read(repo / inv["scan"])
+        if scan_text is None:
+            drifts.append(f"{token!r}: scan file missing on disk: {inv['scan']}")
+        elif inv["scan_pattern"] not in scan_text:
+            drifts.append(
+                f"{token!r}: enforcing pattern {inv['scan_pattern']!r} "
+                f"absent from scan side {inv['scan']}"
+            )
+
+        # Doc side: the documented literal must be present verbatim.
+        doc_text = _read(repo / inv["doc"])
+        if doc_text is None:
+            drifts.append(f"{token!r}: doc file missing on disk: {inv['doc']}")
+        elif token not in doc_text:
+            drifts.append(f"{token!r}: absent from doc side {inv['doc']}")
+    return drifts
+
+
+def main() -> int:
+    drifts = check()
+    if drifts:
+        print("hook-token-invariant check FAILED:")
+        for d in drifts:
+            print(f"  - {d}")
+        return 1
+    print(f"hook-token-invariant check OK ({len(INVARIANTS)} invariants verified)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-hook-token-invariants.py
+++ b/scripts/check-hook-token-invariants.py
@@ -79,6 +79,14 @@ INVARIANTS: list[dict] = [
         "doc": "hooks/preflight-gate/block-sciomc-finding-commit/spec.md",
     },
     {
+        # The enforcing regex accepts a third alias; pinning only the first two
+        # let the spec silently drop this one. Found by codex review on #712.
+        "token": "[user-ratified]",
+        "scan_pattern": r"\[(?:user-approved|ratified-by-user|user-ratified)\]",
+        "scan": "hooks/preflight-gate/block-sciomc-finding-commit/impl.py",
+        "doc": "hooks/preflight-gate/block-sciomc-finding-commit/spec.md",
+    },
+    {
         # The bypass-family detection regex itself — the strongest pin
         # available. bypass-telemetry's _BYPASS_NAME_RE source must equal the
         # regex the spec documents, or the telemetry silently stops counting a

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -5,6 +5,7 @@
 #   1. pytest   — Python unit tests under tests/
 #   2. shell    — shell tests at tests/hooks/*/test_*.sh and tests/test_*.sh
 #   3. manifest — scripts/check-plugin-manifests.py
+#   4. invariants — scripts/check-hook-token-invariants.py
 #
 # Exit code is non-zero if any step fails.
 set -euo pipefail
@@ -65,6 +66,15 @@ fi
 echo ""
 echo "=== manifest check ==="
 if ! python3 ./scripts/check-plugin-manifests.py; then
+  FAILED=1
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Hook-token invariant canary (dual-SoT drift guard, issue #712)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== hook-token invariant check ==="
+if ! python3 ./scripts/check-hook-token-invariants.py; then
   FAILED=1
 fi
 

--- a/tests/test_hook_token_invariants.py
+++ b/tests/test_hook_token_invariants.py
@@ -83,18 +83,30 @@ def test_reworded_scan_pattern_is_detected(tmp_path):
 
 def test_partial_scan_drift_is_detected(tmp_path):
     # The core strengthening: rewording ONLY the enforcing regex line must be
-    # caught even though bare copies of the token survive elsewhere (docstrings,
-    # comments, deny messages). A plain `token in text` check would pass here.
-    repo = _temp_repo(tmp_path)
-    inv = canary.INVARIANTS[0]  # 'Pre-commit verified:' — appears 5x in scan file
-    scan_file = repo / inv["scan"]
-    text = scan_file.read_text()
-    assert text.count(inv["token"]) > 1  # bare token appears in comments too
-    # Mutate only the enforcing fragment; bare token copies remain in the file.
-    scan_file.write_text(text.replace(inv["scan_pattern"], _SENTINEL))
-    remaining = scan_file.read_text()
-    assert inv["token"] in remaining  # a bare copy still survives...
-    drifts = canary.check(repo=repo)  # ...yet the canary still catches the drift
+    # caught even when a bare copy of the token survives elsewhere (a comment,
+    # docstring, deny message). A plain `token in text` check would pass here.
+    # A synthetic scan/doc pair keeps this decoupled from any production hook
+    # file's comment wording (so an unrelated comment cleanup can't break it).
+    inv = {
+        "token": "Pre-commit verified:",
+        "scan_pattern": "^Pre-commit verified:",
+        "scan": "hooks/example/impl.py",
+        "doc": "hooks/example/spec.md",
+    }
+    scan_file = tmp_path / inv["scan"]
+    doc_file = tmp_path / inv["doc"]
+    scan_file.parent.mkdir(parents=True, exist_ok=True)
+    doc_file.parent.mkdir(parents=True, exist_ok=True)
+    # A bare token copy (prose comment) alongside the enforcing regex line.
+    scan_file.write_text(
+        "# deny message mentions Pre-commit verified: in prose\n"
+        'PATTERN = re.compile(r"^Pre-commit verified:[ \\t]*\\S")\n'
+    )
+    doc_file.write_text("Add a `Pre-commit verified:` line.\n")
+    # Reword only the enforcing fragment; the bare comment copy remains.
+    scan_file.write_text(scan_file.read_text().replace(inv["scan_pattern"], _SENTINEL))
+    assert inv["token"] in scan_file.read_text()  # a bare copy still survives...
+    drifts = canary.check(repo=tmp_path, invariants=[inv])  # ...yet drift is caught
     assert any(inv["token"] in d and "scan side" in d for d in drifts)
 
 

--- a/tests/test_hook_token_invariants.py
+++ b/tests/test_hook_token_invariants.py
@@ -1,0 +1,124 @@
+"""Tests for scripts/check-hook-token-invariants.py (issue #712).
+
+The canary pins load-bearing hook tokens to both the hook source that enforces
+them (via ``scan_pattern``, the regex fragment) and the spec that documents
+them (via ``token``). These tests cover:
+
+  - the real tree passes (every pinned token is present on both sides),
+  - a token reworded on either side is detected,
+  - the partial-drift case: the enforcing regex line is reworded while a bare
+    copy of the token survives in a comment — the gap a plain substring check
+    would miss,
+  - a missing file is reported rather than silently passing,
+  - main() exits 0 with a verified count on a clean tree.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO / "scripts" / "check-hook-token-invariants.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("hook_token_canary", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+canary = _load()
+
+# A sentinel that does NOT contain any pinned token/pattern as a substring —
+# appending a suffix would leave the original present and miss the drift.
+_SENTINEL = "<<REWORDED>>"
+
+
+def _temp_repo(tmp_path: Path) -> Path:
+    """Copy every scan/doc file referenced by INVARIANTS into a temp tree."""
+    for inv in canary.INVARIANTS:
+        for side in ("scan", "doc"):
+            src = _REPO / inv[side]
+            dst = tmp_path / inv[side]
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(src, dst)
+    return tmp_path
+
+
+def test_real_tree_holds():
+    # Regression guard + clean-state AC: every pinned invariant holds verbatim
+    # on both sides in the actual repo.
+    assert canary.check() == []
+
+
+def test_invariant_table_is_well_formed():
+    for inv in canary.INVARIANTS:
+        assert set(inv) >= {"token", "scan_pattern", "scan", "doc"}
+        assert isinstance(inv["token"], str) and inv["token"]
+        assert isinstance(inv["scan_pattern"], str) and inv["scan_pattern"]
+        assert inv["scan"].endswith(".py")
+        assert inv["doc"].endswith(".md")
+
+
+def test_reworded_doc_is_detected(tmp_path):
+    repo = _temp_repo(tmp_path)
+    inv = canary.INVARIANTS[0]
+    target = repo / inv["doc"]
+    target.write_text(target.read_text().replace(inv["token"], _SENTINEL))
+    drifts = canary.check(repo=repo)
+    assert any(inv["token"] in d and "doc side" in d for d in drifts)
+
+
+def test_reworded_scan_pattern_is_detected(tmp_path):
+    repo = _temp_repo(tmp_path)
+    inv = canary.INVARIANTS[0]
+    target = repo / inv["scan"]
+    target.write_text(target.read_text().replace(inv["scan_pattern"], _SENTINEL))
+    drifts = canary.check(repo=repo)
+    assert any(inv["token"] in d and "scan side" in d for d in drifts)
+
+
+def test_partial_scan_drift_is_detected(tmp_path):
+    # The core strengthening: rewording ONLY the enforcing regex line must be
+    # caught even though bare copies of the token survive elsewhere (docstrings,
+    # comments, deny messages). A plain `token in text` check would pass here.
+    repo = _temp_repo(tmp_path)
+    inv = canary.INVARIANTS[0]  # 'Pre-commit verified:' — appears 5x in scan file
+    scan_file = repo / inv["scan"]
+    text = scan_file.read_text()
+    assert text.count(inv["token"]) > 1  # bare token appears in comments too
+    # Mutate only the enforcing fragment; bare token copies remain in the file.
+    scan_file.write_text(text.replace(inv["scan_pattern"], _SENTINEL))
+    remaining = scan_file.read_text()
+    assert inv["token"] in remaining  # a bare copy still survives...
+    drifts = canary.check(repo=repo)  # ...yet the canary still catches the drift
+    assert any(inv["token"] in d and "scan side" in d for d in drifts)
+
+
+def test_missing_file_is_reported(tmp_path):
+    custom = [
+        {"token": "X-TOKEN", "scan_pattern": "X-TOKEN", "scan": "nope/a.py", "doc": "nope/b.md"}
+    ]
+    drifts = canary.check(repo=tmp_path, invariants=custom)
+    assert len(drifts) == 2
+    assert all("file missing on disk" in d for d in drifts)
+
+
+def test_main_clean_exits_zero(capsys):
+    rc = canary.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert f"{len(canary.INVARIANTS)} invariants verified" in out
+
+
+def test_bypass_regex_pin_matches_runtime_regex():
+    # The pinned bypass-family pattern must be the exact regex source both the
+    # hook compiles and the spec documents — not a paraphrase.
+    bypass = next(i for i in canary.INVARIANTS if "BYPASS" in i["token"])
+    scan_text = (_REPO / bypass["scan"]).read_text()
+    doc_text = (_REPO / bypass["doc"]).read_text()
+    assert f're.compile(r"{bypass["scan_pattern"]}")' in scan_text
+    assert bypass["token"] in doc_text


### PR DESCRIPTION
## 무엇을 / 왜

ponytail 비교(deep-dive)에서 도출된 P3. praxis의 근본 실패 모드는 **이중 SoT drift** — load-bearing 훅 토큰(enforcing 정규식, bypass env-var 패밀리)이 그것을 스캔하는 훅 소스와 문서화하는 spec.md 사이에서 silently 갈라진다. ponytail은 같은 문제를 `check-rule-copies.js`로 막는다. 이 PR은 그 invariant canary를 praxis에 이식해, 한쪽이 reword되면 CI가 fail하도록 핀한다.

## 변경 (4파일)

- `scripts/check-hook-token-invariants.py` (신규): 7개 invariant를 핀하는 canary. 각 항목은 **scan 측에 enforcing 정규식 fragment**(`re.compile` 라인에만 나타나는 anchored/escaped 형태)를, **doc 측에 문서화된 리터럴**을 핀한다. bare 토큰만 검사하면 enforcing 라인 reword가 주석 사본 뒤로 빠져나가므로 정규식 fragment를 핀(code-reviewer MEDIUM 반영).
- `scripts/run-tests.sh`: canary를 check #4로 연결. `ci.yml`가 `run-tests.sh`를 실행하므로 CI 자동 반영(별도 워크플로 편집 불필요).
- `tests/test_hook_token_invariants.py` (신규, 8 tests): clean tree pass + scan/doc reword 검출 + **partial-drift**(enforcing 라인만 reword, bare 토큰 주석 잔존) 검출 + missing file + bypass 정규식 정확 매칭.
- `hooks/preflight-gate/block-sciomc-finding-commit/spec.md`: `[user-ratified]` 별칭 문서화(아래).

## codex review가 첫 실행에서 잡은 실제 drift

canary 도입 직후 codex review가 enforcing 정규식 `_RATIFICATION_TOKEN_RE`이 세 별칭(`user-approved` / `ratified-by-user` / `user-ratified`)을 허용하는데 spec은 둘만 문서화함을 지적. 세 번째 load-bearing bypass 토큰이 미문서화·미가드 — canary가 막으려는 바로 그 drift였다. premise 검증(grep: 정규식은 매칭, spec엔 부재) 후 spec 문서화 + 7번째 invariant로 핀(commit 34c5205). canary가 자기 목적을 즉시 입증.

## 범위 밖 (이슈 #712 명시)

`Not-tested:` / `Confidence:` 는 어떤 훅도 스캔하지 않는 commit-trailer 컨벤션 → 제외.

## 검증

- pytest **383 passed**(전체 dir) / 8(파일 단독), ruff clean, shellcheck clean(run-tests.sh), manifest check OK.
- standalone canary: **7 invariants verified**, exit 0.
- functional falsification: enforcing 라인만 reword(주석 사본 잔존) → 검출; spec에서 `[user-ratified]` 제거 → 검출.
- 2종 독립 리뷰: omc code-reviewer(MEDIUM 2 = 정규식 fragment 핀 강화 + partial-drift 테스트, LOW 2 = caller-chain 자기 spec 핀 + 중복 예외 제거) + codex(P2 = user-ratified 누락, premise 검증 후 적용).

## 영향 범위

새 CI 검사. 런타임 훅 동작 불변(검사 스크립트 + 테스트 + 1줄 doc). drift 시 CI fail로 surface.

Closes #712

Pre-commit verified: pytest 383 passed + 8 isolated + ruff clean + shellcheck clean + manifest OK + standalone canary 7 invariants + functional falsification (partial-drift + user-ratified removal both caught)
Caller chain verified: check-hook-token-invariants는 standalone CI 스크립트(내부 caller 없음); scripts/run-tests.sh + tests/test_hook_token_invariants.py에서만 호출(grep 확인)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to catch inconsistencies between hook behavior and its documented approval tokens, reducing the chance of outdated or mismatched guidance.
* **Tests**
  * Added automated checks to verify hook-related tokens stay aligned and that changes are detected when either the documented token or the enforced pattern changes.
* **Chores**
  * Expanded the test suite so these consistency checks run automatically during standard test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->