### PR TITLE
fix(hooks): skip shell redirects in branch-name-check

### DIFF
--- a/hooks/preflight-gate/branch-name-check/impl.py
+++ b/hooks/preflight-gate/branch-name-check/impl.py
@@ -83,6 +83,15 @@ _GIT_GLOBAL_BARE_FLAGS = frozenset({
 # Shell separators that end a single command's argument list.
 _SHELL_SEPARATORS = {";", "&&", "||", "|", "&"}
 
+# Shell redirect operators. safe_tokenize (punctuation_chars=';|&') splits `&`
+# out of fd-dup forms, so `git branch 2>&1` arrives as the operator token `2>`
+# followed by a separate `&`-delimited segment — and `2>` is then misread as
+# the first positional (the new branch name). This regex matches a token that
+# *starts* with a redirect operator: optional leading fd digits, then one of
+# `>` `>>` `<` `<<` `<<<` `>&` `<&`, plus the `&>`/`&>>` merge forms. A branch
+# name can never begin this way, so any match is a redirect, not a name.
+_REDIRECT_OPERATOR_RE = re.compile(r"^(?:&>>?|\d*>>?|\d*<<?<?|\d*[<>]&\d*)")
+
 
 # ---------------------------------------------------------------------------
 # Config helpers
@@ -115,6 +124,37 @@ def _get_whitelist() -> frozenset[str]:
 # name for creation commands.  Uses a token walker (not naive space-split) so
 # that `-b` values containing spaces or other edge forms are handled correctly.
 # ---------------------------------------------------------------------------
+
+def _strip_redirects(argv: list[str]) -> list[str]:
+    """Drop shell redirect operators and their targets from argv.
+
+    A bare operator token (`>`, `2>`, `>>`, `<`) consumes the *following* token
+    as its file/fd target (`> /tmp/out`), so both are dropped. An operator with
+    an attached target (`>file`, `2>/dev/null`, `<<EOF`) is a single token and
+    is dropped alone. Tokens containing whitespace cannot be unquoted shell
+    words, so any redirect-like substring in them is literal and left intact
+    (mirrors `_segment_has_redirect` in `_hook_utils.py`). Without this,
+    `git branch 2>&1` (a query) is misread as `git branch 2>` (a creation).
+    """
+    out: list[str] = []
+    i = 0
+    n = len(argv)
+    while i < n:
+        tok = argv[i]
+        if " " in tok or "\t" in tok:
+            out.append(tok)
+            i += 1
+            continue
+        match = _REDIRECT_OPERATOR_RE.match(tok)
+        if match:
+            # Whole token is the operator → also drop its target (next token).
+            # Attached target (`>file`) → drop this token only.
+            i += 2 if match.end() == len(tok) else 1
+            continue
+        out.append(tok)
+        i += 1
+    return out
+
 
 def _strip_git_globals(argv: list[str]) -> list[str]:
     """Strip git global flags between 'git' (argv[0]) and the subcommand.
@@ -164,6 +204,10 @@ def _extract_new_branch(argv: list[str]) -> str | None:
     argv = strip_prefix(argv)
     if not argv or argv[0] != "git":
         return None
+
+    # Drop shell redirect tokens before positional detection so a query like
+    # `git branch 2>&1` is not misparsed as `git branch <name>` (issue #806).
+    argv = _strip_redirects(argv)
 
     sub = _strip_git_globals(argv)
     if not sub:

--- a/hooks/preflight-gate/branch-name-check/impl.py
+++ b/hooks/preflight-gate/branch-name-check/impl.py
@@ -83,14 +83,17 @@ _GIT_GLOBAL_BARE_FLAGS = frozenset({
 # Shell separators that end a single command's argument list.
 _SHELL_SEPARATORS = {";", "&&", "||", "|", "&"}
 
-# Shell redirect operators. safe_tokenize (punctuation_chars=';|&') splits `&`
-# out of fd-dup forms, so `git branch 2>&1` arrives as the operator token `2>`
-# followed by a separate `&`-delimited segment — and `2>` is then misread as
-# the first positional (the new branch name). This regex matches a token that
-# *starts* with a redirect operator: optional leading fd digits, then one of
-# `>` `>>` `<` `<<` `<<<` `>&` `<&`, plus the `&>`/`&>>` merge forms. A branch
-# name can never begin this way, so any match is a redirect, not a name.
-_REDIRECT_OPERATOR_RE = re.compile(r"^(?:&>>?|\d*>>?|\d*<<?<?|\d*[<>]&\d*)")
+# Shell redirect operators. This regex matches a token that *starts* with a
+# redirect operator: optional leading fd digits, then one of `>` `>>` `<` `<<`
+# `<<<` `>&` `<&`, plus the `&>`/`&>>` merge forms. A branch name can never
+# begin this way, so any match is a redirect, not a name.
+#
+# The fd-dup alternative is `\d*[<>]&` WITHOUT a trailing `\d*`: for a merged
+# token like `2>&1` (see `_merge_fd_redirects`) the operator is `2>&` and the
+# target fd `1` is the *attached* target. Matching the trailing `1` too would
+# make `match.end() == len(tok)`, mis-classify the token as a bare operator,
+# and drop the *following* token (the branch name) as a phantom target.
+_REDIRECT_OPERATOR_RE = re.compile(r"^(?:&>>?|\d*>>?|\d*<<?<?|\d*[<>]&)")
 
 
 # ---------------------------------------------------------------------------
@@ -124,6 +127,53 @@ def _get_whitelist() -> frozenset[str]:
 # name for creation commands.  Uses a token walker (not naive space-split) so
 # that `-b` values containing spaces or other edge forms are handled correctly.
 # ---------------------------------------------------------------------------
+
+# A bare redirect operator token that can precede an fd-dup `&` (`2>`, `>`,
+# `1>`, `<`, `0<`). Used to re-merge the `&`-split fd-dup forms below.
+_FD_DUP_LEFT_RE = re.compile(r"^\d*[<>]$")
+# The fd target that follows the `&` in an fd-dup (`2>&1`, `>&-`).
+_FD_DUP_TARGET_RE = re.compile(r"^(?:\d+|-)$")
+
+
+def _merge_fd_redirects(tokens: list[str]) -> list[str]:
+    """Re-merge fd-dup redirect forms that `safe_tokenize` split on `&`.
+
+    `safe_tokenize` uses `punctuation_chars=';|&'`, so `2>&1` tokenizes to
+    `['2>', '&', '1']` and `iter_command_starts` then treats the `&` as a
+    command separator — splitting `git branch 2>&1 bad-name` into two bogus
+    segments and letting `bad-name` slip through unchecked (issue #806 review).
+    This re-joins `<op> & <fd>` (`2>&1`, `1>&2`, `>&-`) and `& <op-target>`
+    (`&>file`) into a single redirect token BEFORE segment splitting, so the
+    trailing branch name stays in the same segment and gets validated.
+
+    A `&` that is a genuine job-control separator (`cmd & other`, `a && b`) is
+    left untouched — it is only merged when the adjacent tokens are themselves
+    redirect-shaped.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(tokens)
+    while i < n:
+        tok = tokens[i]
+        # `<op> & <fd>` → `<op>&<fd>` (e.g. `2>` `&` `1` → `2>&1`).
+        if (
+            i + 2 < n
+            and tokens[i + 1] == "&"
+            and _FD_DUP_LEFT_RE.match(tok)
+            and _FD_DUP_TARGET_RE.match(tokens[i + 2])
+        ):
+            out.append(tok + "&" + tokens[i + 2])
+            i += 3
+            continue
+        # `& <op-target>` → `&<op-target>` (e.g. `&` `>file` → `&>file`).
+        if i + 1 < n and tok == "&" and tokens[i + 1].startswith(">"):
+            out.append("&" + tokens[i + 1])
+            i += 2
+            continue
+        out.append(tok)
+        i += 1
+    return out
+
 
 def _strip_redirects(argv: list[str]) -> list[str]:
     """Drop shell redirect operators and their targets from argv.
@@ -518,6 +568,11 @@ def main() -> int:
     tokens = safe_tokenize(command)
     if not tokens:
         return 0
+
+    # Re-merge fd-dup redirects (`2>&1`) that safe_tokenize split on `&`, so a
+    # branch name after such a redirect stays in the same command segment and
+    # is not dropped as a phantom separator (issue #806 review).
+    tokens = _merge_fd_redirects(tokens)
 
     branch_regex = _get_regex()
     strict = _get_strict()

--- a/hooks/preflight-gate/branch-name-check/spec.md
+++ b/hooks/preflight-gate/branch-name-check/spec.md
@@ -100,6 +100,27 @@ Uses `safe_tokenize` / `iter_command_starts` / `strip_prefix` from `_hook_utils.
 - Env prefixes and wrapper commands (`sudo`, `env`) are peeled before matching
 - Quoted strings protect their contents — `echo "git checkout -b bad"` does not trigger
 - Git global flags (`-C`, `-c`, `--git-dir`, etc.) are stripped before the subcommand check
+- Shell redirect tokens are stripped before positional detection (see below)
+
+### Redirect handling (issue #806)
+
+`git branch` with no positional is a **query**. A trailing shell redirect
+(`git branch 2>&1`, `git branch > /tmp/out`) must not be misread as a branch
+*creation*, since the redirect token would otherwise be captured as the first
+non-flag positional. `_strip_redirects` drops redirect operators (and their
+targets) from the argv before positional detection:
+
+| Form | Example | Handling |
+| --- | --- | --- |
+| fd merge | `2>&1`, `1>&2`, `&>`, `3>&2` | operator token dropped |
+| output redirect | `>`, `>>`, `2>`, `>file`, `2>/dev/null` | attached target dropped with token; spaced target dropped as the next token |
+| input redirect | `<`, `<<`, `<<<`, `<file`, `< input.txt` | same as output |
+| pipe | `git branch \| head` | separate segment — `head` is never read as a name |
+
+A bare operator (`>`, `2>`) consumes the following token as its target; an
+operator with an attached target (`>file`) is a single token. Real creations
+with a trailing redirect (`git branch bad-name > /tmp/log`) are still detected
+and blocked — only the redirect tokens are stripped, not the branch name.
 
 ### Fail-open guarantees
 

--- a/hooks/preflight-gate/branch-name-check/spec.md
+++ b/hooks/preflight-gate/branch-name-check/spec.md
@@ -122,6 +122,18 @@ operator with an attached target (`>file`) is a single token. Real creations
 with a trailing redirect (`git branch bad-name > /tmp/log`) are still detected
 and blocked — only the redirect tokens are stripped, not the branch name.
 
+**fd-dup `&` re-merge.** `safe_tokenize` uses `punctuation_chars=';|&'`, so an
+fd-dup redirect (`2>&1`, `1>&2`, `&>file`) is split on its internal `&` into
+separate tokens, and `iter_command_starts` then treats that `&` as a command
+separator. Without correction, `git checkout -b 2>&1 bad-name` fragments into
+`git checkout -b 2>` and `1 bad-name` — and `bad-name`, which the shell
+actually creates, escapes validation entirely (a **bypass**, not just a false
+positive). `_merge_fd_redirects` re-joins `<op> & <fd>` and `& <op-target>`
+into a single redirect token **before** segment splitting, keeping the branch
+name in the same segment. A genuine job-control `&` (`git status & git checkout
+-b x`, `a && b`) is left untouched — the merge fires only when the tokens
+adjacent to `&` are themselves redirect-shaped.
+
 ### Fail-open guarantees
 
 - Malformed JSON stdin → exit 0 (pass)

--- a/tests/hooks/preflight-gate/test_branch_name_check.sh
+++ b/tests/hooks/preflight-gate/test_branch_name_check.sh
@@ -445,6 +445,36 @@ run_case "git branch hub-5-feat-ok 2>&1 (good creation + redirect, pass)" \
   "silent" \
   '{"tool_name":"Bash","tool_input":{"command":"git branch hub-5-feat-ok 2>&1"}}'
 
+# Critical (issue #806 review): a redirect placed BEFORE the branch name must
+# not let the name slip through. `safe_tokenize` splits `2>&1` on `&`; without
+# re-merging, `git checkout -b 2>&1 bad-name` fragments into two segments and
+# `bad-name` (which the shell actually creates) escapes validation.
+run_case "checkout -b 2>&1 <bad> (redirect before name, block)" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"git checkout -b 2>&1 bad-name"}}'
+
+run_case "checkout -b 2>&1 <good> (redirect before name, pass)" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"git checkout -b 2>&1 hub-5-feat-ok"}}'
+
+run_case "git branch 2>&1 <bad> (redirect before name, block)" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"git branch 2>&1 bad-name"}}'
+
+run_case "switch -c 1>&2 <bad> (fd-dup before name, block)" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"git switch -c 1>&2 bad-branch"}}'
+
+run_case "worktree add -b 2>&1 <bad> <path> (redirect before name, block)" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"git worktree add -b 2>&1 bad-name /tmp/wt"}}'
+
+# Real job-control `&` separator must survive the fd-merge — the second
+# command is still validated.
+run_case "git status & checkout -b <bad> (background sep preserved, block)" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"git status & git checkout -b bad-bg"}}'
+
 # ---------------------------------------------------------------------------
 # git worktree add implicit basename branch creation (P2 bypass paths)
 # ---------------------------------------------------------------------------

--- a/tests/hooks/preflight-gate/test_branch_name_check.sh
+++ b/tests/hooks/preflight-gate/test_branch_name_check.sh
@@ -382,6 +382,70 @@ run_case "git branch issue-1-style-format (style type, pass)" \
   '{"tool_name":"Bash","tool_input":{"command":"git branch issue-1-style-format"}}'
 
 # ---------------------------------------------------------------------------
+# Shell redirect false-positive guard (issue #806)
+# `git branch <redirect>` is a QUERY — the redirect token must not be read as
+# the new branch name. Enumerate every redirect form; all must pass.
+# ---------------------------------------------------------------------------
+
+run_case "git branch 2>&1 (fd merge, query, pass)" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"git branch 2>&1"}}'
+
+run_case "git branch 1>&2 (fd merge reversed, query, pass)" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"git branch 1>&2"}}'
+
+run_case "git branch >file (attached output redirect, query, pass)" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"git branch >file"}}'
+
+run_case "git branch > /tmp/out (spaced output redirect, query, pass)" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"git branch > /tmp/out"}}'
+
+run_case "git branch >> file (append redirect, query, pass)" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"git branch >> file"}}'
+
+run_case "git branch 2>/dev/null (fd output attached, query, pass)" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"git branch 2>/dev/null"}}'
+
+run_case "git branch &>file (fd-all merge, query, pass)" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"git branch &>file"}}'
+
+run_case "git branch <file (attached input redirect, query, pass)" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"git branch <file"}}'
+
+run_case "git branch < input.txt (spaced input redirect, query, pass)" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"git branch < input.txt"}}'
+
+run_case "git branch 3>&2 (arbitrary fd, query, pass)" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"git branch 3>&2"}}'
+
+run_case "git branch | head (pipe, downstream not read as name, pass)" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"git branch | head"}}'
+
+# Regression: real creation with a trailing redirect must STILL be blocked —
+# stripping redirects must not blind the creation check.
+run_case "git branch bad-name > /tmp/log (creation + redirect, block)" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"git branch bad-name > /tmp/log"}}'
+
+run_case "git checkout -b bad-branch 2>&1 (creation + redirect, block)" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"git checkout -b bad-branch 2>&1"}}'
+
+run_case "git branch hub-5-feat-ok 2>&1 (good creation + redirect, pass)" \
+  "silent" \
+  '{"tool_name":"Bash","tool_input":{"command":"git branch hub-5-feat-ok 2>&1"}}'
+
+# ---------------------------------------------------------------------------
 # git worktree add implicit basename branch creation (P2 bypass paths)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 배경

`git branch 2>&1` 처럼 리다이렉트가 붙은 **조회** 명령을 branch-name-check 훅이 브랜치 **생성** 으로 오인해 차단하던 문제를 수정합니다. `git branch` 는 상태 확인의 기본 명령이라 조회마다 차단되어, 정상 조회를 위해 가드를 끄는 잘못된 학습을 유도했습니다.

## 원인

`safe_tokenize` 는 `punctuation_chars=';|&'` 로 `&` 를 분리하므로 `git branch 2>&1` 이 `['git', 'branch', '2>']` 로 잘립니다. `2>` 가 첫 non-flag positional 로 잡혀 새 브랜치명(`impl.py:359` 경로)으로 매칭되어 차단됐습니다.

## 수정

positional 판정 **전** 에 셸 리다이렉트 토큰과 그 대상을 제거하는 `_strip_redirects` 를 추가하고, `_extract_new_branch` 에서 git 확인 직후 argv 전체에 적용했습니다. 모든 하위 추출기(checkout/switch/branch/worktree)가 함께 혜택을 받습니다.

- bare 연산자(`>`, `2>`, `>>`, `<`)는 다음 토큰을 대상으로 함께 제거
- 대상이 붙은 형태(`>file`, `2>/dev/null`)는 단일 토큰으로 제거
- whitespace 포함 토큰은 quoted string 이므로 그대로 보존 (`_hook_utils.py` 의 `_segment_has_redirect` 철학 미러링)

기존 공용 strip 유틸이 없어 `_hook_utils.py` 의 감지 로직을 미러링한 로컬 헬퍼로 구현했습니다 (blast radius 격리, 병렬 sibling 작업과의 shared-file 충돌 회피).

## 열거 (Pre-Implementation Surface Enumeration)

| 형태 | 예 | 결과 |
|---|---|---|
| fd 병합 | `2>&1`, `1>&2`, `&>`, `3>&2` | 통과 |
| 출력 리다이렉트 | `>file`, `> /tmp/out`, `>> file`, `2>/dev/null` | 통과 |
| 입력 리다이렉트 | `<file`, `< input.txt`, `<<<` | 통과 |
| 파이프 | `git branch \| head` | 통과 (head 를 브랜치명으로 안 읽음) |
| 생성 + 리다이렉트 (회귀) | `git branch bad-name > /tmp/log`, `git checkout -b bad-branch 2>&1` | 여전히 차단 |

각 형태를 테스트 케이스로 추가했습니다.

## 검증

Pre-commit verified: test_branch_name_check.sh 98 passed / 0 failed, pytest tests/ 472 passed, ruff check clean.

Caller chain verified: `_strip_redirects` 는 신규 로컬 헬퍼로 `_extract_new_branch`(impl.py) 단일 호출자만 존재 — grep 결과 impl.py 내부 1 caller.

- `bash tests/hooks/preflight-gate/test_branch_name_check.sh` → **98 passed, 0 failed** (리다이렉트 14 케이스 신규)
- `python3 -m pytest tests/ -q` → **472 passed**
- `ruff check hooks/preflight-gate/branch-name-check/impl.py` → clean

Closes #806


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved branch-name validation for Git commands that include shell output or input redirection.
  - Prevented redirect syntax from being mistakenly interpreted as a branch name.
  - Continued detecting and blocking invalid branch names when redirects follow branch-creation commands.
  - Added support for common redirect formats, including file descriptors and merged streams.

- **Documentation**
  - Documented redirect handling and related command behavior.

- **Tests**
  - Added coverage for redirect scenarios across branch creation and query commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->