### PR TITLE
fix(retrospect): narrow Gate-8c hard-block regex to low-FP

### DIFF
--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -713,16 +713,23 @@ else
     # genuine correction may still mark not-run (accepted recall gap). Guarded by
     # -z GATE8_VIOLATION so a more specific Gate-8b laundering message wins.
     if [ -z "$GATE8_VIOLATION" ]; then
-      # Each token must be an UNAMBIGUOUS redirect/correction of the agent, not a
-      # generic Korean imperative. Excluded as too broad (codex PR #717 review):
-      # '하지 마' ("don't <verb>") matches benign 걱정하지 마세요 / 무리하지 마세요;
-      # '라니까' matches benign 사실이라니까; bare '왜 .*했어' matches benign 왜 왔어.
-      # 'I said' is ASCII-boundary-anchored ((^|[^A-Za-z])) so 'AI said it was done'
-      # (substring 'I said ' inside 'AI said ') does not false-match — same boundary
-      # convention as sl_user_correction_re's bare-word tokens. This is a best-effort
-      # precision floor, not an exhaustive benign-phrase enumeration; the >1 tolerance
-      # is the backstop against a single stray match (threat model documented in spec).
-      sl_strong_correction_re="그거 아니야|그거 말고|그게 아니라|내 말은|하라고 했잖아|하라니까|왜 .*안 하고|that's not what I asked|(^|[^A-Za-z])I said "
+      # This is a HARD BLOCK, so it must fire only on a LOW-false-positive signal
+      # (issue #722). Because the consequence asymmetry favours a false-negative
+      # (a missed self-skip is still nudged by the prose self-incrimination layer)
+      # over a false-positive (blocking a clean retrospect erodes trust in the
+      # gate), the set is deliberately narrowed to near-unambiguous redirects —
+      # NOT an exhaustive correction detector. Everyday Korean conversational
+      # tokens were measured as high-FP (7/10 benign phrases matched) and dropped:
+      # '그거 아니야' (benign 그거 아니야? 맞는데), '그거 말고' (그거 말고도),
+      # '그게 아니라' (그게 아니라 그냥), '내 말은' (내 말은 ~ 뜻), '하라니까'
+      # (하라니까 바로 했어요), '왜 .*안 하고' (greedy span over narration),
+      # '(^|[^A-Za-z])I said ' (benign English recap "I said I would …").
+      # Kept tokens verified low-FP via jq probe: benign set 13/13 no-match
+      # (incl. reportive '내가 말한 건 아니지만 …' forms — a greedy '내가 말한 건
+      # .*아니' candidate was rejected for matching exactly those, code-reviewer
+      # #722), genuine corrections 3/3 match. The dropped tokens remain the prose
+      # self-incrimination layer's job, not this hard block's.
+      sl_strong_correction_re="하라고 했잖아|that's not what I asked|그렇게 하지 말라고"
       live_sl_strong_uc_count=$(jq -r --arg re "$sl_strong_correction_re" '
         def human_text_payload:
           (.message.content // .content // empty) as $c

--- a/hooks/completion-verify/retrospect-mix-check/spec.md
+++ b/hooks/completion-verify/retrospect-mix-check/spec.md
@@ -161,25 +161,29 @@ it matches bare `no`/`stop`/`다시`, so benign user turns (`no problem`,
 double-guarded by `sl_clean_like`; Gate-8c is a single condition, so the broad
 regex — combined with Gate-8c scanning the whole session — would force the critic
 on any busy session regardless of real correction (a session-length proxy, not a
-correction proxy). Gate-8c therefore uses a dedicated `sl_strong_correction_re`
-restricted to explicit multi-word redirect/correction phrases (`그거 말고`,
-`그게 아니라`, `그거 아니야`, `that's not what I asked`, `왜 .*안 하고`,
-`I said …`, etc.). Generic Korean imperatives are deliberately excluded — bare
-`하지 마` matches benign `걱정하지 마세요`, `라니까` matches `사실이라니까`, bare
-`왜 .*했어` matches `왜 왔어` (codex PR #717) — and the set is empirically
-verified to match 0/9 benign phrasings and 8/8 genuine corrections. ASCII tokens
-that could appear as a substring of a longer word are boundary-anchored: the
-`I said` marker is written `(^|[^A-Za-z])I said` (with a trailing space in the
-literal) so it does not fire on `AI said it was done` (codex PR #717).
+correction proxy). Gate-8c therefore uses a dedicated `sl_strong_correction_re`.
 
-**Threat-model boundary.** `sl_strong_correction_re` is a best-effort precision
-floor, not an exhaustive enumeration of every benign phrase in every language — a
-hand-rolled correction regex has effectively unbounded corner cases. The design
-accepts that: the `>1` tolerance is the structural backstop (a single stray match
-never blocks), and the consequence of a residual false positive is only that a
-genuinely low-friction retrospect must run the READ-ONLY critic once. New benign
-false-positive reports are handled by adding the phrase to the exclusion set plus
-a regression case, not by claiming the regex is exhaustive. The `>1` tolerance
+**Low-FP narrowing — false-negative bias (issue #722).** A hard block must fire
+only on a low-false-positive signal. The first iteration of this regex still
+carried everyday-Korean conversational tokens (`그거 말고`, `그게 아니라`,
+`그거 아니야`, `내 말은`, `하라니까`, `왜 .*안 하고`, the anchored `I said` token),
+and a measurement found **7 of 10** benign non-correcting phrases matched them
+(e.g. `그거 말고도 더 있어요`, `그게 아니라 그냥 궁금했어요`,
+`하라니까 바로 했어요`). With `>1` tolerance, a quiet retrospect carrying two
+such phrases plus a correctly self-reported `not-run` would false-block. Because
+the **consequence asymmetry** favours a false-negative (a missed self-skip is
+still nudged by the prose self-incrimination layer) over a false-positive
+(blocking a clean retrospect erodes trust in the gate), the set is deliberately
+narrowed to near-unambiguous redirects: `하라고 했잖아`, `that's not what I asked`,
+`그렇게 하지 말라고`. This is **not** an exhaustive correction detector — the
+dropped conversational markers remain the prose layer's job. The kept set is
+empirically verified low-FP: **benign set 13/13 no-match, genuine corrections
+3/3 match**. A greedy `내가 말한 건 .*아니` candidate was rejected during review
+(code-reviewer #722) for matching reportive benign forms like
+`내가 말한 건 아니지만 참고해주세요`. Re-run the jq probe before adding any new
+marker — a candidate that matches a benign phrase is not added.
+
+The `>1` tolerance still
 absorbs a single stray strong marker, so
 a session with exactly one genuine correction may still legitimately mark
 `not-run` (an accepted recall gap that avoids single-marker false blocks). The
@@ -310,7 +314,7 @@ git -C ~/.claude/plugins/.../praxis apply --reverse <patch>
 
 ### Tests
 
-`tests/hooks/completion-verify/test_retrospect_mix_check.sh` covers 111 cases
+`tests/hooks/completion-verify/test_retrospect_mix_check.sh` covers 119 cases
 plus 11 synthetic regression fixtures:
 
 - 4 pass scenarios (behavior-only with rationale, escalated tool, escalated
@@ -347,12 +351,13 @@ plus 11 synthetic regression fixtures:
    ledger → pass; SL7 inline mention (no real fence) → block; SL8 Stage-4
    Actions Executed without ledger → pass (carve-out); SL27 missing
    critic_diff → block
-- 7 Gate-8c critic self-skip floor (issue #715): SL28 critic_diff not-run +
-   2 explicit corrections → block; SL29 not-run + no correction → pass;
-   SL29b not-run + exactly 1 explicit correction → pass (>1 tolerance boundary);
+- 8 Gate-8c critic self-skip floor (issue #715, narrowed #722): SL28 critic_diff
+   not-run + 2 kept-token corrections → block; SL29 not-run + no correction → pass;
+   SL29b not-run + exactly 1 kept-token correction → pass (>1 tolerance boundary);
    SL29c not-run + 2 benign EN markers (no/stop) → pass (tighter regex excludes);
    SL29d not-run + 2 benign KO imperatives (걱정하지 마세요) → pass (codex #717);
    SL29e not-run + 2 'AI said …' (anchored I-said no match) → pass (codex #717);
+   SL29f not-run + 7 dropped-token benign phrases ×2 each → pass (low-FP narrowing #722);
    SL30 critic ran (none|checked) + 2 corrections → pass
 
 ### Category counts (memory_hygiene, output_quality)

--- a/hooks/completion-verify/retrospect-mix-check/spec.md
+++ b/hooks/completion-verify/retrospect-mix-check/spec.md
@@ -314,7 +314,7 @@ git -C ~/.claude/plugins/.../praxis apply --reverse <patch>
 
 ### Tests
 
-`tests/hooks/completion-verify/test_retrospect_mix_check.sh` covers 119 cases
+`tests/hooks/completion-verify/test_retrospect_mix_check.sh` covers 121 cases
 plus 11 synthetic regression fixtures:
 
 - 4 pass scenarios (behavior-only with rationale, escalated tool, escalated
@@ -351,13 +351,15 @@ plus 11 synthetic regression fixtures:
    ledger → pass; SL7 inline mention (no real fence) → block; SL8 Stage-4
    Actions Executed without ledger → pass (carve-out); SL27 missing
    critic_diff → block
-- 8 Gate-8c critic self-skip floor (issue #715, narrowed #722): SL28 critic_diff
+- 10 Gate-8c critic self-skip floor (issue #715, narrowed #722): SL28 critic_diff
    not-run + 2 kept-token corrections → block; SL29 not-run + no correction → pass;
    SL29b not-run + exactly 1 kept-token correction → pass (>1 tolerance boundary);
    SL29c not-run + 2 benign EN markers (no/stop) → pass (tighter regex excludes);
    SL29d not-run + 2 benign KO imperatives (걱정하지 마세요) → pass (codex #717);
    SL29e not-run + 2 'AI said …' (anchored I-said no match) → pass (codex #717);
    SL29f not-run + 7 dropped-token benign phrases ×2 each → pass (low-FP narrowing #722);
+   SL29g not-run + 2 '그렇게 하지 말라고' (third kept token) → block (CodeRabbit #723);
+   SL29h not-run + exactly 1 '그렇게 하지 말라고' → pass (>1 tolerance boundary);
    SL30 critic ran (none|checked) + 2 corrections → pass
 
 ### Category counts (memory_hygiene, output_quality)

--- a/skills/retrospect/references/stage1-2-analysis.md
+++ b/skills/retrospect/references/stage1-2-analysis.md
@@ -290,10 +290,13 @@ refining self-prompts here — the leverage is the **external** signal (the
 externalized critic tier below, or the user's "you hid it?" probe), not a smarter
 self-instruction. That leverage is mechanized, not just described: **Gate-8c**
 in `retrospect-mix-check` blocks a `critic_diff: not-run` whenever the live
-transcript carries more than one *explicit* user-correction marker (a tighter
-regex than Gate-8b's, so benign `no`/`stop`/`다시` turns do not count), so the
-external tier cannot be self-skipped in exactly the case (a genuine user
-correction occurred) its predicate is satisfied. The hook cannot judge *which* failure is worst; it can
+transcript carries more than one *near-unambiguous* user-correction marker (a
+deliberately low-false-positive set — issue #722 — far tighter than Gate-8b's,
+biased toward a false-negative so a clean retrospect is never hard-blocked;
+ambiguous everyday-conversational corrections remain this prose layer's job, not
+the gate's). Within that narrowed set the external tier cannot be self-skipped in
+exactly the case (a genuine, clearly-stated user correction occurred) its
+predicate is satisfied. The hook cannot judge *which* failure is worst; it can
 and does force the external auditor to run when the transcript proves real
 user-visible friction.
 

--- a/tests/hooks/completion-verify/test_retrospect_mix_check.sh
+++ b/tests/hooks/completion-verify/test_retrospect_mix_check.sh
@@ -2055,6 +2055,26 @@ $(mk_user_turn "그거 아니야? 다시 봐도 맞는데")
 $(mk_assistant "$SL29F_TEXT")"
 run_case "SL29f_pass_critic_notrun_narrowed_benign_phrases" "pass" "$SL29F_TRANSCRIPT"
 
+# SL29g: block — the third kept token '그렇게 하지 말라고' had NO positive coverage
+# (CodeRabbit PR #723); SL28's block only jointly exercised '하라고 했잖아' +
+# "that's not what I asked". Two turns each carrying ONLY '그렇게 하지 말라고'
+# (no overlap with the other two alternations) give count=2 (> tolerance) → block,
+# so a typo or accidental drop of this alternation branch flips this case to pass.
+SL29G_TEXT="$(mk_retrospect_stage3_no_ledger "$T1_CARD" "$T1_ROW")
+${SL_LEDGER_ADVERSE_NOTRUN}"
+SL29G_TRANSCRIPT="$(mk_user_turn "그렇게 하지 말라고 했잖아")
+$(mk_user_turn "그렇게 하지 말라고 분명히 말했어")
+$(mk_assistant "$SL29G_TEXT")"
+run_case "SL29g_block_critic_notrun_third_kept_token" "block" "$SL29G_TRANSCRIPT"
+
+# SL29h: pass — boundary for '그렇게 하지 말라고'. Exactly one correction marker
+# stays within the >1 tolerance, mirroring SL29b for the third alternation branch.
+SL29H_TEXT="$(mk_retrospect_stage3_no_ledger "$T1_CARD" "$T1_ROW")
+${SL_LEDGER_ADVERSE_NOTRUN}"
+SL29H_TRANSCRIPT="$(mk_user_turn "그렇게 하지 말라고 했잖아")
+$(mk_assistant "$SL29H_TEXT")"
+run_case "SL29h_pass_critic_notrun_third_kept_token_single" "pass" "$SL29H_TRANSCRIPT"
+
 # SL30: pass — when the critic tier actually ran (critic_diff records a checked
 # result), user corrections in the transcript do not trip Gate-8c.
 SL30_TEXT="$(mk_retrospect_stage3_no_ledger "$T1_CARD" "$T1_ROW")

--- a/tests/hooks/completion-verify/test_retrospect_mix_check.sh
+++ b/tests/hooks/completion-verify/test_retrospect_mix_check.sh
@@ -1978,7 +1978,7 @@ SL_LEDGER_ADVERSE_CRITIC_RAN='<!-- retrospect:suppression_ledger begin -->
 # predicate ("user correction required") was satisfied; self-skip is concealment.
 SL28_TEXT="$(mk_retrospect_stage3_no_ledger "$T1_CARD" "$T1_ROW")
 ${SL_LEDGER_ADVERSE_NOTRUN}"
-SL28_TRANSCRIPT="$(mk_user_turn "아니 그거 말고")
+SL28_TRANSCRIPT="$(mk_user_turn "하라고 했잖아 왜 안 했어")
 $(mk_user_turn "that's not what I asked")
 $(mk_assistant "$SL28_TEXT")"
 run_case "SL28_block_critic_notrun_with_user_corrections" "block" "$SL28_TRANSCRIPT"
@@ -1996,7 +1996,7 @@ run_case "SL29_pass_critic_notrun_no_user_correction" "pass" "$SL29_TRANSCRIPT"
 # -ge off-by-one: a single genuine correction must NOT force the critic).
 SL29B_TEXT="$(mk_retrospect_stage3_no_ledger "$T1_CARD" "$T1_ROW")
 ${SL_LEDGER_ADVERSE_NOTRUN}"
-SL29B_TRANSCRIPT="$(mk_user_turn "아니 그거 말고")
+SL29B_TRANSCRIPT="$(mk_user_turn "하라고 했잖아 왜 안 했어")
 $(mk_assistant "$SL29B_TEXT")"
 run_case "SL29b_pass_critic_notrun_single_user_correction" "pass" "$SL29B_TRANSCRIPT"
 
@@ -2031,11 +2031,35 @@ $(mk_user_turn "AI said it finished the task")
 $(mk_assistant "$SL29E_TEXT")"
 run_case "SL29e_pass_critic_notrun_ai_said_not_anchored_match" "pass" "$SL29E_TRANSCRIPT"
 
+# SL29f: pass — the low-FP narrowing (issue #722). Each of the 7 everyday-Korean/
+# English phrases measured as benign false-positives under the old broad regex
+# appears TWICE here (14 user turns), so a regression on ANY single dropped token
+# would yield 2 matches (> tolerance) and flip this case to block. critic_diff is
+# not-run and none of these are genuine corrections, so the gate must NOT fire.
+SL29F_TEXT="$(mk_retrospect_stage3_no_ledger "$T1_CARD" "$T1_ROW")
+${SL_LEDGER_ADVERSE_NOTRUN}"
+SL29F_TRANSCRIPT="$(mk_user_turn "그거 말고도 더 있어요")
+$(mk_user_turn "그거 말고도 더 봐주세요")
+$(mk_user_turn "내 말은 이것도 좋다는 거예요")
+$(mk_user_turn "내 말은 그게 더 낫다는 뜻이에요")
+$(mk_user_turn "그게 아니라 그냥 궁금했어요")
+$(mk_user_turn "그게 아니라 그냥 확인차였어요")
+$(mk_user_turn "왜 빌드가 안 됐는지 보고 배포는 안 하고 넘어갔어")
+$(mk_user_turn "왜 실패했는지 보고 정리는 안 하고 끝냈어")
+$(mk_user_turn "아까 I said I would check the logs")
+$(mk_user_turn "earlier I said I would verify it")
+$(mk_user_turn "하라니까 바로 했어요")
+$(mk_user_turn "하라니까 그냥 했어요")
+$(mk_user_turn "그거 아니야? 맞는 것 같은데")
+$(mk_user_turn "그거 아니야? 다시 봐도 맞는데")
+$(mk_assistant "$SL29F_TEXT")"
+run_case "SL29f_pass_critic_notrun_narrowed_benign_phrases" "pass" "$SL29F_TRANSCRIPT"
+
 # SL30: pass — when the critic tier actually ran (critic_diff records a checked
 # result), user corrections in the transcript do not trip Gate-8c.
 SL30_TEXT="$(mk_retrospect_stage3_no_ledger "$T1_CARD" "$T1_ROW")
 ${SL_LEDGER_ADVERSE_CRITIC_RAN}"
-SL30_TRANSCRIPT="$(mk_user_turn "아니 그거 말고")
+SL30_TRANSCRIPT="$(mk_user_turn "하라고 했잖아 왜 안 했어")
 $(mk_user_turn "that's not what I asked")
 $(mk_assistant "$SL30_TEXT")"
 run_case "SL30_pass_critic_ran_with_user_corrections" "pass" "$SL30_TRANSCRIPT"


### PR DESCRIPTION
## 무엇을 / 왜

머지된 Gate-8c(PR #717)의 hard-block 정규식 `sl_strong_correction_re`가 **일상 한국어 대화 표현**을 매치했다. 사용자 질문으로 표면화 — 실측 benign 10개 중 **7개 false-match**(`그거 말고도`, `그게 아니라 그냥`, `하라니까 바로 했어요` 등). `>1` tolerance가 단일 매치는 흡수하나, 조용한 retrospect에 이런 표현 2개 + 정확한 `not-run` self-report → **false hard-block**(불필요 critic 강제 + 신뢰 침식).

## 원칙

hard-block은 **저-FP 신호**로만 발화해야 한다. **consequence asymmetry**: false hard-block(clean retrospect 차단·게이트 신뢰 침식) > false-negative(skip 1건 누락, prose self-incrimination 층이 nudge). 따라서 **false-negative로 편향** — near-unambiguous 마커로 좁힘. #715 mechanical 논지는 trustworthy case에서 유지.

## 변경 (Gate-8c만; Gate-8/8b 무변경)

- `impl.sh`: `sl_strong_correction_re` → `하라고 했잖아|that's not what I asked|그렇게 하지 말라고`. 대화체 토큰(`그거 말고`·`그게 아니라`·`내 말은`·`하라니까`·`그거 아니야`·anchored `I said`·`왜 .*안 하고`) 제거.
- `test`: SL28(block)/SL29b(boundary)/SL30 → kept 토큰; **SL29f 신설** — 7개 drop 표현을 각 2회(14 turn) 담아 단일 토큰 회귀 시 block flip(deterministic regression net).
- `spec.md` / `stage1-2-analysis.md`: low-FP narrowing + false-negative-bias 근거, case count 119 갱신.

## 검증

- retrospect-mix-check **119 cases green**, 11 fixtures pass, shellcheck rc=0, markdownlint changed-lines clean
- jq 실측: **benign 13/13 nomatch, genuine 3/3 match**(리뷰어 reportive `내가 말한 건 아니지만…` 포함 nomatch)
- 리뷰 2종: code-reviewer APPROVE(LOW 2건 수정 — greedy `내가 말한 건 .*아니` 후보 거부 + case count 갱신), codex clean

## 영향 범위 / 검증 안 한 것

Gate-8c 정규식 1줄 + 테스트/문서. Gate-8/8b·tolerance 무변경. recall↓(애매한 교정은 prose 층 담당)는 asymmetry상 의도된 trade-off. 실제 세션 교정 표현 다양성은 런타임 관측(Not-tested).

Closes #722

Pre-commit verified: 119 cases green + shellcheck rc=0 + jq benign 13/13·genuine 3/3 + markdownlint changed-lines clean + code-reviewer APPROVE + codex clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened “strong user correction” detection to a smaller, near-unambiguous phrase set to avoid misclassifying ordinary conversational text.
  * Further reduces false positives/incorrect blocking around the critic self-skip decision when transcript correction signals are absent.

* **Tests**
  * Updated existing gate scenarios with revised transcript turns.
  * Added a new regression case to confirm benign phrasing does not trigger blocking, and expanded overall coverage.

* **Documentation**
  * Updated the Gate-8c spec language to reflect the narrowed correction-phrase strategy and validation approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->