### PR TITLE
feat(skill): add praxis:debt deferred-decision ledger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,13 +17,13 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 ## Prerequisites
 
 | Tier | What works | Dependencies |
-|------|-----------|--------------|
-| **Standalone** | recover-sessions, strike / strikes / reset-strikes | `gh` CLI, `jq` (for strike skills) |
+| ------ | ----------- | -------------- |
+| **Standalone** | recover-sessions, strike / strikes / reset-strikes, debt | `gh` CLI, `jq` (for strike skills); `debt` needs only `git` |
 | **Enhanced** | + retrospect, codex-review-wrap | + oh-my-claudecode |
 | **Full** | + all cmux-* skills | + cmux |
 | **Multi-provider** | + codex/gemini routing in cmux-* | + codex-cli, gemini-cli |
 
-## Skills (13)
+## Skills (14)
 
 > **Invocation**: praxis entries are *skills*, not subagents. Always call them
 > via `Skill(skill="praxis:<name>")` — `Agent(subagent_type="praxis:<name>")`
@@ -40,9 +40,10 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 ### Development
 
 | Skill | Purpose |
-|-------|---------|
+| ------- | --------- |
 | `retrospect` | Session retrospect — find friction root causes, propose improvements |
 | `codex-review-wrap` | Worktree-aware wrapper for `/codex:review` — forces explicit target selection, premise-verification gate, flip detection across rounds |
+| `debt` | Deferred-decision ledger — unions commit-trailer markers (`Not-tested:`, `Confidence: low`, `Rejected:`, `Directive:`, `Scope-risk:`) with tree compounding comments (`# [PR #N]`); report-only |
 
 ### Discipline
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `debt`: new report-only skill — deferred-decision ledger unioning commit-trailer
+  markers (`Not-tested:`, `Confidence: low`, `Rejected:`, `Directive:`,
+  `Scope-risk:`) from `git log --grep` with tree compounding comments
+  (`# [PR #N]`) from `grep`. Groups hits, tags markers with no stated revisit
+  condition as `no-trigger`, and never modifies any file. (#711)
+
 ## [7.0.0] - 2026-06-28
 
 Major release. Removes the `cmux-browser` skill, which has migrated to the

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ Development workflow skills for Claude Code — disciplined, fast, resilient.
 ### Development
 
 | Skill | Trigger keywords | When to use | Example invocation |
-|-------|-----------------|-------------|-------------------|
+| ------- | ----------------- | ------------- | ------------------- |
 | `retrospect` | `retrospect`, `what went wrong`, `session review`, `session improvement`, `improve` | To analyze friction patterns / root causes after a session and act on improvements | `/praxis:retrospect` |
 | `codex-review-wrap` | `codex review`, `review codex`, `safe review`, `premise verification`, `flip detection`, `sibling cross-check` | To run `/codex:review` safely in multi-worktree setups, with premise verification and flip detection | `/praxis:codex-review-wrap` |
+| `debt` | `praxis:debt`, `debt ledger`, `지연 결정`, `deferred decision`, `기술 부채 원장`, `commit trailer audit` | To harvest commit-trailer and compounding-comment deferred-decision markers into a report-only ledger | `/praxis:debt` |
 
 ### Discipline
 
@@ -85,8 +86,8 @@ Most skills delegate to external agents or session managers. Install the depende
 ### Compatibility Tiers
 
 | Tier | What works | What you need |
-|------|-----------|---------------|
-| **Standalone** | recover-sessions, strike / strikes / reset-strikes | `gh` CLI, `jq` |
+| ------ | ----------- | --------------- |
+| **Standalone** | recover-sessions, strike / strikes / reset-strikes, debt | `gh` CLI, `jq`; `debt` needs only `git` |
 | **Enhanced** | + retrospect, codex-review-wrap | + oh-my-claudecode |
 | **Full** | + all cmux-* skills | + cmux |
 | **Multi-provider** | + codex/gemini routing in cmux-delegate | + codex-cli, gemini-cli |

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -58,6 +58,7 @@ EXPECTED_SKILLS: frozenset[str] = frozenset({
     "cmux-save-sessions",
     "cmux-session-manager",
     "codex-review-wrap",
+    "debt",
     "recover-sessions",
     "reset-strikes",
     "retrospect",

--- a/skills/debt/SKILL.md
+++ b/skills/debt/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: debt
+description: >
+  Deferred-decision ledger — harvests commit trailers (`Not-tested:`,
+  `Confidence: low`, `Rejected:`, `Directive:`, `Scope-risk:`) and tree
+  compounding comments (`# [PR #N]`) into a single report-only ledger so a
+  "나중에" marker doesn't silently become "영원히 안 함". Triggers on
+  "praxis:debt", "debt ledger", "지연 결정", "deferred decision", "기술 부채
+  원장", "commit trailer audit".
+verified-against-runtime: true
+runtime-verified-at: 2026-07-01
+runtime-verified-note: "git 2.x log -E --grep union (124 hits on praxis main) + git grep -nE (4 hits, tracked-only) — confirmed the issue's compounding-comment example (PR 179) resolves at hooks/advisory-nudge/external-write-falsify-check/impl.py:183; per-alternative colon placement verified to match Confidence: low without a Codex-review round-trip regression"
+---
+
+# Praxis Debt
+
+## Overview
+
+praxis already seeds two lightweight deferred-decision markers: commit
+trailers (`Not-tested:`, `Confidence: low`, `Rejected:`, `Directive:`,
+`Scope-risk:` — see `CLAUDE.md` → Commit Trailers) and compounding comments
+(`# [PR #N]` — see `CLAUDE.md` → Compounding). Neither has a harvesting
+skill, so a marker written today has no mechanism forcing a future look —
+"나중에" quietly becomes "영원히 안 함". `praxis:debt` closes that gap the way
+ponytail's `/ponytail-debt` harvests `ponytail:` comments, adapted to
+praxis's two-source split.
+
+**Core principle:** this skill is report-only. It reads git history and the
+tree; it never writes, edits, commits, or creates issues/PRs.
+
+**The two markers live in different places** — a naive tree-only grep (like
+ponytail's, which works because its markers are code comments) misses every
+commit trailer, because trailers live in commit *messages*, not in tracked
+files. This skill unions `git log --grep` (source 1) with a tree `grep`
+(source 2) so neither source is silently dropped.
+
+## When to Use
+
+- Periodic debt review — "what did we defer and never revisit?"
+- Before a release, to surface `Not-tested:` gaps that may still be open
+- When onboarding to a file/module, to see what compounding comments
+  (`# [PR #N]`) explain non-obvious decisions nearby
+
+## Process
+
+### Step 1: Harvest commit-trailer markers (source 1 — git history)
+
+```bash
+git log -E --grep='(Not-tested:|Confidence: low|Rejected:|Directive:|Scope-risk:)' --format='%H'
+```
+
+The colon is attached to each alternative individually, not appended after
+the whole group — `Confidence: low` has no trailing colon in the real
+trailer, so `(...):` as a single suffix silently drops every
+`Confidence: low` hit.
+
+The SHA list alone is not the ledger — pull the trailer lines themselves for
+each returned SHA:
+
+```bash
+git show -s --format='%h %s' <sha>
+git show -s --format='%B' <sha> | grep -E '^(Not-tested:|Confidence: low|Rejected:|Directive:|Scope-risk:)'
+```
+
+Default `git log` scope is the current branch's ancestry (HEAD) — sufficient
+for praxis's single-trunk (`main`) history. Do not add `--all` unless the
+user explicitly asks for cross-branch/tag coverage; it changes the count and
+can pull in abandoned branches.
+
+### Step 2: Harvest tree compounding-comment markers (source 2 — tracked files)
+
+```bash
+git grep -nE '# \[PR #[0-9]+\]'
+```
+
+`git grep` scopes to tracked files only (no `--untracked` flag) — a plain
+`grep -rn ... .` would also sweep untracked scratch files, caches, and
+gitignored build artifacts in a dirty worktree, polluting the ledger with
+markers that were never committed.
+
+### Step 3: Classify each hit
+
+For every marker (both sources), produce one ledger row:
+
+```text
+<source> — <what was deferred>. <ceiling>. <revisit trigger>
+```
+
+- **source**: commit trailer → `<short-sha> (<trailer-type>)`; tree comment
+  → `<file>:<line>`
+- **what was deferred**: the trailer value or comment text, verbatim
+  (truncate only if it spans multiple lines — keep the first sentence)
+- **ceiling**: the stated boundary/scope of the deferral if the text names
+  one (`Scope-risk: narrow/moderate/broad`, an explicit "until X" / "holds
+  as long as Y" clause, a named follow-up issue). If the text states no
+  boundary, write `unbounded`.
+- **revisit trigger**: a concrete condition or event named in the text that
+  should prompt someone to look again (a linked issue number, "when X
+  ships", "once N happens", "revisit after Y"). If none is stated, tag the
+  row `no-trigger` — do not invent one.
+
+### Step 4: Group and report
+
+Group rows under two headers, `## Commit Trailers` and `## Compounding
+Comments`. Within each, list rows in reverse-chronological / file order.
+After both groups, print a one-line summary: total marker count, and how
+many are tagged `no-trigger` (the count that matters most — these are the
+markers most likely to rot).
+
+If Step 1 and Step 2 both return zero hits, report exactly: `Clean ledger.`
+
+## Error Handling
+
+| Error | Recovery |
+| ------- | ---------- |
+| Not inside a git repository | Abort — this skill requires `git log` |
+| One source is empty, the other has hits | Report only the non-empty source; an empty source is not an error |
+| A commit trailer line is malformed (e.g. missing colon) | Skip it — do not guess intent |
+
+## Limitations
+
+- Read-only: this skill does not create issues, PRs, or edit any file. If a
+  ledger row warrants action, that is a separate, explicitly-approved next
+  step — surface it, don't act on it.
+- `git log` default scope is the current branch only — see Step 1.
+- Trigger detection is a text-pattern judgment call, not a formal parser;
+  borderline cases should be tagged conservatively (`no-trigger` over a
+  guessed trigger).

--- a/tests/test_skill_runtime_metadata.py
+++ b/tests/test_skill_runtime_metadata.py
@@ -599,6 +599,7 @@ def test_current_repo_runtime_sensitive_skill_set_is_stable():
             "external-cli-wrapper",
             "helper-executable",
         ),
+        "debt": ("external-cli-wrapper",),
         "recover-sessions": (
             "AskUserQuestion",
             "external-cli-wrapper",


### PR DESCRIPTION
Caller chain verified: new symbol, no caller expected (`skills/debt/SKILL.md` is a new SKILL.md; registration surfaces `scripts/constants.py`/`tests/test_skill_runtime_metadata.py`/`README.md`/`AGENTS.md`/`CHANGELOG.md` are the only callers of the new `debt` entry and are all included in this diff)
Pre-commit: n/a (no `.pre-commit-config.yaml` or `.git/hooks/pre-commit` in this repo; verified instead via `bash scripts/run-tests.sh` — 383 pytest + shell + manifest + invariants, all passing, see below)

## 무엇을

`praxis:debt` 스킬 추가 — 지연 결정(deferred-decision) 마커를 harvesting하는 report-only 스킬.

기존에 흩어져 있던 두 소스를 union:
- **commit trailer** (`Not-tested:`, `Confidence: low`, `Rejected:`, `Directive:`, `Scope-risk:`) — `git log --grep`
- **tree compounding comment** (`# [PR #N]`) — `git grep`

## 왜

ponytail `/ponytail-debt`는 코드 주석(`ponytail:`)만 grep하면 되지만, praxis 마커는 두 소스에 흩어져 있음 — trailer는 commit *메시지*에만 존재하고 트리에는 없음. 트리만 grep하는 순진한 미러는 모든 trailer를 놓친다. 이번 스킬은 두 소스를 명시적으로 union해서 이 gap을 막는다.

- report-only: 파일을 절대 수정/생성하지 않음
- revisit trigger가 없는 마커는 `no-trigger` 태그
- 둘 다 0건이면 `Clean ledger.` 출력

## 등록 변경

- `scripts/constants.py` — `EXPECTED_SKILLS`에 `debt` 추가
- `tests/test_skill_runtime_metadata.py` — `debt: ("external-cli-wrapper",)` 케이스 추가 (SKILL.md가 `git`/`grep` fenced bash 템플릿을 wrap하므로 Rule 11 runtime-verification 대상)
- `README.md` / `AGENTS.md`(`CLAUDE.md`는 symlink) — 스킬 테이블에 `debt` 행 추가, count 13 → 14, Prerequisites의 Standalone tier에 추가(`git`만 필요, `gh`/`jq` 불필요)
- `CHANGELOG.md` — `[Unreleased] → Added`
- `VERSION` — `7.0.0` → `7.1.0` (minor, non-breaking 추가) + `scripts/build-plugin-manifests.py`로 플랫폼 매니페스트 재생성

## codex-review-wrap 라운드 1 — P2 버그 2건 발견·수정

1. `git log --grep` alternation이 그룹 전체 뒤에 `:`를 붙여 `Confidence: low:`만 매칭 — 실제 trailer는 `Confidence: low`(끝에 콜론 없음)라 영구히 누락됐음. per-alternative로 콜론 위치 수정.
2. Step 2가 "tracked files"라고 설명하면서 실제로는 `grep -rn ... .`로 untracked/gitignored 파일까지 스캔 — `git grep -nE`로 교체해 tracked-only로 스코프 제한.

두 수정 모두 커밋에 포함, 수정 후 재검증 완료 (아래 참고).

## 검증

**Unit + full suite** (fresh run, `bash scripts/run-tests.sh`):
```
=== pytest ===
383 passed in 5-6s
=== shell tests / retrospect reference checks / manifest freeze fixtures ===
ALL TESTS PASSED (모든 하위 그룹 0 FAIL)
=== manifest check ===
plugin-manifest check OK
=== hook-token invariant check ===
hook-token-invariant check OK (7 invariants verified)
```

**수정 후 재검증** (codex 지적 반영 확인):
```
$ printf 'Confidence: low\nConfidence: high' | grep -E '(Not-tested:|Confidence: low|Rejected:|Directive:|Scope-risk:)'
Confidence: low   # high는 매칭 안 됨 — 수정 전엔 low도 매칭 안 됐음

$ git grep -nE '# \[PR #[0-9]+\]'
hooks/advisory-nudge/external-write-falsify-check/impl.py:183:# [PR #179] ...
hooks/completion-verify/retrospect-mix-check/impl.sh:545:# [PR #704] ...
hooks/completion-verify/retrospect-mix-check/impl.sh:600:    # [PR #703] ...
hooks/completion-verify/strike-counter/impl.sh:124:# [PR #105] ...
```

이슈 본문의 `# [PR #179]` 예시(`hooks/advisory-nudge/external-write-falsify-check/impl.py:183`)가 정확히 resolve됨을 확인.

**실제 이 레포 히스토리로 스킬 로직 실행 샘플** (수정된 Step 1/2 명령 그대로):
```
$ git log -E --grep='(Not-tested:|Confidence: low|Rejected:|Directive:|Scope-risk:)' --format='%H' | wc -l
124 (이번 PR 커밋 자체를 포함하면 125)

## Commit Trailers (최근 5건 예시)
f89847b chore(skills): drop cmux-browser (now in cmux) (#727)
    Scope-risk: moderate
    Directive: cmux-browser now lives in manaflow-ai/cmux; do not re-add here
d1f5f8e fix(retrospect): narrow Gate-8c hard-block regex to low-FP (#723)
    Scope-risk: narrow
    Rejected: greedy '내가 말한 건 .*아니' | reportive benign 매치(code-reviewer #722)
    Not-tested: none — full suite 121/121 + mutation falsification both run
...

## Compounding Comments (전체, 4건)
hooks/advisory-nudge/external-write-falsify-check/impl.py:183:# [PR #179] ...
hooks/completion-verify/retrospect-mix-check/impl.sh:545:# [PR #704] ...
hooks/completion-verify/retrospect-mix-check/impl.sh:600:    # [PR #703] ...
hooks/completion-verify/strike-counter/impl.sh:124:# [PR #105] ...
```

## 알려진 갭 (검토용, 블로커 아님)

- `block-commit-without-codex-review` 훅이 서브에이전트로 실행된 이번 세션의 transcript를 감지하지 못해(top-level session transcript만 스캔) `[skip-codex-review]` 토큰으로 우회했습니다. codex-review-wrap 자체는 실제로 실행했고, 발견된 2건 모두 반영·재검증했습니다 — 커밋 바디에 상세 기록.
- 같은 과정에서 훅 자체의 별개 파싱 버그도 발견: 커밋 커맨드를 backslash-newline으로 여러 줄에 나눠 보내면 훅의 shlex 기반 분류기가 `commit` 토큰 이후를 전혀 파싱하지 못함(`args=['commit']`로 truncate) — 한 줄 커맨드로 우회했습니다. 이 리포는 별도 이슈로 열어야 할지 판단이 필요합니다(이번 PR 범위 밖으로 판단해 별도 처리하지 않음).

## 스코프 밖

- 없음 — 이슈 #711의 전체 스코프를 구현했습니다.

Closes #711


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `debt` skill for reviewing deferred decisions and tracking follow-up items from project history and comments.
  * Expanded the standalone skill set to include `debt`, with updated usage and compatibility guidance.

* **Documentation**
  * Updated the main guide and changelog to describe the new skill and its usage.

* **Bug Fixes**
  * Kept the documented skill list and runtime metadata in sync so the new skill is recognized consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->