### PR TITLE
feat(hooks): ready-to-fill falsified scaffold

### DIFF
--- a/hooks/_lib/_fire_ledger.py
+++ b/hooks/_lib/_fire_ledger.py
@@ -104,6 +104,29 @@ def mark_dispatcher_process() -> None:
     _DISPATCHER_PROCESS = True
 
 
+def suppress_coarse_duplicate() -> None:
+    """Skip this process's automatic COARSE fire record (issue #787).
+
+    A standalone hook that calls `record_session_fire` directly already has
+    a RICH record for this invocation. Letting `@fail_open`'s coarse
+    fallback also fire afterwards does not just double-count — when the
+    hook's real decision is "block"/"ask" (signaled via a stdout JSON
+    `permissionDecision`, not exit code 2), the coarse path only ever sees
+    rc=0 and always records "pass". `aggregate_fires()` in
+    skills/bypass-review/bypass-review sums both records unconditionally, so
+    one deny becomes `fires=2, block=1, pass=1` — corrupting the exact
+    per-hook block-rate count this telemetry exists to provide.
+
+    Reuses the dispatcher-process flag: same process-local, one-shot,
+    never-leaks-across-invocations guarantee `mark_dispatcher_process`
+    documents, applied here for the same reason (a richer record for this
+    invocation already exists — skip the redundant coarse fallback). Call
+    only after the RICH record has actually been written, not on every
+    invocation of the hook.
+    """
+    mark_dispatcher_process()
+
+
 def _atomic_append(path: Path, lines: list[str]) -> None:
     """Append `lines` as JSONL with per-line atomic writes; best-effort safe.
 

--- a/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
@@ -333,7 +333,16 @@ def _has_falsified_line(texts: list[str], triggering_labels: list[str]) -> bool:
 
             if marker_at != -1:
                 evidence_region = line[marker_at + len(_PROBE_MARKER) :]
-                if any(token in evidence_region for token in _SCAFFOLD_PLACEHOLDER_TOKENS):
+                # CodeRabbit PR #796 review: deleting everything after the
+                # marker (or moving it to the next physical line) leaves an
+                # empty evidence_region, so the placeholder-token scan finds
+                # nothing and the line silently passes with zero probe
+                # content — the same class of bypass this whole gate exists
+                # to close. A marker-terminated line with no evidence at all
+                # is treated the same as one still carrying a placeholder.
+                if not evidence_region.strip() or any(
+                    token in evidence_region for token in _SCAFFOLD_PLACEHOLDER_TOKENS
+                ):
                     return False
 
             clean_lines.add(" ".join(line.split()))
@@ -462,19 +471,30 @@ def _record_block_telemetry(session_id: object, decision: str) -> None:
     decision with session attribution so that count can come from the ledger
     instead.
 
-    After the RICH record is written, also suppresses this process's coarse
-    fallback (`_fire_ledger.suppress_coarse_duplicate`) — otherwise
-    `aggregate_fires()` sums both the RICH "block"/"ask" record and the
-    COARSE "pass" record for the same call, turning one deny into
-    `fires=2, block=1, pass=1` and corrupting the exact block-rate count
-    this telemetry exists to provide.
+    Always suppresses this process's coarse fallback
+    (`_fire_ledger.suppress_coarse_duplicate`) — otherwise `aggregate_fires()`
+    sums both the RICH "block"/"ask" record and the COARSE "pass" record for
+    the same call, turning one deny into `fires=2, block=1, pass=1` and
+    corrupting the exact block-rate count this telemetry exists to provide.
+
+    Coderabbit PR #796 review: a missing `session_id` previously early-returned
+    before the RICH write, dropping the block/ask decision from
+    `aggregate_fires()`'s `fires`/`block`/`ask` totals entirely — worse than
+    the original coarse-pass bug, since the event vanished from the count
+    rather than being merely mislabeled. `record_session_fire` already
+    coerces a non-str `session_id` to `""`, and `aggregate_fires` only adds a
+    session to its per-session set when it is a non-empty string (verified:
+    `by_hook[...]["sessions"].add(session)` is guarded by
+    `isinstance(session, str) and session`), so emitting the RICH record with
+    an empty session_id counts the decision correctly without polluting
+    per-session aggregation. The RICH write is now unconditional; only
+    per-session attribution is lost when `session_id` is missing, not the
+    decision count itself.
     """
-    if not isinstance(session_id, str) or not session_id:
-        return
+    _fire_ledger.suppress_coarse_duplicate()
     _fire_ledger.record_session_fire(
         _TELEMETRY_HOOK_NAME, _TELEMETRY_HOOK_ROLE, decision, session_id, "AskUserQuestion"
     )
-    _fire_ledger.suppress_coarse_duplicate()
 
 
 def _has_confidence_anchoring(texts: list[str]) -> bool:

--- a/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
@@ -55,6 +55,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from ask_option_text import collect_option_texts  # type: ignore[import-not-found]  # noqa: E402
+import _fire_ledger  # type: ignore[import-not-found]  # noqa: E402
+
+_TELEMETRY_HOOK_NAME = "output-block-falsify-advisory"
+_TELEMETRY_HOOK_ROLE = "advisory-nudge"
 
 # ---------------------------------------------------------------------------
 # Messages
@@ -174,13 +178,171 @@ def _has_exact_recommended_marker(labels: list[str]) -> bool:
     return False
 
 
-def _has_falsified_line(texts: list[str]) -> bool:
-    """True if any question text has a line beginning with 'Falsified:' (exact prefix)."""
+# Issue #787 codex round-2 P1: the ready-to-fill scaffold (see
+# _falsified_scaffold below) itself starts a line with "Falsified:", so a
+# verbatim copy-paste that never fills in the placeholders would otherwise
+# silently satisfy this exact-prefix check with zero probe evidence — the
+# gate this hook exists to enforce. A line carrying any of these literal
+# placeholder tokens in its evidence region does not count as satisfied.
+_SCAFFOLD_PLACEHOLDER_TOKENS = ("<command>", "<observed>", "<...>")
+
+# Issue #787 codex round-5 P2: the scaffold format is
+# "Falsified: {label} — probe: <command> → <observed>; ...", and {label} is
+# seeded verbatim from the actual option label. If an option's own label
+# text happens to contain one of the placeholder tokens (e.g. a label
+# literally reading "Run <command> manually"), scanning the WHOLE line
+# would flag it as unfilled forever, even after the probe/observed content
+# past this marker is genuinely filled in. The evidence a probe must
+# supply lives after this marker, so placeholder scanning is scoped to
+# that region only — the label prefix is never evidence-bearing.
+_PROBE_MARKER = " — probe: "
+
+
+def _has_falsified_line(texts: list[str], triggering_labels: list[str]) -> bool:
+    """True if every label in `triggering_labels` is addressed by its own
+    clean 'Falsified:' line, and NO 'Falsified:'-prefixed, scaffold-shaped
+    line still carries an unfilled scaffold placeholder in its evidence
+    region.
+
+    `triggering_labels` is the deduped list of option labels that triggered
+    T1/T2 for this question. When there are 0 or 1 triggering labels, ANY
+    clean line satisfies the question (the pre-#787 contract, in place
+    since issue #290: a single free-form Falsified line covers the whole
+    question regardless of wording — there is no ambiguity about which
+    option it addresses when only one is in play). When there are 2+
+    triggering labels, each one must be individually covered.
+
+    Issue #787 codex round-9 P1 (count-only verification silent-pass): the
+    prior contract counted DISTINCT clean lines against `required_count`
+    without checking which triggering option each line actually addressed.
+    Two differently-worded lines both about Option A satisfied
+    `required_count=2` for a 2-option question while Option B was never
+    verified at all. A line is now matched to a specific triggering label
+    by checking whether it starts with `"Falsified: {label}"` (the exact
+    shape the scaffold seeds verbatim) — longest labels are checked first
+    so one label can't shadow a longer sibling label that has it as a
+    prefix. Coverage requires every triggering label to have >= 1 matched
+    line; unmatched lines still count toward the single-label-mode
+    "any clean line" contract but no longer inflate a raw count.
+
+    Issue #787 codex round-9 P2 (evidence-embedded marker bypass): round-8
+    anchored the probe-delimiter on `rfind()` (the LAST `— probe:` in the
+    line), assuming the scaffold's real delimiter — inserted once, right
+    after the label — is always the rightmost occurrence. If the EVIDENCE
+    text itself (legitimately placed after the real delimiter) happens to
+    contain a second literal `— probe:` substring, `rfind()` picks that
+    spurious later occurrence instead, pushing an actual unfilled
+    placeholder sitting before it (but still within the real evidence
+    region) outside the scanned window — silent pass. Now that a line is
+    matched to its label first, the delimiter is found via `find()` seeded
+    at the END of the matched label prefix — the FIRST `— probe:` after the
+    label, which is structurally always the real, scaffold-inserted one,
+    regardless of how many more `— probe:`-shaped substrings the evidence
+    text contains afterward. This also still closes round-8's original
+    label-embedded-marker case (a label containing `— probe:` no longer
+    matters, since the scan starts strictly after the whole label prefix).
+    A line that matches no known triggering label (true free-form text, or
+    referencing an option outside the current label set) falls back to the
+    prior `rfind()` behavior — there is no label boundary to anchor on.
+
+    Issue #787 codex round-3 P1 (retained): any unfilled scaffold
+    placeholder anywhere in the evidence region voids satisfaction outright,
+    even when other lines are already filled in correctly — fails closed
+    rather than returning True on the first clean line found.
+
+    Issue #787 codex round-5 P2 (retained): placeholder tokens are only
+    checked in the content after the `— probe:` marker — a line lacking the
+    marker is not scaffold-shaped, so it is never scanned for placeholder
+    tokens at all (issue #787 codex round-6 P2: scanning marker-less lines
+    for bare token substrings falsely perma-blocked genuine free-form
+    evidence whose own wording happened to contain one, e.g. an option
+    literally named `<command>` referenced without ever using the
+    auto-scaffold's `— probe:` phrasing).
+
+    Issue #787 codex round-10 P2 (label-boundary false match): round-9's
+    `line.startswith(f"Falsified: {label}")` matched a label as a bare
+    substring prefix, not a whole-token prefix. With triggering labels
+    `["Run", "Other"]`, a line reading `Falsified: Runtime behavior
+    verified — probe: ...` matched the `"Run"` prefix (since `"Runtime"`
+    starts with `"Run"`) and credited `"Run"` as covered even though the
+    line never actually addresses that option — the real `"Run"` claim
+    stayed unverified while the gate silently passed. round-10 required a
+    non-alphanumeric character immediately after the label prefix.
+
+    Issue #787 codex round-12 P2 (near-miss label prefix): round-10's
+    non-alphanumeric boundary was still too permissive — a genuinely
+    DIFFERENT, unrelated option label that happens to share the triggering
+    label as its own prefix, separated by a space, also has a non-
+    alphanumeric boundary. With triggering labels `["Merge (Recommended)",
+    "Run"]`, a line reading `Falsified: Run now — probe: ...` (evidence
+    that is really about a different `"Run now"` option, not the
+    triggering `"Run"`) matched `"Run"`'s prefix with `" "` as the
+    boundary, wrongly crediting `"Run"` as covered. The only boundary that
+    reliably means "the label ends here and evidence begins" is the
+    scaffold's own delimiter: a label match now counts only when the line
+    ends exactly at the label (remainder empty) or the remainder starts
+    with the literal `_PROBE_MARKER` string. `"Run now"` no longer
+    satisfies `"Run"` because `" now"` does not start with `" — probe: "`.
+    """
+    labels_by_len = sorted(dict.fromkeys(triggering_labels), key=len, reverse=True)
+    single_label_mode = len(labels_by_len) <= 1
+
+    clean_lines: set[str] = set()
+    covered_labels: set[str] = set()
     for text in texts:
         for line in text.splitlines():
-            if line.startswith("Falsified:"):
-                return True
-    return False
+            if not line.startswith("Falsified:"):
+                continue
+
+            matched_label = None
+            label_end = 0
+            for label in labels_by_len:
+                prefix = f"Falsified: {label}"
+                if not line.startswith(prefix):
+                    continue
+                remainder = line[len(prefix) :]
+                # Issue #787 codex round-10 P2: startswith() alone matched
+                # a label as a bare substring prefix, not a whole-token
+                # prefix — labels=["Run", "Other"] let a line reading
+                # "Falsified: Runtime behavior verified — probe: ..." match
+                # "Run" (since "Runtime" starts with "Run"), crediting the
+                # "Run" option as covered even though the line never
+                # actually addresses it. round-10 required a non-
+                # alphanumeric character after the label, but that is still
+                # too weak: issue #787 codex round-12 P2 — a genuinely
+                # DIFFERENT option label sharing the triggering label as its
+                # own prefix, separated by a space (e.g. triggering "Run"
+                # vs. the unrelated text "Run now"), also has a non-
+                # alphanumeric boundary (the space) yet is not evidence for
+                # the triggering label at all. The boundary must be the
+                # scaffold's own delimiter or true end-of-line — nothing
+                # else can be trusted to mean "the label ends here and
+                # evidence begins": the label match only counts when it is
+                # the whole line (remainder empty) or immediately followed
+                # by the literal `_PROBE_MARKER` string.
+                if remainder and not remainder.startswith(_PROBE_MARKER):
+                    continue
+                matched_label = label
+                label_end = len(prefix)
+                break
+
+            if matched_label is not None:
+                marker_at = line.find(_PROBE_MARKER, label_end)
+            else:
+                marker_at = line.rfind(_PROBE_MARKER)
+
+            if marker_at != -1:
+                evidence_region = line[marker_at + len(_PROBE_MARKER) :]
+                if any(token in evidence_region for token in _SCAFFOLD_PLACEHOLDER_TOKENS):
+                    return False
+
+            clean_lines.add(" ".join(line.split()))
+            if matched_label is not None:
+                covered_labels.add(matched_label)
+
+    if single_label_mode:
+        return len(clean_lines) >= 1
+    return all(label in covered_labels for label in labels_by_len)
 
 
 def _has_recommended_marker(labels: list[str]) -> bool:
@@ -205,6 +367,114 @@ def _has_recommended_marker(labels: list[str]) -> bool:
             if marker in label:
                 return True
     return False
+
+
+def _normalize_label(label: str) -> str:
+    """Collapse embedded newlines/whitespace runs to single spaces.
+
+    Issue #787 codex round-11 P2: a raw option label containing a literal
+    newline splits `_falsified_scaffold`'s single-physical-line output
+    across two printed lines (`f"Falsified: {label} — probe: ..."`
+    interpolates the label verbatim). A verbatim copy-paste of that
+    unfilled scaffold then has its placeholder tokens land on the SECOND
+    physical line, which does not start with `Falsified:` — invisible to
+    `_has_falsified_line`'s per-line scan, silently passing an evidence-free
+    question. Normalizing at the single point labels enter the triggering
+    pipeline (this function's callers) keeps every downstream consumer —
+    scaffold generation and `_has_falsified_line` matching alike — on the
+    same "one physical line per label" invariant, without needing the fix
+    duplicated in each consumer.
+    """
+    return " ".join(label.split())
+
+
+def _t1_matching_labels(labels: list[str]) -> list[str]:
+    """Option labels carrying the exact (Recommended)/(추천) marker (T1 scope)."""
+    matched: list[str] = []
+    for label in labels:
+        if any(marker in label for marker in RECOMMENDED_MARKERS_EXACT_EN):
+            matched.append(_normalize_label(label))
+        elif any(marker in label for marker in RECOMMENDED_MARKERS_EXACT_KO):
+            matched.append(_normalize_label(label))
+    return matched
+
+
+def _t2_matching_labels(options: list) -> list[str]:
+    """Option labels whose own label OR description carries an anchoring token (T2 scope)."""
+    matched: list[str] = []
+    for o in options:
+        if not isinstance(o, dict):
+            continue
+        label = o.get("label")
+        if not isinstance(label, str):
+            continue
+        if _has_confidence_anchoring(collect_option_texts([o])):
+            matched.append(_normalize_label(label))
+    return matched
+
+
+def _dedupe_labels(labels: list[str]) -> list[str]:
+    """Order-preserving de-dup for aggregated scaffold labels (issue #787)."""
+    return list(dict.fromkeys(labels))
+
+
+def _falsified_scaffold(labels: list[str]) -> str:
+    """Ready-to-fill `Falsified:` line(s), one per triggering option label.
+
+    Issue #787: the block message previously told the agent to add a
+    `Falsified:` line but left the whole line to be reconstructed on retry,
+    costing +1 turn every time. The label is the one fact this hook can
+    supply with certainty (it is in the blocked tool_input); probe/observed/
+    reason stay as placeholders — the probe itself is the intended cost and
+    is never fabricated here.
+    """
+    if not labels:
+        return ""
+    lines = [
+        f"Falsified: {label} — probe: <command> → <observed>; premise survives because <...>"
+        for label in labels
+    ]
+    return "\n".join(lines)
+
+
+def _build_ask_msg(labels: list[str]) -> str:
+    scaffold = _falsified_scaffold(labels)
+    if not scaffold:
+        return ASK_MSG
+    return f"{ASK_MSG} [scaffold]\n{scaffold}"
+
+
+def _build_anchoring_ask_msg(labels: list[str]) -> str:
+    scaffold = _falsified_scaffold(labels)
+    if not scaffold:
+        return ANCHORING_ASK_MSG
+    return f"{ANCHORING_ASK_MSG} [scaffold]\n{scaffold}"
+
+
+def _record_block_telemetry(session_id: object, decision: str) -> None:
+    """Rich fire-ledger record for a T1/T2 block event (issue #787).
+
+    The coarse @fail_open recorder sees rc=0 for every call here (deny/ask
+    are signaled via a stdout JSON `permissionDecision`, not exit code 2), so
+    it always logs "pass" for this hook — leaving cross-session block-rate
+    measurement to transcript grep, which over-counts sessions that merely
+    quote the block message in a retrospect report. This records the real
+    decision with session attribution so that count can come from the ledger
+    instead.
+
+    After the RICH record is written, also suppresses this process's coarse
+    fallback (`_fire_ledger.suppress_coarse_duplicate`) — otherwise
+    `aggregate_fires()` sums both the RICH "block"/"ask" record and the
+    COARSE "pass" record for the same call, turning one deny into
+    `fires=2, block=1, pass=1` and corrupting the exact block-rate count
+    this telemetry exists to provide.
+    """
+    if not isinstance(session_id, str) or not session_id:
+        return
+    _fire_ledger.record_session_fire(
+        _TELEMETRY_HOOK_NAME, _TELEMETRY_HOOK_ROLE, decision, session_id, "AskUserQuestion"
+    )
+    _fire_ledger.suppress_coarse_duplicate()
 
 
 def _has_confidence_anchoring(texts: list[str]) -> bool:
@@ -310,9 +580,17 @@ def main() -> int:
         questions = tool_input.get("questions") or []
         if not isinstance(questions, list):
             questions = []
-        # tier_decision: None | "deny" (T1) | "ask" (T2)
-        tier_decision: str | None = None
-        msg_to_emit: str = ASK_MSG
+        # Issue #787: scan every question — no early break. Stopping at the
+        # first violating question left later violating questions
+        # unaddressed, so the agent hit a second block on retry even after
+        # filling in the first scaffold. any_t1/any_t2 decide the final
+        # tier (T1 still wins over T2, same as the pre-#787 precedence);
+        # t1_labels/t2_labels aggregate labels from EVERY offending
+        # question so one retry can cover all of them.
+        any_t1_violation = False
+        any_t2_violation = False
+        t1_labels: list[str] = []
+        t2_labels: list[str] = []
         advisory_needed = False
         for q in questions:
             if not isinstance(q, dict):
@@ -329,31 +607,82 @@ def main() -> int:
             # Per-question check: only this question's text counts.
             q_text = q.get("question")
             q_texts = [q_text] if isinstance(q_text, str) else []
-            falsified_present = _has_falsified_line(q_texts)
 
+            # Issue #787 codex round-7 P2: T1 and T2 triggering labels are
+            # computed independently (not via if/elif) because a single
+            # question can carry BOTH an exact (Recommended) option (T1)
+            # AND a separate confidence-anchoring option (T2, e.g. a
+            # "safer" description with no (Recommended) marker). The prior
+            # if/elif skipped the T2 check entirely once T1 matched, so the
+            # T2 option's label never entered `required_count` — a retry
+            # that only filled in the T1 option's evidence silent-passed
+            # with the T2 option's claim never verified. T1 still decides
+            # the FINAL deny-vs-ask precedence below (unchanged), but both
+            # tiers' labels are now pooled into one evidence requirement
+            # for the question, consistent with the existing count-based
+            # (not exact-label-matched) `required_count` contract.
+            t1_triggering: list[str] = []
             if _has_exact_recommended_marker(q_labels):
                 # T1: literal (Recommended) / (추천) marker in label.
                 # Issue #393: upgraded from ask to deny (hard block).
-                if not falsified_present:
-                    tier_decision = "deny"
-                    msg_to_emit = ASK_MSG
-                    break  # T1 deny is final — overrides any prior T2 ask
-            elif _has_confidence_anchoring(collect_option_texts(options)):
+                # Dedup WITHIN this question only (defends against a single
+                # question listing the same label twice) — NOT across
+                # questions (issue #787 codex round-3 P2): each question's
+                # own text is checked independently, so 2 different
+                # questions sharing the same label text each need their
+                # own scaffold line.
+                t1_triggering = _dedupe_labels(_t1_matching_labels(q_labels))
+
+            t2_triggering: list[str] = []
+            if _has_confidence_anchoring(collect_option_texts(options)):
                 # T2 (issue #369): confidence-anchoring framing token in
                 # label OR description. Soft gate — false-positive risk
-                # higher than T1's literal marker. Record but keep scanning
-                # so a later T1 violation can upgrade the decision to deny.
-                if not falsified_present and tier_decision is None:
-                    tier_decision = "ask"
-                    msg_to_emit = ANCHORING_ASK_MSG
+                # higher than T1's literal marker.
+                #
+                # Exclude labels already in t1_triggering: T2's bare
+                # `recommend(?:ed|s)?` pattern matches the literal word
+                # inside "(Recommended)" too, so an option carrying the
+                # exact T1 marker also, incidentally, matches T2. Without
+                # this filter the same label would be appended to BOTH
+                # t1_labels and t2_labels below, double-counting it in
+                # `required_count` and duplicating its scaffold line in
+                # the final `t1_labels + t2_labels` deny message — this is
+                # not a second, independent claim to verify, just the
+                # same marker matching two patterns.
+                t2_triggering = [
+                    label
+                    for label in _dedupe_labels(_t2_matching_labels(options))
+                    if label not in t1_triggering
+                ]
+
+            combined_triggering = _dedupe_labels(t1_triggering + t2_triggering)
+            if combined_triggering:
+                # Each label in combined_triggering (issue #787 codex
+                # round-4 P1, extended round-7, round-9 P1) must be
+                # individually addressed by its own clean line — a scaffold
+                # satisfied by deleting a line, or by pasting distinct-but-
+                # off-target evidence for only one option, must still block.
+                if not _has_falsified_line(q_texts, combined_triggering):
+                    if t1_triggering:
+                        any_t1_violation = True
+                        t1_labels.extend(t1_triggering)
+                    if t2_triggering:
+                        any_t2_violation = True
+                        t2_labels.extend(t2_triggering)
             elif _has_recommended_marker(q_labels):
                 # T3 (dead under new precedence — kept for clarity).
                 advisory_needed = True
 
-        if tier_decision == "deny":
-            _emit_deny(msg_to_emit)
-        elif tier_decision == "ask":
-            _emit_ask(msg_to_emit)
+        if any_t1_violation:
+            # T1 deny is final — overrides any T2 ask — but the scaffold
+            # still aggregates T2 labels too so a question that only
+            # violates T2 doesn't reblock on the very next retry. No
+            # cross-question dedup here (see comment above).
+            _record_block_telemetry(payload.get("session_id"), _fire_ledger.DECISION_BLOCK)
+            _emit_deny(_build_ask_msg(t1_labels + t2_labels))
+        elif any_t2_violation:
+            _record_block_telemetry(payload.get("session_id"), _fire_ledger.DECISION_ASK)
+            _emit_ask(_build_anchoring_ask_msg(t2_labels))
         elif advisory_needed:
             sys.stderr.write(ADVISORY_MSG + "\n")
 

--- a/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
@@ -147,6 +147,240 @@ matched; read-only commands (`git log --all`, `gh pr list`) do not fire.
 
 **Exit code:** `0`.
 
+#### Ready-to-fill `Falsified:` scaffold (issue #787)
+
+Both the T1 deny and T2 ask `permissionDecisionReason` above end with a
+`[scaffold]` marker followed by one copy-paste-ready `Falsified:` line per
+triggering option label, parsed straight from the blocked `tool_input`:
+
+```
+[scaffold]
+Falsified: <option label> — probe: <command> → <observed>; premise survives because <...>
+```
+
+One line is emitted per option that actually carried the marker/token that
+tripped the tier (T1: the exact `(Recommended)`/`(추천)` label; T2: the
+label or description matching an anchoring token) — so a question with two
+triggering options gets two scaffold lines. The label is the only field
+this hook can supply with certainty since it is already in the blocked call;
+`<command>` / `<observed>` / `<...>` stay as placeholders — running the
+actual probe is the intended cost this gate preserves, only the *format
+reconstruction* cost is removed. No scaffold section is appended when
+`Falsified:` is already present (silent-pass path).
+
+When more than one option in the same question triggers the tier, one
+`Falsified:` line is emitted per label. When more than one *question* in
+the payload has a violation, labels from every offending question are
+aggregated into the same scaffold (not just the first one encountered) —
+otherwise fixing only the first question's line would still hit a second
+block on retry for the un-addressed question.
+
+**Anti-bypass guard**: because the scaffold line itself starts with
+`Falsified:`, a verbatim copy-paste that never fills in the placeholders
+would otherwise satisfy the exact-prefix check with zero probe evidence —
+defeating the falsification gate this hook exists to enforce.
+`_has_falsified_line` rejects any line containing the literal placeholder
+tokens `<command>`, `<observed>`, or `<...>` — and fails CLOSED for the
+whole question if even one `Falsified:`-prefixed line still carries a
+placeholder, even when a sibling line in the same question is already
+filled in correctly (a question can have more than one triggering option,
+hence more than one scaffold line — partially filling in only one must not
+let the other ride along unchecked).
+
+Placeholder-token rejection alone still leaves a gap: a line can be
+**omitted entirely** rather than left with a placeholder, and an omitted
+line has no placeholder text for the token check to catch. `_has_falsified_line`
+therefore takes a `triggering_labels` parameter — the deduped list of
+labels that tripped T1/T2 for that question — and requires that every
+label in it is covered by its own matched `Falsified:` line. A question
+with 2 triggering options and only 1 `Falsified:` line (the second
+silently absent, not placeholder-marked) now fails the coverage check and
+still denies. When 0 or 1 labels are triggering, ANY clean line satisfies
+the question — preserving the original single-triggering-label contract
+(issue #290) unchanged.
+
+**Per-label coverage, not raw count (issue #787 codex round-9 P1):** a
+prior version of this gate counted DISTINCT clean lines against
+`required_count` without checking which triggering option each line
+actually addressed — 2 differently-worded lines both about Option A
+satisfied `required_count=2` for a 2-option question while Option B was
+never verified at all. Each clean line is now matched to the specific
+triggering label it addresses by checking whether it starts with
+`"Falsified: {label}"` (the exact shape the scaffold seeds verbatim,
+longest labels checked first so a shorter label can't shadow a longer
+sibling that has it as a prefix); satisfaction requires every triggering
+label to have at least one matched line, not just N distinct lines.
+
+**Scan window (issue #787 codex round-5/6 P2)**: the scaffold seeds each
+line's label segment verbatim from the actual option label (`Falsified:
+{label} — probe: ...`). If an option's own label text happens to contain a
+literal `<command>` / `<observed>` / `<...>` substring, scanning the whole
+line for placeholder tokens would flag it as unfilled forever — no amount
+of genuinely filling in the probe/observed content could ever satisfy the
+gate for that label. The evidence a probe must supply lives after the
+`— probe:` marker, so placeholder-token scanning is scoped to that region
+only (`_PROBE_MARKER`); the label prefix, which is never evidence-bearing,
+is excluded. A line WITHOUT the marker is not scaffold-shaped at all — it
+is never scanned for placeholder tokens (round-6 P2 correction: round-5
+still fell back to scanning the whole marker-less line, which continued to
+falsely perma-block genuine free-form evidence whose own wording happened
+to contain one of the three literal token strings without ever using the
+`— probe:` phrasing; the actual scaffold copy-paste bypass this guard
+exists to close always contains the marker, since it is emitted verbatim
+by `_falsified_scaffold`, so exempting marker-less lines cannot reopen it).
+
+**Duplicate-line dedup (issue #787 codex round-6 P2)**: `required_count`
+counting (see above) previously counted raw clean lines, so a 2-option
+question could be satisfied by pasting the SAME clean `Falsified:` line
+twice — `Falsified:` lines are now deduped by exact text before counting,
+so an identical duplicate contributes nothing toward `required_count` and
+the second triggering option still needs its own distinct line.
+
+**Per-question label scope**: dedup of aggregated scaffold labels applies
+only WITHIN a single question (defends against one question listing the
+same label twice), never ACROSS questions. `Falsified:` satisfaction is
+checked per-question against that question's own text, so if two different
+questions happen to present an option with the identical label text, each
+still needs its own scaffold line — collapsing them to one would leave the
+second question blocked on retry.
+
+**Mixed T1+T2 tier pooling (issue #787 codex round-7 P2)**: a single
+question can carry both an exact `(Recommended)` option (T1) and a
+separate confidence-anchoring option with no marker at all (T2 — e.g. a
+`safer` description). T1 and T2 triggering labels are computed
+independently per question (not via `if`/`elif`) and pooled into one
+combined `required_count` — the prior `if`/`elif` skipped the T2 check
+entirely once T1 matched for the question, so a retry that only supplied
+evidence for the T1 option silent-passed with the T2 option's claim never
+verified. T1 still decides the final deny-vs-ask precedence (unchanged);
+only the per-question evidence requirement changed.
+
+T2's bare `recommend(?:ed|s)?` pattern also matches the literal word
+inside `(Recommended)`, so an option carrying the exact T1 marker
+incidentally also matches T2's check. Labels already present in
+`t1_triggering` are excluded from `t2_triggering` before pooling — without
+this, a pure-T1 2-option question would double-count each label into both
+`t1_labels` and `t2_labels`, producing duplicate scaffold lines in the
+final deny message for a case with no genuine T2-only option at all.
+
+**Real-delimiter anchoring + whitespace-normalized dedup (issue #787 codex
+round-8 P2, two findings):**
+
+1. **Label-embedded marker permablock.** The scaffold's own `— probe:`
+   delimiter is always the LAST occurrence of that substring in the line —
+   it is appended once, after the label, at scaffold-generation time. An
+   option label that itself happens to contain the literal `— probe:`
+   substring (e.g. a label quoting another probe's shape) previously
+   shifted the scan to that earlier, label-internal occurrence via
+   `line.find(_PROBE_MARKER)` (leftmost match), pulling trailing label
+   text — and any placeholder token it contained — into `evidence_region`.
+   That permanently hard-denied the line even after genuine evidence was
+   filled in after the real, rightmost delimiter, with no way to ever
+   satisfy the gate for that label. `_has_falsified_line` now uses
+   `line.rfind(_PROBE_MARKER)` to anchor on the real, last-inserted
+   delimiter instead.
+2. **Whitespace-only duplicate bypass.** Exact-text dedup (round-6 P2)
+   treated two lines differing only by whitespace (e.g. one trailing
+   space, or a doubled internal space) as DISTINCT strings. Pasting the
+   same real evidence line twice with a whitespace-only variation on the
+   second copy satisfied `required_count=2` for a 2-option question while
+   the second triggering option still had zero real evidence. Lines are
+   now whitespace-normalized (`" ".join(line.split())` — strips
+   leading/trailing whitespace and collapses internal runs to one space)
+   before entering the dedup set, so a whitespace-only "duplicate" still
+   collapses to the same clean line and contributes nothing toward
+   `required_count`.
+
+**Label-anchored coverage + delimiter matching (issue #787 codex round-9,
+two findings):**
+
+1. **Count-only verification silent-pass (P1).** The round-4/6/8 contract
+   verified a multi-option question by counting distinct clean lines
+   against `required_count` without ever checking which triggering option
+   each line actually addressed. Two differently-worded lines both
+   starting with `Falsified: Option A ...` satisfied `required_count=2`
+   for a 2-option question while `Option B` was never verified — the
+   count was right, the coverage was wrong. `_has_falsified_line` no
+   longer takes a bare count; it takes the `triggering_labels` list
+   directly and matches each clean line to a specific label via its
+   `"Falsified: {label}"` prefix (longest labels checked first, so a
+   label that is a prefix of a longer sibling label can't shadow it).
+   Satisfaction now requires every triggering label to be covered by its
+   own matched line, closing the coverage gap the raw count could not see.
+2. **Evidence-embedded marker bypass (P2).** Round-8's `rfind()` fix
+   assumed the scaffold's real `— probe:` delimiter is always the
+   RIGHTMOST occurrence in the line, since it's inserted once, after the
+   label, at scaffold-generation time. That assumption breaks when the
+   EVIDENCE text itself (legitimately placed after the real delimiter)
+   contains a second literal `— probe:` substring — `rfind()` then
+   anchors on that spurious, later occurrence, pushing an actual unfilled
+   placeholder sitting before it (but still inside the real evidence
+   region) outside the scanned window. Now that each line is matched to
+   its triggering label first, the delimiter is located via
+   `line.find(_PROBE_MARKER, label_end)` — the FIRST `— probe:`
+   occurrence strictly after the matched label's own text — which is
+   structurally always the real, scaffold-inserted delimiter regardless
+   of how many more `— probe:`-shaped substrings appear later in the
+   evidence. This also still closes round-8's original label-embedded-
+   marker case, since the scan now starts after the whole label prefix
+   rather than depending on which occurrence is textually first or last.
+   A line matching no known triggering label (true free-form text, or
+   referencing an option outside the current label set) falls back to the
+   prior `rfind()` behavior, since there is no label boundary to anchor
+   on for that line.
+
+**Label-boundary false match (issue #787 codex round-10 P2):** round-9's
+`line.startswith(f"Falsified: {label}")` matched a label as a bare
+substring prefix, not a whole-token prefix. With triggering labels
+`["Run", "Other"]`, a line reading `Falsified: Runtime behavior verified
+— probe: ...` matched the `"Run"` prefix (since `"Runtime"` starts with
+`"Run"`) and credited `"Run"` as covered even though the line never
+actually addresses that option — the real `"Run"` claim stayed
+unverified while the multi-option coverage gate silently passed. A label
+match now also requires a boundary immediately after the prefix: either
+the line ends there, or the next character is non-alphanumeric (the
+scaffold's own `" — probe: "` continuation, or any other non-identifier-
+continuing delimiter). `"Runtime"` no longer satisfies `"Run"` because
+`"t"` is alphanumeric. This surface is most reachable for bare (no
+`(Recommended)`/`(추천)` suffix) T2 labels, since a label ending in the
+closing paren of an exact marker already has an inherently safe boundary
+in practice.
+
+**Newline-in-label scaffold splitting (issue #787 codex round-11 P2):**
+`_falsified_scaffold` interpolates each triggering option's raw label
+verbatim into a single f-string line (`f"Falsified: {label} — probe:
+..."`). If the label itself contains a literal newline, that single
+logical line prints as two PHYSICAL lines in the deny/ask message. A
+verbatim copy-paste of that unfilled scaffold then has its `Falsified:`
+prefix on the first physical line and its placeholder-bearing evidence
+(`<command>`, `<observed>`, `<...>`) on the second — which does not start
+with `Falsified:` and is therefore invisible to `_has_falsified_line`'s
+per-physical-line scan, silently passing an evidence-free question.
+Labels are now whitespace-normalized (`" ".join(label.split())` —
+identical to the round-8 whitespace-normalization idiom, collapsing any
+embedded newlines/whitespace runs to single spaces) at the single point
+they enter the triggering pipeline (`_t1_matching_labels` /
+`_t2_matching_labels`), before either scaffold generation or
+`_has_falsified_line` matching consumes them — guaranteeing every
+generated scaffold stays exactly one physical line per label regardless
+of what the raw option label contains.
+
+**Near-miss label prefix (issue #787 codex round-12 P2):** round-10's
+non-alphanumeric boundary was still too permissive — a genuinely
+DIFFERENT, unrelated evidence line that happens to share the triggering
+label as its own prefix, separated by a space, also clears a
+non-alphanumeric boundary check. With triggering labels `["Merge
+(Recommended)", "Run"]`, a line reading `Falsified: Run now — probe:
+...` (evidence that is really about a different `"Run now"` option, not
+the triggering `"Run"`) matched `"Run"`'s prefix with `" "` as the
+boundary, wrongly crediting `"Run"` as covered while the real `"Run"`
+claim stayed unverified. The only boundary that reliably means "the
+label ends here and evidence begins" is the scaffold's own delimiter: a
+label match now counts only when the line ends exactly at the label
+(remainder empty) or the remainder starts with the literal
+`_PROBE_MARKER` string (`" — probe: "`) — not merely any non-alphanumeric
+character.
+
 #### Advisory (Bash bulk-action only)
 
 Note: case-insensitive `(recommended)` alone previously emitted advisory
@@ -165,6 +399,26 @@ instead of surfacing the proposal.
 ```
 
 **Exit code:** `0`.
+
+### Block-event telemetry (issue #787)
+
+Every T1 deny / T2 ask decision also appends one RICH record to the shared
+fire-ledger (`hooks/_lib/_fire_ledger.py`, `record_session_fire`) — hook
+`output-block-falsify-advisory`, role `advisory-nudge`, `decision` = `block`
+(T1) or `ask` (T2), `tool` = `AskUserQuestion`, `session_id` from the hook
+payload. Skipped when `session_id` is missing or empty (cannot attribute).
+
+This exists because this hook signals deny/ask via a stdout JSON
+`permissionDecision`, not exit code 2 — so the universal `@fail_open` coarse
+recorder (which only inspects the return code) always logs `pass` for these
+calls. Before issue #787, cross-session block-rate measurement had to fall
+back to grepping session transcripts for the block message string, which
+over-counts sessions that merely quote the message in a retrospect report.
+The RICH record gives an exact per-session count instead.
+
+Storage/opt-out follow `_fire_ledger`'s existing contract: default
+`~/.praxis/telemetry/fire-events-YYYY-MM-DD.jsonl`, override via
+`PRAXIS_FIRE_TELEMETRY_FILE`, disable via `PRAXIS_FIRE_TELEMETRY_DISABLE=1`.
 
 ### Parsing guarantees
 
@@ -186,7 +440,20 @@ All parsing is done with the Python standard library only.
 bash tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
 ```
 
-Covers 47 cases (44 pre-#682 + 3 new):
+**Harness isolation (issue #787 codex round-6 P2)**: every `run_case`
+invocation calls the hook directly, and the T1/T2 deny/ask cases each write
+a RICH telemetry record. The script exports a throwaway
+`PRAXIS_FIRE_TELEMETRY_FILE` default at the top so these dozens of test
+invocations never land in the real `~/.praxis/telemetry/` store — the
+telemetry-content-checking cases further down still override the var
+per-call to their own `TEL_DIR` paths, which wins for that one invocation.
+Separately, the `pass` expectation in `run_case` now checks stdout is empty
+in addition to stderr — a deny/ask decision also exits 0 with empty
+stderr (it signals via stdout JSON, not stderr), so a stderr-only check
+could not actually distinguish a real silent pass from an undetected
+deny/ask.
+
+Covers 88 cases (47 pre-#787 + 41 new — 5 scaffold, 4 telemetry, 4 multi-question/coarse-dedup fixes, 28 anti-bypass/false-positive):
 
 **T1 deny-escalation (AskUserQuestion, issue #290/#393):**
 
@@ -234,3 +501,56 @@ Covers 47 cases (44 pre-#682 + 3 new):
 - `(Recommended)` + no `Falsified:` → deny message contains `pre-author-template` ASCII marker
 - confidence-anchoring (`safer`) + no `Falsified:` → ask message contains `pre-author-template` ASCII marker
 - `(Recommended)` + column-0 `Falsified:` present → silent pass (regression — template-level message change must not break satisfaction)
+
+**Ready-to-fill scaffold cases (issue #787):**
+
+- T1 deny message embeds `Falsified: <label>` seeded from the triggering option label
+- T1 deny message contains the `[scaffold]` marker
+- T2 ask message embeds `Falsified: <label>` seeded from the anchoring-token-carrying label
+- 2 options both carrying `(Recommended)` → 2 scaffold `Falsified:` lines (one per label)
+- `(Recommended)` + `Falsified:` already present → no scaffold needed (silent pass, regression)
+
+**Block-event telemetry cases (issue #787):**
+
+- T1 deny → 1 RICH fire-ledger record with `decision=block`, correct `hook`/`role`/`tool`/`session_id`
+- T1 deny → the automatic COARSE `pass` duplicate is suppressed (1 total line in the telemetry file, not 2)
+- T2 ask → 1 RICH fire-ledger record with `decision=ask`
+- T2 ask → COARSE duplicate suppressed (1 total line)
+- Silent pass → no RICH record written
+- Missing `session_id` → deny still fires on stdout, but no RICH record (cannot attribute)
+
+**Multi-question aggregation cases (issue #787 codex round-1 P2 fix):**
+
+- 2 separate questions, each with its own T1 violation, no `Falsified:` in either → both labels appear in the deny scaffold (not just the first)
+- 2 separate questions, each with its own T2-only (anchoring) violation → both labels appear in the ask scaffold
+
+**Anti-bypass placeholder-rejection cases (issue #787 codex round-2/3/4/5/6/7/8/9/10/11/12 fixes):**
+
+- T1: copying the unfilled scaffold line verbatim into the question body does NOT satisfy the gate → still deny
+- T2: same unfilled-copy-paste check → still ask
+- T1: scaffold line with all placeholders replaced by real probe output → silent pass (regression — the fix must not make legitimate filled-in evidence unsatisfiable)
+- T1: 1 of 2 scaffold lines filled in, the other still carries a placeholder → still deny (round-3 P1 — a sibling clean line must not let an unfilled one ride along)
+- T1: both scaffold lines for a 2-option question fully filled in → silent pass (regression)
+- 2 different questions presenting the identical triggering label → 2 separate scaffold lines, not collapsed by dedup (round-3 P2)
+- T1: 1 of 2 triggering options has a `Falsified:` line, the other is omitted entirely (no placeholder left anywhere) → still deny (round-4 P1 — placeholder-token rejection alone cannot catch a deleted line; fixed via `required_count`-based counting)
+- T1: single triggering label with its one clean `Falsified:` line → silent pass (regression — `required_count` defaults to 1, preserving the original single-label contract)
+- T1: option label literally contains `<command>`, evidence past `— probe:` genuinely filled in → silent pass (round-5 P2 — the label prefix is never evidence-bearing, so it must not be scanned for placeholder tokens)
+- T1: option label literally contains `<command>` AND the evidence past `— probe:` is still unfilled → still deny (regression — round-5's narrowed scan window must not disable the guard itself)
+- T1: legacy free-form line with no `— probe:` marker whose own wording contains `<command>` → silent pass (round-6 P2 — round-5 still scanned marker-less lines whole; marker-less lines are excluded from placeholder scanning entirely since they are not scaffold-shaped)
+- T1: same clean `Falsified:` line pasted twice for a 2-option question → still deny (round-6 P2 — raw line-count could be satisfied by duplicating one option's evidence; lines are now deduped by exact text before counting)
+- T1: 2 genuinely distinct clean lines for 2 options → silent pass (regression — dedup must reject only exact-text duplicates, not require exact label-text matching)
+- Mixed T1+T2 in one question, only the T1 option's evidence provided → still deny (round-7 P2 — the prior `if`/`elif` skipped the T2 check entirely once T1 matched, so the T2 option's claim never entered `required_count`)
+- Mixed T1+T2 in one question, both options' evidence provided → silent pass (regression)
+- Pure-T1 2-option question → scaffold shows each label exactly once, no duplication (regression — round-7's self-catch: T2's bare `recommend` pattern also matches inside `(Recommended)`, so T1-covered labels must be excluded from `t2_triggering` or they double-count into both `t1_labels` and `t2_labels`)
+- T1: option label itself embeds the `— probe:` delimiter substring plus a placeholder token, real evidence supplied after the actual (rightmost) delimiter → silent pass (round-8 P2 — `find()`'s leftmost match anchored on the label-internal marker instead of the real, last-inserted one, pulling the label's own placeholder text into `evidence_region` and permanently hard-denying; fixed via `rfind()`)
+- T1: same real evidence line pasted twice for a 2-option question with only a whitespace difference (internal double-space) on the second copy → still deny (round-8 P2 — exact-text dedup treated the two as distinct, satisfying `required_count=2` while the second option had zero real evidence; fixed via whitespace normalization before dedup)
+- T1: 2 differently-worded `Falsified:` lines, both prefixed with the SAME triggering label, the other triggering label never addressed → still deny (round-9 P1 — raw distinct-line count satisfied `required_count=2` without checking which option each line actually addressed; fixed via per-label prefix matching and coverage)
+- T1: 2 triggering options, each addressed by its own distinctly-worded `Falsified:` line → silent pass (regression — the round-9 P1 fix maps lines to labels by prefix, it does not require identical wording or more than one line per label)
+- T1: evidence text (after the real `— probe:` delimiter) itself contains a second `— probe:` substring, with an unfilled `<command>` placeholder sitting before that spurious second marker → still deny (round-9 P2 — `rfind()` anchored on the spurious, later marker instead of the real one, pushing the leading placeholder outside the scanned region; fixed via `find()` seeded right after the matched label prefix)
+- T1: same evidence-embeds-a-second-marker shape, but with the evidence genuinely filled in (no placeholder anywhere) → silent pass (regression — the round-9 P2 fix narrows the anchor point, it does not forbid legitimate evidence from containing the word sequence `— probe:` again)
+- T1+T2: a bare (no-marker) triggering label is a literal string-prefix of unrelated evidence text on a sibling line (e.g. `"Rerun"` inside `"Rerunning without confirmation"`) → still deny (round-10 P2 — `startswith()` matched the label as a bare substring prefix without a boundary check, crediting an option that line never actually addresses)
+- T1+T2: same bare-label-is-a-prefix shape, but the label is genuinely addressed by its own whole-token line → silent pass (regression — the round-10 fix requires a boundary after the label, it does not forbid the label from ever matching)
+- An option label contains a literal embedded newline → the deny message's scaffold hint still renders as exactly one physical `Falsified:` line (round-11 P2 — the raw label is normalized before scaffold generation, so the artifact this whole guard depends on can no longer split across lines)
+- Same newline-bearing label, the (now-guaranteed single-line) scaffold copied verbatim and left unfilled → still deny (regression — the fix must not make the placeholder guard unreachable for labels that originally contained a newline)
+- A triggering label (`"Run"`) is the string-prefix of a genuinely different, unrelated evidence line's own text (`"Run now"`) separated by a space → still deny (round-12 P2 — round-10's non-alphanumeric boundary check was too permissive; the boundary must be the exact scaffold delimiter or end-of-line, not any non-alphanumeric character)
+- Same near-miss shape, but the triggering label is genuinely addressed by its own line ending exactly at the scaffold's delimiter → silent pass (regression — the round-12 fix must not forbid the label from ever matching)

--- a/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
@@ -153,7 +153,7 @@ Both the T1 deny and T2 ask `permissionDecisionReason` above end with a
 `[scaffold]` marker followed by one copy-paste-ready `Falsified:` line per
 triggering option label, parsed straight from the blocked `tool_input`:
 
-```
+```text
 [scaffold]
 Falsified: <option label> — probe: <command> → <observed>; premise survives because <...>
 ```
@@ -381,6 +381,32 @@ label match now counts only when the line ends exactly at the label
 `_PROBE_MARKER` string (`" — probe: "`) — not merely any non-alphanumeric
 character.
 
+**Empty scaffold evidence (PR #796 CodeRabbit review):** the `— probe:`
+marker being present was treated as sufficient — a line reading
+`Falsified: <label> — probe:` with nothing (or only whitespace) after the
+marker satisfied the placeholder-token scan, because `any(token in "" for
+token in _SCAFFOLD_PLACEHOLDER_TOKENS)` is vacuously `False` on an empty
+`evidence_region`. Deleting everything after the marker, or moving the
+placeholder tokens onto the next physical line, silently passed a
+zero-content line. An empty or whitespace-only `evidence_region` is now
+treated identically to an unfilled placeholder
+(`not evidence_region.strip() or any(...)`).
+
+**Missing-session_id telemetry undercounting (PR #796 CodeRabbit review):**
+`_record_block_telemetry` early-returned before the RICH write whenever
+`session_id` was absent, by design ("cannot attribute to a session") — but
+this dropped the T1/T2 decision from `aggregate_fires()`'s
+`fires`/`block`/`ask` totals entirely, which is worse than the original
+coarse-duplicate bug the function exists to prevent (that bug mislabeled
+the decision as `pass`; this one made it vanish from the count). Verified
+`record_session_fire` already coerces a non-str `session_id` to `""`, and
+`aggregate_fires` only adds a session to its per-session set when it is a
+non-empty string — so the RICH record is now written unconditionally
+(`session_id=""` when missing), preserving the correct `fires`/`block`/`ask`
+counts without polluting per-session aggregation. Coarse-duplicate
+suppression also moved to run unconditionally, as the function's first
+statement, so it fires even on the missing-`session_id` path.
+
 #### Advisory (Bash bulk-action only)
 
 Note: case-insensitive `(recommended)` alone previously emitted advisory
@@ -453,7 +479,7 @@ stderr (it signals via stdout JSON, not stderr), so a stderr-only check
 could not actually distinguish a real silent pass from an undetected
 deny/ask.
 
-Covers 88 cases (47 pre-#787 + 41 new — 5 scaffold, 4 telemetry, 4 multi-question/coarse-dedup fixes, 28 anti-bypass/false-positive):
+Covers 91 cases (47 pre-#787 + 44 new — 5 scaffold, 5 telemetry, 4 multi-question/coarse-dedup fixes, 30 anti-bypass/false-positive):
 
 **T1 deny-escalation (AskUserQuestion, issue #290/#393):**
 
@@ -524,7 +550,7 @@ Covers 88 cases (47 pre-#787 + 41 new — 5 scaffold, 4 telemetry, 4 multi-quest
 - 2 separate questions, each with its own T1 violation, no `Falsified:` in either → both labels appear in the deny scaffold (not just the first)
 - 2 separate questions, each with its own T2-only (anchoring) violation → both labels appear in the ask scaffold
 
-**Anti-bypass placeholder-rejection cases (issue #787 codex round-2/3/4/5/6/7/8/9/10/11/12 fixes):**
+**Anti-bypass placeholder-rejection cases (issue #787 codex round-2/3/4/5/6/7/8/9/10/11/12 + PR #796 CodeRabbit review fixes):**
 
 - T1: copying the unfilled scaffold line verbatim into the question body does NOT satisfy the gate → still deny
 - T2: same unfilled-copy-paste check → still ask
@@ -554,3 +580,5 @@ Covers 88 cases (47 pre-#787 + 41 new — 5 scaffold, 4 telemetry, 4 multi-quest
 - Same newline-bearing label, the (now-guaranteed single-line) scaffold copied verbatim and left unfilled → still deny (regression — the fix must not make the placeholder guard unreachable for labels that originally contained a newline)
 - A triggering label (`"Run"`) is the string-prefix of a genuinely different, unrelated evidence line's own text (`"Run now"`) separated by a space → still deny (round-12 P2 — round-10's non-alphanumeric boundary check was too permissive; the boundary must be the exact scaffold delimiter or end-of-line, not any non-alphanumeric character)
 - Same near-miss shape, but the triggering label is genuinely addressed by its own line ending exactly at the scaffold's delimiter → silent pass (regression — the round-12 fix must not forbid the label from ever matching)
+- T1: the `— probe:` marker is present, but nothing (or only whitespace) follows it on the same line → still deny (PR #796 CodeRabbit review — an empty `evidence_region` vacuously satisfied the placeholder-token scan since `any()` over an empty string is `False`)
+- Missing `session_id` → the RICH telemetry record is still written, with `session_id=""`, and the COARSE "pass" duplicate remains suppressed (PR #796 CodeRabbit review — the prior early-return dropped the decision from `aggregate_fires()`'s totals entirely rather than merely mislabeling it)

--- a/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
@@ -1028,6 +1028,79 @@ run_case "T1+T2 (issue #787 round-12 P2): label genuinely addressed via the exac
 Falsified: Run — probe: checked run path -> safe; premise survives
 Which one?")"
 
+# Anti-bypass regression (PR #796 CodeRabbit review): the "— probe:" marker
+# is present, but nothing (or only whitespace) follows it on the same
+# line — deleting everything after the marker, or leaving only trailing
+# whitespace, satisfied the gate with zero probe content since the
+# placeholder-token scan finds nothing in an empty evidence_region. The
+# trailing space after "probe:" is built via a Python string literal (not
+# left trailing at end-of-line in this file) so it survives edit-tool
+# whitespace normalization.
+_empty_evidence_decision=$(python3 - <<'PYEOF' | "$HOOK" 2>/dev/null | python3 -c "
+import json, sys
+d = json.loads(sys.stdin.read())
+print(d.get('hookSpecificOutput', {}).get('permissionDecision', 'pass'))
+"
+import json
+question_text = "Falsified: Option A (Recommended) — probe: " + "\nWhat should we do?"
+payload = {
+    "session_id": "test-session",
+    "tool_name": "AskUserQuestion",
+    "tool_input": {
+        "questions": [
+            {
+                "question": question_text,
+                "options": [{"label": "Option A (Recommended)"}, {"label": "Alternative"}],
+            }
+        ]
+    },
+    "cwd": "/tmp",
+}
+print(json.dumps(payload))
+PYEOF
+)
+if [ "$_empty_evidence_decision" = "deny" ]; then
+  echo "  PASS  marker present, empty evidence after it -> still deny (PR #796 CodeRabbit review)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  marker present, empty evidence after it -> still deny (PR #796 CodeRabbit review) (got '$_empty_evidence_decision')"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("marker present, empty evidence after it -> still deny")
+fi
+
+# Regression variant: whitespace-only evidence (not merely zero-length)
+# must also still deny — the fix strips the evidence region before
+# checking emptiness, not just checking for a zero-length string.
+_whitespace_evidence_decision=$(python3 - <<'PYEOF' | "$HOOK" 2>/dev/null | python3 -c "
+import json, sys
+d = json.loads(sys.stdin.read())
+print(d.get('hookSpecificOutput', {}).get('permissionDecision', 'pass'))
+"
+import json
+question_text = "Falsified: Option A (Recommended) — probe: " + "   " + "\nWhat should we do?"
+payload = {
+    "session_id": "test-session",
+    "tool_name": "AskUserQuestion",
+    "tool_input": {
+        "questions": [
+            {
+                "question": question_text,
+                "options": [{"label": "Option A (Recommended)"}, {"label": "Alternative"}],
+            }
+        ]
+    },
+    "cwd": "/tmp",
+}
+print(json.dumps(payload))
+PYEOF
+)
+if [ "$_whitespace_evidence_decision" = "deny" ]; then
+  echo "  PASS  marker present, whitespace-only evidence -> still deny (PR #796 CodeRabbit review)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  marker present, whitespace-only evidence -> still deny (PR #796 CodeRabbit review) (got '$_whitespace_evidence_decision')"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("marker present, whitespace-only evidence -> still deny")
+fi
+
 # Cross-question label preservation (codex round-3 P2 fix): 2 DIFFERENT
 # questions each present an option with the IDENTICAL label text. Global
 # dedup across the whole payload previously collapsed this to 1 scaffold
@@ -1244,8 +1317,14 @@ else
   FAIL=$((FAIL + 1)); FAILED_NAMES+=("silent pass -> no RICH telemetry record")
 fi
 
-# Missing session_id -> deny still fires (stdout unaffected), but no RICH
-# record (cannot attribute to a session).
+# Missing session_id -> deny still fires (stdout unaffected). PR #796
+# CodeRabbit review: previously this early-returned before the RICH write,
+# dropping the decision from aggregate_fires()'s fires/block/ask totals
+# entirely. record_session_fire coerces a non-str session_id to "", and
+# aggregate_fires only adds a session to its per-session set when it is a
+# non-empty string, so the RICH record is now written unconditionally with
+# session_id="" — the decision still counts, only per-session attribution
+# is lost.
 make_ask_payload_no_session() {
   python3 -c "
 import json, sys
@@ -1262,13 +1341,42 @@ print(json.dumps(payload))
 TEL_NOSESS="$TEL_DIR/nosession.jsonl"
 make_ask_payload_no_session '["Best option (Recommended)", "Alternative"]' \
   | PRAXIS_FIRE_TELEMETRY_FILE="$TEL_NOSESS" "$HOOK" >/dev/null 2>&1
-_nosess_tel_count=$(rich_records "$TEL_NOSESS" | wc -l | tr -d ' ')
-if [ "${_nosess_tel_count:-0}" -eq 0 ]; then
-  echo "  PASS  missing session_id -> no RICH telemetry record (issue #787)"
+_nosess_tel=$(rich_records "$TEL_NOSESS" | python3 -c "
+import json, sys
+lines = [json.loads(l) for l in sys.stdin if l.strip()]
+ok = (
+    len(lines) == 1
+    and lines[0].get('decision') == 'block'
+    and lines[0].get('hook') == 'output-block-falsify-advisory'
+    and lines[0].get('session_id') == ''
+)
+print('ok' if ok else 'fail_' + str(lines))
+")
+if [ "$_nosess_tel" = "ok" ]; then
+  echo "  PASS  missing session_id -> RICH record still written with session_id='' (PR #796 review)"
   PASS=$((PASS + 1))
 else
-  echo "  FAIL  missing session_id -> no RICH telemetry record (issue #787) (got $_nosess_tel_count)"
-  FAIL=$((FAIL + 1)); FAILED_NAMES+=("missing session_id -> no RICH telemetry record")
+  echo "  FAIL  missing session_id -> RICH record still written with session_id='' (PR #796 review) ($_nosess_tel)"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("missing session_id -> RICH record still written with session_id=''")
+fi
+
+# Missing session_id -> the COARSE "pass" duplicate must still be suppressed
+# even though the RICH record is now written — otherwise the same call
+# would produce both a RICH "block" and a COARSE "pass" record, corrupting
+# aggregate_fires() the same way the original T1/T2 coarse-duplicate bug did
+# (issue #787 codex round-1 P2). Total line count in the file must be
+# exactly 1 (the RICH record only).
+if [ -f "$TEL_NOSESS" ]; then
+  _nosess_total_lines=$(wc -l < "$TEL_NOSESS" | tr -d ' ')
+else
+  _nosess_total_lines=0
+fi
+if [ "${_nosess_total_lines:-0}" -eq 1 ]; then
+  echo "  PASS  missing session_id -> coarse duplicate suppressed (1 total line = RICH only, PR #796 review)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  missing session_id -> coarse duplicate suppressed (1 total line = RICH only, PR #796 review) (got $_nosess_total_lines lines)"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("missing session_id -> coarse duplicate suppressed")
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
@@ -3,7 +3,9 @@
 #
 # Synthesizes Claude Code PreToolUse payloads and asserts:
 #   advisory → exit 0 + stderr non-empty (contains advisory keyword)
-#   pass     → exit 0 + stderr empty
+#   pass     → exit 0 + stderr empty + stdout empty (issue #787 round-6: a
+#              deny/ask decision also exits 0 with empty stderr, so stdout
+#              must be checked too or a real block would misreport as pass)
 #
 # Usage: bash tests/test_output_block_falsify_advisory.sh
 # Exit:  0 = all pass; 1 = at least one fail
@@ -23,6 +25,20 @@ if [ ! -x "$HOOK" ]; then
   echo "FAIL: hook not executable: $HOOK" >&2
   exit 1
 fi
+
+# Test isolation (issue #787 codex round-6 P2): dozens of run_case calls
+# below trigger T1/T2 deny/ask decisions, each of which writes a RICH
+# telemetry record. Without a default override, those records land in the
+# REAL ~/.praxis/telemetry/fire-events-*.jsonl store this suite runs
+# against — polluting the exact block-rate signal issue #787 added
+# telemetry to measure accurately. Point every hook invocation in this
+# script at a throwaway file by default; the telemetry-content-checking
+# cases further down still override PRAXIS_FIRE_TELEMETRY_FILE per-call to
+# their own TEL_DIR paths, which takes precedence over this export for
+# that single invocation. Cleaned up by the trap registered alongside
+# TEL_DIR below (a single EXIT trap covers both).
+DEFAULT_TEL_FILE="$(mktemp)"
+export PRAXIS_FIRE_TELEMETRY_FILE="$DEFAULT_TEL_FILE"
 
 PASS=0
 FAIL=0
@@ -78,8 +94,13 @@ except Exception:
       esac
       ;;
     pass)
+      # Issue #787 codex round-6 P2: deny/ask decisions also exit 0 with
+      # empty stderr (they signal via a stdout JSON permissionDecision, not
+      # stderr) — checking stderr alone cannot distinguish a real silent
+      # pass from an undetected deny/ask. stdout must be empty too.
       [ "$rc" -eq 0 ] || ok=0
       [ -z "$err" ]   || ok=0
+      [ -z "$out" ]   || ok=0
       ;;
     *)
       echo "FAIL  [$name] unknown expectation: $expectation"
@@ -91,7 +112,7 @@ except Exception:
     echo "PASS  [$name]"
     PASS=$((PASS + 1))
   else
-    echo "FAIL  [$name] expectation=$expectation rc=$rc stderr=${err:-<empty>}"
+    echo "FAIL  [$name] expectation=$expectation rc=$rc stderr=${err:-<empty>} stdout=${out:-<empty>}"
     FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
   fi
 }
@@ -570,6 +591,685 @@ run_case "T1 (issue #682): (Recommended) + column-0 Falsified: → silent pass (
       '["Option A (Recommended)", "Option B"]' \
       "Falsified: checked existing PRs — none found.
 What should we do?")"
+
+# ---------------------------------------------------------------------------
+# Ready-to-fill scaffold cases — issue #787
+# ---------------------------------------------------------------------------
+
+# T1: deny message must embed a copy-paste-ready Falsified: line seeded with
+# the triggering option label, not just the generic instruction text.
+run_case "T1 (issue #787): (Recommended) + no Falsified: → deny embeds ready-to-fill scaffold" \
+  "deny:Falsified: Best option (Recommended)" \
+  "$(make_ask_payload '["Best option (Recommended)", "Alternative"]')"
+
+run_case "T1 (issue #787): scaffold section is marked with [scaffold]" \
+  "deny:[scaffold]" \
+  "$(make_ask_payload '["Best option (Recommended)", "Alternative"]')"
+
+# T2: ask message must embed the same ready-to-fill scaffold, seeded with the
+# anchoring-token-carrying label.
+run_case "T2 (issue #787): safer label + no Falsified: → ask embeds ready-to-fill scaffold" \
+  "ask:Falsified: A safer rollout" \
+  "$(make_ask_payload '["A safer rollout", "B aggressive"]')"
+
+# Structural check: 2 options both carrying the (Recommended) marker must
+# produce 2 scaffold lines (one per triggering label), not just 1. Piped
+# straight into python3's stdin (not embedded as a string literal) because
+# the message text itself contains single quotes that would break a
+# triple-quoted Python literal.
+_scaffold_multi_result=$(make_ask_payload '["Option A (Recommended)", "Option B (Recommended)"]' | "$HOOK" 2>/dev/null | python3 -c "
+import json, sys
+d = json.loads(sys.stdin.read())
+reason = d.get('hookSpecificOutput', {}).get('permissionDecisionReason', '')
+# ASK_MSG's own instructional text has 2 'Falsified: ' occurrences + 1 per
+# triggering label (2) in the scaffold = 4.
+ok = reason.count('Falsified: ') == 4 and 'Option A (Recommended)' in reason and 'Option B (Recommended)' in reason
+print('ok' if ok else 'fail_count=' + str(reason.count('Falsified: ')))
+" 2>/dev/null)
+if [ "$_scaffold_multi_result" = "ok" ]; then
+  echo "  PASS  2 triggering labels -> 2 scaffold Falsified: lines (issue #787)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  2 triggering labels -> 2 scaffold Falsified: lines (issue #787) ($_scaffold_multi_result)"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("2 triggering labels -> 2 scaffold Falsified: lines")
+fi
+
+# Regression: no scaffold section when Falsified: is already present (pass path).
+run_case "T1 (issue #787): (Recommended) + Falsified: present → no scaffold needed (silent pass)" \
+  pass \
+  "$(make_ask_payload_with_question \
+      '["Option A (Recommended)", "Option B"]' \
+      "Falsified: checked no existing PR — none found.
+What should we do?")"
+
+# Anti-bypass regression (codex round-2 P1 fix): copy-pasting the scaffold
+# line VERBATIM (placeholders unfilled) into the question body must NOT
+# silently satisfy the gate — the placeholder line itself starts with
+# "Falsified:", so a naive prefix check would let a probe-free retry through.
+run_case "T1 (issue #787 round-2 P1): unfilled scaffold copy-paste does not satisfy gate — still deny" \
+  "deny:Falsified:" \
+  "$(make_ask_payload_with_question \
+      '["Best option (Recommended)", "Alternative"]' \
+      "Falsified: Best option (Recommended) — probe: <command> → <observed>; premise survives because <...>
+What should we do?")"
+
+# Same anti-bypass check for T2 ask.
+run_case "T2 (issue #787 round-2 P1): unfilled scaffold copy-paste does not satisfy gate — still ask" \
+  "ask:Falsified:" \
+  "$(make_ask_payload_with_descriptions \
+      '["A safer rollout", "B aggressive"]' \
+      '["", ""]' \
+      "Falsified: A safer rollout — probe: <command> → <observed>; premise survives because <...>
+Which one?")"
+
+# Regression: once placeholders are actually filled in with real content
+# (no literal <command>/<observed>/<...> left), the line DOES satisfy the
+# gate — the fix must not make legitimate filled-in evidence unsatisfiable.
+run_case "T1 (issue #787 round-2): scaffold filled in with real probe output → silent pass" \
+  pass \
+  "$(make_ask_payload_with_question \
+      '["Best option (Recommended)", "Alternative"]' \
+      "Falsified: Best option (Recommended) — probe: gh pr list --search feature → no existing PR; premise survives because none found
+What should we do?")"
+
+# Anti-bypass regression (codex round-3 P1 fix): ONE question with 2
+# triggering options -> 2 scaffold lines. Filling in only the FIRST one and
+# leaving the second with unfilled placeholders must NOT satisfy the gate —
+# _has_falsified_line's old "return True on first clean line" let a sibling
+# option's fake evidence ride along unchecked.
+run_case "T1 (issue #787 round-3 P1): 1 of 2 scaffold lines filled, other still placeholder → still deny" \
+  "deny:Falsified:" \
+  "$(make_ask_payload_with_question \
+      '["Option A (Recommended)", "Option B (Recommended)"]' \
+      "Falsified: Option A (Recommended) — probe: gh pr list --search a → none found; premise survives because none found
+Falsified: Option B (Recommended) — probe: <command> → <observed>; premise survives because <...>
+Which one?")"
+
+# Regression: BOTH scaffold lines filled in for the same 2-option question ->
+# silent pass (the round-3 fix must not require MORE than "no placeholder
+# tokens anywhere", it must still accept a fully-filled multi-line case).
+run_case "T1 (issue #787 round-3): both scaffold lines fully filled → silent pass" \
+  pass \
+  "$(make_ask_payload_with_question \
+      '["Option A (Recommended)", "Option B (Recommended)"]' \
+      "Falsified: Option A (Recommended) — probe: gh pr list --search a → none found; premise survives because none found
+Falsified: Option B (Recommended) — probe: gh pr list --search b → none found; premise survives because none found
+Which one?")"
+
+# Anti-bypass regression (codex round-4 P1 fix): ONE question with 2
+# triggering options -> 2 scaffold lines required. Providing evidence for
+# ONLY the first option and OMITTING the second line entirely (no
+# placeholder text left anywhere) must NOT satisfy the gate — the round-3
+# fix only rejected leftover placeholder tokens, but a deleted line has no
+# placeholder to reject, so clean_count (1) must be compared against the
+# number of triggering labels (2), not treated as boolean-satisfied.
+run_case "T1 (issue #787 round-4 P1): 1 of 2 lines provided, other omitted → still deny" \
+  "deny:Falsified:" \
+  "$(make_ask_payload_with_question \
+      '["Option A (Recommended)", "Option B (Recommended)"]' \
+      "Falsified: Option A (Recommended) — probe: gh pr list --search a → none found; premise survives because none found
+Which one?")"
+
+# Regression: a SINGLE triggering label with its one clean Falsified: line
+# still satisfies the gate (round-4's required_count must default to 1 for
+# the common single-option case, not silently demand more).
+run_case "T1 (issue #787 round-4): single triggering label, 1 clean line → silent pass" \
+  pass \
+  "$(make_ask_payload_with_question \
+      '["Best option (Recommended)", "Alternative"]' \
+      "Falsified: Best option (Recommended) — probe: gh pr list --search feature → no existing PR; premise survives because none found
+What should we do?")"
+
+# Anti-false-positive regression (codex round-5 P2 fix): when the OPTION
+# LABEL ITSELF happens to contain a literal placeholder-looking substring
+# (e.g. "<command>"), the scaffold seeds that label verbatim into the
+# Falsified: line's prefix. The old whole-line scan flagged this forever,
+# even after the actual probe/observed evidence past "— probe:" was
+# genuinely filled in — a legitimate retry could never pass. Scoping the
+# placeholder scan to the content after "— probe:" fixes this without
+# weakening the anti-bypass guard (verified by the next case).
+run_case "T1 (issue #787 round-5 P2): label contains literal <command>, evidence filled in → silent pass" \
+  pass \
+  "$(make_ask_payload_with_question \
+      '["Run <command> manually (Recommended)", "Alternative"]' \
+      "Falsified: Run <command> manually (Recommended) — probe: gh pr list --search feature → no existing PR found; premise survives because none found.
+What should we do?")"
+
+# Regression: the anti-bypass guard must still fire when the EVIDENCE
+# region (after "— probe:") is the unfilled part, even though the label
+# prefix also happens to contain a placeholder-looking substring — proves
+# round-5's fix narrowed the scan window without disabling it.
+run_case "T1 (issue #787 round-5): label contains <command> AND evidence unfilled → still deny" \
+  "deny:Falsified:" \
+  "$(make_ask_payload_with_question \
+      '["Run <command> manually (Recommended)", "Alternative"]' \
+      "Falsified: Run <command> manually (Recommended) — probe: <command> → <observed>; premise survives because <...>
+What should we do?")"
+
+# Anti-false-positive regression (codex round-6 P2 fix): a LEGACY free-form
+# Falsified line — no "— probe:" marker at all — whose own genuine wording
+# happens to contain a literal placeholder-looking substring. Round-5 only
+# scoped the scan window when the marker WAS present; a marker-less line
+# still fell back to scanning the whole line, so this case still perma-
+# blocked. Marker-less lines are not scaffold-shaped, so round-6 excludes
+# them from placeholder scanning entirely (the real scaffold copy-paste
+# bypass always contains the marker, since it is emitted verbatim).
+run_case "T1 (issue #787 round-6 P2): legacy free-form line, no marker, contains <command> → silent pass" \
+  pass \
+  "$(make_ask_payload_with_question \
+      '["Run <command> manually (Recommended)", "Alternative"]' \
+      "Falsified: checked how <command> is invoked here, does not apply to this case.
+What should we do?")"
+
+# Anti-bypass regression (codex round-6 P2 fix): a 2-option question where
+# BOTH triggering options exist, but the SAME clean Falsified line is
+# pasted TWICE instead of providing distinct evidence for the second
+# option. required_count counted raw lines, so clean_count==2 satisfied
+# the check without ever addressing Option B. Falsified lines are now
+# deduped by exact text before counting, so the duplicate contributes
+# nothing and the question still denies.
+run_case "T1 (issue #787 round-6 P2): same clean line pasted twice for 2 options → still deny" \
+  "deny:Falsified:" \
+  "$(make_ask_payload_with_question \
+      '["Option A (Recommended)", "Option B (Recommended)"]' \
+      "Falsified: Option A (Recommended) — probe: gh pr list --search a → none found; premise survives because none found
+Falsified: Option A (Recommended) — probe: gh pr list --search a → none found; premise survives because none found
+Which one?")"
+
+# Regression: 2 DISTINCT clean lines for 2 DISTINCT triggering options must
+# still silent-pass (round-6's dedup must not require exact label-text
+# matching — it only rejects exact line-text duplicates).
+run_case "T1 (issue #787 round-6): 2 distinct clean lines for 2 options → silent pass" \
+  pass \
+  "$(make_ask_payload_with_question \
+      '["Option A (Recommended)", "Option B (Recommended)"]' \
+      "Falsified: Option A (Recommended) — probe: gh pr list --search a → none found; premise survives because none found
+Falsified: Option B (Recommended) — probe: gh pr list --search b → none found; premise survives because none found
+Which one?")"
+
+# Anti-bypass regression (codex round-7 P2 fix): ONE question mixes a T1
+# option (exact "(Recommended)" marker) with a SEPARATE T2 option (a
+# "safer" description, no marker). The old if/elif skipped the T2 check
+# entirely once T1 matched for the question, so the T2 option's label
+# never entered required_count — a retry providing evidence for ONLY the
+# T1 option silent-passed with the T2 option's claim never verified.
+run_case "T1 (issue #787 round-7 P2): mixed T1+T2 in one question, only T1 evidence → still deny" \
+  "deny:Falsified: Option B" \
+  "$(make_ask_payload_with_descriptions \
+      '["Option A (Recommended)", "Option B"]' \
+      '["", "This is the safer choice overall"]' \
+      "Falsified: Option A (Recommended) — probe: gh pr list --search a → none found; premise survives because none found
+Which one?")"
+
+# Regression: the SAME mixed question, with evidence for BOTH the T1 and
+# T2 option, must silent-pass (round-7's fix must not require MORE than
+# one clean line per genuinely distinct triggering label).
+run_case "T1 (issue #787 round-7): mixed T1+T2 in one question, both evidence lines → silent pass" \
+  pass \
+  "$(make_ask_payload_with_descriptions \
+      '["Option A (Recommended)", "Option B"]' \
+      '["", "This is the safer choice overall"]' \
+      "Falsified: Option A (Recommended) — probe: gh pr list --search a → none found; premise survives because none found
+Falsified: Option B — probe: checked B directly → not actually safer for this case; premise survives because verified
+Which one?")"
+
+# Regression (codex round-7 self-catch): T2's bare recommend(?:ed|s)?
+# pattern also matches the literal word inside "(Recommended)", so BOTH
+# options in a pure-T1 2-option question also match T2's confidence-
+# anchoring check. Without excluding t1_triggering labels from
+# t2_triggering, this double-counted each label into both t1_labels and
+# t2_labels, producing 4 scaffold lines (2 duplicated) instead of 2 in the
+# deny message for a case that has no genuine T2-only option at all.
+_scaffold_no_dup_result=$(make_ask_payload '["Option A (Recommended)", "Option B (Recommended)"]' | "$HOOK" 2>/dev/null | python3 -c "
+import json, sys
+d = json.loads(sys.stdin.read())
+reason = d.get('hookSpecificOutput', {}).get('permissionDecisionReason', '')
+ok = reason.count('Falsified: Option A (Recommended)') == 1 and reason.count('Falsified: Option B (Recommended)') == 1
+print('ok' if ok else 'a=' + str(reason.count('Falsified: Option A (Recommended)')) + ' b=' + str(reason.count('Falsified: Option B (Recommended)')))
+" 2>/dev/null)
+if [ "$_scaffold_no_dup_result" = "ok" ]; then
+  echo "  PASS  pure-T1 2-option question -> no T2 double-count duplication in scaffold (issue #787 round-7)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  pure-T1 2-option question -> no T2 double-count duplication in scaffold (issue #787 round-7) ($_scaffold_no_dup_result)"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("pure-T1 2-option question -> no T2 double-count duplication")
+fi
+
+# Anti-false-positive regression (codex round-8 P2 fix): an option LABEL
+# that itself contains the literal "— probe:" delimiter substring and a
+# placeholder-looking token (e.g. quoting another probe's shape) used to
+# shift the scan to that label-internal, leftmost marker occurrence via
+# find(), pulling trailing label text — including the placeholder token —
+# into evidence_region and permanently hard-denying even after real
+# evidence was filled in after the actual (rightmost) scaffold delimiter.
+# rfind() now anchors on the real, last-inserted delimiter.
+run_case "T1 (issue #787 round-8 P2): label itself embeds marker+placeholder, real evidence after real delimiter → silent pass" \
+  pass \
+  "$(make_ask_payload_with_question \
+      '["Investigate — probe: <command> approach (Recommended)", "Alternative"]' \
+      "Falsified: Investigate — probe: <command> approach (Recommended) — probe: gh pr list --search x → none found; premise survives because none found
+Which one?")"
+
+# Anti-bypass regression (codex round-8 P2 fix): a 2-option question where
+# the SAME real evidence line is pasted twice, with only a trailing-
+# whitespace difference on the second copy. Exact-text dedup treated the
+# two as DISTINCT, satisfying required_count=2 while Option B still had
+# zero real evidence. Lines are now whitespace-normalized before dedup, so
+# the whitespace-only copy still collapses to 1 clean line and the
+# question still denies.
+run_case "T1 (issue #787 round-8 P2): whitespace-only duplicate line does not satisfy 2nd option → still deny" \
+  "deny:Falsified:" \
+  "$(make_ask_payload_with_question \
+      '["Option A (Recommended)", "Option B (Recommended)"]' \
+      "Falsified: Option A (Recommended) — probe: gh pr list --search a → none found; premise  survives because none found
+Falsified: Option A (Recommended) — probe: gh pr list --search a → none found; premise survives because none found
+Which one?")"
+
+# Anti-bypass regression (codex round-9 P1 fix): 2 DIFFERENTLY-WORDED clean
+# lines that both address Option A, with Option B never addressed at all.
+# The old count-only check treated 2 distinct lines as satisfying
+# required_count=2 for a 2-option question regardless of which option each
+# line actually verified — Option B's claim silently went unverified.
+# Each clean line is now matched to a specific triggering label by its
+# "Falsified: {label}" prefix, so 2 lines both prefixed with "Option A"
+# leave Option B uncovered and the question still denies.
+run_case "T1 (issue #787 round-9 P1): 2 differently-worded lines, both Option A, Option B uncovered → still deny" \
+  "deny:Falsified:" \
+  "$(make_ask_payload_with_question \
+      '["Option A (Recommended)", "Option B (Recommended)"]' \
+      "Falsified: Option A (Recommended) — probe: gh pr list --search a -> none found; premise survives (first check)
+Falsified: Option A (Recommended) — probe: gh issue list --search a -> also none found; premise survives (second check, still Option A only)
+Which one?")"
+
+# Regression: the SAME 2-option question with each option addressed by its
+# OWN, differently-worded line must still silent-pass — the round-9 P1 fix
+# maps lines to labels by prefix match, it does not require identical
+# wording or line count beyond one-per-label.
+run_case "T1 (issue #787 round-9 P1): each option addressed by its own distinctly-worded line → silent pass" \
+  pass \
+  "$(make_ask_payload_with_question \
+      '["Option A (Recommended)", "Option B (Recommended)"]' \
+      "Falsified: Option A (Recommended) — probe: gh pr list --search a -> none found; premise survives (first check)
+Falsified: Option B (Recommended) — probe: gh issue list --search b -> also none found; premise survives (second, distinct check)
+Which one?")"
+
+# Anti-bypass regression (codex round-9 P2 fix): the EVIDENCE text itself
+# (legitimately placed after the real scaffold delimiter) contains a
+# second literal "— probe:" substring, with an unfilled "<command>"
+# placeholder sitting BEFORE that spurious marker but still within the
+# real evidence region. round-8's rfind() anchored on the LAST "— probe:"
+# occurrence — the spurious one — so the leading placeholder fell outside
+# the scanned window and silently passed. The delimiter is now found via
+# find() seeded right after the matched label prefix, so the FIRST
+# "— probe:" after the label (the real, scaffold-inserted one) is used
+# regardless of how many more "— probe:"-shaped substrings appear later in
+# the evidence text — the leading placeholder is caught.
+run_case "T1 (issue #787 round-9 P2): evidence embeds a second marker, unfilled placeholder before it → still deny" \
+  "deny:Falsified:" \
+  "$(make_ask_payload_with_question \
+      '["Option A (Recommended)", "Alternative"]' \
+      "Falsified: Option A (Recommended) — probe: <command> ran — probe: actually done
+What should we do?")"
+
+# Regression: the SAME evidence-embedded-second-marker shape, but with the
+# real evidence genuinely filled in (no placeholder anywhere before the
+# spurious marker) must still silent-pass — the round-9 P2 fix narrows the
+# anchor point, it does not forbid legitimate evidence from containing the
+# word sequence "— probe:" again.
+run_case "T1 (issue #787 round-9 P2): evidence embeds a second marker, no placeholder anywhere → silent pass" \
+  pass \
+  "$(make_ask_payload_with_question \
+      '["Option A (Recommended)", "Alternative"]' \
+      "Falsified: Option A (Recommended) — probe: ran gh pr list — probe: actually done, no PR found
+What should we do?")"
+
+# Anti-bypass regression (codex round-10 P2 fix): a bare (no-marker) T2
+# label ("Rerun") happens to be a literal STRING PREFIX of unrelated
+# evidence text ("Rerunning without confirmation") on the OTHER
+# triggering option's line. round-9's `line.startswith(f"Falsified:
+# {label}")` matched "Rerun" against "Rerunning..." (since "Runtime" ...
+# "Rerunning" both continue the shorter label with more letters), wrongly
+# crediting "Rerun" as covered even though that line never actually
+# addresses it — the real "Rerun" claim stayed unverified.
+run_case "T1+T2 (issue #787 round-10 P2): bare label is a string-prefix of unrelated evidence text → still deny" \
+  "deny:Falsified:" \
+  "$(make_ask_payload_with_descriptions \
+      '["Merge (Recommended)", "Rerun"]' \
+      '["", "This is the safer choice overall"]' \
+      "Falsified: Merge (Recommended) — probe: gh pr list --search x -> none found; premise survives
+Falsified: Rerunning without confirmation — probe: gh issue list -> none found; premise survives
+Which one?")"
+
+# Regression: the SAME bare-label-is-a-prefix shape, but the second line
+# genuinely addresses "Rerun" as its own whole-token label (the marker's
+# leading space forms the required boundary right after the label) must
+# still silent-pass — the round-10 fix requires a boundary after the
+# label, it does not forbid the label from ever matching.
+run_case "T1+T2 (issue #787 round-10 P2): bare label genuinely addressed by its own line → silent pass" \
+  pass \
+  "$(make_ask_payload_with_descriptions \
+      '["Merge (Recommended)", "Rerun"]' \
+      '["", "This is the safer choice overall"]' \
+      "Falsified: Merge (Recommended) — probe: gh pr list --search x -> none found; premise survives
+Falsified: Rerun — probe: checked rerun path -> safe; premise survives
+Which one?")"
+
+# Anti-bypass regression (codex round-11 P2 fix): an option LABEL itself
+# contains a literal embedded newline. `_falsified_scaffold` previously
+# interpolated the raw label verbatim, so the deny message's scaffold hint
+# split across two printed lines — a verbatim copy-paste of that unfilled
+# scaffold then had its placeholder tokens (`<command>` etc.) land on the
+# SECOND physical line, which does not start with `Falsified:` and is
+# invisible to the per-line scan, silently passing. Labels are now
+# whitespace-normalized (embedded newlines collapsed to spaces) at the
+# point they enter the triggering pipeline, so the deny message's scaffold
+# is guaranteed to stay a single physical line regardless of what the raw
+# option label contains — verified here by checking the scaffold segment
+# contains the newline-joined label as ONE line, with no bare "Falsified:
+# Multi" line missing its own evidence marker.
+_newline_label_scaffold_result=$(make_ask_payload '["Multi\nline label (Recommended)", "Alternative"]' | "$HOOK" 2>/dev/null | python3 -c "
+import json, sys
+d = json.loads(sys.stdin.read())
+reason = d.get('hookSpecificOutput', {}).get('permissionDecisionReason', '')
+lines = reason.split('[scaffold]', 1)[-1].splitlines()
+falsified_lines = [l for l in lines if l.startswith('Falsified:')]
+ok = (
+    len(falsified_lines) == 1
+    and 'Multi line label (Recommended)' in falsified_lines[0]
+    and '— probe:' in falsified_lines[0]
+)
+print('ok' if ok else 'falsified_lines=' + repr(falsified_lines))
+")
+if [ "$_newline_label_scaffold_result" = "ok" ]; then
+  echo "  PASS  option label with embedded newline -> scaffold stays a single physical line (issue #787 round-11 P2)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  option label with embedded newline -> scaffold stays a single physical line (issue #787 round-11 P2) ($_newline_label_scaffold_result)"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("option label with embedded newline -> single-line scaffold")
+fi
+
+# Regression: the SAME newline-bearing label, with the (now-guaranteed
+# single-line) scaffold copy-pasted verbatim and left unfilled, must still
+# deny — the round-11 fix must not accidentally make the placeholder guard
+# unreachable for labels that originally contained a newline.
+run_case "T1 (issue #787 round-11 P2): newline-bearing label, unfilled single-line scaffold copy-paste → still deny" \
+  "deny:Falsified:" \
+  "$(make_ask_payload_with_question \
+      '["Multi\nline label (Recommended)", "Alternative"]' \
+      "Falsified: Multi line label (Recommended) — probe: <command> → <observed>; premise survives because <...>
+What should we do?")"
+
+# Anti-bypass regression (codex round-12 P2 fix): round-10's non-
+# alphanumeric boundary was still too weak — a genuinely different,
+# unrelated evidence line that happens to share the triggering label as
+# its own prefix, separated by a space (e.g. triggering "Run" vs.
+# evidence text "Run now"), also has a non-alphanumeric boundary. The
+# "Run" option's real claim is never addressed even though the line
+# gets credited toward it.
+run_case "T1+T2 (issue #787 round-12 P2): near-miss label prefix (triggering \"Run\" vs. evidence \"Run now\") → still deny" \
+  "deny:Falsified:" \
+  "$(make_ask_payload_with_descriptions \
+      '["Merge (Recommended)", "Run"]' \
+      '["", "This is the safer choice overall"]' \
+      "Falsified: Merge (Recommended) — probe: gh pr list --search x -> none found; premise survives
+Falsified: Run now — probe: gh issue list -> none found; premise survives
+Which one?")"
+
+# Regression: the SAME near-miss shape, but "Run" is genuinely addressed
+# by its own line ending exactly at the scaffold's own delimiter → still
+# silent-pass — the round-12 fix must not forbid the label from ever
+# matching, only close the near-miss-prefix collision.
+run_case "T1+T2 (issue #787 round-12 P2): label genuinely addressed via the exact scaffold delimiter → silent pass" \
+  pass \
+  "$(make_ask_payload_with_descriptions \
+      '["Merge (Recommended)", "Run"]' \
+      '["", "This is the safer choice overall"]' \
+      "Falsified: Merge (Recommended) — probe: gh pr list --search x -> none found; premise survives
+Falsified: Run — probe: checked run path -> safe; premise survives
+Which one?")"
+
+# Cross-question label preservation (codex round-3 P2 fix): 2 DIFFERENT
+# questions each present an option with the IDENTICAL label text. Global
+# dedup across the whole payload previously collapsed this to 1 scaffold
+# line — but _has_falsified_line checks each question's own text
+# independently, so fixing only the first occurrence would leave the
+# second question blocked on retry.
+make_ask_payload_two_questions_same_label() {
+  python3 - <<'PYEOF'
+import json
+payload = {
+    "session_id": "test-session",
+    "tool_name": "AskUserQuestion",
+    "tool_input": {
+        "questions": [
+            {"question": "Q1?", "options": [{"label": "Fix now (Recommended)"}, {"label": "Q1 alt"}]},
+            {"question": "Q2?", "options": [{"label": "Fix now (Recommended)"}, {"label": "Q2 alt"}]},
+        ]
+    },
+    "cwd": "/tmp",
+}
+print(json.dumps(payload))
+PYEOF
+}
+_same_label_result=$(make_ask_payload_two_questions_same_label | "$HOOK" 2>/dev/null | python3 -c "
+import json, sys
+d = json.loads(sys.stdin.read())
+reason = d.get('hookSpecificOutput', {}).get('permissionDecisionReason', '')
+ok = reason.count('Falsified: Fix now (Recommended)') == 2
+print('ok' if ok else 'fail_count=' + str(reason.count('Falsified: Fix now (Recommended)')))
+")
+if [ "$_same_label_result" = "ok" ]; then
+  echo "  PASS  2 questions with identical label -> 2 scaffold lines, not deduped away (issue #787)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  2 questions with identical label -> 2 scaffold lines, not deduped away (issue #787) ($_same_label_result)"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("2 questions with identical label -> 2 scaffold lines")
+fi
+
+# Multi-question aggregation (codex round-1 P2 fix): 2 separate questions,
+# each with its OWN T1 violation, no Falsified: in either. Pre-fix, the loop
+# broke on the first violating question and only Q1's label reached the
+# scaffold — fixing Q1 alone would still hit a T1 block on Q2 at retry.
+make_ask_payload_two_t1_questions() {
+  python3 - <<'PYEOF'
+import json
+payload = {
+    "session_id": "test-session",
+    "tool_name": "AskUserQuestion",
+    "tool_input": {
+        "questions": [
+            {"question": "Q1?", "options": [{"label": "Q1 choice (Recommended)"}, {"label": "Q1 alt"}]},
+            {"question": "Q2?", "options": [{"label": "Q2 choice (추천)"}, {"label": "Q2 alt"}]},
+        ]
+    },
+    "cwd": "/tmp",
+}
+print(json.dumps(payload))
+PYEOF
+}
+_two_t1_result=$(make_ask_payload_two_t1_questions | "$HOOK" 2>/dev/null | python3 -c "
+import json, sys
+d = json.loads(sys.stdin.read())
+reason = d.get('hookSpecificOutput', {}).get('permissionDecisionReason', '')
+# Korean text is \u-escaped by json.dump, so only the ASCII label prefix
+# ('Q2 choice', not the '(추천)' suffix) survives as a literal substring.
+ok = 'Q1 choice (Recommended)' in reason and 'Q2 choice' in reason
+print('ok' if ok else 'fail_' + reason[-300:])
+")
+if [ "$_two_t1_result" = "ok" ]; then
+  echo "  PASS  2 separate T1-violating questions -> both labels in scaffold (issue #787)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  2 separate T1-violating questions -> both labels in scaffold (issue #787) ($_two_t1_result)"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("2 separate T1-violating questions -> both labels in scaffold")
+fi
+
+# Multi-question aggregation: 2 separate questions, each with its OWN T2-only
+# (anchoring) violation, neither carrying a T1 marker. Pre-fix, only the
+# first question's label made it into the scaffold (tier_decision is None
+# gate blocked the second).
+make_ask_payload_two_t2_questions() {
+  python3 - <<'PYEOF'
+import json
+payload = {
+    "session_id": "test-session",
+    "tool_name": "AskUserQuestion",
+    "tool_input": {
+        "questions": [
+            {"question": "Q1?", "options": [{"label": "Q1 safer path"}, {"label": "Q1 alt"}]},
+            {"question": "Q2?", "options": [{"label": "Q2 option", "description": "자연스러운 진행"}, {"label": "Q2 alt"}]},
+        ]
+    },
+    "cwd": "/tmp",
+}
+print(json.dumps(payload))
+PYEOF
+}
+_two_t2_result=$(make_ask_payload_two_t2_questions | "$HOOK" 2>/dev/null | python3 -c "
+import json, sys
+d = json.loads(sys.stdin.read())
+h = d.get('hookSpecificOutput', {})
+reason = h.get('permissionDecisionReason', '')
+ok = h.get('permissionDecision') == 'ask' and 'Q1 safer path' in reason and 'Q2 option' in reason
+print('ok' if ok else 'fail_decision=' + str(h.get('permissionDecision')) + '_reason_tail=' + reason[-200:])
+")
+if [ "$_two_t2_result" = "ok" ]; then
+  echo "  PASS  2 separate T2-violating questions -> both labels in scaffold (issue #787)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  2 separate T2-violating questions -> both labels in scaffold (issue #787) ($_two_t2_result)"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("2 separate T2-violating questions -> both labels in scaffold")
+fi
+
+# ---------------------------------------------------------------------------
+# Block-event telemetry cases — issue #787
+# ---------------------------------------------------------------------------
+
+TEL_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEL_DIR"; rm -f "$DEFAULT_TEL_FILE"' EXIT
+
+rich_records() {
+  # $1 = telemetry file. Prints one JSON object per RICH line found.
+  local file="$1"
+  [ -f "$file" ] || return 0
+  python3 -c "
+import json
+with open('$file') as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        r = json.loads(line)
+        if r.get('granularity') == 'rich':
+            print(json.dumps(r))
+"
+}
+
+# T1 deny fires -> 1 RICH record, decision=block, correct hook/role/session/tool.
+TEL_T1="$TEL_DIR/t1.jsonl"
+make_ask_payload '["Best option (Recommended)", "Alternative"]' \
+  | PRAXIS_FIRE_TELEMETRY_FILE="$TEL_T1" "$HOOK" >/dev/null 2>&1
+_t1_tel=$(rich_records "$TEL_T1" | python3 -c "
+import json, sys
+lines = [json.loads(l) for l in sys.stdin if l.strip()]
+ok = (
+    len(lines) == 1
+    and lines[0].get('decision') == 'block'
+    and lines[0].get('hook') == 'output-block-falsify-advisory'
+    and lines[0].get('role') == 'advisory-nudge'
+    and lines[0].get('tool') == 'AskUserQuestion'
+    and lines[0].get('session_id') == 'test-session'
+)
+print('ok' if ok else 'fail_' + str(lines))
+")
+if [ "$_t1_tel" = "ok" ]; then
+  echo "  PASS  T1 deny -> 1 RICH telemetry record (decision=block, issue #787)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  T1 deny -> 1 RICH telemetry record (decision=block, issue #787) ($_t1_tel)"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("T1 deny -> 1 RICH telemetry record")
+fi
+
+# T1 deny -> the automatic COARSE "pass" duplicate from @fail_open must be
+# suppressed (issue #787 codex round-1 P2): without suppression the file
+# would have 2 lines (RICH block + COARSE pass), corrupting aggregate_fires()
+# block-rate counts. Reusing the same TEL_T1 file/call from the case above.
+_t1_total_lines=$(wc -l < "$TEL_T1" 2>/dev/null | tr -d ' ')
+if [ "${_t1_total_lines:-0}" -eq 1 ]; then
+  echo "  PASS  T1 deny -> coarse duplicate suppressed (1 total line, issue #787)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  T1 deny -> coarse duplicate suppressed (1 total line, issue #787) (got $_t1_total_lines lines)"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("T1 deny -> coarse duplicate suppressed")
+fi
+
+# T2 ask fires -> 1 RICH record, decision=ask.
+TEL_T2="$TEL_DIR/t2.jsonl"
+make_ask_payload '["A safer rollout", "B aggressive"]' \
+  | PRAXIS_FIRE_TELEMETRY_FILE="$TEL_T2" "$HOOK" >/dev/null 2>&1
+_t2_tel=$(rich_records "$TEL_T2" | python3 -c "
+import json, sys
+lines = [json.loads(l) for l in sys.stdin if l.strip()]
+ok = len(lines) == 1 and lines[0].get('decision') == 'ask'
+print('ok' if ok else 'fail_' + str(lines))
+")
+if [ "$_t2_tel" = "ok" ]; then
+  echo "  PASS  T2 ask -> 1 RICH telemetry record (decision=ask, issue #787)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  T2 ask -> 1 RICH telemetry record (decision=ask, issue #787) ($_t2_tel)"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("T2 ask -> 1 RICH telemetry record")
+fi
+
+# T2 ask -> same coarse-duplicate suppression as T1 above.
+_t2_total_lines=$(wc -l < "$TEL_T2" 2>/dev/null | tr -d ' ')
+if [ "${_t2_total_lines:-0}" -eq 1 ]; then
+  echo "  PASS  T2 ask -> coarse duplicate suppressed (1 total line, issue #787)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  T2 ask -> coarse duplicate suppressed (1 total line, issue #787) (got $_t2_total_lines lines)"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("T2 ask -> coarse duplicate suppressed")
+fi
+
+# Silent pass -> no RICH record (nothing to count).
+TEL_PASS="$TEL_DIR/pass.jsonl"
+make_ask_payload '["Option A", "Option B"]' \
+  | PRAXIS_FIRE_TELEMETRY_FILE="$TEL_PASS" "$HOOK" >/dev/null 2>&1
+_pass_tel_count=$(rich_records "$TEL_PASS" | wc -l | tr -d ' ')
+if [ "${_pass_tel_count:-0}" -eq 0 ]; then
+  echo "  PASS  silent pass -> no RICH telemetry record (issue #787)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  silent pass -> no RICH telemetry record (issue #787) (got $_pass_tel_count)"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("silent pass -> no RICH telemetry record")
+fi
+
+# Missing session_id -> deny still fires (stdout unaffected), but no RICH
+# record (cannot attribute to a session).
+make_ask_payload_no_session() {
+  python3 -c "
+import json, sys
+labels = json.loads(sys.argv[1])
+options = [{'label': l} for l in labels]
+payload = {
+    'tool_name': 'AskUserQuestion',
+    'tool_input': {'questions': [{'question': 'What should we do?', 'options': options}]},
+    'cwd': '/tmp',
+}
+print(json.dumps(payload))
+" "$1"
+}
+TEL_NOSESS="$TEL_DIR/nosession.jsonl"
+make_ask_payload_no_session '["Best option (Recommended)", "Alternative"]' \
+  | PRAXIS_FIRE_TELEMETRY_FILE="$TEL_NOSESS" "$HOOK" >/dev/null 2>&1
+_nosess_tel_count=$(rich_records "$TEL_NOSESS" | wc -l | tr -d ' ')
+if [ "${_nosess_tel_count:-0}" -eq 0 ]; then
+  echo "  PASS  missing session_id -> no RICH telemetry record (issue #787)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  missing session_id -> no RICH telemetry record (issue #787) (got $_nosess_tel_count)"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("missing session_id -> no RICH telemetry record")
+fi
 
 # ---------------------------------------------------------------------------
 # @fail_open structural assertion

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -394,6 +394,29 @@ def test_dispatcher_process_writes_rich_not_coarse(tmp_path, monkeypatch):
     assert len(recs) == 1 and recs[0]["granularity"] == "rich"
 
 
+def test_suppress_coarse_duplicate_skips_standalone_fire(tmp_path, monkeypatch):
+    """Issue #787: a standalone hook that already wrote a RICH record via
+    record_session_fire must be able to suppress its own subsequent COARSE
+    record — otherwise aggregate_fires() double-counts the same call with a
+    mismatched decision (rich=block/ask, coarse=pass), corrupting block-rate
+    counts. suppress_coarse_duplicate reuses the dispatcher-process flag for
+    this, same mechanism as test_dispatcher_process_writes_rich_not_coarse
+    above, applied outside a real dispatcher context."""
+    out = tmp_path / "fire.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    monkeypatch.setattr(fl, "_DISPATCHER_PROCESS", False)
+    fl.record_session_fire(
+        "output-block-falsify-advisory", "advisory-nudge", "block",
+        "sess-1", "AskUserQuestion",
+    )
+    fl.suppress_coarse_duplicate()
+    fl.record_standalone_fire("output-block-falsify-advisory", "advisory-nudge", 0)
+    recs = [json.loads(line) for line in out.read_text().splitlines() if line.strip()]
+    assert len(recs) == 1
+    assert recs[0]["granularity"] == "rich" and recs[0]["decision"] == "block"
+
+
 def test_atomic_append_skips_non_regular_file(tmp_path):
     """Security guard: a FIFO target is skipped, never opened (no block, no raise)."""
     fifo = tmp_path / "pipe"


### PR DESCRIPTION
## 요약

`output-block-falsify-advisory` 훅의 T1 deny / T2 ask 메시지에 실제 트리거된 옵션 라벨로 시드된 복붙 가능한 `Falsified: <label> — probe: ...` scaffold 줄을 추가했습니다. 매 재시도마다 형식을 처음부터 재구성해야 하는 비용을 없앱니다. 또한 이 훅은 stdout JSON으로 deny/ask를 신호하기 때문에 exit code만 보는 coarse fire-ledger 레코더에는 보이지 않아, block-event 텔레메트리(RICH fire-ledger 레코드, `decision=block/ask`)도 함께 기록하도록 추가했습니다.

Closes #787

## ⚠️ 헤드라인 — diminishing-returns 신호 (3배 초과, 반드시 먼저 읽어주세요)

이 PR은 **12라운드**의 Codex 리뷰를 거쳤습니다. praxis의 `codex-review-wrap` 스킬은 동일 `{file}:{region}`이 기본 임계값 `PRAXIS_DIMINISHING_RETURNS_N=4`를 넘으면 advisory를 발동하는데, `impl.py`의 `_has_falsified_line`(및 라벨 매칭 로직)은 그 **3배 이상**을 초과했습니다. 특히 **라운드 9~12는 4회 연속으로 새로운 우회(bypass) 사례**를 찾아냈고, **라운드 13은 Codex 리뷰가 실행 중 강제 종료(killed)되어 결과를 얻지 못한 채 중단**했습니다 — 즉 "새 발견 없음(convergence)"으로 종료된 라운드가 아직 한 번도 없습니다.

각 라운드의 수정이 이전 수정이 만든 새롭고 점점 더 좁아지는 엣지 케이스를 드러내는 패턴이 반복되었습니다(특히 라운드 10→12는 "라벨 뒤 경계 조건"이라는 같은 축에서 3회 연속 좁혀짐). 이는 string-matching 휴리스틱 접근 자체의 견고성에 한계가 있을 가능성을 시사합니다 — 리뷰어와 병합자는 이 PR을 병합용으로 승인하기 전에, 남은 잔여 우회 벡터가 있을 수 있다는 점을 감안해 주시기 바랍니다. (커밋 트레일러에도 `Not-tested:`로 동일 내용을 명시했습니다.)

## 전체 라운드별 발견 사항 (모두 라이브 프로브로 재현 확인 → 수정 → 회귀 테스트로 검증)

| 라운드 | 발견 | 수정 |
|---|---|---|
| 2~8 | placeholder 미기입 감지, 옵션별 line 삭제 우회, 라벨 텍스트에 placeholder 유사 문자열 포함 시 오탐, marker-less legacy 줄 오탐, 중복 줄 붙여넣기 우회, whitespace-only 중복 우회, 라벨에 delimiter 문자열 포함 시 permablock | placeholder scope를 `— probe:` 마커 이후로 한정, `required_count` 기반 카운트 검증, marker-less 줄 placeholder 스캔 제외, 텍스트 정규화 후 dedup, `rfind()`로 실제 delimiter 앵커링 |
| 9 (P1) | 서로 다른 문구의 두 줄이 모두 같은 옵션(A)만 가리켜도 count-only 검증이 silent-pass — 옵션 B는 전혀 검증 안 됨 | count 기반 → 각 clean line을 트리거 라벨과 매칭시켜 **라벨별 커버리지**로 전환 |
| 9 (P2) | evidence 텍스트 자체에 `— probe:`가 재등장하면 `rfind()`가 진짜 delimiter를 놓치고 그 앞의 미기입 placeholder를 스캔 범위 밖으로 밀어냄 | 매칭된 라벨 끝 지점부터 `find()`로 delimiter 탐색(라운드 8의 label-embedded-marker 케이스도 동시에 유지) |
| 10 (P2) | `"Run"` 라벨이 `"Runtime behavior..."`처럼 완전히 무관한 텍스트의 접두사로 우연히 매칭 | 라벨 뒤 비영숫자(non-alnum) 경계 요구 |
| 11 (P2) | 옵션 라벨 자체에 개행(`\n`)이 있으면 생성된 scaffold가 물리적으로 2줄로 쪼개져, 미기입 placeholder가 있는 두 번째 줄이 `Falsified:`로 시작하지 않아 스캔에서 완전히 빠짐 | 라벨을 트리거 파이프라인 진입 시점(`_t1_matching_labels`/`_t2_matching_labels`)에 whitespace 정규화 |
| 12 (P2) | `"Run"` vs `"Run now"`처럼 공백으로 구분된 서로 다른(무관한) 옵션도 비영숫자 경계를 통과해 라운드 10 수정을 우회 | 경계 조건을 "정확히 scaffold delimiter(`" — probe: "`) 또는 줄 끝"으로 강화 |
| 13 | (미완료 — Codex 리뷰가 실행 중 강제 종료됨, 결과 없음) | — |

Pre-commit verified: `bash tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh` → 88/88 passed (rebase 이후 재확인); `bash scripts/run-tests.sh` → ALL TESTS PASSED, exit 0

## 검증 근거

- **훅 전용 테스트**: `bash tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh` → **88/88 통과** (rebase 이후 재확인 완료)
- **저장소 전체 테스트**: `bash scripts/run-tests.sh` → **ALL TESTS PASSED, EXIT:0** (라운드 12 수정 이후 최종 재실행)
- 각 Codex 발견은 적용 전 Python 직접 호출로 라이브 프로브 재현 → 수정 → 재프로브로 재확인 → 해당 시나리오의 회귀 테스트를 훅 스위트에 추가하는 순서로 처리했습니다.

## 미검증/남겨진 항목

- 위 헤드라인대로, **round 13 미완료로 convergence 미확인**입니다.
- Codex 자체 sandbox 실행 로그에 반복적으로 나타난 `bash tests/hooks/.../test_output_block_falsify_advisory.sh` 관련 "Command failed (exit 1)"은 라운드 8~13에 걸쳐 매번 동일하게 나타났으나, 매 라운드 로컬에서 직접 재실행하여 실제로는 exit 0·전체 통과임을 확인했습니다 — Codex sandbox의 임시 파일 쓰기 제약에서 비롯된 것으로 보이며 실제 테스트 실패가 아닙니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved output validation for AskUserQuestion responses, covering multiple questions and triggering options.
  - Added ready-to-fill `Falsified:` guidance when required evidence is missing.
  - Strengthened detection against incomplete evidence, placeholder text, label mismatches, and formatting bypasses.
  - Added rich telemetry for block and ask decisions while preventing duplicate records.

- **Documentation**
  - Updated behavioral specifications with validation rules, telemetry details, and expanded examples.

- **Tests**
  - Added extensive coverage for multi-question handling, evidence matching, edge cases, and telemetry accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->