### PR TITLE
docs(hooks): on-demand home for merge cleanup seq

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,12 +41,12 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 
 ### Development
 
-| Skill                 | Purpose                                                                                                                                                                                         |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `retrospect`          | Session retrospect — find friction root causes, propose improvements                                                                                                                            |
-| `codex-review-wrap`   | Worktree-aware wrapper for `/codex:review` — forces explicit target selection, premise-verification gate, flip detection across rounds                                                          |
-| `debt`                | Deferred-decision ledger — unions commit-trailer markers (`Not-tested:`, `Confidence: low`, `Rejected:`, `Directive:`, `Scope-risk:`) with tree compounding comments (`# [PR #N]`); report-only |
-| `surface-enumeration` | Pre-implementation input-surface enumeration — enumerate every input variant before writing a parser/validator/sanitizer/classifier so each becomes a required test case                        |
+| Skill                    | Purpose                                                                                                                                                                                                  |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `retrospect`             | Session retrospect — find friction root causes, propose improvements                                                                                                                                     |
+| `codex-review-wrap`      | Worktree-aware wrapper for `/codex:review` — forces explicit target selection, premise-verification gate, flip detection across rounds                                                                   |
+| `debt`                   | Deferred-decision ledger — unions commit-trailer markers (`Not-tested:`, `Confidence: low`, `Rejected:`, `Directive:`, `Scope-risk:`) with tree compounding comments (`# [PR #N]`); report-only          |
+| `surface-enumeration`    | Pre-implementation input-surface enumeration — enumerate every input variant before writing a parser/validator/sanitizer/classifier so each becomes a required test case                                 |
 | `worktree-merge-cleanup` | On-demand home for the pre-merge worktree precondition + unified post-merge cleanup sequence — base-worktree call site, submodule `--force` caveat, squash-ancestry stale-HEAD guard, no-`&&`-chain rule |
 
 ### Discipline

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 | **Full**           | + all cmux-* skills                                      | + cmux                                                      |
 | **Multi-provider** | + codex/gemini routing in cmux-*                         | + codex-cli, gemini-cli                                     |
 
-## Skills (15)
+## Skills (16)
 
 > **Invocation**: praxis entries are *skills*, not subagents. Always call them
 > via `Skill(skill="praxis:<name>")` — `Agent(subagent_type="praxis:<name>")`
@@ -47,6 +47,7 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 | `codex-review-wrap`   | Worktree-aware wrapper for `/codex:review` — forces explicit target selection, premise-verification gate, flip detection across rounds                                                          |
 | `debt`                | Deferred-decision ledger — unions commit-trailer markers (`Not-tested:`, `Confidence: low`, `Rejected:`, `Directive:`, `Scope-risk:`) with tree compounding comments (`# [PR #N]`); report-only |
 | `surface-enumeration` | Pre-implementation input-surface enumeration — enumerate every input variant before writing a parser/validator/sanitizer/classifier so each becomes a required test case                        |
+| `worktree-merge-cleanup` | On-demand home for the pre-merge worktree precondition + unified post-merge cleanup sequence — base-worktree call site, submodule `--force` caveat, squash-ancestry stale-HEAD guard, no-`&&`-chain rule |
 
 ### Discipline
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Development workflow skills for Claude Code — disciplined, fast, resilient.
 | `codex-review-wrap` | `codex review`, `review codex`, `safe review`, `premise verification`, `flip detection`, `sibling cross-check` | To run `/codex:review` safely in multi-worktree setups, with premise verification and flip detection | `/praxis:codex-review-wrap` |
 | `debt` | `praxis:debt`, `debt ledger`, `지연 결정`, `deferred decision`, `기술 부채 원장`, `commit trailer audit` | To harvest commit-trailer and compounding-comment deferred-decision markers into a report-only ledger | `/praxis:debt` |
 | `surface-enumeration` | `surface enumerate`, `input surface enumeration`, `input parser`, `input validation`, `intent classifier`, `정규식 경계`, `입력 표면 열거` | To enumerate every input variant before implementing a parser/validator/sanitizer so each becomes a required test case | `/praxis:surface-enumeration` |
+| `worktree-merge-cleanup` | `merge cleanup`, `post-merge cleanup`, `worktree cleanup`, `delete-branch merge`, `squash-ancestry`, `pre-merge worktree`, `머지 후 정리`, `worktree 정리` | To run `gh pr merge --squash --delete-branch` from the right worktree and clean up afterward (submodule `--force`, squash-ancestry guard, no-`&&`-chain) | `/praxis:worktree-merge-cleanup` |
 
 ### Discipline
 

--- a/hooks/preflight-gate/gh-merge-worktree-precondition/spec.md
+++ b/hooks/preflight-gate/gh-merge-worktree-precondition/spec.md
@@ -12,7 +12,7 @@ runs, instead of letting it fail and requiring manual recovery.
 
 ## Why this exists
 
-Issue #798. CLAUDE.md's "Pre-merge Worktree Precondition" section documents
+Issue #798. The praxis `worktree-merge-cleanup` skill is the on-demand home for
 the required manual sequence (remove the head-branch worktree, then merge)
 after this exact failure mode recurred across PRs #147, #170-173, #175, and
 #796 in this project — six documented occurrences of the same deterministic
@@ -77,8 +77,9 @@ retrieval path at all.
 
 ## Scope decision — compound commands not special-cased
 
-CLAUDE.md's own "Unified post-merge cleanup sequence" explicitly instructs
-agents NOT to collapse `git worktree remove` + `gh pr merge` into a single
+The `worktree-merge-cleanup` skill's "Unified post-merge cleanup sequence"
+explicitly instructs agents NOT to collapse `git worktree remove` +
+`gh pr merge` into a single
 `&&`-chain (a git hard error mid-chain silently short-circuits later steps
 and trailing output from an earlier step is easily misread as success — the
 exact failure mode `Bulk Operation Pre-Enumeration` and this project's own
@@ -87,7 +88,8 @@ earlier segments of the same compound command for a preceding
 `git worktree remove` that would have already resolved the conflict — adding
 that would require path-order-sensitive reasoning in service of a pattern the
 project's own convention already discourages. Run the two steps as separate
-Bash calls, per the documented "Unified post-merge cleanup sequence."
+Bash calls, per the `worktree-merge-cleanup` skill's "Unified post-merge
+cleanup sequence."
 
 ## Fail-open
 

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -66,5 +66,6 @@ EXPECTED_SKILLS: frozenset[str] = frozenset({
     "strikes",
     "surface-enumeration",
     "using-praxis",
+    "worktree-merge-cleanup",
     "writing-praxis-skill",
 })

--- a/skills/worktree-merge-cleanup/SKILL.md
+++ b/skills/worktree-merge-cleanup/SKILL.md
@@ -70,9 +70,11 @@ fatal: 'main' is already used by worktree at /Users/.../<main-worktree>
 3. `cd <base-worktree-path>` or chain `cd <path> && gh pr merge ...` in the same
    Bash call (avoid cwd-reset trap between Bash calls).
 4. Even if the call fails on a worktree conflict, the PR may already be merged
-   on remote (gh order: remote merge → local sync). Manual cleanup:
-   `git worktree remove <path> && git branch -D <branch> && git worktree prune &&
-   git pull origin <base>`.
+   on remote (gh order: remote merge → local sync). Manual cleanup — run each as
+   a **separate** Bash call, never chained (a failure in one step must not
+   short-circuit the rest): `git worktree remove <path>`, then
+   `git branch -D <branch>`, then `git worktree prune`, then
+   `git pull origin <base>`.
 5. **Squash-ancestry stale HEAD guard (post-merge sync mandatory)**: immediately
    after `gh pr merge --squash --delete-branch`, run `git pull origin
    <base-branch>` as a **separate step**. gh merges remote then deletes local

--- a/skills/worktree-merge-cleanup/SKILL.md
+++ b/skills/worktree-merge-cleanup/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: worktree-merge-cleanup
+description: >
+  On-demand home for the pre-merge worktree precondition and the unified
+  post-merge cleanup sequence — how to run `gh pr merge --squash --delete-branch`
+  from the base-branch worktree, the submodule `--force` caveat, the
+  squash-ancestry stale-HEAD guard, and the no-`&&`-chain rule.
+  Triggers on "merge cleanup", "post-merge cleanup", "worktree cleanup",
+  "delete-branch merge", "squash-ancestry", "pre-merge worktree", "머지 후 정리",
+  "worktree 정리". Do NOT activate on "merge conflict resolution" or a plain
+  feature-branch "git merge".
+verified-against-runtime: true
+runtime-verified-at: 2026-07-17
+runtime-verified-note: "gh 2.93.0 + git 2.50.1 — `gh pr merge -s/--squash`, `-d/--delete-branch`, and `git worktree remove -f/--force` confirmed present via --help."
+---
+
+# worktree-merge-cleanup
+
+## Overview
+
+`gh pr merge --squash --delete-branch` does a local checkout of the base branch
+(main / dev / prod) in the post-squash stage, and it deletes the local head
+branch by reachability against the local base HEAD. Both facts make the command
+sensitive to *which worktree* it runs from and *whether the base is synced* —
+get either wrong and the merge fails at the git layer or silently skips the
+local-branch delete, forcing manual recovery.
+
+This skill is the on-demand home for that procedure. The always-loaded rule set
+keeps only a pointer here; the deterministic `--delete-branch` failure mode is
+additionally enforced structurally by the `gh-merge-worktree-precondition`
+PreToolUse hook (see [Relationship to enforcement](#relationship-to-enforcement)).
+
+**Core principle:** run the post-merge cleanup steps as *separate* Bash calls,
+never collapsed into one `&&`-chain — a git hard error mid-sequence
+short-circuits the chain and its trailing output is easily misread as success.
+
+## When to Use
+
+- About to merge a PR with `gh pr merge --squash --delete-branch` from an
+  issue-branch worktree.
+- The merge just failed with `fatal: '<base>' is already used by worktree at ...`
+  or `cannot delete branch 'X' used by worktree at ...`.
+- After a squash-merge the local feature branch was not deleted
+  (`warning: deleting branch 'X' ... not yet merged to HEAD`).
+- Cleaning up a worktree that contains a submodule.
+
+## Pre-call checklist
+
+`gh pr merge --squash --delete-branch` must be **called from the worktree that
+owns the base branch**. Calling from an issue-branch worktree triggers the git
+exclusive-ref guard:
+
+```text
+fatal: 'main' is already used by worktree at /Users/.../<main-worktree>
+```
+
+1. Confirm the worktree occupying the base branch with `git worktree list`.
+2. **If `--delete-branch` is included**: remove the PR head branch's worktree
+   first (`git worktree remove <issue-worktree-path>`). The post-merge local
+   branch delete fails if the branch is still occupied — `cannot delete branch
+   'X' used by worktree at ...` — even when invoked from the base (main)
+   worktree, because the failing branch is the *head*, not the base. After
+   removal, re-run `git worktree list` to confirm.
+   - ⚠️ **Submodule-containing worktree**: plain `git worktree remove` is
+     rejected with `fatal: working trees containing submodules cannot be moved
+     or removed`. Use `git worktree remove --force <path>` **only after
+     confirming the worktree is clean** (`git -C <path> status --porcelain`
+     empty). `--force` destroys uncommitted changes in a dirty worktree, so
+     never make it the default.
+3. `cd <base-worktree-path>` or chain `cd <path> && gh pr merge ...` in the same
+   Bash call (avoid cwd-reset trap between Bash calls).
+4. Even if the call fails on a worktree conflict, the PR may already be merged
+   on remote (gh order: remote merge → local sync). Manual cleanup:
+   `git worktree remove <path> && git branch -D <branch> && git worktree prune &&
+   git pull origin <base>`.
+5. **Squash-ancestry stale HEAD guard (post-merge sync mandatory)**: immediately
+   after `gh pr merge --squash --delete-branch`, run `git pull origin
+   <base-branch>` as a **separate step**. gh merges remote then deletes local
+   branch by reachability against local HEAD — but does not fetch the local
+   base, so if local base is still at pre-merge SHA the delete silently skips
+   (`warning: deleting branch 'X' that has been merged to 'refs/remotes/origin/X',
+   but not yet merged to HEAD`). Distinct from item 4's worktree case — only
+   `git pull` fixes it, not `git worktree remove`.
+
+## Unified post-merge cleanup sequence
+
+Covers both sub-cases (worktree conflict + squash-ancestry gap):
+
+```bash
+cd <base-worktree-path>
+git switch <base-branch>
+gh pr merge <N> --squash --delete-branch
+git pull origin <base-branch>                              # resolve squash-ancestry gap
+git branch -d <feature-branch> 2>/dev/null \
+  || git branch -D <feature-branch>                        # fallback (may already be deleted)
+git worktree prune
+```
+
+Even if stdout shows only "deleted remote branch" or is empty, verify local
+cleanup separately: confirm with `git branch | grep <feature-branch>`.
+
+⚠️ Do NOT collapse the sequence into a single `&&`-chain. A git hard error
+mid-sequence (submodule worktree missing `--force`, divergent pull)
+short-circuits `&&`, silently skips remaining steps, and trailing output from an
+earlier step is easily misread as "cleanup done". Run steps separately; after a
+fragile step (worktree remove / pull) fails, re-verify primitive state with
+`git worktree list` / `git branch | grep`.
+
+## Relationship to enforcement
+
+| Layer | Home | Covers |
+| ------- | ------ | -------- |
+| Structural enforcement | `gh-merge-worktree-precondition` PreToolUse hook | Blocks `gh pr merge ... --delete-branch` when the head branch is still checked out in another worktree — one deterministic slice of checklist item 2 |
+| On-demand procedure (this skill) | `worktree-merge-cleanup` | The full manual sequence: base-worktree call site, submodule `--force`, squash-ancestry stale-HEAD guard, unified cleanup, no-`&&`-chain |
+| Always-loaded | user-level rule set | A pointer to this skill only |
+
+The hook is the automated guard for the single failure mode that can be checked
+before the command runs; this skill is the reference for everything the hook
+does not (and structurally cannot) enforce.
+
+## Limitations
+
+- The sequence assumes the squash-merge workflow (`--squash`). A merge-commit or
+  rebase-merge strategy has different local-branch reachability semantics and is
+  out of scope here.
+- Worktree-recovery after an accidental removal is a separate concern (recover
+  via `git worktree add`, never `git clone`).

--- a/tests/test_skill_runtime_metadata.py
+++ b/tests/test_skill_runtime_metadata.py
@@ -611,6 +611,7 @@ def test_current_repo_runtime_sensitive_skill_set_is_stable():
             "helper-executable",
         ),
         "surface-enumeration": ("external-cli-wrapper",),
+        "worktree-merge-cleanup": ("external-cli-wrapper",),
         "writing-praxis-skill": (
             "AskUserQuestion",
             "Skill(...)",


### PR DESCRIPTION
## 요약

always-loaded user-level `CLAUDE.md`(= `ai-dotfiles/shared/AGENTS.md` 심링크) 슬림화 연작. `### Pre-merge Worktree Precondition` 블록(32줄 — 단일 최대 블록)의 **온디맨드 홈**을 praxis에 신설한다.

라우팅 선례(praxis #786) 패턴 계승 — enforcement는 훅, 상세는 온디맨드, always-loaded는 포인터.

## 홈 형태 결정 — 신규 스킬 `worktree-merge-cleanup`

이슈가 제시한 후보 (a) 신규 스킬 vs (b) 기존 worktree 훅 `spec.md` 흡수 중 **(a) 신규 스킬**을 택했다.

sibling 컨벤션 조사 근거:

1. **#786이 경계를 세움** — "키워드→타겟 자동화는 훅+spec, 지식 주입은 스킬"(라우팅은 키워드 매핑이라 훅, 이 시퀀스는 다단계 수동 git 절차 how-to = **지식 주입**이라 스킬).
2. **Component Responsibilities 표**(Hook=side-effect/automation, Skill=knowledge injection)와 일치.
3. **훅 spec 흡수는 SRP 위반** — `gh-merge-worktree-precondition` 훅은 `--delete-branch` base-worktree 실패 모드 **한 조각**만 구조적으로 enforce한다. 전체 절차(squash-ancestry stale HEAD 가드, submodule `--force`, unified cleanup, no-`&&`-chain)를 그 훅의 spec.md에 흡수하면 "이 훅이 하는 일"과 "전체 수동 절차"가 뒤섞여 spec SRP가 깨진다.
4. **결과: 3-홈 분리 완성** — 훅(enforcement) / 스킬(온디맨드 상세) / always-loaded(포인터). 이슈가 명시한 "enforcement은 훅, 상세는 온디맨드, always-loaded는 포인터"에 정확히 대응.

## gh-merge-worktree-precondition 훅과의 관계 (중복 아닌 참조)

훅은 pre-merge 시점에 검사 가능한 단일 결정적 실패 모드(head 브랜치가 다른 worktree에 체크아웃된 채 `--delete-branch`)만 block한다. 스킬은 훅이 구조적으로 담을 수 없는 나머지 전 절차의 SoT다. 훅 spec.md의 기존 크로스레퍼런스(`Pre-merge Worktree Precondition` / `Unified post-merge cleanup sequence`)를 새 스킬로 재지정해 ai-dotfiles 슬림 후에도 참조가 유효하게 유지되도록 했다. 스킬에도 관계 표를 추가.

## 변경 파일

- `skills/worktree-merge-cleanup/SKILL.md` (신규) — 시퀀스 **전문 보존**(요약 없음). frontmatter는 지식-홈이지만 bash 펜스에 `gh`/`git` 명령을 담아 external-cli-wrapper로 분류되므로, 문서화한 CLI 표면(`gh pr merge -s/--squash`, `-d/--delete-branch`, `git worktree remove -f/--force`)을 `--help`로 live 확인 후 truthful `verified-against-runtime` 필드 추가.
- `AGENTS.md`(=`CLAUDE.md` 심링크) — Skills 개수 15→16, Development 테이블 자기 행 추가.
- `README.md` — Development 테이블 자기 행 추가(트리거 키워드 verbatim).
- `hooks/preflight-gate/gh-merge-worktree-precondition/spec.md` — 크로스레퍼런스 3곳을 새 스킬로 재지정.
- `scripts/constants.py` — `EXPECTED_SKILLS`에 등록.
- `tests/test_skill_runtime_metadata.py` — runtime-sensitive 스킬 pin 셋에 추가.

## 검증

- `python3 scripts/check-plugin-manifests.py` → `plugin-manifest check OK`
- `python3 -m pytest tests/ -q` → `472 passed`
- `npx markdownlint-cli2 skills/worktree-merge-cleanup/SKILL.md` → `0 issues`
- 새 홈에서 시퀀스 전문 접근 grep 확인: `Squash-ancestry stale HEAD guard`, `Unified post-merge cleanup sequence`, `working trees containing submodules cannot be moved`, `--delete-branch`(10회) 모두 present.
- CLI 플래그 live 확인: gh 2.93.0 / git 2.50.1.

## 비범위 — 잔여 절반

- **ai-dotfiles 컴패니언 PR**: `shared/AGENTS.md` 본문 768–799를 이 스킬 참조 포인터로 치환 + 심링크 live 반영 + always-loaded에서 cleanup 시퀀스 grep 부재 확인. **별 repo·별 PR**로 진행(이 PR 범위 밖).
- ai-dotfiles 컴패니언이 남으므로 `Refs #791` 사용(`Closes` 금지).

Caller chain verified: N/A -- docs/skill-only change (no code symbol)
Pre-commit verified: check-plugin-manifests.py OK; pytest 472 passed; markdownlint SKILL.md 0 issues

Refs #791


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `worktree-merge-cleanup` development skill to guide on-demand post–squash-merge worktree cleanup.
  - Includes handling for worktree conflicts, missing local branch deletion, stale branch prevention, and submodule worktrees.

- **Documentation**
  - Updated the skill catalog and README to include the new skill and example usage.
  - Refined merge precondition documentation to explicitly reference `worktree-merge-cleanup` and emphasize running cleanup steps as separate commands (no `&&` chaining).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->