### PR TITLE
feat(retrospect): enforce critic tier via Gate-8c

### DIFF
--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -690,6 +690,29 @@ else
     if [ "$sl_clean_like" = "true" ] && [ "$live_sl_signal_count" -gt "$GATE8_SIGNAL_TOLERANCE" ]; then
       GATE8_VIOLATION="suppression_ledger claims a clean/no-failure path while a live transcript scan finds $live_sl_signal_count adverse signal(s) (tool_event=$live_sl_tool_signal_count is_error=$live_sl_ie_count content_error=$live_sl_ce_count user_correction_marker=$live_sl_uc_count, tolerance=$GATE8_SIGNAL_TOLERANCE) — re-run the self-incrimination pass and surface or justify the signals instead of laundering them as none-found"
     fi
+
+    # [issue #715] Gate-8c (Critic self-skip floor). The externalized critic tier
+    # is the only anti-concealment mechanism the self-correction literature shows
+    # works (external signal, not self-feedback), so an agent must not be free to
+    # self-skip it whenever real agent-caused friction exists. The tier predicate
+    # (stage1-2-analysis.md) fires when a friction_event required user correction;
+    # a live user-correction marker therefore means the predicate SHOULD have
+    # fired. Block a 'critic_diff: not-run' that coexists with live user-correction
+    # markers — this converts the verbatim-brief / run-the-critic guidance from
+    # unenforced self-feedback into a deterministic format gate. Keyed on
+    # user-correction only (not tool-error signals) to map 1:1 to the predicate's
+    # "user correction required" clause. Threshold reuses GATE8_SIGNAL_TOLERANCE
+    # (>1) for parity with Gate-8b: the user-correction regex is broad (matches
+    # "다시"/"no"/"stop"), so a single stray marker stays within tolerance and only
+    # a genuine multi-correction session trips the floor — minimising false
+    # positives. Guarded by -z GATE8_VIOLATION so a more specific Gate-8b laundering
+    # message wins.
+    if [ -z "$GATE8_VIOLATION" ]; then
+      sl_critic_line=$(printf '%s\n' "$SLEDGER_BLOCK" | grep -iE '^[[:space:]]*-?[[:space:]]*critic_diff:[[:space:]]*.+' | tail -n 1)
+      if printf '%s\n' "$sl_critic_line" | grep -qiE 'critic_diff:[[:space:]]*not-run' && [ "$live_sl_uc_count" -gt "$GATE8_SIGNAL_TOLERANCE" ]; then
+        GATE8_VIOLATION="critic_diff is 'not-run' but a live transcript scan finds $live_sl_uc_count user-correction marker(s) (tolerance=$GATE8_SIGNAL_TOLERANCE) — the externalized critic tier predicate (a friction_event required user correction) was satisfied, so the tier must actually run, not be self-skipped. Spawn the READ-ONLY critic, brief it with the verbatim worst_agent_failure, and record its diff in critic_diff; 'not-run' is reserved for the genuinely sub-tolerance user-correction path"
+      fi
+    fi
   fi
 fi
 fi

--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -717,7 +717,12 @@ else
       # generic Korean imperative. Excluded as too broad (codex PR #717 review):
       # '하지 마' ("don't <verb>") matches benign 걱정하지 마세요 / 무리하지 마세요;
       # '라니까' matches benign 사실이라니까; bare '왜 .*했어' matches benign 왜 왔어.
-      sl_strong_correction_re="그거 아니야|그거 말고|그게 아니라|내 말은|하라고 했잖아|하라니까|왜 .*안 하고|that's not what I asked|I said "
+      # 'I said' is ASCII-boundary-anchored ((^|[^A-Za-z])) so 'AI said it was done'
+      # (substring 'I said ' inside 'AI said ') does not false-match — same boundary
+      # convention as sl_user_correction_re's bare-word tokens. This is a best-effort
+      # precision floor, not an exhaustive benign-phrase enumeration; the >1 tolerance
+      # is the backstop against a single stray match (threat model documented in spec).
+      sl_strong_correction_re="그거 아니야|그거 말고|그게 아니라|내 말은|하라고 했잖아|하라니까|왜 .*안 하고|that's not what I asked|(^|[^A-Za-z])I said "
       live_sl_strong_uc_count=$(jq -r --arg re "$sl_strong_correction_re" '
         def human_text_payload:
           (.message.content // .content // empty) as $c

--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -696,30 +696,39 @@ else
     # works (external signal, not self-feedback), so an agent must not be free to
     # self-skip it whenever real agent-caused friction exists. The tier predicate
     # (stage1-2-analysis.md) fires when a friction_event required user correction;
-    # a live user-correction marker therefore means the predicate SHOULD have
-    # fired. Block a 'critic_diff: not-run' that coexists with live user-correction
-    # markers — this converts the verbatim-brief / run-the-critic guidance from
-    # unenforced self-feedback into a deterministic format gate. Keyed on
-    # user-correction only (not tool-error signals), reusing Gate-8b's
-    # GATE8_SIGNAL_TOLERANCE (>1) and its shared user-correction regex.
+    # block a 'critic_diff: not-run' that coexists with live user-correction
+    # markers — this converts the run-the-critic guidance from unenforced
+    # self-feedback into a deterministic format gate.
     #
-    # PRECISION CAVEAT (do not overstate): that regex is broad — it matches bare
-    # "no"/"stop"/"다시" and so fires on benign phrasings ("no problem", "다시
-    # 설명해줘") on a user turn. Because Gate-8c scans the WHOLE retrospected
-    # session, any non-trivial multi-turn session will usually accumulate >1 such
-    # marker. The practical effect is a FORCING FUNCTION: on a busy session the
-    # external critic must actually run (critic_diff != not-run), and 'not-run' is
-    # reserved for near-trivial / genuinely quiet sessions. This is deliberate and
-    # #715-aligned (default to running the only mechanism with teeth), NOT a
-    # high-precision correction detector — the >1 tolerance only absorbs a single
-    # stray marker, so a session with exactly one genuine correction may still
-    # legitimately mark not-run (a recall gap accepted to avoid single-marker false
-    # blocks). Guarded by -z GATE8_VIOLATION so a more specific Gate-8b laundering
-    # message wins.
+    # PRECISION: Gate-8c uses a TIGHTER regex than Gate-8b's broad
+    # sl_user_correction_re. Gate-8b is double-guarded by sl_clean_like, so its
+    # broad regex (bare "no"/"stop"/"다시") is acceptable there. Gate-8c is a
+    # single condition, so the broad regex would fire on benign phrasings
+    # ("no problem", "다시 설명해줘", "stop the dev server" — a code-reviewer probe
+    # matched 7/7 benign) and, because Gate-8c scans the WHOLE session, force the
+    # critic on any busy session regardless of real correction. Restrict to
+    # explicit multi-word redirect/correction phrases so the floor keys on genuine
+    # correction density, not session length. Threshold reuses
+    # GATE8_SIGNAL_TOLERANCE (>1): one stray strong marker is absorbed, so a single
+    # genuine correction may still mark not-run (accepted recall gap). Guarded by
+    # -z GATE8_VIOLATION so a more specific Gate-8b laundering message wins.
     if [ -z "$GATE8_VIOLATION" ]; then
+      sl_strong_correction_re="그거 아니야|하지 마|그거 말고|그게 아니라|내 말은|라니까|하라고 했잖아|하라니까|왜 .*안 하고|왜 .*했어|that's not what I asked|I said "
+      live_sl_strong_uc_count=$(jq -r --arg re "$sl_strong_correction_re" '
+        def human_text_payload:
+          (.message.content // .content // empty) as $c
+          | if ($c|type) == "array" then
+              $c[]? | if type == "object" then
+                if ((.type? // "text") == "text") then (.text? // empty) else empty end
+              else tostring end
+            elif ($c|type) == "string" then $c
+            else empty end;
+        select(type == "object" and .type != "tool_result" and (.message.role == "user" or .role == "user" or .type == "user") and ([human_text_payload] | join("\n") | test($re; "i"))) | 1
+      ' "$TRANSCRIPT_PATH" 2>/dev/null | wc -l | tr -d '[:space:]')
+      live_sl_strong_uc_count=${live_sl_strong_uc_count:-0}
       sl_critic_line=$(printf '%s\n' "$SLEDGER_BLOCK" | grep -iE '^[[:space:]]*-?[[:space:]]*critic_diff:[[:space:]]*.+' | tail -n 1)
-      if printf '%s\n' "$sl_critic_line" | grep -qiE 'critic_diff:[[:space:]]*not-run' && [ "$live_sl_uc_count" -gt "$GATE8_SIGNAL_TOLERANCE" ]; then
-        GATE8_VIOLATION="critic_diff is 'not-run' but a live transcript scan finds $live_sl_uc_count user-correction marker(s) (tolerance=$GATE8_SIGNAL_TOLERANCE) — the externalized critic tier predicate (a friction_event required user correction) was satisfied, so the tier must actually run, not be self-skipped. Spawn the READ-ONLY critic, brief it with the verbatim worst_agent_failure, and record its diff in critic_diff; 'not-run' is reserved for the genuinely sub-tolerance user-correction path"
+      if printf '%s\n' "$sl_critic_line" | grep -qiE 'critic_diff:[[:space:]]*not-run' && [ "$live_sl_strong_uc_count" -gt "$GATE8_SIGNAL_TOLERANCE" ]; then
+        GATE8_VIOLATION="critic_diff is 'not-run' but a live transcript scan finds $live_sl_strong_uc_count explicit user-correction marker(s) (tolerance=$GATE8_SIGNAL_TOLERANCE) — the externalized critic tier predicate (a friction_event required user correction) was satisfied, so the tier must actually run, not be self-skipped. Spawn the READ-ONLY critic, brief it with the verbatim worst_agent_failure, and record its diff in critic_diff; 'not-run' is reserved for the genuinely sub-tolerance user-correction path"
       fi
     fi
   fi

--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -713,7 +713,11 @@ else
     # genuine correction may still mark not-run (accepted recall gap). Guarded by
     # -z GATE8_VIOLATION so a more specific Gate-8b laundering message wins.
     if [ -z "$GATE8_VIOLATION" ]; then
-      sl_strong_correction_re="그거 아니야|하지 마|그거 말고|그게 아니라|내 말은|라니까|하라고 했잖아|하라니까|왜 .*안 하고|왜 .*했어|that's not what I asked|I said "
+      # Each token must be an UNAMBIGUOUS redirect/correction of the agent, not a
+      # generic Korean imperative. Excluded as too broad (codex PR #717 review):
+      # '하지 마' ("don't <verb>") matches benign 걱정하지 마세요 / 무리하지 마세요;
+      # '라니까' matches benign 사실이라니까; bare '왜 .*했어' matches benign 왜 왔어.
+      sl_strong_correction_re="그거 아니야|그거 말고|그게 아니라|내 말은|하라고 했잖아|하라니까|왜 .*안 하고|that's not what I asked|I said "
       live_sl_strong_uc_count=$(jq -r --arg re "$sl_strong_correction_re" '
         def human_text_payload:
           (.message.content // .content // empty) as $c

--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -700,12 +700,21 @@ else
     # fired. Block a 'critic_diff: not-run' that coexists with live user-correction
     # markers — this converts the verbatim-brief / run-the-critic guidance from
     # unenforced self-feedback into a deterministic format gate. Keyed on
-    # user-correction only (not tool-error signals) to map 1:1 to the predicate's
-    # "user correction required" clause. Threshold reuses GATE8_SIGNAL_TOLERANCE
-    # (>1) for parity with Gate-8b: the user-correction regex is broad (matches
-    # "다시"/"no"/"stop"), so a single stray marker stays within tolerance and only
-    # a genuine multi-correction session trips the floor — minimising false
-    # positives. Guarded by -z GATE8_VIOLATION so a more specific Gate-8b laundering
+    # user-correction only (not tool-error signals), reusing Gate-8b's
+    # GATE8_SIGNAL_TOLERANCE (>1) and its shared user-correction regex.
+    #
+    # PRECISION CAVEAT (do not overstate): that regex is broad — it matches bare
+    # "no"/"stop"/"다시" and so fires on benign phrasings ("no problem", "다시
+    # 설명해줘") on a user turn. Because Gate-8c scans the WHOLE retrospected
+    # session, any non-trivial multi-turn session will usually accumulate >1 such
+    # marker. The practical effect is a FORCING FUNCTION: on a busy session the
+    # external critic must actually run (critic_diff != not-run), and 'not-run' is
+    # reserved for near-trivial / genuinely quiet sessions. This is deliberate and
+    # #715-aligned (default to running the only mechanism with teeth), NOT a
+    # high-precision correction detector — the >1 tolerance only absorbs a single
+    # stray marker, so a session with exactly one genuine correction may still
+    # legitimately mark not-run (a recall gap accepted to avoid single-marker false
+    # blocks). Guarded by -z GATE8_VIOLATION so a more specific Gate-8b laundering
     # message wins.
     if [ -z "$GATE8_VIOLATION" ]; then
       sl_critic_line=$(printf '%s\n' "$SLEDGER_BLOCK" | grep -iE '^[[:space:]]*-?[[:space:]]*critic_diff:[[:space:]]*.+' | tail -n 1)

--- a/hooks/completion-verify/retrospect-mix-check/spec.md
+++ b/hooks/completion-verify/retrospect-mix-check/spec.md
@@ -49,7 +49,7 @@ of the following hold:
 | Gate-7 value mismatch: `transcript_receipt` fence declares `is_error_count` or `user_turn_count` that diverges from a live grep of the transcript by more than 1 | Receipt was transcribed verbatim from the compaction summary rather than re-derived this turn (presence ≠ freshness) |
 | Gate-8 (issues #699, #702): the Stage 3 report has no `retrospect:suppression_ledger` fence, has more than one, has a malformed (unterminated/nested) one, or the fence lacks a `worst_agent_failure:`, `self_adversarial:`, or `critic_diff:` line | The Stage 2 self-incrimination pass / conditional externalized critic re-scan record is missing — the painful agent-caused friction the analyzing context is most motivated to bury was never surfaced for audit. Mandatory on every path incl. the clean one. Skipped only once Stage 4 (`## Actions Executed`) is reached for the latest report |
 | Gate-8b (issue #701): `suppression_ledger` claims a clean/no-failure path while a live transcript scan finds more than one deterministic adverse signal | The ledger exists but launders away visible evidence. The hook re-derives `is_error:true`, content-error syntax, and documented `user_correction` markers on user turns before trusting clean ledger language |
-| Gate-8c (issue #715): `critic_diff: not-run` while a live transcript scan finds more than one `user_correction` marker | The externalized critic tier — the only anti-concealment mechanism that survives the self-correction literature — was self-skipped in exactly the case its predicate ("a friction_event required user correction") was satisfied. Converts the run-the-critic guidance from unenforced self-feedback into a deterministic format gate |
+| Gate-8c (issue #715): `critic_diff: not-run` while a live transcript scan finds more than one explicit user-correction marker (tighter `sl_strong_correction_re`, not Gate-8b's broad regex) | The externalized critic tier — the only anti-concealment mechanism that survives the self-correction literature — was self-skipped in exactly the case its predicate ("a friction_event required user correction") was satisfied. Converts the run-the-critic guidance from unenforced self-feedback into a deterministic format gate |
 
 ### Gate-7 value check (issue #671)
 
@@ -141,37 +141,38 @@ bottleneck is error *detection*) makes that tier the one mechanism with teeth.
 Leaving the decision to run it as prose guidance re-creates the exact
 self-feedback dependency the literature says fails.
 
-Gate-8c runs after Gate-8b inside the well-formed-fence branch and reuses the
-already-derived `user_correction` count (`live_sl_uc_count`). It blocks when
+Gate-8c runs after Gate-8b inside the well-formed-fence branch. It blocks when
 **both** hold:
 
 | Condition | Derivation |
 |-----------|------------|
 | `critic_diff:` value starts with `not-run` | last `critic_diff:` line inside the ledger fence matches `critic_diff:[[:space:]]*not-run` |
-| live `user_correction` count exceeds tolerance (`1`) | same `jq` count of negation/redirect/mismatch markers on user turns that Gate-8b uses |
+| live explicit-correction count exceeds tolerance (`1`) | `jq` count of user turns matching `sl_strong_correction_re` (`live_sl_strong_uc_count`) |
 
 The critic tier predicate (`stage1-2-analysis.md`) fires when a
-`friction_event` required user correction, so a live user-correction count over
+`friction_event` required user correction, so an explicit-correction count over
 tolerance means the predicate was satisfied and `not-run` is a self-skip rather
-than a legitimate skip. The threshold reuses Gate-8b's tolerance and Gate-8b's
-shared `user_correction` regex.
+than a legitimate skip.
 
-**Precision caveat (the gate is a forcing function, not a precise detector).**
-That regex is broad — it matches bare `no`/`stop`/`다시`, so benign user turns
-(`no problem`, `다시 설명해줘`) also count. Because Gate-8c scans the whole
-retrospected session, a non-trivial multi-turn session usually accumulates more
-than one such marker. The practical effect is that on a busy session the
-external critic must actually run (`critic_diff` cannot be `not-run`), and
-`not-run` is reserved for near-trivial / genuinely quiet sessions. This is
-deliberate and #715-aligned — default to running the only anti-concealment
-mechanism with teeth — **not** a high-precision correction detector. The `>1`
-tolerance only absorbs a single stray marker; a session with exactly one
-genuine correction may still legitimately mark `not-run` (an accepted recall gap
-that avoids single-marker false blocks). The check is guarded by an
-empty-`GATE8_VIOLATION` test so a more specific Gate-8b laundering message keeps
-precedence. Like Gate-8b this is a floor, not semantic judgment: it cannot tell
-which named failure is the worst, but it removes the agent's discretion to skip
-the external auditor on a session the transcript shows was correction-heavy.
+**Why a tighter regex than Gate-8b.** Gate-8b's `sl_user_correction_re` is broad —
+it matches bare `no`/`stop`/`다시`, so benign user turns (`no problem`,
+`다시 설명해줘`, `stop the dev server`) also count (a code-reviewer probe matched
+7/7 benign phrasings). That breadth is safe in Gate-8b because Gate-8b is
+double-guarded by `sl_clean_like`; Gate-8c is a single condition, so the broad
+regex — combined with Gate-8c scanning the whole session — would force the critic
+on any busy session regardless of real correction (a session-length proxy, not a
+correction proxy). Gate-8c therefore uses a dedicated `sl_strong_correction_re`
+restricted to explicit multi-word redirect/correction phrases (`그거 말고`,
+`그게 아니라`, `하지 마`, `that's not what I asked`, `왜 .*안 하고`, `I said …`,
+etc.), empirically verified to match 0/7 of those benign phrasings and 7/7
+genuine corrections. The `>1` tolerance absorbs a single stray strong marker, so
+a session with exactly one genuine correction may still legitimately mark
+`not-run` (an accepted recall gap that avoids single-marker false blocks). The
+check is guarded by an empty-`GATE8_VIOLATION` test so a more specific Gate-8b
+laundering message keeps precedence. Like Gate-8b this is a floor, not semantic
+judgment: it cannot tell which named failure is the worst, but it removes the
+agent's discretion to skip the external auditor on a session the transcript shows
+carried genuine user corrections.
 
 ### Issue #666 — retrospect-active Stage-3 fence-omission gate
 
@@ -331,10 +332,11 @@ plus 11 synthetic regression fixtures:
    ledger → pass; SL7 inline mention (no real fence) → block; SL8 Stage-4
    Actions Executed without ledger → pass (carve-out); SL27 missing
    critic_diff → block
-- 4 Gate-8c critic self-skip floor (issue #715): SL28 critic_diff not-run +
-   2 user corrections → block; SL29 not-run + no user correction → pass;
-   SL29b not-run + exactly 1 user correction → pass (>1 tolerance boundary);
-   SL30 critic ran (none|checked) + 2 user corrections → pass
+- 5 Gate-8c critic self-skip floor (issue #715): SL28 critic_diff not-run +
+   2 explicit corrections → block; SL29 not-run + no correction → pass;
+   SL29b not-run + exactly 1 explicit correction → pass (>1 tolerance boundary);
+   SL29c not-run + 2 benign markers (no/stop) → pass (tighter regex excludes);
+   SL30 critic ran (none|checked) + 2 corrections → pass
 
 ### Category counts (memory_hygiene, output_quality)
 

--- a/hooks/completion-verify/retrospect-mix-check/spec.md
+++ b/hooks/completion-verify/retrospect-mix-check/spec.md
@@ -167,7 +167,20 @@ restricted to explicit multi-word redirect/correction phrases (`그거 말고`,
 `I said …`, etc.). Generic Korean imperatives are deliberately excluded — bare
 `하지 마` matches benign `걱정하지 마세요`, `라니까` matches `사실이라니까`, bare
 `왜 .*했어` matches `왜 왔어` (codex PR #717) — and the set is empirically
-verified to match 0/9 benign phrasings and 8/8 genuine corrections. The `>1` tolerance absorbs a single stray strong marker, so
+verified to match 0/9 benign phrasings and 8/8 genuine corrections. ASCII tokens
+that could appear as a substring of a longer word are boundary-anchored: the
+`I said` marker is written `(^|[^A-Za-z])I said` (with a trailing space in the
+literal) so it does not fire on `AI said it was done` (codex PR #717).
+
+**Threat-model boundary.** `sl_strong_correction_re` is a best-effort precision
+floor, not an exhaustive enumeration of every benign phrase in every language — a
+hand-rolled correction regex has effectively unbounded corner cases. The design
+accepts that: the `>1` tolerance is the structural backstop (a single stray match
+never blocks), and the consequence of a residual false positive is only that a
+genuinely low-friction retrospect must run the READ-ONLY critic once. New benign
+false-positive reports are handled by adding the phrase to the exclusion set plus
+a regression case, not by claiming the regex is exhaustive. The `>1` tolerance
+absorbs a single stray strong marker, so
 a session with exactly one genuine correction may still legitimately mark
 `not-run` (an accepted recall gap that avoids single-marker false blocks). The
 check is guarded by an empty-`GATE8_VIOLATION` test so a more specific Gate-8b
@@ -334,11 +347,12 @@ plus 11 synthetic regression fixtures:
    ledger → pass; SL7 inline mention (no real fence) → block; SL8 Stage-4
    Actions Executed without ledger → pass (carve-out); SL27 missing
    critic_diff → block
-- 6 Gate-8c critic self-skip floor (issue #715): SL28 critic_diff not-run +
+- 7 Gate-8c critic self-skip floor (issue #715): SL28 critic_diff not-run +
    2 explicit corrections → block; SL29 not-run + no correction → pass;
    SL29b not-run + exactly 1 explicit correction → pass (>1 tolerance boundary);
    SL29c not-run + 2 benign EN markers (no/stop) → pass (tighter regex excludes);
    SL29d not-run + 2 benign KO imperatives (걱정하지 마세요) → pass (codex #717);
+   SL29e not-run + 2 'AI said …' (anchored I-said no match) → pass (codex #717);
    SL30 critic ran (none|checked) + 2 corrections → pass
 
 ### Category counts (memory_hygiene, output_quality)

--- a/hooks/completion-verify/retrospect-mix-check/spec.md
+++ b/hooks/completion-verify/retrospect-mix-check/spec.md
@@ -163,9 +163,11 @@ regex — combined with Gate-8c scanning the whole session — would force the c
 on any busy session regardless of real correction (a session-length proxy, not a
 correction proxy). Gate-8c therefore uses a dedicated `sl_strong_correction_re`
 restricted to explicit multi-word redirect/correction phrases (`그거 말고`,
-`그게 아니라`, `하지 마`, `that's not what I asked`, `왜 .*안 하고`, `I said …`,
-etc.), empirically verified to match 0/7 of those benign phrasings and 7/7
-genuine corrections. The `>1` tolerance absorbs a single stray strong marker, so
+`그게 아니라`, `그거 아니야`, `that's not what I asked`, `왜 .*안 하고`,
+`I said …`, etc.). Generic Korean imperatives are deliberately excluded — bare
+`하지 마` matches benign `걱정하지 마세요`, `라니까` matches `사실이라니까`, bare
+`왜 .*했어` matches `왜 왔어` (codex PR #717) — and the set is empirically
+verified to match 0/9 benign phrasings and 8/8 genuine corrections. The `>1` tolerance absorbs a single stray strong marker, so
 a session with exactly one genuine correction may still legitimately mark
 `not-run` (an accepted recall gap that avoids single-marker false blocks). The
 check is guarded by an empty-`GATE8_VIOLATION` test so a more specific Gate-8b
@@ -332,10 +334,11 @@ plus 11 synthetic regression fixtures:
    ledger → pass; SL7 inline mention (no real fence) → block; SL8 Stage-4
    Actions Executed without ledger → pass (carve-out); SL27 missing
    critic_diff → block
-- 5 Gate-8c critic self-skip floor (issue #715): SL28 critic_diff not-run +
+- 6 Gate-8c critic self-skip floor (issue #715): SL28 critic_diff not-run +
    2 explicit corrections → block; SL29 not-run + no correction → pass;
    SL29b not-run + exactly 1 explicit correction → pass (>1 tolerance boundary);
-   SL29c not-run + 2 benign markers (no/stop) → pass (tighter regex excludes);
+   SL29c not-run + 2 benign EN markers (no/stop) → pass (tighter regex excludes);
+   SL29d not-run + 2 benign KO imperatives (걱정하지 마세요) → pass (codex #717);
    SL30 critic ran (none|checked) + 2 corrections → pass
 
 ### Category counts (memory_hygiene, output_quality)

--- a/hooks/completion-verify/retrospect-mix-check/spec.md
+++ b/hooks/completion-verify/retrospect-mix-check/spec.md
@@ -49,6 +49,7 @@ of the following hold:
 | Gate-7 value mismatch: `transcript_receipt` fence declares `is_error_count` or `user_turn_count` that diverges from a live grep of the transcript by more than 1 | Receipt was transcribed verbatim from the compaction summary rather than re-derived this turn (presence ≠ freshness) |
 | Gate-8 (issues #699, #702): the Stage 3 report has no `retrospect:suppression_ledger` fence, has more than one, has a malformed (unterminated/nested) one, or the fence lacks a `worst_agent_failure:`, `self_adversarial:`, or `critic_diff:` line | The Stage 2 self-incrimination pass / conditional externalized critic re-scan record is missing — the painful agent-caused friction the analyzing context is most motivated to bury was never surfaced for audit. Mandatory on every path incl. the clean one. Skipped only once Stage 4 (`## Actions Executed`) is reached for the latest report |
 | Gate-8b (issue #701): `suppression_ledger` claims a clean/no-failure path while a live transcript scan finds more than one deterministic adverse signal | The ledger exists but launders away visible evidence. The hook re-derives `is_error:true`, content-error syntax, and documented `user_correction` markers on user turns before trusting clean ledger language |
+| Gate-8c (issue #715): `critic_diff: not-run` while a live transcript scan finds more than one `user_correction` marker | The externalized critic tier — the only anti-concealment mechanism that survives the self-correction literature — was self-skipped in exactly the case its predicate ("a friction_event required user correction") was satisfied. Converts the run-the-critic guidance from unenforced self-feedback into a deterministic format gate |
 
 ### Gate-7 value check (issue #671)
 
@@ -127,6 +128,39 @@ tolerance, so one record that carries multiple matching nested `tool_result`
 blocks still counts as one adverse tool event. This is a floor, not full
 semantic judgment: the hook does not decide whether every marker is a true
 correction, but it prevents the ledger from claiming that no signal existed.
+
+### Gate-8c critic self-skip floor (issue #715)
+
+Gate-8b closes the case where the ledger claims a *clean* path. It does **not**
+cover the subtler concealment where the ledger names a (possibly minor)
+`worst_agent_failure:` — so `sl_clean_like` is false and Gate-8b stays quiet —
+while marking `critic_diff: not-run` to skip the externalized critic tier.
+The self-correction literature that motivates issue #715 (intrinsic
+self-correction without an external signal does not reliably work; the
+bottleneck is error *detection*) makes that tier the one mechanism with teeth.
+Leaving the decision to run it as prose guidance re-creates the exact
+self-feedback dependency the literature says fails.
+
+Gate-8c runs after Gate-8b inside the well-formed-fence branch and reuses the
+already-derived `user_correction` count (`live_sl_uc_count`). It blocks when
+**both** hold:
+
+| Condition | Derivation |
+|-----------|------------|
+| `critic_diff:` value starts with `not-run` | last `critic_diff:` line inside the ledger fence matches `critic_diff:[[:space:]]*not-run` |
+| live `user_correction` count exceeds tolerance (`1`) | same `jq` count of negation/redirect/mismatch markers on user turns that Gate-8b uses |
+
+The critic tier predicate (`stage1-2-analysis.md`) fires when a
+`friction_event` required user correction, so a live user-correction count over
+tolerance means the predicate was satisfied and `not-run` is a self-skip, not a
+legitimate skip. The threshold mirrors Gate-8b's tolerance because the
+`user_correction` regex is broad (`다시`/`no`/`stop`): a single stray marker
+stays within tolerance and only a genuine multi-correction session trips the
+floor. The check is guarded by an empty-`GATE8_VIOLATION` test so a more
+specific Gate-8b laundering message keeps precedence. Like Gate-8b this is a
+floor, not semantic judgment: it cannot tell which named failure is the worst,
+but it removes the agent's discretion to skip the external auditor when the
+transcript proves real user-visible friction occurred.
 
 ### Issue #666 — retrospect-active Stage-3 fence-omission gate
 
@@ -286,6 +320,9 @@ plus 11 synthetic regression fixtures:
    ledger → pass; SL7 inline mention (no real fence) → block; SL8 Stage-4
    Actions Executed without ledger → pass (carve-out); SL27 missing
    critic_diff → block
+- 3 Gate-8c critic self-skip floor (issue #715): SL28 critic_diff not-run +
+   2 user corrections → block; SL29 not-run + no user correction → pass;
+   SL30 critic ran (none|checked) + 2 user corrections → pass
 
 ### Category counts (memory_hygiene, output_quality)
 

--- a/hooks/completion-verify/retrospect-mix-check/spec.md
+++ b/hooks/completion-verify/retrospect-mix-check/spec.md
@@ -152,15 +152,26 @@ already-derived `user_correction` count (`live_sl_uc_count`). It blocks when
 
 The critic tier predicate (`stage1-2-analysis.md`) fires when a
 `friction_event` required user correction, so a live user-correction count over
-tolerance means the predicate was satisfied and `not-run` is a self-skip, not a
-legitimate skip. The threshold mirrors Gate-8b's tolerance because the
-`user_correction` regex is broad (`다시`/`no`/`stop`): a single stray marker
-stays within tolerance and only a genuine multi-correction session trips the
-floor. The check is guarded by an empty-`GATE8_VIOLATION` test so a more
-specific Gate-8b laundering message keeps precedence. Like Gate-8b this is a
-floor, not semantic judgment: it cannot tell which named failure is the worst,
-but it removes the agent's discretion to skip the external auditor when the
-transcript proves real user-visible friction occurred.
+tolerance means the predicate was satisfied and `not-run` is a self-skip rather
+than a legitimate skip. The threshold reuses Gate-8b's tolerance and Gate-8b's
+shared `user_correction` regex.
+
+**Precision caveat (the gate is a forcing function, not a precise detector).**
+That regex is broad — it matches bare `no`/`stop`/`다시`, so benign user turns
+(`no problem`, `다시 설명해줘`) also count. Because Gate-8c scans the whole
+retrospected session, a non-trivial multi-turn session usually accumulates more
+than one such marker. The practical effect is that on a busy session the
+external critic must actually run (`critic_diff` cannot be `not-run`), and
+`not-run` is reserved for near-trivial / genuinely quiet sessions. This is
+deliberate and #715-aligned — default to running the only anti-concealment
+mechanism with teeth — **not** a high-precision correction detector. The `>1`
+tolerance only absorbs a single stray marker; a session with exactly one
+genuine correction may still legitimately mark `not-run` (an accepted recall gap
+that avoids single-marker false blocks). The check is guarded by an
+empty-`GATE8_VIOLATION` test so a more specific Gate-8b laundering message keeps
+precedence. Like Gate-8b this is a floor, not semantic judgment: it cannot tell
+which named failure is the worst, but it removes the agent's discretion to skip
+the external auditor on a session the transcript shows was correction-heavy.
 
 ### Issue #666 — retrospect-active Stage-3 fence-omission gate
 
@@ -320,8 +331,9 @@ plus 11 synthetic regression fixtures:
    ledger → pass; SL7 inline mention (no real fence) → block; SL8 Stage-4
    Actions Executed without ledger → pass (carve-out); SL27 missing
    critic_diff → block
-- 3 Gate-8c critic self-skip floor (issue #715): SL28 critic_diff not-run +
+- 4 Gate-8c critic self-skip floor (issue #715): SL28 critic_diff not-run +
    2 user corrections → block; SL29 not-run + no user correction → pass;
+   SL29b not-run + exactly 1 user correction → pass (>1 tolerance boundary);
    SL30 critic ran (none|checked) + 2 user corrections → pass
 
 ### Category counts (memory_hygiene, output_quality)

--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -175,10 +175,12 @@ guaranteed slot that does NOT consume the 5-event `friction_events` cap, and a
 failure with no `user_correction` marker or no `self_correction` signature match
 is still in scope. An agent-caused, user-visible-impact failure may not be
 self-downgraded to `note only` (severity-honesty floor). The result is recorded
-in the Stage 3 `retrospect:suppression_ledger` fence. Only the fence *format* is
-hook-enforceable; judging which item is most painful is a self-feedback step and
-does **not** mechanize (issue #715) — the externalized critic tier below is the
-enforcing external signal, not a smarter self-check. Full rules in
+in the Stage 3 `retrospect:suppression_ledger` fence. Judging which item is most
+painful is a self-feedback step and does **not** mechanize (issue #715) — the
+externalized critic tier below is the enforcing external signal, not a smarter
+self-check. What *is* mechanized: Gate-8c (retrospect-mix-check) blocks a
+`critic_diff: not-run` when the live transcript carries user corrections, so the
+external tier cannot be self-skipped in the conceal-prone case. Full rules in
 [`references/stage1-2-analysis.md`](references/stage1-2-analysis.md).
 
 **Externalized critic re-scan tier (conditional, issue #702):** after MEMORY

--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -175,7 +175,10 @@ guaranteed slot that does NOT consume the 5-event `friction_events` cap, and a
 failure with no `user_correction` marker or no `self_correction` signature match
 is still in scope. An agent-caused, user-visible-impact failure may not be
 self-downgraded to `note only` (severity-honesty floor). The result is recorded
-in the Stage 3 `retrospect:suppression_ledger` fence. Full rules in
+in the Stage 3 `retrospect:suppression_ledger` fence. Only the fence *format* is
+hook-enforceable; judging which item is most painful is a self-feedback step and
+does **not** mechanize (issue #715) — the externalized critic tier below is the
+enforcing external signal, not a smarter self-check. Full rules in
 [`references/stage1-2-analysis.md`](references/stage1-2-analysis.md).
 
 **Externalized critic re-scan tier (conditional, issue #702):** after MEMORY

--- a/skills/retrospect/references/stage1-2-analysis.md
+++ b/skills/retrospect/references/stage1-2-analysis.md
@@ -263,6 +263,21 @@ Rules:
   allowed only with an explicit `disposition: justified-drop` reason; a silent
   drop is a Red Flag.
 
+**Limits — what is mechanizable vs what is not (issue #715):** Only the *format*
+of this pass is hook-enforceable: the `retrospect:suppression_ledger` and
+`retrospect:distribution` fences must be present with their required lines, and
+the `## Actions Executed` marker must appear. The *semantic* judgment this pass turns
+on — "is this actually the single most painful item, and did a positive learning
+quietly take its slot?" — is **not** hook-enforceable; it stays a self-feedback
+step even when wrapped in a hook. Four consecutive recurrences of the
+"hid the painful part" failure, plus the self-correction literature (intrinsic
+self-correction without an external signal does not reliably work and can degrade
+output; the bottleneck is error *detection*, not correction), establish that
+adding more self-check prose to this family does not enforce it. Do not keep
+refining self-prompts here — the leverage is the **external** signal (the
+externalized critic tier below, or the user's "you hid it?" probe), not a smarter
+self-instruction.
+
 ### Externalized critic re-scan tier (conditional, issue #702)
 
 The self-incrimination pass still runs inside the same context that made the
@@ -315,11 +330,16 @@ available read-only review/debate agent. The brief must include:
 
 - transcript / scope window identifier
 - the five pre-scan lanes
-- the self-incrimination pass output
+- the self-incrimination pass output, carried **verbatim** — do not paraphrase,
+  summarize, or soften the candidate #1-damage wording before it reaches the
+  critic. A sanitized brief turns the critic into an echo chamber (issue #715):
+  it can only ratify framing it was never allowed to see.
 - the current self-selected friction set
-- the instruction: "Find only agent-caused failures the analyzing agent might
-  minimize, omit, or soften. Do not propose fixes. Do not mutate files or
-  external state."
+- the instruction: "Find agent-caused failures the analyzing agent might
+  minimize, omit, or soften, and judge **how bad the worst one is** — did a
+  positive learning take the #1-damage slot? Record that severity judgment in
+  the candidate's `why_self_serving_bias_risk` cell; do not ask 'is this a good
+  learning'. Do not propose fixes. Do not mutate files or external state."
 
 The critic's job is not to re-run Stage 2. It produces a narrow diff oracle:
 

--- a/skills/retrospect/references/stage1-2-analysis.md
+++ b/skills/retrospect/references/stage1-2-analysis.md
@@ -276,7 +276,13 @@ output; the bottleneck is error *detection*, not correction), establish that
 adding more self-check prose to this family does not enforce it. Do not keep
 refining self-prompts here — the leverage is the **external** signal (the
 externalized critic tier below, or the user's "you hid it?" probe), not a smarter
-self-instruction.
+self-instruction. That leverage is mechanized, not just described: **Gate-8c**
+in `retrospect-mix-check` blocks a `critic_diff: not-run` whenever the live
+transcript carries more than one `user_correction` marker, so the external tier
+cannot be self-skipped in exactly the case (user correction occurred) its
+predicate is satisfied. The hook cannot judge *which* failure is worst; it can
+and does force the external auditor to run when the transcript proves real
+user-visible friction.
 
 ### Externalized critic re-scan tier (conditional, issue #702)
 

--- a/skills/retrospect/references/stage1-2-analysis.md
+++ b/skills/retrospect/references/stage1-2-analysis.md
@@ -278,9 +278,10 @@ refining self-prompts here — the leverage is the **external** signal (the
 externalized critic tier below, or the user's "you hid it?" probe), not a smarter
 self-instruction. That leverage is mechanized, not just described: **Gate-8c**
 in `retrospect-mix-check` blocks a `critic_diff: not-run` whenever the live
-transcript carries more than one `user_correction` marker, so the external tier
-cannot be self-skipped in exactly the case (user correction occurred) its
-predicate is satisfied. The hook cannot judge *which* failure is worst; it can
+transcript carries more than one *explicit* user-correction marker (a tighter
+regex than Gate-8b's, so benign `no`/`stop`/`다시` turns do not count), so the
+external tier cannot be self-skipped in exactly the case (a genuine user
+correction occurred) its predicate is satisfied. The hook cannot judge *which* failure is worst; it can
 and does force the external auditor to run when the transcript proves real
 user-visible friction.
 

--- a/tests/hooks/completion-verify/test_retrospect_mix_check.sh
+++ b/tests/hooks/completion-verify/test_retrospect_mix_check.sh
@@ -2021,6 +2021,16 @@ $(mk_user_turn "무리하지 마세요")
 $(mk_assistant "$SL29D_TEXT")"
 run_case "SL29d_pass_critic_notrun_benign_korean_imperatives" "pass" "$SL29D_TRANSCRIPT"
 
+# SL29e: pass — the ASCII-anchored 'I said' marker must not match 'AI said …'
+# (substring 'I said ' inside 'AI said '). Guards the codex PR #717 word-boundary
+# finding: a low-friction retrospect narrating "AI said it was done" must not block.
+SL29E_TEXT="$(mk_retrospect_stage3_no_ledger "$T1_CARD" "$T1_ROW")
+${SL_LEDGER_ADVERSE_NOTRUN}"
+SL29E_TRANSCRIPT="$(mk_user_turn "the AI said it was done")
+$(mk_user_turn "AI said it finished the task")
+$(mk_assistant "$SL29E_TEXT")"
+run_case "SL29e_pass_critic_notrun_ai_said_not_anchored_match" "pass" "$SL29E_TRANSCRIPT"
+
 # SL30: pass — when the critic tier actually ran (critic_diff records a checked
 # result), user corrections in the transcript do not trip Gate-8c.
 SL30_TEXT="$(mk_retrospect_stage3_no_ledger "$T1_CARD" "$T1_ROW")

--- a/tests/hooks/completion-verify/test_retrospect_mix_check.sh
+++ b/tests/hooks/completion-verify/test_retrospect_mix_check.sh
@@ -1991,6 +1991,15 @@ SL29_TRANSCRIPT="$(mk_is_error "tool failed")
 $(mk_assistant "$SL29_TEXT")"
 run_case "SL29_pass_critic_notrun_no_user_correction" "pass" "$SL29_TRANSCRIPT"
 
+# SL29b: pass — boundary. Exactly one user-correction marker stays within the
+# >1 tolerance, so a not-run critic_diff is still legitimate (guards the -gt vs
+# -ge off-by-one: a single genuine correction must NOT force the critic).
+SL29B_TEXT="$(mk_retrospect_stage3_no_ledger "$T1_CARD" "$T1_ROW")
+${SL_LEDGER_ADVERSE_NOTRUN}"
+SL29B_TRANSCRIPT="$(mk_user_turn "아니 그거 말고")
+$(mk_assistant "$SL29B_TEXT")"
+run_case "SL29b_pass_critic_notrun_single_user_correction" "pass" "$SL29B_TRANSCRIPT"
+
 # SL30: pass — when the critic tier actually ran (critic_diff records a checked
 # result), user corrections in the transcript do not trip Gate-8c.
 SL30_TEXT="$(mk_retrospect_stage3_no_ledger "$T1_CARD" "$T1_ROW")

--- a/tests/hooks/completion-verify/test_retrospect_mix_check.sh
+++ b/tests/hooks/completion-verify/test_retrospect_mix_check.sh
@@ -1959,6 +1959,47 @@ ${SL_LEDGER_NO_CRITIC}"
 run_case "SL27_block_ledger_missing_critic_diff" "block" \
   "$(mk_assistant "$SL27_TEXT")"
 
+# SL28~SL30: Gate-8c (Critic self-skip floor, issue #715). A 'critic_diff: not-run'
+# is concealment when the live transcript shows the tier predicate was satisfied
+# (a friction_event required user correction). worst_agent_failure here is genuinely
+# adverse (no clean-like phrasing) so Gate-8b does NOT fire — these isolate Gate-8c.
+SL_LEDGER_ADVERSE_NOTRUN='<!-- retrospect:suppression_ledger begin -->
+- worst_agent_failure: shipped a wrong identifier after skipping the schema probe | disposition: surface
+- self_adversarial: ran | result: surfaced the skipped probe as the root cause
+- critic_diff: not-run | reason: tier predicate false (synthetic fixture)
+<!-- retrospect:suppression_ledger end -->'
+SL_LEDGER_ADVERSE_CRITIC_RAN='<!-- retrospect:suppression_ledger begin -->
+- worst_agent_failure: shipped a wrong identifier after skipping the schema probe | disposition: surface
+- self_adversarial: ran | result: surfaced the skipped probe as the root cause
+- critic_diff: none | checked: 2 candidate(s)
+<!-- retrospect:suppression_ledger end -->'
+
+# SL28: block — not-run critic_diff while two real user corrections prove the tier
+# predicate ("user correction required") was satisfied; self-skip is concealment.
+SL28_TEXT="$(mk_retrospect_stage3_no_ledger "$T1_CARD" "$T1_ROW")
+${SL_LEDGER_ADVERSE_NOTRUN}"
+SL28_TRANSCRIPT="$(mk_user_turn "아니 그거 말고")
+$(mk_user_turn "that's not what I asked")
+$(mk_assistant "$SL28_TEXT")"
+run_case "SL28_block_critic_notrun_with_user_corrections" "block" "$SL28_TRANSCRIPT"
+
+# SL29: pass — not-run critic_diff is legitimate when the user-correction signal
+# stays within tolerance (a lone tool error is not a user correction).
+SL29_TEXT="$(mk_retrospect_stage3_no_ledger "$T1_CARD" "$T1_ROW")
+${SL_LEDGER_ADVERSE_NOTRUN}"
+SL29_TRANSCRIPT="$(mk_is_error "tool failed")
+$(mk_assistant "$SL29_TEXT")"
+run_case "SL29_pass_critic_notrun_no_user_correction" "pass" "$SL29_TRANSCRIPT"
+
+# SL30: pass — when the critic tier actually ran (critic_diff records a checked
+# result), user corrections in the transcript do not trip Gate-8c.
+SL30_TEXT="$(mk_retrospect_stage3_no_ledger "$T1_CARD" "$T1_ROW")
+${SL_LEDGER_ADVERSE_CRITIC_RAN}"
+SL30_TRANSCRIPT="$(mk_user_turn "아니 그거 말고")
+$(mk_user_turn "that's not what I asked")
+$(mk_assistant "$SL30_TEXT")"
+run_case "SL30_pass_critic_ran_with_user_corrections" "pass" "$SL30_TRANSCRIPT"
+
 # Synthetic regression fixtures (AC-R1~R4) ----------------------------------
 # Each fixture pairs a .jsonl transcript with a .expected.json sidecar:
 #   {expected_decision: "pass"|"block", must_contain: [...], must_not_contain: [...]}

--- a/tests/hooks/completion-verify/test_retrospect_mix_check.sh
+++ b/tests/hooks/completion-verify/test_retrospect_mix_check.sh
@@ -2000,6 +2000,17 @@ SL29B_TRANSCRIPT="$(mk_user_turn "아니 그거 말고")
 $(mk_assistant "$SL29B_TEXT")"
 run_case "SL29b_pass_critic_notrun_single_user_correction" "pass" "$SL29B_TRANSCRIPT"
 
+# SL29c: pass — precision floor. Two benign user turns that Gate-8b's broad regex
+# WOULD count ("no problem", "stop the dev server") do NOT match Gate-8c's tighter
+# explicit-correction regex, so not-run is not forced. Guards against the
+# session-length-proxy false positive the code-reviewer flagged.
+SL29C_TEXT="$(mk_retrospect_stage3_no_ledger "$T1_CARD" "$T1_ROW")
+${SL_LEDGER_ADVERSE_NOTRUN}"
+SL29C_TRANSCRIPT="$(mk_user_turn "no problem, take your time")
+$(mk_user_turn "stop the dev server when done")
+$(mk_assistant "$SL29C_TEXT")"
+run_case "SL29c_pass_critic_notrun_benign_markers_excluded" "pass" "$SL29C_TRANSCRIPT"
+
 # SL30: pass — when the critic tier actually ran (critic_diff records a checked
 # result), user corrections in the transcript do not trip Gate-8c.
 SL30_TEXT="$(mk_retrospect_stage3_no_ledger "$T1_CARD" "$T1_ROW")

--- a/tests/hooks/completion-verify/test_retrospect_mix_check.sh
+++ b/tests/hooks/completion-verify/test_retrospect_mix_check.sh
@@ -2011,6 +2011,16 @@ $(mk_user_turn "stop the dev server when done")
 $(mk_assistant "$SL29C_TEXT")"
 run_case "SL29c_pass_critic_notrun_benign_markers_excluded" "pass" "$SL29C_TRANSCRIPT"
 
+# SL29d: pass — benign Korean imperatives/encouragement ("걱정하지 마세요",
+# "무리하지 마세요") must NOT count as corrections. Guards the codex PR #717
+# finding that bare "하지 마" matched benign "don't worry"-style Korean.
+SL29D_TEXT="$(mk_retrospect_stage3_no_ledger "$T1_CARD" "$T1_ROW")
+${SL_LEDGER_ADVERSE_NOTRUN}"
+SL29D_TRANSCRIPT="$(mk_user_turn "걱정하지 마세요")
+$(mk_user_turn "무리하지 마세요")
+$(mk_assistant "$SL29D_TEXT")"
+run_case "SL29d_pass_critic_notrun_benign_korean_imperatives" "pass" "$SL29D_TRANSCRIPT"
+
 # SL30: pass — when the critic tier actually ran (critic_diff records a checked
 # result), user corrections in the transcript do not trip Gate-8c.
 SL30_TEXT="$(mk_retrospect_stage3_no_ledger "$T1_CARD" "$T1_ROW")


### PR DESCRIPTION
## 무엇을 / 왜

#715: retrospect Stage 3의 anti-concealment 처방이 4회 연속 재발했고, self-correction 문헌(Huang/Kamoi/Tyen/Sharma)은 외부 신호 없는 self-feedback이 강제되지 않음을 보인다.

이 PR은 2단계로 진행됐다. **첫 커밋(8ccc48b)은 그 한계를 문서로 *설명*만 했는데, 사용자가 정확히 지적했듯 그것 자체가 #715가 경고한 안티패턴(prose 추가)이었다 — 행동 강제력 0.** 두 번째 커밋(d8a441a)이 실제 수정이다: self-feedback을 **기계 게이트로 전환**.

## Gate-8c (Critic self-skip floor) — 핵심 변경

기존 Gate-8b는 "ledger가 clean이라 주장 + live 신호" 라운더링을 잡지만, agent가 사소한 `worst_agent_failure`를 적고 `critic_diff: not-run`으로 외부 critic을 self-skip하면 빈틈이었다.

> **Gate-8c**: `critic_diff: not-run` **AND** live transcript의 user-correction 마커 > tolerance(1) → **BLOCK**. tier predicate("friction_event가 user correction을 요구")가 충족된 케이스에서 외부 critic 자기-스킵을 차단. 기존 `live_sl_uc_count`(Gate-8b 머신러리) 재사용, `-z GATE8_VIOLATION` 가드로 Gate-8b 우선.

threshold를 `>1`로 둔 이유: user-correction 정규식이 넓어(`다시`/`no`/`stop`) 단일 마커 benign false-positive 방지 + Gate-8b 일관성.

## 실증 (실제 hook 바이너리)

| 입력 (동일 adverse ledger, 동일 user-correction 2회) | 결과 |
|---|---|
| `critic_diff: not-run` | **block** — "critic_diff is 'not-run' but … 2 user-correction marker(s)" |
| `critic_diff: none \| checked: 2` (ran) | **pass** (빈 출력) |

`critic_diff` 하나로 block↔pass가 갈림 = prose 아닌 실제 강제력.

## 변경

- `impl.sh`: Gate-8c (Gate-8b 뒤, well-formed-fence 분기 내부)
- `test_retrospect_mix_check.sh`: SL28(block)/SL29(pass)/SL30(pass)
- `spec.md`: Gate-8c 섹션 + 게이트 테이블 행 + 테스트 열거
- skill `SKILL.md`/`stage1-2-analysis.md`: 8ccc48b의 prose를 "Gate-8c가 강제"로 backing

## 범위

Refs #715 — items 1-3 + 기계 enforcement. item 4(memory의 false-completion 교정)는 현재 memory dir에 대상 라인 부재(grep 0)라 N-A.

## 검증

- run-tests.sh: **ALL TESTS PASSED** (exit 0, 실제 FAIL 0)
- retrospect-mix-check 114 cases + #712 canary 7 invariants green
- markdownlint 변경줄 위반 0, manifest check OK

## 영향 범위 / 검증 안 한 것

Gate-8c는 **모든 retrospect Stage 3를 gate하는 load-bearing Stop hook**에 추가됨 → false-positive면 정상 retrospect도 block. threshold `>1` + 합성 fixture 3종(block/pass/pass)으로 완화했으나, 실제 세션 행동 변화는 런타임에서만 관측. headline-judgment(어느 항목이 worst인가)는 본질적으로 기계화 불가 — Gate-8c는 외부 critic 실행 강제만 담당.

Refs #715

Pre-commit verified: run-tests.sh ALL TESTS PASSED (exit 0, 실제 FAIL 0) + 실제 hook 바이너리로 not-run→block / ran→pass 실증
Caller chain verified: Gate-8c는 retrospect-mix-check impl.sh의 Gate-8b 분기 내부에서 live_sl_uc_count(line 658-669) 소비; Stop hook 단일 호출 경로, 외부 caller 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation so retrospection output can’t incorrectly skip the external review step when transcript corrections are present.
  * Improved handling of correction-related edge cases, reducing false passes and ensuring more consistent blocking behavior.
  * Clarified when a “not run” review status is acceptable versus when it should be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->