### PR TITLE
feat(bypass-review): add rework-commit outcome-proxy signal

### DIFF
--- a/skills/bypass-review/bypass-review
+++ b/skills/bypass-review/bypass-review
@@ -10,7 +10,8 @@ forwarding, deferred).
 Issue #689: per-hook aggregation view + tool-error co-occurrence.
 Issue #710 (remaining scope): fire-rate mode gains advise_ignored_rate,
 bypass_count (joined against bypass-events), and a best-effort outcome-proxy
-section (strike counts only — see OUTCOME PROXY LIMITATIONS below).
+section (strike / external-write-revert / rework-commit signals — see
+OUTCOME PROXY LIMITATIONS below).
 
 Usage:
   bypass-review [OPTIONS]
@@ -28,16 +29,18 @@ Options:
                          directory used for the outcome-proxy section
                          (default: $PRAXIS_STATE_DIR/strikes or
                          ~/.praxis/state/strikes)
+  --repo PATH            fire-rate mode only: git repo to correlate commits
+                         against for the rework-commit outcome-proxy signal
+                         (default: current working directory)
   -h, --help             Show this message and exit
 
-OUTCOME PROXY LIMITATIONS (issue #710 item 3 / issue #737, fire-rate mode):
-  strike_count and external_write_revert_count are computed. Two items from
-  the original issue text are still NOT implemented because no telemetry
-  source currently records them:
+OUTCOME PROXY LIMITATIONS (issue #710 item 3 / issue #737 / issue #741,
+fire-rate mode):
+  strike_count, external_write_revert_count, and rework_commit_count are
+  computed. One item from the original issue text is still NOT implemented
+  because no telemetry source currently records it:
     - re-clarification loop     (requires transcript-level turn analysis,
                                   out of scope for this JSONL ledger)
-    - rework commits            (requires git-log correlation per session,
-                                  not present in fire-events/bypass-events)
   Strike state itself is a lower bound: the strike-counter TTL-deletes state
   after 7 days and `/praxis:reset-strikes` deletes it immediately on reset,
   so a session's true historical strike count may already be gone by the
@@ -52,6 +55,23 @@ OUTCOME PROXY LIMITATIONS (issue #710 item 3 / issue #737, fire-rate mode):
   hooks/advisory-nudge/destructive-bash-guard/impl.py. A nonzero count means
   "destructive-bash-guard flagged something in this session", not "a revert
   specifically occurred".
+  rework_commit_count (issue #741) is trailer-first + timestamp-heuristic,
+  mirroring bypass_count's exact-map + heuristic-fallback structure:
+    - Trailer: a `Session-Id: <session_id>` commit trailer is parsed exactly
+      when present (case-insensitive key, first match wins). This repo has
+      no commit-msg hook to insert it automatically — it is a MANUAL
+      convention only, so adoption depends on the committer remembering to
+      add it. The trailer only correlates commits made AFTER this
+      convention exists; it is NOT retroactively backfillable onto
+      historical commits.
+    - Fallback: commits without the trailer are matched to the fire-ledger
+      session whose nearest recorded hook-fire timestamp is within
+      REWORK_WINDOW_SECONDS (900s / 15 minutes) of the commit's author
+      date. Same lossy nature already accepted for bypass_count's
+      _nearest_hook_by_timestamp fallback: two sessions active within the
+      window are indistinguishable by timestamp alone, and a commit with no
+      session active within the window is silently excluded (counted
+      toward no session) rather than guessed.
 
 Output sections:
   1. Summary — total events + date window
@@ -84,6 +104,7 @@ import json
 import os
 import re
 import shlex
+import subprocess
 import sys
 from collections import Counter
 from datetime import datetime, timedelta, timezone
@@ -122,6 +143,22 @@ _FIRE_DECISIONS = ("block", "ask", "advise", "pass")
 # outcome-proxy signal — cited verbatim from
 # hooks/advisory-nudge/destructive-bash-guard's manifest `name`.
 DESTRUCTIVE_BASH_GUARD_HOOK = "destructive-bash-guard"
+
+# issue #741: commit trailer key for the rework-commit outcome-proxy signal.
+# Named to match the existing trailer family's Capitalized-Hyphenated style
+# (Confidence, Not-tested, Constraint, Rejected, Directive, Scope-risk — see
+# global CLAUDE.md "Commit Trailers"). Manual convention only — no
+# commit-msg hook inserts it; see module docstring "OUTCOME PROXY
+# LIMITATIONS" for the retroactive-coverage limitation this implies.
+REWORK_SESSION_TRAILER = "Session-Id"
+
+# issue #741: timestamp-heuristic fallback window (seconds) for commits
+# lacking the Session-Id trailer — see compute_rework_commit_counts.
+REWORK_WINDOW_SECONDS = 900  # 15 minutes
+
+_SESSION_TRAILER_RE = re.compile(
+    rf"^{REWORK_SESSION_TRAILER}:\s*(\S+)\s*$", re.MULTILINE | re.IGNORECASE
+)
 
 _INLINE_ENV_TOKEN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 _ENV_OPTIONS_WITH_VALUE = {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}
@@ -205,6 +242,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "fire-rate mode only: override the strike-state directory used "
             "for the outcome-proxy section (default: "
             "$PRAXIS_STATE_DIR/strikes or ~/.praxis/state/strikes)"
+        ),
+    )
+    parser.add_argument(
+        "--repo",
+        dest="repo_path",
+        default=None,
+        metavar="PATH",
+        help=(
+            "fire-rate mode only: git repo to correlate commits against for "
+            "the rework-commit outcome-proxy signal (default: current "
+            "working directory)"
         ),
     )
     return parser.parse_args(argv)
@@ -1070,21 +1118,30 @@ def compute_external_write_revert_counts(fire_events: list[dict]) -> dict[str, i
     return counts
 
 
-def compute_outcome_proxy(fire_events: list[dict], state_dir: Path) -> dict[str, dict]:
+def compute_outcome_proxy(
+    fire_events: list[dict],
+    state_dir: Path,
+    rework_counts: dict[str, int] | None = None,
+) -> dict[str, dict]:
     """Return dict[session_id] -> {strike_count, strike_state_available,
-    external_write_revert_count}.
+    external_write_revert_count, rework_commit_count}.
 
     Only covers sessions that appear in the fire-events window. Sessions
     whose strike state already expired (7-day TTL) or was reset show
     strike_state_available=False, strike_count=0 — NOT proof of zero strikes.
     external_write_revert_count is a best-effort proxy — see
     compute_external_write_revert_counts / module docstring.
+    rework_commit_count is trailer-first + timestamp-heuristic — see
+    compute_rework_commit_counts / module docstring. `rework_counts` (issue
+    #741) is precomputed by the caller because it needs `days`-scoped git log
+    output, which this function has no repo path to fetch on its own.
     """
     sessions = sorted({
         ev.get(F_FIRE_SESSION) for ev in fire_events
         if isinstance(ev.get(F_FIRE_SESSION), str) and ev.get(F_FIRE_SESSION)
     })
     revert_counts = compute_external_write_revert_counts(fire_events)
+    rework_counts = rework_counts or {}
     result: dict[str, dict] = {}
     for sid in sessions:
         state = load_strike_state(state_dir, sid)
@@ -1092,8 +1149,120 @@ def compute_outcome_proxy(fire_events: list[dict], state_dir: Path) -> dict[str,
             "strike_count": state["count"] if state else 0,
             "strike_state_available": state is not None,
             "external_write_revert_count": revert_counts.get(sid, 0),
+            "rework_commit_count": rework_counts.get(sid, 0),
         }
     return result
+
+
+# ---------------------------------------------------------------------------
+# rework-commits (issue #741, follow-up to #737 item 3) — trailer-first +
+# timestamp-heuristic fallback, mirroring bypass_count's exact-map +
+# heuristic structure (see _nearest_hook_by_timestamp above).
+# ---------------------------------------------------------------------------
+
+def parse_session_trailer(commit_body: str) -> str | None:
+    """Return the `Session-Id:` trailer value from a commit message body, or
+    None if absent. Case-insensitive key match; first occurrence wins."""
+    if not commit_body:
+        return None
+    match = _SESSION_TRAILER_RE.search(commit_body)
+    return match.group(1) if match else None
+
+
+def load_git_commits(repo_path: Path, days: int) -> list[dict]:
+    """Return [{sha, timestamp: datetime, body: str}, ...] for commits in
+    `repo_path` within the last `days` days (author date).
+
+    Fails open to an empty list if `repo_path` is not a git repo, `git` is
+    unavailable, or the process errors/times out — this is a best-effort
+    proxy signal (see module docstring), not a hard dependency the report
+    should crash over.
+    """
+    since = (datetime.now(tz=timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
+    try:
+        proc = subprocess.run(
+            [
+                "git", "-C", str(repo_path), "log", f"--since={since}",
+                "--pretty=format:%H%x1f%aI%x1f%B%x1e",
+            ],
+            capture_output=True, text=True, check=False, timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if proc.returncode != 0 or not proc.stdout:
+        return []
+    commits: list[dict] = []
+    for record in proc.stdout.split("\x1e"):
+        record = record.strip("\n")
+        if not record:
+            continue
+        parts = record.split("\x1f", 2)
+        if len(parts) != 3:
+            continue
+        sha, ts_raw, body = parts
+        ts = _parse_fire_ts(ts_raw)
+        if ts is None:
+            continue
+        commits.append({"sha": sha, "timestamp": ts, "body": body})
+    return commits
+
+
+def _session_timestamp_index(fire_events: list[dict]) -> dict[str, list[datetime]]:
+    out: dict[str, list[datetime]] = {}
+    for ev in fire_events:
+        sid = ev.get(F_FIRE_SESSION)
+        ts = _parse_fire_ts(ev.get(F_FIRE_TIMESTAMP))
+        if isinstance(sid, str) and sid and ts:
+            out.setdefault(sid, []).append(ts)
+    return out
+
+
+def _nearest_session_by_timestamp(
+    commit_ts: datetime,
+    session_ts_index: dict[str, list[datetime]],
+    window_seconds: int,
+) -> str | None:
+    """Return the session_id whose nearest fire-event timestamp to
+    `commit_ts` is within `window_seconds`, or None if no session has an
+    event that close. Mirrors _nearest_hook_by_timestamp's nearest-wins tie
+    break, scoped by a hard window cutoff instead of a candidate set."""
+    best_sid: str | None = None
+    best_delta: float | None = None
+    for sid, timestamps in session_ts_index.items():
+        for ts in timestamps:
+            delta = abs((ts - commit_ts).total_seconds())
+            if delta <= window_seconds and (best_delta is None or delta < best_delta):
+                best_delta = delta
+                best_sid = sid
+    return best_sid
+
+
+def compute_rework_commit_counts(
+    commits: list[dict],
+    fire_events: list[dict],
+    window_seconds: int = REWORK_WINDOW_SECONDS,
+) -> dict[str, int]:
+    """Return dict[session_id] -> commit count correlated to that session.
+
+    Trailer-first: a commit body carrying a `Session-Id:` trailer is
+    attributed directly (exact, no heuristic) — mirrors bypass_env_exact_map's
+    priority over the family-token heuristic. Commits without the trailer
+    fall back to timestamp-proximity against the fire-ledger's session
+    activity timestamps (nearest session within `window_seconds`); commits
+    matching no session within the window are silently excluded, not counted
+    toward any session — see module docstring "OUTCOME PROXY LIMITATIONS".
+    """
+    session_ts_index = _session_timestamp_index(fire_events)
+    counts: dict[str, int] = {}
+    for commit in commits:
+        sid = parse_session_trailer(commit.get("body", ""))
+        if not sid:
+            ts = commit.get("timestamp")
+            if isinstance(ts, datetime):
+                sid = _nearest_session_by_timestamp(ts, session_ts_index, window_seconds)
+        if sid:
+            counts[sid] = counts.get(sid, 0) + 1
+    return counts
 
 
 def default_manifest_path() -> Path:
@@ -1247,6 +1416,10 @@ def _render_outcome_proxy_section(lines: list[str], outcome_proxy: dict[str, dic
         sid: r for sid, r in outcome_proxy.items()
         if r.get("external_write_revert_count", 0) > 0
     }
+    with_rework = {
+        sid: r for sid, r in outcome_proxy.items()
+        if r.get("rework_commit_count", 0) > 0
+    }
     available = sum(1 for r in outcome_proxy.values() if r["strike_state_available"])
     lines.append(
         f"  Sessions in window : {len(outcome_proxy)}  "
@@ -1254,6 +1427,7 @@ def _render_outcome_proxy_section(lines: list[str], outcome_proxy: dict[str, dic
     )
     lines.append(f"  Sessions with strikes : {len(with_strikes)}")
     lines.append(f"  Sessions with external-write-revert signal : {len(with_reverts)}")
+    lines.append(f"  Sessions with rework-commit signal : {len(with_rework)}")
     if with_strikes:
         lines.append("")
         col = 40
@@ -1268,20 +1442,31 @@ def _render_outcome_proxy_section(lines: list[str], outcome_proxy: dict[str, dic
         lines.append(f"  {'─' * col}  {'─' * 13}")
         for sid in sorted(with_reverts, key=lambda s: with_reverts[s]["external_write_revert_count"], reverse=True):
             lines.append(f"  {sid:<{col}}  {with_reverts[sid]['external_write_revert_count']:>13}")
+    if with_rework:
+        lines.append("")
+        col = 40
+        lines.append(f"  {'Session':<{col}}  {'Rework commits':>14}")
+        lines.append(f"  {'─' * col}  {'─' * 14}")
+        for sid in sorted(with_rework, key=lambda s: with_rework[s]["rework_commit_count"], reverse=True):
+            lines.append(f"  {sid:<{col}}  {with_rework[sid]['rework_commit_count']:>14}")
     lines.append("")
     lines.append(
-        "  strike_count and external_write_revert_count are implemented.\n"
-        "  re-clarification-loop and rework-commit signals are NOT computed —\n"
-        "  no telemetry source records them yet (see module docstring\n"
-        "  'OUTCOME PROXY LIMITATIONS'). strike_count itself is a lower bound:\n"
-        "  state is TTL-deleted after 7 days and cleared on /praxis:reset-strikes,\n"
-        "  so a session showing 0 may have had strikes that already expired.\n"
+        "  strike_count, external_write_revert_count, and rework_commit_count\n"
+        "  are implemented. re-clarification-loop is NOT computed — no\n"
+        "  telemetry source records it yet (see module docstring 'OUTCOME\n"
+        "  PROXY LIMITATIONS'). strike_count itself is a lower bound: state is\n"
+        "  TTL-deleted after 7 days and cleared on /praxis:reset-strikes, so a\n"
+        "  session showing 0 may have had strikes that already expired.\n"
         "  external_write_revert_count (issue #737) is a COARSE proxy — it\n"
         "  conflates destructive-bash-guard's new revert-signal patterns\n"
         "  (`git revert`, `gh pr close`, `gh issue reopen`) with its\n"
         "  pre-existing destructive-command detections (`rm -rf`, etc.); a\n"
         "  nonzero count means the hook flagged SOMETHING, not specifically\n"
-        "  a revert (see module docstring)."
+        "  a revert (see module docstring). rework_commit_count (issue #741)\n"
+        "  is trailer-first (`Session-Id:` commit trailer, manual convention,\n"
+        "  NOT retroactive) + timestamp-heuristic fallback (nearest session\n"
+        "  activity within 15 minutes, lossy like the other two proxies) —\n"
+        "  see module docstring."
     )
 
 
@@ -1407,7 +1592,15 @@ def run_fire_rate(args: argparse.Namespace, telemetry_dir: Path) -> int:
     exact_map = bypass_env_exact_map(manifest_path)
     bypass_join = join_bypass_to_hooks(events, bypass_events, exact_map=exact_map)
     state_dir = Path(args.state_dir) if args.state_dir else default_strike_state_dir()
-    outcome_proxy = compute_outcome_proxy(events, state_dir)
+
+    # issue #741: rework-commit signal correlates this window's fire-event
+    # sessions against git commits in `--repo` (default: cwd) — see
+    # compute_rework_commit_counts / module docstring "OUTCOME PROXY
+    # LIMITATIONS" for the trailer-first + timestamp-heuristic design.
+    repo_path = Path(args.repo_path) if args.repo_path else Path.cwd()
+    commits = load_git_commits(repo_path, args.days)
+    rework_counts = compute_rework_commit_counts(commits, events)
+    outcome_proxy = compute_outcome_proxy(events, state_dir, rework_counts=rework_counts)
 
     print(render_fire_report(
         by_hook, args.days, telemetry_dir, roster,

--- a/skills/bypass-review/bypass-review
+++ b/skills/bypass-review/bypass-review
@@ -160,6 +160,12 @@ _SESSION_TRAILER_RE = re.compile(
     rf"^{REWORK_SESSION_TRAILER}:\s*(\S+)\s*$", re.MULTILINE | re.IGNORECASE
 )
 
+# issue #741 (CodeRabbit PR #742 nitpick): a trailer line has the git
+# trailer shape `Key: value` — used to scope trailer parsing to the
+# terminal blank-line-separated paragraph so prose mentioning
+# "Session-Id:" earlier in the body isn't misread as the trailer.
+_TRAILER_LINE_RE = re.compile(r"^[A-Za-z][A-Za-z0-9-]*:\s*\S.*$")
+
 _INLINE_ENV_TOKEN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 _ENV_OPTIONS_WITH_VALUE = {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}
 _BYPASS_PREFIXES = (
@@ -1160,18 +1166,46 @@ def compute_outcome_proxy(
 # heuristic structure (see _nearest_hook_by_timestamp above).
 # ---------------------------------------------------------------------------
 
+def _trailer_block(commit_body: str) -> str:
+    """Return the trailing trailer/footer block of a commit message — the
+    last blank-line-separated paragraph, if every non-blank line in it has
+    the git trailer shape `Key: value` — or "" if the message has no such
+    block. Scopes trailer parsing to the terminal paragraph so prose
+    mentioning e.g. "Session-Id:" earlier in the body isn't misread."""
+    stripped = commit_body.strip()
+    if not stripped:
+        return ""
+    paragraphs = re.split(r"\n\s*\n", stripped)
+    last = paragraphs[-1]
+    lines = [ln for ln in last.splitlines() if ln.strip()]
+    if lines and all(_TRAILER_LINE_RE.match(ln) for ln in lines):
+        return last
+    return ""
+
+
 def parse_session_trailer(commit_body: str) -> str | None:
-    """Return the `Session-Id:` trailer value from a commit message body, or
-    None if absent. Case-insensitive key match; first occurrence wins."""
+    """Return the `Session-Id:` trailer value from a commit message's
+    terminal trailer block, or None if absent. Case-insensitive key match;
+    first occurrence wins. Only the trailing `Key: value` paragraph is
+    inspected (git trailer convention) — a "Session-Id:" mention in earlier
+    prose is ignored."""
     if not commit_body:
         return None
-    match = _SESSION_TRAILER_RE.search(commit_body)
+    block = _trailer_block(commit_body)
+    if not block:
+        return None
+    match = _SESSION_TRAILER_RE.search(block)
     return match.group(1) if match else None
 
 
 def load_git_commits(repo_path: Path, days: int) -> list[dict]:
     """Return [{sha, timestamp: datetime, body: str}, ...] for commits in
-    `repo_path` within the last `days` days (author date).
+    `repo_path` within the last `days` days (committer date).
+
+    Uses committer date (not author date) because `git log --since` itself
+    filters by committer date (CodeRabbit PR #742 finding) — using author
+    date for the returned timestamp would let the two diverge and skew the
+    timestamp-heuristic proximity match on rebased/backdated commits.
 
     Fails open to an empty list if `repo_path` is not a git repo, `git` is
     unavailable, or the process errors/times out — this is a best-effort
@@ -1183,7 +1217,7 @@ def load_git_commits(repo_path: Path, days: int) -> list[dict]:
         proc = subprocess.run(
             [
                 "git", "-C", str(repo_path), "log", f"--since={since}",
-                "--pretty=format:%H%x1f%aI%x1f%B%x1e",
+                "--pretty=format:%H%x1f%cI%x1f%B%x1e",
             ],
             capture_output=True, text=True, check=False, timeout=10,
         )

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -20,6 +20,7 @@ import io
 import json
 import os
 import stat
+import subprocess
 import sys
 from contextlib import redirect_stdout
 from datetime import datetime, timezone
@@ -659,11 +660,11 @@ def test_compute_outcome_proxy_joins_fire_sessions_to_strike_state(tmp_path):
     result = cli.compute_outcome_proxy(fire_events, state_dir)
     assert result["s1"] == {
         "strike_count": 3, "strike_state_available": True,
-        "external_write_revert_count": 0,
+        "external_write_revert_count": 0, "rework_commit_count": 0,
     }
     assert result["s2"] == {
         "strike_count": 0, "strike_state_available": False,
-        "external_write_revert_count": 0,
+        "external_write_revert_count": 0, "rework_commit_count": 0,
     }
 
 
@@ -742,13 +743,181 @@ def test_default_strike_state_dir_respects_praxis_state_dir_override(tmp_path, m
 
 
 # ---------------------------------------------------------------------------
+# issue #741: rework-commit outcome-proxy signal (trailer-first +
+# timestamp-heuristic fallback, mirrors bypass_count's exact-map + heuristic
+# structure — see _nearest_hook_by_timestamp above).
+# ---------------------------------------------------------------------------
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    # Inline user.name/email (not global config) so the test doesn't depend
+    # on the host's git config being pre-populated.
+    return subprocess.run(
+        ["git", "-C", str(repo), "-c", "user.name=Test", "-c", "user.email=test@example.com", *args],
+        capture_output=True, text=True, check=True,
+    )
+
+
+def test_parse_session_trailer_extracts_value():
+    body = "feat: add thing\n\nSome body text.\n\nSession-Id: sess-abc-123\n"
+    assert cli.parse_session_trailer(body) == "sess-abc-123"
+
+
+def test_parse_session_trailer_missing_returns_none():
+    assert cli.parse_session_trailer("feat: add thing\n\nNo trailer here.\n") is None
+
+
+def test_parse_session_trailer_case_insensitive_key():
+    assert cli.parse_session_trailer("fix: x\n\nsession-id: sess-lower\n") == "sess-lower"
+
+
+def test_parse_session_trailer_empty_body_returns_none():
+    assert cli.parse_session_trailer("") is None
+
+
+def test_compute_rework_commit_counts_trailer_exact_match():
+    commits = [
+        {"sha": "a1", "timestamp": datetime(2026, 6, 26, 0, 0, 0, tzinfo=timezone.utc),
+         "body": "feat: x\n\nSession-Id: s-exact\n"},
+    ]
+    counts = cli.compute_rework_commit_counts(commits, fire_events=[])
+    assert counts == {"s-exact": 1}
+
+
+def test_compute_rework_commit_counts_timestamp_heuristic_fallback():
+    commit_ts = datetime(2026, 6, 26, 12, 0, 0, tzinfo=timezone.utc)
+    commits = [{"sha": "b2", "timestamp": commit_ts, "body": "fix: y\n\nno trailer\n"}]
+    fire_events = [
+        {"session_id": "s-heuristic", "timestamp": "2026-06-26T12:03:00+00:00"},
+    ]
+    counts = cli.compute_rework_commit_counts(commits, fire_events)
+    assert counts == {"s-heuristic": 1}
+
+
+def test_compute_rework_commit_counts_outside_window_unattributed():
+    commit_ts = datetime(2026, 6, 26, 12, 0, 0, tzinfo=timezone.utc)
+    commits = [{"sha": "c3", "timestamp": commit_ts, "body": "fix: z\n\nno trailer\n"}]
+    fire_events = [
+        # 1 hour away, default window is 900s (15 min) — outside the window.
+        {"session_id": "s-far", "timestamp": "2026-06-26T13:00:00+00:00"},
+    ]
+    counts = cli.compute_rework_commit_counts(commits, fire_events)
+    assert counts == {}
+
+
+def test_compute_rework_commit_counts_trailer_priority_over_heuristic():
+    commit_ts = datetime(2026, 6, 26, 12, 0, 0, tzinfo=timezone.utc)
+    commits = [{"sha": "d4", "timestamp": commit_ts,
+                "body": "fix: z\n\nSession-Id: s-trailer\n"}]
+    fire_events = [
+        {"session_id": "s-nearby", "timestamp": "2026-06-26T12:00:05+00:00"},
+    ]
+    counts = cli.compute_rework_commit_counts(commits, fire_events)
+    assert counts == {"s-trailer": 1}
+
+
+def test_load_git_commits_reads_trailer_from_real_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "f.txt").write_text("1")
+    _git(repo, "add", "f.txt")
+    _git(repo, "commit", "-q", "-m", "feat: add f\n\nSession-Id: s-real")
+    commits = cli.load_git_commits(repo, days=7)
+    assert len(commits) == 1
+    assert cli.parse_session_trailer(commits[0]["body"]) == "s-real"
+
+
+def test_load_git_commits_non_git_dir_returns_empty(tmp_path):
+    assert cli.load_git_commits(tmp_path, days=7) == []
+
+
+def test_compute_outcome_proxy_surfaces_rework_commit_count(tmp_path):
+    state_dir = tmp_path / "strikes"
+    state_dir.mkdir()
+    fire_events = [
+        {"hook": "h", "session_id": "s1", "timestamp": "2026-06-26T00:00:00+00:00"},
+    ]
+    result = cli.compute_outcome_proxy(fire_events, state_dir, rework_counts={"s1": 4})
+    assert result["s1"]["rework_commit_count"] == 4
+
+
+def test_fire_rate_report_shows_nonzero_rework_commit_signal_trailer(tmp_path, monkeypatch):
+    """Acceptance criterion (issue #741): a trailer-tagged commit surfaces as
+    a nonzero rework-commit value in the Outcome Proxy section."""
+    today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+    telem_dir = tmp_path / "telemetry"
+    telem_dir.mkdir()
+    fire_out = telem_dir / f"fire-events-{today}.jsonl"
+    state_dir = tmp_path / "strikes"
+    state_dir.mkdir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "f.txt").write_text("1")
+    _git(repo, "add", "f.txt")
+    _git(repo, "commit", "-q", "-m", "feat: x\n\nSession-Id: s-trailer-e2e")
+
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(fire_out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    members = [("advisory-nudge", "protected-paths-guard", Path("x"))]
+    fl.record_group_fires(members, [(0, "", "nudge")], _payload("s-trailer-e2e", "Write"))
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = cli.main([
+            "fire-rate", "--dir", str(telem_dir), "--state-dir", str(state_dir),
+            "--repo", str(repo),
+        ])
+    report = buf.getvalue()
+
+    assert rc == 0
+    assert "Sessions with rework-commit signal : 1" in report
+    assert "s-trailer-e2e" in report
+
+
+def test_fire_rate_report_shows_nonzero_rework_commit_signal_heuristic(tmp_path, monkeypatch):
+    """Acceptance criterion (issue #741): a commit with no Session-Id trailer
+    still surfaces via the timestamp-heuristic fallback (nearest session
+    activity within the window)."""
+    today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+    telem_dir = tmp_path / "telemetry"
+    telem_dir.mkdir()
+    fire_out = telem_dir / f"fire-events-{today}.jsonl"
+    state_dir = tmp_path / "strikes"
+    state_dir.mkdir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "f.txt").write_text("1")
+    _git(repo, "add", "f.txt")
+    _git(repo, "commit", "-q", "-m", "fix: y (no trailer)")
+
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(fire_out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    members = [("advisory-nudge", "protected-paths-guard", Path("x"))]
+    fl.record_group_fires(members, [(0, "", "nudge")], _payload("s-heuristic-e2e", "Write"))
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = cli.main([
+            "fire-rate", "--dir", str(telem_dir), "--state-dir", str(state_dir),
+            "--repo", str(repo),
+        ])
+    report = buf.getvalue()
+
+    assert rc == 0
+    assert "Sessions with rework-commit signal : 1" in report
+    assert "s-heuristic-e2e" in report
+
+
+# ---------------------------------------------------------------------------
 # issue #710 remaining scope: end-to-end fire-rate report renders new sections
 # ---------------------------------------------------------------------------
 
 def test_fire_rate_report_includes_remaining_scope_sections(tmp_path, monkeypatch):
     """Real writer output (record_group_fires + bypass hook's own JSONL schema)
     flows through run_fire_rate end-to-end and produces non-trivial values for
-    all three remaining-scope metrics — no mirrored/mocked business logic."""
+    all remaining-scope metrics — no mirrored/mocked business logic."""
     today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
     telem_dir = tmp_path / "telemetry"
     telem_dir.mkdir()
@@ -756,6 +925,11 @@ def test_fire_rate_report_includes_remaining_scope_sections(tmp_path, monkeypatc
     bypass_out = telem_dir / f"bypass-events-{today}.jsonl"
     state_dir = tmp_path / "strikes"
     state_dir.mkdir()
+    # Empty repo (no commits in window) — keeps the rework-commit signal
+    # hermetic instead of depending on cwd's real git history.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
 
     monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(fire_out))
     monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
@@ -784,6 +958,7 @@ def test_fire_rate_report_includes_remaining_scope_sections(tmp_path, monkeypatc
     with redirect_stdout(buf):
         rc = cli.main([
             "fire-rate", "--dir", str(telem_dir), "--state-dir", str(state_dir),
+            "--repo", str(repo),
         ])
     report = buf.getvalue()
 

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -749,10 +749,13 @@ def test_default_strike_state_dir_respects_praxis_state_dir_override(tmp_path, m
 # ---------------------------------------------------------------------------
 
 def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
-    # Inline user.name/email (not global config) so the test doesn't depend
-    # on the host's git config being pre-populated.
+    # Inline user.name/email/gpgsign (not global config) so the test doesn't
+    # depend on the host's git config being pre-populated — commit.gpgsign=false
+    # avoids a non-interactive gpg/pinentry failure if the host/CI has
+    # gpgsign=true set globally (CodeRabbit PR #742 finding).
     return subprocess.run(
-        ["git", "-C", str(repo), "-c", "user.name=Test", "-c", "user.email=test@example.com", *args],
+        ["git", "-C", str(repo), "-c", "user.name=Test", "-c", "user.email=test@example.com",
+         "-c", "commit.gpgsign=false", *args],
         capture_output=True, text=True, check=True,
     )
 
@@ -772,6 +775,13 @@ def test_parse_session_trailer_case_insensitive_key():
 
 def test_parse_session_trailer_empty_body_returns_none():
     assert cli.parse_session_trailer("") is None
+
+
+def test_parse_session_trailer_ignores_prose_mention():
+    # CodeRabbit PR #742 nitpick: a "Session-Id:"-shaped line in prose
+    # (not the terminal trailer block) must not be misread as a trailer.
+    body = "feat: x\n\nSee Session-Id: not-a-trailer for context.\n\nConfidence: high\n"
+    assert cli.parse_session_trailer(body) is None
 
 
 def test_compute_rework_commit_counts_trailer_exact_match():
@@ -829,6 +839,28 @@ def test_load_git_commits_reads_trailer_from_real_repo(tmp_path):
 
 def test_load_git_commits_non_git_dir_returns_empty(tmp_path):
     assert cli.load_git_commits(tmp_path, days=7) == []
+
+
+def test_load_git_commits_uses_committer_date_not_author_date(tmp_path):
+    # CodeRabbit PR #742 Major finding: `git log --since` filters by
+    # committer date, so the returned timestamp must be committer date too —
+    # otherwise a rebased/backdated commit's author date (year 2000 here)
+    # would skew the timestamp-heuristic proximity match.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "f.txt").write_text("1")
+    _git(repo, "add", "f.txt")
+    env = os.environ.copy()
+    env["GIT_AUTHOR_DATE"] = "2000-01-01T00:00:00+00:00"
+    subprocess.run(
+        ["git", "-C", str(repo), "-c", "user.name=Test", "-c", "user.email=test@example.com",
+         "-c", "commit.gpgsign=false", "commit", "-q", "-m", "feat: old author date"],
+        capture_output=True, text=True, check=True, env=env,
+    )
+    commits = cli.load_git_commits(repo, days=1)
+    assert len(commits) == 1
+    assert commits[0]["timestamp"].year != 2000
 
 
 def test_compute_outcome_proxy_surfaces_rework_commit_count(tmp_path):


### PR DESCRIPTION
Pre-commit: n/a (repo has no pre-commit hook/config; verified instead via `bash scripts/run-tests.sh` — pytest 전체 + shell tests + manifest check + hook-token invariant check, "ALL TESTS PASSED", exit 0)

## 배경

#737 "outcome-proxy signals beyond strike_count"의 3개 신호 중 `external-write revert`는 PR #739로 이미 구현·머지됐다. 이 PR은 남은 신호 중 `rework commits`(session_id ↔ git commit 상관관계)를 구현한다. 설계는 `.omc/specs/deep-interview-issue-737-outcome-proxy.md`(Round 3)에서 사전 확정됨.

## 구현 내용

- `skills/bypass-review/bypass-review`에 trailer-first + timestamp-heuristic fallback 구조 추가 (`bypass_count`의 `_nearest_hook_by_timestamp` exact-map + heuristic-fallback 구조를 그대로 미러링).
  - `parse_session_trailer` — 커밋 본문에서 `Session-Id:` trailer를 파싱(대소문자 무시, 첫 매치 사용).
  - `load_git_commits` — `--repo` (기본값: cwd)에서 `git log`를 실행해 SHA/작성 시각/본문을 수집. 저장소가 아니거나 git 실행 실패 시 fail-open으로 빈 리스트 반환(강한 의존성 아님, best-effort proxy 원칙 유지).
  - `compute_rework_commit_counts` — trailer 우선(정확 매칭) → 없으면 fire-ledger 세션 활동 타임스탬프와 커밋 시각을 비교해 15분(900초, `REWORK_WINDOW_SECONDS`) 이내 가장 가까운 세션에 귀속. 윈도우 밖이면 어느 세션에도 귀속하지 않음(추측하지 않음).
  - `compute_outcome_proxy`에 `rework_commit_count` 키 추가, `_render_outcome_proxy_section`에 "Sessions with rework-commit signal" 테이블 추가.
  - 신규 CLI 플래그 `--repo PATH` (fire-rate 모드 전용).

## OPEN DECISION 해결

1. **Trailer key 이름**: `Session-Id:` 채택. 기존 trailer 패밀리(`Confidence:`, `Not-tested:`, `Constraint:`, `Rejected:`, `Directive:`, `Scope-risk:` — 전역 CLAUDE.md "Commit Trailers")의 Capitalized-Hyphenated 네이밍 스타일과 일치시킴(`Scope-risk`, `Not-tested`와 동일한 2-word hyphenated 패턴).
2. **Trailer 삽입 시점**: (a) 수동 컨벤션으로만 문서화, 자동화(commit-msg 훅) 없음을 채택. 이 저장소에는 git trailer 삽입 훅 인프라가 전혀 없고(그린필드), 이슈 스코프 자체가 "follow-up으로 미룰 수 있는" 자동화를 명시적으로 배제하지 않았지만 과도한 엔지니어링을 피하기 위해 최소 구현으로 시작. 한계는 모듈 docstring `OUTCOME PROXY LIMITATIONS`에 명시.

## 완료 조건 대조

이슈 완료 조건: "`bypass-review fire-rate` 출력에 rework-commits 신호가 synthetic fixture 기준 0이 아닌 실제 값으로 나타나고(trailer 매칭 케이스 + heuristic 폴백 케이스 모두), trailer가 retroactive하게 적용되지 않는다는 한계와 heuristic 폴백의 lossy 특성이 `OUTCOME PROXY LIMITATIONS` 문서 섹션에 명시됨."

- [x] trailer 매칭 케이스: `test_fire_rate_report_shows_nonzero_rework_commit_signal_trailer` — 실제 git 저장소에 `Session-Id:` trailer가 포함된 커밋을 만들고, `fire-rate` 출력에 `Sessions with rework-commit signal : 1`이 나타남을 검증.
- [x] heuristic 폴백 케이스: `test_fire_rate_report_shows_nonzero_rework_commit_signal_heuristic` — trailer 없는 커밋 + 인접 시각의 fire-ledger 세션으로 동일하게 검증.
- [x] retroactive 한계 + heuristic lossy 특성: `OUTCOME PROXY LIMITATIONS` 섹션(모듈 docstring)에 명시.

이슈가 요구한 범위(신호 구현 + 2개 OPEN DECISION 해결 + 문서화)를 모두 충족하여 **Closes #741**을 사용한다.

## 검증

`bash scripts/run-tests.sh` 전체 스위트 통과(pytest + shell tests + manifest check + hook-token invariant check, `ALL TESTS PASSED`, exit 0). 신규 hook을 추가하지 않아 `check-plugin-manifests.py` / `check-hook-token-invariants.py` 모두 drift 없음.

## 한계 / 배포되지 않은 점

- Trailer는 이 PR 머지 이후 작성되는 커밋에만 적용됨(retroactive 불가) — 명시된 non-goal.
- Trailer 삽입은 수동 컨벤션. 자동 삽입 훅은 이번 스코프에서 의도적으로 제외(over-engineering 회피). 채택률은 committer의 습관에 의존.
- Heuristic 폴백은 15분 윈도우 내 세션이 여러 개면 가장 가까운 것 하나에만 귀속되고, 윈도우 밖 커밋은 어느 세션에도 집계되지 않음 — `bypass_count`가 이미 받아들인 것과 동일한 lossy 특성.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Outcome Proxy” rework-related signal (rework-commit count) to fire-rate results.
  * Extended the “Outcome Proxy — Best Effort” section to list sessions with rework-commit activity and clarified detection behavior.
  * Added a `--repo` option to analyze a specific git repository.

* **Bug Fixes**
  * Improved attribution of rework activity to sessions by prioritizing commit trailer metadata, with a best-effort timestamp fallback.

* **Tests**
  * Added coverage for trailer parsing and end-to-end report rendering with a temporary git repo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->