### PR TITLE
docs(hooks): evidence-based hook prune audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 | [`ARCHITECTURE.md`](ARCHITECTURE.md) | Skill ↔ hook ↔ manifest dependency graph — provider routing, hook index, multi-platform packaging |
 | [`RUNTIME_CONSTRAINTS.md`](RUNTIME_CONSTRAINTS.md) | Fixed Claude Code runtime limits every skill must respect |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Skill and hook contribution conventions, live-runtime verification gate |
+| [`docs/hook-prune-audit.md`](docs/hook-prune-audit.md) | Evidence-based keep/merge/drop verdict per hook, scored from the fire-rate ledger (issue #713) |
 
 ## Prerequisites
 

--- a/docs/hook-prune-audit.md
+++ b/docs/hook-prune-audit.md
@@ -3,9 +3,10 @@
 Evidence-based `keep` / `merge` / `drop` verdict for every hook in
 `hooks/manifest.json`, scored against the fire-rate ledger `bypass-review
 fire-rate` produces (issue #710). This applies ponytail's deletion-over-addition
-lens to praxis's own hook accretion — see
-[`deep-dive-ponytail-vs-praxis-improvements.md`](../.omc/specs/deep-dive-ponytail-vs-praxis-improvements.md)
-P4.
+lens to praxis's own hook accretion — see the P4 work item in
+`.omc/specs/deep-dive-ponytail-vs-praxis-improvements.md` (local planning
+artifact — `.omc/` is gitignored, so this is a plain-text pointer rather than
+a repo-relative link).
 
 ## Data source
 
@@ -23,10 +24,11 @@ sessions**). Test-fixture rows emitted by `tests/test_fire_ledger.py` (`adv`,
 
 ## Axis 1 — never-fired
 
-**Result: none.** Every hook that emits fire-events (55 of 58) fired at least
-once in the window. This is expected — the sample covers the tail end of this
-very session's Wave 1 work, which exercised nearly every gate class (commit,
-PR create, merge, AskUserQuestion, bulk write).
+**Result: none.** Every hook that emits fire-events (54 of 58 — the other 4
+are the uninstrumented shell hooks below) fired at least once in the window.
+This is expected — the sample covers the tail end of this very session's
+Wave 1 work, which exercised nearly every gate class (commit, PR create,
+merge, AskUserQuestion, bulk write).
 
 4 hooks are **shell (`.sh`) implementations with no `@fail_open` / dispatch
 chokepoint** and emit no fire-events at all, so they cannot be scored on any
@@ -106,16 +108,18 @@ advisory) — a 30-day/49-session window without a match is consistent with
 
 | Verdict | Count | Hooks |
 | --- | --- | --- |
-| **Keep** (active or narrow-safety-net) | 51 | All PreToolUse/PostToolUse hooks scored above, plus all hooks with nonzero block/ask/advise activity not otherwise discussed |
+| **Keep** (active or narrow-safety-net) | 50 | All measured PreToolUse/PostToolUse hooks not listed in the two rows below, including every hook with nonzero block/ask/advise activity |
 | **Investigate** (non-drop follow-up) | 2 | `pre-gh-pr-create-dedup-gate` (advisory message clarity), `memory-hint` (keyword-match coverage) |
 | **Merge candidate, blocked on prerequisite** | 2 | `pre-output-falsification-gate` + `output-block-falsify-advisory` — revisit only after Cluster B3's shared-matcher extraction lands and a further fire-rate window still shows full overlap |
 | **Unmeasurable — instrument first** | 4 | `codex-review-route`, `completion-verify`, `retrospect-mix-check`, `strike-counter` (shell hooks, no fire-event emission) |
 | **Drop** | 0 | — |
+| **Total** | 58 | Matches `hooks/manifest.json`'s registered hook count (50+2+2+4) |
 
 ## Bottom line
 
-No hook meets the bar for removal on the current evidence. The 60-hook count
-itself is not, on this data, an accretion of dead weight — it's mostly narrow,
+No hook meets the bar for removal on the current evidence. The 58-hook count
+itself (the ponytail-comparison spec's "~60 hooks" framing, rounded) is not,
+on this data, an accretion of dead weight — it's mostly narrow,
 non-overlapping safety nets whose low individual fire-rate is exactly what a
 targeted advisory should look like. The actionable follow-ups are smaller and
 different in kind: (1) finish Cluster B3's code dedup before reconsidering a

--- a/docs/hook-prune-audit.md
+++ b/docs/hook-prune-audit.md
@@ -1,0 +1,125 @@
+# Hook Prune Audit (issue #713)
+
+Evidence-based `keep` / `merge` / `drop` verdict for every hook in
+`hooks/manifest.json`, scored against the fire-rate ledger `bypass-review
+fire-rate` produces (issue #710). This applies ponytail's deletion-over-addition
+lens to praxis's own hook accretion — see
+[`deep-dive-ponytail-vs-praxis-improvements.md`](../.omc/specs/deep-dive-ponytail-vs-praxis-improvements.md)
+P4.
+
+## Data source
+
+```bash
+./skills/bypass-review/bypass-review fire-rate -d 30
+```
+
+Window: 2026-06-02 → 2026-07-01 (fire-event instrumentation itself only starts
+2026-06-26 — the first 24 days of the requested 30-day lookback have no
+fire-events at all, so the effective sample is **2026-06-26 → 2026-07-01, 49
+sessions**). Test-fixture rows emitted by `tests/test_fire_ledger.py` (`adv`,
+`ask`, `deny`, `crash`, `pass`, `p1`, `p2`, `boom*`, `real_block`, `allow`,
+`_lib`) are excluded from every table below — cross-checked against
+`hooks/manifest.json`'s 58 registered hook names.
+
+## Axis 1 — never-fired
+
+**Result: none.** Every hook that emits fire-events (55 of 58) fired at least
+once in the window. This is expected — the sample covers the tail end of this
+very session's Wave 1 work, which exercised nearly every gate class (commit,
+PR create, merge, AskUserQuestion, bulk write).
+
+4 hooks are **shell (`.sh`) implementations with no `@fail_open` / dispatch
+chokepoint** and emit no fire-events at all, so they cannot be scored on any
+axis below: `codex-review-route`, `completion-verify`, `retrospect-mix-check`,
+`strike-counter`. This is a measurement gap, not a verdict — **follow-up
+recommendation**: port these to the `@fail_open` decorator (or an equivalent
+coarse fire-event emit) so a future audit can actually score them.
+
+## Axis 2 — advise-ignored-rate high
+
+Only hooks with an `Observed` (non-right-censored) sample appear here; n is
+small across the board (13–24), so treat percentages as directional, not
+statistically solid.
+
+| Hook | Ignored / Observed | Rate | Verdict |
+| --- | --- | --- | --- |
+| `pre-gh-pr-create-dedup-gate` | 7 / 23 | 30% | **Investigate** — the highest ignored-rate of any advisory hook. Worth checking whether the advisory message clearly states *what to do next* (vs. just flagging), since a 30% ignore rate on a duplicate-issue-search nudge suggests the message isn't actionable enough. Not a drop candidate — it protects against real duplicate-issue creation. |
+| `destructive-bash-guard` | 2 / 13 | 15% | Keep as-is — small n, no action needed. |
+| `momentum-rule-retrieval-gate`, `inspection-chain-advisory`, `count-assertion-verify`, `pre-output-falsification-gate`, `cli-flag-incompat-advisory`, `bash-worktree-existence-advisory`, `external-write-path-existence-check` | 0 / n | 0% | Keep — advisories are being heeded when observed. |
+
+## Axis 3 — coverage-duplicate
+
+Two known duplicate-*code* pairs from the 2026-06-04 quality audit
+(`project_praxis_audit_spec` Cluster B) were cross-checked against fire-rate
+behavior to see if the duplication also shows up as duplicate *coverage*:
+
+| Pair | Fire-rate behavior | Verdict |
+| --- | --- | --- |
+| `pre-output-falsification-gate` (advise ×10 / 4625 fires) vs. `output-block-falsify-advisory` (advise ×0 / 5181 fires) | Both scan for the same "self-authored proposal without falsification" pattern (Cluster B3 — shared evaluative-marker/`Falsified:`-phrase matcher, not yet extracted to `hooks/_lib/`). `output-block-falsify-advisory` never actually advised in this window despite firing more often — either its matcher is narrower/stricter than `pre-output-falsification-gate`'s, or it is the AskUserQuestion-specific escalation path (ask/deny) documented in its own spec (`(Recommended)` + no `Falsified:` line → deny/ask) while `pre-output-falsification-gate` is the softer stderr-only nudge. | **Merge is premature** — they occupy different severities (deny-capable vs. advisory-only) on the same detection logic. Complete Cluster B3's code-dedup first (shared `_lib` matcher); revisit whether the *hook* pair should merge only after both consume the same extracted matcher and a further window shows continued full overlap. |
+| `commit-title-length-check` (ask ×44 / 3835) vs. `commit-title-format-check` (block ×692 / 5315) | Different fire counts and different escalation levels (ask vs. block) — they gate different failure modes (length vs. format) that happen to share a git-title-parsing helper (Cluster B2). | **Not coverage-duplicate** — keep both hooks; only the shared parser code is a dedup target. |
+
+**False-positive check (naming-only clustering, ruled out):** `pre-merge-approval-gate`,
+`merge-state-claim-gate`, `merge-menu-review-options-advisory`, and
+`pr-state-refetch-gate` all contain "merge" in their name and could look like
+a 4-way duplicate cluster from naming alone. They are **not** — each gates a
+distinct point in the merge lifecycle: pre-merge ask-surface (PreToolUse),
+post-hoc claim verification (Stop), AskUserQuestion menu-option advisory
+(PreToolUse), and live PR-state re-fetch (PreToolUse, issue #719, this Wave).
+Defense-in-depth across different event types, not redundant coverage of the
+same token. No action.
+
+## Axis 4 — advisory-only-never-escalated
+
+**Scope restriction (premise-verification):** the fire-rate report's own
+caveat states that `Stop`/`UserPromptSubmit`-event hooks return a decision via
+a stdout JSON field while exiting 0 — their blocks are invisible to the coarse
+fire-event count and fold into "Pass". Scoring these on this axis would report
+a false "never escalates" for hooks whose escalation is simply unmeasured.
+**Excluded from this axis**: `merge-state-claim-gate`, `completion-signal-gate`,
+`readonly-verify-deferral-gate`, `strike-counter` (Stop); `session-intent`,
+`postcompact-context`, `retrospect-active-marker`, `codex-review-route` (UPS).
+Hooks with a `strict_env` field also default to advisory-only pass-through
+until a user opts into strict mode — a 0-block count for these is the designed
+default, not evidence of dead code, so they're also excluded from a "drop"
+read (though still listed below for completeness).
+
+Remaining `PreToolUse`/`PostToolUse` hooks with **zero block AND zero advise**
+across 49 sessions / 30 days (i.e., every fire resolved to a silent Pass):
+
+| Hook | Fires | Purpose (verified via spec.md) | Verdict |
+| --- | --- | --- | --- |
+| `memory-hint` | 5053 | Emits a stderr hint when a tool call's text matches keywords from a memory file marked `hookable: true`. **Premise check**: an initial read suggested no hookable memories exist — **falsified** by `grep -rl "hookable: true" .../memory/*.md` → **13 files** in this project's own memory store declare `hookable: true` (including one, `feedback_worktree_context_pre_git_op.md`, whose own body documents a past session where the hook *should* have fired and didn't until frontmatter was added). The mechanism is live and in active use. | **KEEP** — but flag as **monitor**: 0 fires across 5053 evaluations with 13 hookable entries registered is worth checking (do the `hookKeywords` lists actually match tokens that appear in real `tool_input` text?) as a separate, narrower follow-up — not this issue's scope. |
+| `jq-config-empty-dict-advisory` | 4819 | Warns before `jq` silently returns `empty` / crashes on a size-0 or malformed config JSON. | **KEEP** — narrow safety-net for a silent-failure mode (accidentally-emptied config file); rare-but-real, not obsolete. |
+| `external-api-literal-trigger` | 4503 | Advisory to verify ALL_CAPS/SQL-identifier literals against real API/schema values before writing them. | **KEEP** — spec documents 3 real catches in 30 days elsewhere in the codebase; pattern-match is broad but the underlying failure (guessed enum/catalog values) is a recurring, real class per `feedback_external_cli_verify_first`. |
+| `pre-edit-md-escape-advisory` | 1780 | Nudges a Read-before-Edit on `.md` files containing escape-sensitive tokens (`\|`, `\[`, HTML entities) to prevent exact-match Edit failures. | **KEEP** — documented root cause (issue #230, Obsidian-style escaped wikilinks); niche trigger, real recovery-cost avoidance when it fires. |
+| `advisory-wrapper-signature-verify` | 1057 | Warns before writing wrapper/client code that delegates to underlying functions without having read their real signatures. | **KEEP** — spec documents 4 prior incidents (wrong exception attributes, factory signature mismatches). Narrow trigger (wrapper-shaped files + delegation pattern), real failure class. |
+| `version-bump-evidence-check` | 3835 | Requires evidence of `VERSION`/manifest/`CHANGELOG.md` sync before a release PR. `strict_env`-gated. | **KEEP** — **not a dead-code signal**: the last actual `VERSION` bump (6.3.3, PR #706) landed 2026-06-25, one day *before* fire-event instrumentation began (2026-06-26). The trigger condition (a version-bump PR) simply did not occur inside the measurable window — falsifies the "never needed" read. Re-check after the next release PR (#707's checklist should make this easy to verify going forward). |
+| `output-block-falsify-advisory` | 5181 | See Axis 3 — occupies the deny/ask-escalation half of the falsification-gate pair. | **KEEP** — see Axis 3 merge discussion; not scored as "unused", it's paired with a sibling that does carry the advisory load. |
+
+No hook in this remaining set is recommended for **drop**. Every "inert in
+this window" hook guards a documented, previously-real failure class whose
+trigger condition is narrow by design (that's the point of a targeted
+advisory) — a 30-day/49-session window without a match is consistent with
+"working as intended, rare trigger" rather than "obsolete".
+
+## Summary verdict table
+
+| Verdict | Count | Hooks |
+| --- | --- | --- |
+| **Keep** (active or narrow-safety-net) | 51 | All PreToolUse/PostToolUse hooks scored above, plus all hooks with nonzero block/ask/advise activity not otherwise discussed |
+| **Investigate** (non-drop follow-up) | 2 | `pre-gh-pr-create-dedup-gate` (advisory message clarity), `memory-hint` (keyword-match coverage) |
+| **Merge candidate, blocked on prerequisite** | 2 | `pre-output-falsification-gate` + `output-block-falsify-advisory` — revisit only after Cluster B3's shared-matcher extraction lands and a further fire-rate window still shows full overlap |
+| **Unmeasurable — instrument first** | 4 | `codex-review-route`, `completion-verify`, `retrospect-mix-check`, `strike-counter` (shell hooks, no fire-event emission) |
+| **Drop** | 0 | — |
+
+## Bottom line
+
+No hook meets the bar for removal on the current evidence. The 60-hook count
+itself is not, on this data, an accretion of dead weight — it's mostly narrow,
+non-overlapping safety nets whose low individual fire-rate is exactly what a
+targeted advisory should look like. The actionable follow-ups are smaller and
+different in kind: (1) finish Cluster B3's code dedup before reconsidering a
+hook merge, (2) instrument the 4 shell hooks so they're scoreable, (3) look at
+why `pre-gh-pr-create-dedup-gate`'s advisory is ignored 30% of the time, and
+(4) confirm `memory-hint`'s 13 registered keyword sets actually match real
+tool-call text.


### PR DESCRIPTION
## 배경

`.omc/specs/deep-dive-ponytail-vs-praxis-improvements.md` P4 작업 항목: ponytail의 deletion-over-addition 렌즈를 praxis 자신의 hook 누적(58개)에 적용. #710(fire-ledger)의 실측 데이터가 있어야 착수 가능한 hard-dependent 작업이었고, PR #731이 `advise_ignored_rate` 지표를 완료하면서 이번에 착수했다.

Closes #713

## 방법

`./skills/bypass-review/bypass-review fire-rate -d 30` 실행 결과(fire-event 계측 자체가 2026-06-26에 시작되어 실효 구간은 2026-06-26~07-01, 49 세션)를 `hooks/manifest.json`의 58개 등록 hook과 대조해 4축으로 채점:

1. **never-fired** — 계측 가능한 hook 중 0건
2. **advise-ignored-rate 높음** — `pre-gh-pr-create-dedup-gate`(30%, n=23)만 유의미
3. **coverage-duplicate** — Cluster B2/B3(기존 품질 감사)의 code-dedup 대상 pair를 fire-rate로 교차검증, `merge` 성 대신 named-clustering false-positive(4개 merge 관련 hook)도 별도 반증
4. **advisory-only-never-escalated** — Stop/UserPromptSubmit 이벤트 hook은 리포트 자체 caveat(coarse fire-count로 escalation 불가시)에 따라 axis 제외, strict_env 보유 hook은 기본이 advisory이므로 block=0을 "죽은 코드"로 오독하지 않도록 배제. 남은 "0-fire" 후보 6개는 각 spec.md를 읽어 실제 목적/과거 사례 확인 후 판정.

## 결과

**drop 0건.** 60개에 가까운 hook 누적이 실제로는 좁은 트리거의 비중복 safety-net들이며, 낮은 fire율 자체가 "의도대로 동작"의 증거임을 확인. 액션 가능한 follow-up 4건(범위 밖, 별도 후속):

1. Cluster B3(`pre-output-falsification-gate` + `output-block-falsify-advisory`) 코드 dedup 완료 후 hook merge 재검토
2. uninstrumented shell hook 4개(`codex-review-route`/`completion-verify`/`retrospect-mix-check`/`strike-counter`) 계측 추가
3. `pre-gh-pr-create-dedup-gate` advisory 메시지 명확성 검토(30% ignored)
4. `memory-hint` — 13개 hookable 메모리가 등록돼 있음에도 5053회 평가 중 0회 advise, keyword 매칭 커버리지 확인 필요

## codex-review-wrap 적용 결과

Codex 리뷰 P2 finding 2건, 둘 다 premise 검증 후 반영:

- **깨진 링크**: `.omc/specs/...`로의 markdown 링크가 `.gitignore`(24행 `.omc/`)로 미추적되어 GitHub에서 404 — `git ls-files`로 확인, plain-text 경로 참조로 전환
- **카운트 산술 불일치**: "58개 중 55개 fire + 4개 unmeasurable = 59"로 manifest 전체(58)와 불일치 — `hooks/manifest.json`을 직접 파싱해 재계산한 결과 54(수동 카운트 오프바이원)가 정확한 값. 본문·summary 표 정정, Total 검증 행 추가.

## 검증

Pre-commit verified: `bash scripts/run-tests.sh`(issue-713 worktree, 두 커밋 모두) → ALL TESTS PASSED (67 pass unit / 5 pass manifest smoke / hook-token invariant 7건); `npx markdownlint-cli@0.49.0 docs/hook-prune-audit.md`(CI가 실제 사용하는 버전) → clean

## 미검증

- `pre-gh-pr-create-dedup-gate`/`destructive-bash-guard`의 ignored-rate는 n=13-24로 표본이 작아 방향성 참고 수준
- `memory-hint`의 13개 hookKeywords가 실제 tool_input 텍스트와 매칭되는지는 이 PR 범위 밖(별도 follow-up)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Hook Prune Audit report with a clear keep/merge/drop verdict summary for registered hooks.
  * Documented evidence, sampling caveats, and outcome counts across hook categories.
  * Included follow-up items for incomplete coverage, unanswered cases, and validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->