### PR TITLE
docs(retrospect): chunk Stage 1 rule loading

### DIFF
--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -89,7 +89,10 @@ Run only approved actions, then verify the resulting artifacts.
 
 Before scanning the conversation:
 
-1. Read global and project rule files.
+1. Read global and project rule files — load large files (a packaged `SKILL.md`
+   can exceed ~1500 lines) in bounded section/line-range chunks, never a single
+   broad read that can truncate and silently drop tail rules (see
+   [`references/stage1-2-analysis.md`](references/stage1-2-analysis.md)).
 2. Identify the rule categories you will scan against.
 3. Turn each category into a calibration question.
 

--- a/skills/retrospect/references/appendices.md
+++ b/skills/retrospect/references/appendices.md
@@ -60,6 +60,11 @@ The following are structural stop signals:
 - The Stop hook parses the distribution card and unified findings table
 - Post-compaction sessions also require the `retrospect:transcript_receipt`
   fence
+- When compaction (or a chunked/bounded rule or transcript read) leaves the
+  transcript or tool census partial, record that limit on the Stage 3
+  `Stage 2 caveats:` line (e.g. `tool census partial: post-compaction salient
+  window only`) instead of implying full coverage — a partial scan reported as
+  complete is itself a concealment
 - Stage 4 action procedures and artifact verification live in
   [`stage4-execution.md`](stage4-execution.md)
 - Worked examples live in [`report-template.md`](report-template.md)

--- a/skills/retrospect/references/stage1-2-analysis.md
+++ b/skills/retrospect/references/stage1-2-analysis.md
@@ -11,6 +11,18 @@ Before scanning the conversation:
 1. Read global and project rule files.
    - Global: `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md`
    - Project: `AGENTS.md` in cwd
+   - **Large rule files — chunked load (MUST).** Rule files, and on some hosts
+     this skill's own packaged `SKILL.md`, can be long (a single-file `SKILL.md`
+     has exceeded ~1500 lines on the Codex host). Loading one with a single broad
+     `rg` or whole-file read can truncate the output, silently dropping the rules
+     at the tail and calibrating against a partial standard. Instead:
+     - Read by section/heading or in bounded line ranges (`sed -n`, or a `Read`
+       with `offset`+`limit`) — one Stage's worth at a time, not a whole-file dump.
+     - When a broad `rg` is unavoidable, cap the match count (a low output limit
+       on the host's grep tool, or `--max-count` for `rg`) and page through
+       sections rather than emitting every match at once.
+     - If any rule read comes back truncated, re-read the missing range before
+       calibrating — never proceed on a partial rule set.
 2. Identify the rule categories you are scanning against.
    - workflow discipline
    - evidence-based delivery


### PR DESCRIPTION
## 무엇을 / 왜

retrospect Stage 1은 global/project rule 파일을 로드한다. Codex host에서 packaged `SKILL.md`가 ~1500 lines를 초과하고, broad `rg`/whole-file로 한 번에 읽으면 출력이 truncate되어 **tail rule이 silent drop** → partial standard로 calibration된다. 이번 retrospect 실행에서도 broad rule lookup이 ~22k tokens로 잘렸고 이후 작은 chunk·targeted read로 복구했다.

## 변경 (3파일, doc-only)

- `references/stage1-2-analysis.md`: Stage 1에 **chunked-load MUST** 불릿 — section/line-range 읽기(`sed -n` / `Read offset+limit`), broad `rg`는 match count cap + section 페이징, truncation 시 missing range 재읽기.
- `SKILL.md`: Stage 1 step 1에 chunked-load 포인터.
- `references/appendices.md`: post-compaction 또는 chunked read로 transcript·tool census가 partial이면 Stage 3 `Stage 2 caveats:` 라인에 기록(complete로 위장 = concealment).

## 범위

Closes #708 — 이슈 3개 작업 항목(chunked read 지침 / broad rg cap / census caveat 절차) + 완료 조건 전부 충족.

## 검증

- markdownlint clean(변경줄 0), manifest OK, retrospect routing 67 pass, retrospect-mix-check fixtures pass
- 리뷰 2종: `oh-my-claudecode:code-reviewer` APPROVE(LOW 1건=`max_output` 비존재 플래그→일반화 수정), codex clean

## 영향 범위 / 검증 안 한 것

doc-only — Stop hook 파서(`transcript_receipt`/`tool_census` fence) 무변경, blast radius 0. 지침-준수 행동은 런타임에서만 관측(Not-tested).

Pre-commit verified: markdownlint clean(변경줄 0) + manifest check OK + retrospect routing 67 pass + retrospect-mix-check fixtures pass

Closes #708
