### PR TITLE
refactor(ask-falsify-gate): allow evidence in description

### DIFF
--- a/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
@@ -637,36 +637,6 @@ def main() -> int:
             # Per-question check: only this question's text counts.
             q_text = q.get("question")
             q_texts = [q_text] if isinstance(q_text, str) else []
-            # Issue #828: a `Falsified:` line placed in an option's own
-            # `description` field also counts. A PreToolUse hook cannot see
-            # the assistant's own preceding prose (confirmed infeasible —
-            # see pre-output-falsification-gate's Lane A "A3 INFEASIBILITY
-            # NOTE"), so the evidence cannot be moved out of `tool_input`
-            # entirely. Splitting it across each option's own `description`
-            # instead of concatenating it into one long `question` string
-            # keeps `question` short/single-purpose, reducing the
-            # long+multiline+non-ASCII payload shape implicated in the
-            # harness's malformed-tool-call-emission bug (upstream
-            # anthropics/claude-code #69522/#79339/#74800).
-            #
-            # `description` ONLY — codex review caught that pulling in
-            # `collect_option_texts()` (label + description) let a single
-            # triggering option's own LABEL satisfy T1/T2 with zero real
-            # probe evidence: in `_has_falsified_line`'s single-label mode
-            # (<=1 triggering label), ANY clean `Falsified:`-prefixed line
-            # anywhere in `texts` passes, so an option literally labeled
-            # `"Falsified: Option A (Recommended) — probe: ..."` silent-
-            # passed the gate it was itself triggering — a self-referential
-            # bypass with no falsification cost at all. `label` is
-            # attacker/model-controlled input already scanned for the
-            # (Recommended)/anchoring MARKER (T1/T2 detection above); it
-            # must never also double as the evidence that satisfies the
-            # marker it carries.
-            for o in options:
-                if isinstance(o, dict):
-                    desc = o.get("description")
-                    if isinstance(desc, str):
-                        q_texts.append(desc)
 
             # Issue #787 codex round-7 P2: T1 and T2 triggering labels are
             # computed independently (not via if/elif) because a single
@@ -717,12 +687,66 @@ def main() -> int:
 
             combined_triggering = _dedupe_labels(t1_triggering + t2_triggering)
             if combined_triggering:
+                # Issue #828: a `Falsified:` line placed in a TRIGGERING
+                # option's own `description` field also counts. A
+                # PreToolUse hook cannot see the assistant's own preceding
+                # prose (confirmed infeasible — see
+                # pre-output-falsification-gate's Lane A "A3 INFEASIBILITY
+                # NOTE"), so the evidence cannot be moved out of
+                # `tool_input` entirely. Splitting it across each
+                # triggering option's own `description` instead of
+                # concatenating it into one long `question` string keeps
+                # `question` short/single-purpose, reducing the
+                # long+multiline+non-ASCII payload shape implicated in the
+                # harness's malformed-tool-call-emission bug (upstream
+                # anthropics/claude-code #69522/#79339/#74800).
+                #
+                # Scoped to TRIGGERING options only, and computed here
+                # (after combined_triggering exists) rather than
+                # unconditionally for every option in the question — two
+                # codex-review-caught bypasses required this:
+                #
+                # 1. label excluded from evidence: pulling in
+                #    collect_option_texts() (label + description) let a
+                #    single triggering option's own LABEL satisfy T1/T2
+                #    with zero real probe evidence (single-label mode
+                #    accepts "any clean line anywhere"). `label` already
+                #    carries the (Recommended)/anchoring MARKER; it must
+                #    never also double as the evidence proving that
+                #    marker's own premise.
+                # 2. non-triggering options excluded: adding EVERY
+                #    option's description unconditionally let an unrelated,
+                #    non-triggering option's description (with its own
+                #    unrelated `Falsified:` line) satisfy the gate for a
+                #    *different* triggering option in single-label mode —
+                #    the actual triggering option's premise was never
+                #    falsified at all. Live probe: a lone `(Recommended)`
+                #    option with no description, paired with a sibling
+                #    option whose description read
+                #    "Falsified: unrelated ... premise survives because
+                #    n/a" → silent pass (rc=0, empty stdout) before this
+                #    fix. Only a triggering option's OWN description can
+                #    supply its evidence.
+                triggering_norm = set(combined_triggering)
+                falsify_texts = list(q_texts)
+                for o in options:
+                    if not isinstance(o, dict):
+                        continue
+                    label = o.get("label")
+                    if not isinstance(label, str):
+                        continue
+                    if _normalize_label(label) not in triggering_norm:
+                        continue
+                    desc = o.get("description")
+                    if isinstance(desc, str):
+                        falsify_texts.append(desc)
+
                 # Each label in combined_triggering (issue #787 codex
                 # round-4 P1, extended round-7, round-9 P1) must be
                 # individually addressed by its own clean line — a scaffold
                 # satisfied by deleting a line, or by pasting distinct-but-
                 # off-target evidence for only one option, must still block.
-                if not _has_falsified_line(q_texts, combined_triggering):
+                if not _has_falsified_line(falsify_texts, combined_triggering):
                     if t1_triggering:
                         any_t1_violation = True
                         t1_labels.extend(t1_triggering)

--- a/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
@@ -432,6 +432,54 @@ def _t2_matching_labels(options: list) -> list[str]:
     return matched
 
 
+def _t1_triggering_indices(options: list) -> set[int]:
+    """Indices (into `options`) of options carrying the exact (Recommended)/(추천) marker.
+
+    Issue #828 codex round-3 P2: evidence-collection must key on option
+    IDENTITY (index), not on normalized label text. Two distinct options
+    can share the same normalized label (e.g. "Option  A" and "Option A"
+    both collapse to "Option A") — matching by label string let a
+    non-triggering option's unrelated `Falsified:` description satisfy a
+    *different*, triggering option with the same normalized label. Live
+    probe: option 0 label="Option  A" description="safer path overall"
+    (T2-triggering, no evidence of its own) + option 1 label="Option A"
+    description="Falsified: unrelated ... premise survives because n/a"
+    (non-triggering) → silent pass (rc=0, empty stdout) under label-string
+    matching. Index-based matching closes this because index 0 and index
+    1 are never equal.
+    """
+    indices: set[int] = set()
+    for idx, o in enumerate(options):
+        if not isinstance(o, dict):
+            continue
+        label = o.get("label")
+        if not isinstance(label, str):
+            continue
+        if any(marker in label for marker in RECOMMENDED_MARKERS_EXACT_EN):
+            indices.add(idx)
+        elif any(marker in label for marker in RECOMMENDED_MARKERS_EXACT_KO):
+            indices.add(idx)
+    return indices
+
+
+def _t2_triggering_indices(options: list) -> set[int]:
+    """Indices (into `options`) of options whose own label OR description
+    carries an anchoring token (T2 scope). See `_t1_triggering_indices` for
+    why index identity, not label text, is the matching key (issue #828
+    codex round-3 P2).
+    """
+    indices: set[int] = set()
+    for idx, o in enumerate(options):
+        if not isinstance(o, dict):
+            continue
+        label = o.get("label")
+        if not isinstance(label, str):
+            continue
+        if _has_confidence_anchoring(collect_option_texts([o])):
+            indices.add(idx)
+    return indices
+
+
 def _dedupe_labels(labels: list[str]) -> list[str]:
     """Order-preserving de-dup for aggregated scaffold labels (issue #787)."""
     return list(dict.fromkeys(labels))
@@ -727,15 +775,29 @@ def main() -> int:
                 #    n/a" → silent pass (rc=0, empty stdout) before this
                 #    fix. Only a triggering option's OWN description can
                 #    supply its evidence.
-                triggering_norm = set(combined_triggering)
+                # 3. index identity, not label-string matching (codex
+                #    round-3 P2): matching via
+                #    `_normalize_label(label) in triggering_norm` conflates
+                #    two DIFFERENT options that happen to share the same
+                #    normalized label — e.g. "Option  A" (double space,
+                #    T2-triggering) and "Option A" (non-triggering). The
+                #    non-triggering option's unrelated `Falsified:`
+                #    description satisfied the triggering option's gate.
+                #    Live probe: options=[{label:"Option  A",
+                #    description:"safer path overall"}, {label:"Option A",
+                #    description:"Falsified: unrelated ... premise
+                #    survives because n/a"}] → silent pass (rc=0, empty
+                #    stdout) before this fix. `_t1_triggering_indices` /
+                #    `_t2_triggering_indices` key on option position in
+                #    `options`, which two distinct options can never share.
+                t1_idx = _t1_triggering_indices(options)
+                t2_idx = _t2_triggering_indices(options) - t1_idx
+                triggering_indices = t1_idx | t2_idx
                 falsify_texts = list(q_texts)
-                for o in options:
+                for idx, o in enumerate(options):
+                    if idx not in triggering_indices:
+                        continue
                     if not isinstance(o, dict):
-                        continue
-                    label = o.get("label")
-                    if not isinstance(label, str):
-                        continue
-                    if _normalize_label(label) not in triggering_norm:
                         continue
                     desc = o.get("description")
                     if isinstance(desc, str):

--- a/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
@@ -33,8 +33,10 @@ This hook adds a structural enforcement point at two surfaces:
          for ergonomics: framing-token detection is broader and carries
          higher false-positive risk than the literal T1 marker.
 
-     When `Falsified:` is present in the question body, both tiers
-     silent-pass.
+     When `Falsified:` is present in the question body OR the triggering
+     option's own `description` field, both tiers silent-pass (issue #828:
+     the description-field path lets the evidence stay out of the shared
+     `question` string, keeping it short — see `q_texts` construction below).
 
   2. Bash — bulk-action commands containing patterns like "close all",
      "delete all", "merge all" (+ Korean equivalents). Advisory only.
@@ -73,8 +75,8 @@ ADVISORY_MSG = (
 )
 
 ASK_MSG = (
-    "(Recommended) 라벨이 있으나 question body 에 "
-    "'Falsified: <disconfirming test 결과>' 가 없음. "
+    "(Recommended) 라벨이 있으나 question body 또는 해당 옵션의 description "
+    "필드 어디에도 'Falsified: <disconfirming test 결과>' 가 없음. "
     "CLAUDE.md Self-Falsify Before Recommendation Lock 룰. "
     # Template-level guidance (issue #682): the problem is not only this call —
     # the AskUserQuestion compose template is missing the field. Bake a
@@ -86,14 +88,19 @@ ASK_MSG = (
     "첫 칼럼 시작 'Falsified: <검증 결과>' 줄을 템플릿에 포함하라 — "
     "인스턴스 수정이 아닌 템플릿 수정이 필요하다. "
     "'Falsified:' 는 자기 줄 첫 칼럼에서 시작해야 한다 (startswith 검사) — "
-    "질문문 중간/불릿/코드펜스 내부 배치는 미검출."
+    "질문문 중간/불릿/코드펜스 내부 배치는 미검출. "
+    # Issue #828: prefer the option's own description field over the
+    # question body so long/multiline evidence doesn't accumulate in one
+    # shared string.
+    "[trigger-reduction] question 은 짧게 유지하고, Falsified: 줄은 해당 옵션 "
+    "(Recommended) 의 description 필드에 넣는 것을 권장 — 두 위치 모두 검증됨."
 )
 
 ANCHORING_ASK_MSG = (
     "옵션 라벨/설명에 confidence-anchoring framing 토큰 (safer/safest/"
     "natural/obvious/clearly/default/prefer/recommend/안전한/자연스러운/"
-    "당연히/분명히/추천/기본값) 이 있으나 question body 에 "
-    "'Falsified: <disconfirming test 결과>' 가 없음. "
+    "당연히/분명히/추천/기본값) 이 있으나 question body 또는 해당 옵션의 "
+    "description 필드 어디에도 'Falsified: <disconfirming test 결과>' 가 없음. "
     "CLAUDE.md Output-Block-Level Falsification Gate. "
     # Template-level guidance (issue #682): bake the Falsified: line into the
     # AskUserQuestion compose template for every anchoring-framed option, not
@@ -104,7 +111,10 @@ ANCHORING_ASK_MSG = (
     "첫 칼럼 시작 'Falsified: <검증 결과>' 줄을 템플릿에 포함하라 — "
     "인스턴스 수정이 아닌 템플릿 수정이 필요하다. "
     "'Falsified:' 는 자기 줄 첫 칼럼에서 시작해야 한다 (startswith 검사) — "
-    "질문문 중간/불릿/코드펜스 내부 배치는 미검출."
+    "질문문 중간/불릿/코드펜스 내부 배치는 미검출. "
+    # Issue #828: same trigger-reduction guidance as ASK_MSG.
+    "[trigger-reduction] question 은 짧게 유지하고, Falsified: 줄은 해당 옵션의 "
+    "description 필드에 넣는 것을 권장 — 두 위치 모두 검증됨."
 )
 
 # ---------------------------------------------------------------------------
@@ -627,6 +637,36 @@ def main() -> int:
             # Per-question check: only this question's text counts.
             q_text = q.get("question")
             q_texts = [q_text] if isinstance(q_text, str) else []
+            # Issue #828: a `Falsified:` line placed in an option's own
+            # `description` field also counts. A PreToolUse hook cannot see
+            # the assistant's own preceding prose (confirmed infeasible —
+            # see pre-output-falsification-gate's Lane A "A3 INFEASIBILITY
+            # NOTE"), so the evidence cannot be moved out of `tool_input`
+            # entirely. Splitting it across each option's own `description`
+            # instead of concatenating it into one long `question` string
+            # keeps `question` short/single-purpose, reducing the
+            # long+multiline+non-ASCII payload shape implicated in the
+            # harness's malformed-tool-call-emission bug (upstream
+            # anthropics/claude-code #69522/#79339/#74800).
+            #
+            # `description` ONLY — codex review caught that pulling in
+            # `collect_option_texts()` (label + description) let a single
+            # triggering option's own LABEL satisfy T1/T2 with zero real
+            # probe evidence: in `_has_falsified_line`'s single-label mode
+            # (<=1 triggering label), ANY clean `Falsified:`-prefixed line
+            # anywhere in `texts` passes, so an option literally labeled
+            # `"Falsified: Option A (Recommended) — probe: ..."` silent-
+            # passed the gate it was itself triggering — a self-referential
+            # bypass with no falsification cost at all. `label` is
+            # attacker/model-controlled input already scanned for the
+            # (Recommended)/anchoring MARKER (T1/T2 detection above); it
+            # must never also double as the evidence that satisfies the
+            # marker it carries.
+            for o in options:
+                if isinstance(o, dict):
+                    desc = o.get("description")
+                    if isinstance(desc, str):
+                        q_texts.append(desc)
 
             # Issue #787 codex round-7 P2: T1 and T2 triggering labels are
             # computed independently (not via if/elif) because a single

--- a/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
@@ -467,13 +467,17 @@ def _t2_triggering_indices(options: list) -> set[int]:
     carries an anchoring token (T2 scope). See `_t1_triggering_indices` for
     why index identity, not label text, is the matching key (issue #828
     codex round-3 P2).
+
+    Unlike T1 (marker lives in `label` only), T2's OR-contract means a
+    missing/non-string `label` must not exclude an option whose
+    `description` alone carries the anchoring token (PR #829 CodeRabbit
+    review) — `collect_option_texts([o])` already tolerates a non-string
+    `label` by omitting it from the scanned text, so no separate guard is
+    needed here.
     """
     indices: set[int] = set()
     for idx, o in enumerate(options):
         if not isinstance(o, dict):
-            continue
-        label = o.get("label")
-        if not isinstance(label, str):
             continue
         if _has_confidence_anchoring(collect_option_texts([o])):
             indices.add(idx)

--- a/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
@@ -86,10 +86,10 @@ edits the user requested, reversible exploration commands.
 
 | Tool | Trigger condition | Decision |
 | ------ | ----------------- | ---------- |
-| `AskUserQuestion` (T1) | Option `label` contains exact `(Recommended)` or `(추천)` AND question body has no `Falsified:` line | `permissionDecision: deny` (ASK_MSG) |
-| `AskUserQuestion` (T1) | Option `label` contains exact `(Recommended)` or `(추천)` AND question body has `Falsified:` line | Silent pass |
-| `AskUserQuestion` (T2, issue #369) | Option `label` OR `description` contains a confidence-anchoring framing token AND question body has no `Falsified:` line | `permissionDecision: ask` (ANCHORING_ASK_MSG) |
-| `AskUserQuestion` (T2) | Same as above + `Falsified:` present | Silent pass |
+| `AskUserQuestion` (T1) | Option `label` contains exact `(Recommended)` or `(추천)` AND no `Falsified:` line in the question body or any option `description` | `permissionDecision: deny` (ASK_MSG) |
+| `AskUserQuestion` (T1) | Option `label` contains exact `(Recommended)` or `(추천)` AND a `Falsified:` line is present (question body OR option `description`, issue #828) | Silent pass |
+| `AskUserQuestion` (T2, issue #369) | Option `label` OR `description` contains a confidence-anchoring framing token AND no `Falsified:` line in the question body or any option `description` | `permissionDecision: ask` (ANCHORING_ASK_MSG) |
+| `AskUserQuestion` (T2) | Same as above + `Falsified:` present (question body OR option `description`, issue #828) | Silent pass |
 | `AskUserQuestion` (T3) | Option `label` contains case-insensitive `(recommended)` only | Dead under new precedence — T2's bare `recommend(ed\|s)?` token catches it first as ask |
 | `Bash` | Command matches a bulk-action mutation keyword (see table below) | Advisory stderr |
 | Any other tool | — | Silent pass-through |
@@ -100,15 +100,121 @@ edits the user requested, reversible exploration commands.
 `(Recommended)` and `(추천)` in option labels are the canonical signal for a
 self-authored proposal block about to be surfaced. When these exact tokens
 (case-sensitive, including parentheses) are detected, the hook checks the
-`question` field of each question object for a line that starts with `Falsified:`
-(exact prefix at line start, as in `Falsified: checked no existing PR — none found`).
+`question` field of each question object, plus every option's own
+`description` field (issue #828 — see below; NOT `label`), for a line that
+starts with `Falsified:` (exact prefix at line start, as in `Falsified:
+checked no existing PR — none found`).
 
 - **`Falsified:` present** → silent pass. The model has provided verifiable
   evidence of a disconfirming test.
 - **`Falsified:` absent** → `permissionDecision: deny` with ASK_MSG (hard block — issue #393). The model
   must add the falsification line and retry.
 
-T1 scans `options[].label` ONLY — description is scanned by T2 (below).
+T1's *marker* scan (is `(Recommended)`/`(추천)` present at all) reads
+`options[].label` ONLY — description is scanned for the marker by T2
+(below). The *evidence* scan (does a `Falsified:` line exist) reads the
+question body AND every option's `description` (issue #828) — never
+`label`. See "Why `description` only, never `label`" below for why this
+distinction is load-bearing, not stylistic.
+
+#### AskUserQuestion T1/T2 evidence location: question body OR option description (issue #828)
+
+**Why this exists**: praxis skill `praxis:cmux-delegate` (and this hook
+itself) require a `Falsified:` line to satisfy T1/T2 before the deny/ask
+decision clears. Before issue #828 the only place `_has_falsified_line`
+scanned was `questions[].question` — the single string field carrying the
+literal user-facing question text. In practice this pushed the model to
+prepend the full falsification rationale (often multi-paragraph, Korean,
+multi-line) onto that one field, because the alternative was retrying the
+tool call with no way to record the evidence anywhere else the hook would
+accept.
+
+That shape — a long, multi-line, non-ASCII (CJK) string inside a single
+tool-call argument — matches the trigger conditions reported for a
+Claude Code harness bug where tool-call arguments are double-encoded to a
+JSON string and rejected as malformed input
+(`{"__unparsedToolInput": {...}}` / `InputValidationError`; upstream
+anthropics/claude-code
+[#69522](https://github.com/anthropics/claude-code/issues/69522),
+[#79339](https://github.com/anthropics/claude-code/issues/79339),
+[#74800](https://github.com/anthropics/claude-code/issues/74800)). This
+hook's own T1/T2 requirement was a **self-inflicted contributor** to that
+trigger: every `(Recommended)` call was forced to inflate `question` with
+exactly the long/multiline/non-ASCII payload shape the bug is sensitive to.
+
+**Feasibility investigation — moving the check to preceding assistant
+prose (rejected, infeasible)**: the original idea was to let the model
+write the `Falsified:` line as ordinary assistant text *before* the
+`AskUserQuestion` tool call, and have this PreToolUse hook read that
+preceding prose from the transcript instead of from `tool_input` at all —
+fully removing the evidence from the tool call's JSON payload. This is
+infeasible: a `PreToolUse` hook only receives the already-parsed
+`tool_input` for the call it is gating; it cannot see the text blocks the
+assistant emitted in the same in-flight turn, because those blocks are not
+yet flushed to the transcript file when the hook runs (confirmed by this
+repo's own prior investigation — see `pre-output-falsification-gate`
+Lane A's "A3 INFEASIBILITY NOTE" in `impl.py`, which hit and documented the
+identical limitation: "A PreToolUse hook cannot see the assistant turn
+being authored — only the tool_input being submitted"). The
+`extract_last_assistant_text` / `has_tool_in_turn` helpers in `_lib/_transcript.py`
+that could theoretically do this are used only by **Stop** hooks (see
+`hooks/completion-verify/*`), which fire after the full turn — including
+any pre-tool-call text — has already been persisted. No PreToolUse hook in
+this repo reads current-turn assistant prose for this reason.
+
+**What shipped instead**: since the evidence cannot leave `tool_input`
+entirely, it is now allowed to live in a smaller, more naturally-scoped
+field within `tool_input` — each triggering option's own `description` —
+instead of being concatenated into the single shared `question` string.
+`_has_falsified_line` already matched a `Falsified:` line by its
+`"Falsified: {label}"` prefix regardless of which text it came from, so no
+change to that matching logic was needed; only the set of texts fed into it
+(`q_texts`) was widened to include each option's `description` (not
+`label` — see the next subsection). This:
+
+- Keeps `question` short and single-line (just the actual question sentence)
+  in the common case, reducing the long+multiline+non-ASCII payload shape.
+- Distributes multi-option evidence across N smaller per-option strings
+  instead of one large concatenated block.
+- Requires no transcript access and no new failure mode — it is a pure
+  `tool_input`-local check, same as the pre-#828 contract.
+- Is fully backward compatible: a `Falsified:` line in `question` still
+  satisfies the gate exactly as before (no regression), so an agent that
+  keeps the old convention does not get newly blocked.
+
+The `[trigger-reduction]` sentence appended to both `ASK_MSG` and
+`ANCHORING_ASK_MSG` (see Response shape below) tells the model to prefer
+the option-`description` placement going forward.
+
+**Why `description` only, never `label` (codex review, in-vivo P2 catch
+during this issue's own review pass)**: the first implementation widened
+`q_texts` using the existing `collect_option_texts(options)` helper, which
+returns label + description per option (it already existed for T2's
+anchoring-token scan). That reintroduced a self-referential bypass:
+`_has_falsified_line`'s single-triggering-label mode (issue #290 contract
+— when `len(triggering_labels) <= 1`, ANY clean `Falsified:`-prefixed line
+anywhere in `texts` satisfies the gate) does not care which option a line
+came from when there is only one triggering option. A single `(Recommended)`
+option whose own **label** was crafted to read
+`"Falsified: Option A (Recommended) — probe: fake → fake; premise survives
+because fake"` silent-passed the gate it was itself triggering — the
+model could satisfy the falsification requirement by writing a
+label that merely *looks like* evidence, with zero actual probe run and
+zero real observation. Live probe (`impl.py` fed that exact payload) → rc=0,
+empty stdout — confirmed silent pass before the fix.
+
+`label` is the same field the `(Recommended)`/`(추천)` marker itself lives
+in (T1's marker scan) and the same field T2 scans for anchoring tokens —
+it must never also serve as the evidence proving that marker's own premise,
+or the gate collapses to "does the label contain a `Falsified:`-shaped
+string", which any single-line edit can satisfy trivially. `description`
+does not have this problem: T1's marker scan reads `label` only (never
+`description`), so a `description` field can carry `Falsified:` evidence
+without also being the very marker the evidence is supposed to falsify.
+The fix (see `impl.py` `q_texts` construction) collects only `o.get("description")`
+per option, never `o.get("label")`. Regression test: "AskUserQuestion:
+label itself crafted as a Falsified: line, no description → still T1 deny
+(issue #828 codex P2)" in the test suite.
 
 #### AskUserQuestion T2: confidence-anchoring framing (issue #369)
 
@@ -171,7 +277,7 @@ matched; read-only commands (`git log --all`, `gh pr list`) do not fire.
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "permissionDecision": "deny",
-    "permissionDecisionReason": "(Recommended) 라벨이 있으나 question body 에 'Falsified: <disconfirming test 결과>' 가 없음. CLAUDE.md Self-Falsify Before Recommendation Lock 룰. [pre-author-template] 이번 호출뿐 아니라 앞으로 (Recommended) 라벨을 붙일 때마다 AskUserQuestion 작성 직전(도구 호출 전) 에 첫 칼럼 시작 'Falsified: <검증 결과>' 줄을 템플릿에 포함하라 — 인스턴스 수정이 아닌 템플릿 수정이 필요하다. 'Falsified:' 는 자기 줄 첫 칼럼에서 시작해야 한다 (startswith 검사) — 질문문 중간/불릿/코드펜스 내부 배치는 미검출."
+    "permissionDecisionReason": "(Recommended) 라벨이 있으나 question body 또는 해당 옵션의 description 필드 어디에도 'Falsified: <disconfirming test 결과>' 가 없음. CLAUDE.md Self-Falsify Before Recommendation Lock 룰. [pre-author-template] 이번 호출뿐 아니라 앞으로 (Recommended) 라벨을 붙일 때마다 AskUserQuestion 작성 직전(도구 호출 전) 에 첫 칼럼 시작 'Falsified: <검증 결과>' 줄을 템플릿에 포함하라 — 인스턴스 수정이 아닌 템플릿 수정이 필요하다. 'Falsified:' 는 자기 줄 첫 칼럼에서 시작해야 한다 (startswith 검사) — 질문문 중간/불릿/코드펜스 내부 배치는 미검출. [trigger-reduction] question 은 짧게 유지하고, Falsified: 줄은 해당 옵션 (Recommended) 의 description 필드에 넣는 것을 권장 — 두 위치 모두 검증됨."
   }
 }
 ```
@@ -188,7 +294,7 @@ matched; read-only commands (`git log --all`, `gh pr list`) do not fire.
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "permissionDecision": "ask",
-    "permissionDecisionReason": "옵션 라벨/설명에 confidence-anchoring framing 토큰 (safer/safest/natural/obvious/clearly/default/prefer/recommend/안전한/자연스러운/당연히/분명히/추천/기본값) 이 있으나 question body 에 'Falsified: <disconfirming test 결과>' 가 없음. CLAUDE.md Output-Block-Level Falsification Gate. [pre-author-template] 이번 호출뿐 아니라 앞으로 confidence-anchoring 토큰을 옵션 라벨/설명에 쓸 때마다 AskUserQuestion 작성 직전(도구 호출 전) 에 첫 칼럼 시작 'Falsified: <검증 결과>' 줄을 템플릿에 포함하라 — 인스턴스 수정이 아닌 템플릿 수정이 필요하다. 'Falsified:' 는 자기 줄 첫 칼럼에서 시작해야 한다 (startswith 검사) — 질문문 중간/불릿/코드펜스 내부 배치는 미검출."
+    "permissionDecisionReason": "옵션 라벨/설명에 confidence-anchoring framing 토큰 (safer/safest/natural/obvious/clearly/default/prefer/recommend/안전한/자연스러운/당연히/분명히/추천/기본값) 이 있으나 question body 또는 해당 옵션의 description 필드 어디에도 'Falsified: <disconfirming test 결과>' 가 없음. CLAUDE.md Output-Block-Level Falsification Gate. [pre-author-template] 이번 호출뿐 아니라 앞으로 confidence-anchoring 토큰을 옵션 라벨/설명에 쓸 때마다 AskUserQuestion 작성 직전(도구 호출 전) 에 첫 칼럼 시작 'Falsified: <검증 결과>' 줄을 템플릿에 포함하라 — 인스턴스 수정이 아닌 템플릿 수정이 필요하다. 'Falsified:' 는 자기 줄 첫 칼럼에서 시작해야 한다 (startswith 검사) — 질문문 중간/불릿/코드펜스 내부 배치는 미검출. [trigger-reduction] question 은 짧게 유지하고, Falsified: 줄은 해당 옵션의 description 필드에 넣는 것을 권장 — 두 위치 모두 검증됨."
   }
 }
 ```
@@ -527,7 +633,7 @@ stderr (it signals via stdout JSON, not stderr), so a stderr-only check
 could not actually distinguish a real silent pass from an undetected
 deny/ask.
 
-Covers 91 cases (47 pre-#787 + 44 new — 5 scaffold, 5 telemetry, 4 multi-question/coarse-dedup fixes, 30 anti-bypass/false-positive):
+Covers 95 cases (91 pre-#828 + 4 new — description-field satisfaction, per-label coverage regression via description, T2 via description, label-only self-referential bypass regression):
 
 **T1 deny-escalation (AskUserQuestion, issue #290/#393):**
 
@@ -535,6 +641,13 @@ Covers 91 cases (47 pre-#787 + 44 new — 5 scaffold, 5 telemetry, 4 multi-quest
 - Option label `(추천)` + no `Falsified:` → `permissionDecision: deny`
 - Option label `(Recommended)` + `Falsified:` line present → silent pass
 - Non-recommended option labels → silent pass
+
+**Description-field evidence location (issue #828):**
+
+- Option label `(Recommended)` + `Falsified:` line in that option's own `description` (not `question`) → silent pass, `question` stays short
+- 2 triggering `(Recommended)` options, only one covered via `description`, the other has no `Falsified:` line anywhere → still `deny` (per-label coverage still enforced across mixed sources)
+- T2 anchoring token (`safer`) + `Falsified:` line in the same option's `description` → `ask` → silent pass once evidence supplied
+- Single `(Recommended)` option with no `description` at all, whose own `label` is crafted to read as a clean `Falsified:` line → still `deny` (regression for the self-referential label-as-evidence bypass caught by codex review — see spec detail above)
 
 **T2 ask-escalation (AskUserQuestion, issue #369):**
 - KO `가장 안전한` in `options[].description` + no `Falsified:` → `ask` (ANCHORING_ASK_MSG) — in-vivo regression for the ai-dotfiles PR #84 session

--- a/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
@@ -86,10 +86,10 @@ edits the user requested, reversible exploration commands.
 
 | Tool | Trigger condition | Decision |
 | ------ | ----------------- | ---------- |
-| `AskUserQuestion` (T1) | Option `label` contains exact `(Recommended)` or `(추천)` AND no `Falsified:` line in the question body or any option `description` | `permissionDecision: deny` (ASK_MSG) |
-| `AskUserQuestion` (T1) | Option `label` contains exact `(Recommended)` or `(추천)` AND a `Falsified:` line is present (question body OR option `description`, issue #828) | Silent pass |
-| `AskUserQuestion` (T2, issue #369) | Option `label` OR `description` contains a confidence-anchoring framing token AND no `Falsified:` line in the question body or any option `description` | `permissionDecision: ask` (ANCHORING_ASK_MSG) |
-| `AskUserQuestion` (T2) | Same as above + `Falsified:` present (question body OR option `description`, issue #828) | Silent pass |
+| `AskUserQuestion` (T1) | Option `label` contains exact `(Recommended)` or `(추천)` AND no `Falsified:` line in the question body or that triggering option's own `description` | `permissionDecision: deny` (ASK_MSG) |
+| `AskUserQuestion` (T1) | Option `label` contains exact `(Recommended)` or `(추천)` AND a `Falsified:` line is present (question body OR that triggering option's own `description`, issue #828) | Silent pass |
+| `AskUserQuestion` (T2, issue #369) | Option `label` OR `description` contains a confidence-anchoring framing token AND no `Falsified:` line in the question body or that triggering option's own `description` | `permissionDecision: ask` (ANCHORING_ASK_MSG) |
+| `AskUserQuestion` (T2) | Same as above + `Falsified:` present (question body OR that triggering option's own `description`, issue #828) | Silent pass |
 | `AskUserQuestion` (T3) | Option `label` contains case-insensitive `(recommended)` only | Dead under new precedence — T2's bare `recommend(ed\|s)?` token catches it first as ask |
 | `Bash` | Command matches a bulk-action mutation keyword (see table below) | Advisory stderr |
 | Any other tool | — | Silent pass-through |
@@ -113,9 +113,10 @@ checked no existing PR — none found`).
 T1's *marker* scan (is `(Recommended)`/`(추천)` present at all) reads
 `options[].label` ONLY — description is scanned for the marker by T2
 (below). The *evidence* scan (does a `Falsified:` line exist) reads the
-question body AND every option's `description` (issue #828) — never
-`label`. See "Why `description` only, never `label`" below for why this
-distinction is load-bearing, not stylistic.
+question body AND each **triggering** option's own `description` (issue
+#828) — never `label`, and never a non-triggering option's description.
+See the two "Why …" subsections below for why both scoping decisions are
+load-bearing, not stylistic.
 
 #### AskUserQuestion T1/T2 evidence location: question body OR option description (issue #828)
 
@@ -169,8 +170,10 @@ instead of being concatenated into the single shared `question` string.
 `_has_falsified_line` already matched a `Falsified:` line by its
 `"Falsified: {label}"` prefix regardless of which text it came from, so no
 change to that matching logic was needed; only the set of texts fed into it
-(`q_texts`) was widened to include each option's `description` (not
-`label` — see the next subsection). This:
+(`q_texts`) was widened to include each **triggering** option's own
+`description` (not `label`, and not every option in the question — see the
+two subsections below for why both scoping decisions are load-bearing).
+This:
 
 - Keeps `question` short and single-line (just the actual question sentence)
   in the common case, reducing the long+multiline+non-ASCII payload shape.
@@ -215,6 +218,36 @@ The fix (see `impl.py` `q_texts` construction) collects only `o.get("description
 per option, never `o.get("label")`. Regression test: "AskUserQuestion:
 label itself crafted as a Falsified: line, no description → still T1 deny
 (issue #828 codex P2)" in the test suite.
+
+**Why evidence is scoped to TRIGGERING options only, never every option in
+the question (codex review round-2, second in-vivo P2 catch)**: the fix
+above still added the description of **every** option in the question to
+`q_texts` unconditionally — not just the triggering ones. That reopened
+the same single-triggering-label-mode gap from a different angle: a
+question with exactly one triggering `(Recommended)` option and **no
+description on that option at all**, paired with a second, non-triggering
+option whose own unrelated description happened to read
+`"Falsified: totally unrelated evidence about something else — probe:
+n/a → n/a; premise survives because n/a"`, silent-passed — because
+single-label mode accepts "any clean `Falsified:` line anywhere in
+`texts`" and does not check which option contributed it. The actual
+triggering option's premise was never falsified; an unrelated sibling
+option's unrelated text satisfied the gate on its behalf. Live probe
+(`impl.py` fed that exact 2-option payload) → rc=0, empty stdout —
+confirmed silent pass before this second fix.
+
+The fix computes `combined_triggering` (the deduped T1+T2 triggering
+label set) **before** collecting description evidence, then only appends
+an option's `description` to the evidence pool when that option's own
+(normalized) label is a member of `combined_triggering` — mirroring the
+existing `"Falsified: {label}"` per-label ownership contract that already
+governs multi-label coverage matching, just applied one step earlier (at
+evidence-collection time, not only at coverage-checking time). A
+non-triggering option's description is never evidence for anything; only
+a triggering option's own description can supply its own evidence.
+Regression test: "AskUserQuestion: non-triggering option's unrelated
+Falsified: description does not cover a different triggering option →
+still T1 deny (issue #828 codex round-2 P2)" in the test suite.
 
 #### AskUserQuestion T2: confidence-anchoring framing (issue #369)
 
@@ -633,7 +666,7 @@ stderr (it signals via stdout JSON, not stderr), so a stderr-only check
 could not actually distinguish a real silent pass from an undetected
 deny/ask.
 
-Covers 95 cases (91 pre-#828 + 4 new — description-field satisfaction, per-label coverage regression via description, T2 via description, label-only self-referential bypass regression):
+Covers 96 cases (91 pre-#828 + 5 new — description-field satisfaction, per-label coverage regression via description, T2 via description, label-only self-referential bypass regression, cross-option unrelated-description bypass regression):
 
 **T1 deny-escalation (AskUserQuestion, issue #290/#393):**
 
@@ -648,6 +681,7 @@ Covers 95 cases (91 pre-#828 + 4 new — description-field satisfaction, per-lab
 - 2 triggering `(Recommended)` options, only one covered via `description`, the other has no `Falsified:` line anywhere → still `deny` (per-label coverage still enforced across mixed sources)
 - T2 anchoring token (`safer`) + `Falsified:` line in the same option's `description` → `ask` → silent pass once evidence supplied
 - Single `(Recommended)` option with no `description` at all, whose own `label` is crafted to read as a clean `Falsified:` line → still `deny` (regression for the self-referential label-as-evidence bypass caught by codex review — see spec detail above)
+- Single triggering `(Recommended)` option with no `description` of its own, paired with a different non-triggering option whose unrelated `description` reads a clean `Falsified:` line → still `deny` (regression for the cross-option unrelated-description bypass caught by codex review round-2 — see spec detail above)
 
 **T2 ask-escalation (AskUserQuestion, issue #369):**
 

--- a/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
@@ -650,6 +650,7 @@ Covers 95 cases (91 pre-#828 + 4 new — description-field satisfaction, per-lab
 - Single `(Recommended)` option with no `description` at all, whose own `label` is crafted to read as a clean `Falsified:` line → still `deny` (regression for the self-referential label-as-evidence bypass caught by codex review — see spec detail above)
 
 **T2 ask-escalation (AskUserQuestion, issue #369):**
+
 - KO `가장 안전한` in `options[].description` + no `Falsified:` → `ask` (ANCHORING_ASK_MSG) — in-vivo regression for the ai-dotfiles PR #84 session
 - EN `safer` / `safest` / `prefer this` / `obvious choice` in label or description → `ask`
 - KO `자연스러운` / `안전한` / `당연히` in description → `ask`

--- a/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
@@ -113,10 +113,10 @@ checked no existing PR — none found`).
 T1's *marker* scan (is `(Recommended)`/`(추천)` present at all) reads
 `options[].label` ONLY — description is scanned for the marker by T2
 (below). The *evidence* scan (does a `Falsified:` line exist) reads the
-question body AND each **triggering** option's own `description` (issue
-#828) — never `label`, and never a non-triggering option's description.
-See the two "Why …" subsections below for why both scoping decisions are
-load-bearing, not stylistic.
+question body AND each **triggering** option's own `description` (issue #828)
+— never `label`, and never a non-triggering option's description. See the
+"Why …" subsections below for why each scoping decision is load-bearing,
+not stylistic.
 
 #### AskUserQuestion T1/T2 evidence location: question body OR option description (issue #828)
 
@@ -248,6 +248,42 @@ a triggering option's own description can supply its own evidence.
 Regression test: "AskUserQuestion: non-triggering option's unrelated
 Falsified: description does not cover a different triggering option →
 still T1 deny (issue #828 codex round-2 P2)" in the test suite.
+
+**Why matching must key on option identity (index), not normalized label
+text (codex review round-3, third in-vivo P2 catch)**: the round-2 fix
+still matched evidence ownership via `_normalize_label(label) in
+triggering_norm` — a set of normalized label STRINGS. Two distinct options
+can normalize to the identical string (e.g. `"Option  A"` with a doubled
+internal space and `"Option A"` both collapse to `"Option A"` under
+`_normalize_label`'s whitespace-run collapsing). When one such option is
+the actual T2-triggering option (via a `safer`-style anchoring token, no
+evidence of its own) and the OTHER, non-triggering option happens to share
+the same normalized label, that sibling's unrelated `Falsified:`
+description was accepted as if it belonged to the triggering option — the
+triggering option's own premise was still never falsified. Live probe
+(`impl.py` fed `options=[{label:"Option  A", description:"safer path
+overall"}, {label:"Option A", description:"Falsified: unrelated ...
+premise survives because n/a"}]`) → rc=0, empty stdout — confirmed silent
+pass before this third fix.
+
+The fix replaces label-string matching with two new index-keyed helpers,
+`_t1_triggering_indices(options)` and `_t2_triggering_indices(options)`,
+which record the POSITION of each triggering option within the `options`
+list rather than its (normalizable) label text. Two distinct list
+positions are never equal, so a same-labeled sibling can no longer donate
+its description to a different option's evidence requirement. This
+mirrors the round-1 fix's "label must never double as evidence" principle
+one layer deeper: round-1 closed the case where a label IS its own
+evidence; round-2 closed the case where a DIFFERENT option's description
+covers the wrong evidence slot by omission; round-3 closes the case where
+label TEXT COLLISION, not omission, misroutes a different option's
+description into the wrong slot. The pre-existing label-based
+`t1_triggering` / `t2_triggering` / `combined_triggering` machinery used
+for messaging (scaffold text, deny/ask reason) is unchanged — only the
+evidence-collection step now reads option identity directly. Regression
+test: "AskUserQuestion: non-triggering option sharing a normalized label
+with the triggering option does not supply its evidence → still T2 ask
+(issue #828 codex round-3 P2)" in the test suite.
 
 #### AskUserQuestion T2: confidence-anchoring framing (issue #369)
 
@@ -666,7 +702,7 @@ stderr (it signals via stdout JSON, not stderr), so a stderr-only check
 could not actually distinguish a real silent pass from an undetected
 deny/ask.
 
-Covers 96 cases (91 pre-#828 + 5 new — description-field satisfaction, per-label coverage regression via description, T2 via description, label-only self-referential bypass regression, cross-option unrelated-description bypass regression):
+Covers 97 cases (91 pre-#828 + 6 new — description-field satisfaction, per-label coverage regression via description, T2 via description, label-only self-referential bypass regression, cross-option unrelated-description bypass regression, same-normalized-label index-identity bypass regression):
 
 **T1 deny-escalation (AskUserQuestion, issue #290/#393):**
 

--- a/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
@@ -451,6 +451,23 @@ run_case "AskUserQuestion: non-triggering option's unrelated Falsified: descript
       '[null, "Falsified: totally unrelated evidence about something else — probe: n/a → n/a; premise survives because n/a"]' \
       'Which approach?')"
 
+# Case 2g (issue #828 codex review round-3 P2 — same-normalized-label
+# cross-option collision): two DIFFERENT options can share the same
+# normalized label (e.g. "Option  A" double-space vs "Option A"). Before
+# this fix, evidence collection matched by `_normalize_label(label) in
+# triggering_norm` (a string set) rather than option identity, so a
+# non-triggering option's unrelated `Falsified:` description satisfied a
+# DIFFERENT, T2-triggering option that merely shared the same normalized
+# label and carried no evidence of its own. Index-based matching
+# (`_t1_triggering_indices` / `_t2_triggering_indices`) closes this: two
+# distinct options never share the same index.
+run_case "AskUserQuestion: non-triggering option sharing a normalized label with the triggering option does not supply its evidence → still T2 ask (issue #828 codex round-3 P2)" \
+  "ask:Falsified:" \
+  "$(make_ask_payload_with_descriptions \
+      '["Option  A", "Option A"]' \
+      '["safer path overall", "Falsified: totally unrelated evidence about something else — probe: n/a → n/a; premise survives because n/a"]' \
+      'Which approach?')"
+
 # Case 3 (updated by issue #369): (Recommended) in description-only is now
 # scanned by T2 (bare `recommended` token, label OR description). Original
 # expectation `pass` upgraded to `ask` — false-positive guard was over-

--- a/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
@@ -436,6 +436,21 @@ run_case "AskUserQuestion: label itself crafted as a Falsified: line, no descrip
   "$(make_ask_payload \
       '["Falsified: Option A (Recommended) (Recommended) — probe: fake → fake; premise survives because fake"]')"
 
+# Case 2f (issue #828 codex review round-2 P2 — cross-option description
+# bypass): a single triggering (Recommended) option with NO description of
+# its own must NOT be satisfied by a DIFFERENT, non-triggering option's
+# unrelated `Falsified:` line. Before this fix, adding every option's
+# description unconditionally to q_texts let single-label mode ("any clean
+# line anywhere satisfies") accept evidence that never addressed the
+# actual triggering option at all — the triggering option's premise was
+# never falsified. Only a triggering option's OWN description counts.
+run_case "AskUserQuestion: non-triggering option's unrelated Falsified: description does not cover a different triggering option → still T1 deny (issue #828 codex round-2 P2)" \
+  "deny:Falsified:" \
+  "$(make_ask_payload_with_descriptions \
+      '["Option A (Recommended)", "Option B"]' \
+      '[null, "Falsified: totally unrelated evidence about something else — probe: n/a → n/a; premise survives because n/a"]' \
+      'Which approach?')"
+
 # Case 3 (updated by issue #369): (Recommended) in description-only is now
 # scanned by T2 (bare `recommended` token, label OR description). Original
 # expectation `pass` upgraded to `ask` — false-positive guard was over-

--- a/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
@@ -389,6 +389,53 @@ run_case "AskUserQuestion: (Recommended) + no Falsified: → T1 deny (issue #393
   "deny:Falsified:" \
   "$(make_ask_payload '["Best option (Recommended)", "Alternative"]')"
 
+# Case 2b (issue #828): Falsified: line in the triggering option's OWN
+# description field (not the question body) also satisfies T1 — the
+# question field itself stays short, which is the trigger-reduction this
+# issue exists for.
+run_case "AskUserQuestion: (Recommended) + Falsified: in option description (not body) → pass (issue #828)" \
+  pass \
+  "$(make_ask_payload_with_descriptions \
+      '["Option A (Recommended)"]' \
+      '["Falsified: Option A (Recommended) — probe: grep for existing PR → none found; premise survives because no in-flight PR covers this."]' \
+      'Which approach?')"
+
+# Case 2c (issue #828 regression): per-label coverage still enforced when
+# evidence is supplied via description — 2 triggering options, only one
+# covered (via its own description), the other has no Falsified: line
+# anywhere → still deny.
+run_case "AskUserQuestion: 2x (Recommended), only one covered via description → still T1 deny (issue #828)" \
+  "deny:Falsified:" \
+  "$(make_ask_payload_with_descriptions \
+      '["Option A (Recommended)", "Option B (Recommended)"]' \
+      '["Falsified: Option A (Recommended) — probe: grep → none found; premise survives because none.", "plain description, no evidence"]' \
+      'Which approach?')"
+
+# Case 2d (issue #828): T2 (confidence-anchoring) also satisfied via a
+# Falsified: line placed in the anchoring option's own description field
+# (the line must still start at column 0 within the field, same contract
+# as the question-body path — a leading newline puts it there).
+run_case "T2: 'safer' + Falsified: line in same description field → pass (issue #828)" \
+  pass \
+  "$(make_ask_payload_with_descriptions \
+      '["Option A", "Option B"]' \
+      "$(python3 -c 'import json; print(json.dumps(["safer choice.\nFalsified: Option A — probe: ran both, no measurable difference; premise survives because none.", "Alternative"]))')" \
+      'Which approach?')"
+
+# Case 2e (issue #828 codex review P2 — self-referential label bypass):
+# a single (Recommended) option whose own LABEL is crafted to read as a
+# clean `Falsified:` line (no `description` at all) must NOT satisfy the
+# gate. Only `description` is a valid evidence source — `label` is the
+# same attacker/model-controlled field the (Recommended) marker itself
+# lives in, so it must never double as the evidence proving that marker's
+# premise. Regression for a real bypass caught by codex review (single-
+# label mode: "any clean Falsified: line anywhere" previously included
+# `collect_option_texts()`'s label text).
+run_case "AskUserQuestion: label itself crafted as a Falsified: line, no description → still T1 deny (issue #828 codex P2)" \
+  "deny:Falsified:" \
+  "$(make_ask_payload \
+      '["Falsified: Option A (Recommended) (Recommended) — probe: fake → fake; premise survives because fake"]')"
+
 # Case 3 (updated by issue #369): (Recommended) in description-only is now
 # scanned by T2 (bare `recommended` token, label OR description). Original
 # expectation `pass` upgraded to `ask` — false-positive guard was over-
@@ -621,9 +668,10 @@ _scaffold_multi_result=$(make_ask_payload '["Option A (Recommended)", "Option B 
 import json, sys
 d = json.loads(sys.stdin.read())
 reason = d.get('hookSpecificOutput', {}).get('permissionDecisionReason', '')
-# ASK_MSG's own instructional text has 2 'Falsified: ' occurrences + 1 per
-# triggering label (2) in the scaffold = 4.
-ok = reason.count('Falsified: ') == 4 and 'Option A (Recommended)' in reason and 'Option B (Recommended)' in reason
+# ASK_MSG's own instructional text has 3 'Falsified: ' occurrences (issue
+# #828 added a 3rd, in the [trigger-reduction] description-field hint) + 1
+# per triggering label (2) in the scaffold = 5.
+ok = reason.count('Falsified: ') == 5 and 'Option A (Recommended)' in reason and 'Option B (Recommended)' in reason
 print('ok' if ok else 'fail_count=' + str(reason.count('Falsified: ')))
 " 2>/dev/null)
 if [ "$_scaffold_multi_result" = "ok" ]; then


### PR DESCRIPTION
## 배경

`AskUserQuestion` `(Recommended)`/confidence-anchoring 게이트(T1/T2)는 `Falsified:` 줄을 요구한다. 지금까지는 그 줄이 오직 `questions[].question` (하나의 공유 문자열) 안에만 있어야 통과했다 — 그 결과 매 `(Recommended)` 호출마다 검증 근거(종종 다단락·한글·multi-line)가 이 한 필드에 몰려 들어갔다.

이 payload 형태(길고·multi-line·non-ASCII)는 Claude Code 하네스가 tool-call 인자를 double-encode 하여 `{"__unparsedToolInput": {...}}` / `InputValidationError` 로 거부하는 버그(upstream anthropics/claude-code [#69522](https://github.com/anthropics/claude-code/issues/69522) / [#79339](https://github.com/anthropics/claude-code/issues/79339) / [#74800](https://github.com/anthropics/claude-code/issues/74800))의 트리거 조건과 정확히 일치한다. 즉 이 게이트 자신의 요구사항이 트리거 페이로드를 부풀리는 자기기여 요인이었다.

Closes #828

## 조사 — "assistant 산문으로 이전" 은 불가능 (검증됨)

가장 먼저 검토한 접근은 `Falsified:` 를 `AskUserQuestion` 호출 직전의 assistant 산문으로 옮기고, 이 PreToolUse hook 이 transcript 에서 그 산문을 읽어 검증하는 것이었다 — evidence 를 `tool_input` 밖으로 완전히 빼내는 방식.

**결론: 불가능 (확인됨).** `PreToolUse` hook 은 자신이 게이팅하는 호출의 이미 파싱된 `tool_input` 만 받는다 — 같은 in-flight 턴에서 assistant 가 emit 한 텍스트 블록은 hook 실행 시점에 아직 transcript 파일에 flush 되지 않아 볼 수 없다.

- 이 저장소 자체의 선행 조사가 동일 결론을 문서화하고 있음: `hooks/advisory-nudge/pre-output-falsification-gate/impl.py` Lane A 의 "A3 INFEASIBILITY NOTE" — "A PreToolUse hook cannot see the assistant turn being authored — only the tool_input being submitted."
- `_lib/_transcript.py` 의 `extract_last_assistant_text`/`has_tool_in_turn` 헬퍼는 실제로 **Stop** hook (`hooks/completion-verify/*`) 에서만 쓰인다 — Stop 은 턴 전체(도구 호출 전 텍스트 포함)가 이미 영속화된 뒤에 발동하므로 가능하지만, PreToolUse 는 불가능.

## 구현 (대안 — feasible)

evidence 를 `tool_input` 밖으로 뺄 수 없으므로, 공유 `question` 문자열 대신 **각 옵션 자신의 `description` 필드**에 담을 수 있도록 확장했다.

- `_has_falsified_line()` 은 이미 "어느 텍스트에서 왔는지"와 무관하게 `Falsified: {label}` prefix 로 매칭하므로 매칭 로직은 변경 없음 — `q_texts` 구성에 각 옵션의 `description` 만 추가.
- **`label` 은 절대 포함하지 않음** — codex review 가 1차 구현(옵션 label+description 모두 포함)에서 실제 우회를 하나 찾아냈다: 단일 triggering 옵션의 **label 자체**를 `"Falsified: Option A (Recommended) — probe: fake → fake; premise survives because fake"` 형태로 작성하면 실제 검증 없이 게이트를 통과했다(single-label-mode "any clean line" 계약 때문). Probe 로 재현·수정 후 재검증 완료(아래 검증 섹션).
- `question` 은 짧게 유지 가능해짐 — 하위 호환: 기존처럼 `question` 안에 `Falsified:` 를 두는 것도 계속 통과.
- ASK_MSG/ANCHORING_ASK_MSG 에 `[trigger-reduction]` 안내문 추가 — 앞으로는 `description` 배치를 권장.

## 검증

**단위/통합 테스트** (`tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh`):

```
Results: 95 passed, 0 failed
```

91개 기존 케이스(회귀 없음) + 신규 4개:
- `(Recommended)` + `description` 에만 `Falsified:` → pass
- 2개 triggering 옵션 중 1개만 `description` 로 커버 → 여전히 deny (per-label coverage 유지)
- T2 anchoring + `description` 의 `Falsified:` → pass
- **label 자체를 Falsified: 형태로 위장, description 없음 → 여전히 deny** (codex review 가 잡은 우회의 회귀 테스트)

**lint/syntax**:
```
ruff check hooks/advisory-nudge/output-block-falsify-advisory/impl.py  → All checks passed!
shellcheck --severity=warning tests/.../test_output_block_falsify_advisory.sh → (clean, 0 output)
python3 -m py_compile impl.py → OK
```

**저장소 전체 스위트** (`scripts/run-tests.sh`): `ALL TESTS PASSED`, exit 0 (본 hook 섹션 `Results: 95 passed, 0 failed` 포함).

**payload 크기 감소 실측** (한글 multi-line rationale 예시):

```
question 필드 — before: len=142 lines=2
question 필드 — after : len=14  lines=1
```

`question` 이 evidence 를 담지 않게 되어 짧고 single-line 을 유지 — upstream 버그가 지목하는 long+multiline+non-ASCII 형태를 이 게이트가 더 이상 강제하지 않음.

**codex review**: `praxis:codex-review-wrap` 1라운드 실행 — P2 finding 1건(위 label-bypass) 확인 → live probe 로 재현(before: rc=0 empty stdout = silent pass; after fix: rc=0 deny JSON) → 수정 + 회귀 테스트 추가 완료.

## 검증되지 않은 부분

- 이슈 완료 조건의 "(선택) 길이 advisory" 항목(question+options 총량이 임계 초과 시 nudge)은 이번 PR 범위에서 제외 — 핵심 트리거 감소(question 필드를 짧게 유지 가능하게 하는 구조 변경)만 다루고, 선택 항목은 별도 후속으로 남김.
- 실제 Claude Code 하네스에서 malformed-tool-call-emission 버그 자체의 재현/해소는 검증 범위 밖(하네스 근본 fix 는 Anthropic 소관, upstream 이슈로 참조만).

## 영향 범위 / 리스크

- 단일 hook(`output-block-falsify-advisory`) + 해당 spec/테스트만 변경. 다른 hook·skill 영향 없음.
- 하위 호환: 기존 `question` body 배치 계속 통과.
- `Not-tested`: 없음 (핵심 변경·회귀 모두 신규 테스트로 커버).

Pre-commit verified: `bash tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh` → 95 passed, 0 failed; `ruff check` → All checks passed; `bash scripts/run-tests.sh` → ALL TESTS PASSED (exit 0)
Caller chain verified: N/A — hook 로직 내부 수정, 신규 심볼 없음; 호출부는 Claude Code PreToolUse dispatch (hooks/manifest.json 등록, 변경 없음)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `AskUserQuestion` now treats `Falsified:` as satisfying evidence when it appears in the triggering option’s `description` (in addition to the question body).
  * Prevents bypasses from `Falsified:` found only in labels, unrelated options, or cross-option attribution (including label-normalization collision cases).
* **Documentation**
  * Updated T1/T2 deny/ask guidance, including `[trigger-reduction]` instructions to keep `question` short and place `Falsified:` in the relevant option `description`.
* **Tests**
  * Expanded coverage from 91 to 97 with new description-based and regression scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->