### PR TITLE
fix(hooks): scan subagent transcripts for codex-review

### DIFF
--- a/hooks/preflight-gate/block-commit-without-codex-review/impl.py
+++ b/hooks/preflight-gate/block-commit-without-codex-review/impl.py
@@ -17,14 +17,42 @@ Block conditions (ALL must hold):
       cherry-pick/revert). Commits wrapped in a subshell/group (`(git …)`),
       command substitution (`$(git …)` / backtick), or chained behind a
       space-less separator (`true;git commit …`) are detected too.
-  (b) The session transcript contains NO `Skill` tool_use with
-      input.skill == "praxis:codex-review-wrap" AND no
-      `/praxis:codex-review-wrap` slash-command invocation
+  (b) NEITHER the session's own transcript NOR any of its subagent
+      transcripts (`<session-dir>/subagents/agent-*.jsonl`) contains a
+      `Skill` tool_use with input.skill == "praxis:codex-review-wrap", and
+      the root transcript has no `/praxis:codex-review-wrap` slash-command
+      invocation either.
+
+      Subagent transcripts are scanned because a
+      `Skill(praxis:codex-review-wrap)` call made *inside* a Task/Agent-
+      dispatched subagent is recorded only in that subagent's own JSONL
+      file — the
+      root transcript sees just the subagent's final tool_result text, with
+      no `isSidechain` entries at all (verified against live
+      ~/.claude/projects/<project>/<session_id>*.jsonl files: 0 isSidechain
+      lines in the root transcript, full subagent turns only under
+      <session_id>/subagents/). A root-only scan is structurally blind to
+      review work a subagent actually performed (praxis issue #730,
+      surfaced during issue #720). Each Claude Code session (and therefore
+      each worktree/ultrawork branch, which runs as its own session) has
+      its own transcript file and its own sibling subagents/ directory, so
+      this scan never crosses session boundaries.
 
 Allow conditions (escape hatches):
   - The commit -m/--message message contains a [skip-codex-review] token
-    (a -F file / heredoc body is not argv-visible — use the env bypass there)
-  - CLAUDE_HOOK_BYPASS_CODEX_REVIEW_GATE=1 env var
+    (a -F file / heredoc body is not argv-visible — use the persistent env
+    bypass there instead, see below)
+  - CLAUDE_HOOK_BYPASS_CODEX_REVIEW_GATE=1 set as a PERSISTENT environment
+    variable (exported before Claude Code starts, or configured via the
+    host's session/settings env) — NOT as an inline command prefix. The
+    PreToolUse hook runs as a separate process that only inherits the
+    Claude Code host's own environment; `CLAUDE_HOOK_BYPASS_CODEX_REVIEW_GATE=1
+    git commit …` places the assignment inside `tool_input.command`, which is
+    data the hook inspects, not env applied to the hook process itself — it
+    never reaches this process's `os.environ`. Verified empirically during
+    issue #720 work (the identical inline-prefix bypass is documented, and
+    equally non-functional, on the sibling `block-sciomc-finding-commit`
+    gate — see that hook's spec.md).
   - git commit --amend / git merge / git rebase / git cherry-pick / git revert
   - Missing / unreadable / oversized transcript → fail-open (cannot enforce)
   - Malformed / unparseable command (unbalanced quotes) → fail-open
@@ -33,7 +61,7 @@ NOT exempt: --allow-empty / --allow-empty-message. They permit an empty commit
 or empty message but do NOT prevent staged content from being committed, so
 exempting them would let `git commit --allow-empty -m x` (with staged changes)
 bypass the gate. An intentional empty CI-trigger commit uses the skip token or
-the env bypass instead.
+the persistent env bypass instead.
 
 Semantics: a whole-transcript scan means one codex-review-wrap invocation in
 the session satisfies all subsequent commits — the same coarse session-level
@@ -392,21 +420,36 @@ _SLASH_RE = re.compile(r"^\s*/(?:praxis:)?codex-review-wrap(?:\s.*)?$")
 _CMDNAME_RE = re.compile(r"^\s*<command-name>/?(?:praxis:)?codex-review-wrap(?:\s|</|$)")
 
 
-def _scan_transcript(path: str) -> bool | None:
-    """Return True if codex-review-wrap was invoked, False if not, None if the
-    transcript cannot be read (caller treats None as fail-open)."""
+def _read_lines(path: str) -> list[str] | None:
+    """Bounded read of a transcript file into stripped, non-empty lines.
+
+    Returns None when the path is missing, unreadable, or larger than
+    `_MAX_BYTES` (caller decides how to treat None per call site)."""
     try:
         p = Path(path)
         if not p.is_file() or p.stat().st_size > _MAX_BYTES:
             return None
-        lines = p.read_text(encoding="utf-8", errors="replace").splitlines()
+        raw = p.read_text(encoding="utf-8", errors="replace").splitlines()
     except (OSError, ValueError):
         return None
+    return [line.strip() for line in raw if line.strip()]
 
+
+def _lines_invoke_skill(lines: list[str], *, check_slash: bool) -> bool:
+    """True if any JSONL line carries a genuine codex-review-wrap invocation.
+
+    Shared by both the root-transcript scan and the per-subagent-transcript
+    scan below — the event shape (`message.content[].tool_use`) is identical
+    in both file kinds (subagent JSONL is written in the same Anthropic
+    message format, just under `<session>/subagents/agent-*.jsonl`).
+
+    `check_slash` scopes the `/praxis:codex-review-wrap` slash-command check
+    to the root transcript only (subagent scans pass `check_slash=False`): a
+    slash command is a literal *human* keystroke, and a subagent's "user"
+    turns are Task-dispatch prompts / tool_results, never human input — the
+    slash channel cannot fire there in genuine operation, so checking it
+    would only be a phantom code path a fabricated transcript could abuse."""
     for line in lines:
-        line = line.strip()
-        if not line:
-            continue
         try:
             obj = json.loads(line)
         except (json.JSONDecodeError, ValueError):
@@ -422,8 +465,62 @@ def _scan_transcript(path: str) -> bool | None:
         # <command-name> marker) so an assistant suggestion cannot satisfy it.
         if _has_skill_tool_use(obj):
             return True
-        if obj.get("type") == "user" and _has_slash_command(obj):
+        if check_slash and obj.get("type") == "user" and _has_slash_command(obj):
             return True
+    return False
+
+
+def _subagents_dir(transcript_path: str) -> Path | None:
+    """Return `<session-dir>/subagents/` for a root transcript path, if it
+    exists on disk.
+
+    Claude Code lays subagent transcripts out as a sibling directory named
+    after the session: root transcript `<project-dir>/<session_id>.jsonl`,
+    subagent transcripts `<project-dir>/<session_id>/subagents/agent-*.jsonl`
+    (one file per Task/Agent-dispatched subagent, live-verified against
+    `~/.claude/projects/<project>/<session_id>/subagents/`). Each session
+    (and therefore each worktree/ultrawork branch, which runs as its own
+    Claude Code session) has its own transcript and its own sibling
+    subagents/ directory, so this never reaches across sessions.
+
+    Returns None (not an error — just "nothing to scan") when the transcript
+    path has no `.jsonl` suffix or the sibling directory does not exist,
+    e.g. when the hook fires for a session that spawned no subagents yet.
+    """
+    p = Path(transcript_path)
+    if p.suffix != ".jsonl":
+        return None
+    candidate = p.with_suffix("") / "subagents"
+    return candidate if candidate.is_dir() else None
+
+
+def _scan_transcript(path: str) -> bool | None:
+    """Return True if codex-review-wrap was invoked in the session's own
+    transcript OR any of its subagent transcripts, False if not invoked
+    anywhere, None if the root transcript cannot be read (caller treats
+    None as fail-open).
+
+    A subagent transcript that is individually unreadable/oversized is
+    skipped (that one subagent's history just cannot contribute a PASS) —
+    it does not turn the overall result into a fail-open None, since the
+    root transcript (the thing we can actually read) already answered the
+    question definitively for everything outside that one subagent run.
+    """
+    root_lines = _read_lines(path)
+    if root_lines is None:
+        return None  # missing/unreadable/oversized root → cannot enforce
+    if _lines_invoke_skill(root_lines, check_slash=True):
+        return True
+
+    subagents_dir = _subagents_dir(path)
+    if subagents_dir is not None:
+        # check_slash=False: a subagent transcript's "user" turns are
+        # Task-dispatch prompts / tool_results, never human keystrokes, so
+        # slash-command detection is root-only (see _lines_invoke_skill).
+        for agent_file in subagents_dir.glob("agent-*.jsonl"):
+            agent_lines = _read_lines(str(agent_file))
+            if agent_lines and _lines_invoke_skill(agent_lines, check_slash=False):
+                return True
     return False
 
 
@@ -478,10 +575,14 @@ def _emit_block_message() -> None:
                 "Resolve by one of:",
                 "  1. Run the review (it is a model-invocable skill, not an agent):",
                 "       Skill(skill=\"praxis:codex-review-wrap\")",
-                "     then re-run the commit (one run satisfies all commits this session).",
+                "     then re-run the commit (one run satisfies all commits this session,",
+                "     including one run inside a subagent this session dispatched).",
                 "  2. Skip for this commit: add a [skip-codex-review] token to the",
                 "     commit message (e.g. trivial docs/typo change).",
-                "  3. One-off bypass: prefix with CLAUDE_HOOK_BYPASS_CODEX_REVIEW_GATE=1",
+                "  3. Persistent bypass: set CLAUDE_HOOK_BYPASS_CODEX_REVIEW_GATE=1 in your",
+                "     environment BEFORE starting Claude Code (settings env / shell export).",
+                "     An inline prefix on this command does NOT work — the hook process",
+                "     never sees it.",
                 "",
                 "Fail-open: missing/unreadable transcript and non-content commits",
                 "(--amend / merge / rebase / cherry-pick / revert) pass.",

--- a/hooks/preflight-gate/block-commit-without-codex-review/spec.md
+++ b/hooks/preflight-gate/block-commit-without-codex-review/spec.md
@@ -4,7 +4,8 @@ Supported hosts: claude
 
 `hooks/preflight-gate/block-commit-without-codex-review/impl.py` intercepts every Bash tool call and
 hard-blocks a content `git commit` when `praxis:codex-review-wrap` has not been
-invoked anywhere in the current session.
+invoked anywhere in the current session — including inside any subagent that
+session dispatched (see [Subagent transcript scanning](#subagent-transcript-scanning-issue-730) below).
 
 ### Why this exists
 
@@ -27,11 +28,12 @@ Both conditions must hold for a block (exit 2):
    `git rebase`, `git cherry-pick`, and `git revert` are exempt. `--allow-empty`
    / `--allow-empty-message` are **not** exempt: they only permit an empty
    commit / message and do not prevent staged content from being committed, so
-   a content commit using them is still gated (use the skip token or env bypass
-   for an intentional empty CI-trigger commit).
-2. The session transcript contains no `Skill` tool_use with
-   `input.skill == "praxis:codex-review-wrap"` and no `/praxis:codex-review-wrap`
-   slash-command invocation (a prose mention such as "should I run
+   a content commit using them is still gated (use the skip token or the
+   persistent env bypass for an intentional empty CI-trigger commit).
+2. Neither the session's own transcript nor any of its subagent transcripts
+   contains a `Skill` tool_use with `input.skill == "praxis:codex-review-wrap"`,
+   and the root transcript has no `/praxis:codex-review-wrap` slash-command
+   invocation either (a prose mention such as "should I run
    /praxis:codex-review-wrap?" does not count — the match is line-anchored).
 
 | Situation | Action |
@@ -39,20 +41,55 @@ Both conditions must hold for a block (exit 2):
 | `git commit -m "..."` with no codex-review-wrap invocation this session | **BLOCKED** (exit 2) |
 | `git commit` after a `Skill(praxis:codex-review-wrap)` tool_use | **PASS** (review ran) |
 | `git commit` after a `/praxis:codex-review-wrap` slash command | **PASS** (review ran) |
+| `git commit` after a subagent ran `Skill(praxis:codex-review-wrap)` | **PASS** (review ran, in a subagent transcript — issue #730) |
 | `git commit --amend` / `git revert` / `git merge` | **PASS** (non-content / exempt) |
 | `git commit -m "docs [skip-codex-review]"` | **PASS** (skip token) |
 
 Granularity is session-level: one codex-review-wrap invocation satisfies all
-subsequent commits in the same session (whole-transcript scan), matching the
-other commit / PR review gates.
+subsequent commits in the same session (whole-transcript scan, root +
+subagents), matching the other commit / PR review gates.
+
+### Subagent transcript scanning (issue #730)
+
+A `Skill(praxis:codex-review-wrap)` call made *inside* a Task/Agent-dispatched
+subagent is recorded only in that subagent's own JSONL file — the root
+transcript carries no `isSidechain` entries at all (live-verified: 0
+`isSidechain` lines across sampled root transcripts, full subagent turns only
+under the sibling `subagents/` directory). A root-only scan is therefore
+structurally blind to review work a subagent actually performed, which forced
+use of the `[skip-codex-review]` escape hatch even when a real review had run
+(surfaced during issue #720 work).
+
+The hook now also scans `<session-dir>/subagents/agent-*.jsonl` — the sibling
+directory Claude Code writes one file into per dispatched subagent, keyed off
+the root transcript path (`<project-dir>/<session_id>.jsonl` →
+`<project-dir>/<session_id>/subagents/`). Each Claude Code session — and
+therefore each worktree/ultrawork branch, since each runs as its own session
+— has its own transcript and its own sibling `subagents/` directory, so this
+scan never crosses session boundaries: a review run in one worktree's session
+does not satisfy the gate for a commit in a different worktree's session. A
+subagent transcript that is individually unreadable/oversized is skipped
+(that one subagent's history just can't contribute a PASS); it does not
+turn the whole scan into a fail-open, since the root transcript already
+answered the question for everything outside that one subagent run.
 
 ### Escape hatches
 
 - Add a `[skip-codex-review]` token to the commit `-m` / `--message` message
   for a deliberate skip (e.g. a trivial docs / typo change). A token elsewhere
   in a compound command does not count — for `-F file` / heredoc commits use
-  the env bypass instead.
-- Set `CLAUDE_HOOK_BYPASS_CODEX_REVIEW_GATE=1` for a one-off bypass.
+  the persistent env bypass instead (see below).
+- Set `CLAUDE_HOOK_BYPASS_CODEX_REVIEW_GATE=1` as a **persistent** environment
+  variable — exported in the shell *before* Claude Code starts, or configured
+  via the host's session/settings env. **This does NOT work as an inline
+  command prefix** (`CLAUDE_HOOK_BYPASS_CODEX_REVIEW_GATE=1 git commit …`):
+  the PreToolUse hook runs as a separate process that only inherits the
+  Claude Code host's own environment. An inline assignment lives inside
+  `tool_input.command` — data the hook inspects, not env applied to the hook
+  process — so it never reaches this process's `os.environ`. Verified
+  empirically during issue #720 work; the identical inline-prefix bypass is
+  documented (and equally non-functional as written) on the sibling
+  [`block-sciomc-finding-commit`](../block-sciomc-finding-commit/spec.md) gate.
 - Missing / unreadable / oversized (`>50MB`) transcript → silent pass (cannot
   enforce). Malformed stdin or an unparseable command (unbalanced quotes) →
   silent fail-open.
@@ -88,13 +125,15 @@ does not execute it) — correctly ignored.
 bash tests/hooks/preflight-gate/test_block_commit_without_codex_review.sh
 ```
 
-Covers 47 cases: block paths (no invocation, wrong skill, `-F` body, prose-only
-slash mention), pass paths (Skill tool_use, slash command, garbage-line
-resilience), exemptions (amend / allow-empty / merge / revert / rebase /
-cherry-pick), escape hatches (`-m` skip token incl. joined / `--message=`
-forms, env bypass), token-level edge cases (`git commit-tree` plumbing,
-`echo "git commit"`, `git log --grep`, `--amend` inside the message, skip
-token outside the message via `;` / `&&`, commit after `&&`),
+Covers 51 cases: block paths (no invocation, wrong skill, `-F` body, prose-only
+slash mention, subagent dir present but no subagent invocation, slash-command
+line inside a subagent transcript not satisfying the gate), pass paths (Skill
+tool_use, slash command, garbage-line resilience, Skill tool_use inside a
+subagent transcript — issue #730), exemptions (amend / allow-empty / merge /
+revert / rebase / cherry-pick), escape hatches (`-m` skip token incl. joined /
+`--message=` forms, persistent env bypass), token-level edge cases (`git commit-tree`
+plumbing, `echo "git commit"`, `git log --grep`, `--amend` inside the message,
+skip token outside the message via `;` / `&&`, commit after `&&`),
 hardened-parser bypass forms (grouped `(git commit …)`, unquoted substitution
 `$(git commit …)`, no-space separator `true;git commit …`, nested substitution,
 quoted substitution, single-quoted literal pass, double-quoted literal pass,

--- a/tests/hooks/preflight-gate/test_block_commit_without_codex_review.sh
+++ b/tests/hooks/preflight-gate/test_block_commit_without_codex_review.sh
@@ -45,6 +45,47 @@ printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"ty
 
 NONEXISTENT_TX="/tmp/does-not-exist-praxis-425-$$.jsonl"
 
+# Subagent-transcript fixtures (praxis issue #730) ---------------------------
+# Claude Code lays subagent transcripts out as
+# <project-dir>/<session_id>/subagents/agent-*.jsonl next to the root
+# <project-dir>/<session_id>.jsonl — reproduce that layout under a temp dir so
+# the root path's `.jsonl` suffix + stem-dir lookup resolves correctly.
+SUB_TX_ROOT_DIR=$(mktemp -d)
+SUB_SESSION_ID="session-$$"
+SUB_ROOT_TX="$SUB_TX_ROOT_DIR/$SUB_SESSION_ID.jsonl"
+SUB_AGENTS_DIR="$SUB_TX_ROOT_DIR/$SUB_SESSION_ID/subagents"
+mkdir -p "$SUB_AGENTS_DIR"
+
+# Root transcript has no review evidence of its own.
+printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"implementing"}]}}' >"$SUB_ROOT_TX"
+
+# Subagent transcript DOES contain the Skill tool_use (matches live-observed
+# subagent JSONL shape: message.content[] tool_use with name=Skill).
+printf '%s\n' '{"parentUuid":null,"isSidechain":true,"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Skill","input":{"skill":"praxis:codex-review-wrap"},"caller":{"type":"direct"}}]}}' >"$SUB_AGENTS_DIR/agent-abc123.jsonl"
+
+# A second, sibling temp-dir layout where the subagents dir exists but no
+# agent transcript invokes codex-review-wrap — must still BLOCK.
+SUB_TX_ROOT_DIR_NOINVOKE=$(mktemp -d)
+SUB_SESSION_ID_NOINVOKE="session-noinvoke-$$"
+SUB_ROOT_TX_NOINVOKE="$SUB_TX_ROOT_DIR_NOINVOKE/$SUB_SESSION_ID_NOINVOKE.jsonl"
+SUB_AGENTS_DIR_NOINVOKE="$SUB_TX_ROOT_DIR_NOINVOKE/$SUB_SESSION_ID_NOINVOKE/subagents"
+mkdir -p "$SUB_AGENTS_DIR_NOINVOKE"
+printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"implementing"}]}}' >"$SUB_ROOT_TX_NOINVOKE"
+printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"x.py"}}]}}' >"$SUB_AGENTS_DIR_NOINVOKE/agent-def456.jsonl"
+
+# A third layout: the subagent transcript has a literal
+# "/praxis:codex-review-wrap" line as a `user`-type entry — this is NOT a
+# genuine human slash-command keystroke (subagent "user" turns are
+# Task-dispatch prompts / tool_results), so it must NOT satisfy the gate.
+# Regression guard for the root-only slash-scoping fix (code-review MEDIUM).
+SUB_TX_ROOT_DIR_SLASH=$(mktemp -d)
+SUB_SESSION_ID_SLASH="session-slash-$$"
+SUB_ROOT_TX_SLASH="$SUB_TX_ROOT_DIR_SLASH/$SUB_SESSION_ID_SLASH.jsonl"
+SUB_AGENTS_DIR_SLASH="$SUB_TX_ROOT_DIR_SLASH/$SUB_SESSION_ID_SLASH/subagents"
+mkdir -p "$SUB_AGENTS_DIR_SLASH"
+printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"implementing"}]}}' >"$SUB_ROOT_TX_SLASH"
+printf '%s\n' '{"type":"user","isSidechain":true,"message":{"role":"user","content":"/praxis:codex-review-wrap"}}' >"$SUB_AGENTS_DIR_SLASH/agent-ghi789.jsonl"
+
 PASS=0; FAIL=0; FAILED_NAMES=()
 
 # run_case <name> <block|pass> <tool_name> <command> [transcript_path|"NONE"] [env]
@@ -151,7 +192,11 @@ run_case "skip token in -m" pass Bash \
 run_case "skip token case-insensitive" pass Bash \
   'git commit -m "docs: typo [SKIP-CODEX-REVIEW]"' "$TX_WITHOUT"
 
-run_case "env bypass" pass Bash \
+# NOTE: this simulates the env var already present in the hook's OWN process
+# env (the only case that actually works — see spec.md Escape hatches). It
+# does NOT simulate `CLAUDE_HOOK_BYPASS_CODEX_REVIEW_GATE=1 git commit …` as
+# an inline command prefix, which never reaches this process (issue #730).
+run_case "persistent env var in hook process bypasses the gate" pass Bash \
   'git commit -m "x"' "$TX_WITHOUT" "CLAUDE_HOOK_BYPASS_CODEX_REVIEW_GATE=1"
 
 # ---------------------------------------------------------------------------
@@ -273,6 +318,19 @@ run_case "git --version commit is terminal option (pass)" pass Bash \
   'git --version commit' "$TX_WITHOUT"
 
 # ---------------------------------------------------------------------------
+# Subagent-transcript scanning (praxis issue #730)
+# ---------------------------------------------------------------------------
+
+run_case "codex-review-wrap run inside a subagent this session satisfies the gate" pass Bash \
+  'git commit -m "feat: x"' "$SUB_ROOT_TX"
+
+run_case "subagent dir exists but no subagent invoked codex-review-wrap" block Bash \
+  'git commit -m "feat: x"' "$SUB_ROOT_TX_NOINVOKE"
+
+run_case "slash-command line inside a subagent transcript does NOT satisfy the gate" block Bash \
+  'git commit -m "feat: x"' "$SUB_ROOT_TX_SLASH"
+
+# ---------------------------------------------------------------------------
 # Fail-open cases
 # ---------------------------------------------------------------------------
 
@@ -319,6 +377,7 @@ fi
 # ---------------------------------------------------------------------------
 
 rm -f "$TX_WITH_SKILL" "$TX_WITH_SLASH" "$TX_ASSISTANT_SLASH" "$TX_WITHOUT" "$TX_WRONG_SKILL" "$TX_GARBAGE_PLUS_SKILL"
+rm -rf "$SUB_TX_ROOT_DIR" "$SUB_TX_ROOT_DIR_NOINVOKE" "$SUB_TX_ROOT_DIR_SLASH"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## 배경

`block-commit-without-codex-review` 훅이 root session transcript만 스캔해, 서브에이전트가 `Skill(praxis:codex-review-wrap)`으로 실제 리뷰를 수행해도 감지하지 못하는 구조적 blind spot이 있었다(issue #720 작업 중 발견). 문서화된 `CLAUDE_HOOK_BYPASS_CODEX_REVIEW_GATE=1` 인라인 prefix 우회도 실제로는 동작하지 않아 문서와 실동작이 불일치했다.

Closes #730

## 무엇을 고쳤나

### 1. 서브에이전트 transcript 스캔 확장

`_scan_transcript`가 root transcript 외에 `<session-dir>/subagents/agent-*.jsonl`도 스캔하도록 확장했다. 라이브 검증 결과 root transcript에는 `isSidechain` 항목이 전혀 없고, 서브에이전트 전체 turn은 `subagents/` 하위 파일에만 기록됨을 확인했다. 세션(및 worktree/ultrawork 브랜치)마다 자기 자신의 `subagents/` 디렉토리를 가지므로 세션 경계를 넘어서는 스캔은 발생하지 않는다. 개별 서브에이전트 transcript가 읽기 불가/과대용량이면 그 서브에이전트만 스킵하고(fail-open으로 전체를 무효화하지 않음), root transcript가 나머지를 이미 답했으므로 안전하다.

### 2. env var 우회 문서 수정

`CLAUDE_HOOK_BYPASS_CODEX_REVIEW_GATE=1`는 인라인 커맨드 prefix로는 동작하지 않는다 — PreToolUse 훅이 별도 프로세스로 실행되며 Claude Code 호스트 자신의 환경만 상속받기 때문에, 인라인 assignment는 `tool_input.command` 안의 데이터일 뿐 훅 프로세스의 `os.environ`에 도달하지 못한다(issue #720 작업 중 실증, sibling `block-sciomc-finding-commit`에도 동일 패턴 확인·cross-reference 추가). spec.md와 `_emit_block_message()` 안내 메시지 모두 "Claude Code 시작 전에 export된 persistent 환경변수"로만 동작함을 명시하도록 수정했다.

### 3. sibling 훅 blind spot 점검

`block-sciomc-finding-commit`도 동일한 root-transcript-only 구조와 동일한 인라인-prefix 우회 무효 패턴을 갖고 있음을 확인했다. 이 PR 스코프(이슈 #730이 지정한 훅 하나)에서는 손대지 않고, spec.md에 cross-reference만 추가했다 — 별도 수정이 필요하면 후속 이슈로 분리할 수 있다.

## 검증

Pre-commit verified: `bash scripts/run-tests.sh` → ALL TESTS PASSED (전체 pytest + shell 스위트, 신규/확장된 `test_block_commit_without_codex_review.sh` 포함). `./scripts/check-plugin-manifests.py` → OK (신규 훅 없음, 기존 훅만 수정이라 manifest 변경 없음).

## 미검증

- 실제 멀티 worktree/ultrawork 병렬 세션에서의 e2e 재현(각 worktree가 자기 세션·subagents 디렉토리를 갖는다는 것은 라이브 파일 구조로 확인했으나, 병렬 실행 중 실시간 동작은 synthetic fixture 기반 테스트로만 검증)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Commit gating now correctly recognizes codex-review activity anywhere in the current session, including subagent transcripts.
  * Improved handling of missing or unreadable subagent logs so valid sessions are not blocked incorrectly.
  * Updated bypass behavior to require a persistent environment setting, and clarified that inline prefixes do not work.
* **Tests**
  * Expanded coverage for subagent transcript scenarios, false-positive slash-command text, and the revised bypass flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->