### PR TITLE
fix(completion-verify): block echo-fabricated evidence

### DIFF
--- a/hooks/completion-verify/completion-verify/impl.sh
+++ b/hooks/completion-verify/completion-verify/impl.sh
@@ -11,6 +11,9 @@
 #         is paste'd as a substring of the assistant message text — i.e. the
 #         specific "12 passed" / "tests passed" / "lint clean" / "✅" / etc.
 #         token that triggered L3 must appear verbatim in the message.
+#   L3/L2 consider only "genuine" tool_results — those produced by a command
+#   that is NOT an echo/printf-only fabrication of the success token, so
+#   `echo "tests passed"` cannot satisfy the gate. [issue #758]
 #   Otherwise, block with a {decision: block, reason: ...} JSON payload.
 
 command -v jq >/dev/null 2>&1 || exit 0
@@ -58,24 +61,35 @@ TURN_JSON=$(tail -n 400 "$TRANSCRIPT_PATH" | jq -sc '
        | select(.message.role == "assistant" and (.isSidechain // false) == false)
        | (.message.content // [])[]
        | select(.type == "tool_use" and .name == "Bash")
-       | .id]) as $bash_ids
+       | {id: .id, cmd: (.input.command // "")}]) as $bash_uses
+  | ($bash_uses | map(.id)) as $bash_ids
   | ([$turn[]
        | select(.message.role == "user")
        | (.message.content // [])[]
        | select(.type == "tool_result"
                 and (.tool_use_id as $t | $bash_ids | any(. == $t)))
-       | (if (.content | type) == "string" then .content
-          elif (.content | type) == "array" then
-            (.content | map(select(.type == "text") | .text) | join("\n"))
-          else "" end)]
-     | join("\n---\n")) as $bash_outputs
-  | {last_text: $last_text, bash_outputs: $bash_outputs}
+       | {tid: .tool_use_id,
+          text: (if (.content | type) == "string" then .content
+                 elif (.content | type) == "array" then
+                   (.content | map(select(.type == "text") | .text) | join("\n"))
+                 else "" end)}]) as $results
+  | ([$results[] | .text] | join("\n---\n")) as $bash_outputs
+  | ([$results[]
+       | . as $r
+       | (($bash_uses[] | select(.id == $r.tid) | .cmd) // "") as $cmd
+       | select(((($cmd | test("^\\s*(echo|printf)\\b")) and (($cmd | test("[;&|`$\\n]")) | not))) | not)
+       | $r.text]
+     | join("\n---\n")) as $genuine_outputs
+  | {last_text: $last_text, bash_outputs: $bash_outputs, genuine_outputs: $genuine_outputs}
 ' 2>/dev/null)
 
 [ -z "$TURN_JSON" ] && exit 0
 
 LAST_TEXT=$(printf '%s' "$TURN_JSON" | jq -r '.last_text // ""')
 BASH_OUTPUTS=$(printf '%s' "$TURN_JSON" | jq -r '.bash_outputs // ""')
+# genuine_outputs excludes results produced by echo/printf-only commands, so a
+# fabricated `echo "tests passed"` cannot satisfy the evidence gate. [issue #758]
+GENUINE_OUTPUTS=$(printf '%s' "$TURN_JSON" | jq -r '.genuine_outputs // ""')
 
 [ -z "$LAST_TEXT" ] && exit 0
 
@@ -90,15 +104,18 @@ block_reason=""
 
 if [ -z "$BASH_OUTPUTS" ]; then
   block_reason="No Bash verification command was run in this turn. Run a real verify command (test/lint/build) and paste its output BEFORE declaring completion."
-elif ! printf '%s' "$BASH_OUTPUTS" | grep -qE "$EVIDENCE_PATTERNS"; then
+elif [ -z "$GENUINE_OUTPUTS" ]; then
+  block_reason="Your only Bash 'verification' this turn was an echo/printf of the success token, not a real command. Run an actual test/lint/build and paste ITS output BEFORE declaring completion."
+elif ! printf '%s' "$GENUINE_OUTPUTS" | grep -qE "$EVIDENCE_PATTERNS"; then
   block_reason="Bash output present but lacks a verification signal (e.g., 'tests passed', 'exit code 0', 'lint clean'). Re-run an actual verify command."
 else
   # Paste check: each EVIDENCE_PATTERNS-matching span in tool_result must
   # appear verbatim in the assistant message. Span-based (not line-based)
   # so decorated output like '======== 12 passed in 0.85s ========' counts
-  # when the assistant cites '12 passed in 0.85s'.
+  # when the assistant cites '12 passed in 0.85s'. Spans are drawn from
+  # genuine (non-echo/printf) outputs only. [issue #758]
   paste_detected=false
-  evidence_spans=$(printf '%s' "$BASH_OUTPUTS" | grep -oE "$EVIDENCE_PATTERNS")
+  evidence_spans=$(printf '%s' "$GENUINE_OUTPUTS" | grep -oE "$EVIDENCE_PATTERNS")
   while IFS= read -r span; do
     [ -z "$span" ] && continue
     if printf '%s' "$LAST_TEXT" | grep -qF -e "$span"; then

--- a/hooks/completion-verify/completion-verify/spec.md
+++ b/hooks/completion-verify/completion-verify/spec.md
@@ -25,8 +25,9 @@ The turn passes only if **all** of the following hold:
 | Gate | Condition |
 | ------ | ----------- |
 | L1 | A `Bash` tool_use occurred in this turn |
-| L3 | Its `tool_result.content` matches `EVIDENCE_PATTERNS` (`X passed`, `tests passed`, `\bPASS\b`, `exit code 0`, `lint clean`, `테스트.*통과`, `✅`, etc.) |
-| L2 | At least one `EVIDENCE_PATTERNS`-matching span from that `tool_result` is paste'd verbatim in the assistant message text — e.g. `12 passed`, `tests passed`, `lint clean`, `✅` |
+| L4 | At least one Bash tool_result is **genuine** — produced by a command that is not an `echo`/`printf`-only fabrication of the success token (issue #758) |
+| L3 | A genuine `tool_result.content` matches `EVIDENCE_PATTERNS` (`X passed`, `tests passed`, `\bPASS\b`, `exit code 0`, `lint clean`, `테스트.*통과`, `✅`, etc.) |
+| L2 | At least one `EVIDENCE_PATTERNS`-matching span from that genuine `tool_result` is paste'd verbatim in the assistant message text — e.g. `12 passed`, `tests passed`, `lint clean`, `✅` |
 
 A claim with no Bash, with Bash but no evidence signal, or with evidence but
 the verify token not quoted, all block. Tool results from non-Bash tools
@@ -34,6 +35,22 @@ the verify token not quoted, all block. Tool results from non-Bash tools
 executed Bash command qualifies. Span-based paste detection is decoration-
 agnostic — pytest's `============= 12 passed in 0.85s =============` border
 output passes when the assistant cites `12 passed in 0.85s`.
+
+### Anti-gaming: echo/printf-fabricated evidence (issue #758)
+
+The gate reads `tool_result` content **and** the producing command
+(`tool_use.input.command`). A result whose command is `echo`/`printf`-only —
+matches `^\s*(echo|printf)\b` and contains none of `; & | $` backtick or a
+newline — is excluded from the evidence set, so `echo "5 tests passed"` no
+longer satisfies L3/L2. A command that chains (`pytest -q; echo done`) or
+substitutes (`echo "$(pytest -q)"`) runs a real command and stays genuine.
+
+**Limitation** (documented, not a bug): a real-command *disguise* such as
+`true && echo "tests passed"` or `echo a && echo "tests passed"` is not
+caught — the threat model is the model's own lazy single-`echo "done"`
+pattern, not adversarial evasion. The chaining char in a disguise keeps the
+command in the genuine set by design (avoiding false positives on real
+chained verification).
 
 ### Response
 
@@ -75,11 +92,14 @@ same pattern the marker would re-enable.
 
 ### Tests
 
-`tests/test_completion_verify.sh` covers 12 cases: 8 acceptance scenarios
+`tests/test_completion_verify.sh` covers 17 cases: 8 acceptance scenarios
 (same-turn pass, no-Bash claim, no-evidence claim, no-paste claim,
 mid-message claim ignored, non-Bash tool ignored, realistic pytest
-output, Korean evidence) and 4 fail-safes (`stop_hook_active`, missing
-transcript, empty file, malformed JSONL). Run before editing the hook:
+output, Korean evidence), 5 anti-gaming scenarios (echo-fabricated blocked,
+printf-fabricated blocked, real command chained with echo passes, Korean
+echo-fabricated blocked, echo of command-substitution passes — issue #758),
+and 4 fail-safes (`stop_hook_active`, missing transcript, empty file,
+malformed JSONL). Run before editing the hook:
 
 ```bash
 ./tests/test_completion_verify.sh

--- a/tests/hooks/completion-verify/test_completion_verify.sh
+++ b/tests/hooks/completion-verify/test_completion_verify.sh
@@ -210,6 +210,63 @@ $ASST7A
 $RESULT7
 $ASST7B"
 
+# AG1 — echo-fabricated evidence (echo of the success token) → block [#758] --
+USER_AG1=$(mk_user_text "run the tests")
+BASH_AG1=$(mk_bash_use "ag1" 'echo "5 tests passed"')
+ASST_AG1A=$(mk_assistant "verifying..." "[$BASH_AG1]")
+RESULT_AG1=$(mk_tool_result "ag1" "5 tests passed")
+ASST_AG1B=$(mk_assistant "5 tests passed. All done.")
+run_case "AG1 echo-fabricated evidence blocked" block "$USER_AG1
+$ASST_AG1A
+$RESULT_AG1
+$ASST_AG1B"
+
+# AG2 — printf-fabricated evidence → block [#758] ---------------------------
+USER_AG2=$(mk_user_text "check it")
+BASH_AG2=$(mk_bash_use "ag2" 'printf "PASS\n"')
+ASST_AG2A=$(mk_assistant "checking..." "[$BASH_AG2]")
+RESULT_AG2=$(mk_tool_result "ag2" "PASS")
+ASST_AG2B=$(mk_assistant "PASS. All done.")
+run_case "AG2 printf-fabricated evidence blocked" block "$USER_AG2
+$ASST_AG2A
+$RESULT_AG2
+$ASST_AG2B"
+
+# AG3 — real command chained with echo (has ';') → pass [#758] --------------
+USER_AG3=$(mk_user_text "run tests")
+BASH_AG3=$(mk_bash_use "ag3" 'pytest -q; echo cleanup')
+ASST_AG3A=$(mk_assistant "running..." "[$BASH_AG3]")
+RESULT_AG3=$(mk_tool_result "ag3" "12 passed in 0.85s")
+ASST_AG3B=$(mk_assistant "12 passed in 0.85s. All done.")
+run_case "AG3 real command chained with echo passes" pass "$USER_AG3
+$ASST_AG3A
+$RESULT_AG3
+$ASST_AG3B"
+
+# AG4 — Korean echo-fabricated evidence → block [#758] ---------------------
+USER_AG4=$(mk_user_text "테스트 돌려봐")
+BASH_AG4=$(mk_bash_use "ag4" 'echo "테스트 통과"')
+ASST_AG4A=$(mk_assistant "확인 중..." "[$BASH_AG4]")
+RESULT_AG4=$(mk_tool_result "ag4" "테스트 통과")
+ASST_AG4B=$(mk_assistant "테스트 통과. 작업 완료.")
+run_case "AG4 Korean echo-fabricated evidence blocked" block "$USER_AG4
+$ASST_AG4A
+$RESULT_AG4
+$ASST_AG4B"
+
+# AG5 — echo of command-substitution (has '$(') runs a real command → pass [#758]
+USER_AG5=$(mk_user_text "run pytest")
+# SC2016: the $(...) is intentional literal command-string data, not for expansion.
+# shellcheck disable=SC2016
+BASH_AG5=$(mk_bash_use "ag5" 'echo "$(pytest -q)"')
+ASST_AG5A=$(mk_assistant "running..." "[$BASH_AG5]")
+RESULT_AG5=$(mk_tool_result "ag5" "3 passed in 0.10s")
+ASST_AG5B=$(mk_assistant "3 passed in 0.10s. All done.")
+run_case "AG5 echo of command-substitution passes" pass "$USER_AG5
+$ASST_AG5A
+$RESULT_AG5
+$ASST_AG5B"
+
 # Fail-safe 1 — stop_hook_active=true → pass (no block) ---------------------
 fs_payload=$(jq -nc '{transcript_path: "/dev/null", stop_hook_active: true, session_id: "x"}')
 fs_out=$(printf '%s' "$fs_payload" | "$HOOK" 2>/dev/null)


### PR DESCRIPTION
## 배경

`completion-verify` Stop 게이트는 완료 주장 시 same-turn Bash `tool_result` 에 증거 토큰이 있고 메시지에 verbatim paste 됐는지만 검사했다. 게이트가 `tool_result` 존재만 볼 뿐 **그 결과를 만든 명령**은 보지 않아, 실제 검증 없이 성공 토큰을 `echo` 하는 것만으로 하드 게이트를 통과할 수 있었다:

```
echo "5 tests passed"  →  tool_result "5 tests passed"  →  paste  →  PASS
```

> 이 개선은 원래 검토하던 "completion-verify 가 sufficiency 판정을 OMC verify 에 위임"(S3)의 대안이다. Stop 훅은 셸 서브프로세스라 Agent/Skill 호출이 원리적으로 불가능해 sufficiency 판정을 만들 수 없다. 그 천장 안에서 게이트 실효성을 실제로 높이는 anti-gaming 개선이다.

## 변경

- `impl.sh` 단일 jq 패스에서 각 Bash `tool_use` 의 `.input.command` 를 함께 추출 → echo/printf-only 명령(체이닝/치환 문자 `; & | \` $` 없음)의 출력을 증거 집합에서 제외한 `genuine_outputs` 계산. L3(증거 신호)/L2(verbatim paste) 검사를 `genuine_outputs` 에 대해 수행.
- Bash 는 돌았지만 genuine 출력이 전부 비면(=전부 echo/printf-only) 새 block 메시지로 거부.
- 실 명령 체인(`pytest -q; echo done`)·치환(`echo "$(pytest)"`)은 genuine 으로 유지 → false positive 방지.
- `spec.md`: L4 게이트 행 + anti-gaming 조항 + 한계(`true && echo "..."` 같은 adversarial 위장은 위협 모델 밖, 의도적 미탐지) 명시.

## 검증

completion-verify 스위트 (17/17, anti-gaming 5 케이스 신규):

```
Results: 17 pass, 0 fail
```

레포 전체 스위트 (`bash scripts/run-tests.sh`):

```
=== summary ===
PASS: 67
FAIL: 0
Results: 5 pass, 0 fail
=== manifest check ===  plugin-manifest check OK
=== hook-token invariant check ===  hook-token-invariant check OK (7 invariants verified)
ALL TESTS PASSED
```

shellcheck clean.

## 완료 조건

- [x] `impl.sh`: `genuine_outputs` 계산 + echo/printf-only 제외 + 새 block 메시지
- [x] `spec.md`: anti-gaming 조항 + 한계 명시
- [x] `test_completion_verify.sh`: 기존 12 케이스 유지 + anti-gaming 5 케이스 (단일 echo→block / printf→block / `pytest;echo` real→pass / 한국어 echo 위조→block / `echo "$(...)"` 치환→pass)
- [x] 전체 스위트 pass 첨부

Pre-commit verified: completion-verify 17/17 + full suite 67 PASS/0 FAIL, shellcheck clean

Closes #758
