### PR TITLE
refactor(retrospect): codify stage 2.5 gates

### DIFF
--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -7,8 +7,8 @@ description: >
   Triggers on "retrospect", "what went wrong", "session review",
   "session improvement", "what was the issue", "improve".
 verified-against-runtime: true
-runtime-verified-at: 2026-06-16
-runtime-verified-note: "tests/test_retrospect_falsify_recommended.sh + test_retrospect_routing.sh + retrospect hook suites — Stage 3 AskUserQuestion recommendations require falsification traces, and the active-marker/report-fence contract stays aligned."
+runtime-verified-at: 2026-07-13
+runtime-verified-note: "tests/test_retrospect_falsify_recommended.sh + test_retrospect_routing.sh + retrospect hook suites, plus audit-distribution-gates.py differential verification (issue #774): 6/6 script-vs-Stop-hook verdict agreement on mirrored gate classes, and a live violation→fix→clean loop on real session-friction drafts."
 ---
 
 # Retrospect

--- a/skills/retrospect/SKILL.md
+++ b/skills/retrospect/SKILL.md
@@ -249,19 +249,16 @@ miss. Use the full trigger list, audit surfaces, and trail rules in
 
 ### Stage 2.5: Action Distribution Audit
 
-Stage 2.5 is the last gate before Stage 3 output. Run the complete gate suite
-from [`references/stage2.5-audit.md`](references/stage2.5-audit.md).
+Stage 2.5 is the last gate before Stage 3 output. Follow
+[`references/stage2.5-audit.md`](references/stage2.5-audit.md): write the
+draft findings table to a scratch file, run the deterministic audit script
+(`audit-distribution-gates.py` — owns Gate-1 mechanical checks, Gate-2,
+backing_repo, Gate-4, Gate-5, and the distribution card), and evaluate the
+semantic gates yourself (Gate-1 category correctness, Gate-3 evidence
+robustness, Gate-6 oracle match — verdicts passed via `--gate3` / `--gate6`).
 
-**Required gates:**
-
-- Gate-1: categorical integrity
-- Gate-2: memory-only rationale schema
-- Gate-3: evidence robustness for compound actions
-- Gate-4: external-repo authorization pre-check for `upstream_feedback`
-- Gate-5: `memory_scan` completeness
-- Gate-6: oracle-match completeness for stored-value corrections
-
-**Output:** a distribution card with action counts plus gate verdicts.
+**Output:** the script-rendered distribution card with action counts plus gate
+verdicts — paste it verbatim, never hand-edit it.
 
 If a gate still fails after 2 per-finding re-entries, surface the documented
 override prompt rather than silently continuing.

--- a/skills/retrospect/audit-distribution-gates.py
+++ b/skills/retrospect/audit-distribution-gates.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""Deterministic Stage 2.5 gate audit for the retrospect skill (issue #774).
+
+Producer-side pre-flight: parses a Stage 3 draft (unified findings table +
+memory_scan evidence blocks) and runs every mechanically-checkable Stage 2.5
+gate, mirroring the Stop hook's parsing semantics
+(hooks/completion-verify/retrospect-mix-check/impl.sh) so a clean audit here
+cannot be blocked later by the hook on the same checks.
+
+Semantic gates stay with the agent: Gate-3 (evidence robustness) and Gate-6
+(oracle match) verdicts are supplied via --gate3 / --gate6. The script refuses
+to leave Gate-3 unevaluated (None or NA) when compound findings exist; Gate-6
+applicability (stored-value corrections) is not mechanically detectable, so
+its verdict is fully agent-trusted. Session-level Stop-hook gates (7-10:
+transcript receipt, suppression ledger, silent-pass coverage, critic roots)
+are out of scope here — a script-clean draft can still be hook-blocked on
+those.
+
+Usage:
+  audit-distribution-gates.py --draft <stage3-draft.md>
+      [--signals <pre-scan-signal-text.txt>]
+      [--gate3 PASS|FAIL|NA] [--gate6 PASS|FAIL|NA]
+      [--reinforce-memory N]
+
+Output (stdout): violations + advisories + rendered distribution card.
+Exit codes: 0 = no violations, 1 = violations found, 2 = usage/input error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+TABLE_HEADER = (
+    "| # | Category | Tool Layer | Pattern | Root Cause | Rule / Gap "
+    "| Repeat? | Proposed Actions (1~2) | Rationale | Priority |"
+)
+
+VALID_CATEGORIES = {
+    "behavioral", "tool", "workflow", "spec-gap", "memory_hygiene",
+    "output_quality",
+}
+VALID_TOOL_LAYERS = {"mcp", "cli", "builtin", "skill"}
+VALID_ACTIONS = {
+    "memory", "issue", "claude_md_draft", "skill_idea", "hook_code",
+    "upstream_feedback",
+}
+NONBEHAVIORAL = {"tool", "workflow", "spec-gap"}
+
+# Mirrors impl.sh:357 (Schema A) and impl.sh:358 (Schema B) verbatim.
+SCHEMA_A_RE = re.compile(
+    r"^\s*not (issue|claude_md_draft|skill_idea|hook_code|upstream_feedback): .+"
+)
+SCHEMA_B_RE = re.compile(r"^\s*not-others: .+")
+# Mirrors impl.sh:381 verbatim.
+BACKING_REPO_RE = re.compile(
+    r"^\s*backing_repo: ([A-Za-z0-9_][A-Za-z0-9_.-]*)/[A-Za-z0-9_][A-Za-z0-9_.-]*"
+)
+# Literal Stage 4 warning prefix required on external rows (stage2.5-audit.md
+# Gate-4); Stage 4 scans this exact string — a paraphrase disables the gate.
+EXTERNAL_WARNING = "⚠ EXTERNAL: per-action approval required at Stage 4"
+
+# Gate-1 behavioral-only safeguard keyword set (stage2.5-audit.md Gate-1).
+SAFEGUARD_KEYWORDS = [
+    "gh", "kubectl", "MCP", "--state", "permission denied", "timeout",
+    "--help", "flag",
+]
+# Per-finding behavioral-label falsification keywords (stage2.5-audit.md
+# Gate-1). `--<opt>` is expressed as a regex over long-option tokens.
+LABEL_FALSIFY_KEYWORDS = [
+    "probe", "scan scope", "skill", "hook", "missing", "gap", "scope",
+    "미구현", "누락", "flag", "spec", "rule absent",
+]
+LONG_OPT_RE = re.compile(r"--[A-Za-z][A-Za-z0-9-]*")
+
+
+def keyword_hit(keyword: str, text: str) -> bool:
+    """ASCII keywords match on ASCII-letter boundaries (`spec` must not match
+    `respect`/`expected`); multi-word/symbol phrases and Korean tokens match as
+    substrings. `\\b` is useless between Hangul and ASCII, hence lookarounds."""
+    if re.fullmatch(r"[A-Za-z]+", keyword):
+        return re.search(
+            rf"(?<![A-Za-z]){re.escape(keyword)}(?![A-Za-z])", text,
+            re.IGNORECASE) is not None
+    return keyword in text
+
+PIPE_SENTINEL = "\x01PIPE\x01"
+BR_RE = re.compile(r"<br */?>")
+
+MEMORY_SCAN_BLOCK_RE = re.compile(
+    r"<!--\s*memory_scan finding #(\d+):(.*?)-->", re.DOTALL
+)
+
+
+class Finding:
+    def __init__(self, num: str, categories: list[str], tool_layer: str,
+                 pattern: str, root_cause: str, repeat_cell: str,
+                 actions: list[str], rationale: str) -> None:
+        self.num = num
+        self.categories = categories
+        self.tool_layer = tool_layer
+        self.pattern = pattern
+        self.root_cause = root_cause
+        self.repeat_cell = repeat_cell
+        self.actions = actions
+        self.rationale = rationale
+
+    @property
+    def is_memory_only(self) -> bool:
+        return self.actions == ["memory"]
+
+    @property
+    def rationale_lines(self) -> list[str]:
+        return BR_RE.sub("\n", self.rationale).splitlines()
+
+
+def parse_table(draft_text: str) -> tuple[list[Finding] | None, list[str]]:
+    """Extract findings rows using the hook's parsing semantics."""
+    lines = draft_text.splitlines()
+    try:
+        header_idx = next(
+            i for i, ln in enumerate(lines) if ln.strip() == TABLE_HEADER
+        )
+    except StopIteration:
+        return None, ["draft contains no unified findings table "
+                      f"(fixed header not found: `{TABLE_HEADER[:40]}…`)"]
+
+    violations = []
+    findings = []
+    for ln in lines[header_idx + 1:]:
+        if not ln.strip().startswith("|"):
+            break
+        if ln.strip().startswith("|---") or set(ln.strip()) <= {"|", "-", " "}:
+            continue
+        protected = ln.replace("\\|", PIPE_SENTINEL)
+        trimmed = protected.strip()
+        trimmed = trimmed[1:] if trimmed.startswith("|") else trimmed
+        trimmed = trimmed[:-1] if trimmed.endswith("|") else trimmed
+        cells = [c.strip().replace(PIPE_SENTINEL, "|") for c in trimmed.split("|")]
+        if len(cells) != 10:
+            violations.append(
+                f"finding #{cells[0] if cells else '?'}: row has {len(cells)} "
+                "cells, expected 10 — table schema violation (an unescaped "
+                "'|' adds cells; escape it as '\\|')"
+            )
+            continue
+        actions = []
+        for tok in cells[7].split(","):
+            t = tok.strip()
+            if t and t not in actions:
+                actions.append(t)
+        categories = [c.strip() for c in cells[1].split(",") if c.strip()]
+        findings.append(Finding(
+            num=cells[0], categories=categories, tool_layer=cells[2],
+            pattern=cells[3], root_cause=cells[4], repeat_cell=cells[6],
+            actions=actions, rationale=cells[8],
+        ))
+    return findings, violations
+
+
+def parse_memory_scan_blocks(draft_text: str) -> dict[str, dict[str, str]]:
+    """Map finding number -> dict of memory_scan fields."""
+    blocks = {}
+    for m in MEMORY_SCAN_BLOCK_RE.finditer(draft_text):
+        fields = {}
+        for ln in m.group(2).splitlines():
+            if ":" in ln:
+                k, v = ln.split(":", 1)
+                fields[k.strip()] = v.strip()
+        blocks[m.group(1)] = fields
+    return blocks
+
+
+def resolve_own_orgs() -> tuple[set[str], bool]:
+    """Allowlist resolution per stage2.5-audit.md Gate-4 priority order.
+
+    Returns (set of lowercase handles, fallback_used).
+    """
+    env = os.environ.get("PRAXIS_OWN_ORGS", "").strip()
+    if env:
+        return {h.strip().lower() for h in env.split(",") if h.strip()}, False
+    try:
+        out = subprocess.run(
+            ["gh", "api", "user", "--jq", ".login"],
+            capture_output=True, text=True, timeout=10,
+        )
+        login = out.stdout.strip()
+        if out.returncode == 0 and login:
+            return {login.lower()}, False
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return set(), True  # conservative fallback: all owners external
+
+
+def audit(findings: list[Finding], ms_blocks: dict[str, dict[str, str]],
+          signal_text: str, gate3: str | None, gate6: str | None,
+          reinforce_memory: int) -> tuple[list[str], list[str], str]:
+    violations = []
+    advisories = []
+
+    # --- row-level enum / schema checks (Gate-1 categorical integrity) ---
+    for f in findings:
+        bad_cats = [c for c in f.categories if c not in VALID_CATEGORIES]
+        if not f.categories or bad_cats:
+            violations.append(
+                f"finding #{f.num}: invalid category[] "
+                f"({', '.join(bad_cats) or 'empty'})"
+            )
+        if f.tool_layer not in VALID_TOOL_LAYERS | {"—"}:
+            violations.append(
+                f"finding #{f.num}: Tool Layer = '{f.tool_layer}' "
+                "(must be mcp|cli|builtin|skill|—)"
+            )
+        elif "tool" in f.categories and f.tool_layer not in VALID_TOOL_LAYERS:
+            violations.append(
+                f"finding #{f.num}: category has tool but Tool Layer = "
+                f"'{f.tool_layer}' (must be mcp|cli|builtin|skill)"
+            )
+        bad_actions = [a for a in f.actions if a not in VALID_ACTIONS]
+        if not f.actions or bad_actions:
+            violations.append(
+                f"finding #{f.num}: invalid Proposed Actions "
+                f"({', '.join(bad_actions) or 'empty'})"
+            )
+        if len(f.actions) > 2:
+            violations.append(
+                f"finding #{f.num}: {len(f.actions)} proposed actions after "
+                "dedupe, max 2"
+            )
+
+    gate1_fail = False
+    for f in findings:
+        # Hook-mirrored: tool/workflow/spec-gap labeled + memory-only action.
+        if NONBEHAVIORAL & set(f.categories) and f.is_memory_only:
+            violations.append(
+                f"finding #{f.num} (category={','.join(f.categories)}): "
+                "tool/workflow/spec-gap labeled but Proposed Actions = memory only"
+            )
+            gate1_fail = True
+        # Per-finding behavioral-label falsification keyword scan.
+        if f.categories == ["behavioral"]:
+            hits = [k for k in LABEL_FALSIFY_KEYWORDS
+                    if keyword_hit(k, f.root_cause)]
+            hits += LONG_OPT_RE.findall(f.root_cause)
+            if hits and "behavioral-label-justify:" not in f.rationale:
+                violations.append(
+                    f"finding #{f.num}: behavioral-only label but root cause "
+                    f"carries signal keywords ({', '.join(sorted(set(hits)))}) — "
+                    "add the honest second category or a "
+                    "behavioral-label-justify: line"
+                )
+                gate1_fail = True
+
+    # Behavioral-only safeguard: all findings behavioral-only -> keyword scan.
+    if findings and all(f.categories == ["behavioral"] for f in findings):
+        corpus = signal_text + "\n" + "\n".join(
+            f.pattern + "\n" + f.root_cause for f in findings
+        )
+        hits = sorted({k for k in SAFEGUARD_KEYWORDS
+                       if keyword_hit(k, corpus)})
+        if hits:
+            advisories.append(
+                "behavioral-only safeguard: signal text contains "
+                f"tool/workflow indicators ({', '.join(hits)}) — surface the "
+                "keyword set to the user and require explicit confirmation "
+                "before Stage 3"
+            )
+
+    # --- Gate-2: memory-only rationale schema (hook-mirrored) ---
+    gate2_applicable = False
+    gate2_fail = False
+    for f in findings:
+        if not f.is_memory_only:
+            continue
+        gate2_applicable = True
+        a_actions = {m.group(1) for ln in f.rationale_lines
+                     for m in [SCHEMA_A_RE.match(ln)] if m}
+        a = sum(1 for ln in f.rationale_lines if SCHEMA_A_RE.match(ln))
+        b = sum(1 for ln in f.rationale_lines if SCHEMA_B_RE.match(ln))
+        schema_a = a == 5 and len(a_actions) == 5
+        schema_b = 1 <= b <= 2 and a == 0
+        if not schema_a and not schema_b:
+            violations.append(
+                f"finding #{f.num}: memory-only row Rationale matches neither "
+                f"schema A (5 'not <action>: ...' lines covering all five "
+                f"non-memory types, found {a} lines / {len(a_actions)} "
+                f"distinct) nor schema B (1-2 'not-others: ...' lines, "
+                f"found {b})"
+            )
+            gate2_fail = True
+
+    # --- backing_repo declaration for routed actions (hook-mirrored) ---
+    for f in findings:
+        if not {"upstream_feedback", "issue"} & set(f.actions):
+            continue
+        if not any(BACKING_REPO_RE.match(ln) for ln in f.rationale_lines):
+            violations.append(
+                f"finding #{f.num}: Proposed Actions contains "
+                "upstream_feedback or issue but Rationale missing "
+                "backing_repo: <owner/repo> — return to Stage 2 step 7"
+            )
+
+    # --- Gate-4: external-repo authorization pre-check ---
+    upstream = [f for f in findings if "upstream_feedback" in f.actions]
+    if not upstream:
+        gate4 = "NA"
+    else:
+        own_orgs, fallback = resolve_own_orgs()
+        any_external = fallback
+        if fallback:
+            advisories.append(
+                "gate-4: allowlist unresolved (no PRAXIS_OWN_ORGS, gh "
+                "unavailable) — conservative fallback treats all owners as "
+                "external"
+            )
+        for f in upstream:
+            owner = None
+            for ln in f.rationale_lines:
+                m = BACKING_REPO_RE.match(ln)
+                if m:
+                    owner = m.group(1).lower()
+                    break
+            if owner is None:
+                continue  # backing_repo violation already recorded above
+            external = fallback or owner not in own_orgs
+            if external:
+                any_external = True
+                if EXTERNAL_WARNING not in f.rationale:
+                    violations.append(
+                        f"finding #{f.num}: external backing_repo owner "
+                        f"'{owner}' but Rationale lacks the literal warning "
+                        f"prefix '{EXTERNAL_WARNING}'"
+                    )
+        gate4 = "WARN" if any_external else "PASS"
+
+    # --- Gate-5: memory-scan completeness ---
+    memory_findings = [f for f in findings if "memory" in f.actions]
+    if not memory_findings:
+        gate5 = "NA"
+    else:
+        gate5 = "PASS"
+        for f in memory_findings:
+            fields = ms_blocks.get(f.num)
+            if fields is None:
+                violations.append(
+                    f"finding #{f.num}: memory action but no "
+                    f"'<!-- memory_scan finding #{f.num}: ... -->' evidence block"
+                )
+                gate5 = "FAIL"
+                continue
+            missing = []
+            if fields.get("scanned") != "true":
+                missing.append("scanned: true")
+            if not fields.get("candidates_reviewed"):
+                missing.append("candidates_reviewed")
+            if fields.get("repeat") not in ("true", "false"):
+                missing.append("repeat")
+            if not fields.get("repeat_count", "").lstrip("-").isdigit():
+                missing.append("repeat_count")
+            if missing:
+                violations.append(
+                    f"finding #{f.num}: memory_scan block incomplete "
+                    f"(missing/invalid: {', '.join(missing)})"
+                )
+                gate5 = "FAIL"
+
+    # --- Gate-3 / Gate-6: semantic verdicts supplied by the agent ---
+    compound = [f for f in findings if len(f.actions) == 2]
+    if compound and gate3 in (None, "NA"):
+        violations.append(
+            f"{len(compound)} compound (2-action) finding(s) present but "
+            f"--gate3 {'not supplied' if gate3 is None else 'NA claimed'} — "
+            "evaluate Gate-3 (a)/(b)/(c) per stage2.5-audit.md and pass "
+            "PASS or FAIL"
+        )
+        gate3 = "FAIL"
+    elif not compound:
+        if gate3 not in (None, "NA"):
+            advisories.append(
+                f"gate-3: no compound findings; overriding supplied "
+                f"'{gate3}' to NA"
+            )
+        gate3 = "NA"
+    gate6 = gate6 or "NA"
+
+    gate1 = "FAIL" if gate1_fail else ("PASS" if findings else "NA")
+    gate2 = ("FAIL" if gate2_fail else "PASS") if gate2_applicable else "NA"
+    if not findings:
+        gate2 = gate4 = gate5 = "NA"
+
+    # --- distribution card ---
+    counts = {a: 0 for a in
+              ("memory", "issue", "claude_md_draft", "skill_idea",
+               "hook_code", "upstream_feedback")}
+    for f in findings:
+        for a in f.actions:
+            if a in counts:
+                counts[a] += 1
+    counts["memory"] += reinforce_memory
+    hygiene = sum(1 for f in findings if "memory_hygiene" in f.categories)
+    quality = sum(1 for f in findings if "output_quality" in f.categories)
+
+    card = ["<!-- retrospect:distribution begin -->"]
+    card += [f"- {k}: {v}" for k, v in counts.items()]
+    card += [f"- memory_hygiene: {hygiene}", f"- output_quality: {quality}"]
+    card += [
+        f"- gate_1_verdict: {gate1}", f"- gate_2_verdict: {gate2}",
+        f"- gate_3_verdict: {gate3}", f"- gate_4_verdict: {gate4}",
+        f"- gate_5_verdict: {gate5}", f"- gate_6_verdict: {gate6}",
+    ]
+    card.append("<!-- retrospect:distribution end -->")
+    return violations, advisories, "\n".join(card)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Deterministic Stage 2.5 gate audit for the retrospect skill")
+    ap.add_argument("--draft", required=True,
+                    help="Stage 3 draft markdown (findings table + fences)")
+    ap.add_argument("--signals", default=None,
+                    help="pre-scan signal text file (Gate-1 safeguard corpus)")
+    ap.add_argument("--gate3", choices=["PASS", "FAIL", "NA"], default=None)
+    ap.add_argument("--gate6", choices=["PASS", "FAIL", "NA"], default=None)
+    ap.add_argument("--reinforce-memory", type=int, default=0,
+                    help="successful_patterns rows whose reinforce_action is "
+                         "memory (added to the memory count)")
+    args = ap.parse_args()
+
+    try:
+        with open(args.draft, encoding="utf-8") as fh:
+            draft_text = fh.read()
+    except OSError as e:
+        print(f"error: cannot read draft: {e}", file=sys.stderr)
+        return 2
+
+    signal_text = ""
+    if args.signals:
+        try:
+            with open(args.signals, encoding="utf-8") as fh:
+                signal_text = fh.read()
+        except OSError as e:
+            print(f"error: cannot read signals: {e}", file=sys.stderr)
+            return 2
+
+    findings, parse_violations = parse_table(draft_text)
+    if findings is None:
+        print("## gate-audit violations")
+        for v in parse_violations:
+            print(f"- {v}")
+        return 1
+
+    ms_blocks = parse_memory_scan_blocks(draft_text)
+    violations, advisories, card = audit(
+        findings, ms_blocks, signal_text, args.gate3, args.gate6,
+        args.reinforce_memory,
+    )
+    violations = parse_violations + violations
+
+    if violations:
+        print("## gate-audit violations")
+        for v in violations:
+            print(f"- {v}")
+    if advisories:
+        print("## gate-audit advisories")
+        for a in advisories:
+            print(f"- {a}")
+    print("## distribution card")
+    print(card)
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/retrospect/audit-distribution-gates.py
+++ b/skills/retrospect/audit-distribution-gates.py
@@ -377,6 +377,11 @@ def audit(findings: list[Finding], ms_blocks: dict[str, dict[str, str]],
             "PASS or FAIL"
         )
         gate3 = "FAIL"
+    elif compound and gate3 == "FAIL":
+        violations.append(
+            "gate-3 verdict is FAIL — resolve the compound-finding evidence "
+            "per stage2.5-audit.md (downgrade/demote) before Stage 3"
+        )
     elif not compound:
         if gate3 not in (None, "NA"):
             advisories.append(
@@ -384,6 +389,11 @@ def audit(findings: list[Finding], ms_blocks: dict[str, dict[str, str]],
                 f"'{gate3}' to NA"
             )
         gate3 = "NA"
+    if gate6 == "FAIL":
+        violations.append(
+            "gate-6 verdict is FAIL — re-probe with the stored oracle or "
+            "reroute per stage2.5-audit.md before Stage 3"
+        )
     gate6 = gate6 or "NA"
 
     gate1 = "FAIL" if gate1_fail else ("PASS" if findings else "NA")

--- a/skills/retrospect/references/stage2.5-audit.md
+++ b/skills/retrospect/references/stage2.5-audit.md
@@ -4,25 +4,135 @@ Detailed gate procedures for [`../SKILL.md`](../SKILL.md) Stage 2.5.
 `SKILL.md` names the gates; this file defines how each gate passes, fails, and
 hands off to Stage 3.
 
-## Gate sequence
+Deterministic checks are owned by the audit script; only semantic judgment
+stays in-context (issue #774).
 
-Run the gates in this order for the current finding set:
+## Run the deterministic audit first
 
-1. Gate-1 — categorical integrity
-2. Gate-2 — memory-only rationale schema
-3. Gate-3 — evidence robustness for compound actions
-4. Gate-4 — external-repo pre-check for `upstream_feedback`
-5. Gate-5 — `memory_scan` completeness
-6. Gate-6 — oracle-match completeness
+Write the Stage 3 draft (unified findings table + `memory_scan` evidence
+blocks) to a scratch file, then run:
 
-Each finding gets at most 2 gate-driven re-entries before you must surface the
-documented override prompt to the user.
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/retrospect/audit-distribution-gates.py" \
+  --draft <stage3-draft.md> \
+  [--signals <pre-scan-signal-text.txt>] \
+  [--gate3 PASS|FAIL|NA] [--gate6 PASS|FAIL|NA] \
+  [--reinforce-memory N]
+```
 
-### Override prompt after 2 re-entries
+The script mechanizes, mirroring the Stop hook's parsing semantics
+(`hooks/completion-verify/retrospect-mix-check/impl.sh`):
 
-When any gate still fails after the per-finding re-entry cap, stop the loop and
-surface the gate-specific 3-way prompt. Do not invent a fourth "continue
-looping" path.
+- **table schema** — 10-cell rows, valid `category[]` / `Tool Layer` /
+  `Proposed Actions` enums, 1-2 actions after dedupe
+- **Gate-1 (mechanical half)** — tool/workflow/spec-gap labeled finding with
+  `Proposed Actions = memory` (single); per-finding behavioral-label
+  falsification keyword scan (requires the honest second category or a
+  `behavioral-label-justify:` line); Behavioral-only safeguard (all findings)
+  keyword scan over `--signals` + Pattern/Root Cause text (emitted as an
+  advisory — surface it to the user and require explicit confirmation before
+  Stage 3)
+- **Gate-2** — memory-only rationale Schema A (exactly 5
+  `not <action>: <reason>` lines) or Schema B (1-2 `not-others: <dim-tags>`
+  lines, no Schema A lines)
+- **backing_repo** — any row routing `upstream_feedback` or `issue` must
+  declare `backing_repo: <owner>/<repo>` in Rationale
+- **Gate-4** — allowlist resolution (`PRAXIS_OWN_ORGS` →
+  `gh api user --jq .login` → conservative all-external fallback), owner
+  classification, and the literal external warning prefix
+  `⚠ EXTERNAL: per-action approval required at Stage 4` on external rows
+  (Stage 4 scans that exact string; a paraphrase disables the per-action
+  approval gate). Verdict `WARN` means at least one external finding exists,
+  or the conservative fallback was required — Stage 4 must then require
+  per-action approval for external rows
+- **Gate-5** — every memory-action finding needs a complete
+  `<!-- memory_scan finding #N: ... -->` block (`scanned: true`,
+  `candidates_reviewed`, `repeat`, `repeat_count`)
+- **distribution card** — rendered on stdout in the canonical fence format;
+  paste it into Stage 3 verbatim
+
+Exit codes: `0` clean, `1` violations (fix the draft and re-run), `2`
+usage/input error. `--reinforce-memory N` adds `successful_patterns` rows
+whose `reinforce_action` is `memory` to the memory count.
+
+Scope note: the script is a pre-flight for the Stop hook's per-finding checks
+only. Session-level hook gates (Gate-7 transcript receipt, Gate-8/8b/8c
+suppression ledger, Gate-9 silent-pass coverage, Gate-10 critic roots) are not
+mirrored here — a script-clean draft can still be hook-blocked on those.
+
+Do NOT hand-compute anything the script owns; do NOT hand-edit the card the
+script rendered.
+
+## Semantic gates (agent judgment, before trusting the card)
+
+### Gate-1 (semantic half): category correctness
+
+The script validates enum membership and keyword signals; it cannot judge
+whether the chosen categories match the finding's actual root cause. Before
+accepting the card, confirm per finding that the label reflects the root-cause
+evidence — action choice must never drive category narrowing. If the
+behavioral-only safeguard advisory fired, surface the keyword set to the user
+and log the confirmation.
+
+### Gate-3: evidence robustness for compound actions
+
+Applies to each finding with exactly two `Proposed Actions` (single-action
+findings skip Gate-3). Evaluate all three sub-conditions, then pass the
+verdict via `--gate3`. The script refuses to default Gate-3 when compound
+findings exist.
+
+- **(a) per-action evidence pointer** — each action must cite at least one
+  explicit friction-event observation in the Rationale cell (sub-bullet or
+  inline `(observed: <event-id or one-line>)`). An action present only because
+  a category default filled the table returns to Stage 2 step 7.
+- **(b) sibling decision-coupling** — if action B's outcome decides a question
+  action A presupposes, keep the stronger-evidence action and demote the
+  weaker one to a Stage 3 trigger line:
+  `Finding #N: file <action> when <observation predicate>`.
+- **(c) single-observation downgrade** — for each action backed by exactly one
+  observation with `repeat=false`, downgrade one tier:
+
+| Original action | Downgraded to | Rationale |
+| ----------------- | --------------- | ----------- |
+| `upstream_feedback` | `memory` | One observation against an external party does not justify upstream-write cost |
+| `issue` | `memory` | One observation without repeat does not justify systemic tracking |
+| `hook_code` | `skill_idea` | One observation does not justify enforcement code |
+| `claude_md_draft` | `memory` | One-observation rule changes risk over-fitting |
+| `skill_idea` | `memory` | One observation does not justify a skill artifact |
+| `memory` | no downgrade | Already the lowest tier |
+
+If a downgrade makes the action set memory-only while the finding still
+carries `tool` / `workflow` / `spec-gap`, re-run the audit script (its Gate-1
+check re-fires). The downgrade itself does not consume a re-entry; the
+resulting Gate-1 re-evaluation does.
+
+### Gate-6: oracle-match completeness
+
+For every stored-value correction finding (an action that would invalidate or
+overwrite a stored numeric value), the `oracle_match` field must be present in
+the finding's Rationale — with `oracle_match: true` when the action would
+invalidate or overwrite the stored value. Applicability is not mechanically
+detectable, so the script trusts the `--gate6` verdict; run the producer
+procedure honestly before passing it:
+
+1. Read the originating entry's stored oracle: matching basis, cohort, unit.
+2. Re-probe with the same matching basis / cohort / unit before treating the
+   stored value as stale or wrong.
+3. `oracle_match: true` only when the falsification probe used that same
+   oracle.
+4. A different-oracle probe is a cohort-shift observation, not falsification
+   of the stored value.
+
+If the originating entry did not record its oracle, defer falsification and
+route the work to an annotation update rather than fabricating a correction.
+No stored-value corrections in the finding set → `--gate6 NA` (or omit).
+
+## Re-entry and override
+
+Each finding gets at most 2 gate-driven re-entries (fix draft → re-run
+script, or re-evaluate a semantic gate). When a gate still fails after the
+cap, stop the loop and surface the gate-specific 3-way prompt — do not invent
+a fourth "continue looping" path:
 
 - Gate-1 / Gate-2 / Gate-3:
   `"Finding #N의 Gate-X가 2회 재진입 후에도 통과되지 않습니다. 어떻게 진행할까요? [a] rationale 직접 입력 / [b] action 직접 지정 / [c] note only 강등."`
@@ -34,223 +144,11 @@ looping" path.
 Record the selected option and the user's supplied rationale in the Stage 3
 trail before proceeding.
 
-## Gate-1: categorical integrity
+## Distribution card semantics
 
-Purpose: block label backsliding that hides a tool/workflow/spec-gap defect as
-`behavioral` or `memory` only.
-
-Pass when:
-
-- every finding has a valid `category[]`
-- any finding with `tool` has `Tool Layer`
-- the chosen categories match the actual root cause
-
-Fail when:
-
-- a required category is missing
-- a `tool` finding has `Tool Layer = —`
-- a behavioral-only label contradicts the finding's own root-cause evidence
-- any finding whose `category[]` intersects `tool`, `workflow`, or `spec-gap`
-  has `Proposed Actions = memory` as a single, non-compound action
-
-Behavioral-only safeguard (all findings): if all findings are labeled
-`behavioral` only, run a final keyword sanity check on the original pre-scan
-signal text. If any signal contains tool/workflow indicators such as `gh`,
-`kubectl`, `MCP`, `--state`, `permission denied`, `timeout`, `--help`, or
-`flag`, surface the keyword set to the user and require explicit confirmation
-before Stage 3. If the user confirms, log the confirmation with the keyword set.
-
-Per-finding behavioral-label falsification: for each finding labeled
-`behavioral` only, scan its root-cause text for spec-gap/tool/workflow signal
-keywords: `probe`, `scan scope`, `skill`, `hook`, `missing`, `gap`, `scope`,
-`미구현`, `누락`, `flag`, `--<opt>`, `spec`, `rule absent`. If any signal is
-present, the finding must either add the honest second category or include
-`behavioral-label-justify: <why this is NOT spec-gap/tool/workflow despite the keyword>`.
-If neither is present, return the finding to Gate-1 / Stage 2 categorization for
-label re-evaluation; do not let action choice drive category narrowing.
-
-## Gate-2: memory-only rationale schema
-
-Purpose: prevent unsupported `memory`-only resolutions.
-
-This gate applies only to findings whose `Proposed Actions` is exactly
-`memory`.
-
-Accept either:
-
-- **Schema A**: exactly 5 lines of `not <action>: <reason>` covering every
-  non-memory action type
-- **Schema B**: 1-2 lines of `not-others: <dimension tags>`
-
-Generic one-line rationales do not pass Gate-2.
-
-## Gate-3: evidence robustness for compound actions
-
-Purpose: make sure dual-action plans are actually justified. For each finding
-with exactly two `Proposed Actions`, evaluate all three sub-conditions below.
-Single-action findings skip Gate-3.
-
-### Gate-3(a): per-action evidence pointer
-
-Each action must cite at least one explicit friction-event observation that
-supports that action. Citations live in the Rationale cell as a sub-bullet or
-inline `(observed: <event-id or one-line>)` reference. If an action is present
-only because a category default filled the table, return it to Stage 2 step 7
-(action assignment) and add observation citations before re-entering Gate-3.
-
-### Gate-3(b): sibling decision-coupling
-
-If action B's outcome decides a question that action A already presupposes, the
-pair is decision-coupled and both actions cannot be executed together. Keep the
-stronger-evidence action and demote the weaker action to a Stage 3 trigger
-condition line: `Finding #N: file <action> when <observation predicate>`.
-
-Example: a `claude_md_draft` that asserts "behavior X is intentional" coupled
-with `upstream_feedback` asking whether X is intentional is contradictory. Keep
-one; demote the other to a trigger.
-
-### Gate-3(c): single-observation downgrade
-
-For each action backed by exactly one observation and `repeat=false`, downgrade
-one tier:
-
-| Original action | Downgraded to | Rationale |
-| ----------------- | --------------- | ----------- |
-| `upstream_feedback` | `memory` | One observation against an external party does not justify upstream-write cost |
-| `issue` | `memory` | One observation without repeat does not justify systemic tracking |
-| `hook_code` | `skill_idea` | One observation does not justify enforcement code |
-| `claude_md_draft` | `memory` | One-observation rule changes risk over-fitting |
-| `skill_idea` | `memory` | One observation does not justify a skill artifact |
-| `memory` | no downgrade | Already the lowest tier |
-
-If the resulting action set becomes memory-only while the finding still carries
-`tool`, `workflow`, or `spec-gap`, re-run Gate-1. The downgrade itself does not
-consume a re-entry; the resulting Gate-1 re-evaluation does.
-
-### Gate-3 outcomes
-
-- all applicable sub-conditions pass -> keep both actions and emit
-  `gate_3_verdict: PASS`
-- any sub-condition changes the action set -> apply the downgrade/demotion and
-  re-enter the affected gate path
-- no compound findings -> `gate_3_verdict: NA`
-- unresolved violation after the per-finding re-entry cap -> surface the
-  documented 3-way user override prompt
-
-## Gate-4: external-repo authorization pre-check
-
-Purpose: classify `upstream_feedback` findings before Stage 3 ranking so that
-external writes cannot slip through as if they were ordinary internal issues.
-
-For each `upstream_feedback` finding:
-
-1. parse `backing_repo: <owner>/<repo>` from the Rationale cell
-2. resolve the own-org allowlist
-3. classify the owner as internal or external
-4. annotate external findings with the literal Stage 4 warning prefix:
-   `⚠ EXTERNAL: per-action approval required at Stage 4`
-5. emit `gate_4_verdict`
-
-Own-org allowlist resolution, in priority order:
-
-1. `PRAXIS_OWN_ORGS` as comma-separated handles
-2. `gh api user --jq .login` as the single own handle
-3. conservative fallback: treat all `backing_repo` owners as external
-
-Classification: extract `owner` from `backing_repo: <owner>/<repo>` and compare
-case-insensitively against the resolved allowlist. If owner is absent from the
-allowlist, mark the finding `external=true`. If the `backing_repo:` declaration
-is absent, Gate-4 skips that finding here; Stage 4 Action 4 step 0's
-missing-declaration abort is the downstream enforcement.
-
-For external findings, the literal warning prefix must appear in the Stage 3
-Rationale cell for the `upstream_feedback (external)` row. Stage 4 scans that
-exact string before creating/commenting/editing in an external repository; a
-paraphrase disables the per-action approval gate. The same row must also carry
-`backing_repo: <owner>/<repo>` so Stage 4 can route the approval decision to the
-right repository boundary.
-
-Verdicts:
-
-- `PASS` -> zero external findings; all `upstream_feedback` rows are internal
-- `WARN` -> at least one external finding exists, or conservative fallback was
-  required; Stage 4 must require per-action approval for external rows
-- `NA` -> no `upstream_feedback` findings
-
-## Gate-5: memory-scan completeness
-
-Purpose: prove that the MEMORY.md repeat scan actually happened for any finding
-that wants a `memory` action.
-
-For every memory-action finding, require:
-
-- `memory_scan.scanned == true`
-- `memory_scan.candidates_reviewed` present
-- `repeat` present
-- `repeat_count` present
-
-If the scan could not run because the index is inaccessible, record that in the
-`memory_scan` field rather than silently skipping the field.
-
-## Gate-6: oracle-match completeness
-
-Purpose: prevent overwriting stored numeric values with a probe that measured a
-different quantity.
-
-For every stored-value correction finding, require:
-
-- `oracle_match` field present
-- `oracle_match: true` when the action would invalidate or overwrite the stored
-  value
-
-Producer procedure:
-
-1. Read the originating entry's stored oracle: matching basis, cohort, and unit.
-2. Re-probe with the same matching basis / cohort / unit before treating the
-   stored value as stale or wrong.
-3. Record `oracle_match: true` only when the falsification probe used that same
-   oracle.
-4. Treat a different-oracle probe as a cohort-shift observation, not as
-   falsification of the stored value.
-
-If the originating entry did not record its oracle, defer falsification and
-route the work to an annotation update rather than fabricating a correction.
-
-## Distribution card
-
-On pass, Stage 2.5 hands Stage 3 the canonical distribution card:
-
-```markdown
-<!-- retrospect:distribution begin -->
-- memory: {n}
-- issue: {n}
-- claude_md_draft: {n}
-- skill_idea: {n}
-- hook_code: {n}
-- upstream_feedback: {n}
-- memory_hygiene: {n}
-- output_quality: {n}
-- gate_1_verdict: {PASS|FAIL|NA}
-- gate_2_verdict: {PASS|FAIL|NA}
-- gate_3_verdict: {PASS|FAIL|NA}
-- gate_4_verdict: {PASS|WARN|NA}
-- gate_5_verdict: {PASS|FAIL|NA}
-- gate_6_verdict: {PASS|FAIL|NA}
-<!-- retrospect:distribution end -->
-```
-
-Semantics:
-
-- `memory_hygiene` and `output_quality` are category counts, not action keys
-- `gate_1_verdict`, `gate_2_verdict`, and `gate_4_verdict` are structurally
-  relevant to the Stop-hook path
-- `gate_3_verdict`, `gate_5_verdict`, and `gate_6_verdict` are emitted for
-  procedural audit even when the Stop hook does not parse them
-
-## Re-entry and override
-
-If a finding still fails a gate after 2 re-entries:
-
-- do not keep looping
-- surface the documented override prompt for that gate
-- record the user's selection in the report trail
+The script renders the canonical card (all six action counts, the
+`memory_hygiene` / `output_quality` category counts, and
+`gate_1..6_verdict`). `gate_1_verdict`, `gate_2_verdict`, and
+`gate_4_verdict` are structurally relevant to the Stop-hook path;
+`gate_3_verdict`, `gate_5_verdict`, and `gate_6_verdict` are emitted for
+procedural audit even when the Stop hook does not parse them.

--- a/tests/test_audit_distribution_gates.py
+++ b/tests/test_audit_distribution_gates.py
@@ -1,0 +1,339 @@
+"""Functional tests for skills/retrospect/audit-distribution-gates.py (#774).
+
+Each case invokes the script as a subprocess — the same surface the retrospect
+skill uses — against a synthetic Stage 3 draft.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).resolve().parent.parent
+    / "skills" / "retrospect" / "audit-distribution-gates.py"
+)
+
+HEADER = (
+    "| # | Category | Tool Layer | Pattern | Root Cause | Rule / Gap "
+    "| Repeat? | Proposed Actions (1~2) | Rationale | Priority |"
+)
+SEP = "|---|---|---|---|---|---|---|---|---|---|"
+
+SCHEMA_A = (
+    "not issue: no repeat<br>not claude_md_draft: too narrow<br>"
+    "not skill_idea: no workflow<br>not hook_code: no enforcement need<br>"
+    "not upstream_feedback: internal only"
+)
+
+
+def row(num: int, category: str, layer: str, actions: str, rationale: str,
+        root_cause: str = "plain cause", pattern: str = "p",
+        repeat: str = "false") -> str:
+    return (f"| {num} | {category} | {layer} | {pattern} | {root_cause} "
+            f"| rule | {repeat} | {actions} | {rationale} | P2 |")
+
+
+def run(tmp_path: Path, draft: str, *extra_args: str,
+        env_extra: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    draft_file = tmp_path / "draft.md"
+    draft_file.write_text(draft, encoding="utf-8")
+    env = dict(os.environ, PRAXIS_OWN_ORGS="devseunggwan")
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--draft", str(draft_file), *extra_args],
+        capture_output=True, text=True, env=env,
+    )
+
+
+def draft_of(*rows: str, extra: str = "") -> str:
+    return "\n".join(["## Retrospect Report", "", HEADER, SEP, *rows, "", extra])
+
+
+MS_BLOCK = (
+    "<!-- memory_scan finding #1:\n  scanned: true\n"
+    "  candidates_reviewed: memory/foo.md\n  repeat: false\n"
+    "  repeat_count: 0\n-->"
+)
+
+
+def test_clean_memory_only_schema_a(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "behavioral", "—", "memory", SCHEMA_A), extra=MS_BLOCK))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "- memory: 1" in r.stdout
+    assert "- gate_2_verdict: PASS" in r.stdout
+    assert "- gate_5_verdict: PASS" in r.stdout
+
+
+def test_schema_b_passes(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "behavioral", "—", "memory", "not-others: tool,workflow"),
+        extra=MS_BLOCK))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "- gate_2_verdict: PASS" in r.stdout
+
+
+def test_schema_neither_fails_gate2(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "behavioral", "—", "memory", "generic one-liner"),
+        extra=MS_BLOCK))
+    assert r.returncode == 1
+    assert "matches neither schema A" in r.stdout
+    assert "- gate_2_verdict: FAIL" in r.stdout
+
+
+def test_gate1_tool_memory_only_blocks(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "tool", "cli", "memory", SCHEMA_A), extra=MS_BLOCK))
+    assert r.returncode == 1
+    assert "memory only" in r.stdout
+    assert "- gate_1_verdict: FAIL" in r.stdout
+
+
+def test_degenerate_memory_memory_is_memory_only(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "tool", "cli", "memory, memory", SCHEMA_A), extra=MS_BLOCK))
+    assert r.returncode == 1
+    assert "memory only" in r.stdout
+
+
+def test_behavioral_label_falsify_keyword_requires_justify(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "behavioral", "—", "memory", SCHEMA_A,
+            root_cause="hook missing for the --state flag"),
+        extra=MS_BLOCK))
+    assert r.returncode == 1
+    assert "behavioral-label-justify" in r.stdout
+
+
+def test_behavioral_label_justify_line_passes(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "behavioral", "—", "memory",
+            SCHEMA_A + "<br>behavioral-label-justify: keyword is incidental",
+            root_cause="hook missing for the --state flag"),
+        extra=MS_BLOCK))
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_tool_without_tool_layer_fails(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "tool", "—", "issue", "backing_repo: devseunggwan/praxis")))
+    assert r.returncode == 1
+    assert "Tool Layer" in r.stdout
+
+
+def test_routed_action_missing_backing_repo(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(row(1, "workflow", "—", "issue", "no repo here")))
+    assert r.returncode == 1
+    assert "backing_repo" in r.stdout
+
+
+def test_gate4_internal_owner_passes(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "workflow", "—", "upstream_feedback",
+            "backing_repo: devseunggwan/praxis")))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "- gate_4_verdict: PASS" in r.stdout
+
+
+def test_gate4_external_owner_needs_warning_prefix(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "workflow", "—", "upstream_feedback",
+            "backing_repo: someoneelse/repo")))
+    assert r.returncode == 1
+    assert "literal warning prefix" in r.stdout
+    assert "- gate_4_verdict: WARN" in r.stdout
+
+
+def test_gate4_external_with_warning_prefix_warns_but_passes(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "workflow", "—", "upstream_feedback",
+            "backing_repo: someoneelse/repo<br>"
+            "⚠ EXTERNAL: per-action approval required at Stage 4")))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "- gate_4_verdict: WARN" in r.stdout
+
+
+def test_gate5_missing_block_fails(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(row(1, "behavioral", "—", "memory", SCHEMA_A)))
+    assert r.returncode == 1
+    assert "memory_scan" in r.stdout
+    assert "- gate_5_verdict: FAIL" in r.stdout
+
+
+def test_gate5_incomplete_block_fails(tmp_path: Path) -> None:
+    incomplete = ("<!-- memory_scan finding #1:\n  scanned: true\n"
+                  "  repeat: false\n-->")
+    r = run(tmp_path, draft_of(
+        row(1, "behavioral", "—", "memory", SCHEMA_A), extra=incomplete))
+    assert r.returncode == 1
+    assert "incomplete" in r.stdout
+
+
+def test_compound_without_gate3_flag_fails(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "tool", "cli", "memory, issue",
+            SCHEMA_A + "<br>backing_repo: devseunggwan/praxis"),
+        extra=MS_BLOCK))
+    assert r.returncode == 1
+    assert "--gate3 not supplied" in r.stdout
+
+
+def test_compound_with_gate3_pass(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "tool", "cli", "memory, issue",
+            SCHEMA_A + "<br>backing_repo: devseunggwan/praxis"),
+        extra=MS_BLOCK), "--gate3", "PASS")
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "- gate_3_verdict: PASS" in r.stdout
+
+
+def test_zero_findings_all_na(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of())
+    assert r.returncode == 0, r.stdout + r.stderr
+    for g in range(1, 7):
+        assert f"- gate_{g}_verdict: NA" in r.stdout
+
+
+def test_no_table_is_error(tmp_path: Path) -> None:
+    r = run(tmp_path, "just prose, no table")
+    assert r.returncode == 1
+    assert "no unified findings table" in r.stdout
+
+
+def test_short_row_schema_violation(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of("| 1 | behavioral | memory |"))
+    assert r.returncode == 1
+    assert "expected 10" in r.stdout
+
+
+def test_escaped_pipe_in_rationale(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "behavioral", "—", "memory",
+            SCHEMA_A.replace("no repeat", "a \\| b")), extra=MS_BLOCK))
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_invalid_action_token(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(row(1, "behavioral", "—", "banana", "x")))
+    assert r.returncode == 1
+    assert "invalid Proposed Actions" in r.stdout
+
+
+def test_reinforce_memory_added_to_count(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "workflow", "—", "issue", "backing_repo: devseunggwan/praxis")),
+        "--reinforce-memory", "2")
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "- memory: 2" in r.stdout
+
+
+def test_behavioral_only_safeguard_advisory(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "behavioral", "—", "memory", SCHEMA_A,
+            pattern="kubectl timeout while waiting"), extra=MS_BLOCK))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "behavioral-only safeguard" in r.stdout
+
+
+def test_word_boundary_no_false_positive(tmp_path: Path) -> None:
+    # `respect`/`expected`/`high` must not hit `spec`/`gh` (code-reviewer #774).
+    r = run(tmp_path, draft_of(
+        row(1, "behavioral", "—", "memory", SCHEMA_A,
+            root_cause="agent did not respect the expected high-level intent"),
+        extra=MS_BLOCK))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "behavioral-only safeguard" not in r.stdout
+
+
+def test_gate3_na_claim_with_compound_is_violation(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "tool", "cli", "memory, issue",
+            SCHEMA_A + "<br>backing_repo: devseunggwan/praxis"),
+        extra=MS_BLOCK), "--gate3", "NA")
+    assert r.returncode == 1
+    assert "NA claimed" in r.stdout
+    assert "- gate_3_verdict: FAIL" in r.stdout
+
+
+def test_gate4_conservative_fallback_all_external(tmp_path: Path) -> None:
+    # No PRAXIS_OWN_ORGS and no gh on PATH -> every owner is external.
+    draft_file = tmp_path / "draft.md"
+    draft_file.write_text(draft_of(
+        row(1, "workflow", "—", "upstream_feedback",
+            "backing_repo: devseunggwan/praxis")), encoding="utf-8")
+    env = {k: v for k, v in os.environ.items() if k != "PRAXIS_OWN_ORGS"}
+    env["PATH"] = str(tmp_path)  # empty dir: gh resolution fails
+    r = subprocess.run(
+        [sys.executable, str(SCRIPT), "--draft", str(draft_file)],
+        capture_output=True, text=True, env=env,
+    )
+    assert r.returncode == 1
+    assert "conservative fallback" in r.stdout
+    assert "- gate_4_verdict: WARN" in r.stdout
+
+
+def test_signals_file_feeds_safeguard(tmp_path: Path) -> None:
+    signals = tmp_path / "signals.txt"
+    signals.write_text("permission denied while calling kubectl",
+                       encoding="utf-8")
+    r = run(tmp_path, draft_of(
+        row(1, "behavioral", "—", "memory", SCHEMA_A), extra=MS_BLOCK),
+        "--signals", str(signals))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "behavioral-only safeguard" in r.stdout
+
+
+def test_more_than_two_actions_violation(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "workflow", "—", "issue, hook_code, skill_idea",
+            "backing_repo: devseunggwan/praxis")))
+    assert r.returncode == 1
+    assert "max 2" in r.stdout
+
+
+def test_invalid_category_token(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(row(1, "vibes", "—", "memory", SCHEMA_A),
+                               extra=MS_BLOCK))
+    assert r.returncode == 1
+    assert "invalid category[]" in r.stdout
+
+
+def test_extra_cells_unescaped_pipe_rejected(tmp_path: Path) -> None:
+    # codex #774 F1: an unescaped '|' adds an 11th cell — must not pass.
+    r = run(tmp_path, draft_of(
+        row(1, "behavioral", "—", "memory", SCHEMA_A,
+            pattern="a | b unescaped"), extra=MS_BLOCK))
+    assert r.returncode == 1
+    assert "expected 10" in r.stdout
+
+
+def test_nontool_row_invalid_tool_layer_rejected(tmp_path: Path) -> None:
+    # codex #774 F2: Tool Layer enum applies to every row, not only tool rows.
+    r = run(tmp_path, draft_of(
+        row(1, "behavioral", "banana", "memory", SCHEMA_A), extra=MS_BLOCK))
+    assert r.returncode == 1
+    assert "mcp|cli|builtin|skill|—" in r.stdout
+
+
+def test_schema_a_duplicate_lines_fail(tmp_path: Path) -> None:
+    # codex #774 F3: five duplicate 'not issue:' lines must not pass Schema A.
+    dup = "<br>".join(["not issue: reason"] * 5)
+    r = run(tmp_path, draft_of(
+        row(1, "behavioral", "—", "memory", dup), extra=MS_BLOCK))
+    assert r.returncode == 1
+    assert "distinct" in r.stdout
+    assert "- gate_2_verdict: FAIL" in r.stdout
+
+
+def test_gate6_flag_embedded_in_card(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "behavioral", "—", "memory",
+            SCHEMA_A + "<br>oracle_match: true"), extra=MS_BLOCK),
+        "--gate6", "PASS")
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "- gate_6_verdict: PASS" in r.stdout

--- a/tests/test_audit_distribution_gates.py
+++ b/tests/test_audit_distribution_gates.py
@@ -337,3 +337,23 @@ def test_gate6_flag_embedded_in_card(tmp_path: Path) -> None:
         "--gate6", "PASS")
     assert r.returncode == 0, r.stdout + r.stderr
     assert "- gate_6_verdict: PASS" in r.stdout
+
+
+def test_gate3_fail_is_violation(tmp_path: Path) -> None:
+    # CodeRabbit #775: explicit FAIL must not exit 0 with a clean audit.
+    r = run(tmp_path, draft_of(
+        row(1, "tool", "cli", "memory, issue",
+            SCHEMA_A + "<br>backing_repo: devseunggwan/praxis"),
+        extra=MS_BLOCK), "--gate3", "FAIL")
+    assert r.returncode == 1
+    assert "gate-3 verdict is FAIL" in r.stdout
+    assert "- gate_3_verdict: FAIL" in r.stdout
+
+
+def test_gate6_fail_is_violation(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "behavioral", "—", "memory", SCHEMA_A), extra=MS_BLOCK),
+        "--gate6", "FAIL")
+    assert r.returncode == 1
+    assert "gate-6 verdict is FAIL" in r.stdout
+    assert "- gate_6_verdict: FAIL" in r.stdout

--- a/tests/test_skill_runtime_metadata.py
+++ b/tests/test_skill_runtime_metadata.py
@@ -605,7 +605,11 @@ def test_current_repo_runtime_sensitive_skill_set_is_stable():
             "external-cli-wrapper",
             "helper-executable",
         ),
-        "retrospect": ("AskUserQuestion", "external-cli-wrapper"),
+        "retrospect": (
+            "AskUserQuestion",
+            "external-cli-wrapper",
+            "helper-executable",
+        ),
         "writing-praxis-skill": (
             "AskUserQuestion",
             "Skill(...)",


### PR DESCRIPTION
## 배경

retrospect Stage 2.5 게이트 스위트(257줄 산문)를 에이전트가 in-context로 손수 실행하던 것을, 결정론적 검사만 producer-side 스크립트로 코드화합니다. 스킬체인 분리 검토 결과 부적합 판정(같은 컨텍스트 주입 + hook lifecycle 계약)에 따른 대안 트랙입니다.

Closes #774

## 변경 사항

| 파일 | 변경 |
|---|---|
| `skills/retrospect/audit-distribution-gates.py` | 신규 (476줄) — Stage 3 draft markdown 입력, 기계 게이트 일괄 검사 + distribution card 렌더링 |
| `tests/test_audit_distribution_gates.py` | 신규 — functional 테스트 33케이스 (subprocess 실제 호출 표면) |
| `skills/retrospect/references/stage2.5-audit.md` | 257→160줄 — 기계 검사 산문을 스크립트 계약으로 대체, 의미 판단(Gate-1 적합성/Gate-3/Gate-6)과 override 프롬프트만 잔존 |
| `skills/retrospect/SKILL.md` | Stage 2.5 섹션 스크립트 라우팅으로 동기화 |

**스크립트가 소유하는 검사**: 10셀 테이블 스키마(unescaped pipe 차단), category/Tool Layer/actions enum, Gate-1 기계 검사(memory-only 위반 + behavioral-label 키워드 word-boundary 스캔), Gate-2 Schema A(distinct 5종)/B, backing_repo, Gate-4 allowlist 분류 + `⚠ EXTERNAL` prefix, Gate-5 memory_scan 필드, distribution card 생성.

**의미 판단 잔존**: Gate-3(a/b/c)·Gate-6은 `--gate3`/`--gate6` verdict 주입 — compound finding 존재 시 NA/미지정 거부.

**Stop hook 불변**: `retrospect-mix-check` 및 기존 테스트 스위트 무변경. 스크립트는 hook 파싱 의미(impl.sh:357/358/381 regex verbatim)를 미러링하는 pre-flight.

## 검증

- `python3 -m pytest tests/test_audit_distribution_gates.py` → 33 passed
- `./scripts/run-tests.sh` → ALL TESTS PASSED (pytest 454 + 전체 shell 스위트 + manifest + invariants)
- **hook 크로스체크**: 스크립트-clean draft를 합성 JSONL transcript로 실제 Stop hook에 투입 → exit 0, 무차단
- 코드 리뷰 2단: `oh-my-claudecode:code-reviewer` (MEDIUM 3건 수정 반영: substring 오탐 word-boundary화, `--gate3 NA` 우회 차단, Gate-6 docstring 정정) + codex review (P2 3건 수정 반영: extra-cell 거부, 전 row Tool Layer enum, Schema A distinct 커버리지)

## 미검증 / 한계

- Gate-4의 `gh api user` allowlist 해석 경로는 네트워크 의존이라 단위 테스트 미포함 (env-var 경로·no-gh fallback은 테스트 커버)
- 세션 레벨 hook 게이트(7~10)는 스크립트 범위 밖 — 문서에 scope note 명시
- 이 PR은 문서 ~130줄 순감이며, 2,353줄 코퍼스의 근본 축소는 별도 트랙(fire-rate prune)

Pre-commit verified: ./scripts/run-tests.sh → ALL TESTS PASSED (pytest 454건 + shell 스위트 전체 + manifest/invariant 체크); hook cross-check exit 0
Caller chain verified: grep found 2 callers — skills/retrospect/references/stage2.5-audit.md:16 (스킬 실행 계약) + tests/test_audit_distribution_gates.py:16; 신규 스크립트로 코드 caller 없음이 정상


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated audit tool for validating retrospect findings, evidence, action distribution, and gate outcomes.
  * Added distribution cards summarizing action counts, quality categories, and audit verdicts.
  * Added support for semantic gate inputs and configurable audit options.

* **Documentation**
  * Updated retrospect guidance with the new audit workflow, validation responsibilities, override process, and oracle-matching rules.

* **Tests**
  * Added comprehensive coverage for table validation, evidence completeness, action constraints, ownership checks, safeguards, and gate behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->