### PR TITLE
feat(retrospect): include sidechain events in corpus

### DIFF
--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -157,6 +157,13 @@ Run the symmetric pre-scan before agent calls. The full mechanics live in
 - `user_correction`
 - `self_correction`
 
+The friction/error lanes scan the full corpus **including `isSidechain: true`
+(subagent) events**, attributed to their delegated agent — so friction inside
+`git-master` / `review-*` is not misread as parent "smooth" (issue #763). This
+observation-layer inclusion does not touch the enforcement-layer discipline
+gates' intentional `isSidechain` filter. Full rule in
+[`references/stage1-2-analysis.md`](references/stage1-2-analysis.md).
+
 **Mandatory categorization:**
 
 Every emitted finding must carry at least one of:

--- a/skills/retrospect/references/stage1-2-analysis.md
+++ b/skills/retrospect/references/stage1-2-analysis.md
@@ -191,6 +191,28 @@ jsonl when readable and emit the Stage 3 transcript receipt trail. The same
 scope window applies to `tool_census`, `user_correction`, and
 `self_correction`, so their counts and early-exit decisions share one oracle.
 
+**Sidechain (subagent) inclusion — observation layer (MUST, issue #763).**
+The friction/error lanes (`friction_events`, `tool_census`, `self_correction`,
+and the `is_error` enumeration below) scan the **full corpus, including
+`isSidechain: true` transcript entries** — the events produced inside delegated
+agents (`git-master`, the `review-*` family, `tracer`/`analyst`, any spawned
+subagent). A subagent's `session_id` is identical to the parent's, so
+`isSidechain` is the only discriminator: attribute sidechain-origin friction to
+its delegated agent and surface it distinctly rather than dropping it. Dropping
+sidechain events lets repeated tool errors / retries / verification gaps that
+happened *inside* a delegated agent read as parent-session "smooth / no
+corrections" — the sidechain variant of the global `Retrospect = full corpus,
+not salient window` rule.
+
+This inclusion is **scoped to the observation/retrospect layer only**. It does
+**not** override the discipline-gate `isSidechain` filters in the enforcement
+layer (`completion-verify`, `merge-state-claim-gate`), which correctly exclude
+sidechain entries so that a subagent's *intermediate* completion claim is never
+mistaken for the parent turn's completion. Observation-layer inclusion and
+enforcement-layer exclusion are both correct; do not conflate them or "fix" one
+by changing the other. Retrospect never emits a completion-claim block, so
+including sidechain friction here carries no enforcement risk.
+
 1. **`friction_events`**
    - up to 5 friction events feeding the friction analysis path
 2. **`successful_patterns`**


### PR DESCRIPTION
## 배경

이슈 #763 — praxis 관찰 계층(retrospect/fire-ledger)이 sidechain(subagent) 이벤트에 blind 하여, 위임 agent(git-master, review-* 등) 안에서 일어난 friction/에러/검증 이벤트가 retrospect 에서 누락돼 부모 세션이 "smooth / no corrections" 로 오판될 수 있는 문제.

## 조사 결과 (조사-우선 과제)

이슈는 두 서브타겟을 가졌고, 조사 후 하나는 구현·하나는 infeasible 로 확정했습니다.

### 서브타겟 1 (헤드라인) — retrospect corpus sidechain 복원 → 구현

retrospect 스킬은 transcript JSONL 을 직접 읽으며 `isSidechain` 신호가 거기 존재합니다. friction/error lane(`friction_events`, `tool_census`, `self_correction`, `is_error`)이 `isSidechain: true` 엔트리를 포함해 full corpus 를 스캔하도록 지침을 명시하고, 그 friction 을 위임 agent 에 귀속시켜 distinct 하게 surface 하도록 했습니다.

### 서브타겟 2 — fire-ledger `is_sidechain` 필드 → **infeasible-by-design**

`hooks/_lib/_fire_ledger.py` 의 `_extract_payload()` 는 PreToolUse stdin payload 에서 `session_id`/`tool_name` 만 뽑습니다. **payload 에는 sidechain 판별 신호가 없습니다** — 레포 전체에서 모든 `isSidechain` 읽기는 transcript JSONL 기반(`_transcript.py`, `completion-verify`, `merge-state-claim-gate`)이며, PreToolUse payload 에서 읽는 곳은 하나도 없습니다. 즉 ledger-write 시점(hot-path dispatcher)에는 subagent 여부를 알 수 없고, subagent 의 `session_id` 는 부모와 동일합니다. `transcript_path` 를 write-time 에 읽어 추론하는 것은 (a) 현재 tool_use 가 아직 append 되지 않아 fragile 하고 (b) hot-path 에 transcript read 를 추가합니다. → ledger 필드는 **불가능하며 올바르게 미구현**입니다.

## 변경

- `skills/retrospect/references/stage1-2-analysis.md` (+22): Stage 2 Pre-scan 에 "Sidechain inclusion — observation layer" 블록. **관찰 계층 한정** — enforcement 게이트(`completion-verify`, `merge-state-claim-gate`)의 `isSidechain` 필터는 의도적으로 옳으므로(subagent 의 intermediate 완료 주장을 부모 완료로 오인 방지) 건드리지 않음을 명시.
- `skills/retrospect/SKILL.md` (+7): 상단 Pre-scan lane 리스트에 discoverability 포인터.

실행/hook 코드 무변경 (prose-only, 2 files +29).

## 검증

```
bash scripts/run-tests.sh
→ pytest 431 passed in 6.18s
→ retrospect shell suite: PASS: 67 / FAIL: 0
→ plugin-manifest check OK
→ hook-token-invariant check OK (7 invariants)
→ ALL TESTS PASSED
```

codex review: findings 없음 ("실행 동작을 깨뜨리거나 잘못된 지침으로 이어지는 문제 없음").

Pre-commit verified: bash scripts/run-tests.sh → 431 pytest + 67 retrospect shell + manifest + hook-token invariants, ALL TESTS PASSED

독립 spot-verify (위임 산출물 검증): 모든 `hooks/` 의 `isSidechain` 읽기가 transcript 기반임을 grep 으로 재확인, diff 가 prose-only 임을 확인.

## 범위 판정

헤드라인(관찰 계층 가시성 복원)은 완료, ledger 서브타겟은 infeasible-by-design 로 확정 — 남은 actionable 작업 없음. (향후 Claude Code 가 hook payload 에 sidechain 플래그를 추가하면 그때 ledger 필드가 가능해지지만, 이는 플랫폼 변경 의존 speculative work 입니다.)

Closes #763
