### PR TITLE
feat(telemetry): fire-rate remaining metrics

### DIFF
--- a/skills/bypass-review/bypass-review
+++ b/skills/bypass-review/bypass-review
@@ -8,6 +8,9 @@ human review.
 Phase 2 of issue #456 (Phase 1 = hook that writes the log; Phase 3 = HTTP
 forwarding, deferred).
 Issue #689: per-hook aggregation view + tool-error co-occurrence.
+Issue #710 (remaining scope): fire-rate mode gains advise_ignored_rate,
+bypass_count (joined against bypass-events), and a best-effort outcome-proxy
+section (strike counts only — see OUTCOME PROXY LIMITATIONS below).
 
 Usage:
   bypass-review [OPTIONS]
@@ -21,7 +24,27 @@ Options:
                          (e.g. --per-hook SCIOMC_GATE).  Family names are
                          normalized bypass var suffixes — see Section 3 output
                          for the list of families in the current window.
+  --state-dir PATH       fire-rate mode only: override the strike-state
+                         directory used for the outcome-proxy section
+                         (default: $PRAXIS_STATE_DIR/strikes or
+                         ~/.praxis/state/strikes)
   -h, --help             Show this message and exit
+
+OUTCOME PROXY LIMITATIONS (issue #710 item 3, fire-rate mode):
+  Only strike_count is computed — read from the per-session state JSON
+  written by hooks/completion-verify/strike-counter/impl.sh
+  ($STATE_DIR/<session_id>.json, field `count`). Three items from the
+  original issue text are NOT implemented because no telemetry source
+  currently records them:
+    - external-write revert     (no revert/undo event is logged anywhere)
+    - re-clarification loop     (requires transcript-level turn analysis,
+                                  out of scope for this JSONL ledger)
+    - rework commits            (requires git-log correlation per session,
+                                  not present in fire-events/bypass-events)
+  Strike state itself is a lower bound: the strike-counter TTL-deletes state
+  after 7 days and `/praxis:reset-strikes` deletes it immediately on reset,
+  so a session's true historical strike count may already be gone by the
+  time this report runs.
 
 Output sections:
   1. Summary — total events + date window
@@ -51,6 +74,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import shlex
 import sys
@@ -158,6 +182,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "Show detailed per-event breakdown for one hook/rule family "
             "(e.g. SCIOMC_GATE). Family names are the normalized suffixes "
             "shown in the Per-Hook Aggregation section."
+        ),
+    )
+    parser.add_argument(
+        "--state-dir",
+        dest="state_dir",
+        default=None,
+        metavar="PATH",
+        help=(
+            "fire-rate mode only: override the strike-state directory used "
+            "for the outcome-proxy section (default: "
+            "$PRAXIS_STATE_DIR/strikes or ~/.praxis/state/strikes)"
         ),
     )
     return parser.parse_args(argv)
@@ -741,6 +776,289 @@ def aggregate_fires(events: list[dict]) -> dict[str, dict]:
     return by_hook
 
 
+# ---------------------------------------------------------------------------
+# advise_ignored_rate (issue #710 remaining scope)
+#
+# Definition: for hook H, an "advise" fire in session S is a candidate. Its
+# outcome is the NEXT fire-event for that SAME hook in that SAME session
+# (fire-events only carry hook/session/tool/decision/timestamp — there is no
+# tool_input/command field to diff literal content against, so "did the next
+# tool call change" is approximated by "did this hook's own next evaluation
+# recur identically"). Only a next decision of "advise" again counts as
+# ignored — the same condition fired again unchanged, i.e. the user's next
+# tool call did not address what was flagged. A next decision of "pass"
+# means the hook no longer flags anything (the call changed enough to
+# satisfy it — heeded, NOT ignored). A next decision of block/ask means the
+# hook's own verdict escalated (also NOT "unchanged" — a different outcome).
+# Advise fires with no subsequent same-hook fire in the session are
+# right-censored (outcome unobservable) and excluded from the "observed"
+# denominator, not silently counted either way.
+# ---------------------------------------------------------------------------
+
+def compute_advise_ignored(fire_events: list[dict]) -> dict[str, dict]:
+    """Return dict[hook] -> {advise_fires, observed, ignored, rate}.
+
+    `rate` is `ignored / observed`, or None when `observed == 0`.
+    """
+    by_session_hook: dict[tuple[str, str], list[dict]] = {}
+    for ev in fire_events:
+        hook = ev.get(F_FIRE_HOOK)
+        sid = ev.get(F_FIRE_SESSION)
+        if not (isinstance(hook, str) and hook and isinstance(sid, str) and sid):
+            continue
+        by_session_hook.setdefault((sid, hook), []).append(ev)
+
+    result: dict[str, dict] = {}
+    for (_sid, hook), evs in by_session_hook.items():
+        evs.sort(key=lambda e: e.get(F_FIRE_TIMESTAMP) or "")
+        row = result.setdefault(
+            hook, {"advise_fires": 0, "observed": 0, "ignored": 0}
+        )
+        for i, ev in enumerate(evs):
+            if ev.get(F_FIRE_DECISION) != "advise":
+                continue
+            row["advise_fires"] += 1
+            nxt = evs[i + 1] if i + 1 < len(evs) else None
+            if nxt is None:
+                continue  # right-censored: no later same-hook fire to compare
+            row["observed"] += 1
+            if nxt.get(F_FIRE_DECISION) == "advise":
+                row["ignored"] += 1  # same condition recurred unchanged
+
+    for row in result.values():
+        row["rate"] = (row["ignored"] / row["observed"]) if row["observed"] else None
+    return result
+
+
+# ---------------------------------------------------------------------------
+# bypass_count (issue #710 remaining scope)
+#
+# Primary path: hooks/manifest.json declares an authoritative `mode.bypass_env`
+# list on some hook entries (verified: 22/64 hooks in the current manifest,
+# zero vars mapping to more than one hook) — e.g.
+# block-gh-issue-create-without-dup-search declares
+# mode.bypass_env == ["CLAUDE_HOOK_BYPASS_DUP_GATE"]. When a bypass event's
+# var name is an exact hit in this map, attribution is exact — no heuristic
+# involved.
+#
+# Fallback path: for bypass vars the manifest does NOT declare (most hooks
+# manage their own bypass env ad hoc, without a manifest `mode.bypass_env`
+# entry), fall back to a heuristic joined on session_id (exact) + hook name
+# (bypass var family tokens must be a SUBSET of the hook's kebab-case tokens,
+# e.g. family "PROTECTED_PATHS" <= hook "protected-paths-guard") + timestamp
+# (nearest, to break ties when more than one hook in the session matches the
+# family token-subset). This is best-effort, NOT a stored mapping, and a
+# family that shares no tokens with any fired hook's name falls into the
+# "(unattributed)" bucket rather than being silently mis-attributed.
+# ---------------------------------------------------------------------------
+
+def bypass_env_exact_map(manifest_path: Path) -> dict[str, str]:
+    """Return dict[bypass_env_var] -> hook_name from manifest `mode.bypass_env`.
+
+    Authoritative when present. A var declared on more than one hook (not
+    observed in the current manifest, but a manifest edit could introduce it)
+    is ambiguous and excluded here, falling through to the token heuristic.
+    """
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    raw: dict[str, list[str]] = {}
+    for hook in manifest.get("hooks", []):
+        if not isinstance(hook, dict):
+            continue
+        name = hook.get("name")
+        mode = hook.get("mode")
+        if not (isinstance(name, str) and name and isinstance(mode, dict)):
+            continue
+        bypass_env = mode.get("bypass_env")
+        if not isinstance(bypass_env, list):
+            continue
+        for var in bypass_env:
+            if isinstance(var, str) and var:
+                raw.setdefault(var, []).append(name)
+    return {var: hooks[0] for var, hooks in raw.items() if len(hooks) == 1}
+
+def _parse_fire_ts(raw: object) -> datetime | None:
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+def _hook_tokens(hook_name: str) -> set[str]:
+    return {t for t in hook_name.split("-") if t}
+
+
+def _family_tokens(family: str) -> set[str]:
+    return {t.lower() for t in family.split("_") if t}
+
+
+def match_family_to_hooks(family: str, hook_names: set[str]) -> set[str]:
+    """Return the subset of `hook_names` whose tokens fully cover `family`."""
+    ftoks = _family_tokens(family)
+    if not ftoks:
+        return set()
+    return {h for h in hook_names if ftoks <= _hook_tokens(h)}
+
+
+def _hooks_fired_in_session(fire_events: list[dict]) -> dict[str, set[str]]:
+    by_session: dict[str, set[str]] = {}
+    for ev in fire_events:
+        sid = ev.get(F_FIRE_SESSION)
+        hook = ev.get(F_FIRE_HOOK)
+        if isinstance(sid, str) and sid and isinstance(hook, str) and hook:
+            by_session.setdefault(sid, set()).add(hook)
+    return by_session
+
+
+def _hook_session_timestamps(
+    fire_events: list[dict],
+) -> dict[tuple[str, str], list[datetime]]:
+    out: dict[tuple[str, str], list[datetime]] = {}
+    for ev in fire_events:
+        sid = ev.get(F_FIRE_SESSION)
+        hook = ev.get(F_FIRE_HOOK)
+        ts = _parse_fire_ts(ev.get(F_FIRE_TIMESTAMP))
+        if isinstance(sid, str) and sid and isinstance(hook, str) and hook and ts:
+            out.setdefault((sid, hook), []).append(ts)
+    return out
+
+
+def _nearest_hook_by_timestamp(
+    candidates: set[str],
+    session_id: str,
+    bypass_ts: datetime,
+    hook_ts_index: dict[tuple[str, str], list[datetime]],
+) -> str | None:
+    best_hook: str | None = None
+    best_delta: float | None = None
+    for hook in candidates:
+        for ts in hook_ts_index.get((session_id, hook), []):
+            delta = abs((ts - bypass_ts).total_seconds())
+            if best_delta is None or delta < best_delta:
+                best_delta = delta
+                best_hook = hook
+    return best_hook
+
+
+UNATTRIBUTED = "(unattributed)"
+
+
+def join_bypass_to_hooks(
+    fire_events: list[dict],
+    bypass_events: list[dict],
+    exact_map: dict[str, str] | None = None,
+) -> dict[str, dict]:
+    """Return dict[hook] -> {bypass_count, sessions}; UNATTRIBUTED bucket for
+    bypass vars that neither `exact_map` nor the family-token heuristic can
+    resolve to one hook.
+
+    `exact_map` (see `bypass_env_exact_map`) is checked first — when a var is
+    a manifest-declared bypass_env for a hook, that hook is attributed
+    directly, without regard to whether it also fired in this session (the
+    manifest is the source of truth for hook identity; requiring session
+    co-occurrence on top of an exact match would only produce false
+    negatives). Vars absent from `exact_map` fall through to the session-
+    scoped family-token heuristic.
+    """
+    session_hooks = _hooks_fired_in_session(fire_events)
+    hook_ts_index = _hook_session_timestamps(fire_events)
+    exact_map = exact_map or {}
+    result: dict[str, dict] = {}
+
+    def _bump(target: str, sid: str) -> None:
+        row = result.setdefault(target, {"bypass_count": 0, "sessions": set()})
+        row["bypass_count"] += 1
+        if sid:
+            row["sessions"].add(sid)
+
+    for ev in bypass_events:
+        sid = ev.get(FIELD_SESSION_ID)
+        if not isinstance(sid, str) or not sid:
+            continue
+        bypass_vars = _coerce_bypass_vars(ev.get(FIELD_BYPASS_ENV_VARS))
+        if not bypass_vars:
+            continue
+        ts = _parse_fire_ts(ev.get(FIELD_TIMESTAMP))
+        hooks_in_session = session_hooks.get(sid) or set()
+
+        for var in bypass_vars:
+            exact_hook = exact_map.get(var)
+            if exact_hook:
+                _bump(exact_hook, sid)
+                continue
+
+            family = derive_bypass_family(var)
+            candidates = match_family_to_hooks(family, hooks_in_session)
+            if len(candidates) == 1:
+                _bump(next(iter(candidates)), sid)
+            elif len(candidates) > 1 and ts is not None:
+                nearest = _nearest_hook_by_timestamp(candidates, sid, ts, hook_ts_index)
+                _bump(nearest if nearest else UNATTRIBUTED, sid)
+            else:
+                _bump(UNATTRIBUTED, sid)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# outcome-proxy (issue #710 item 3, best-effort — see module docstring
+# "OUTCOME PROXY LIMITATIONS" for why only strike_count is implemented)
+# ---------------------------------------------------------------------------
+
+def default_strike_state_dir() -> Path:
+    """Mirror hooks/completion-verify/strike-counter/impl.sh's STATE_DIR resolution."""
+    override = os.environ.get("PRAXIS_STATE_DIR", "").strip()
+    if override:
+        return Path(override) / "strikes"
+    home_override = os.environ.get("PRAXIS_HOME", "").strip()
+    base = Path(home_override) if home_override else Path.home() / ".praxis"
+    return base / "state" / "strikes"
+
+
+def load_strike_state(state_dir: Path, session_id: str) -> dict | None:
+    """Read `<state_dir>/<session_id>.json`; None if absent/unreadable/malformed."""
+    path = state_dir / f"{session_id}.json"
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    count = data.get("count")
+    reasons = data.get("reasons")
+    return {
+        "count": count if isinstance(count, int) else 0,
+        "reasons": reasons if isinstance(reasons, list) else [],
+    }
+
+
+def compute_outcome_proxy(fire_events: list[dict], state_dir: Path) -> dict[str, dict]:
+    """Return dict[session_id] -> {strike_count, strike_state_available}.
+
+    Only covers sessions that appear in the fire-events window. Sessions
+    whose strike state already expired (7-day TTL) or was reset show
+    strike_state_available=False, strike_count=0 — NOT proof of zero strikes.
+    """
+    sessions = sorted({
+        ev.get(F_FIRE_SESSION) for ev in fire_events
+        if isinstance(ev.get(F_FIRE_SESSION), str) and ev.get(F_FIRE_SESSION)
+    })
+    result: dict[str, dict] = {}
+    for sid in sessions:
+        state = load_strike_state(state_dir, sid)
+        result[sid] = {
+            "strike_count": state["count"] if state else 0,
+            "strike_state_available": state is not None,
+        }
+    return result
+
+
 def default_manifest_path() -> Path:
     """hooks/manifest.json resolved relative to this CLI's real (de-symlinked) path."""
     # __file__ is symlinked from ~/.local/bin into the repo's skills/bypass-review/.
@@ -815,11 +1133,111 @@ def bash_group_roster(manifest_path: Path) -> set[str] | None:
         return None
 
 
+def _render_advise_ignored_section(lines: list[str], advise_ignored: dict[str, dict]) -> None:
+    lines.append(_render_header("Advise-Ignored Detail (issue #710)"))
+    rows = {h: r for h, r in advise_ignored.items() if r["advise_fires"] > 0}
+    if not rows:
+        lines.append("  (no advise-decision fires in this window)")
+        return
+    col = 34
+    lines.append(
+        f"  {'Hook':<{col}}  {'Advise':>6}  {'Observed':>8}  {'Ignored':>7}  {'Rate':>5}"
+    )
+    lines.append(
+        f"  {'─' * col}  {'─' * 6}  {'─' * 8}  {'─' * 7}  {'─' * 5}"
+    )
+    for hook in sorted(rows, key=lambda h: rows[h]["advise_fires"], reverse=True):
+        r = rows[hook]
+        rate = f"{100 * r['rate']:.0f}%" if r["rate"] is not None else "n/a"
+        lines.append(
+            f"  {hook:<{col}}  {r['advise_fires']:>6}  {r['observed']:>8}  "
+            f"{r['ignored']:>7}  {rate:>5}"
+        )
+    lines.append("")
+    lines.append(
+        "  Observed = advise fires that had a LATER same-hook fire in the same\n"
+        "  session to compare against (right-censored fires excluded — no way to\n"
+        "  tell if the last advise of a session was heeded). Ignored = that later\n"
+        "  fire was 'advise' again — the same condition recurred unchanged. A\n"
+        "  later 'pass' means the hook stopped flagging (heeded, NOT ignored);\n"
+        "  a later block/ask means the verdict escalated (also NOT ignored — a\n"
+        "  different outcome, not a recurrence). Rate = ignored / observed. This\n"
+        "  approximates 'did the flagged pattern recur' via the hook's own\n"
+        "  re-evaluation, not a literal command diff (fire-events carry no\n"
+        "  tool_input field)."
+    )
+
+
+def _render_bypass_attribution_section(
+    lines: list[str], bypass_join: dict[str, dict]
+) -> None:
+    lines.append(_render_header("Bypass Attribution (issue #710)"))
+    if not bypass_join:
+        lines.append("  (no bypass events joined to this window's fired hooks)")
+        return
+    col = 34
+    lines.append(f"  {'Hook':<{col}}  {'Bypasses':>8}  {'Sessions':>8}")
+    lines.append(f"  {'─' * col}  {'─' * 8}  {'─' * 8}")
+    attributed = {h: r for h, r in bypass_join.items() if h != UNATTRIBUTED}
+    for hook in sorted(attributed, key=lambda h: attributed[h]["bypass_count"], reverse=True):
+        r = attributed[hook]
+        lines.append(f"  {hook:<{col}}  {r['bypass_count']:>8}  {len(r['sessions']):>8}")
+    unattr = bypass_join.get(UNATTRIBUTED)
+    if unattr:
+        lines.append(f"  {UNATTRIBUTED:<{col}}  {unattr['bypass_count']:>8}  {len(unattr['sessions']):>8}")
+    lines.append("")
+    lines.append(
+        "  Attribution priority: (1) exact — manifest `mode.bypass_env` declares\n"
+        "  this var for one hook; (2) fallback heuristic — session_id (exact) +\n"
+        "  hook name (bypass var family tokens must subset the hook's kebab-case\n"
+        "  tokens) + timestamp (nearest, to break ties when >1 hook in the\n"
+        "  session matches). '(unattributed)' = bypass events whose var is not\n"
+        "  manifest-declared AND whose family matched zero or >1 ambiguous\n"
+        "  fired hooks — NOT dropped, still counted, just not attributable to a\n"
+        "  specific hook row above."
+    )
+
+
+def _render_outcome_proxy_section(lines: list[str], outcome_proxy: dict[str, dict]) -> None:
+    lines.append(_render_header("Outcome Proxy — Best Effort (issue #710 item 3)"))
+    if not outcome_proxy:
+        lines.append("  (no sessions in this window)")
+        return
+    with_strikes = {
+        sid: r for sid, r in outcome_proxy.items() if r["strike_count"] > 0
+    }
+    available = sum(1 for r in outcome_proxy.values() if r["strike_state_available"])
+    lines.append(
+        f"  Sessions in window : {len(outcome_proxy)}  "
+        f"(strike state available for {available})"
+    )
+    lines.append(f"  Sessions with strikes : {len(with_strikes)}")
+    if with_strikes:
+        lines.append("")
+        col = 40
+        lines.append(f"  {'Session':<{col}}  {'Strikes':>7}")
+        lines.append(f"  {'─' * col}  {'─' * 7}")
+        for sid in sorted(with_strikes, key=lambda s: with_strikes[s]["strike_count"], reverse=True):
+            lines.append(f"  {sid:<{col}}  {with_strikes[sid]['strike_count']:>7}")
+    lines.append("")
+    lines.append(
+        "  ONLY strike_count is implemented. external-write-revert,\n"
+        "  re-clarification-loop, and rework-commit signals are NOT computed —\n"
+        "  no telemetry source records them yet (see module docstring\n"
+        "  'OUTCOME PROXY LIMITATIONS'). strike_count itself is a lower bound:\n"
+        "  state is TTL-deleted after 7 days and cleared on /praxis:reset-strikes,\n"
+        "  so a session showing 0 may have had strikes that already expired."
+    )
+
+
 def render_fire_report(
     by_hook: dict[str, dict],
     days: int,
     telemetry_dir: Path,
     roster: tuple[set[str], set[str]] | None,
+    advise_ignored: dict[str, dict] | None = None,
+    bypass_join: dict[str, dict] | None = None,
+    outcome_proxy: dict[str, dict] | None = None,
 ) -> str:
     lines: list[str] = []
     today = datetime.now(tz=timezone.utc).date()
@@ -867,6 +1285,11 @@ def render_fire_report(
         "     also fold into Pass; session id is absent. A coarse 'Fires' count\n"
         "     ≈ how often the hook's matcher matched, not how often it engaged."
     )
+
+    # ── issue #710 remaining scope: advise_ignored_rate / bypass_count / outcome-proxy ──
+    _render_advise_ignored_section(lines, advise_ignored or {})
+    _render_bypass_attribution_section(lines, bypass_join or {})
+    _render_outcome_proxy_section(lines, outcome_proxy or {})
 
     # ── Never-fired set (instrumentable roster only) ──
     lines.append(_render_header("Never Fired (instrumentable roster − hooks above)"))
@@ -919,7 +1342,24 @@ def run_fire_rate(args: argparse.Namespace, telemetry_dir: Path) -> int:
         Path(args.manifest_path) if args.manifest_path else default_manifest_path()
     )
     roster = roster_split(manifest_path)
-    print(render_fire_report(by_hook, args.days, telemetry_dir, roster))
+
+    # issue #710 remaining scope: bypass_count joins fire-events against the
+    # SAME telemetry_dir's bypass-events-*.jsonl files (both are written to
+    # ~/.praxis/telemetry by default — see hooks/_lib/_fire_ledger.py and
+    # hooks/postuse-correction/bypass-telemetry/impl.py resolve_*_path()).
+    bypass_events = load_events(telemetry_dir, args.days)
+    advise_ignored = compute_advise_ignored(events)
+    exact_map = bypass_env_exact_map(manifest_path)
+    bypass_join = join_bypass_to_hooks(events, bypass_events, exact_map=exact_map)
+    state_dir = Path(args.state_dir) if args.state_dir else default_strike_state_dir()
+    outcome_proxy = compute_outcome_proxy(events, state_dir)
+
+    print(render_fire_report(
+        by_hook, args.days, telemetry_dir, roster,
+        advise_ignored=advise_ignored,
+        bypass_join=bypass_join,
+        outcome_proxy=outcome_proxy,
+    ))
     return 0
 
 

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -397,3 +397,325 @@ def test_aggregate_marks_coarse_hooks():
     agg = cli.aggregate_fires(events)
     assert agg["c"]["coarse"] is True
     assert agg["r"]["coarse"] is False
+
+
+# ---------------------------------------------------------------------------
+# issue #710 remaining scope: advise_ignored_rate
+# ---------------------------------------------------------------------------
+
+def test_advise_ignored_counts_recurrence_without_escalation():
+    """advise@0's next fire is advise@10 (ignored); advise@10's next fire is
+    block@20 (escalated, not ignored) -> observed=2, ignored=1, rate=0.5."""
+    events = [
+        {"hook": "h", "session_id": "s1", "decision": "advise", "timestamp": "2026-06-26T00:00:00+00:00"},
+        {"hook": "h", "session_id": "s1", "decision": "advise", "timestamp": "2026-06-26T00:00:10+00:00"},
+        {"hook": "h", "session_id": "s1", "decision": "block", "timestamp": "2026-06-26T00:00:20+00:00"},
+    ]
+    result = cli.compute_advise_ignored(events)
+    row = result["h"]
+    assert row["advise_fires"] == 2
+    assert row["observed"] == 2
+    assert row["ignored"] == 1
+    assert row["rate"] == 0.5
+
+
+def test_advise_ignored_escalation_to_block_is_not_ignored():
+    events = [
+        {"hook": "h", "session_id": "s1", "decision": "advise", "timestamp": "2026-06-26T00:00:00+00:00"},
+        {"hook": "h", "session_id": "s1", "decision": "block", "timestamp": "2026-06-26T00:00:10+00:00"},
+    ]
+    result = cli.compute_advise_ignored(events)
+    row = result["h"]
+    assert row["observed"] == 1
+    assert row["ignored"] == 0
+    assert row["rate"] == 0.0
+
+
+def test_advise_ignored_last_fire_in_session_is_right_censored():
+    """A trailing advise with no follow-up in the session is excluded from
+    the observed denominator — it must not be silently counted either way."""
+    events = [
+        {"hook": "h", "session_id": "s1", "decision": "advise", "timestamp": "2026-06-26T00:00:00+00:00"},
+    ]
+    result = cli.compute_advise_ignored(events)
+    row = result["h"]
+    assert row["advise_fires"] == 1
+    assert row["observed"] == 0
+    assert row["ignored"] == 0
+    assert row["rate"] is None
+
+
+def test_advise_ignored_scoped_per_session_not_cross_session():
+    """The 'next fire' lookup must not cross session boundaries — a fire in
+    session s2 must never resolve session s1's advise outcome."""
+    events = [
+        {"hook": "h", "session_id": "s1", "decision": "advise", "timestamp": "2026-06-26T00:00:00+00:00"},
+        {"hook": "h", "session_id": "s2", "decision": "block", "timestamp": "2026-06-26T00:00:05+00:00"},
+    ]
+    result = cli.compute_advise_ignored(events)
+    row = result["h"]
+    assert row["observed"] == 0  # s1's lone advise has no same-session follow-up
+    assert row["rate"] is None
+
+
+def test_advise_ignored_pass_after_advise_is_heeded_not_ignored():
+    """A 'pass' after 'advise' means the hook stopped flagging — the call
+    changed enough to satisfy it. Must NOT be counted as ignored (codex
+    review finding, praxis PR): counting pass as ignored inflates the rate
+    on the exact case the metric exists to distinguish from real recurrence."""
+    events = [
+        {"hook": "h", "session_id": "s1", "decision": "advise", "timestamp": "2026-06-26T00:00:00+00:00"},
+        {"hook": "h", "session_id": "s1", "decision": "pass", "timestamp": "2026-06-26T00:00:10+00:00"},
+    ]
+    result = cli.compute_advise_ignored(events)
+    row = result["h"]
+    assert row["observed"] == 1
+    assert row["ignored"] == 0
+    assert row["rate"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# issue #710 remaining scope: bypass_count join
+# ---------------------------------------------------------------------------
+
+def test_join_bypass_to_hooks_unique_family_match():
+    fire_events = [
+        {"hook": "protected-paths-guard", "session_id": "s1", "timestamp": "2026-06-26T00:00:00+00:00"},
+    ]
+    bypass_events = [
+        {"session_id": "s1", "timestamp": "2026-06-26T00:00:05+00:00",
+         "bypass_env_vars": ["PRAXIS_HOOK_BYPASS_PROTECTED_PATHS"]},
+    ]
+    result = cli.join_bypass_to_hooks(fire_events, bypass_events)
+    assert result["protected-paths-guard"]["bypass_count"] == 1
+    assert result["protected-paths-guard"]["sessions"] == {"s1"}
+    assert cli.UNATTRIBUTED not in result
+
+
+def test_join_bypass_to_hooks_no_matching_hook_in_session_is_unattributed():
+    """A bypass var with no hook of that family firing in the session must
+    be counted, not silently dropped."""
+    fire_events = [
+        {"hook": "unrelated-hook", "session_id": "s1", "timestamp": "2026-06-26T00:00:00+00:00"},
+    ]
+    bypass_events = [
+        {"session_id": "s1", "timestamp": "2026-06-26T00:00:05+00:00",
+         "bypass_env_vars": ["PRAXIS_HOOK_BYPASS_PROTECTED_PATHS"]},
+    ]
+    result = cli.join_bypass_to_hooks(fire_events, bypass_events)
+    assert "protected-paths-guard" not in result
+    assert result[cli.UNATTRIBUTED]["bypass_count"] == 1
+
+
+def test_join_bypass_to_hooks_ambiguous_family_resolved_by_nearest_timestamp():
+    """Two hooks in the same session both subset-match the family tokens;
+    the one whose fire timestamp is closer to the bypass event wins."""
+    fire_events = [
+        {"hook": "push-verify-a", "session_id": "s1", "timestamp": "2026-06-26T00:00:00+00:00"},
+        {"hook": "push-verify-b", "session_id": "s1", "timestamp": "2026-06-26T00:10:00+00:00"},
+    ]
+    bypass_events = [
+        {"session_id": "s1", "timestamp": "2026-06-26T00:00:02+00:00",
+         "bypass_env_vars": ["PRAXIS_PUSH_VERIFY_BYPASS"]},
+    ]
+    result = cli.join_bypass_to_hooks(fire_events, bypass_events)
+    assert result["push-verify-a"]["bypass_count"] == 1
+    assert "push-verify-b" not in result
+
+
+def test_join_bypass_to_hooks_session_scoped():
+    """A bypass event must only match hooks that fired in the SAME session."""
+    fire_events = [
+        {"hook": "protected-paths-guard", "session_id": "s2", "timestamp": "2026-06-26T00:00:00+00:00"},
+    ]
+    bypass_events = [
+        {"session_id": "s1", "timestamp": "2026-06-26T00:00:05+00:00",
+         "bypass_env_vars": ["PRAXIS_HOOK_BYPASS_PROTECTED_PATHS"]},
+    ]
+    result = cli.join_bypass_to_hooks(fire_events, bypass_events)
+    assert "protected-paths-guard" not in result
+    assert result[cli.UNATTRIBUTED]["bypass_count"] == 1
+
+
+def test_match_family_to_hooks_subset_semantics():
+    hooks = {"protected-paths-guard", "destructive-bash-guard"}
+    assert cli.match_family_to_hooks("PROTECTED_PATHS", hooks) == {"protected-paths-guard"}
+    assert cli.match_family_to_hooks("DESTRUCTIVE_BASH", hooks) == {"destructive-bash-guard"}
+    assert cli.match_family_to_hooks("NOTHING_MATCHES", hooks) == set()
+
+
+# ---------------------------------------------------------------------------
+# issue #710 remaining scope: exact manifest mode.bypass_env mapping
+# (codex review finding, praxis PR: the token heuristic alone sent
+# CLAUDE_HOOK_BYPASS_DUP_GATE to '(unattributed)' even though the manifest
+# already declares its exact owning hook)
+# ---------------------------------------------------------------------------
+
+def test_bypass_env_exact_map_reads_manifest_declaration(tmp_path):
+    manifest = {"hooks": [
+        {"name": "block-gh-issue-create-without-dup-search",
+         "mode": {"bypass_env": ["CLAUDE_HOOK_BYPASS_DUP_GATE"]}},
+        {"name": "no-bypass-hook"},
+    ]}
+    mpath = tmp_path / "manifest.json"
+    mpath.write_text(json.dumps(manifest))
+    result = cli.bypass_env_exact_map(mpath)
+    assert result == {"CLAUDE_HOOK_BYPASS_DUP_GATE": "block-gh-issue-create-without-dup-search"}
+
+
+def test_bypass_env_exact_map_excludes_ambiguous_var(tmp_path):
+    """A var declared on >1 hook is ambiguous -> excluded (falls through to
+    the heuristic) rather than picking one arbitrarily."""
+    manifest = {"hooks": [
+        {"name": "hook-a", "mode": {"bypass_env": ["PRAXIS_SHARED_BYPASS"]}},
+        {"name": "hook-b", "mode": {"bypass_env": ["PRAXIS_SHARED_BYPASS"]}},
+    ]}
+    mpath = tmp_path / "manifest.json"
+    mpath.write_text(json.dumps(manifest))
+    assert cli.bypass_env_exact_map(mpath) == {}
+
+
+def test_bypass_env_exact_map_missing_manifest_returns_empty(tmp_path):
+    assert cli.bypass_env_exact_map(tmp_path / "nope.json") == {}
+
+
+def test_join_bypass_to_hooks_exact_map_takes_priority_over_heuristic():
+    """DUP_GATE's family tokens {dup, gate} do not subset
+    'block-gh-issue-create-without-dup-search' (no 'gate' token in the hook
+    name) -- the heuristic alone would misfire this to unattributed. The
+    exact map must resolve it correctly regardless."""
+    fire_events = [
+        {"hook": "block-gh-issue-create-without-dup-search", "session_id": "s1",
+         "timestamp": "2026-06-26T00:00:00+00:00"},
+    ]
+    bypass_events = [
+        {"session_id": "s1", "timestamp": "2026-06-26T00:00:05+00:00",
+         "bypass_env_vars": ["CLAUDE_HOOK_BYPASS_DUP_GATE"]},
+    ]
+    # Heuristic alone (no exact_map) -> unattributed, proving the bug existed.
+    heuristic_only = cli.join_bypass_to_hooks(fire_events, bypass_events)
+    assert "block-gh-issue-create-without-dup-search" not in heuristic_only
+    assert heuristic_only[cli.UNATTRIBUTED]["bypass_count"] == 1
+
+    # With the exact map -> correctly attributed.
+    exact_map = {"CLAUDE_HOOK_BYPASS_DUP_GATE": "block-gh-issue-create-without-dup-search"}
+    result = cli.join_bypass_to_hooks(fire_events, bypass_events, exact_map=exact_map)
+    assert result["block-gh-issue-create-without-dup-search"]["bypass_count"] == 1
+    assert cli.UNATTRIBUTED not in result
+
+
+def test_join_bypass_to_hooks_exact_map_attributes_even_without_session_fire():
+    """Exact-map attribution does not require the hook to have fired in the
+    bypass event's session — the manifest is authoritative on hook identity."""
+    fire_events: list[dict] = []  # hook never fired in fire-events at all
+    bypass_events = [
+        {"session_id": "s1", "timestamp": "2026-06-26T00:00:05+00:00",
+         "bypass_env_vars": ["CLAUDE_HOOK_BYPASS_DUP_GATE"]},
+    ]
+    exact_map = {"CLAUDE_HOOK_BYPASS_DUP_GATE": "block-gh-issue-create-without-dup-search"}
+    result = cli.join_bypass_to_hooks(fire_events, bypass_events, exact_map=exact_map)
+    assert result["block-gh-issue-create-without-dup-search"]["bypass_count"] == 1
+
+
+def test_bypass_env_exact_map_matches_real_manifest_dup_gate_entry():
+    """Falsification against the REAL repo manifest (not a synthetic fixture)
+    -- confirms the codex review's cited example still holds in this tree."""
+    real_manifest = _REPO / "hooks" / "manifest.json"
+    result = cli.bypass_env_exact_map(real_manifest)
+    assert result.get("CLAUDE_HOOK_BYPASS_DUP_GATE") == "block-gh-issue-create-without-dup-search"
+
+
+# ---------------------------------------------------------------------------
+# issue #710 remaining scope: outcome-proxy (strike_count, best-effort)
+# ---------------------------------------------------------------------------
+
+def test_load_strike_state_reads_count_and_reasons(tmp_path):
+    state_dir = tmp_path / "strikes"
+    state_dir.mkdir()
+    (state_dir / "sess-1.json").write_text(json.dumps({"count": 2, "reasons": ["a", "b"]}))
+    state = cli.load_strike_state(state_dir, "sess-1")
+    assert state == {"count": 2, "reasons": ["a", "b"]}
+
+
+def test_load_strike_state_missing_file_returns_none(tmp_path):
+    assert cli.load_strike_state(tmp_path / "strikes", "sess-missing") is None
+
+
+def test_load_strike_state_malformed_json_returns_none(tmp_path):
+    state_dir = tmp_path / "strikes"
+    state_dir.mkdir()
+    (state_dir / "sess-bad.json").write_text("not json{")
+    assert cli.load_strike_state(state_dir, "sess-bad") is None
+
+
+def test_compute_outcome_proxy_joins_fire_sessions_to_strike_state(tmp_path):
+    state_dir = tmp_path / "strikes"
+    state_dir.mkdir()
+    (state_dir / "s1.json").write_text(json.dumps({"count": 3, "reasons": ["x"]}))
+    fire_events = [
+        {"hook": "h", "session_id": "s1", "timestamp": "2026-06-26T00:00:00+00:00"},
+        {"hook": "h", "session_id": "s2", "timestamp": "2026-06-26T00:00:05+00:00"},
+    ]
+    result = cli.compute_outcome_proxy(fire_events, state_dir)
+    assert result["s1"] == {"strike_count": 3, "strike_state_available": True}
+    assert result["s2"] == {"strike_count": 0, "strike_state_available": False}
+
+
+def test_default_strike_state_dir_respects_praxis_state_dir_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRAXIS_STATE_DIR", str(tmp_path))
+    assert cli.default_strike_state_dir() == tmp_path / "strikes"
+
+
+# ---------------------------------------------------------------------------
+# issue #710 remaining scope: end-to-end fire-rate report renders new sections
+# ---------------------------------------------------------------------------
+
+def test_fire_rate_report_includes_remaining_scope_sections(tmp_path, monkeypatch):
+    """Real writer output (record_group_fires + bypass hook's own JSONL schema)
+    flows through run_fire_rate end-to-end and produces non-trivial values for
+    all three remaining-scope metrics — no mirrored/mocked business logic."""
+    today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+    telem_dir = tmp_path / "telemetry"
+    telem_dir.mkdir()
+    fire_out = telem_dir / f"fire-events-{today}.jsonl"
+    bypass_out = telem_dir / f"bypass-events-{today}.jsonl"
+    state_dir = tmp_path / "strikes"
+    state_dir.mkdir()
+
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(fire_out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+
+    # Two dispatches of the same hook in the same session: advise then advise
+    # again (ignored), via the real writer.
+    members = [("advisory-nudge", "protected-paths-guard", Path("x"))]
+    fl.record_group_fires(members, [(0, "", "nudge")], _payload("s1", "Write"))
+    fl.record_group_fires(members, [(0, "", "nudge")], _payload("s1", "Write"))
+
+    # bypass-events file uses the real writer's own field schema (session_id,
+    # tool, bypass_env_vars, tool_input, tool_result_status).
+    bypass_record = {
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+        "session_id": "s1",
+        "tool": "Write",
+        "bypass_env_vars": ["PRAXIS_HOOK_BYPASS_PROTECTED_PATHS"],
+        "tool_input": "echo hi",
+        "tool_result_status": "ok",
+    }
+    bypass_out.write_text(json.dumps(bypass_record) + "\n")
+
+    (state_dir / "s1.json").write_text(json.dumps({"count": 1, "reasons": ["late verification"]}))
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = cli.main([
+            "fire-rate", "--dir", str(telem_dir), "--state-dir", str(state_dir),
+        ])
+    report = buf.getvalue()
+
+    assert rc == 0
+    assert "Advise-Ignored Detail" in report
+    assert "protected-paths-guard" in report
+    assert "100%" in report  # both advise fires ignored (no escalation)
+    assert "Bypass Attribution" in report
+    assert "Outcome Proxy" in report
+    assert "s1" in report and "1" in report  # strike_count surfaced


### PR DESCRIPTION
## 배경

이슈 #710의 잔여 스코프(PR #714 이후 남은 부분) 구현: `advise_ignored_rate`, `bypass_count`, outcome-proxy(item 3, best-effort).

## 변경 사항

### 1. `advise_ignored_rate`
같은 세션·같은 hook의 "advise" fire 이후, 다음 same-hook fire가 다시 "advise"이면 (같은 조건이 변화 없이 재발) ignored로 카운트. `pass`는 hook이 더 이상 flag하지 않는 것(=heeded, 해소됨), `block`/`ask`는 escalation — 둘 다 ignored 아님. 세션 내 후속 fire가 없는 마지막 advise는 right-censored로 관측 분모에서 제외(모른다는 것을 모른다고 표시).

fire-events 스키마엔 tool_input(커맨드 내용)이 없어 리터럴 diff는 불가능 — hook 자체 재평가 재발 여부로 근사한 proxy임을 리포트에 명시.

### 2. `bypass_count`
1차: `hooks/manifest.json`의 `mode.bypass_env` (22/64 hook에 선언, 검증 결과 var→hook 충돌 0건) — 있으면 exact match.
2차(폴백): manifest에 선언 없는 var는 session_id + hook 이름 token-subset heuristic + nearest-timestamp tie-break. 매칭 실패는 `(unattributed)` 버킷으로 명시적 집계(silent drop 아님).

### 3. outcome-proxy (item 3, best-effort)
strike_count만 구현 — `hooks/completion-verify/strike-counter/impl.sh`가 쓰는 세션별 state JSON을 join. 원래 이슈에 명시된 나머지 3개 신호(external-write revert / re-clarification loop / rework commits)는 **현재 어떤 telemetry에도 기록되지 않아 구현하지 않음** — 모듈 docstring "OUTCOME PROXY LIMITATIONS"에 각각 왜 불가능한지 명시.

### 리포트 확장
기존 `bypass-review fire-rate` 출력에 3개 섹션 추가(Advise-Ignored Detail / Bypass Attribution / Outcome Proxy). 기존 Per-Hook Fire Counts 테이블은 재구조화하지 않음.

## Codex 리뷰 반영

`praxis:codex-review-wrap` 1라운드 실행, P2 2건 모두 반영:
1. advise 이후 `pass`를 ignored로 잘못 카운트하던 버그 → 수정(관련 테스트 추가)
2. bypass attribution이 manifest의 정확한 `mode.bypass_env` 매핑을 무시하고 heuristic만 쓰던 문제(`CLAUDE_HOOK_BYPASS_DUP_GATE` 사례로 실증) → exact-map 우선 로직 추가

## 검증

- `python3 -m pytest tests/test_fire_ledger.py -q` → 52 passed (기존 30 + 신규 22)
- `bash scripts/run-tests.sh` 전체 스위트 → `ALL TESTS PASSED` (pytest 405 passed 포함)
- synthetic fixture로 `bypass-review fire-rate` 직접 실행 → 세 지표 모두 0이 아닌 실제 값 산출 확인 (advise-ignored 50%/0%, bypass attribution exact-map 매칭, outcome-proxy strike_count 표시)

## 검증 안 한 것

- `bypass_count`의 nearest-timestamp tie-break(폴백 경로)과 outcome-proxy TTL 만료 동작은 synthetic fixture로만 검증 — 실제 multi-day 프로덕션 telemetry 대상 검증은 아님

## Closes vs Refs

이슈 #710의 원본 5개 항목 중: item 1(fire-ledger writer)·item 4(report)는 PR #714에서 완료, item 2(파생 지표)는 이번 PR로 전부 완료, item 5(A/B)는 원래부터 후속 sub-phase로 명시 이연. 다만 **item 3(outcome proxy)은 4개 신호 중 1개(strike_count)만 best-effort 구현**이고 나머지 3개는 telemetry 부재로 구현하지 못했음을 위에 명시함 — 이슈 본문이 명시한 스코프의 일부만 충족하므로 `Closes` 대신 `Refs #710` 사용. item 3 나머지 신호는 추가 계측(transcript 분석, git-log 상관 등) 없이는 불가능해 후속 이슈로 분리하는 편이 적절하다고 판단됨.

Refs #710