### PR TITLE
ci: automate release integrity — count guard + tagless cut

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,23 @@ jobs:
             './**/*.md'
           fail: true
 
+  # Release-count guard (#750): fail a version-bump PR whose newest CHANGELOG
+  # section declares "N PRs since X.Y.Z" that disagrees with the PRs actually
+  # merged into the release. Self-gating — passes when the count matches, skips
+  # sections without the count line, and fails open when history is too shallow
+  # to resolve the range — so it is safe to run on every push/PR.
+  changelog:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history + tags so the guard can resolve the [prev]..[current]
+          # changelog-section commit range via `git log -S`.
+          fetch-depth: 0
+          persist-credentials: false
+      - run: bash scripts/check-changelog-completeness.sh
+
   # reviewdog posts inline review comments, which only works in PR context —
   # so the two reviewdog jobs are gated to pull_request and skip on push:main.
   actionlint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,15 +3,21 @@ name: release
 # Publishes a GitHub Release whenever a vX.Y.Z tag is pushed. The release body
 # is the matching CHANGELOG.md section (via scripts/extract-changelog-section.sh)
 # plus a fixed Install/Update footer, so the release notes always track the
-# changelog. workflow_dispatch lets a maintainer (re)generate one release by
-# tag — re-running is idempotent (an existing release is edited, not duplicated).
+# changelog.
+#
+# workflow_dispatch is the tagless cut path (#750): a maintainer runs it with a
+# tag input and — if that tag does not yet exist — the "Ensure tag exists" step
+# creates and pushes it from inside Actions (using GITHUB_TOKEN, which can push
+# refs/tags/* that a policy-restricted session cannot), pointed at the checked-out
+# commit only when its VERSION matches. Dispatching an already-existing tag just
+# re-generates that release, so re-running is idempotent (edited, not duplicated).
 on:
   push:
     tags: ["v*"]
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to (re)generate the release for, e.g. v6.2.0"
+        description: "Tag to cut/(re)generate the release for, e.g. v7.1.0"
         required: true
 
 # Least-privilege default (mirrors ci.yml / codeql.yml); the release job
@@ -51,6 +57,38 @@ jobs:
             tag="${GITHUB_REF_NAME}"
           fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      # Tagless cut path: on workflow_dispatch, create the tag inside Actions
+      # when it is absent so releasing never needs a hand-pushed tag. The tag is
+      # placed on the checked-out commit (default branch HEAD) ONLY when its
+      # VERSION file matches the requested version, so a stale checkout can't be
+      # mistagged. Re-generating an existing release (tag already fetched by the
+      # fetch-depth:0 checkout) skips creation. On the push:tags path this step
+      # is skipped and behavior is unchanged.
+      - name: Ensure tag exists
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ steps.tag.outputs.tag }}"
+          version="${tag#v}"
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            echo "tag ${tag} already exists — skipping creation (re-generate path)"
+            exit 0
+          fi
+          file_version="$(cat VERSION)"
+          if [ "${file_version}" != "${version}" ]; then
+            echo "::error::VERSION file (${file_version}) does not match requested tag ${tag}. Bump VERSION to ${version} and merge it before cutting the release." >&2
+            exit 1
+          fi
+          sha="$(git rev-parse HEAD)"
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${tag}" -m "${tag}" "${sha}"
+          # persist-credentials:false keeps the token out of .git/config, so
+          # authenticate this single push via a tokened remote URL.
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "refs/tags/${tag}"
+          echo "created and pushed ${tag} at ${sha}"
 
       - name: Build release notes
         id: notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,12 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ github.token }}
+          # Bind through env — the tag traces to the user-supplied dispatch
+          # input, so inlining it into this GH_TOKEN-holding run block would be a
+          # shell-injection vector (matches the "Resolve tag" hardening pattern).
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          tag="${{ steps.tag.outputs.tag }}"
+          tag="${TAG}"
           version="${tag#v}"
           if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
             echo "tag ${tag} already exists — skipping creation (re-generate path)"
@@ -92,8 +96,10 @@ jobs:
 
       - name: Build release notes
         id: notes
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          tag="${{ steps.tag.outputs.tag }}"
+          tag="${TAG}"
           version="${tag#v}"
           notes="$(mktemp)"
           # ANSI-C quoting keeps the ``` code fence literal (single quotes would
@@ -108,9 +114,11 @@ jobs:
       - name: Create or update release
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          NOTES_FILE: ${{ steps.notes.outputs.file }}
         run: |
-          tag="${{ steps.tag.outputs.tag }}"
-          notes="${{ steps.notes.outputs.file }}"
+          tag="${TAG}"
+          notes="${NOTES_FILE}"
           if gh release view "$tag" >/dev/null 2>&1; then
             echo "release $tag exists — updating notes"
             gh release edit "$tag" --notes-file "$notes"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ci`: release-integrity automation — a `changelog` CI job + `scripts/check-changelog-completeness.sh`
+  fail a version-bump PR whose `## [X.Y.Z]` section declares an "N PRs since
+  X.Y.Z" count that disagrees with the PRs actually merged into the release (the
+  v7.1.0 notes claimed 4 while 11 merged). `release.yml` `workflow_dispatch` now
+  creates and pushes the release tag from inside Actions when it is absent, so
+  cutting a release no longer needs a hand-pushed tag. (#750)
+
 ## [7.1.0] - 2026-07-03
 
 11 PRs since 7.0.0. Minor release. Headline changes: the `debt`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,19 +225,20 @@ Releases are automated by `.github/workflows/release.yml`. To cut one:
 
 1. In your version-bump PR, set `VERSION` and move the `## [Unreleased]`
    entries under a new `## [X.Y.Z] - YYYY-MM-DD` header in `CHANGELOG.md`.
-2. After it merges to `main`, tag the merge commit and push the tag:
-
-   ```bash
-   git tag vX.Y.Z && git push origin vX.Y.Z
-   ```
-
-3. The `release` workflow builds the body from that CHANGELOG section (via
+2. After it merges to `main`, trigger the `release` workflow via
+   `workflow_dispatch` with the tag (e.g. `v7.1.0`) — from the Actions tab or
+   `gh workflow run release.yml -f tag=vX.Y.Z`. When the tag does not yet
+   exist, the workflow **creates and pushes it from inside Actions**, pointed
+   at the `main` commit whose `VERSION` matches, then publishes the release. No
+   hand-pushed tag is needed (and a policy-restricted session that cannot push
+   `refs/tags/*` is not a blocker).
+3. The workflow builds the body from that CHANGELOG section (via
    `scripts/extract-changelog-section.sh`) plus a fixed Install/Update footer
    and publishes the GitHub Release.
 
-To (re)generate a single release by hand, run the workflow via
-`workflow_dispatch` with the tag (e.g. `v6.2.0`). Re-running edits the
-existing release instead of duplicating it.
+Re-running `workflow_dispatch` on an existing tag just edits that release
+instead of duplicating it. Pushing a `vX.Y.Z` tag by hand still works as a
+fallback and triggers the same publish path.
 
 ### Pre-PR checklist (version bump)
 
@@ -257,10 +258,20 @@ manifests silently:
 # 3. The release workflow can extract that section (this is the release
 #    body's actual source, not CHANGELOG.md read informally)
 bash scripts/extract-changelog-section.sh X.Y.Z
+
+# 4. The new section's "N PRs since X.Y.Z" count matches the PRs actually
+#    merged into the release (guards the #750 omission — a hand-written count
+#    that undercounts silently drops entries from the published notes). CI runs
+#    this too (the `changelog` job).
+bash scripts/check-changelog-completeness.sh
 ```
 
 If step 3 exits non-zero (exit 2 = version not found in `CHANGELOG.md`), the
-section header doesn't match `VERSION` — fix it before opening the PR.
+section header doesn't match `VERSION` — fix it before opening the PR. If step 4
+exits non-zero, reconcile the changelog: add the missing entries and correct the
+`N PRs since` count (or, for a PR deliberately folded into another entry, adjust
+the count). The count is bounded by the `## [prev]`..`## [current]` section
+range, so post-release hotfixes never inflate a frozen release's number.
 
 ## Testing
 

--- a/scripts/check-changelog-completeness.sh
+++ b/scripts/check-changelog-completeness.sh
@@ -100,9 +100,13 @@ fi
 # ---------------------------------------------------------------------------
 # 3. Count unique release PRs (trailing "(#N)"), excluding the version bump.
 # ---------------------------------------------------------------------------
+# `|| true` rescues the whole pipeline under `set -euo pipefail`: an all-bump
+# section (grep -vE matches nothing) or a section with no "(#N)" (grep -oE
+# matches nothing) makes a grep exit 1, which pipefail would surface as a fatal
+# substitution failure — the zero-PR case must fall through to the comparison.
 prs="$(printf '%s\n' "$subjects" \
   | grep -vE '^chore(\([^)]*\))?: bump version' \
-  | grep -oE '\(#[0-9]+\)$' | tr -cd '0-9\n' | sed '/^$/d' | sort -u)"
+  | grep -oE '\(#[0-9]+\)$' | tr -cd '0-9\n' | sed '/^$/d' | sort -u || true)"
 actual="$(printf '%s' "$prs" | grep -c . || true)"
 
 # ---------------------------------------------------------------------------

--- a/scripts/check-changelog-completeness.sh
+++ b/scripts/check-changelog-completeness.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# check-changelog-completeness.sh — fail when a release section's "N PRs since
+# X.Y.Z" count disagrees with the PRs actually merged into that release (#750).
+#
+# Why a COUNT check and not a per-PR presence check: the v7.1.0 notes claimed
+# "4 PRs since 7.0.0" while 11 had merged — four user-facing PRs (#729, #731,
+# #733, #738) were silently dropped from the hand-written changelog, which is
+# the source of the published release body (extract-changelog-section.sh →
+# release.yml). A presence check keyed on the PR number is unreliable here
+# because praxis cites the *issue* number as often as the PR (e.g. the debt
+# skill is `(#711)` though its PR is #732), so a PR-number scan false-flags
+# correctly-documented entries. The intro's "N PRs since P.Q.R" line, by
+# contrast, is an unambiguous integer that was exactly what went wrong — this
+# guard recomputes it from git and fails on a mismatch, listing the PRs so the
+# author reconciles the count (and, in practice, the missing entries).
+#
+# Scope: only the NEWEST release section is checked, and only when it carries a
+# "N PRs since P.Q.R" line (the minor-release convention). A section without
+# that line — e.g. a major release written as prose — is skipped. The count is
+# bounded by the two changelog sections, not by git tags, because this repo's
+# release tags lag the changelog (tags stop at v6.3.0 while 6.3.1–7.1.0 sit
+# untagged); the range is [commit that introduced `## [P.Q.R]`] .. [commit that
+# introduced `## [thisVersion]`], excluding the version-bump commit itself, so
+# post-release hotfixes never inflate a frozen release's count.
+#
+# Env overrides:
+#   CHANGELOG_FILE           changelog path (default: <repo>/CHANGELOG.md)
+#   PRAXIS_CC_SUBJECTS_FILE  test hook — newline-separated commit subjects used
+#                            as the release range instead of `git log`; when
+#                            set, git boundary detection is skipped
+#
+# Exit codes:
+#   0   count matches, or the section opts out (no "N PRs since" line)
+#   1   declared count disagrees with the computed count
+#   2   usage / environment error
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHANGELOG="${CHANGELOG_FILE:-$REPO_ROOT/CHANGELOG.md}"
+
+if [[ ! -f "$CHANGELOG" ]]; then
+  echo "error: CHANGELOG not found at $CHANGELOG" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# 1. Newest release version + its "N PRs since P.Q.R" claim.
+# ---------------------------------------------------------------------------
+# First "## [X.Y.Z]" header (Unreleased has no dotted version, so it is skipped).
+this_version="$(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' "$CHANGELOG" | head -n1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)"
+if [[ -z "$this_version" ]]; then
+  echo "warning: no released '## [X.Y.Z]' section found; nothing to check" >&2
+  exit 0
+fi
+
+# The claim line lives in the section body: "<N> PRs since <P.Q.R>".
+claim_line="$(awk -v ver="$this_version" '
+  $0 ~ "^## \\[" ver "\\]" { cap = 1; next }
+  cap && /^## \[/          { exit }
+  cap                      { print }
+' "$CHANGELOG" | grep -iE '[0-9]+ PRs? since [0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)"
+
+if [[ -z "$claim_line" ]]; then
+  echo "note: [$this_version] has no 'N PRs since X.Y.Z' line — count check skipped"
+  exit 0
+fi
+
+declared="$(printf '%s' "$claim_line" | grep -oiE '[0-9]+ PRs? since' | grep -oE '^[0-9]+')"
+prev_version="$(printf '%s' "$claim_line" | grep -oE 'since [0-9]+\.[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+
+if [[ -z "$declared" || -z "$prev_version" ]]; then
+  echo "warning: could not parse the 'N PRs since X.Y.Z' claim ('$claim_line'); skipping" >&2
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Collect the release range's commit subjects.
+# ---------------------------------------------------------------------------
+subjects=""
+if [[ -n "${PRAXIS_CC_SUBJECTS_FILE:-}" ]]; then
+  if [[ ! -f "$PRAXIS_CC_SUBJECTS_FILE" ]]; then
+    echo "error: PRAXIS_CC_SUBJECTS_FILE not found at $PRAXIS_CC_SUBJECTS_FILE" >&2
+    exit 2
+  fi
+  subjects="$(cat "$PRAXIS_CC_SUBJECTS_FILE")"
+else
+  # Boundaries = the commits that first introduced each section header. -S
+  # counts occurrences of the literal; the earliest such commit is the add.
+  top="$(git -C "$REPO_ROOT" log --reverse --format=%H -S"## [${this_version}]" -- "$CHANGELOG" | head -n1 || true)"
+  bottom="$(git -C "$REPO_ROOT" log --reverse --format=%H -S"## [${prev_version}]" -- "$CHANGELOG" | head -n1 || true)"
+  if [[ -z "$top" || -z "$bottom" ]]; then
+    # A shallow clone (or a squashed history) can hide one boundary. Fail open:
+    # this guard must never block a PR just because it cannot see enough history.
+    echo "warning: could not resolve the [$prev_version]..[$this_version] commit range (shallow clone?); skipping" >&2
+    exit 0
+  fi
+  subjects="$(git -C "$REPO_ROOT" log "${bottom}..${top}" --no-merges --format='%s')"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Count unique release PRs (trailing "(#N)"), excluding the version bump.
+# ---------------------------------------------------------------------------
+prs="$(printf '%s\n' "$subjects" \
+  | grep -vE '^chore(\([^)]*\))?: bump version' \
+  | grep -oE '\(#[0-9]+\)$' | tr -cd '0-9\n' | sed '/^$/d' | sort -u)"
+actual="$(printf '%s' "$prs" | grep -c . || true)"
+
+# ---------------------------------------------------------------------------
+# 4. Compare.
+# ---------------------------------------------------------------------------
+if [[ "$actual" -ne "$declared" ]]; then
+  echo "error: [$this_version] declares '$declared PRs since $prev_version' but $actual PR(s) merged into the release:" >&2
+  printf '  #%s\n' $prs >&2
+  echo "" >&2
+  echo "Reconcile the changelog: add the missing entries and correct the count" >&2
+  echo "(or fix the count if a PR is intentionally folded into another entry)." >&2
+  exit 1
+fi
+
+echo "changelog-completeness OK — [$this_version] declares $declared PRs since $prev_version and $actual merged"

--- a/tests/test_check_changelog_completeness.sh
+++ b/tests/test_check_changelog_completeness.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# test_check_changelog_completeness.sh — verify
+# scripts/check-changelog-completeness.sh, the release-count guard (issue #750).
+#
+# The script's git-boundary detection is bypassed via PRAXIS_CC_SUBJECTS_FILE so
+# every case is a self-contained fixture: a synthetic CHANGELOG (its newest
+# section carrying — or omitting — a "N PRs since X.Y.Z" line) plus an injected
+# list of release-range commit subjects. This exercises the parse + count +
+# compare logic without a real git history.
+#
+# Usage: bash tests/test_check_changelog_completeness.sh
+# Exit:  0 = all pass; 1 = at least one fail
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+GUARD="$ROOT_DIR/scripts/check-changelog-completeness.sh"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+run_case() { # name actual_exit expected_exit
+  local name="$1" actual="$2" expected="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expected_exit=$expected got=$actual"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+echo "test_check_changelog_completeness"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Shared subject list: 4 real PRs since 7.0.0 (a bump commit is included to
+# prove it is excluded from the count).
+cat >"$TMP/subjects_4.txt" <<'EOF'
+feat(skill): add debt deferred-decision ledger (#732)
+fix(retrospect): read each is_error body individually (#729)
+docs(release): unify version bump checklist (#728)
+feat(hooks): re-fetch PR state before PR-contingent question (#733)
+chore: bump version to 7.1.0 (#746)
+EOF
+
+changelog_with_claim() { # version prev count  -> path
+  local ver="$1" prev="$2" count="$3"
+  local path="$TMP/cl_${ver}_${count}.md"
+  cat >"$path" <<EOF
+# Changelog
+
+## [Unreleased]
+
+## [${ver}] - 2026-07-03
+
+${count} PRs since ${prev}. Minor release.
+
+### Added
+- something (#732)
+
+## [${prev}] - 2026-06-28
+
+### Removed
+- old thing (#726)
+EOF
+  printf '%s' "$path"
+}
+
+# Case 1: declared count matches actual (4) -> pass (exit 0).
+cl="$(changelog_with_claim 7.1.0 7.0.0 4)"
+CHANGELOG_FILE="$cl" PRAXIS_CC_SUBJECTS_FILE="$TMP/subjects_4.txt" bash "$GUARD" >/dev/null 2>&1
+run_case "count-matches-passes" "$?" 0
+
+# Case 2: declared count too low (the real v7.1.0 bug: said 4, 4 merged here but
+# claim says 9) -> mismatch -> fail (exit 1).
+cl="$(changelog_with_claim 7.1.0 7.0.0 9)"
+CHANGELOG_FILE="$cl" PRAXIS_CC_SUBJECTS_FILE="$TMP/subjects_4.txt" bash "$GUARD" >/dev/null 2>&1
+run_case "count-mismatch-fails" "$?" 1
+
+# Case 3: bump commit is not counted — a subjects list of exactly one real PR
+# plus a bump must count as 1, not 2.
+cat >"$TMP/subjects_1.txt" <<'EOF'
+fix(hooks): scan subagent transcripts (#738)
+chore(release): bump version to 7.1.0 (#746)
+EOF
+cl="$(changelog_with_claim 7.1.0 7.0.0 1)"
+CHANGELOG_FILE="$cl" PRAXIS_CC_SUBJECTS_FILE="$TMP/subjects_1.txt" bash "$GUARD" >/dev/null 2>&1
+run_case "bump-commit-excluded" "$?" 0
+
+# Case 4: a section without a "N PRs since" line opts out -> pass (exit 0),
+# even though the injected range has PRs.
+cat >"$TMP/cl_noclaim.md" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+## [7.0.0] - 2026-06-28
+
+Major release. Removes the cmux-browser skill.
+
+### Removed
+- cmux-browser (#726)
+EOF
+CHANGELOG_FILE="$TMP/cl_noclaim.md" PRAXIS_CC_SUBJECTS_FILE="$TMP/subjects_4.txt" bash "$GUARD" >/dev/null 2>&1
+run_case "no-claim-line-skips" "$?" 0
+
+# Case 5: duplicate PR reference in the range is counted once.
+cat >"$TMP/subjects_dup.txt" <<'EOF'
+feat(a): thing (#732)
+feat(a): thing follow-up squashed (#732)
+fix(b): other (#729)
+EOF
+cl="$(changelog_with_claim 7.1.0 7.0.0 2)"
+CHANGELOG_FILE="$cl" PRAXIS_CC_SUBJECTS_FILE="$TMP/subjects_dup.txt" bash "$GUARD" >/dev/null 2>&1
+run_case "duplicate-pr-counted-once" "$?" 0
+
+# Case 6: missing CHANGELOG -> environment error (exit 2).
+CHANGELOG_FILE="$TMP/does-not-exist.md" PRAXIS_CC_SUBJECTS_FILE="$TMP/subjects_4.txt" bash "$GUARD" >/dev/null 2>&1
+run_case "missing-changelog-errors" "$?" 2
+
+echo ""
+echo "test_check_changelog_completeness: $PASS passed, $FAIL failed"
+if [ "$FAIL" -ne 0 ]; then
+  echo "failed: ${FAILED_NAMES[*]}" >&2
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #750.

## Why

v7.1.0 surfaced two independent release-process gaps (the notes themselves were backfilled in #747):

1. **Silent changelog undercount** — the `## [7.1.0]` section claimed "4 PRs since 7.0.0" while **11** had merged; four user-facing PRs (#729, #731, #733, #738) were dropped from the hand-written notes. Because `scripts/extract-changelog-section.sh` is the *source* of the published GitHub release body, they would have vanished from the release. Nothing checked this.
2. **Tag push not automatable** — `release.yml` fires on `push: tags`, but a policy-restricted session cannot push a `refs/tags/*` ref (`git push origin v7.1.0` → 403). Tag/release creation *is* possible from inside Actions (v6.3.0 was published by `github-actions[bot]`), so tagging belongs in CI.

## What

### Guard 1 — changelog count check
- **`scripts/check-changelog-completeness.sh`** recomputes the newest section's `"N PRs since X.Y.Z"` claim from git history and fails on a mismatch, printing the release's PR list.
- A **count** check rather than per-PR presence: praxis cites the *issue* number as often as the PR (e.g. the debt skill is `(#711)` though its PR is #732), so a PR-number presence scan false-flags correctly-documented entries. The `N PRs` integer is unambiguous and was exactly what went wrong.
- The range is bounded by the `## [prev]`..`## [current]` **changelog-section commits**, not git tags (this repo's tags lag the changelog), and excludes the version-bump commit — so post-release hotfixes never inflate a frozen release's count.
- Wired as a dedicated `fetch-depth:0` **`changelog` CI job**. Self-gating: passes when the count matches, skips sections without the count line, fails open on shallow history — safe to run on every push/PR.
- **`tests/test_check_changelog_completeness.sh`** — 6 fixture cases via injected commit subjects (no git history needed).

### Guard 2 — tagless release cut
- `release.yml` `workflow_dispatch` now **creates and pushes the tag from inside Actions** when it is absent (GITHUB_TOKEN can push `refs/tags/*`), pointed at the checked-out commit **only when its `VERSION` matches** the requested version — so a stale checkout can't be mistagged. Existing-tag dispatch and the `push:tags` path are unchanged.

### Docs
- `CONTRIBUTING.md` release section rewritten around the tagless flow; the pre-PR checklist gains the completeness step.

## Verification

- Guard **passes** on the fixed repo (`11 == 11`) and **fails** on the buggy `c7f8481` changelog (declared 4, 11 merged), listing all 11 PRs.
- New + existing changelog tests, `check-plugin-manifests.py`, and cli-scripts parity all pass; both new shell files are shellcheck-clean; workflows parse as YAML.
- `actionlint` was not run locally (its release-asset download is egress-blocked); the workflow edits reuse the file's existing `steps.outputs`-in-`run` pattern that already passes the CI `actionlint` job, which will validate this PR.
- **Not executed end-to-end:** the `release.yml` tag-creation step was not run against GitHub via a real dispatch; its `VERSION`-match / tag-exists branches are verified by inspection.

## Follow-up (out of scope)

Full `release-please` / `git-cliff` changelog *generation* (option B) remains a possible later step if this lighter guard proves insufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rs2jQZdbPyGJjZ4eST7wU1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CI-based changelog completeness validation to detect “N PRs since X.Y.Z” count mismatches early.
  * Enhanced release workflows to automatically create/push missing tags, supporting the “tagless cut path.”
* **Bug Fixes**
  * Ensured rerunning a release for an existing tag updates the existing release rather than creating duplicates.
* **Documentation**
  * Updated contributor release instructions and changelog guidance for the new verification and tag flow.
* **Tests**
  * Added integration-style tests covering match/mismatch, deduplication, exclusions, and missing/invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->