### PR TITLE
fix(hooks): resolve memory-hint dir-slug mismatch

### DIFF
--- a/hooks/advisory-nudge/memory-hint/impl.py
+++ b/hooks/advisory-nudge/memory-hint/impl.py
@@ -172,6 +172,9 @@ def parse_frontmatter(raw: str) -> dict | None:
     }
 
 
+_SLUG_CHAR_RE = re.compile(r"[^a-zA-Z0-9]")
+
+
 def resolve_memory_dir() -> str | None:
     """Return the resolved memory directory path or None if missing."""
     env_dir = os.environ.get("PRAXIS_MEMORY_DIR", "").strip()
@@ -180,7 +183,15 @@ def resolve_memory_dir() -> str | None:
 
     home = os.path.expanduser("~")
     cwd = os.getcwd()
-    slug = cwd.replace("/", "-")
+    # Claude Code replaces every non-alphanumeric character individually
+    # (not collapsed runs) — e.g. /Users/nathan.song/.claude slugs to
+    # -Users-nathan-song--claude (double dash, since "/." is two chars).
+    # A prior cwd.replace("/", "-") only touched slashes, so any other
+    # special character (a literal "." in a username, for one) left the
+    # fallback path permanently unresolvable — this fallback ran, found
+    # None, and the entire hookable/hookKeywords surface silently never
+    # fired for any memory in the store.
+    slug = _SLUG_CHAR_RE.sub("-", cwd)
     fallback = os.path.join(home, ".claude", "projects", slug, "memory")
     return fallback if os.path.isdir(fallback) else None
 

--- a/hooks/advisory-nudge/memory-hint/spec.md
+++ b/hooks/advisory-nudge/memory-hint/spec.md
@@ -92,7 +92,14 @@ clarify *why* a block fired.
 Memory directory resolution order:
 1. `PRAXIS_MEMORY_DIR` env var (when set + points to an existing directory)
 2. fallback `~/.claude/projects/{slugified-cwd}/memory/` — slugify rule:
-   replace `/` with `-` on the absolute cwd
+   replace every non-alphanumeric character in the absolute cwd with `-`
+   (per-character, not collapsed) — matches Claude Code's own project-slug
+   convention, e.g. `/Users/nathan.song/.claude` → `-Users-nathan-song--claude`
+   (double dash from the adjacent `/` and `.`). A naive `cwd.replace("/", "-")`
+   left any other special character (such as a literal `.` in a home-directory
+   segment) un-slugified, permanently desyncing the fallback path from the
+   real project directory and silently disabling this hook end-to-end for
+   affected users (issue #799).
 3. neither resolves → exit 0 silently (no fallback attempt, no error)
 
 Five exit-0 fail-safe paths:
@@ -115,6 +122,8 @@ NOT supported — any parse error skips that memory, never the hook.
 bash tests/test_memory_hint.sh
 ```
 
-Covers 21 cases: hit/silent core paths, frontmatter gates, noise cap, mtime
+Covers 36 cases: hit/silent core paths, frontmatter gates, noise cap, mtime
 ordering, discovery fail-safes, malformed inputs, AC-21 (no description),
-AC-22 (scalar rejection), AC-23 (case sensitivity).
+AC-22 (scalar rejection), AC-23 (case sensitivity), and (35) the
+`resolve_memory_dir()` fallback-path per-character slugification fix
+(issue #799).

--- a/tests/hooks/advisory-nudge/test_memory_hint.sh
+++ b/tests/hooks/advisory-nudge/test_memory_hint.sh
@@ -276,6 +276,59 @@ run_input_case "34 hit: ASCII keyword adjacent to Hangul splits as separate toke
   "hit:hook_edit_event.md" "$FIXTURES_MAIN" Edit \
   '{"file_path": "/tmp/x.py", "old_string": "EditEventToken할까요?", "new_string": "y"}'
 
+# --- AC-35/36: resolve_memory_dir() fallback-path slugification -------------
+# All cases above always set PRAXIS_MEMORY_DIR explicitly, so the fallback
+# branch in resolve_memory_dir() (cwd -> ~/.claude/projects/<slug>/memory)
+# was never exercised by this suite. That gap let a real bug ship silently:
+# the fallback slugified cwd via cwd.replace("/", "-") only, which does not
+# match Claude Code's actual per-character non-alphanumeric replacement
+# (e.g. "/Users/nathan.song/.claude" slugs to "-Users-nathan-song--claude",
+# not "-Users-nathan.song-.claude") — any home path containing a special
+# character other than "/" left the fallback path permanently unresolvable
+# for that user, silently disabling every hookable memory unconditionally.
+FALLBACK_HOME=$(cd "$(mktemp -d)" && pwd -P)
+# cwd containing a literal "." mirrors the real-world failure (a "." inside
+# a path segment, as in a username like "nathan.song"). Resolve via `pwd -P`
+# (physical path) so this test is immune to macOS's /var -> /private/var
+# symlink, which would otherwise desync the expected slug from what
+# os.getcwd() actually reports.
+FALLBACK_CWD="$FALLBACK_HOME/work/my.repo"
+mkdir -p "$FALLBACK_CWD"
+FALLBACK_SLUG=$(python3 -c "
+import re
+print(re.sub(r'[^a-zA-Z0-9]', '-', '$FALLBACK_CWD'))
+")
+FALLBACK_MEMDIR="$FALLBACK_HOME/.claude/projects/$FALLBACK_SLUG/memory"
+mkdir -p "$FALLBACK_MEMDIR"
+cat > "$FALLBACK_MEMDIR/fallback-slug-probe.md" <<'EOF'
+---
+name: fallback-slug-probe
+description: probe memory for the resolve_memory_dir fallback-path test
+hookable: true
+hookKeywords: [FallbackSlugToken]
+---
+probe body
+EOF
+
+FALLBACK_ERR=$(mktemp)
+(
+  cd "$FALLBACK_CWD" || exit 1
+  echo '{"tool_name": "Bash", "tool_input": {"command": "echo FallbackSlugToken"}}' \
+    | env -u PRAXIS_MEMORY_DIR HOME="$FALLBACK_HOME" "$HOOK" >/dev/null 2>"$FALLBACK_ERR"
+)
+FALLBACK_RC=$?
+FALLBACK_OUT=$(cat "$FALLBACK_ERR")
+rm -f "$FALLBACK_ERR"
+rm -rf "$FALLBACK_HOME"
+
+if [ "$FALLBACK_RC" -eq 0 ] && printf '%s' "$FALLBACK_OUT" | grep -q "fallback-slug-probe.md"; then
+  echo "PASS  [35 hit: resolve_memory_dir() fallback path matches Claude Code's per-char slug for a cwd containing \".\"]"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL  [35 hit: resolve_memory_dir() fallback path matches Claude Code's per-char slug for a cwd containing \".\"] (rc=$FALLBACK_RC, stderr=$FALLBACK_OUT)"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("35 resolve_memory_dir fallback slug match")
+fi
+
 # --- summary -----------------------------------------------------------------
 echo ""
 echo "Passed: $PASS  Failed: $FAIL"


### PR DESCRIPTION
## 배경

Closes #799

PR #796 세션의 retrospect(2026-07-16)에서, `feedback_worktree_context_pre_git_op.md` 메모리의 `hookable`/`hookKeywords` 프론트매터가 `gh pr merge` worktree-precondition 재발(6번째)을 전혀 막지 못한 이유를 근본원인 분석함.

## 근본 원인

`memory-hint` hook의 `resolve_memory_dir()` fallback 경로(`PRAXIS_MEMORY_DIR` 미설정 시)가 cwd를 `cwd.replace("/", "-")`로만 슬러그화했는데, Claude Code의 실제 프로젝트 슬러그 컨벤션은 **모든** non-alphanumeric 문자를 개별 치환한다(`~/.claude/projects/` 디렉터리명으로 실증: `/Users/nathan.song/.claude` → `-Users-nathan-song--claude`, `/`와 `.`가 인접해 더블 대시가 됨).

이 사용자의 홈 경로(`nathan.song`)처럼 `/` 외의 특수문자가 포함된 경로에서는 fallback 경로가 영구적으로 해석 불가능해져, `resolve_memory_dir()`가 `None`을 반환하고 `index_memories()`가 단 한 번도 실행되지 않았음 — **모든** hookable 메모리가 이 사용자 환경 전체에서 도입 시점부터 조용히 무력화되어 있었음.

## 수정

- per-character 정규식(`[^a-zA-Z0-9]`, `+` 없음 — collapse 하지 않음)으로 교체
- 구현 전 실제 `~/.claude/projects/` 디렉터리명 여러 개를 대조해 "연속 non-alnum을 하나로 collapse"하는 정규식도 틀렸음을 미리 확인(더블 대시 케이스에서 깨짐)하고 배제

## 검증

- 신규 회귀 테스트(케이스 35) 추가 — 기존 35개 케이스 전부 `PRAXIS_MEMORY_DIR`을 명시적으로 세팅해서 fallback 경로가 한 번도 테스트되지 않았던 커버리지 gap을 직접 겨냥
- 격리된 임시 `HOME`/cwd(경로에 `.` 포함) 구성 후 hook을 직접 invoke해 fallback 경로 매칭 확인
- 테스트 자체가 macOS `/var → /private/var` 심볼릭링크로 1차 실패했고, 이를 실제 버그와 무관한 테스트 결함으로 진단해 물리 경로(`pwd -P`) 정규화로 수정
- `bash tests/hooks/advisory-nudge/test_memory_hint.sh` — 36/36 통과 (기존 35 + 신규 1, 회귀 없음)

```
Passed: 36  Failed: 0
```

## 체크리스트

Pre-commit verified: `bash tests/hooks/advisory-nudge/test_memory_hint.sh` 36/36 통과
Caller chain verified: `resolve_memory_dir()`는 동일 파일 `main()` 내부에서만 호출되는 내부 함수 — 외부 caller 없음, 시그니처 변경 없음(반환 타입/의미 동일)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected fallback memory-directory resolution for working directories containing punctuation or other non-alphanumeric characters.
  * Improved consistency with project path slug conventions.

* **Tests**
  * Added coverage verifying fallback memory lookup and per-character path slugification.

* **Documentation**
  * Updated the memory hint specification to reflect the corrected fallback-path behavior and expanded test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->