### PR TITLE
feat(skill): add surface-enumeration skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,12 +41,12 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 
 ### Development
 
-| Skill               | Purpose                                                                                                                                                                                         |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `retrospect`        | Session retrospect — find friction root causes, propose improvements                                                                                                                            |
-| `codex-review-wrap` | Worktree-aware wrapper for `/codex:review` — forces explicit target selection, premise-verification gate, flip detection across rounds                                                          |
-| `debt`              | Deferred-decision ledger — unions commit-trailer markers (`Not-tested:`, `Confidence: low`, `Rejected:`, `Directive:`, `Scope-risk:`) with tree compounding comments (`# [PR #N]`); report-only |
-| `surface-enumeration` | Pre-implementation input-surface enumeration — before writing a parser/validator/sanitizer/classifier, list every input variant (escape/comment/negation/boundary/quote/encoding/container) so each becomes a required test case; knowledge-injection, no runtime gate |
+| Skill                 | Purpose                                                                                                                                                                                         |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `retrospect`          | Session retrospect — find friction root causes, propose improvements                                                                                                                            |
+| `codex-review-wrap`   | Worktree-aware wrapper for `/codex:review` — forces explicit target selection, premise-verification gate, flip detection across rounds                                                          |
+| `debt`                | Deferred-decision ledger — unions commit-trailer markers (`Not-tested:`, `Confidence: low`, `Rejected:`, `Directive:`, `Scope-risk:`) with tree compounding comments (`# [PR #N]`); report-only |
+| `surface-enumeration` | Pre-implementation input-surface enumeration — enumerate every input variant before writing a parser/validator/sanitizer/classifier so each becomes a required test case                        |
 
 ### Discipline
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 | **Full**           | + all cmux-* skills                                      | + cmux                                                      |
 | **Multi-provider** | + codex/gemini routing in cmux-*                         | + codex-cli, gemini-cli                                     |
 
-## Skills (14)
+## Skills (15)
 
 > **Invocation**: praxis entries are *skills*, not subagents. Always call them
 > via `Skill(skill="praxis:<name>")` — `Agent(subagent_type="praxis:<name>")`
@@ -46,6 +46,7 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 | `retrospect`        | Session retrospect — find friction root causes, propose improvements                                                                                                                            |
 | `codex-review-wrap` | Worktree-aware wrapper for `/codex:review` — forces explicit target selection, premise-verification gate, flip detection across rounds                                                          |
 | `debt`              | Deferred-decision ledger — unions commit-trailer markers (`Not-tested:`, `Confidence: low`, `Rejected:`, `Directive:`, `Scope-risk:`) with tree compounding comments (`# [PR #N]`); report-only |
+| `surface-enumeration` | Pre-implementation input-surface enumeration — before writing a parser/validator/sanitizer/classifier, list every input variant (escape/comment/negation/boundary/quote/encoding/container) so each becomes a required test case; knowledge-injection, no runtime gate |
 
 ### Discipline
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Development workflow skills for Claude Code — disciplined, fast, resilient.
 | `retrospect` | `retrospect`, `what went wrong`, `session review`, `session improvement`, `improve` | To analyze friction patterns / root causes after a session and act on improvements | `/praxis:retrospect` |
 | `codex-review-wrap` | `codex review`, `review codex`, `safe review`, `premise verification`, `flip detection`, `sibling cross-check` | To run `/codex:review` safely in multi-worktree setups, with premise verification and flip detection | `/praxis:codex-review-wrap` |
 | `debt` | `praxis:debt`, `debt ledger`, `지연 결정`, `deferred decision`, `기술 부채 원장`, `commit trailer audit` | To harvest commit-trailer and compounding-comment deferred-decision markers into a report-only ledger | `/praxis:debt` |
+| `surface-enumeration` | `surface enumerate`, `input surface enumeration`, `input parser`, `input validation`, `intent classifier`, `정규식 경계`, `입력 표면 열거` | To enumerate every input variant before implementing a parser/validator/sanitizer so each becomes a required test case | `/praxis:surface-enumeration` |
 
 ### Discipline
 

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -64,6 +64,7 @@ EXPECTED_SKILLS: frozenset[str] = frozenset({
     "retrospect",
     "strike",
     "strikes",
+    "surface-enumeration",
     "using-praxis",
     "writing-praxis-skill",
 })

--- a/skills/surface-enumeration/SKILL.md
+++ b/skills/surface-enumeration/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: surface-enumeration
+description: >
+  Pre-implementation input-surface enumeration — before writing a
+  parser/validator/sanitizer/classifier, enumerate every input variant so each
+  becomes a required test case.
+  Triggers on "surface enumerate", "input surface enumeration", "input parser",
+  "input validation", "intent classifier", "정규식 경계", "입력 표면 열거".
+  Do NOT activate on "surface a question", "user-facing surface", or merely
+  explaining an existing parser.
+verified-against-runtime: true
+runtime-verified-at: 2026-07-14
+runtime-verified-note: "python3 3.14.5 — SKILL.md Step 4 regex examples executed live: re.search(r'\\bpush\\b', 'push할까요?') → False (Unicode \\w suppresses the ASCII word boundary between 'h' and '할'), re.search(r'(?<![a-z])push(?![a-z])', 'push할까요?') → True; confirms the mixed-text word-boundary guidance in Step 2."
+---
+
+# surface-enumeration
+
+## Overview
+
+Code that validates, classifies, routes, sanitizes, or interprets variable input
+fails one missed variant at a time. A reviewer finds case A, you fix it, the next
+round finds case B, and so on — each round is a full round-trip because the input
+surface was never enumerated up front. This skill front-loads that enumeration:
+list the variants **before** implementing, turn each into a test case, and re-run
+the full list after every fix.
+
+**Core principle:** enumerate the input surface before writing the handler — a
+variant you did not list is a variant you did not test.
+
+## When to Use
+
+- Implementing anything that inspects variable input: SQL/shell/markup parsers,
+  sanitizers, auth/validation checks, intent/command classifiers, tokenizers,
+  routers, regex matchers.
+- A reviewer (Codex / BugBot / human) just found a missed input case — before
+  fixing only that case, enumerate the whole surface so the next round is empty.
+- Designing a mock/fixture for input-handling code (each enumerated variant is a
+  fixture case, including a must-fail case).
+
+Skip for code with a fixed, closed input (a function called only with an enum you
+control) or a single-token mechanical transform with no interpretation.
+
+## Process
+
+### Step 1: Classify the input-handling code
+
+Name what the code does to the input — this selects which variant families apply:
+
+| Code class | Example | Highest-risk families |
+| ---------- | ------- | --------------------- |
+| Security / validation | SQL filter, sanitizer, auth check | keyword-in-literal, marker-in-comment, multi-statement, quote mismatch |
+| NLP / signal detection | intent classifier, command-signal hook | affirmation, **negation**, **status/question**, continuation-without-headline, substring-vs-word-boundary |
+| Regex over mixed text | Korean+English command strings | ASCII word-boundary in Unicode (`\b` is Unicode-aware) |
+| Text / grammar parser | shell/SQL/markup tokenizer | comment/heredoc stripping, quoting variants, command-position-only keywords, direction-sensitive ranges, path-invoked binaries, dynamic expansions |
+| Bulk / stateful | 100+ item loop, multi-run write | connection lifecycle, per-item isolation, idempotency (see limitations) |
+
+### Step 2: Enumerate the surface
+
+Walk the checklist and write down each variant that applies. Do not stop at the
+"obvious" ones — the missed variant is by definition not obvious.
+
+- **Escape / quoting**: single vs double quote — in SQL `'--'` is a string
+  literal while `"--"` is a quoted identifier, so they take different parse
+  paths even though the enclosed value is identical; also escaped quote,
+  backslash, nested quotes.
+- **Comment / marker position**: keyword inside a string literal; comment marker
+  inside a literal; literal marker inside a comment.
+- **Multi-statement / separator**: semicolon-joined statements, newline-joined.
+- **Negation forms**: `don't proceed`, `진행하지 마`, `not X` — a signal detector
+  that only matches the affirmative form misfires on the negation.
+- **Status / question forms**: `진행 상황을 알려줘`, `should I push?` — a question
+  about X is not a command to do X.
+- **Continuation without the headline token**: `계속해` ("keep going") vs
+  `계속 진행` ("continue proceeding") — the token you keyed on may be absent.
+- **Substring vs word boundary**: `Product plan` vs `production`, `prod` vs
+  `prod-only`. In Korean+English mixed text Python `re.\w` is Unicode-aware, so
+  `\bpush\b` does NOT separate `push` from `할까요`; use `(?<![a-z])foo(?![a-z])`.
+- **Non-executable text**: comments, heredoc/string bodies that must be stripped
+  before parsing; command-position-only reserved words (`echo done` does not
+  close a loop); direction-sensitive ranges (`{30..1}`); path-invoked binaries
+  (`/bin/sleep` vs bare `sleep`); dynamic expansions (`$(...)`, `$VAR`) needing
+  explicit fail-open.
+- **Encoding / container / integrity**: alternate encodings, wrapped/nested
+  container formats, missing field, truncated/corrupt payload.
+
+Cover **both** dimensions: semantic coverage (count/threshold math) does NOT
+substitute for syntactic coverage (the variants above), and vice versa. Scope
+each construct independently — never merge tokens across sibling constructs into
+one verdict.
+
+### Step 3: Promote each variant to a test case
+
+Every enumerated variant becomes a required test case, including at least one
+**must-fail** case (input that should be rejected → assert the error/raise, not a
+silent default branch). For mocks/fixtures, cite field names from vendor docs or
+a working baseline — never mirror them from the code under test (that produces a
+tautological pass).
+
+### Step 4: Verify each test input actually reproduces its variant
+
+An input that does not reproduce the intended variant gives a false pass. Confirm
+before relying on it:
+
+```bash
+# word-boundary claim in mixed text — verify the regex actually behaves as assumed
+python3 -c "import re; print(bool(re.search(r'\bpush\b', 'push할까요?')))"
+# SQL marker — '--' (string literal) parses differently than "--" (identifier)
+```
+
+### Step 5: Re-run the full list after every fix
+
+When a reviewer finds a new case, add it to the enumeration and re-run the
+**entire** list — not just the one new test. "Unit tests pass" ≠ "surface
+covered". The goal is a review round that discovers nothing new.
+
+## Limitations
+
+- Enumeration is a discipline, not a solver — it lists variant *families*; the
+  concrete variants still require domain knowledge of the input format.
+- Bulk/stateful concerns (connection lifecycle, per-item failure isolation,
+  reconnect policy, partial-progress checkpointing, write-path idempotency for
+  repeated runs) are named here but their full treatment is a separate concern —
+  enumerate them explicitly when the code mutates an external system in a loop.
+- Does not enforce at the tool layer; it is knowledge injection. A structural
+  gate (e.g. a commit-time hook) is a complementary, separate mechanism.

--- a/tests/test_skill_runtime_metadata.py
+++ b/tests/test_skill_runtime_metadata.py
@@ -610,6 +610,7 @@ def test_current_repo_runtime_sensitive_skill_set_is_stable():
             "external-cli-wrapper",
             "helper-executable",
         ),
+        "surface-enumeration": ("external-cli-wrapper",),
         "writing-praxis-skill": (
             "AskUserQuestion",
             "Skill(...)",


### PR DESCRIPTION
## 요약

글로벌 CLAUDE.md `Pre-Implementation Surface Enumeration` 규칙을 코드화한 지식-주입 skill `praxis:surface-enumeration` 를 추가한다. parser / validator / sanitizer / classifier 등 가변 입력을 검증·분류하는 코드를 구현하기 **전에** 입력 표면 변형(escape / comment / negation / boundary / quote / encoding / container)을 열거해 각 변형을 필수 테스트 케이스로 승격시키는 것이 목적. (gap 분석 3-이슈 플랜 중 A)

## 변경

- `skills/surface-enumeration/SKILL.md` 신규 — 순수 지식 skill (외부 CLI 래핑/AskUserQuestion/Skill delegation 없음)
- 등록 4곳: `scripts/constants.py` EXPECTED_SKILLS · `AGENTS.md`(Skills 14→15 + 표) · `README.md` 표 · `tests/test_skill_runtime_metadata.py` frozen stability dict

## 검증

- `scripts/run-tests.sh` 전체 스위트 green (467 pytest + shell + surface-freeze), `check-plugin-manifests.py` OK, `ruff` clean
- SKILL.md Step 4 regex 예시 실제 실행 검증 (python3 3.14.5): `re.search(r'\bpush\b', 'push할까요?')` → False (Unicode `\w`가 ASCII word boundary 억제) 확인 → frontmatter note에 기록
- description 416자로 500자 런타임 제한(`CONTRIBUTING.md`) 이하 유지

## 리뷰

- `oh-my-claudecode:code-reviewer`: CRITICAL/HIGH 0. MEDIUM(generic 트리거 단어)·LOW 2건 반영
- `praxis:codex-review-wrap` → codex P2(description 699자 초과) premise 검증(CONTRIBUTING.md:24-25 "under 500 characters" 확인, 실측 700자) 후 416자로 축소

## 미검증 / caveat

- routing 라이브 라운드트립(실제 트리거 키워드 발화→skill 활성화)은 미실시 — 지식 skill이라 runtime 부작용 없음
- 500자 제한을 강제하는 check는 부재(CONTRIBUTING 문서로만 존재) — 별도 후속 후보

Closes #781

Pre-commit verified: run-tests.sh full suite green + check-plugin-manifests OK + ruff clean (commit 40cc749)
Caller chain verified: N/A — knowledge skill + registration only; no code symbol callers. registration sites (constants EXPECTED_SKILLS / runtime-metadata test dict / AGENTS.md / README) all updated and green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the new **surface-enumeration** development skill.
  - Introduced guidance for identifying input variations and ensuring each is covered by appropriate validation tests, including failure cases.
  - Added examples and checklists covering quoting, comments, separators, Unicode boundaries, paths, expansions, encoding, and integrity issues.

- **Documentation**
  - Updated the skills index and README to include the new skill and its invocation.
  - Updated skill metadata to recognize the expanded skill set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->