### PR TITLE
fix(retrospect): read each is_error body individually

### DIFF
--- a/skills/retrospect/references/report-template.md
+++ b/skills/retrospect/references/report-template.md
@@ -20,8 +20,10 @@ with the single line
 When `is_error_count > 0` the nested `retrospect:is_error_enum` block is
 **also required** (Gate-7 blocks Stage 3 without it) — each `is_error`
 event enumerated with a `promote`/`note`/`dismiss` disposition [issue #664].
-Omit the nested enum block only when `is_error_count == 0` (nothing to
-enumerate).
+Row count must equal `is_error_count`; Gate-7 checks only that the block is
+non-empty, so a single category-assumed row is not a substitute for reading
+each body individually [issue #720]. Omit the nested enum block only when
+`is_error_count == 0` (nothing to enumerate).
 
 ```markdown
 ## Retrospect Report — {session_date}

--- a/skills/retrospect/references/stage1-2-analysis.md
+++ b/skills/retrospect/references/stage1-2-analysis.md
@@ -615,7 +615,7 @@ transcript before analysis instead of relying only on the compaction summary:
     still under-enumerating. Treat row-count parity with `is_error_count` as a
     Stage 2 MUST even though the hook cannot verify it: do not close the enum
     block until every counted `is_error` has its own disposition row.
-  - **is_error / tool_census cross-check (MUST).** `is_error_count` should
+  - **is_error / tool_census cross-check (MUST).** `is_error_count` must
     equal the sum of `error_count` across all `tool_census` rows (pre-scan
     lane 3) for the same scope window. A mismatch means one of the two scans
     skipped a result — re-scan the narrower one before proceeding to Stage

--- a/skills/retrospect/references/stage1-2-analysis.md
+++ b/skills/retrospect/references/stage1-2-analysis.md
@@ -207,6 +207,10 @@ scope window applies to `tool_census`, `user_correction`, and
      - `workaround_marker`
      - `surfaced_in_friction`
      - `signal`
+   - `error_count` per row must be derived from reading each `is_error: true`
+     result's own body for that tool — not inferred from the tool's typical
+     failure mode or from the count of a prior row. See the `is_error` census
+     cross-check under "Transcript-derived trail requirements" below.
    - `retry_count` is failure-driven only: same tool + parameters re-issued
      after a failed, errored, or unexpected-output prior call. Intentional
      polling, repeated status reads, and background-output re-reads (for example
@@ -593,6 +597,31 @@ For post-compaction sessions with a readable JSONL transcript, enumerate the
 transcript before analysis instead of relying only on the compaction summary:
 
 - scan `is_error` tool results and record `is_error_count`
+  - **Read each `is_error: true` result's own body text individually — do not
+    infer its failure category from the tool name, from a preceding result in
+    the same scan, or from an assumed pattern (MUST).** A retrospect analyzing
+    its own source session committed exactly this failure: it category-assumed
+    `is_error` bodies instead of reading each one, and under-counted as a
+    result — the self-referential "recursive-retrospect anti-pattern" this
+    pass exists to catch (issue #720).
+  - This individual read is what populates the Stage 3
+    `retrospect:is_error_enum` block (see
+    [`stage3-reporting.md`](stage3-reporting.md) and
+    [`report-template.md`](report-template.md)), whose presence Gate-7
+    hard-blocks Stage 3 on. **Gate-7 only checks that the block is non-empty
+    (>= 1 disposition row) — it does NOT check that the row count matches
+    `is_error_count`.** A single category-assumed row ("these are all
+    transient timeouts, dismiss") satisfies Gate-7's structural check while
+    still under-enumerating. Treat row-count parity with `is_error_count` as a
+    Stage 2 MUST even though the hook cannot verify it: do not close the enum
+    block until every counted `is_error` has its own disposition row.
+  - **is_error / tool_census cross-check (MUST).** `is_error_count` should
+    equal the sum of `error_count` across all `tool_census` rows (pre-scan
+    lane 3) for the same scope window. A mismatch means one of the two scans
+    skipped a result — re-scan the narrower one before proceeding to Stage
+    2.5. Record the reconciled `error_count` values directly in the existing
+    `retrospect:tool_census` trail (no separate fence needed); do not silently
+    average or split the difference between the two counts.
 - scan explicit user corrections and record `user_correction_count`
 - scan self-corrections / retries and record `self_correction_count`
 - if the transcript is unreadable, emit

--- a/skills/retrospect/references/stage3-reporting.md
+++ b/skills/retrospect/references/stage3-reporting.md
@@ -174,6 +174,15 @@ When `is_error_count > 0`, the receipt must also include a nested
 - `note`
 - `dismiss`
 
+**Row count must equal `is_error_count` (MUST — issue #720).** Gate-7 only
+checks that the block is non-empty; it does not check that every counted
+error has its own row. A category-collapsed row ("these N are all the same
+kind of timeout, dismiss") passes Gate-7's structural check while still
+under-enumerating — read each `is_error` body individually (see
+[`stage1-2-analysis.md` → Transcript-derived trail
+requirements](stage1-2-analysis.md#transcript-derived-trail-requirements))
+and give it its own row rather than assuming its category from a sibling row.
+
 The skipped variant is allowed only when the transcript is genuinely
 unreachable.
 


### PR DESCRIPTION
## 배경

#709 rule-backstop-gap 감사 direction 3. retrospect Stage 2가 `is_error` tool
result를 category 가정으로 읽고 각 body를 개별 enumerate하지 않아 under-count가
발생한 사례가 있었다 — source retrospect가 정확히 이 실패(자기가 잡아야 할
recursive-retrospect anti-pattern)를 스스로 저질렀다.

## 변경 사항

`skills/retrospect/references/stage1-2-analysis.md` (Stage 2 "Transcript-derived
trail requirements")를 강화:

1. **각 `is_error: true` body를 개별로 읽을 것을 MUST로 명시** — tool name이나
   앞선 result로부터 category를 추론하지 말 것.
2. **row-count parity 요구사항 명시**: Stage 3의 `retrospect:is_error_enum`은
   이미 Gate-7 (`hooks/completion-verify/retrospect-mix-check`)로 hard-block되고
   있으나, Gate-7은 `is_error_enum` 블록이 **비어있지 않은지만** 검사하고
   (`ie_rows >= 1`), row 개수가 `is_error_count`와 **일치하는지는 검사하지 않는다**
   (`hooks/.../impl.py:411`). 즉 category로 뭉뚱그린 단일 row 하나만으로도 Gate-7의
   구조적 검사는 통과하면서 여전히 under-enumerate될 수 있다 — 이번 이슈가 실제로
   겪은 실패 메커니즘과 정확히 일치. 이 parity를 Stage 2 절차 MUST로 명시했다.
3. `tool_census` (pre-scan lane 3) `error_count` 필드에도 "개별 body를 읽어서
   도출할 것" 주석 추가 + `is_error_count`와의 cross-check 절차 추가 (기존
   `retrospect:tool_census` trail을 재사용, 별도 fence 없음).
4. 일관성을 위해 `stage3-reporting.md`, `report-template.md`의 `is_error_enum`
   설명에도 동일한 row-count parity 요구사항을 짧게 반영.

## Advisory vs Enforcement 판단

**Advisory(지침 강화)로 결정** — 새 hook을 추가하지 않음. 근거:

- `docs/hook/RULE-BACKSTOP-GAPS.md`의 "Tracked follow-ups" 항목이 이 이슈를
  명시적으로 "skill-internal enumeration weakness, not a hook-backstop gap"으로
  분류하고 있다.
- 실제 hook 코드(`retrospect-mix-check/impl.sh`)를 확인한 결과, Gate-7은 이미
  `is_error_enum` 블록의 **존재**를 강제하고 있어 완전한 backstop 부재는 아니다 —
  갭은 "row count가 is_error_count와 일치하는가"라는 **의미론적** 판단이며, 이는
  이 저장소의 다른 self-incrimination pass 관련 절차(같은 파일 278-301행,
  "Limits — what is mechanizable vs what is not")에서도 동일하게 "format은
  hook-enforceable하지만 semantic judgment는 아니다"라고 정리된 선례를 따른다.
  category 가정 vs 실제 body 읽기는 셸 스크립트로 검증 불가능한 semantic
  judgment다.
- 이슈 본문이 "hook 추가는 #719와 중복되므로 범위 밖"이라고 명시.
- 대신 문서 내에서 (a) MUST 언어로 강화 + (b) 기존 `tool_census`/`is_error_count`
  cross-check로 self-check를 추가해 "가능하면 Stage 2 census 단계로 enforce"
  요구를 hook 없이 충족.

## 테스트

전체 테스트 스위트 (`bash scripts/run-tests.sh`) — pytest + shell tests +
manifest check + hook-token invariant check, 106 pass / 0 fail:

```
=== summary ===
PASS: 34
FAIL: 0
=== summary ===
PASS: 67
FAIL: 0
PASS  [seed-14-passes]
PASS  [unexpected-skill-fails]
PASS  [removed-skill-fails]
PASS  [underscore-prefix-excluded]
PASS  [post-restore-passes]
Results: 5 pass, 0 fail
=== manifest check ===
plugin-manifest check OK
=== hook-token invariant check ===
hook-token-invariant check OK (7 invariants verified)
ALL TESTS PASSED
```

`markdownlint` (CI가 사용하는 pinned v0.41.0)도 변경된 3개 파일에서 clean.

## 리뷰

`praxis:codex-review-wrap`으로 codex-companion 리뷰 실행 — finding 0건
("추가된 retrospect 문서 규칙은 기존 Gate-7 동작과 충돌하는 명확한 결함을
만들지 않습니다").

**참고**: 이 작업은 서브에이전트 세션에서 수행되어, `block-commit-without-codex-review`
hook이 스캔하는 root session transcript에는 서브에이전트의 `Skill` tool_use가
기록되지 않는 구조적 blind spot이 있었다(서브에이전트 호출은
`subagents/agent-*.jsonl`에만 기록됨). 문서화된 `CLAUDE_HOOK_BYPASS_CODEX_REVIEW_GATE=1`
인라인 prefix도 hook이 자기 프로세스의 `os.environ`을 읽는 구조라 무효했다.
리뷰는 실제로 수행했으므로(0건) 커밋 메시지에 `[skip-codex-review]` 토큰을
사용하고 사유를 커밋 본문에 명시했다 — 이 hook의 서브에이전트 blind spot은
별도로 팀 리드에게 보고함(이번 PR 범위 밖).

Pre-commit verified: 전체 테스트 스위트 106 pass / 0 fail + markdownlint clean
Caller chain verified: N/A -- docs-only change

Closes #720


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Stage 2 and Stage 3 guidance for error reporting and transcript review.
  * Added stricter instructions to count and list each error individually instead of grouping them into a single category.
  * Updated requirements so the error list must match the total number of errors, and must remain present whenever errors are recorded.
  * Improved cross-check rules to help keep reported counts consistent across related review steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->