### PR TITLE
docs(release): unify version bump checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,6 +239,29 @@ To (re)generate a single release by hand, run the workflow via
 `workflow_dispatch` with the tag (e.g. `v6.2.0`). Re-running edits the
 existing release instead of duplicating it.
 
+### Pre-PR checklist (version bump)
+
+Before opening a version-bump PR, verify all three artifacts are in sync —
+missing any one of these breaks the automated release body or ships stale
+manifests silently:
+
+```bash
+# 1. VERSION and generated manifests match
+./scripts/build-plugin-manifests.py
+./scripts/check-plugin-manifests.py   # verify no drift
+
+# 2. CHANGELOG.md has a `## [X.Y.Z] - YYYY-MM-DD` section for the new
+#    version — confirm the `## [Unreleased]` entries were moved under it,
+#    not left behind
+
+# 3. The release workflow can extract that section (this is the release
+#    body's actual source, not CHANGELOG.md read informally)
+bash scripts/extract-changelog-section.sh X.Y.Z
+```
+
+If step 3 exits non-zero (exit 2 = version not found in `CHANGELOG.md`), the
+section header doesn't match `VERSION` — fix it before opening the PR.
+
 ## Testing
 
 ```bash


### PR DESCRIPTION
## 요약

`CONTRIBUTING.md`의 `## Releasing` 섹션에 버전 범프 PR을 열기 전 저자가 직접 실행하는 "Pre-PR checklist (version bump)" 소섹션을 추가했습니다.

## 배경 (Issue #707)

2026-06-25 retrospect에서 확인된 follow-up입니다. PR #706에서 patch version bump는 최종적으로 VERSION, generated manifests, CHANGELOG.md를 모두 갱신했고 CI도 통과했지만, 첫 계획은 VERSION/manifest sync 중심이었고 `scripts/extract-changelog-section.sh`가 release-note body의 SOT라는 표면은 Codex review 이후에야 보정되었습니다.

기존 `## Releasing` 섹션은 릴리스 워크플로우가 자동으로 무엇을 하는지만 설명했고, PR 저자가 머지 전에 무엇을 직접 검증해야 하는지는 명시하지 않았습니다. 이번 변경은 VERSION / generated manifests / CHANGELOG.md 세 산출물 동기화와 `extract-changelog-section.sh <version>` 실행을 하나의 체크리스트로 묶었습니다.

## 검증

- `bash scripts/extract-changelog-section.sh 7.0.0` — 현재 `VERSION`(7.0.0) 기준 CHANGELOG 섹션이 정상 추출됨 (exit 0)
- `bash scripts/run-tests.sh` (전체 스위트: pytest + shell 훅 테스트 + manifest check) — 전부 통과

```
=== summary ===
PASS: 67
FAIL: 0
PASS  [seed-14-passes]
PASS  [unexpected-skill-fails]
PASS  [removed-skill-fails]
PASS  [underscore-prefix-excluded]
PASS  [post-restore-passes]

Results: 5 pass, 0 fail

=== manifest check ===
plugin-manifest check OK

=== hook-token invariant check ===
hook-token-invariant check OK (7 invariants verified)

ALL TESTS PASSED
```

## 변경 범위

`CONTRIBUTING.md` 1개 파일, 23줄 추가 (문서 전용, 코드/훅/스크립트 변경 없음).

Closes #707

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a pre-PR checklist for version bump changes.
  * Clarified the required release-readiness checks, including verifying generated artifacts, confirming changelog updates, and validating the release workflow input.
  * Added guidance for handling version mismatch issues before opening a release-related PR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->