### PR TITLE
feat(hooks): detect external-write revert commands

### DIFF
--- a/hooks/advisory-nudge/destructive-bash-guard/impl.py
+++ b/hooks/advisory-nudge/destructive-bash-guard/impl.py
@@ -45,6 +45,23 @@ Fail-open contract:
   • Non-Bash tool → exit 0
   • Empty / whitespace command → exit 0
   • Any uncaught exception in inner logic → swallowed, exit 0
+
+Outcome-proxy signal detection (issue #737, deep-interview spec
+`.omc/specs/deep-interview-issue-737-outcome-proxy.md`):
+
+  In addition to the destructive-command surfaces above, this hook detects
+  `git revert`, `gh pr close`, and `gh issue reopen` — command-pattern
+  detection only (the moment a revert-style command executes), NOT
+  state-reversal correlation. These are NOT destructive commands (revert is
+  the *safe* way to undo, not a data-loss risk), so they are reported via a
+  separate, non-alarming "outcome-proxy signal detected" stderr note rather
+  than the "destructive command detected" banner, and they never escalate to
+  `permissionDecision: ask` even under `PRAXIS_DESTRUCTIVE_BASH_STRICT=1`.
+  The stderr write still makes the fire-ledger dispatcher record a
+  decision=advise fire for this hook (see `hooks/_lib/_fire_ledger.py`),
+  which is what `bypass-review fire-rate`'s Outcome Proxy section reads.
+  Reuses the same `safe_tokenize`/`iter_command_starts`/`strip_prefix`
+  pipeline — no new hook, no new manifest entry (issue #737 constraint).
 """
 from __future__ import annotations
 
@@ -318,6 +335,61 @@ def _is_shred(argv: list[str]) -> bool:
     return os.path.basename(argv[0]) == "shred"
 
 
+def _is_git_revert(argv: list[str]) -> bool:
+    """True iff argv invokes `git revert` (any flags/target).
+
+    Mirrors `_is_git_reset_hard`'s subcommand-skip loop so `git -C dir
+    revert HEAD` and `git -c user.name=x revert HEAD` are still detected.
+    """
+    if not argv or os.path.basename(argv[0]) != "git":
+        return False
+    i = 1
+    n = len(argv)
+    while i < n:
+        tok = argv[i]
+        if tok in {"-C", "-c"} and i + 1 < n:
+            i += 2
+            continue
+        if tok.startswith("-"):
+            i += 1
+            continue
+        break
+    return i < n and argv[i] == "revert"
+
+
+
+# `-R`/`--repo` is an inherited gh flag that MAY precede the subcommand —
+# verified live: `gh -R o/r pr close --help` and `gh --repo o/r issue
+# reopen --help` both exit 0 (codex-review-wrap round 1 finding, issue
+# #737). Its value is a separate token in this form, so it must be
+# skipped as a flag+value pair, not just a bare flag.
+_GH_FLAGS_WITH_ARG = frozenset({"-R", "--repo"})
+
+
+def _is_gh_subcommand(argv: list[str], group: str, action: str) -> bool:
+    """True iff argv invokes `gh <group> <action>` (leading flags skipped).
+
+    `gh` has no `-C`/`env`-style prefix in `PREFIX_WRAPPERS`, so leading
+    flags are skipped inline here. `-R`/`--repo <value>` (separate-token
+    form) and `--repo=<value>` (glued form) are both consumed without
+    stopping the scan; other bare leading flags are skipped without value
+    consumption, matching the conservative style of the other detectors in
+    this module (false-negative on an edge case is acceptable; a
+    false-positive `ask` prompt is not).
+    """
+    if not argv or os.path.basename(argv[0]) != "gh":
+        return False
+    rest = argv[1:]
+    i = 0
+    while i < len(rest) and rest[i].startswith("-"):
+        tok = rest[i]
+        if tok in _GH_FLAGS_WITH_ARG and i + 1 < len(rest):
+            i += 2
+            continue
+        i += 1
+    return rest[i:i + 2] == [group, action]
+
+
 def _is_fork_bomb(command: str) -> bool:
     """Detect the canonical fork-bomb idiom `:(){ :|:& };:`.
 
@@ -376,7 +448,27 @@ def _classify_segment(raw_argv: list[str]) -> str | None:
     return None
 
 
+def _classify_signal_segment(argv: list[str]) -> str | None:
+    """Return a one-line reason string if `argv` is an outcome-proxy signal
+    (issue #737), else None. Deliberately separate from `_classify_segment`
+    — these are undo/reversal-adjacent actions, not destructive ones, so
+    they must not be labeled "destructive command detected" or escalate to
+    `ask` under strict mode. `argv` is expected to already be `strip_prefix`d
+    by the caller (mirrors `_classify_segment`'s contract).
+    """
+    if not argv:
+        return None
+    if _is_git_revert(argv):
+        return "`git revert` — external-write revert signal"
+    if _is_gh_subcommand(argv, "pr", "close"):
+        return "`gh pr close` — external-write revert signal"
+    if _is_gh_subcommand(argv, "issue", "reopen"):
+        return "`gh issue reopen` — external-write revert signal"
+    return None
+
+
 _ADVISORY_HEADER = "[destructive-bash-guard] destructive command detected"
+_SIGNAL_HEADER = "[destructive-bash-guard] outcome-proxy signal detected"
 
 
 def _advisory_text(reasons: list[str], strict: bool) -> str:
@@ -396,6 +488,21 @@ def _advisory_text(reasons: list[str], strict: bool) -> str:
         "    • Soften strict mode: unset PRAXIS_DESTRUCTIVE_BASH_STRICT\n"
         "\n"
         "  Reference: issue #463"
+    )
+
+
+def _signal_text(reasons: list[str]) -> str:
+    body_lines = "\n".join(f"    - {r}" for r in reasons)
+    return (
+        f"{_SIGNAL_HEADER} — INFORMATIONAL (not blocked)\n"
+        "\n"
+        f"  Detected:\n{body_lines}\n"
+        "\n"
+        "  This is a reversal/undo-style command, not a destructive one — the\n"
+        "  command proceeds unchanged. Recorded as a fire-ledger telemetry\n"
+        "  signal only (bypass-review fire-rate's Outcome Proxy section).\n"
+        "\n"
+        "  Reference: issue #737"
     )
 
 
@@ -427,22 +534,40 @@ def main() -> int:
         reasons.append(reason)
         seen.add(reason)
 
+    signal_reasons: list[str] = []
+    signal_seen: set[str] = set()
+
     for raw_argv in iter_command_starts(tokens):
         reason = _classify_segment(raw_argv)
         if reason and reason not in seen:
             reasons.append(reason)
             seen.add(reason)
 
-    if not reasons:
+        argv = strip_prefix(raw_argv)
+        if argv:
+            signal_reason = _classify_signal_segment(argv)
+            if signal_reason and signal_reason not in signal_seen:
+                signal_reasons.append(signal_reason)
+                signal_seen.add(signal_reason)
+
+    if not reasons and not signal_reasons:
         return 0
 
     strict = os.environ.get("PRAXIS_DESTRUCTIVE_BASH_STRICT", "").strip() == "1"
 
-    if strict:
-        emit_decision("ask", _advisory_text(reasons, strict=True))
+    if reasons and strict:
+        text = _advisory_text(reasons, strict=True)
+        if signal_reasons:
+            text += "\n\n" + _signal_text(signal_reasons)
+        emit_decision("ask", text)
         return 0
 
-    sys.stderr.write(_advisory_text(reasons, strict=False) + "\n")
+    stderr_parts = []
+    if reasons:
+        stderr_parts.append(_advisory_text(reasons, strict=False))
+    if signal_reasons:
+        stderr_parts.append(_signal_text(signal_reasons))
+    sys.stderr.write("\n\n".join(stderr_parts) + "\n")
     return 0
 
 

--- a/hooks/advisory-nudge/destructive-bash-guard/spec.md
+++ b/hooks/advisory-nudge/destructive-bash-guard/spec.md
@@ -53,13 +53,42 @@ These device targets are NOT flagged when used as redirect targets:
 
 `/dev/null`, `/dev/stdout`, `/dev/stderr`, `/dev/zero`, `/dev/tty`
 
+### Outcome-proxy signal detection (issue #737)
+
+Separate from the destructive-command rules above, this hook also detects
+`git revert`, `gh pr close`, and `gh issue reopen` — reversal/undo-adjacent
+commands, NOT destructive ones. This is command-pattern detection only (the
+moment the command executes), not state-reversal correlation (whether an
+earlier mutation was actually undone).
+
+| Rule | Matches | Examples |
+| ------ | --------- | ---------- |
+| `git revert` | `git revert` (any flags/target) | `git revert HEAD`, `git revert --no-edit HEAD~1` |
+| `gh pr close` | `gh pr close` (leading `gh` flags skipped, incl. `-R`/`--repo <value>`) | `gh pr close 5`, `gh -R o/r pr close 5`, `gh --repo=o/r pr close 5` |
+| `gh issue reopen` | `gh issue reopen` (leading `gh` flags skipped, incl. `-R`/`--repo <value>`) | `gh issue reopen 10`, `gh --repo o/r issue reopen 10` |
+
+These fire a **separate** stderr note — `"[destructive-bash-guard] outcome-proxy
+signal detected"` — never the "destructive command detected" banner, and they
+never escalate to `permissionDecision: ask` even under
+`PRAXIS_DESTRUCTIVE_BASH_STRICT=1` (the command is not destructive, so strict
+mode has nothing to gate). The stderr write still makes the shared
+fire-ledger dispatcher (`hooks/_lib/_fire_ledger.py`) record a
+`decision=advise` fire for this hook, which `bypass-review fire-rate`'s
+Outcome Proxy section reads as a best-effort `external_write_revert_count`
+signal (see that script's module docstring "OUTCOME PROXY LIMITATIONS" for
+the precision caveat — the fire-ledger schema cannot distinguish these
+patterns from the hook's pre-existing destructive-command detections).
+
+`PRAXIS_HOOK_BYPASS_DESTRUCTIVE_BASH=1` silences these too (full hook
+bypass); the strict-mode env var has no effect on them.
+
 ### Modes
 
 | Env var | Effect |
 | --------- | -------- |
 | (unset) | Advisory — stderr text, exit 0. Command proceeds. |
-| `PRAXIS_DESTRUCTIVE_BASH_STRICT=1` | Ask — emit `permissionDecision: ask` JSON. User confirms via runtime prompt. |
-| `PRAXIS_HOOK_BYPASS_DESTRUCTIVE_BASH=1` | Full bypass — exit 0 silently. |
+| `PRAXIS_DESTRUCTIVE_BASH_STRICT=1` | Ask — emit `permissionDecision: ask` JSON for destructive-command matches. Outcome-proxy signal matches are unaffected (still informational stderr only). |
+| `PRAXIS_HOOK_BYPASS_DESTRUCTIVE_BASH=1` | Full bypass — exit 0 silently (covers both destructive and outcome-proxy signal detection). |
 
 ### Examples
 
@@ -153,4 +182,7 @@ bash tests/hooks/advisory-nudge/test_destructive_bash_guard.sh
 Cases cover: every detection rule, false-positive guards (`rm -i`, `removed/`
 path, `git clean -n`, safe device targets, non-recursive chmod), compound
 command decomposition (`mkdir x && rm -rf x`), strict-mode JSON output,
-bypass env var, and infrastructure fail-open.
+bypass env var, infrastructure fail-open, and the outcome-proxy signal rules
+(`git revert`, `gh pr close`, `gh issue reopen` — including that strict mode
+does NOT escalate them to `ask`, and that a compound command mixing a
+destructive match with a signal match emits both).

--- a/skills/bypass-review/bypass-review
+++ b/skills/bypass-review/bypass-review
@@ -30,13 +30,10 @@ Options:
                          ~/.praxis/state/strikes)
   -h, --help             Show this message and exit
 
-OUTCOME PROXY LIMITATIONS (issue #710 item 3, fire-rate mode):
-  Only strike_count is computed — read from the per-session state JSON
-  written by hooks/completion-verify/strike-counter/impl.sh
-  ($STATE_DIR/<session_id>.json, field `count`). Three items from the
-  original issue text are NOT implemented because no telemetry source
-  currently records them:
-    - external-write revert     (no revert/undo event is logged anywhere)
+OUTCOME PROXY LIMITATIONS (issue #710 item 3 / issue #737, fire-rate mode):
+  strike_count and external_write_revert_count are computed. Two items from
+  the original issue text are still NOT implemented because no telemetry
+  source currently records them:
     - re-clarification loop     (requires transcript-level turn analysis,
                                   out of scope for this JSONL ledger)
     - rework commits            (requires git-log correlation per session,
@@ -45,6 +42,16 @@ OUTCOME PROXY LIMITATIONS (issue #710 item 3, fire-rate mode):
   after 7 days and `/praxis:reset-strikes` deletes it immediately on reset,
   so a session's true historical strike count may already be gone by the
   time this report runs.
+  external_write_revert_count (issue #737) is a COARSE proxy: it counts
+  destructive-bash-guard fire-ledger records with a non-pass decision in the
+  session. The fire-ledger schema (timestamp/session_id/tool/hook/role/
+  decision) carries no per-pattern detail, so this count cannot distinguish
+  the revert-signal patterns it was added for (`git revert`, `gh pr close`,
+  `gh issue reopen`) from that hook's pre-existing destructive-command
+  detections (`rm -rf`, `git reset --hard`, etc.) — see
+  hooks/advisory-nudge/destructive-bash-guard/impl.py. A nonzero count means
+  "destructive-bash-guard flagged something in this session", not "a revert
+  specifically occurred".
 
 Output sections:
   1. Summary — total events + date window
@@ -110,6 +117,11 @@ F_FIRE_DECISION = "decision"
 F_FIRE_GRANULARITY = "granularity"
 
 _FIRE_DECISIONS = ("block", "ask", "advise", "pass")
+
+# issue #737: hook name whose non-pass fires proxy the external-write-revert
+# outcome-proxy signal — cited verbatim from
+# hooks/advisory-nudge/destructive-bash-guard's manifest `name`.
+DESTRUCTIVE_BASH_GUARD_HOOK = "destructive-bash-guard"
 
 _INLINE_ENV_TOKEN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 _ENV_OPTIONS_WITH_VALUE = {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}
@@ -1038,23 +1050,48 @@ def load_strike_state(state_dir: Path, session_id: str) -> dict | None:
     }
 
 
+def compute_external_write_revert_counts(fire_events: list[dict]) -> dict[str, int]:
+    """Return dict[session_id] -> count of destructive-bash-guard non-pass fires.
+
+    Issue #737, best-effort COARSE proxy — see module docstring "OUTCOME
+    PROXY LIMITATIONS" for why this conflates the new revert-signal patterns
+    with destructive-bash-guard's pre-existing destructive-command detections.
+    """
+    counts: dict[str, int] = {}
+    for ev in fire_events:
+        if ev.get(F_FIRE_HOOK) != DESTRUCTIVE_BASH_GUARD_HOOK:
+            continue
+        if ev.get(F_FIRE_DECISION) == "pass":
+            continue
+        sid = ev.get(F_FIRE_SESSION)
+        if not isinstance(sid, str) or not sid:
+            continue
+        counts[sid] = counts.get(sid, 0) + 1
+    return counts
+
+
 def compute_outcome_proxy(fire_events: list[dict], state_dir: Path) -> dict[str, dict]:
-    """Return dict[session_id] -> {strike_count, strike_state_available}.
+    """Return dict[session_id] -> {strike_count, strike_state_available,
+    external_write_revert_count}.
 
     Only covers sessions that appear in the fire-events window. Sessions
     whose strike state already expired (7-day TTL) or was reset show
     strike_state_available=False, strike_count=0 — NOT proof of zero strikes.
+    external_write_revert_count is a best-effort proxy — see
+    compute_external_write_revert_counts / module docstring.
     """
     sessions = sorted({
         ev.get(F_FIRE_SESSION) for ev in fire_events
         if isinstance(ev.get(F_FIRE_SESSION), str) and ev.get(F_FIRE_SESSION)
     })
+    revert_counts = compute_external_write_revert_counts(fire_events)
     result: dict[str, dict] = {}
     for sid in sessions:
         state = load_strike_state(state_dir, sid)
         result[sid] = {
             "strike_count": state["count"] if state else 0,
             "strike_state_available": state is not None,
+            "external_write_revert_count": revert_counts.get(sid, 0),
         }
     return result
 
@@ -1206,12 +1243,17 @@ def _render_outcome_proxy_section(lines: list[str], outcome_proxy: dict[str, dic
     with_strikes = {
         sid: r for sid, r in outcome_proxy.items() if r["strike_count"] > 0
     }
+    with_reverts = {
+        sid: r for sid, r in outcome_proxy.items()
+        if r.get("external_write_revert_count", 0) > 0
+    }
     available = sum(1 for r in outcome_proxy.values() if r["strike_state_available"])
     lines.append(
         f"  Sessions in window : {len(outcome_proxy)}  "
         f"(strike state available for {available})"
     )
     lines.append(f"  Sessions with strikes : {len(with_strikes)}")
+    lines.append(f"  Sessions with external-write-revert signal : {len(with_reverts)}")
     if with_strikes:
         lines.append("")
         col = 40
@@ -1219,14 +1261,27 @@ def _render_outcome_proxy_section(lines: list[str], outcome_proxy: dict[str, dic
         lines.append(f"  {'─' * col}  {'─' * 7}")
         for sid in sorted(with_strikes, key=lambda s: with_strikes[s]["strike_count"], reverse=True):
             lines.append(f"  {sid:<{col}}  {with_strikes[sid]['strike_count']:>7}")
+    if with_reverts:
+        lines.append("")
+        col = 40
+        lines.append(f"  {'Session':<{col}}  {'Revert signal':>13}")
+        lines.append(f"  {'─' * col}  {'─' * 13}")
+        for sid in sorted(with_reverts, key=lambda s: with_reverts[s]["external_write_revert_count"], reverse=True):
+            lines.append(f"  {sid:<{col}}  {with_reverts[sid]['external_write_revert_count']:>13}")
     lines.append("")
     lines.append(
-        "  ONLY strike_count is implemented. external-write-revert,\n"
-        "  re-clarification-loop, and rework-commit signals are NOT computed —\n"
+        "  strike_count and external_write_revert_count are implemented.\n"
+        "  re-clarification-loop and rework-commit signals are NOT computed —\n"
         "  no telemetry source records them yet (see module docstring\n"
         "  'OUTCOME PROXY LIMITATIONS'). strike_count itself is a lower bound:\n"
         "  state is TTL-deleted after 7 days and cleared on /praxis:reset-strikes,\n"
-        "  so a session showing 0 may have had strikes that already expired."
+        "  so a session showing 0 may have had strikes that already expired.\n"
+        "  external_write_revert_count (issue #737) is a COARSE proxy — it\n"
+        "  conflates destructive-bash-guard's new revert-signal patterns\n"
+        "  (`git revert`, `gh pr close`, `gh issue reopen`) with its\n"
+        "  pre-existing destructive-command detections (`rm -rf`, etc.); a\n"
+        "  nonzero count means the hook flagged SOMETHING, not specifically\n"
+        "  a revert (see module docstring)."
     )
 
 

--- a/tests/hooks/advisory-nudge/test_destructive_bash_guard.sh
+++ b/tests/hooks/advisory-nudge/test_destructive_bash_guard.sh
@@ -61,6 +61,15 @@ print(json.dumps({
       echo "$err" | grep -q "\[destructive-bash-guard\]" || ok=0
       echo "$err" | grep -q "ADVISORY" || ok=0
       ;;
+    signal)
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$out" ]   || ok=0
+      echo "$err" | grep -q "\[destructive-bash-guard\]" || ok=0
+      echo "$err" | grep -q "outcome-proxy signal detected" || ok=0
+      echo "$err" | grep -q "INFORMATIONAL" || ok=0
+      # never the destructive banner, never wording implying blocking
+      echo "$err" | grep -q "destructive command detected" && ok=0
+      ;;
     ask)
       [ "$rc" -eq 0 ] || ok=0
       [ -z "$err" ]   || ok=0
@@ -232,6 +241,38 @@ run_case "shred -u -z secret.txt" advisory "shred -u -z secret.txt"
 run_case "fork bomb canonical" advisory ":(){ :|:& };:"
 run_case "fork bomb no spaces" advisory ":(){:|:&};:"
 run_case "named bomb() (legit user function — out of scope)" silent "bomb(){ echo hi; }; bomb"
+
+# === SIGNAL — outcome-proxy revert-adjacent commands (issue #737) =========
+
+run_case "git revert HEAD" signal "git revert HEAD"
+run_case "git revert --no-edit HEAD~1" signal "git revert --no-edit HEAD~1"
+run_case "git -C /tmp revert HEAD" signal "git -C /tmp revert HEAD"
+run_case "gh pr close 5" signal "gh pr close 5"
+run_case "gh pr close https://github.com/o/r/pull/5" signal "gh pr close https://github.com/o/r/pull/5"
+run_case "gh issue reopen 10" signal "gh issue reopen 10"
+run_case "gh -R o/r pr close 5 (-R before subcommand)" signal "gh -R octocat/Hello-World pr close 5"
+run_case "gh --repo o/r issue reopen 10 (--repo before subcommand)" signal "gh --repo octocat/Hello-World issue reopen 10"
+run_case "gh --repo=o/r pr close 5 (glued --repo=)" signal "gh --repo=octocat/Hello-World pr close 5"
+run_case "gh pr close 5 -R o/r (-R after args)" signal "gh pr close 5 -R octocat/Hello-World"
+
+# === SILENT — commands that must NOT trigger the revert signal =============
+
+run_case "git reset HEAD (not revert)" silent "git reset HEAD foo"
+run_case "git log --oneline (not revert)" silent "git log --oneline"
+run_case "gh pr status (not close)" silent "gh pr status"
+run_case "gh pr view 5 (not close)" silent "gh pr view 5"
+run_case "gh issue list (not reopen)" silent "gh issue list"
+run_case "gh issue close 10 (opposite action)" silent "gh issue close 10"
+run_case "gh pr merge 5 (not close)" silent "gh pr merge 5"
+
+# === ADVISORY+SIGNAL — compound command carries both categories ============
+
+run_case "rm -rf x && git revert HEAD (both fire)" advisory "rm -rf /tmp/x && git revert HEAD"
+
+# === ASK — strict mode does NOT escalate signal-only commands ==============
+
+run_case "git revert in strict mode stays signal (not ask)" signal "git revert HEAD" "PRAXIS_DESTRUCTIVE_BASH_STRICT=1"
+run_case "gh pr close in strict mode stays signal (not ask)" signal "gh pr close 5" "PRAXIS_DESTRUCTIVE_BASH_STRICT=1"
 
 # === ADVISORY — compound command decomposition =============================
 

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -657,8 +657,83 @@ def test_compute_outcome_proxy_joins_fire_sessions_to_strike_state(tmp_path):
         {"hook": "h", "session_id": "s2", "timestamp": "2026-06-26T00:00:05+00:00"},
     ]
     result = cli.compute_outcome_proxy(fire_events, state_dir)
-    assert result["s1"] == {"strike_count": 3, "strike_state_available": True}
-    assert result["s2"] == {"strike_count": 0, "strike_state_available": False}
+    assert result["s1"] == {
+        "strike_count": 3, "strike_state_available": True,
+        "external_write_revert_count": 0,
+    }
+    assert result["s2"] == {
+        "strike_count": 0, "strike_state_available": False,
+        "external_write_revert_count": 0,
+    }
+
+
+# issue #737: external-write-revert coarse proxy (destructive-bash-guard
+# non-pass fires) — see compute_external_write_revert_counts.
+
+def test_compute_external_write_revert_counts_counts_non_pass_fires():
+    fire_events = [
+        {"hook": "destructive-bash-guard", "session_id": "s1", "decision": "advise"},
+        {"hook": "destructive-bash-guard", "session_id": "s1", "decision": "advise"},
+        {"hook": "destructive-bash-guard", "session_id": "s2", "decision": "pass"},
+        {"hook": "other-hook", "session_id": "s1", "decision": "advise"},
+    ]
+    counts = cli.compute_external_write_revert_counts(fire_events)
+    assert counts == {"s1": 2}
+
+
+def test_compute_external_write_revert_counts_ignores_missing_session():
+    fire_events = [
+        {"hook": "destructive-bash-guard", "session_id": "", "decision": "advise"},
+        {"hook": "destructive-bash-guard", "decision": "advise"},
+    ]
+    assert cli.compute_external_write_revert_counts(fire_events) == {}
+
+
+def test_compute_outcome_proxy_surfaces_external_write_revert_count(tmp_path):
+    state_dir = tmp_path / "strikes"
+    state_dir.mkdir()
+    fire_events = [
+        {"hook": "destructive-bash-guard", "session_id": "s1", "decision": "advise",
+         "timestamp": "2026-06-26T00:00:00+00:00"},
+    ]
+    result = cli.compute_outcome_proxy(fire_events, state_dir)
+    assert result["s1"]["external_write_revert_count"] == 1
+
+
+def test_fire_rate_report_shows_nonzero_external_write_revert_signal(tmp_path, monkeypatch):
+    """Acceptance criterion (issue #737): a synthetic fixture that triggers one
+    of the 3 new revert-signal patterns (here: `git revert`, represented by the
+    real writer's own destructive-bash-guard advise fire) shows a nonzero
+    external-write-revert value in the Outcome Proxy section."""
+    today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+    telem_dir = tmp_path / "telemetry"
+    telem_dir.mkdir()
+    fire_out = telem_dir / f"fire-events-{today}.jsonl"
+    state_dir = tmp_path / "strikes"
+    state_dir.mkdir()
+
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(fire_out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+
+    # Real writer output: destructive-bash-guard fires with stderr set, as it
+    # does when impl.py detects `git revert` (see _signal_text in impl.py).
+    members = [("advisory-nudge", "destructive-bash-guard", Path("x"))]
+    fl.record_group_fires(
+        members, [(0, "", "[destructive-bash-guard] outcome-proxy signal detected")],
+        _payload("s-revert", "Bash"),
+    )
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = cli.main([
+            "fire-rate", "--dir", str(telem_dir), "--state-dir", str(state_dir),
+        ])
+    report = buf.getvalue()
+
+    assert rc == 0
+    assert "Outcome Proxy" in report
+    assert "Sessions with external-write-revert signal : 1" in report
+    assert "s-revert" in report
 
 
 def test_default_strike_state_dir_respects_praxis_state_dir_override(tmp_path, monkeypatch):


### PR DESCRIPTION
## 요약

이슈 #737 (`feat(telemetry): outcome-proxy signals beyond strike_count`)의 3개 시그널 중 **첫 번째(external-write revert)만** 구현합니다. 나머지 2개(re-clarification loop, rework commits)는 deep-interview 스펙에서 이미 별도 follow-up 이슈로 분리하기로 결정되었으며, 오케스트레이터가 별도로 처리합니다 — 이 PR에서는 다루지 않습니다.

Refs #737 — 이슈 전체가 아닌 일부 스코프만 다루므로 `Closes`를 사용하지 않습니다.

## 변경 사항

- `hooks/advisory-nudge/destructive-bash-guard/impl.py` — 기존 `safe_tokenize`/`iter_command_starts`/`strip_prefix` 파이프라인을 재사용해 `git revert`, `gh pr close`, `gh issue reopen` 3개 패턴을 감지. 신규 훅을 만들지 않고 기존 훅을 확장(spec Constraint 준수).
- `hooks/advisory-nudge/destructive-bash-guard/spec.md` — 새 outcome-proxy 시그널 규칙 문서화.
- `skills/bypass-review/bypass-review` — `compute_outcome_proxy`에 `external_write_revert_count` 필드 추가, Outcome Proxy 섹션 렌더링/모듈 docstring 업데이트 (issue #710 item 3의 "external-write revert" 항목을 미구현 목록에서 이동).
- `tests/hooks/advisory-nudge/test_destructive_bash_guard.sh` — 신규 패턴 + strict-mode 비에스컬레이션 + gh 인계 플래그(`-R`/`--repo`) 케이스 추가.
- `tests/test_fire_ledger.py` — `compute_external_write_revert_counts` 단위 테스트 + end-to-end fire-rate 리포트 acceptance 테스트(synthetic fixture로 nonzero 값 확인).

## destructive-bash-guard의 decision 정책을 어떻게 정했는지

**decision=advise를 선택했지만, 기존 "destructive command detected" 배너와는 분리된 별도의 informational 배너("outcome-proxy signal detected")를 신설했습니다.** 이유:

1. **왜 순수 `pass`(무배너)가 아닌가**: fire-ledger는 `decision` 필드만으로 이벤트를 구분하는데, `pass`는 감지되지 않은 모든 일반 bash 호출과 동일한 값이라 Acceptance Criteria("synthetic fixture로 nonzero 값 확인")를 만족할 방법이 없습니다. `decision != pass`가 되어야 fire-ledger dispatcher(`record_group_fires`)가 이 훅의 fire를 "advise"로 기록하고, bypass-review가 그 신호를 읽을 수 있습니다.
2. **왜 기존 "destructive command detected" 배너에 합류시키지 않았는가**: `git revert`는 파괴적 명령이 아니라 오히려 `git reset --hard`의 **안전한 대안**입니다. 같은 배너/문구를 쓰면 사용자에게 사실과 다른 경고("destructive command detected")를 보내는 셈이라, 별도의 non-alarming 문구("outcome-proxy signal detected — INFORMATIONAL (not blocked)")로 분리했습니다.
3. **왜 strict-mode에서 `ask`로 에스컬레이션하지 않는가**: strict mode(`PRAXIS_DESTRUCTIVE_BASH_STRICT=1`)는 "파괴적 명령을 실행 전에 확인받는다"는 계약인데, revert류는 파괴적이지 않으므로 이 계약 대상이 아닙니다. 그래서 강제로 stderr만 쓰고 절대 `ask`로 승격하지 않도록 별도 경로로 구현했습니다.

**알려진 한계 (문서화 완료, PR 리뷰 시 참고)**: fire-ledger 스키마(`timestamp/session_id/tool/hook/role/decision`)에는 패턴별 세부 정보가 없어서, `external_write_revert_count`는 사실상 "destructive-bash-guard가 이 세션에서 뭔가를 flag했다"는 coarse proxy입니다. 새 revert 시그널과 기존 파괴적 명령 감지(`rm -rf` 등)를 ledger 레벨에서 구분할 수 없습니다. 이 한계는 `compute_outcome_proxy`/`_render_outcome_proxy_section`/모듈 docstring 세 곳에 모두 명시했습니다. 스키마 변경 없이 정밀도를 높이려면 별도 이슈가 필요합니다.

## 검증

Pre-commit verified: 아래 4개 명령 모두 실행 완료, 통과.

```
bash tests/hooks/advisory-nudge/test_destructive_bash_guard.sh   # 117 passed, 0 failed
python3 -m pytest tests/test_fire_ledger.py -q                    # 56 passed
bash scripts/run-tests.sh                                         # ALL TESTS PASSED
python3 ./scripts/check-plugin-manifests.py                       # plugin-manifest check OK
```

Caller chain verified: grep으로 `compute_outcome_proxy`의 유일한 프로덕션 호출자(`skills/bypass-review/bypass-review:1410`, `run_fire_rate` 내부)와 테스트 2곳(`tests/test_fire_ledger.py:659,699`)을 확인 — 반환 dict에 새 키(`external_write_revert_count`)를 추가해도 기존 호출부는 동일하게 동작(기존 키는 그대로 유지).

**신규 훅 없음**: `hooks/manifest.json` 변경 없음 (`git status --porcelain hooks/manifest.json` 빈 출력으로 확인) → `check-plugin-manifests.py` drift 없음.

**codex-review-wrap 1라운드 실행**: P2 finding 1건(`gh -R/--repo`가 subcommand 앞에 올 때 감지 누락) — `gh -R o/r pr close --help`/`gh --repo o/r issue reopen --help` 실행으로 premise 검증 후 수정 완료, 회귀 테스트 4건 추가.

## 다음 단계 (이 PR 스코프 아님)

이슈 #737의 나머지 2개 시그널은 별도 follow-up 이슈로 분리됩니다:
- re-clarification loop (반복 AskUserQuestion 감지)
- rework commits (trailer-first + timestamp-heuristic fallback)
