### PR TITLE
docs(hook): ask-end-option agent-facing decision

### DIFF
--- a/hooks/preflight-gate/block-ask-end-option/spec.md
+++ b/hooks/preflight-gate/block-ask-end-option/spec.md
@@ -27,6 +27,50 @@ Text rules in global `~/.claude/CLAUDE.md` or skill bodies alone cannot enforce 
 `loaded != retrieved` limit. This hook enforces the rule at the tool
 boundary, where the check runs mechanically regardless of retrieval state.
 
+### Agent-facing: when to surface an end option
+
+The hook below enforces the rule mechanically at the tool boundary. This
+section is the human-facing decision logic it backs — the reference an
+agent consults when deciding whether an `AskUserQuestion` call should carry
+an end option at all. Formerly this table lived in always-loaded
+`~/.claude/CLAUDE.md`; it moved here so the always-loaded surface can shrink
+to a one-line pointer while the enforcement stays at the tool boundary.
+
+Do **not** mechanically transcribe "end here" / "session end" / "여기서 종료"
+boilerplate from skill guides into `AskUserQuestion` options without context
+verification. Unilateral end declarations ("이 세션을 여기서 마무리합니다" /
+"I'll wrap up here", "다음 세션에서 진행하세요" / "continue in the next
+session") are forbidden.
+
+The stop-signal set and its scope are defined authoritatively in
+[Stop signals (user message)](#stop-signals-user-message) below — this table
+summarizes the decision, it is **not** a second signal list. The hook reads
+only the **most recent** user message (not accumulated earlier context), and
+recognizes Korean bare tokens (`종료`, `여기까지`, `그만`, `마무리`, `스톱`,
+`중단`) but only English *phrases* (`stop here`, `we're done`, `cancel this`,
+…) — bare English words (`stop` / `done` / `cancel`) are deliberately not
+signals. Surface an end option only under a signal the hook actually
+recognizes, or the call is blocked at the tool boundary.
+
+| Context signal | Surface end option? |
+| --- | --- |
+| The **most recent** user message carries an explicit stop signal from the recognized set ([Stop signals](#stop-signals-user-message)) | OK to add as 4th option |
+| 4+ step chained intent clearly established (e.g., worktree → planning → sub-issue → start work) | End surface ignores intent — **omit** |
+| Natural next actionable step clearly exists in immediate context | Surface that step, or wait for explicit user direction |
+
+**Skill-guide boilerplate handling:** even when a skill's "Step N — chaining"
+section lists an "end here" option, this rule takes precedence (global
+CLAUDE.md → `Rule Conflict Precedence — CLAUDE.md over Skills`). Apply the
+context table; omit or include based on signal.
+
+**Exceptions (skills where ending IS the intent):** in issue-closing skills
+(`close-hub-issue`, equivalent) and release / deploy completion skills,
+ending is the legitimate terminal step. The hook has **no skill-context
+detection** — it cannot see which skill is running — so an end option in
+these flows is still blocked unless the most recent user message carries an
+explicit stop signal. When ending is genuinely intended but no stop signal is
+present, opt out for that call with `PRAXIS_ASK_END_ADVISORY=1`.
+
 ### What is blocked
 
 | Scenario | Action |

--- a/hooks/preflight-gate/block-ask-end-option/spec.md
+++ b/hooks/preflight-gate/block-ask-end-option/spec.md
@@ -38,9 +38,14 @@ to a one-line pointer while the enforcement stays at the tool boundary.
 
 Do **not** mechanically transcribe "end here" / "session end" / "여기서 종료"
 boilerplate from skill guides into `AskUserQuestion` options without context
-verification. Unilateral end declarations ("이 세션을 여기서 마무리합니다" /
-"I'll wrap up here", "다음 세션에서 진행하세요" / "continue in the next
-session") are forbidden.
+verification. **Agent-generated** unilateral end declarations ("이 세션을
+여기서 마무리합니다" / "I'll wrap up here", "다음 세션에서 진행하세요" /
+"continue in the next session") are forbidden. The same phrases carry the
+opposite weight when they come from the **user**: `다음 세션` in the user's
+most recent message is a recognized stop signal
+([Stop signals](#stop-signals-user-message)) and legitimately permits an end
+option — the prohibition is on the agent originating the language, not on
+honoring it.
 
 The stop-signal set and its scope are defined authoritatively in
 [Stop signals (user message)](#stop-signals-user-message) below — this table


### PR DESCRIPTION
## 배경

always-loaded user-level `CLAUDE.md`(= `ai-dotfiles/shared/AGENTS.md` 심링크) 슬림화 연작의 #790. 라우팅 선례(#786 훅 + #789 병합, ai-dotfiles #159)와 동일 패턴 — **enforcement는 훅, 상세 지식은 훅 spec(온디맨드), always-loaded는 1줄 포인터**.

이번 대상은 `## AskUserQuestion End-Option Surface Restriction`. enforcement는 `block-ask-end-option` 훅이 AskUserQuestion tool-call 시점에 이미 수행 중 — 본문은 그 human-readable 사본이라 중복이다.

## 변경 (praxis 절반)

본문의 **agent-facing 결정 로직**(context-signal 표 + skill-guide 우선순위 + 예외)을 `block-ask-end-option/spec.md`의 새 `Agent-facing: when to surface an end option` 섹션으로 이전. 포인터가 가리킬 온디맨드 SoT 확보.

- 이 섹션은 "에이전트가 언제 end option을 surface할지"의 판단 기준 — 훅 구현(아래 `What is blocked`)과 audience가 다르므로 별도 섹션으로 분리.

## codex 리뷰 반영 (P2 2건)

옮긴 표가 훅 자기 spec 안에서 내부 모순(위 "surface해도 됨" ↔ 아래 "차단")을 만들지 않도록, impl.py 실제 동작에 정합화:

1. **stop-signal 행** — bare EN 토큰(`stop`/`done`/`cancel`) 제거(훅은 phrase만 인정), "accumulated context" 제거(훅은 최신 메시지 1개만), authoritative `Stop signals` 섹션 참조로 drift 방지.
2. **예외 블록** — "훅은 skill-context 무인지 → 명시 stop signal 없으면 여전히 차단, opt-out은 `PRAXIS_ASK_END_ADVISORY=1`" 명시.

## 검증

- markdownlint(repo config): 내 추가 라인(30–73)에 신규 위반 0 (기존 4건은 전부 범위 밖, `filter_mode: added`로 CI 무영향)
- `check-plugin-manifests.py`: OK
- 앵커 `#stop-signals-user-message` 타깃 헤딩 실재(line 159)

Pre-commit verified: markdownlint(repo config) 추가 라인 신규 위반 0, check-plugin-manifests.py OK, spec 앵커 타깃 실재 확인. codex P2 2건은 impl.py 소스(STOP_SIGNALS_EN_PHRASES line 128 / read_last_user_message line 348 / skill 예외 코드 부재) 직접 대조로 정합화.
Caller chain verified: N/A — docs-only change (spec.md 문서 이전, impl 무변경; enforcement 경로는 기존 block-ask-end-option 훅 그대로)

Refs #790 (praxis 절반 — ai-dotfiles 컴패니언 본문제거 PR이 나머지 절반)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for when an end option should appear in user-facing questions.
  * Documented recognized stop signals, including Korean tokens and English phrases.
  * Clarified that only the latest user message is evaluated and that chained requests suppress the end option.
  * Added precedence rules for conflicting guidance and exceptions for issue-closing and release completion flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->