### PR TITLE
docs(retrospect): fix stale memory-hint event coverage note

### DIFF
--- a/skills/retrospect/references/stage4-execution.md
+++ b/skills/retrospect/references/stage4-execution.md
@@ -28,15 +28,17 @@ For each approved action:
 
    **Frontmatter contract — `memory-hint` opt-in (mandatory consideration)**
 
-   In addition to standard fields (`name`, `description`, `type`), every new memory MUST evaluate whether to include the `memory-hint` opt-in fields — `hookable` and `hookKeywords`. The full field spec (parser semantics, matching rules, fail-open contract) lives in `hooks/advisory-nudge/memory-hint/spec.md`; this section defines the authoring-time decision. Use top-level `type:` (consistent with `hooks/advisory-nudge/memory-hint/spec.md` example and existing on-disk memory files); do **not** nest under `metadata:`.
+   In addition to standard fields (`name`, `description`, `type`), every new memory MUST evaluate whether to include the `memory-hint` opt-in fields — `hookable` and `hookKeywords`. The full field spec (parser semantics, matching rules, fail-open contract) lives in `hooks/advisory-nudge/memory-hint/spec.md`; this section defines the authoring-time decision. The parser ignores `type` entirely and reads `hookable` / `hookKeywords` / `hookEvents` regardless of nesting depth (the regexes are indentation-tolerant), so place `type:` per your host's memory convention — this repo's on-disk memories nest taxonomy fields under `metadata:`. Only the opt-in fields' spelling and single-line list form matter for the hook.
 
    ```yaml
    ---
    name: my-memory
    description: Short rule statement
-   type: feedback
-   hookable: true                           # opt into PreToolUse surface
-   hookKeywords: [keyword1, keyword2]       # whole-token match (case-sensitive)
+   metadata:                                # this repo nests taxonomy fields here
+     type: feedback
+     hookable: true                         # opt into PreToolUse surface
+     hookKeywords: [keyword1, keyword2]      # flat single-line list, whole-token (case-sensitive)
+     hookEvents: [Bash, Edit]               # optional; default [Bash] when omitted
    ---
    ```
 
@@ -56,7 +58,8 @@ For each approved action:
    - Whole-token, case-sensitive matching only (per `hooks/advisory-nudge/memory-hint/spec.md`). List multiple casings explicitly if needed (`[Edit, edit]`).
    - 1–4 keywords typical; >5 raises false-positive risk linearly.
    - **Avoid generic English words** (`add`, `run`, `test`, `update`) — they fire on unrelated commands and erode the hint signal.
-   - When the memory targets a non-Bash event (Edit, Write, AskUserQuestion, etc.), the current `memory-hint.py` only fires on Bash — record the intent in the description so a future event-coverage expansion can surface it.
+   - **`hookKeywords` must be a flat single-line list** (`[a, b]`). Multi-line YAML-block form (`- item` on separate lines) and scalar form (`hookKeywords: foo`) are silently skipped — the entire memory is then dropped (not indexed at all) and the hint never fires. Verify the list is single-line before committing.
+   - When the memory targets a non-Bash event, add `hookEvents:` to opt in — `memory-hint.py` supports `[Bash, Edit, Write, NotebookEdit, AskUserQuestion]` (default `[Bash]` when omitted). Unsupported tool names in the list are dropped; if every listed event is unsupported the parser keeps the `[Bash]` default.
 
    **⚠️ MANDATORY: Duplicate check before creating any memory file:**
 
@@ -248,7 +251,7 @@ For each approved action:
 
    | Artifact | Verification |
    | ---------- | ------------- |
-   | MEMORY.md feedback (new) | File exists + MEMORY.md index updated + `hookable`/`hookKeywords` frontmatter decision recorded (true with keywords, OR false with rationale in Actions Executed report) |
+   | MEMORY.md feedback (new) | File exists + MEMORY.md index updated + `hookable`/`hookKeywords` frontmatter decision recorded (true with keywords, OR false with rationale in Actions Executed report) + if the memory targets a non-Bash tool, confirm `hookEvents` lists that tool (a missing/mistyped `hookEvents` silently reverts to `[Bash]` and the hint never fires on the intended event) |
    | MEMORY.md feedback (merged) | Existing file updated (diff shown) + MEMORY.md index description updated if needed + if existing entry had `hookable: false` **or the field is missing entirely** and merged context now meets the retrieval-critical default, re-evaluate and add/update frontmatter (most pre-existing memories lack `hookable` — missing field is the dominant case, not false) |
    | GitHub issue | `gh issue view {url}` returns valid data |
    | Upstream feedback | `gh issue view {url}` returns valid data + URL repo matches `verified_backing_repo` from step 0 + label convention is correct for the verified repo (`tool-friction:{layer}` ONLY when verified repo is the praxis distribution; otherwise the repo's own convention label per Action 4's label rule) |

--- a/skills/retrospect/references/stage4-execution.md
+++ b/skills/retrospect/references/stage4-execution.md
@@ -59,7 +59,7 @@ For each approved action:
    - 1–4 keywords typical; >5 raises false-positive risk linearly.
    - **Avoid generic English words** (`add`, `run`, `test`, `update`) — they fire on unrelated commands and erode the hint signal.
    - **`hookKeywords` must be a flat single-line list** (`[a, b]`). Multi-line YAML-block form (`- item` on separate lines) and scalar form (`hookKeywords: foo`) are silently skipped — the entire memory is then dropped (not indexed at all) and the hint never fires. Verify the list is single-line before committing.
-   - When the memory targets a non-Bash event, add `hookEvents:` to opt in — `memory-hint.py` supports `[Bash, Edit, Write, NotebookEdit, AskUserQuestion]` (default `[Bash]` when omitted). Unsupported tool names in the list are dropped; if every listed event is unsupported the parser keeps the `[Bash]` default.
+   - When the memory targets a non-Bash event, add `hookEvents:` to opt in — the memory-hint hook (`hooks/advisory-nudge/memory-hint/impl.py`) supports `[Bash, Edit, Write, NotebookEdit, AskUserQuestion]` (default `[Bash]` when omitted). Unsupported tool names in the list are dropped; if every listed event is unsupported the parser keeps the `[Bash]` default.
 
    **⚠️ MANDATORY: Duplicate check before creating any memory file:**
 


### PR DESCRIPTION
## 배경

`skills/retrospect/references/stage4-execution.md` 의 memory-hint 서술이 실제 hook 구현과 어긋나 있어 정정합니다. 2026-07-14 retrospect 세션에서 이 stale 문구가 "AskUserQuestion 대상 memory 배선 불가능"이라는 잘못된 전제로 escalation 논거를 만들 뻔했다가 manifest 직독으로 반증된 사례가 계기입니다.

## 변경 내용 (docs-only, 단일 파일)

- **L31 규범 정정**: "top-level `type:` 쓰고 `metadata:` 중첩 말라"는 서술 제거. 실제 파서는 `type` 을 무시하고 `hookable`/`hookKeywords`/`hookEvents` 를 indentation-tolerant regex 로 읽으므로 중첩 여부 무관. 이 repo on-disk memory 는 `metadata:` 중첩이 다수 → 현실 반영.
- **L59 stale 정정**: "memory-hint.py only fires on Bash" → 실제 5개 이벤트(`Bash/Edit/Write/NotebookEdit/AskUserQuestion`) 지원 + `hookEvents:` opt-in 필드로 정정.
- **hookKeywords 함정 명시(신규)**: flat single-line list 만 유효, multi-line block/scalar 형식은 memory 전체가 silent drop 됨을 1줄 추가.
- **예시 블록 정합화**: top-level → 이 repo 실제 `metadata:` 중첩 형식 + `hookEvents` 예시 추가.
- **검증 matrix 보강**(codex review 반영): non-Bash 대상 memory 는 `hookEvents` 일치를 완료 검증 항목에 포함 — 오배선이 완료로 보고되는 gap 차단.

## 검증

- Functional test — `PRAXIS_MEMORY_DIR` 격리로 `impl.py` 실제 실행:
  - nested `metadata:` + `hookEvents:[AskUserQuestion]` → AskUserQuestion 에서 발화 ✅ / 같은 memory Bash 이벤트 → 미발화 ✅
  - multi-line `hookKeywords` → 미발화(drop) / flat `[x]` control → 발화 ✅
- Review: `oh-my-claudecode:code-reviewer`(APPROVE, LOW nit 1건 반영) + `praxis:codex-review-wrap`(codex P2 1건 반영, premise 검증 후 적용).

Caller chain verified: N/A -- docs-only change (skills/retrospect/references/stage4-execution.md 서술 정정, 코드/심볼 변경 없음)

Pre-commit verified: docs-only change, repo has no pre-commit config; 문서가 주장하는 hook 동작을 `PRAXIS_MEMORY_DIR` 격리로 `impl.py` 직접 실행해 검증(위 검증 섹션). 나머지는 CI(.github/workflows/ci.yml).

Closes #779


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the required metadata format for new memory feedback entries.
  * Documented valid event targeting, fallback behavior, and strict formatting rules for keyword lists.
  * Expanded completion checks to verify hook settings and tool-specific event targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->