### PR TITLE
refactor(ci): manifests via release-please extra-files

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,14 +5,22 @@ name: release-please
 # "release PR" that bumps VERSION + CHANGELOG.md. Merging that PR tags the
 # commit and publishes the GitHub Release.
 #
+# VERSION is the single source of truth; the per-platform manifests are
+# generated from it (scripts/build-plugin-manifests.py) and their version field
+# is gated by scripts/check-plugin-manifests.py's VERSION-DRIFT check. The
+# release PR bumps those version fields directly via the `extra-files`
+# (type: json, jsonpath: $..version) list in release-please-config.json — same
+# commit as the VERSION/CHANGELOG bump — so the drift gate passes with no extra
+# push. jsonpath-plus + detect-indent (the libs release-please uses) were
+# verified to produce byte-identical output to build-plugin-manifests.py, so
+# no manifest regeneration/commit step is needed here.
+#
 # Why a PAT (RELEASE_PLEASE_TOKEN) instead of the default GITHUB_TOKEN:
 # GitHub does not start workflow runs for events created by GITHUB_TOKEN, so a
-# release PR opened with it would carry NO CI checks, and the manifest-sync
-# push below would not re-trigger them either. The PAT (fine-grained: Contents,
-# Issues, and Pull requests each read+write — Issues is needed because
-# release-please labels the release PR via the Issues API) makes both the
-# release PR and the sync push run the normal `ci` checks. See
-# CONTRIBUTING.md → Releases for setup.
+# release PR opened with it would carry NO CI checks. The PAT (fine-grained:
+# Contents, Issues, and Pull requests each read+write — Issues is needed because
+# release-please labels the release PR via the Issues API) makes the release PR
+# run the normal `ci` checks. See CONTRIBUTING.md → Releases for setup.
 on:
   push:
     branches: [main]
@@ -40,48 +48,3 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-      # VERSION is the single source of truth; the 10 per-platform manifests are
-      # generated from it (scripts/build-plugin-manifests.py) and their version
-      # is gated by scripts/check-plugin-manifests.py's VERSION-DRIFT check. When
-      # release-please bumps VERSION in the release PR, regenerate the manifests
-      # on that PR branch so the drift gate passes. Pushed with the PAT so the
-      # release PR's `ci` checks re-run against the synced tree.
-      # Guard on `prs_created` (a plain boolean-string output), NOT on `pr`.
-      # On a *tagging* run (release PR already merged → tag+Release published,
-      # no new PR opened) `steps.release.outputs.pr` is empty. Referencing
-      # `fromJson(steps.release.outputs.pr)` inside `env:` makes GitHub evaluate
-      # `fromJson('')` while setting the step up — which throws
-      # "Error reading JToken from JsonReader" and fails the run even though the
-      # step's `if:` is false. So: gate on `prs_created`, pass the raw PR JSON
-      # through env (empty string is harmless — no fromJson at eval time), and
-      # parse the branch name with jq inside `run:`, which only executes when the
-      # guard holds.
-      - name: Sync platform manifests on the release PR
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          PR_JSON: ${{ steps.release.outputs.pr }}
-        run: |
-          PR_BRANCH="$(printf '%s' "${PR_JSON}" | jq -r '.headBranchName')"
-          if [ -z "${PR_BRANCH}" ] || [ "${PR_BRANCH}" = "null" ]; then
-            echo "no release PR branch in outputs — nothing to sync" >&2
-            exit 1
-          fi
-          git clone --branch "${PR_BRANCH}" --depth 1 \
-            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" rp
-          cd rp
-          python3 scripts/build-plugin-manifests.py
-          # `git status --porcelain` (not `git diff --quiet`) so a newly generated
-          # file — build-plugin-manifests.py can mkdir/write new hook wrappers —
-          # is detected, and `git add -A` stages new/modified/deleted alike (a
-          # bare `commit -am` would silently drop an untracked new file).
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "manifests already in sync — nothing to commit"
-            exit 0
-          fi
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "chore: sync platform manifests to release version"
-          git push origin "HEAD:${PR_BRANCH}"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,7 +15,16 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "version-file": "VERSION"
+      "version-file": "VERSION",
+      "extra-files": [
+        { "type": "json", "path": ".claude-plugin/plugin.json", "jsonpath": "$..version" },
+        { "type": "json", "path": ".claude-plugin/marketplace.json", "jsonpath": "$..version" },
+        { "type": "json", "path": ".agents/plugins/marketplace.json", "jsonpath": "$..version" },
+        { "type": "json", "path": ".cursor-plugin/plugin.json", "jsonpath": "$..version" },
+        { "type": "json", "path": ".opencode/plugin.json", "jsonpath": "$..version" },
+        { "type": "json", "path": "gemini-extension.json", "jsonpath": "$..version" },
+        { "type": "json", "path": "plugins/praxis/.codex-plugin/plugin.json", "jsonpath": "$..version" }
+      ]
     }
   }
 }


### PR DESCRIPTION
## 목적

release PR 에서 매니페스트 버전을 맞추던 **2차 clone→commit→push sync 스텝**을 release-please 네이티브 `extra-files` 로 대체해 **근본 제거**합니다. #757/#759(태깅-run 실패)는 이 sync 스텝이 존재해서 생긴 증상이었고, 이 PR 은 스텝 자체를 없애 원인을 제거합니다.

## 무엇이 바뀌나

**추가** — `release-please-config.json` `packages["."]` 에 `extra-files` 7개:
```json
{ "type": "json", "path": "<manifest>", "jsonpath": "$..version" }
```
release-please 가 VERSION/CHANGELOG bump 과 **같은 릴리즈 커밋에서** 7개 매니페스트의 `version` 필드를 직접 갱신 → `check-plugin-manifests.py` VERSION-DRIFT 게이트 통과.

**제거** — `release-please.yml` 의 `Sync platform manifests` 스텝 전체 삭제. 워크플로우는 이제 release-please-action 스텝 하나만 남음. #759 의 `fromJson`/`prs_created` 가드도 스텝과 함께 소멸.

**유지** — PAT(`RELEASE_PLEASE_TOKEN`) · `issues:write` · `contents:write`. release PR 의 CI 트리거 · PR 라벨링 · 릴리즈 커밋/태그에 여전히 필요.

## 효과

| | before | after |
|---|---|---|
| release PR CI 실행 | 2회 (PR open + sync push) | 1회 |
| 매니페스트 bump | 별도 PAT clone + bot 커밋 | 릴리즈 커밋에 인라인 |
| 취약점 | fromJson env-eval, 태깅-run 실패 | 스텝 부재로 소멸 |

## 검증

Pre-commit verified: `bash scripts/run-tests.sh` → ALL TESTS PASSED (67 shell + 5 + **manifest check OK** + hook-token invariant); `release-please.yml` actionlint clean; `release-please-config.json` 공식 release-please JSON 스키마 통과.

**포맷 충실도 실증 (핵심)** — sync 스텝 없이 통과하려면 extra-files 출력이 `build-plugin-manifests.py`(`json.dumps(indent=2, ensure_ascii=False)+"\n"`) 와 바이트 동일해야 함. release-please 가 쓰는 실제 라이브러리(`jsonpath-plus` + `detect-indent`)로 `GenericJson.updateContent` + `jsonStringify` 를 재현해 7개 매니페스트 전부 테스트 → **byte-identical** (em-dash raw · trailing newline · indent 일치). committed 매니페스트 idempotency 도 확인.

리뷰 2종 모두 **APPROVE** (blocking 0):
- **codex** clean — `~/.npm` 의 실제 release-please updater 구현과 생성 스크립트 출력을 직접 대조, correctness 문제 없음
- **oh-my-claudecode:code-reviewer** — byte-identity 를 release-please 소스(`generic-json.ts`/`json-stringify.ts`)+7개 매니페스트 재직렬화로 독립 재확인. 커버리지 정확(`grep -rl '"version"'` = extra-files 7개와 정확히 일치), over-match 없음(`$schema` 는 `version` 키 아님 → 미매칭), 2-version marketplace 양쪽 bump 정당. LOW 1건 = 아래 dormant forward-risk

## 미검증 / 주의

- 실제 push:main dispatch 로 release PR 을 재현하지는 않음(real-lib byte-identity + 스키마 검증까지). 머지 후 release-please 가 재생성한 release PR 에서 (a) sync-step 커밋 없음 (b) 매니페스트 version 정확 (c) `test` job green 으로 최종 확인.
- **[LOW · dormant]** extra-files 는 파일 전체를 JS `JSON.stringify` 로 재직렬화하므로, 이 7개 매니페스트의 문자열 필드에 향후 `U+2028`/`U+2029`(JS 는 ` ` 이스케이프, Python `ensure_ascii=False` 는 raw) 같은 이색 문자가 들어가면 release PR 에서 drift 가 뜰 수 있음. 현재 유일한 non-ASCII 는 em-dash(`—`, 양쪽 동일) 라 안전하고, 발생 시 drift 게이트가 release PR 에서 **loud 하게** 실패시켜 배포 전 차단하므로 silent 위험은 없음. 이 PR 범위 밖(atomic)이라 defer.

Closes #761


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation so version numbers stay consistent across platform-specific files.
  * Added checks to help prevent release manifest drift and keep generated release data byte-identical.
* **Documentation**
  * Clarified release workflow notes and versioning guidance for maintainers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->