### PR TITLE
docs(hooks): move falsify gate detail to specs

### DIFF
--- a/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
@@ -34,6 +34,54 @@ References: issue [#221](https://github.com/devseunggwan/praxis/issues/221) (adv
 [#290](https://github.com/devseunggwan/praxis/issues/290) (T1 ask escalation),
 [#369](https://github.com/devseunggwan/praxis/issues/369) (T2 confidence-anchoring extension).
 
+### Source rule detail (always-loaded SoT reference)
+
+The always-loaded `~/.claude/CLAUDE.md` keeps only the 1-line headline + STOP
+imperative for this gate; the full detail lives here as the reference SoT
+(issue [#793](https://github.com/devseunggwan/praxis/issues/793) partial-slim —
+the headline stays always-loaded to shape pre-tool-call reasoning, the detail
+below moves to the hook backing it). This hook structurally enforces the
+`AskUserQuestion` and `Bash` subset of the rule; the remaining trigger forms
+below stay agent-side retrieval discipline (no PreToolUse surface exists to
+intercept assistant prose).
+
+**Triggers** — output forms that require the gate to fire BEFORE the text is surfaced:
+
+- Action item / follow-up / "P2/P3" / "Recommended" labeled proposal in answer trailer
+- Hub issue title + body + 24-repo checkbox block
+- PR title + body + design table
+- `AskUserQuestion` menu option labeled `(Recommended)` or framed as "safe" / "natural" / "safer"
+- Design tables or scope summaries presented mid-answer to a question the user did not ask
+
+Of these, the hook structurally catches the `AskUserQuestion` evaluative-option
+trigger (T1/T2 in the detection table below) and the `Bash` bulk-action
+downstream-consequence trigger. The answer-trailer proposal, Hub issue body, PR
+body, and mid-answer design table are surfaced as assistant prose — no
+PreToolUse surface exists to intercept them, so they remain agent-retrieval
+discipline.
+
+**Mandatory pre-output question** — asked in the agent's internal reasoning, not the user-facing text:
+
+> "Is this proposal's stated objective already addressed by in-flight work, a
+> merged PR, an existing artifact, or a parallel proposal in the same session?
+> If I had to cite the link that breaks this proposal's necessity, what would
+> it be?"
+
+If a concrete invalidating link/artifact exists → **STOP**. Do not surface the
+proposal. Report the existing solution instead, in one sentence.
+
+**Externalization** — for high-stakes output (irreversible mutation,
+external-surface write, schema change, multi-repo PR, Hub issue body), spawn
+`Agent(subagent_type="oh-my-claudecode:critic")` **in parallel** with the
+self-falsification step. Brief it with the proposal + the invalidating-link
+question and ask it to disprove. Same-cache self-debate inherits the same
+anchoring; a separate context window does not. Skip when self-falsification
+already produced a concrete invalidating link, or when the output is in the
+Out-of-scope set below.
+
+**Out of scope** — single-token answers to direct user questions, mechanical
+edits the user requested, reversible exploration commands.
+
 ### What is detected
 
 | Tool | Trigger condition | Decision |


### PR DESCRIPTION
## 개요

always-loaded `~/.claude/CLAUDE.md`(= `ai-dotfiles/shared/AGENTS.md` 심링크) 슬림화 연작의 praxis 절반. `### Output-Block-Level Falsification Gate` 블록 상세를 이를 구조적으로 enforce 하는 훅 `output-block-falsify-advisory` 의 `spec.md` 로 이전해 **참조 SoT** 로 만든다.

부분 슬림 스코프에 따라 headline 1줄 + STOP imperative 는 always-loaded 잔류(pre-tool 추론 shaping 유지) 대상이며 이는 ai-dotfiles 컴패니언 PR 몫이다. 이 PR 은 상세를 훅 spec 으로 옮기는 절반만 담당한다.

Refs #793 (ai-dotfiles 컴패니언 PR 로 headline 축약 + 훅 참조 포인터 잔여 절반 처리)

## 배치 판단 근거

두 falsify 훅 중 상세의 홈:

- `output-block-falsify-advisory` — "Output-Block-Level Falsification Gate" 룰의 **직접 구조 enforcement** (spec 의 Why-this-exists 가 룰 원문을 인용). → 상세의 홈으로 선택.
- `pre-output-falsification-gate` — Recommendation-lock(Lane A) + repeated read-only probe(Lane B) 담당 sibling. 이 룰 상세의 홈 아님 → 미수정.

훅이 tool-call 시점에 구조적으로 잡는 대상은 `AskUserQuestion`/`Bash` subset 뿐이므로, 나머지 trigger(answer-trailer 제안, Hub issue body, PR body, mid-answer design table)는 prose-only 로 intercept 불가함을 spec 에 명시 구분해 두었다.

## 추가/skip 대조표

이전 대상 상세를 항목별로 두 훅 spec 과 대조(grep) → 부재 항목만 추가:

| 원문 항목 (CLAUDE.md 283–299) | 기존 spec 상태 | 조치 | spec 내 위치 |
| --- | --- | --- | --- |
| Triggers 목록 5개 (answer-trailer / Hub issue+24-repo checkbox / PR+design table / AskUserQuestion (Recommended)·safe·natural·safer / mid-answer design table) | 부재 (detection 표는 AskUserQuestion·Bash subset 만) | **추가** | spec.md:47–61 |
| Mandatory pre-output 질문 verbatim + STOP consequence | 패러프레이즈만 존재(advisory 메시지, ex-L422–423), verbatim 부재 | **추가**(verbatim) | spec.md:63–70 |
| Externalization sub-rule (critic 병렬 spawn·brief·skip 조건) | 부재 (grep `critic`/`externaliz` 0 히트) | **추가** | spec.md:72–79 |
| Out-of-scope 목록 (single-token / mechanical edit / reversible exploration) | 부재 | **추가** | spec.md:81–83 |

skip 항목: 없음 (4개 상세 모두 두 spec 부재 → 전건 추가).

## 검증

- **이전 토큰 grep 전건 히트**: `24-repo checkbox`(L51), `PR title + body + design table`(L52), `Design tables or scope summaries`(L54), `cite the link that breaks`(L67), `oh-my-claudecode:critic`(L75), `Same-cache self-debate`(L77), `Out of scope`/`single-token`/`reversible exploration commands`(L82–83) 모두 히트.
- **markdownlint**: `npx markdownlint-cli2 <spec>` — 신규 지적 0. baseline(origin/main) 7건 = 편집 후 7건, 동일 에러 타입, 라인 번호만 +47 시프트(삽입 라인 수). 삽입 범위(L37–84) 내 에러 0.
- **pytest**: `python3 -m pytest tests/ -q` → 472 passed, 회귀 0.

Caller chain verified: N/A -- docs-only change (spec.md 문서 이전, 코드/심볼 변경 없음)
Pre-commit verified: markdownlint 신규 지적 0(baseline 7=편집후 7), pytest 472 passed

## 커밋

- `docs(hooks): move falsify gate detail to specs` — `Confidence: high`, `Session-Id`, `Pre-commit verified:` 트레일러 포함.
