### PR TITLE
fix(hooks): confirm label absence before blocking

### DIFF
--- a/hooks/preflight-gate/gh-label-verify/impl.py
+++ b/hooks/preflight-gate/gh-label-verify/impl.py
@@ -26,9 +26,15 @@ Pipeline:
      name -q '.[].name'`, cached per-repo for PRAXIS_GH_LABEL_CACHE_TTL_SEC
      (default 300) at <XDG_CACHE_HOME or ~/.cache>/claude-praxis/
      gh-label-cache.json. Cache corrupt / unwritable → in-memory only.
-  6. If any extracted label is absent from the fetched set → exit 2 with
-     a stderr block listing the missing labels and a sample of valid
-     labels for the repo.
+  6. Decide whether absence from that set is proof. The listing is row-
+     limited, so when it comes back full the repo may hold labels we cannot
+     see; each absent label is then re-checked via
+     `gh api repos/<r>/labels/<name>` and only a 404 counts as absent
+     (anything else → fail-open). A listing under the limit is complete, so
+     absence is proof on its own and no re-check is needed — which also
+     keeps the gate working offline off a warm cache.
+  7. If any label is absent → exit 2 with a stderr block listing the
+     missing labels and a sample of valid labels for the repo.
 
 Fail-open in every infrastructure-error path: gh missing, network fail,
 auth fail, shlex parse error, transcript missing, cwd not a git repo
@@ -48,6 +54,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from urllib.parse import quote
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
@@ -138,13 +145,23 @@ def _process_segment(argv: list[str], cwd: str) -> int:
     if not repo:
         return 0
 
-    valid = _get_labels(repo)
-    if valid is None:
+    got = _get_labels(repo)
+    if got is None:
         return 0
+    valid, truncated = got
 
     missing = [lbl for lbl in labels if lbl not in valid]
     if not missing:
         return 0
+
+    # A truncated listing hides the repo's tail, so absence from it proves
+    # nothing — confirm each candidate against the API and block only on a
+    # definite 404. A complete listing is proof on its own, which also keeps
+    # the gate working offline off a warm cache.
+    if truncated:
+        missing = [lbl for lbl in missing if _label_absent(repo, lbl)]
+        if not missing:
+            return 0
 
     _emit_block(missing, repo, sorted(valid)[:20])
     return 2
@@ -243,11 +260,14 @@ def _cache_ttl_sec() -> int:
         return _DEFAULT_CACHE_TTL_SEC
 
 
-def _get_labels(repo: str) -> frozenset[str] | None:
-    """Return the set of label names defined in `repo`, with caching.
+def _get_labels(repo: str) -> tuple[frozenset[str], bool] | None:
+    """Return (label names defined in `repo`, truncated), with caching.
 
     Returns None when the label set cannot be determined (gh missing,
     network failure, auth failure) — caller treats this as fail-open.
+
+    A cache entry written before `truncated` was tracked is read as truncated,
+    so a stale entry can never justify a block on its own.
     """
     now = time.time()
     cache_path = _cache_path()
@@ -261,14 +281,19 @@ def _get_labels(repo: str) -> frozenset[str] | None:
             and isinstance(labels, list)
             and (now - fetched_at) < _cache_ttl_sec()
         ):
-            return frozenset(labels)
+            return frozenset(labels), bool(entry.get("truncated", True))
 
     fetched = _fetch_labels(repo)
     if fetched is None:
         return None
-    cache[repo] = {"labels": sorted(fetched), "fetched_at": now}
+    names, truncated = fetched
+    cache[repo] = {
+        "labels": sorted(names),
+        "fetched_at": now,
+        "truncated": truncated,
+    }
     _save_cache(cache_path, cache)
-    return frozenset(fetched)
+    return frozenset(names), truncated
 
 
 def _load_cache(path: Path) -> dict:
@@ -291,7 +316,12 @@ def _save_cache(path: Path, cache: dict) -> None:
         pass
 
 
-def _fetch_labels(repo: str) -> set[str] | None:
+def _fetch_labels(repo: str) -> tuple[set[str], bool] | None:
+    """Return (labels, truncated) for `repo`, or None on any fetch failure.
+
+    `truncated` is True when the listing filled the row limit — the repo may
+    hold more labels than we can see, so absence from `labels` proves nothing.
+    """
     try:
         r = subprocess.run(
             [
@@ -309,7 +339,29 @@ def _fetch_labels(repo: str) -> set[str] | None:
         return None
     if r.returncode != 0:
         return None
-    return {ln.strip() for ln in r.stdout.splitlines() if ln.strip()}
+    labels = {ln.strip() for ln in r.stdout.splitlines() if ln.strip()}
+    return labels, len(labels) >= _GH_LABEL_LIMIT
+
+
+def _label_absent(repo: str, label: str) -> bool:
+    """True only when the API definitively reports `label` missing (404).
+
+    Every other outcome — success, network/auth failure, an unexpected status —
+    returns False so the gate fails open rather than blocking on an absence it
+    could not prove.
+    """
+    try:
+        r = subprocess.run(
+            ["gh", "api", f"repos/{repo}/labels/{quote(label, safe='')}"],
+            capture_output=True,
+            text=True,
+            timeout=_GH_LABEL_FETCH_TIMEOUT_SEC,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    if r.returncode == 0:
+        return False
+    return "404" in r.stderr
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/preflight-gate/gh-label-verify/impl.py
+++ b/hooks/preflight-gate/gh-label-verify/impl.py
@@ -32,7 +32,9 @@ Pipeline:
      `gh api repos/<r>/labels/<name>` and only a 404 counts as absent
      (anything else → fail-open). A listing under the limit is complete, so
      absence is proof on its own and no re-check is needed — which also
-     keeps the gate working offline off a warm cache.
+     keeps the gate working offline off a warm cache. Listing and re-checks
+     share one deadline drawn from the gate's manifest timeout; once it
+     passes, remaining re-checks fail open rather than overrun the budget.
   7. If any label is absent → exit 2 with a stderr block listing the
      missing labels and a sample of valid labels for the repo.
 
@@ -75,6 +77,13 @@ _GH_LABEL_FETCH_TIMEOUT_SEC = 10
 _GIT_REMOTE_TIMEOUT_SEC = 2
 _GH_LABEL_LIMIT = 300
 
+# hooks/manifest.json gives this gate a 15s timeout. The listing fetch and the
+# per-label re-checks share that one budget, so they need a common deadline —
+# left to their own 10s each they would overrun it and the host would kill the
+# hook mid-session. The margin covers interpreter startup and process spawn.
+_HOOK_TIMEOUT_SEC = 15
+_HOOK_TIMEOUT_MARGIN_SEC = 2
+
 _LABEL_FLAGS: frozenset[str] = frozenset({"--label", "-l", "--add-label"})
 _REPO_FLAGS: frozenset[str] = frozenset({"--repo", "-R"})
 _HELP_FLAGS: frozenset[str] = frozenset({"--help", "-h"})
@@ -98,6 +107,7 @@ _REPO_URL_RE = re.compile(r"[:/]([^/:\s]+)/([^/\s]+?)(?:\.git)?/?$")
 
 @fail_open
 def main() -> int:
+    deadline = time.monotonic() + (_HOOK_TIMEOUT_SEC - _HOOK_TIMEOUT_MARGIN_SEC)
     try:
         payload = json.loads(sys.stdin.read())
     except (json.JSONDecodeError, ValueError):
@@ -120,7 +130,7 @@ def main() -> int:
 
     for raw_argv in iter_command_starts(tokens):
         argv = strip_prefix(list(raw_argv))
-        rc = _process_segment(argv, cwd)
+        rc = _process_segment(argv, cwd, deadline)
         if rc != 0:
             return rc
     return 0
@@ -128,7 +138,7 @@ def main() -> int:
 
 
 
-def _process_segment(argv: list[str], cwd: str) -> int:
+def _process_segment(argv: list[str], cwd: str, deadline: float) -> int:
     if len(argv) < 3 or argv[0] != "gh":
         return 0
     if (argv[1], argv[2]) not in _LABELED_SUBCMDS:
@@ -159,7 +169,7 @@ def _process_segment(argv: list[str], cwd: str) -> int:
     # definite 404. A complete listing is proof on its own, which also keeps
     # the gate working offline off a warm cache.
     if truncated:
-        missing = [lbl for lbl in missing if _label_absent(repo, lbl)]
+        missing = [lbl for lbl in missing if _label_absent(repo, lbl, deadline)]
         if not missing:
             return 0
 
@@ -343,25 +353,50 @@ def _fetch_labels(repo: str) -> tuple[set[str], bool] | None:
     return labels, len(labels) >= _GH_LABEL_LIMIT
 
 
-def _label_absent(repo: str, label: str) -> bool:
+def _split_host(repo: str) -> tuple[str | None, str]:
+    """Split gh's `[HOST/]OWNER/REPO` into (host, `OWNER/REPO`).
+
+    `gh label list --repo` resolves the optional host itself; `gh api` does not,
+    so the host has to move to `--hostname` or the request goes to github.com
+    with the host stuck in the path.
+    """
+    parts = repo.split("/")
+    if len(parts) == 3:
+        return parts[0], f"{parts[1]}/{parts[2]}"
+    return None, repo
+
+
+def _label_absent(repo: str, label: str, deadline: float) -> bool:
     """True only when the API definitively reports `label` missing (404).
 
-    Every other outcome — success, network/auth failure, an unexpected status —
-    returns False so the gate fails open rather than blocking on an absence it
-    could not prove.
+    Every other outcome — success, network/auth failure, an unexpected status,
+    no time left in the hook's budget — returns False so the gate fails open
+    rather than blocking on an absence it could not prove.
     """
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        return False
+
+    host, owner_repo = _split_host(repo)
+    cmd = ["gh", "api"]
+    if host:
+        cmd += ["--hostname", host]
+    cmd.append(f"repos/{owner_repo}/labels/{quote(label, safe='')}")
     try:
         r = subprocess.run(
-            ["gh", "api", f"repos/{repo}/labels/{quote(label, safe='')}"],
+            cmd,
             capture_output=True,
             text=True,
-            timeout=_GH_LABEL_FETCH_TIMEOUT_SEC,
+            timeout=min(remaining, _GH_LABEL_FETCH_TIMEOUT_SEC),
         )
     except (OSError, subprocess.SubprocessError):
         return False
     if r.returncode == 0:
         return False
-    return "404" in r.stderr
+    # Match the status marker, not a bare "404": gh echoes the request URL on
+    # connection errors, so a label like `hub-issue-404` would otherwise read
+    # its own name back as proof of its absence.
+    return "(HTTP 404)" in r.stderr
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hooks/preflight-gate/test_gh_label_verify.sh
+++ b/tests/hooks/preflight-gate/test_gh_label_verify.sh
@@ -63,10 +63,13 @@ if [ "$1" = "label" ] && [ "$2" = "list" ]; then
       *) shift ;;
     esac
   done
+  # `gh` resolves the optional [HOST/] prefix itself; canned repos are keyed
+  # by OWNER/REPO, so drop it.
+  case "$repo" in */*/*) repo="${repo#*/}" ;; esac
   case "$repo" in
     acme/repo)
       printf 'bug\nenhancement\ntool-friction:cli\n' ;;
-    acme/truncated)
+    acme/truncated|acme/neterr)
       # Fill the row limit (300) so the listing looks truncated. `tail-label`
       # is deliberately absent from it but real — see the `gh api` arm.
       printf 'head-label\n'
@@ -81,16 +84,33 @@ if [ "$1" = "label" ] && [ "$2" = "list" ]; then
   exit 0
 fi
 
-# `gh api repos/<owner>/<repo>/labels/<name>` — ground truth for existence.
+# `gh api [--hostname <h>] repos/<owner>/<repo>/labels/<name>` — ground truth
+# for existence. `gh api` does NOT parse a [HOST/] prefix out of the path, so
+# a caller must pass the host via --hostname; keying truth off the path alone
+# therefore catches a caller that leaves the host in the path.
 if [ "$1" = "api" ]; then
-  case "$2" in
+  shift
+  path=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --hostname) shift 2 ;;
+      *) path="$1"; shift ;;
+    esac
+  done
+  case "$path" in
     repos/*/labels/*)
-      repo="${2#repos/}"; repo="${repo%%/labels/*}"
-      name="${2##*/labels/}"
+      repo="${path#repos/}"; repo="${repo%%/labels/*}"
+      name="${path##*/labels/}"
       truth=""
       case "$repo" in
         acme/repo)      truth='bug enhancement tool-friction:cli' ;;
         acme/truncated) truth='head-label tail-label' ;;
+        acme/neterr)
+          # gh echoes the request URL on a connection error, so the label name
+          # lands in stderr — a label called *404* must not read its own name
+          # back as proof of absence.
+          echo "Get \"https://api.github.com/$path\": dial tcp: connect: connection refused" >&2
+          exit 1 ;;
       esac
       for l in $truth; do
         if [ "$l" = "$name" ]; then exit 0; fi
@@ -180,6 +200,19 @@ run_case "gh pr create --label tail-label (listing truncated, label real) — si
 run_case "gh pr create --label ghost (listing truncated, label absent) — block" \
   "block" \
   '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label ghost --repo acme/truncated --title t --body b"}}'
+
+# gh echoes the request URL on a connection error, so a label named *404*
+# appears in its own failure message. Only the `(HTTP 404)` status marker
+# means absent — a network error must fail open.
+run_case "gh pr create --label hub-issue-404 (re-check hits network error) — silent" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label hub-issue-404 --repo acme/neterr --title t --body b"}}'
+
+# gh accepts [HOST/]OWNER/REPO. `gh label list` resolves the host itself, but
+# `gh api` needs it in --hostname — left in the path it would 404 on a real label.
+run_case "gh pr create --label tail-label --repo <host>/acme/truncated — silent" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label tail-label --repo ghe.example.com/acme/truncated --title t --body b"}}'
 
 run_case "gh issue create --label bug (exists) — silent" \
   "silent" \
@@ -392,6 +425,43 @@ if [ "$_uncaught_rc" -eq 0 ] && [ -z "$_uncaught_out" ]; then
 else
   echo "  FAIL  main() not wrapped by @fail_open (rc=$_uncaught_rc, out=$(echo "$_uncaught_out" | head -c 200))"
   FAIL=$((FAIL + 1)); FAILED_NAMES+=("main() is wrapped by the shared @fail_open guard")
+fi
+
+# ---------------------------------------------------------------------------
+# Re-check honours the shared hook deadline
+# ---------------------------------------------------------------------------
+
+# The listing fetch and the per-label re-checks share the gate's 15s manifest
+# budget. Once the deadline passes, a re-check must fail open immediately
+# rather than spawn gh and overrun. Asserted directly: reproducing it through
+# a payload would mean burning the whole budget in wall-clock.
+_deadline_out=$(python3 - << PYEOF 2>&1
+import sys, importlib.util, time
+spec = importlib.util.spec_from_file_location("impl", "$HOOK")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+# gh would exit 0 here (label exists) — if it were consulted, absent=False for
+# the wrong reason. Make any spawn a hard failure instead.
+def _boom(*a, **k):
+    raise AssertionError("gh spawned after the deadline had passed")
+mod.subprocess.run = _boom
+
+if mod._label_absent("acme/repo", "ghost", time.monotonic() - 1) is not False:
+    sys.stderr.write("expired deadline did not fail open\n"); sys.exit(1)
+
+# Budget must be derived from the manifest timeout, not exceed it.
+if mod._HOOK_TIMEOUT_SEC - mod._HOOK_TIMEOUT_MARGIN_SEC >= mod._HOOK_TIMEOUT_SEC:
+    sys.stderr.write("deadline leaves no margin under the manifest timeout\n"); sys.exit(1)
+PYEOF
+)
+_deadline_rc=$?
+if [ "$_deadline_rc" -eq 0 ] && [ -z "$_deadline_out" ]; then
+  echo "  PASS  expired deadline fails open without spawning gh"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL  deadline not honoured (rc=$_deadline_rc, out=$(echo "$_deadline_out" | head -c 200))"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("expired deadline fails open without spawning gh")
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/hooks/preflight-gate/test_gh_label_verify.sh
+++ b/tests/hooks/preflight-gate/test_gh_label_verify.sh
@@ -34,14 +34,21 @@ trap 'rm -rf "$TMPDIR"' EXIT
 # ---------------------------------------------------------------------------
 #
 # The stub recognises a handful of canned repos:
-#   acme/repo   → labels: bug, enhancement, tool-friction:cli
-#   acme/empty  → labels: (none)
-#   acme/fail   → exit 1 (simulates network/auth failure)
-#   anything else → exit 1
+#   acme/repo      → labels: bug, enhancement, tool-friction:cli
+#   acme/empty     → labels: (none)
+#   acme/fail      → exit 1 (simulates network/auth failure)
+#   acme/truncated → `label list` returns only `head-label`, but the label
+#                    `tail-label` really exists and is reachable via
+#                    `gh api`. Simulates a repo with more labels than the
+#                    row limit, where the tail is invisible to the listing.
+#   anything else  → exit 1
 #
-# Only `gh label list --repo <r> ...` is recognised — any other invocation
-# (e.g. `gh issue create`) exits 0 with empty output, so test payloads
-# that would otherwise call `gh` for real are inert.
+# Two invocations are recognised:
+#   `gh label list --repo <r> ...`      → the canned listing above
+#   `gh api repos/<r>/labels/<name>`    → exit 0 when the label really
+#       exists, else `gh: Not Found (HTTP 404)` on stderr + exit 1
+# Any other invocation (e.g. `gh issue create`) exits 0 with empty output,
+# so test payloads that would otherwise call `gh` for real are inert.
 MOCK_BIN="$TMPDIR/mockbin"
 mkdir -p "$MOCK_BIN"
 cat > "$MOCK_BIN/gh" <<'EOF'
@@ -59,6 +66,11 @@ if [ "$1" = "label" ] && [ "$2" = "list" ]; then
   case "$repo" in
     acme/repo)
       printf 'bug\nenhancement\ntool-friction:cli\n' ;;
+    acme/truncated)
+      # Fill the row limit (300) so the listing looks truncated. `tail-label`
+      # is deliberately absent from it but real — see the `gh api` arm.
+      printf 'head-label\n'
+      for i in $(seq 1 299); do printf 'filler-%s\n' "$i"; done ;;
     acme/empty)
       : ;;
     acme/fail|"")
@@ -67,6 +79,26 @@ if [ "$1" = "label" ] && [ "$2" = "list" ]; then
       exit 1 ;;
   esac
   exit 0
+fi
+
+# `gh api repos/<owner>/<repo>/labels/<name>` — ground truth for existence.
+if [ "$1" = "api" ]; then
+  case "$2" in
+    repos/*/labels/*)
+      repo="${2#repos/}"; repo="${repo%%/labels/*}"
+      name="${2##*/labels/}"
+      truth=""
+      case "$repo" in
+        acme/repo)      truth='bug enhancement tool-friction:cli' ;;
+        acme/truncated) truth='head-label tail-label' ;;
+      esac
+      for l in $truth; do
+        if [ "$l" = "$name" ]; then exit 0; fi
+      done
+      echo "gh: Not Found (HTTP 404)" >&2
+      exit 1
+      ;;
+  esac
 fi
 exit 0
 EOF
@@ -137,6 +169,17 @@ run_case "gh pr create --label bug (exists) — silent" \
 run_case "gh pr create --label nope (missing) — block" \
   "block" \
   '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label nope --repo acme/repo --title t --body b"}}'
+
+# Regression (#803): the listing is row-limited, so a repo with more labels
+# than the limit hides its tail. Absence from the listing must not block on
+# its own — `tail-label` is real and the API says so.
+run_case "gh pr create --label tail-label (listing truncated, label real) — silent" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label tail-label --repo acme/truncated --title t --body b"}}'
+
+run_case "gh pr create --label ghost (listing truncated, label absent) — block" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label ghost --repo acme/truncated --title t --body b"}}'
 
 run_case "gh issue create --label bug (exists) — silent" \
   "silent" \


### PR DESCRIPTION
Closes #803

Pre-commit verified: 이 repo 에는 pre-commit 훅이 없어(`.pre-commit-config.yaml` 부재, `core.hooksPath` 미설정, `.git/hooks/pre-commit` 부재) 커밋 전 검증을 수동 실행했습니다 — `bash tests/hooks/preflight-gate/test_gh_label_verify.sh` → `Result: 33/33 passed`, `ruff check hooks/preflight-gate/gh-label-verify/impl.py` → `All checks passed!`, `python3 -m py_compile` OK, `bash -n` OK. rebase 후 재실행도 33/33. CI 는 `.github/workflows/ci.yml`.

## 문제

`gh-label-verify` 가 `gh label list --limit 300` 으로 라벨셋을 가져온 뒤, **그 목록에 없으면 곧 부재**로 단정해 차단했습니다. 라벨 수가 한도를 넘는 repo 는 꼬리가 통째로 보이지 않으므로, 실재하는 라벨에 대해 `--label` 이 차단됩니다. fail-closed 라 우회로도 없고, 피해를 되돌릴 백필(`gh pr edit --add-label`) 조차 같은 결함에 재차단됩니다.

`laplacetec/laplace-airflow-dags` 는 라벨 **713 개**(그중 `hub-issue-*` 667 개, PR 마다 1 개씩 단조 증가)라 꼬리가 확실히 컷 밖입니다.

## 접근

목록이 **한도를 채웠는지**를 추적합니다. 한도 미만이면 목록은 완전하므로 부재가 곧 증거 — 기존처럼 확인 없이 차단하고, 캐시만으로 오프라인 동작도 유지합니다. 한도를 채웠으면 잘렸을 수 있으므로, 없는 라벨만 `gh api repos/<r>/labels/<name>` 로 재확인해 **404 일 때만** 차단합니다. 그 외(성공/네트워크·인증 실패)는 fail-open 이라, "인프라 실패가 세션을 막지 않는다"는 이 모듈의 기존 원칙과 일치합니다.

`truncated` 도입 이전에 쓰인 캐시 엔트리는 truncated 로 읽어, 낡은 엔트리가 단독으로 차단 근거가 되지 않게 했습니다.

라벨 300 개 미만인 대다수 repo 는 API 호출이 **추가로 발생하지 않습니다** — 비용은 잘린 목록의 차단 경로에서만 라벨당 1 회입니다.

### 기각한 대안

- **limit 을 1000 으로 상향**: 절벽을 옮길 뿐입니다. `hub-issue-*` 가 PR 마다 늘어나므로 재발이 예정되어 있습니다.
- **`gh label list --search <name>` 로 타겟 조회** (#803 본문의 (c) 안): **fuzzy 매치라 반증됐습니다** — `--search "hub-issue-3977"` 이 `hub-issue-512`, `hub-issue-631` 까지 반환합니다. 없는 라벨이 fuzzy 로 통과하는 false-pass 가 생겨 게이트가 무력화됩니다.

## 검증

### 단위 테스트 — 33/33 통과

```
Result: 33/33 passed
```

첫 커밋의 신규 회귀 2 건 (canned repo `acme/truncated`: 목록은 한도 300 을 채우되 `tail-label` 은 그 안에 없고, `gh api` 는 실재로 응답):

- `--label tail-label` (목록 잘림 + 라벨 실재) → **silent** — #803 재발 방지
- `--label ghost` (목록 잘림 + 라벨 부재) → **block** — 게이트 본래 가치 보존

### Codex review 반영 (2 번째 커밋)

리뷰가 낸 3 건 모두 전제 검증에서 살아남아 수정했습니다 — 세 건 다 제가 넣은 결함입니다.

- **[P1] 훅 예산 초과**: `hooks/manifest.json` 의 이 게이트 timeout 은 15s 인데, 목록 조회와 재조회가 각자 10s 를 썼습니다. cache miss + 재조회 1 회만으로 예산을 넘겨 훅이 강제 종료됩니다. 진입 시 deadline 을 하나 잡아 세그먼트·재조회가 공유하고, 만료 후에는 gh 를 띄우지 않고 fail-open 합니다.
- **[P2] 오류 문자열 오판**: gh 는 연결 오류 시 요청 URL 을 stderr 에 실으므로, `hub-issue-404` 같은 라벨은 **자기 이름을 부재 증거로 되읽습니다**. 실측: `GH_HOST=127.0.0.1:1 gh api repos/acme/repo/labels/hub-issue-404` → `Get "https://127.0.0.1:1/api/v3/repos/acme/repo/labels/hub-issue-404": ... connection refused` — `404` 포함. `(HTTP 404)` status marker 로 판별하도록 고쳤습니다.
- **[P2] Enterprise hostname**: `gh --repo` 는 `[HOST/]OWNER/REPO` 를 지원하고 `gh label list` 는 host 를 스스로 해석하지만 `gh api` 는 아닙니다. host 가 path 에 남아 GHES 의 실재 라벨이 전부 404 로 판정됩니다. `--hostname` 으로 분리했습니다. **이건 재조회 경로와 함께 제가 새로 넣은 회귀** 입니다 — 이 변경 전에는 `gh label list` 가 알아서 처리하던 형식입니다.

신규 회귀 3 건 (`acme/neterr` = 목록 잘림 + api 가 URL 을 실은 연결 오류):

- `--label hub-issue-404 --repo acme/neterr` → **silent** — 네트워크 오류를 부재로 오판하지 않음
- `--label tail-label --repo ghe.example.com/acme/truncated` → **silent** — host 를 `--hostname` 으로 넘김
- `_label_absent(..., deadline=과거)` → gh 를 spawn 하지 않고 즉시 False (payload 로 재현하려면 예산 13s 를 실시간으로 태워야 해 계약을 직접 단언)

기존 캐시 효능 테스트 2 건(`cache-hit blocks/passes ... when gh is gone`)도 그대로 통과합니다. 초안에서는 모든 부재를 무조건 확인하게 만들어 이 중 block 쪽이 깨졌고, 그래서 truncation 인지 방식으로 재설계했습니다.

### 기능 테스트 — 실제 결함 아티팩트 (라벨 713 개 실 repo)

스텁은 메커니즘 재현일 뿐이라, 실제로 차단을 일으킨 repo 로 직접 검증했습니다.

```
$ echo '{"tool_name":"Bash","tool_input":{"command":"gh issue create --label hub-issue-3977 --repo laplacetec/laplace-airflow-dags --title t --body b"}}' \
    | python3 hooks/preflight-gate/gh-label-verify/impl.py
  exit=0            # 통과 — 수정 전에는 여기서 차단됐음

$ echo '{"tool_name":"Bash","tool_input":{"command":"gh issue create --label totally-fake-xyz999 --repo laplacetec/laplace-airflow-dags --title t --body b"}}' \
    | python3 hooks/preflight-gate/gh-label-verify/impl.py
BLOCKED: gh label(s) not found in laplacetec/laplace-airflow-dags: totally-fake-xyz999
```

오탐은 사라지고 진짜 오타는 여전히 잡힙니다.

### 린트

`ruff check` → `All checks passed!` · `python3 -m py_compile` OK · `bash -n` OK

## 검증하지 않은 것

- **인증 실패(403)·서버 오류(5xx) 는 실 환경에서 재현하지 않았습니다.** 연결 오류는 스텁으로 덮었고 `_label_absent` 는 `(HTTP 404)` marker 가 있을 때만 True 를 반환하지만, 실제 403/5xx 응답으로 확인하지는 않았습니다.
- **예산 초과 경로를 실시간으로 태워보지 않았습니다.** deadline 만료 시 fail-open 은 계약 단언으로 검증했고, 실 repo 실행은 2s 로 15s 예산 안에 들어왔습니다(느린 네트워크에서의 실제 초과는 미재현).
- 라벨명이 URL 인코딩되는 경로(`quote(label, safe='')`)는 공백 포함 라벨(`good first issue`)로 실 API 확인했으나, 그 외 특수문자(`/`, `#` 등)는 확인하지 않았습니다.

## 영향 범위

`gh issue/pr create/edit` 에 `--label` 을 쓰는 모든 세션. 완화 방향(오탐 제거)이라 이 변경으로 새로 차단되는 케이스는 없습니다 — 유일한 동작 축소는 "목록이 잘린 repo 에서 gh 로 확인이 불가능할 때 차단하지 않음"이며, 이는 모듈의 fail-open 원칙과 일치합니다.

## 별건 (이 PR 범위 밖)

#803 작업 목록의 마지막 항목 — `laplacetec/laplace-airflow-dags` PR #9270 에 `hub-issue-3981` 백필 — 은 이 수정이 배포된 뒤 정상 경로로 처리해야 하므로 별도 건으로 남깁니다.
