### PR TITLE
fix(hooks): detect over-claiming in falsify check

### DIFF
--- a/hooks/advisory-nudge/external-write-falsify-check/impl.py
+++ b/hooks/advisory-nudge/external-write-falsify-check/impl.py
@@ -19,6 +19,13 @@ When the body contains hypothesis markers (might / could / potentially / appears
 to / is failing / 가설 / 추정), it emits a stderr advisory reminding the user
 to verify each factual claim with executed evidence before posting.
 
+The hypothesis scan catches the UNDER-claiming polarity (too uncertain to
+publish). The opposite polarity — a confident but false COMPLETION claim
+(반영했습니다 / "I've updated the PR") — carries zero hedging tokens and would
+pass the hypothesis scan by construction. A separate over-claiming scan
+(issue #802) detects first-person modification-completion phrases and reminds
+the author to cross-check each claim against a tool call that actually ran.
+
 Additionally, when the body contains author-exempt claim shapes (mapping table
 rows or bash code blocks with unverified identifiers) and no verification call
 (gh label list / DESCRIBE / <binary> --help) is found in the recent transcript,
@@ -26,9 +33,11 @@ it emits a separate advisory (issue #183).
 
 Exits 0 by default — this is an advisory, not a block. Set
 `PRAXIS_EXTERNAL_WRITE_STRICT=1` to convert hypothesis-marker detection into a
-hard block (exit 2). Set `PRAXIS_AUTHOR_EXEMPT_STRICT=1` to convert author-exempt
-detection into a hard block (exit 2). Set `PRAXIS_CLUSTER_APPROVAL_STRICT=1` to
-convert cluster-approval staging detection into a hard block (exit 2).
+hard block (exit 2). Set `PRAXIS_OVERCLAIM_STRICT=1` to convert over-claiming
+detection into a hard block (exit 2). Set `PRAXIS_AUTHOR_EXEMPT_STRICT=1` to
+convert author-exempt detection into a hard block (exit 2). Set
+`PRAXIS_CLUSTER_APPROVAL_STRICT=1` to convert cluster-approval staging detection
+into a hard block (exit 2).
 
 Uses shlex tokenization (same approach as block-gh-state-all.py / side-effect-scan.py)
 so that pattern references inside quoted strings, echo arguments, or comments
@@ -250,6 +259,67 @@ def _has_hypothesis_marker(body: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Over-claiming (false-completion) marker scan (issue #802)
+# ---------------------------------------------------------------------------
+# The opposite polarity of the hypothesis scan. A confident but false completion
+# claim ("§3 제안도 반영했습니다" when §3 was never executed) has no hedging
+# token, so the hypothesis scan passes it by construction. Retrospect
+# 2026-07-17 observed exactly this: a review reply asserted two review items
+# were incorporated when only one ran; the false sentences mapped 1:1 onto the
+# un-executed items (structural projection of the review ask onto the draft).
+#
+# Full claim↔tool-call verification is an NL-matching problem and out of scope
+# (the issue is explicit about this). The realistic gate is an advisory that
+# fires on first-person modification-completion phrases and asks the author to
+# self-cross-check each claim against a tool call that actually ran.
+#
+# Scope is the review-reply projection verb family (reflected / organized /
+# fixed / changed / replaced / updated / completed). The Korean markers require
+# an active completion inflection (했/함) so that verification/status nouns
+# ("검증 완료: 819 rows") and the passive 됐 form ("prod에 반영됐습니다" — a
+# factual observation, and the applied-on-branch check's domain) do not surface.
+_OVERCLAIM_MARKERS_KO = (
+    "반영했", "반영함",
+    "정리했", "정리함",
+    "바꿨",
+    "변경했",
+    "수정했",
+    "완료했", "완료함",
+    "교체했",
+    "추가했",
+    "제거했",
+    "삭제했",
+    "업데이트했",
+    "갱신했",
+)
+
+# English first-person completion claims. Anchored to "I've / I have + verb" or
+# "verb + the <artifact>" so bare ambiguous past tense ("the value changed")
+# does not false-positive.
+_OVERCLAIM_MARKERS_EN = (
+    re.compile(
+        r"\bi(?:'ve|\s+have)\s+"
+        r"(?:updated|fixed|changed|rewrote|rewritten|reorganized|replaced|"
+        r"addressed|incorporated|revised|adjusted|reflected|removed|added|edited)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:updated|rewrote|rewritten|reorganized|revised|edited|replaced)\s+"
+        r"the\s+(?:pr|body|description|comment|doc|docstring)\b",
+        re.IGNORECASE,
+    ),
+)
+
+
+def _has_overclaim_marker(body: str) -> bool:
+    if not body:
+        return False
+    if any(marker in body for marker in _OVERCLAIM_MARKERS_KO):
+        return True
+    return any(p.search(body) for p in _OVERCLAIM_MARKERS_EN)
+
+
+# ---------------------------------------------------------------------------
 # Author-exempt claim-shape detection (issue #183)
 # ---------------------------------------------------------------------------
 # Detects unverified identifiers the agent authored itself: mapping table rows
@@ -403,6 +473,21 @@ ADVISORY_MESSAGE = (
     ".omc/plans/ instead.\n"
     "Set PRAXIS_EXTERNAL_WRITE_STRICT=1 to convert this advisory into a "
     "hard block (exit 2).\n"
+)
+
+OVERCLAIM_ADVISORY = (
+    "REMINDER (External-Surface Write / Over-Claiming): body contains "
+    "first-person completion claims (반영했 / 정리했 / 수정했 · \"I've "
+    "updated\") asserting work is done.\n"
+    "The falsification gate scans for UNDER-claiming (hypothesis hedging); "
+    "an over-claim — a confident but false 'done' claim — carries no hedging "
+    "token and passes by construction (issue #802).\n"
+    "Cross-check EACH completion claim against a tool call that actually ran "
+    "this session. Remove or correct any claim whose action was not executed — "
+    "execution scope silently narrows while the draft still matches the full "
+    "ask.\n"
+    "Set PRAXIS_OVERCLAIM_STRICT=1 to convert this advisory into a hard block "
+    "(exit 2).\n"
 )
 
 AUTHOR_EXEMPT_ADVISORY = (
@@ -653,6 +738,15 @@ def main() -> int:
         if _has_hypothesis_marker(b):
             sys.stderr.write(ADVISORY_MESSAGE)
             if os.environ.get("PRAXIS_EXTERNAL_WRITE_STRICT") == "1":
+                exit_code = 2
+            break
+
+    # --- Check 5: over-claiming completion phrases (issue #802) ---
+    # Opposite polarity of Check 1 — runs independently so a body can trip both.
+    for b in all_bodies:
+        if _has_overclaim_marker(b):
+            sys.stderr.write(OVERCLAIM_ADVISORY)
+            if os.environ.get("PRAXIS_OVERCLAIM_STRICT") == "1":
                 exit_code = 2
             break
 

--- a/hooks/advisory-nudge/external-write-falsify-check/spec.md
+++ b/hooks/advisory-nudge/external-write-falsify-check/spec.md
@@ -39,7 +39,7 @@ question.
 | `mcp__*notion*__*create_page*` / `*update_page*`                                   | text fields contain hypothesis marker                                        | Check 1            |
 | `Write` to staging path (`/tmp/*-issue-*.md`, `/tmp/*-pr-*.md`, `.omc/plans/*.md`) | cluster-approval language in last 5 user messages                            | Check 3            |
 | any `gh` / MCP write body above                                                    | applied-on-branch claim line without reachability probe in recent transcript | Check 4            |
-| any `gh` / MCP write body above                                                    | first-person completion claim (over-claiming — 반영했 / "I've updated")       | Check 5            |
+| any `gh` / MCP write body above                                                    | first-person completion claim (over-claiming, e.g. "I've updated")           | Check 5            |
 | `gh issue list` / `gh search issues` / Read tool                                   | —                                                                            | passthrough silent |
 
 Hypothesis markers (whole-segment substring match): English 16 —

--- a/hooks/advisory-nudge/external-write-falsify-check/spec.md
+++ b/hooks/advisory-nudge/external-write-falsify-check/spec.md
@@ -39,6 +39,7 @@ question.
 | `mcp__*notion*__*create_page*` / `*update_page*`                                   | text fields contain hypothesis marker                                        | Check 1            |
 | `Write` to staging path (`/tmp/*-issue-*.md`, `/tmp/*-pr-*.md`, `.omc/plans/*.md`) | cluster-approval language in last 5 user messages                            | Check 3            |
 | any `gh` / MCP write body above                                                    | applied-on-branch claim line without reachability probe in recent transcript | Check 4            |
+| any `gh` / MCP write body above                                                    | first-person completion claim (over-claiming — 반영했 / "I've updated")       | Check 5            |
 | `gh issue list` / `gh search issues` / Read tool                                   | —                                                                            | passthrough silent |
 
 Hypothesis markers (whole-segment substring match): English 16 —
@@ -88,6 +89,7 @@ export PRAXIS_EXTERNAL_WRITE_STRICT=1   # Check 1: hypothesis markers
 export PRAXIS_AUTHOR_EXEMPT_STRICT=1    # Check 2: author-exempt identifiers
 export PRAXIS_CLUSTER_APPROVAL_STRICT=1 # Check 3: cluster-approval staging
 export PRAXIS_APPLIED_CLAIM_STRICT=1    # Check 4: applied-on-branch claims
+export PRAXIS_OVERCLAIM_STRICT=1        # Check 5: over-claiming completion claims
 ```
 
 Each env var controls its own check independently. All accept the **literal
@@ -279,13 +281,76 @@ deferred to a 3rd consumer per repo convention); that Stop-hook gates the
 Default: advisory (exit 0). Set `PRAXIS_APPLIED_CLAIM_STRICT=1` for hard
 block (exit 2).
 
+### Over-claiming detection (issue #802)
+
+A fifth advisory fires when the write body contains a **first-person
+modification-completion claim** — the *opposite polarity* of the Check 1
+hypothesis scan. Check 1 catches under-claiming (too uncertain to publish);
+this catches over-claiming (a confident but false "done" claim). A completion
+claim like `§3 제안도 반영했습니다` carries **zero hedging tokens**, so Check 1
+passes it by construction — retrospect 2026-07-17 observed a review reply
+asserting two review items were incorporated when only one actually ran, the
+false sentences mapping 1:1 onto the un-executed items (structural projection
+of the review ask onto the draft).
+
+Full claim↔tool-call verification is an NL-matching problem and out of scope
+(the issue is explicit). The gate is a **pure-detection advisory** with no
+transcript-clearing arm — the failing case *did* run a tool (a docstring fix),
+just not one matching every claim, so an "any tool activity" clearing rule
+would suppress exactly the case to catch. The author self-cross-checks each
+claim.
+
+#### What is detected
+
+- **Korean** (whole-string substring, requires an active completion inflection
+  `했`/`함`): `반영했` / `반영함`, `정리했` / `정리함`, `바꿨`, `변경했`,
+  `수정했`, `완료했` / `완료함`, `교체했`, `추가했`, `제거했`, `삭제했`,
+  `업데이트했`, `갱신했`. Verification/status nouns (`검증 완료: 819 rows`) and
+  the passive `됐` form (`prod에 반영됐습니다` — a factual observation, and the
+  applied-on-branch check's domain) are deliberately excluded.
+- **English** (anchored regex so bare ambiguous past tense does not fire):
+  `I've` / `I have` + `{updated, fixed, changed, rewrote, rewritten,
+  reorganized, replaced, addressed, incorporated, revised, adjusted, reflected,
+  removed, added, edited}`; or `{updated, rewrote, rewritten, reorganized,
+  revised, edited, replaced} the {pr, body, description, comment, doc,
+  docstring}`.
+
+#### Advisory text
+
+```text
+REMINDER (External-Surface Write / Over-Claiming): body contains
+first-person completion claims (반영했 / 정리했 / 수정했 · "I've updated")
+asserting work is done.
+The falsification gate scans for UNDER-claiming (hypothesis hedging); an
+over-claim — a confident but false 'done' claim — carries no hedging token
+and passes by construction (issue #802).
+Cross-check EACH completion claim against a tool call that actually ran this
+session. Remove or correct any claim whose action was not executed ...
+Set PRAXIS_OVERCLAIM_STRICT=1 to convert this advisory into a hard block
+(exit 2).
+```
+
+Default: advisory (exit 0). Set `PRAXIS_OVERCLAIM_STRICT=1` for hard block
+(exit 2).
+
+#### Known limits
+
+- **Fires on truthful completion claims too.** The check cannot tell a true
+  `수정했습니다` from a false one, so it fires on every external write whose
+  body carries a completion verb. This is accepted: the advisory is a
+  self-cross-check reminder, not a truth oracle (the issue is N=1 with the
+  falseness only detectable by claim↔tool-call diff).
+- Scope is the review-reply projection verb family. Ordinary factual verbs
+  (`추가했`/`added` etc.) are included but bare English past tense without the
+  `I've` / verb-the-artifact anchor is not, to bound false positives.
+
 ### Tests
 
 ```bash
 bash tests/hooks/advisory-nudge/test_external_write_falsify_check.sh
 ```
 
-Covers 48 cases across the warn / silent / strict-block dimensions:
+Covers 60 cases across the warn / silent / strict-block dimensions:
 `gh` write subcommands (`comment`, `create`, `edit`, `review`) with each
 body flag form (`--body`, `-b`, `--body-file`, `-F`, `--body=value`),
 MCP slack / notion writes including nested shapes (Notion
@@ -305,7 +370,11 @@ does NOT clear the claim**, merge-base / baseRefName evidence clearing,
 negated claim, branch-token-only, applied-token-only, strict mode block,
 `grep baseRefName` non-clearing, long-flag `--contains` clearing,
 `without incident` still firing, `released the lock` silent,
-baseRefName-only query non-clearing).
+baseRefName-only query non-clearing), and 12 over-claiming cases (#802:
+KO 반영했 / 정리했 / 바꿨 / 완료했 claims, EN `I have updated` / `rewrote the
+description`, MCP slack completion claim, false-positive guards for the 완료
+noun form / passive 반영됐 form / bare EN past tense, strict-mode block, and
+strict-mode silent when no over-claim present).
 
 ### Evidence-trail follow-up
 

--- a/tests/hooks/advisory-nudge/test_external_write_falsify_check.sh
+++ b/tests/hooks/advisory-nudge/test_external_write_falsify_check.sh
@@ -35,13 +35,15 @@ run_case() {
   local err_file
   err_file=$(mktemp)
   if [ "$strict" = "strict" ]; then
-    echo "$payload" | env -u PRAXIS_CLUSTER_APPROVAL_STRICT -u PRAXIS_APPLIED_CLAIM_STRICT PRAXIS_EXTERNAL_WRITE_STRICT=1 python3 "$HOOK" >/dev/null 2>"$err_file"
+    echo "$payload" | env -u PRAXIS_CLUSTER_APPROVAL_STRICT -u PRAXIS_APPLIED_CLAIM_STRICT -u PRAXIS_OVERCLAIM_STRICT PRAXIS_EXTERNAL_WRITE_STRICT=1 python3 "$HOOK" >/dev/null 2>"$err_file"
   elif [ "$strict" = "cluster_strict" ]; then
-    echo "$payload" | env -u PRAXIS_EXTERNAL_WRITE_STRICT -u PRAXIS_APPLIED_CLAIM_STRICT PRAXIS_CLUSTER_APPROVAL_STRICT=1 python3 "$HOOK" >/dev/null 2>"$err_file"
+    echo "$payload" | env -u PRAXIS_EXTERNAL_WRITE_STRICT -u PRAXIS_APPLIED_CLAIM_STRICT -u PRAXIS_OVERCLAIM_STRICT PRAXIS_CLUSTER_APPROVAL_STRICT=1 python3 "$HOOK" >/dev/null 2>"$err_file"
   elif [ "$strict" = "applied_strict" ]; then
-    echo "$payload" | env -u PRAXIS_EXTERNAL_WRITE_STRICT -u PRAXIS_CLUSTER_APPROVAL_STRICT PRAXIS_APPLIED_CLAIM_STRICT=1 python3 "$HOOK" >/dev/null 2>"$err_file"
+    echo "$payload" | env -u PRAXIS_EXTERNAL_WRITE_STRICT -u PRAXIS_CLUSTER_APPROVAL_STRICT -u PRAXIS_OVERCLAIM_STRICT PRAXIS_APPLIED_CLAIM_STRICT=1 python3 "$HOOK" >/dev/null 2>"$err_file"
+  elif [ "$strict" = "overclaim_strict" ]; then
+    echo "$payload" | env -u PRAXIS_EXTERNAL_WRITE_STRICT -u PRAXIS_CLUSTER_APPROVAL_STRICT -u PRAXIS_APPLIED_CLAIM_STRICT PRAXIS_OVERCLAIM_STRICT=1 python3 "$HOOK" >/dev/null 2>"$err_file"
   else
-    echo "$payload" | env -u PRAXIS_EXTERNAL_WRITE_STRICT -u PRAXIS_CLUSTER_APPROVAL_STRICT -u PRAXIS_APPLIED_CLAIM_STRICT python3 "$HOOK" >/dev/null 2>"$err_file"
+    echo "$payload" | env -u PRAXIS_EXTERNAL_WRITE_STRICT -u PRAXIS_CLUSTER_APPROVAL_STRICT -u PRAXIS_APPLIED_CLAIM_STRICT -u PRAXIS_OVERCLAIM_STRICT python3 "$HOOK" >/dev/null 2>"$err_file"
   fi
   local rc=$?
   local err
@@ -366,6 +368,66 @@ run_case "applied: baseRefName-only query does NOT clear (warn)" \
   "warn" "advisory" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"gh issue comment 100 --body \\\"The fix is applied to prod.\\\"\"},\"transcript_path\":\"$AP_TRANSCRIPT_BRO\"}"
 rm -f "$AP_TRANSCRIPT_BRO"
+
+# --- over-claiming (false-completion) detection (issue #802) ---
+
+# KO first-person completion claim in a review reply → warn.
+run_case "overclaim: KO 반영했습니다 (warn)" \
+  "warn" "advisory" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr comment 9248 --body \"§3 제안도 반영했습니다.\""}}'
+
+run_case "overclaim: KO 정리했습니다 (warn)" \
+  "warn" "advisory" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr comment 9248 --body \"§7 체크박스는 근거를 달아 정리했습니다.\""}}'
+
+run_case "overclaim: KO 바꿨습니다 (warn)" \
+  "warn" "advisory" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue comment 100 --body \"PR 본문을 전수 논증으로 바꿨습니다.\""}}'
+
+run_case "overclaim: KO 완료했습니다 (warn)" \
+  "warn" "advisory" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue comment 100 --body \"요청한 작업을 모두 완료했습니다.\""}}'
+
+# EN first-person completion claim → warn.
+run_case "overclaim: EN I have updated (warn)" \
+  "warn" "advisory" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr comment 50 --body \"I have updated the PR body per your review.\""}}'
+
+run_case "overclaim: EN rewrote the description (warn)" \
+  "warn" "advisory" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr comment 50 --body \"Rewrote the description to use an exhaustive argument.\""}}'
+
+# MCP surface carries the over-claim → warn.
+run_case "overclaim: MCP slack 수정했습니다 (warn)" \
+  "warn" "advisory" \
+  '{"tool_name":"mcp__slack__slack_send_message","tool_input":{"text":"지적하신 부분을 수정했습니다."}}'
+
+# --- over-claiming false-positive guards → silent ---
+
+# 완료 as a noun ("verification complete"), not 완료했 → silent.
+run_case "overclaim: KO 검증 완료 noun form (silent)" \
+  "silent" "advisory" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue comment 100 --body \"검증 완료: 819 rows.\""}}'
+
+# Passive 됐 form ("was reflected") is a factual observation, not a first-person
+# completion claim; no branch token so applied-on-branch also stays silent.
+run_case "overclaim: KO passive 반영됐 form (silent)" \
+  "silent" "advisory" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue comment 100 --body \"요청 사항이 반영됐습니다.\""}}'
+
+# Bare ambiguous EN past tense (no I've / no verb-the-artifact) → silent.
+run_case "overclaim: EN bare past tense (silent)" \
+  "silent" "advisory" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue comment 100 --body \"The value changed after the migration ran.\""}}'
+
+# --- over-claiming strict mode → block ---
+run_case "overclaim: strict mode + KO claim (block)" \
+  "block" "overclaim_strict" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue comment 100 --body \"리뷰 지적을 반영했습니다.\""}}'
+
+run_case "overclaim: strict mode + no over-claim (silent)" \
+  "silent" "overclaim_strict" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue comment 100 --body \"Verified by tests.\""}}'
 
 echo ""
 echo "Result: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## 배경

`external-write-falsify-check` 는 외부 surface write 를 가로채 **hypothesis 마커**(불확실성 hedging)만 스캔한다. 즉 게이트의 오라클은 "너무 불확실해서 게시하면 안 되는 문장"이다. 반대 극성인 **과대주장**(실행하지 않은 것을 확신에 차 완료로 서술 — `반영했습니다` / `정리했습니다`)은 hedging 토큰이 0개라 구조적으로(by construction) 통과했다.

2026-07-17 retrospect 에서 실제 사례가 관측됐다: 리뷰 회신 초안이 §3·§7 두 항목을 "반영/정리했다"고 서술했으나 실제 실행된 것은 다른 항목 하나뿐이었고, 허위 문장 2개는 미실행 리뷰 항목 2개에 정확히 1:1 대응했다 (무작위 오류가 아니라 리뷰 ask 전체에 초안을 맞춘 구조적 투영).

## 변경 내용

Check 5 (over-claiming 탐지)를 추가했다. Check 1 (hypothesis)과 독립 실행되어 한 body 가 양쪽 다 트립할 수 있다.

- **한국어 마커**: 능동 완료 어미(`했`/`함`)를 요구 — `반영했`/`정리했`/`수정했`/`바꿨`/`변경했`/`완료했`/`교체했`/`추가했`/`제거했`/`삭제했`/`업데이트했`/`갱신했` 등. 명사형 `검증 완료: 819 rows` 와 수동형 `반영됐`(사실 관찰, applied-on-branch 검사 영역)은 배제.
- **영어 마커**: `I've`/`I have` + 완료 동사, 또는 `verb + the <artifact>`(pr/body/description/...)로 앵커링해 모호한 단순 과거형(`the value changed`) 오탐 방지.
- **순수 탐지 advisory** — transcript-clearing arm 없음. 실패 케이스가 도구를 실행하긴 했으므로(docstring 수정) "도구 활동이 있으면 clear" 규칙은 정탐을 무력화한다. 완전 자동 주장↔도구호출 diff 는 NL 매칭이라 범위 밖(이슈 명시).
- `PRAXIS_OVERCLAIM_STRICT=1` 로 advisory → hard block(exit 2) 전환. 기존 4개 strict env 와 동일 컨벤션.

impl.py + 테스트 12케이스 확장 + spec.md 갱신.

## Surface enumeration (각 변형 = 테스트 케이스)

- warn: KO `반영했`/`정리했`/`바꿨`/`완료했`, EN `I have updated`/`rewrote the description`, MCP slack 완료 주장
- silent (false-positive guard): `완료` 명사형, 수동 `반영됐` 형, 모호한 EN 단순 과거형
- block: strict 모드 + KO 주장 / strict 모드 + 주장 없음(silent)

## 검증

- 훅 shell 테스트: `bash tests/hooks/advisory-nudge/test_external_write_falsify_check.sh` → **60 passed, 0 failed** (기존 48 + 신규 12)
- `python3 -m pytest tests/ -q` → **472 passed**
- `ruff check hooks/advisory-nudge/external-write-falsify-check/impl.py` → **All checks passed**
- `python3 scripts/check-plugin-manifests.py` → **plugin-manifest check OK**

## 한계 (정직하게)

- **참인 완료 주장에도 발화한다.** NL 로 참/거짓을 가릴 수 없어, 완료 동사를 담은 외부 write body 마다 fire 한다. advisory(비차단) 자기대조 리마인더이지 truth oracle 이 아니다 (이슈 N=1, 허위 여부는 주장별 도구호출 diff 로만 판별 가능).
- 공유 파일(`manifest.json`, `hooks.json`, `INDEX.md`, `ARCHITECTURE.md`)은 미변경 — 신규 파일이 아니라 기존 등록된 훅의 로직 확장이므로 index 갱신 불필요.

Caller chain verified: `_has_overclaim_marker` 는 impl.py `main()` 의 Check 5 루프에서 호출; 훅 자체는 기존 등록된 external-write-falsify-check 로 manifest 진입점 불변
Pre-commit verified: shell 60 passed/0 failed, pytest 472 passed, ruff clean, check-plugin-manifests OK

Closes #802
