### PR TITLE
docs: note squash-title drives release-please bump

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,6 +241,14 @@ Releases are fully automated by `.github/workflows/release-please.yml`
 4. Merge the release PR (squash). The next push-to-`main` run tags the commit
    `vX.Y.Z` and publishes the GitHub Release.
 
+> **Squash-merge determines the version bump.** Because every PR is squash-merged,
+> release-please sees one commit per PR whose type is the **PR title's**
+> Conventional Commit type — not the individual branch commits. A `ci:` / `chore:`
+> / `docs:` PR title bumps **patch**; `feat:` bumps **minor**; a `!` / `BREAKING
+> CHANGE` bumps **major**. Title release-worthy PRs accordingly. To force a
+> specific version regardless of title, put `Release-As: X.Y.Z` in the merged
+> commit body (a one-time override — see the release-please README).
+
 ### One-time setup — the `RELEASE_PLEASE_TOKEN` secret
 
 release-please must act through a fine-grained PAT (or a GitHub App), **not**


### PR DESCRIPTION
## 배경

#753 로 release-please 도입 후 첫 release PR(#754)이 **7.1.1(patch)** 로 계산됨. praxis 는 squash merge 를 강제하므로, release-please 는 개별 커밋이 아니라 **PR 제목의 Conventional Commit 타입**(#753 은 `ci:`)으로 버전을 매깁니다.

## 변경

- `CONTRIBUTING.md` Releasing 절에 규칙 명시: squash 제목 타입이 bump 결정(`ci`/`chore`/`docs`→patch, `feat`→minor, `!`/BREAKING→major), override 는 `Release-As:` footer.
- 이 PR 의 커밋 body 에 `Release-As: 7.2.0` footer 포함 → 머지 시 release-please 가 **#754 를 7.2.0(minor) 로 갱신**. 첫 릴리즈를 기능성 minor 로 발행하려는 의도.

## 검증

Pre-commit verified: docs-only change; `grep -nE '^\*\*[^*]+\*\*$' CONTRIBUTING.md` → no MD036 standalone-emphasis lines. `Release-As: 7.2.0` footer confirmed present in commit body (`git log -1 --format=%B`).

## 머지 후

release-please 가 push:main 에서 재실행되어 #754 를 `chore(main): release 7.2.0` 으로 갱신 → 매니페스트 sync 재실행. 이후 #754 를 머지하면 v7.2.0 발행.

Closes #755
