### PR TITLE
fix(ci): guard release-please sync on tagging run

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,12 +47,27 @@ jobs:
       # release-please bumps VERSION in the release PR, regenerate the manifests
       # on that PR branch so the drift gate passes. Pushed with the PAT so the
       # release PR's `ci` checks re-run against the synced tree.
+      # Guard on `prs_created` (a plain boolean-string output), NOT on `pr`.
+      # On a *tagging* run (release PR already merged → tag+Release published,
+      # no new PR opened) `steps.release.outputs.pr` is empty. Referencing
+      # `fromJson(steps.release.outputs.pr)` inside `env:` makes GitHub evaluate
+      # `fromJson('')` while setting the step up — which throws
+      # "Error reading JToken from JsonReader" and fails the run even though the
+      # step's `if:` is false. So: gate on `prs_created`, pass the raw PR JSON
+      # through env (empty string is harmless — no fromJson at eval time), and
+      # parse the branch name with jq inside `run:`, which only executes when the
+      # guard holds.
       - name: Sync platform manifests on the release PR
-        if: ${{ steps.release.outputs.pr }}
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          PR_BRANCH: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
         run: |
+          PR_BRANCH="$(printf '%s' "${PR_JSON}" | jq -r '.headBranchName')"
+          if [ -z "${PR_BRANCH}" ] || [ "${PR_BRANCH}" = "null" ]; then
+            echo "no release PR branch in outputs — nothing to sync" >&2
+            exit 1
+          fi
           git clone --branch "${PR_BRANCH}" --depth 1 \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" rp
           cd rp


### PR DESCRIPTION
## 증상

#753 로 도입한 release-please 워크플로우의 **태깅 run**(release PR 머지 후 v태그 + GitHub Release 를 발행하는 run)이 `failure` 로 종료됩니다. v7.2.0 은 정상 발행됐지만(release 스텝이 먼저 실행) run 상태가 빨갛게 뜨고, 이후 **모든 릴리즈의 태깅 run 이 같은 방식으로 실패**합니다.

## 원인

`Sync platform manifests on the release PR` 스텝의 `env` 블록:

```yaml
if: ${{ steps.release.outputs.pr }}
env:
  PR_BRANCH: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
```

태깅 run 에선 새 release PR 이 열리지 않아 `steps.release.outputs.pr` 가 빈 문자열입니다. GitHub 은 스텝의 `env` 표현식을 **`if` 가 false 여도 스텝 셋업 시점에 평가**하므로 `fromJson('')` 이 `Error reading JToken from JsonReader. Path '', line 0, position 0` 을 던지고 run 이 실패합니다.

## 수정

1. 게이트를 `if: ${{ steps.release.outputs.prs_created == 'true' }}` 로 변경 — `prs_created` 는 "release PR 이 생성/갱신됨"을 나타내는 문서화된 boolean 출력. 태깅 run 에선 false 라 스텝이 정상 skip.
2. `env` 에서 `fromJson` 제거 → raw `PR_JSON: ${{ steps.release.outputs.pr }}` 로 넘기고(빈 문자열은 무해), `run` 안에서 `jq -r '.headBranchName'` 로 파싱. 빈/`null` 브랜치는 loud 하게 `exit 1`.

이제 태깅 run 에서 예외를 던지는 표현식 경로가 남지 않고, PR 생성 run 에서는 동작이 동일합니다.

## 검증

Pre-commit verified: `bash scripts/run-tests.sh` → ALL TESTS PASSED (67 shell + 5 + manifest check + hook-token invariant); `release-please.yml` **actionlint clean**; jq 파싱을 real-PR-JSON / empty-string 두 케이스로 실행 검증; YAML parse OK.

- **codex review** clean — diff 범위 회귀/실행불능 없음
- **oh-my-claudecode:code-reviewer** APPROVE — `prs_created`(*"true if any pull request was created or updated"*) / `pr`(*"unset if no release created"*) 출력을 pinned SHA `45996ed`(v5.0.0) README 로 직접 대조 확인, env-time `fromJson` 제거로 실패 경로 완전 제거, 새 `run` 블록 shell-safe(quoting/empty guard/pipefail) 확인. Nit 2건(향후 monorepo 결합, `exit 1` 의도성)은 non-blocking·변경 불필요

## 미검증 / 주의

- 실제 push:main dispatch 로 태깅 run 을 재현하지는 않음(workflow-eval 동작을 actionlint + jq 케이스 테스트 + pinned-SHA README 로 검증). 다음 릴리즈의 태깅 run 에서 최종 확인 가능.

Closes #757


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release workflow reliability so release and publishing runs no longer fail when no new pull request is created.
  * Added safer handling for release metadata, reducing errors during automated release processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->