### PR TITLE
feat(hooks): escalate repeated same-session blocks

### DIFF
--- a/hooks/_lib/_fire_ledger.py
+++ b/hooks/_lib/_fire_ledger.py
@@ -287,3 +287,86 @@ def record_session_fire(hook: str, role: str, decision: str, session_id: str, to
         _atomic_append(resolve_path(), [json.dumps(record, ensure_ascii=False)])
     except Exception:
         pass  # fail-open — never break the hook
+
+
+def count_session_fires(hook: str, session_id: str, decision: str | None = None) -> int:
+    """Count today's RICH fire records for `(hook, session_id)`; the in-session
+    read path this ledger previously lacked (issue #805).
+
+    Every writer above is append-only: the ledger records that a hook fired but
+    offers no way for a hook to ask, at its own fire time, "how many times have I
+    already fired this session?" A preflight gate that repeats the same block on
+    the same session is a strong signal the agent is bypassing rather than
+    resolving — this read lets the gate consume that signal (escalate its
+    message) instead of re-emitting an identical block. Counterpart to the
+    record_* writers; read-only, never mutates the ledger.
+
+    Filters to granularity=="rich" — only rich records carry a real session_id
+    (coarse records always store ""), so a coarse record can never match a real
+    session_id anyway; the explicit filter documents intent and guards a future
+    coarse record that happens to carry one. When `decision` is given only
+    records with that decision are counted (e.g. decision="block" to count prior
+    blocks, ignoring pass/advise fires of the same hook); None counts every
+    decision.
+
+    Reads only today's file (resolve_path()) — the same daily-rotation file the
+    writers append to. A session straddling UTC midnight loses its pre-midnight
+    fires here; that is an accepted bound — an escalation counter resetting at
+    midnight under-counts (a benign missed escalation), never over-counts (which
+    would false-escalate a first-of-day block).
+
+    Timing note for dispatched Bash-group members: the dispatcher records a
+    member's fire AFTER running its main() (see _dispatch.run_group), so a gate
+    calling this from inside its own main() sees only its PRIOR fires this
+    session, not the in-flight one — exactly the "already blocked N times before
+    now" count an escalation wants.
+
+    Fail-open: any error (disabled, missing/unreadable file, non-regular target,
+    malformed lines) → 0. A telemetry read must never break the calling hook,
+    and 0 means "no escalation" — the safe default that leaves the base block
+    message intact.
+    """
+    if _disabled():
+        return 0
+    if not isinstance(session_id, str) or not session_id:
+        return 0
+    try:
+        path = resolve_path()
+        # Mirror _atomic_append's regular-file guard: O_NONBLOCK so opening a
+        # FIFO swapped in at the path fails fast (ENXIO) instead of blocking the
+        # calling hook; O_NOFOLLOW rejects a symlinked final component. Then
+        # fstat the opened fd to confirm a regular file before reading.
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+        try:
+            fd = os.open(path, flags)
+        except OSError:
+            return 0
+        try:
+            if not stat.S_ISREG(os.fstat(fd).st_mode):
+                return 0
+            with os.fdopen(fd, encoding="utf-8", errors="replace") as f:
+                fd = -1  # ownership transferred to the file object
+                count = 0
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except (json.JSONDecodeError, ValueError):
+                        continue
+                    if not isinstance(rec, dict):
+                        continue
+                    if rec.get("granularity") != "rich":
+                        continue
+                    if rec.get("hook") != hook or rec.get("session_id") != session_id:
+                        continue
+                    if decision is not None and rec.get("decision") != decision:
+                        continue
+                    count += 1
+                return count
+        finally:
+            if fd >= 0:
+                os.close(fd)
+    except Exception:
+        return 0

--- a/hooks/preflight-gate/block-commit-without-codex-review/impl.py
+++ b/hooks/preflight-gate/block-commit-without-codex-review/impl.py
@@ -86,10 +86,25 @@ import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
+import _fire_ledger  # type: ignore[import-not-found]  # noqa: E402
 from pathlib import Path
 
 _TARGET_SKILL = "praxis:codex-review-wrap"
 _MAX_BYTES = 50 * 1024 * 1024
+
+# Fire-ledger identity — must match this hook's manifest `name`/`role`, since the
+# dispatcher keys its RICH fire records off the manifest entry (see
+# hooks/manifest.json). count_session_fires filters on these exact strings.
+_HOOK_NAME = "block-commit-without-codex-review"
+_HOOK_ROLE = "preflight-gate"
+
+# Escalate the block message once this gate has ALREADY blocked the same session
+# at least this many times before the current block (issue #805). 1 → the 2nd
+# block onward carries the escalated wording; the 1st keeps the plain message.
+# The block/allow verdict is unchanged either way — escalation only strengthens
+# the message (form (a)), never relaxes or tightens the gate, so it adds no
+# bypass incentive.
+_ESCALATE_AFTER_PRIOR_BLOCKS = 1
 
 
 @fail_open
@@ -126,8 +141,22 @@ def main() -> int:
     if invoked:
         return 0  # codex-review-wrap ran this session → allow
 
-    _emit_block_message()
+    _emit_block_message(_prior_block_count(payload.get("session_id")))
     return 2
+
+
+def _prior_block_count(session_id) -> int:
+    """Blocks this gate already emitted for `session_id` this session, read from
+    the fire ledger (issue #805). 0 when session_id is absent or the ledger is
+    unreadable/opted-out — fail-open to the non-escalated message.
+
+    Counts decision=="block" only: a prior pass/advise fire of this hook is not
+    a repeated block and must not inflate the escalation counter. The dispatcher
+    records the current block AFTER this hook returns, so the in-flight block is
+    excluded — this is strictly the count of blocks BEFORE now."""
+    if not isinstance(session_id, str) or not session_id:
+        return 0
+    return _fire_ledger.count_session_fires(_HOOK_NAME, session_id, decision="block")
 
 
 
@@ -562,34 +591,55 @@ def _has_slash_command(obj: dict) -> bool:
     return False
 
 
-def _emit_block_message() -> None:
-    sys.stderr.write(
-        "\n".join(
-            [
-                "BLOCKED: `git commit` without a `praxis:codex-review-wrap` review pass this session.",
-                "",
-                "Rule (AGENTS.md Deliver table): codex-review-wrap is a second mandatory",
-                "independent review pass before commit — an independent Codex pass after",
-                "omc:code-reviewer that catches defects a single reviewer misses.",
-                "",
-                "Resolve by one of:",
-                "  1. Run the review (it is a model-invocable skill, not an agent):",
-                "       Skill(skill=\"praxis:codex-review-wrap\")",
-                "     then re-run the commit (one run satisfies all commits this session,",
-                "     including one run inside a subagent this session dispatched).",
-                "  2. Skip for this commit: add a [skip-codex-review] token to the",
-                "     commit message (e.g. trivial docs/typo change).",
-                "  3. Persistent bypass: set CLAUDE_HOOK_BYPASS_CODEX_REVIEW_GATE=1 in your",
-                "     environment BEFORE starting Claude Code (settings env / shell export).",
-                "     An inline prefix on this command does NOT work — the hook process",
-                "     never sees it.",
-                "",
-                "Fail-open: missing/unreadable transcript and non-content commits",
-                "(--amend / merge / rebase / cherry-pick / revert) pass.",
-            ]
-        )
-        + "\n"
+def _escalation_banner(prior_blocks: int) -> list[str]:
+    """Form-(a) escalation preface (issue #805): shown from the 2nd same-session
+    block onward. It does NOT repeat the base message louder — it names the exact
+    anti-pattern the repeat signals (changing HOW the commit is invoked instead
+    of running the review), which is the observed failure mode a plain re-block
+    does not address. The gate verdict is unchanged; only the wording escalates.
+    """
+    times = "time" if prior_blocks == 1 else "times"
+    return [
+        f"ESCALATION: this gate has already blocked `git commit` {prior_blocks} {times} "
+        "in this session.",
+        "Changing HOW you invoke the commit (heredoc, -F file, subshell, a",
+        "different separator) does NOT change the gate condition — it re-checks the",
+        "same session for a codex-review-wrap pass and blocks again. The only",
+        "resolutions are the three below. Run option 1 now (or option 2/3 only if",
+        "this commit genuinely qualifies for a skip).",
+        "",
+    ]
+
+
+def _emit_block_message(prior_blocks: int = 0) -> None:
+    lines: list[str] = []
+    if prior_blocks >= _ESCALATE_AFTER_PRIOR_BLOCKS:
+        lines.extend(_escalation_banner(prior_blocks))
+    lines.extend(
+        [
+            "BLOCKED: `git commit` without a `praxis:codex-review-wrap` review pass this session.",
+            "",
+            "Rule (AGENTS.md Deliver table): codex-review-wrap is a second mandatory",
+            "independent review pass before commit — an independent Codex pass after",
+            "omc:code-reviewer that catches defects a single reviewer misses.",
+            "",
+            "Resolve by one of:",
+            "  1. Run the review (it is a model-invocable skill, not an agent):",
+            "       Skill(skill=\"praxis:codex-review-wrap\")",
+            "     then re-run the commit (one run satisfies all commits this session,",
+            "     including one run inside a subagent this session dispatched).",
+            "  2. Skip for this commit: add a [skip-codex-review] token to the",
+            "     commit message (e.g. trivial docs/typo change).",
+            "  3. Persistent bypass: set CLAUDE_HOOK_BYPASS_CODEX_REVIEW_GATE=1 in your",
+            "     environment BEFORE starting Claude Code (settings env / shell export).",
+            "     An inline prefix on this command does NOT work — the hook process",
+            "     never sees it.",
+            "",
+            "Fail-open: missing/unreadable transcript and non-content commits",
+            "(--amend / merge / rebase / cherry-pick / revert) pass.",
+        ]
     )
+    sys.stderr.write("\n".join(lines) + "\n")
 
 
 if __name__ == "__main__":

--- a/hooks/preflight-gate/block-commit-without-codex-review/spec.md
+++ b/hooks/preflight-gate/block-commit-without-codex-review/spec.md
@@ -83,9 +83,10 @@ condition, so each re-check blocks again on the same ground — and, with an
 identical message every time, the 1st block and the 3rd are indistinguishable.
 
 The hook now reads its own prior fires back from the fire ledger
-(`_fire_ledger.count_session_fires`, the in-session read path added in issue
-#805) and, from the **2nd same-session block onward**, prepends an escalation
-banner that names that exact anti-pattern ("changing HOW you invoke the commit
+(`_fire_ledger.count_session_fires`, the in-session read path added in
+issue #805) and, from the **2nd same-session block onward**, prepends an
+escalation banner that names that exact anti-pattern ("changing HOW you invoke
+the commit
 does NOT change the gate condition — run the review"). The count is
 session-scoped and `decision="block"`-filtered: only prior *blocks* of this hook
 in this `session_id` raise it, and the dispatcher records each block *after* the
@@ -169,7 +170,8 @@ hardened-parser bypass forms (grouped `(git commit …)`, unquoted substitution
 quoted substitution, single-quoted literal pass, double-quoted literal pass,
 terminal options `--help`/`--version`), out-of-scope (non-Bash tool, `git push`
 / `git status`), fail-open (no `transcript_path`, nonexistent path,
-malformed stdin, unparseable command), and repeated-block escalation (issue
-#805: 1st same-session block has no banner, 2nd block escalates, a different
-session is independent). The `count_session_fires` read primitive is unit-tested
+malformed stdin, unparseable command), and repeated-block escalation
+(issue #805: 1st same-session block has no banner, 2nd block escalates, a
+different session is independent). The `count_session_fires` read primitive is
+unit-tested
 in `tests/test_fire_ledger.py`.

--- a/hooks/preflight-gate/block-commit-without-codex-review/spec.md
+++ b/hooks/preflight-gate/block-commit-without-codex-review/spec.md
@@ -73,6 +73,36 @@ subagent transcript that is individually unreadable/oversized is skipped
 turn the whole scan into a fail-open, since the root transcript already
 answered the question for everything outside that one subagent run.
 
+### Escalation on repeated same-session block (issue #805)
+
+The block verdict is self-sufficient, but a session that hits it repeatedly is
+a signal in itself: the agent is changing *how* it invokes the commit (heredoc,
+`-F` file, subshell, a different separator) rather than running the review the
+message asks for. Those input-shape changes are orthogonal to the gate
+condition, so each re-check blocks again on the same ground — and, with an
+identical message every time, the 1st block and the 3rd are indistinguishable.
+
+The hook now reads its own prior fires back from the fire ledger
+(`_fire_ledger.count_session_fires`, the in-session read path added in issue
+#805) and, from the **2nd same-session block onward**, prepends an escalation
+banner that names that exact anti-pattern ("changing HOW you invoke the commit
+does NOT change the gate condition — run the review"). The count is
+session-scoped and `decision="block"`-filtered: only prior *blocks* of this hook
+in this `session_id` raise it, and the dispatcher records each block *after* the
+hook returns, so the in-flight block is excluded (the banner reports blocks
+*before* now).
+
+This is a **message-only** escalation (option (a) of the issue): the block/allow
+verdict is unchanged — escalation never relaxes the gate (which would create a
+bypass incentive) nor tightens it (e.g. revoking the skip token, which would
+punish a legitimately trivial commit). Fail-open throughout: a missing / opted-
+out / unreadable ledger, or an absent `session_id`, yields count 0 and the plain
+(non-escalated) message. Granularity is session-level, matching the gate's
+existing model (one review satisfies all commits this session); it does not
+distinguish "episode" boundaries (the same commit retried vs. a genuinely
+different commit) — an accepted bound, since the banner's claim ("this gate
+already blocked N times this session") is true regardless of episode structure.
+
 ### Escape hatches
 
 - Add a `[skip-codex-review]` token to the commit `-m` / `--message` message
@@ -125,7 +155,7 @@ does not execute it) — correctly ignored.
 bash tests/hooks/preflight-gate/test_block_commit_without_codex_review.sh
 ```
 
-Covers 51 cases: block paths (no invocation, wrong skill, `-F` body, prose-only
+Covers 54 cases: block paths (no invocation, wrong skill, `-F` body, prose-only
 slash mention, subagent dir present but no subagent invocation, slash-command
 line inside a subagent transcript not satisfying the gate), pass paths (Skill
 tool_use, slash command, garbage-line resilience, Skill tool_use inside a
@@ -138,5 +168,8 @@ hardened-parser bypass forms (grouped `(git commit …)`, unquoted substitution
 `$(git commit …)`, no-space separator `true;git commit …`, nested substitution,
 quoted substitution, single-quoted literal pass, double-quoted literal pass,
 terminal options `--help`/`--version`), out-of-scope (non-Bash tool, `git push`
-/ `git status`), and fail-open (no `transcript_path`, nonexistent path,
-malformed stdin, unparseable command).
+/ `git status`), fail-open (no `transcript_path`, nonexistent path,
+malformed stdin, unparseable command), and repeated-block escalation (issue
+#805: 1st same-session block has no banner, 2nd block escalates, a different
+session is independent). The `count_session_fires` read primitive is unit-tested
+in `tests/test_fire_ledger.py`.

--- a/tests/hooks/preflight-gate/test_block_commit_without_codex_review.sh
+++ b/tests/hooks/preflight-gate/test_block_commit_without_codex_review.sh
@@ -373,6 +373,66 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Repeated same-session block escalation (issue #805)
+#
+# The block message escalates from the 2nd same-session block onward, read from
+# the fire ledger (count_session_fires). These cases point the ledger at a temp
+# file, seed prior RICH block records for a session_id, and assert the
+# ESCALATION banner appears only when a prior block exists — while the block
+# verdict (rc 2) is unchanged in every case.
+# ---------------------------------------------------------------------------
+
+ESC_LEDGER=$(mktemp)
+ESC_SESSION="sess-escalate-$$"
+
+# emits a RICH block record for the given session into the ledger
+esc_seed_block() {
+  local sid="$1"
+  printf '%s\n' "{\"granularity\":\"rich\",\"hook\":\"block-commit-without-codex-review\",\"session_id\":\"$sid\",\"decision\":\"block\"}" >>"$ESC_LEDGER"
+}
+
+# run_escalation_case <name> <session_id> <expect-banner:yes|no>
+run_escalation_case() {
+  local name="$1" sid="$2" expect_banner="$3"
+  local payload err_file rc err_content has_banner
+  payload=$(python3 -c '
+import json, sys
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {"command": "git commit -m \"feat: x\""},
+    "transcript_path": sys.argv[1],
+    "session_id": sys.argv[2],
+}))' "$TX_WITHOUT" "$sid")
+  err_file=$(mktemp)
+  echo "$payload" | env "PRAXIS_FIRE_TELEMETRY_FILE=$ESC_LEDGER" "$HOOK" >/dev/null 2>"$err_file"
+  rc=$?
+  err_content=$(cat "$err_file"); rm -f "$err_file"
+
+  local ok=1
+  # verdict is always block (rc 2 + non-empty stderr), regardless of escalation
+  [ "$rc" -eq 2 ] && [ -n "$err_content" ] || ok=0
+  case "$err_content" in *ESCALATION*) has_banner=yes;; *) has_banner=no;; esac
+  [ "$has_banner" = "$expect_banner" ] || ok=0
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS [block/banner=$expect_banner] $name"; ((PASS++))
+  else
+    echo "FAIL [block/banner want=$expect_banner got=$has_banner rc=$rc] $name"
+    ((FAIL++)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# 1st block for the session: ledger empty → no escalation banner
+run_escalation_case "1st same-session block: no escalation banner" "$ESC_SESSION" no
+# after 1 prior block: 2nd block escalates
+esc_seed_block "$ESC_SESSION"
+run_escalation_case "2nd same-session block: escalation banner present" "$ESC_SESSION" yes
+# a different session with no prior blocks is independent (no escalation)
+run_escalation_case "different session is independent: no banner" "other-session-$$" no
+
+rm -f "$ESC_LEDGER"
+
+# ---------------------------------------------------------------------------
 # Cleanup + summary
 # ---------------------------------------------------------------------------
 

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -313,6 +313,119 @@ def test_record_session_fire_non_string_session_and_tool_default_empty(tmp_path,
     assert rec["session_id"] == "" and rec["tool"] == ""
 
 
+# ---------------------------------------------------------------------------
+# Reader: count_session_fires (issue #805 — in-session read path for a preflight
+# gate to consume its own repeated-block signal)
+# ---------------------------------------------------------------------------
+
+def _write_records(path: Path, records: list[dict]) -> None:
+    path.write_text("".join(json.dumps(r) + "\n" for r in records), encoding="utf-8")
+
+
+def test_count_session_fires_missing_file_returns_zero(tmp_path, monkeypatch):
+    out = tmp_path / "nope.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    assert fl.count_session_fires("h", "s1", decision="block") == 0
+
+
+def test_count_session_fires_filters_hook_session_and_decision(tmp_path, monkeypatch):
+    out = tmp_path / "fire.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    _write_records(out, [
+        {"granularity": "rich", "hook": "gate", "session_id": "s1", "decision": "block"},
+        {"granularity": "rich", "hook": "gate", "session_id": "s1", "decision": "block"},
+        {"granularity": "rich", "hook": "gate", "session_id": "s1", "decision": "pass"},
+        {"granularity": "rich", "hook": "other", "session_id": "s1", "decision": "block"},
+        {"granularity": "rich", "hook": "gate", "session_id": "s2", "decision": "block"},
+    ])
+    # decision-filtered: only s1's own blocks of `gate`
+    assert fl.count_session_fires("gate", "s1", decision="block") == 2
+    # decision=None: every decision for (gate, s1) — 2 blocks + 1 pass
+    assert fl.count_session_fires("gate", "s1") == 3
+    assert fl.count_session_fires("gate", "s2", decision="block") == 1
+    assert fl.count_session_fires("gate", "s3", decision="block") == 0
+    assert fl.count_session_fires("other", "s1", decision="block") == 1
+
+
+def test_count_session_fires_excludes_coarse_records(tmp_path, monkeypatch):
+    """A coarse record carries session_id="" so it can never match a real
+    session anyway, but the granularity filter makes the exclusion explicit —
+    a future coarse record that DID carry a session_id must still not count."""
+    out = tmp_path / "fire.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    _write_records(out, [
+        {"granularity": "rich", "hook": "gate", "session_id": "s1", "decision": "block"},
+        {"granularity": "coarse", "hook": "gate", "session_id": "s1", "decision": "block"},
+    ])
+    assert fl.count_session_fires("gate", "s1", decision="block") == 1
+
+
+def test_count_session_fires_empty_session_returns_zero(tmp_path, monkeypatch):
+    out = tmp_path / "fire.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    _write_records(out, [
+        {"granularity": "rich", "hook": "gate", "session_id": "", "decision": "block"},
+    ])
+    assert fl.count_session_fires("gate", "", decision="block") == 0
+    assert fl.count_session_fires("gate", None, decision="block") == 0  # type: ignore[arg-type]
+
+
+def test_count_session_fires_opt_out_returns_zero(tmp_path, monkeypatch):
+    out = tmp_path / "fire.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_DISABLE", "1")
+    _write_records(out, [
+        {"granularity": "rich", "hook": "gate", "session_id": "s1", "decision": "block"},
+    ])
+    assert fl.count_session_fires("gate", "s1", decision="block") == 0
+
+
+def test_count_session_fires_skips_malformed_lines(tmp_path, monkeypatch):
+    out = tmp_path / "fire.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    out.write_text(
+        "not json{\n"
+        + json.dumps({"granularity": "rich", "hook": "gate", "session_id": "s1", "decision": "block"}) + "\n"
+        + "\n"  # blank line
+        + json.dumps(["not", "a", "dict"]) + "\n",
+        encoding="utf-8",
+    )
+    assert fl.count_session_fires("gate", "s1", decision="block") == 1
+
+
+def test_count_session_fires_non_regular_file_returns_zero(tmp_path, monkeypatch):
+    """Security/robustness guard: a FIFO at the path must not block or raise —
+    mirrors _atomic_append's regular-file guard on the read side."""
+    fifo = tmp_path / "pipe"
+    os.mkfifo(fifo)
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(fifo))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    assert fl.count_session_fires("gate", "s1", decision="block") == 0
+    assert stat.S_ISFIFO(os.lstat(fifo).st_mode)  # untouched
+
+
+def test_count_session_fires_roundtrip_with_real_writer(tmp_path, monkeypatch):
+    """No SUT-mirrored mock: the dispatcher's own record_group_fires writes the
+    RICH block record, and count_session_fires reads it back. This locks the
+    exact field contract (hook/session_id/decision/granularity) both halves
+    share — a rename on either side fails this test."""
+    out = tmp_path / "fire.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    members = [("preflight-gate", "block-commit-without-codex-review", Path("x"))]
+    # Two blocking dispatches in the same session, as the real gate produces.
+    fl.record_group_fires(members, [(2, "", "")], _payload("s-round", "Bash"))
+    fl.record_group_fires(members, [(2, "", "")], _payload("s-round", "Bash"))
+    assert fl.count_session_fires(
+        "block-commit-without-codex-review", "s-round", decision="block"
+    ) == 2
+
+
 def test_roster_split_separates_shell_hooks(tmp_path):
     manifest = {"hooks": [
         {"name": "a", "event": "PreToolUse", "matcher": "Bash"},   # py (instrumentable)


### PR DESCRIPTION
## 배경

`block-commit-without-codex-review` 게이트는 설계대로 동작하지만, 같은 세션에서
같은 커밋을 반복 차단해도 매번 **동일한 메시지**만 재출력한다. 에이전트가 입력
방식(heredoc, `-F` file, subshell, 구분자)만 바꾸며 우회를 시도하면 게이트 조건과
무관하게 같은 차단이 반복되는데, 이 "반복" 신호가 어디에서도 소비되지 않았다.
fire ledger 는 세션별 발화를 **기록**하고 있었지만, 훅이 발화 시점에 "이번 세션에
이미 N회 차단했다"를 **되읽는 경로**가 없었다.

Closes #805

## 변경 내용

### 1. `_fire_ledger.count_session_fires()` — in-session read API (`hooks/_lib/_fire_ledger.py`)

append 전용이던 ledger 에 read 경로를 추가. 오늘자 파일에서 `(hook, session_id)`
의 RICH 레코드를 세고, `decision` 인자로 특정 판정만 집계(예: `decision="block"`
→ 이전 block 만). 설계 특성:

- `granularity=="rich"` 필터 — coarse 레코드는 `session_id=""` 라 실제 세션과
  절대 매치되지 않지만, 명시적 필터로 의도를 문서화하고 미래의 coarse 레코드도 방어.
- 오늘자 파일만 조회(writer 와 동일한 일일 회전). UTC 자정을 넘는 세션은 under-count
  (자정에 카운터 리셋 = 양성 미escalation), never over-count(false-escalate 없음).
- writer 의 정규 파일 가드를 read 측에도 미러(O_NOFOLLOW/O_NONBLOCK + fstat) —
  FIFO/심링크 스왑에도 블록/raise 없음.
- opt-out/미존재/비정규/손상 라인 → 0 (fail-open, 안전 기본값 = 미escalation).

### 2. 반복 차단 에스컬레이션 배선 (`block-commit-without-codex-review/impl.py`)

차단 직전 자신의 이전 동일세션 block 수를 읽어, **2회차부터**(`prior_blocks >= 1`)
메시지에 에스컬레이션 배너를 prepend. 배너는 실제 anti-pattern("입력 방식을 바꾸는
것은 게이트 조건을 바꾸지 않는다 — 지금 리뷰를 실행하라")을 지목한다.

## 미결 항목 확정 (이슈 본문 3개 논점)

| 논점 | 결정 | 근거 |
|---|---|---|
| 임계 N | 이전 block ≥1 → **2회차부터** | 이슈의 실측 사례에서 차단 2 에서 조기 포착. 메시지 강화만이라 조기 발동 부작용 없음 |
| 에스컬레이션 형태 | **(a) 메시지 강화만** | (b) 사용자 surface = 마찰+정당한 반복 오탐, (c) skip 토큰 무효화 = 정당한 trivial 커밋 차단. 이슈가 명시한 "판정(block/allow)은 불변" 불변식을 지키는 유일한 형태 |
| 반복 정의 | **session 단위** (`decision="block"` 필터) | gate 의 기존 granularity(리뷰 1회가 세션 내 모든 커밋 충족)와 일치. episode 단위는 accepted bound 로 spec 명시 — 배너 주장("이 세션에 이미 N회 차단")은 episode 구조와 무관하게 참 |

배너의 순환성 우려("메시지로 안 되니 메시지를 고친다")는 배너 **내용**을 관찰된
실패 모드에 정조준하여 완화 — 단순히 같은 메시지를 크게 반복하지 않는다.

## 범위 판단

read primitive(`count_session_fires`)는 `_lib` 에 두어 **향후 preflight gate 가
재사용** 가능하게 하고(이슈 제안 #1), 소비는 동기가 된 **단일 hook** 에만 배선
(제안 #2). 신규 hook 이 아니므로 `manifest.json` / 플랫폼 `hooks.json` /
`docs/hook/INDEX.md` / `ARCHITECTURE.md` / `test_dispatch.py` **무변경** — sibling
PR(#804/#807) 과 공유 파일 충돌 0.

## 검증

- `python3 -m pytest tests/ -q` → **480 passed** (신규 `count_session_fires`
  단위 테스트 9개: 필터/coarse 제외/빈 세션/opt-out/손상 라인/FIFO 가드/실제
  writer roundtrip 포함)
- `bash tests/hooks/preflight-gate/test_block_commit_without_codex_review.sh`
  → **54 passed, 0 failed** (에스컬레이션 회귀 3개: 1회차 배너 없음 / 2회차 배너 /
  다른 세션 독립)
- `ruff check` (수정 3파일) → All checks passed
- `python3 scripts/check-plugin-manifests.py` → OK
- codex-review-wrap (praxis:codex-review-wrap) → 결함 없음(pytest/ruff/shellcheck
  통과, fact-modifying finding 0 → premise/flip gate 미적용)

Pre-commit verified: 위 pytest 480 / shell 54 / ruff / manifest-check 결과.

Caller chain verified: `_emit_block_message` 의 유일 호출부는 `main()` 이며 기본값
`prior_blocks=0` 으로 하위호환. `count_session_fires` 는 신규 심볼로 기존 호출자
없음(writer 3종은 무변경).

## 미검증 / 주의

- **UTC 자정 경계**: 자정을 넘는 세션의 pre-midnight 차단은 오늘자 파일에서 누락 →
  카운터가 자정에 리셋될 수 있음(설계상 accepted, under-count 만 발생).
- 프로덕션에선 dispatcher 가 RICH block 을 기록하지만, 훅을 standalone 실행하면
  RICH 레코드가 없어 에스컬레이션이 발동하지 않음(테스트는 ledger 를 직접 seed 해
  프로덕션 상태를 재현).
