### PR TITLE
fix(momentum-gate): scope merge-briefing window to prior turn

### DIFF
--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -354,18 +354,16 @@ _APPROVAL_TOKENS = frozenset({
     "좋습니다", "그래", "ㄱ",
 })
 
-# Recording-fidelity proxy: a current turn with this many tool_use-bearing
-# assistant entries but zero text-bearing ones signals a harness that is not
-# recording assistant narration (issue #826 blind spot) — the briefing may be
-# real yet invisible, so escalation demotes to advisory rather than deny.
+# Recording-fidelity proxy: when the ENTIRE scanned window holds assistant
+# messages with tool activity but ZERO recorded text, the harness is dropping
+# assistant narration (issue #826 blind spot) — a real briefing is invisible,
+# so escalation demotes to advisory. A single recorded text block anywhere
+# proves recording works, so a normal tool-only turn (with narration in earlier
+# turns) is NOT treated as unreliable and still denies on a genuine skip.
 _FIDELITY_MIN_TOOLUSE = 3
 
-# PR number a `gh pr merge` targets (positional number or /pull/N URL); the
-# optional -R/--repo global flag may precede `pr`.
-_MERGE_PR_RE = re.compile(
-    r"gh\s+(?:(?:-R|--repo)\s+\S+\s+)?pr\s+merge\s+(?:\S*?/pull/(\d+)|(\d+))",
-    re.IGNORECASE,
-)
+# A single positional token that is a bare PR number or a …/pull/N URL.
+_PULL_TOKEN_RE = re.compile(r"^(?:\S*/pull/(\d+)|(\d+))$")
 
 
 def _load_turn_entries(transcript_path: str) -> list[dict] | None:
@@ -429,11 +427,17 @@ def _assistant_text(entries: list[dict], lo: int, hi: int) -> str:
     return "\n".join(texts)
 
 
-def _fidelity_unreliable(entries: list[dict], lo: int) -> bool:
-    """True when the current turn (entries[lo:]) shows tool activity but no
-    recorded narration — a proxy for a harness that drops assistant text."""
+def _recording_unreliable(entries: list[dict]) -> bool:
+    """True when the whole window shows tool activity but ZERO recorded assistant
+    text — a harness dropping narration (issue #826), not a mere quiet turn.
+
+    Scanning the whole window (not just the current turn) is what separates a
+    non-recording harness from a normal tool-only turn: the latter still has
+    narration somewhere in earlier turns, so a genuine briefing skip is NOT
+    excused just because the final turn happened to be tool-only.
+    """
     n_text = n_tool = 0
-    for ev in entries[lo:]:
+    for ev in entries:
         msg = ev.get("message")
         if not isinstance(msg, dict) or msg.get("role") != "assistant" or ev.get("isSidechain"):
             continue
@@ -448,7 +452,7 @@ def _fidelity_unreliable(entries: list[dict], lo: int) -> bool:
                 n_text += 1
             if any(isinstance(b, dict) and b.get("type") == "tool_use" for b in content):
                 n_tool += 1
-    return n_tool >= _FIDELITY_MIN_TOOLUSE and n_text == 0
+    return n_text == 0 and n_tool >= _FIDELITY_MIN_TOOLUSE
 
 
 def _user_message_text(content: object) -> str:
@@ -469,13 +473,37 @@ def _is_approval_reply(content: object) -> bool:
     return norm in _APPROVAL_TOKENS
 
 
-def _merge_target_pr(payload: dict) -> str | None:
-    """PR number the `gh pr merge` command targets, or None (branch-name merge)."""
-    cmd = (payload.get("tool_input") or {}).get("command")
-    if not isinstance(cmd, str):
+def _segment_merge_target(argv: list[str]) -> str | None:
+    """PR number a `gh pr merge` argv segment targets (first bare-number/pull
+    positional after `merge`), or None for a branch-name/numberless merge."""
+    argv = strip_prefix(argv)
+    if not _is_gh_pr_merge(argv):
         return None
-    m = _MERGE_PR_RE.search(cmd)
-    return (m.group(1) or m.group(2)) if m else None
+    # Scan only the tokens AFTER `pr merge` for a PR token, so a numeric global
+    # flag value before the subcommand cannot be mistaken for the target. Body
+    # values (`--body "closes 999"`) tokenize with internal whitespace, so they
+    # never match the anchored bare-number/pull pattern.
+    for i in range(len(argv) - 1):
+        if argv[i] == "pr" and argv[i + 1] == "merge":
+            for tok in argv[i + 2:]:
+                m = _PULL_TOKEN_RE.match(tok)
+                if m:
+                    return m.group(1) or m.group(2)
+            return None
+    return None
+
+
+def _merge_segments(command: object) -> list[str | None]:
+    """One entry per `gh pr merge` segment in a (possibly compound) command:
+    its PR number, or None when the segment merges by branch (no number)."""
+    if not isinstance(command, str):
+        return []
+    out: list[str | None] = []
+    for argv in iter_command_starts(safe_tokenize(command)):
+        stripped = strip_prefix(argv)
+        if _is_gh_pr_merge(stripped):
+            out.append(_segment_merge_target(stripped))
+    return out
 
 
 def _mentions_pr(text: str, pr: str) -> bool:
@@ -509,19 +537,31 @@ def _merge_escalation_reason(payload: dict) -> str | None:
     # briefing → user approval → merge, which places the briefing in the turn
     # BEFORE the approving user message — outside the since-last-user window.
     # When the last user message is a short approval reply, also score the prior
-    # assistant turn, gated on it referencing THIS PR so a stale prior-turn
-    # briefing for a different PR cannot satisfy the gate.
-    target_pr = _merge_target_pr(payload)
-    if target_pr and len(idxs) >= 2 and _is_approval_reply(entries[idxs[-1]].get("message", {}).get("content")):
+    # assistant turn.
+    segments = _merge_segments((payload.get("tool_input") or {}).get("command"))
+    # A single approval authorizes ONE merge; a compound `merge A && merge B`
+    # must not ride one approval (No Approval Transfer), so ≥2 targets skip the
+    # extension entirely and fall through to deny.
+    single_merge = len(segments) == 1
+    if single_merge and len(idxs) >= 2 \
+            and _is_approval_reply(entries[idxs[-1]].get("message", {}).get("content")):
         prev_text = _assistant_text(entries, idxs[-2] + 1, idxs[-1])
-        if _mentions_pr(prev_text, target_pr) \
+        # A trivial-PR briefing in the prior turn is also carved out.
+        if _is_trivial_merge(prev_text):
+            return None
+        target_pr = segments[0]
+        # Correlate to the target PR when the command names one; a numberless
+        # branch merge has no PR to correlate, so a real prior-turn briefing +
+        # approval suffices (the merge runs on the current branch).
+        correlated = target_pr is None or _mentions_pr(prev_text, target_pr)
+        if correlated \
                 and _briefing_item_count(current_text + "\n" + prev_text) >= MERGE_BRIEFING_MIN_ITEMS:
             return None
 
     # Non-recording fallback (issue #826, fidelity axis): a harness that drops
     # assistant narration makes a real briefing invisible. Demote to advisory
     # (fail safe) rather than hard-deny a legitimate merge.
-    if _fidelity_unreliable(entries, lo):
+    if _recording_unreliable(entries):
         return None
 
     return format_block(

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -354,16 +354,35 @@ _APPROVAL_TOKENS = frozenset({
     "좋습니다", "그래", "ㄱ",
 })
 
-# Recording-fidelity proxy: when the ENTIRE scanned window holds assistant
-# messages with tool activity but ZERO recorded text, the harness is dropping
-# assistant narration (issue #826 blind spot) — a real briefing is invisible,
-# so escalation demotes to advisory. A single recorded text block anywhere
-# proves recording works, so a normal tool-only turn (with narration in earlier
-# turns) is NOT treated as unreliable and still denies on a genuine skip.
-_FIDELITY_MIN_TOOLUSE = 3
-
 # A single positional token that is a bare PR number or a …/pull/N URL.
 _PULL_TOKEN_RE = re.compile(r"^(?:\S*/pull/(\d+)|(\d+))$")
+
+# `gh pr merge` flags that consume a following value token — skipped when
+# scanning for the first positional (the merge target) so a flag value like
+# `--subject 833` is never mistaken for the PR number (issue #826, P2#6).
+_MERGE_VALUE_FLAGS = frozenset({
+    "-b", "--body", "-F", "--body-file", "-t", "--subject",
+    "--match-head-commit", "--author-email",
+})
+
+# Read-only `gh pr` verbs whose positional PR argument identifies the PR the
+# session is operating on. A numberless `gh pr merge` runs on the current
+# branch, so its real target is derived from the most recent such command in
+# the window — the mandated Pre-Merge probe (`gh pr checks/view N`).
+_CONTEXT_VERBS = frozenset({
+    "view", "checks", "diff", "ready", "edit", "status", "comment", "review",
+})
+_CONTEXT_VALUE_FLAGS = frozenset({
+    "-b", "--body", "-F", "--body-file", "-t", "--title", "--subject",
+    "--json", "--jq", "--template", "--repo", "-R",
+})
+
+# Shell constructs that repeat a single textual merge segment at runtime
+# (`for pr in 833 999; do gh pr merge "$pr"; done`, `xargs gh pr merge`). One
+# approval must not ride a loop, so their presence disables the single-approval
+# window extension. Matched as whole tokens (not a substring regex) so a
+# hyphenated branch name like `issue-1-fix-for-x` is never mistaken for a loop.
+_LOOP_KEYWORDS = frozenset({"for", "while", "until", "xargs"})
 
 
 def _load_turn_entries(transcript_path: str) -> list[dict] | None:
@@ -427,34 +446,6 @@ def _assistant_text(entries: list[dict], lo: int, hi: int) -> str:
     return "\n".join(texts)
 
 
-def _recording_unreliable(entries: list[dict]) -> bool:
-    """True when the whole window shows tool activity but ZERO recorded assistant
-    text — a harness dropping narration (issue #826), not a mere quiet turn.
-
-    Scanning the whole window (not just the current turn) is what separates a
-    non-recording harness from a normal tool-only turn: the latter still has
-    narration somewhere in earlier turns, so a genuine briefing skip is NOT
-    excused just because the final turn happened to be tool-only.
-    """
-    n_text = n_tool = 0
-    for ev in entries:
-        msg = ev.get("message")
-        if not isinstance(msg, dict) or msg.get("role") != "assistant" or ev.get("isSidechain"):
-            continue
-        content = msg.get("content", [])
-        if isinstance(content, str):
-            if content.strip():
-                n_text += 1
-            continue
-        if isinstance(content, list):
-            if any(isinstance(b, dict) and b.get("type") == "text"
-                   and isinstance(b.get("text"), str) and b["text"].strip() for b in content):
-                n_text += 1
-            if any(isinstance(b, dict) and b.get("type") == "tool_use" for b in content):
-                n_tool += 1
-    return n_text == 0 and n_tool >= _FIDELITY_MIN_TOOLUSE
-
-
 def _user_message_text(content: object) -> str:
     """Flatten a user message's content (str or block list) to plain text."""
     if isinstance(content, str):
@@ -473,24 +464,59 @@ def _is_approval_reply(content: object) -> bool:
     return norm in _APPROVAL_TOKENS
 
 
-def _segment_merge_target(argv: list[str]) -> str | None:
-    """PR number a `gh pr merge` argv segment targets (first bare-number/pull
-    positional after `merge`), or None for a branch-name/numberless merge."""
-    argv = strip_prefix(argv)
-    if not _is_gh_pr_merge(argv):
-        return None
-    # Scan only the tokens AFTER `pr merge` for a PR token, so a numeric global
-    # flag value before the subcommand cannot be mistaken for the target. Body
-    # values (`--body "closes 999"`) tokenize with internal whitespace, so they
-    # never match the anchored bare-number/pull pattern.
-    for i in range(len(argv) - 1):
-        if argv[i] == "pr" and argv[i + 1] == "merge":
-            for tok in argv[i + 2:]:
-                m = _PULL_TOKEN_RE.match(tok)
-                if m:
-                    return m.group(1) or m.group(2)
-            return None
+def _first_positional(tokens: list[str], value_flags: frozenset[str]) -> str | None:
+    """First positional token, skipping option flags and each value-flag's
+    following value — so `--subject 833` never yields `833` as a positional."""
+    j = 0
+    n = len(tokens)
+    while j < n:
+        tok = tokens[j]
+        if tok == "--":
+            return tokens[j + 1] if j + 1 < n else None
+        if tok.startswith("-"):
+            if "=" not in tok and tok in value_flags and j + 1 < n:
+                j += 2
+            else:
+                j += 1
+            continue
+        return tok
     return None
+
+
+def _gh_pr_target(argv: list[str], verbs: frozenset[str],
+                  value_flags: frozenset[str]) -> str | None:
+    """PR number the first positional of a `gh pr <verb>` segment resolves to
+    (bare number or …/pull/N), or None when the segment has no numeric target.
+
+    Global flags before the subcommand are walked exactly as `_is_gh_pr_merge`
+    does, so a numeric global-flag value cannot be mistaken for the target."""
+    argv = strip_prefix(argv)
+    if not argv or argv[0] != "gh":
+        return None
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        if tok == "--":
+            i += 1
+            break
+        if not tok.startswith("-"):
+            break
+        i += 1
+        if "=" not in tok and tok in GH_GLOBAL_FLAGS_WITH_ARG and i < len(argv):
+            i += 1
+    if i + 1 >= len(argv) or argv[i] != "pr" or argv[i + 1] not in verbs:
+        return None
+    pos = _first_positional(argv[i + 2:], value_flags)
+    if pos is None:
+        return None
+    m = _PULL_TOKEN_RE.match(pos)
+    return (m.group(1) or m.group(2)) if m else None
+
+
+def _segment_merge_target(argv: list[str]) -> str | None:
+    """PR number a `gh pr merge` segment targets (its first positional), or None
+    for a branch-name / numberless merge."""
+    return _gh_pr_target(argv, frozenset({"merge"}), _MERGE_VALUE_FLAGS)
 
 
 def _merge_segments(command: object) -> list[str | None]:
@@ -509,6 +535,40 @@ def _merge_segments(command: object) -> list[str | None]:
 def _mentions_pr(text: str, pr: str) -> bool:
     """True when the text references the target PR (`#N` or the bare number)."""
     return re.search(rf"#{pr}\b|\b{pr}\b", text) is not None
+
+
+def _context_pr_from_window(entries: list[dict], lo: int, hi: int) -> str | None:
+    """PR number named by the most recent read-only `gh pr <verb> N` (the
+    mandated Pre-Merge probe) in the window's assistant tool_use Bash commands,
+    or None when no such command resolves a target."""
+    found: str | None = None
+    for ev in entries[lo:hi]:
+        msg = ev.get("message")
+        if not isinstance(msg, dict) or msg.get("role") != "assistant" or ev.get("isSidechain"):
+            continue
+        content = msg.get("content", [])
+        if not isinstance(content, list):
+            continue
+        for b in content:
+            if not (isinstance(b, dict) and b.get("type") == "tool_use"
+                    and b.get("name") == "Bash"):
+                continue
+            cmd = (b.get("input") or {}).get("command")
+            if not isinstance(cmd, str):
+                continue
+            for argv in iter_command_starts(safe_tokenize(cmd)):
+                pr = _gh_pr_target(argv, _CONTEXT_VERBS, _CONTEXT_VALUE_FLAGS)
+                if pr is not None:
+                    found = pr  # last (most recent) resolved target wins
+    return found
+
+
+def _has_repetition(command: object) -> bool:
+    """True when the command wraps the merge in a shell loop / xargs — a single
+    approval must not authorize a repeated merge (No Approval Transfer)."""
+    if not isinstance(command, str):
+        return False
+    return any(tok in _LOOP_KEYWORDS for tok in safe_tokenize(command))
 
 
 def _merge_escalation_reason(payload: dict) -> str | None:
@@ -537,32 +597,35 @@ def _merge_escalation_reason(payload: dict) -> str | None:
     # briefing → user approval → merge, which places the briefing in the turn
     # BEFORE the approving user message — outside the since-last-user window.
     # When the last user message is a short approval reply, also score the prior
-    # assistant turn.
-    segments = _merge_segments((payload.get("tool_input") or {}).get("command"))
-    # A single approval authorizes ONE merge; a compound `merge A && merge B`
-    # must not ride one approval (No Approval Transfer), so ≥2 targets skip the
-    # extension entirely and fall through to deny.
-    single_merge = len(segments) == 1
+    # assistant turn — scored ALONE, so text authored AFTER the approval cannot
+    # supplement a briefing the user never saw before approving (P2#5).
+    command = (payload.get("tool_input") or {}).get("command")
+    segments = _merge_segments(command)
+    # A single approval authorizes ONE merge. A compound `merge A && merge B` (≥2
+    # segments) or a shell loop repeating one segment (`for pr in …; do merge`)
+    # must not ride a single approval (No Approval Transfer) → skip the extension.
+    single_merge = len(segments) == 1 and not _has_repetition(command)
     if single_merge and len(idxs) >= 2 \
             and _is_approval_reply(entries[idxs[-1]].get("message", {}).get("content")):
         prev_text = _assistant_text(entries, idxs[-2] + 1, idxs[-1])
-        # A trivial-PR briefing in the prior turn is also carved out.
-        if _is_trivial_merge(prev_text):
-            return None
         target_pr = segments[0]
-        # Correlate to the target PR when the command names one; a numberless
-        # branch merge has no PR to correlate, so a real prior-turn briefing +
-        # approval suffices (the merge runs on the current branch).
-        correlated = target_pr is None or _mentions_pr(prev_text, target_pr)
-        if correlated \
-                and _briefing_item_count(current_text + "\n" + prev_text) >= MERGE_BRIEFING_MIN_ITEMS:
-            return None
-
-    # Non-recording fallback (issue #826, fidelity axis): a harness that drops
-    # assistant narration makes a real briefing invisible. Demote to advisory
-    # (fail safe) rather than hard-deny a legitimate merge.
-    if _recording_unreliable(entries):
-        return None
+        if target_pr is not None:
+            correlated = _mentions_pr(prev_text, target_pr)
+        else:
+            # A numberless branch merge names no PR; derive the actual target
+            # from the window's Pre-Merge probe and correlate against THAT.
+            # Fail closed when the target cannot be resolved — an unresolved
+            # target may differ from the briefed PR (No Approval Transfer, P1#2).
+            ctx_pr = _context_pr_from_window(entries, idxs[-2] + 1, len(entries))
+            correlated = ctx_pr is not None and _mentions_pr(prev_text, ctx_pr)
+        # The trivial-PR carve-out and the briefing-count pass apply ONLY once
+        # the merge is correlated to the briefed PR — never to an unrelated
+        # trivial/complete briefing about a different PR (P1#1).
+        if correlated:
+            if _is_trivial_merge(prev_text):
+                return None
+            if _briefing_item_count(prev_text) >= MERGE_BRIEFING_MIN_ITEMS:
+                return None
 
     return format_block(
         rule_name="Pre-Merge Reporting briefing",

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -359,10 +359,14 @@ _PULL_TOKEN_RE = re.compile(r"^(?:\S*/pull/(\d+)|(\d+))$")
 
 # `gh pr merge` flags that consume a following value token — skipped when
 # scanning for the first positional (the merge target) so a flag value like
-# `--subject 833` is never mistaken for the PR number (issue #826, P2#6).
+# `--subject 833` is never mistaken for the PR number (issue #826, P2#6). The
+# gh *global* value flags (`-R`/`--repo`, …) are included because they may trail
+# the subcommand (`gh pr merge -R org/repo 999`); without skipping their value,
+# `org/repo` would be read as the positional and 999 misclassified (P1d).
 _MERGE_VALUE_FLAGS = frozenset({
     "-b", "--body", "-F", "--body-file", "-t", "--subject",
     "--match-head-commit", "--author-email",
+    "-R", "--repo", "--hostname", "--color",
 })
 
 # Read-only `gh pr` verbs whose positional PR argument identifies the PR the
@@ -483,10 +487,11 @@ def _first_positional(tokens: list[str], value_flags: frozenset[str]) -> str | N
     return None
 
 
-def _gh_pr_target(argv: list[str], verbs: frozenset[str],
-                  value_flags: frozenset[str]) -> str | None:
-    """PR number the first positional of a `gh pr <verb>` segment resolves to
-    (bare number or …/pull/N), or None when the segment has no numeric target.
+def _gh_pr_positional(argv: list[str], verbs: frozenset[str],
+                      value_flags: frozenset[str]) -> str | None:
+    """First positional token of a `gh pr <verb>` segment — the RAW token, which
+    may be a PR number, a …/pull/N URL, or a branch name — or None when the
+    segment has no positional at all (a bare `gh pr merge --squash`).
 
     Global flags before the subcommand are walked exactly as `_is_gh_pr_merge`
     does, so a numeric global-flag value cannot be mistaken for the target."""
@@ -506,29 +511,32 @@ def _gh_pr_target(argv: list[str], verbs: frozenset[str],
             i += 1
     if i + 1 >= len(argv) or argv[i] != "pr" or argv[i + 1] not in verbs:
         return None
-    pos = _first_positional(argv[i + 2:], value_flags)
+    return _first_positional(argv[i + 2:], value_flags)
+
+
+def _gh_pr_target(argv: list[str], verbs: frozenset[str],
+                  value_flags: frozenset[str]) -> str | None:
+    """PR *number* the first positional resolves to (bare number or …/pull/N),
+    or None when the segment has no positional OR the positional is a non-numeric
+    branch name."""
+    pos = _gh_pr_positional(argv, verbs, value_flags)
     if pos is None:
         return None
     m = _PULL_TOKEN_RE.match(pos)
     return (m.group(1) or m.group(2)) if m else None
 
 
-def _segment_merge_target(argv: list[str]) -> str | None:
-    """PR number a `gh pr merge` segment targets (its first positional), or None
-    for a branch-name / numberless merge."""
-    return _gh_pr_target(argv, frozenset({"merge"}), _MERGE_VALUE_FLAGS)
-
-
 def _merge_segments(command: object) -> list[str | None]:
-    """One entry per `gh pr merge` segment in a (possibly compound) command:
-    its PR number, or None when the segment merges by branch (no number)."""
+    """One entry per `gh pr merge` segment in a (possibly compound) command: its
+    first positional token (PR number OR branch name), or None when the segment
+    has no positional (`gh pr merge --squash`, a current-branch merge)."""
     if not isinstance(command, str):
         return []
     out: list[str | None] = []
     for argv in iter_command_starts(safe_tokenize(command)):
         stripped = strip_prefix(argv)
         if _is_gh_pr_merge(stripped):
-            out.append(_segment_merge_target(stripped))
+            out.append(_gh_pr_positional(stripped, frozenset({"merge"}), _MERGE_VALUE_FLAGS))
     return out
 
 
@@ -608,16 +616,25 @@ def _merge_escalation_reason(payload: dict) -> str | None:
     if single_merge and len(idxs) >= 2 \
             and _is_approval_reply(entries[idxs[-1]].get("message", {}).get("content")):
         prev_text = _assistant_text(entries, idxs[-2] + 1, idxs[-1])
-        target_pr = segments[0]
-        if target_pr is not None:
-            correlated = _mentions_pr(prev_text, target_pr)
-        else:
-            # A numberless branch merge names no PR; derive the actual target
-            # from the window's Pre-Merge probe and correlate against THAT.
-            # Fail closed when the target cannot be resolved — an unresolved
-            # target may differ from the briefed PR (No Approval Transfer, P1#2).
+        pos = segments[0]
+        if pos is None:
+            # Truly numberless (`gh pr merge --squash`) → runs on the CURRENT
+            # branch. Derive the real target from the window's mandated Pre-Merge
+            # probe (`gh pr checks/view N`) and correlate against THAT. Fail
+            # closed when no probe resolves a target (No Approval Transfer, P1#2).
             ctx_pr = _context_pr_from_window(entries, idxs[-2] + 1, len(entries))
             correlated = ctx_pr is not None and _mentions_pr(prev_text, ctx_pr)
+        else:
+            m = _PULL_TOKEN_RE.match(pos)
+            if m:
+                correlated = _mentions_pr(prev_text, m.group(1) or m.group(2))
+            else:
+                # A NAMED branch (`gh pr merge feature-x`) targets that branch's
+                # PR — which cannot be mapped to a number without a live `gh`
+                # call, and is NOT the current branch, so the window probe does
+                # not identify it. Fail closed (round-3 P1b): a prior probe of a
+                # different PR must not be treated as this branch's target.
+                correlated = False
         # The trivial-PR carve-out and the briefing-count pass apply ONLY once
         # the merge is correlated to the briefed PR — never to an unrelated
         # trivial/complete briefing about a different PR (P1#1).

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -579,6 +579,56 @@ def _has_repetition(command: object) -> bool:
     return any(tok in _LOOP_KEYWORDS for tok in safe_tokenize(command))
 
 
+def _prior_turn_extension_passes(entries: list[dict], idxs: list[int],
+                                 command: object) -> bool:
+    """True when the prior-turn briefing satisfies the gate (issue #826).
+
+    The mandated flow is briefing → user approval → merge, which places the
+    briefing in the turn BEFORE the approving user message — outside the
+    since-last-user window. When the last user message is a short approval reply,
+    the immediately preceding assistant turn is scored ALONE (so text authored
+    AFTER the approval cannot supplement a briefing the user never saw), and only
+    when the merge is correlated to the briefed PR.
+    """
+    segments = _merge_segments(command)
+    # A single approval authorizes ONE merge. A compound `merge A && merge B` (≥2
+    # segments) or a shell loop repeating one segment (`for pr in …; do merge`)
+    # must not ride a single approval (No Approval Transfer) → no extension.
+    if len(segments) != 1 or _has_repetition(command) or len(idxs) < 2:
+        return False
+    if not _is_approval_reply(entries[idxs[-1]].get("message", {}).get("content")):
+        return False
+
+    prev_text = _assistant_text(entries, idxs[-2] + 1, idxs[-1])
+    pos = segments[0]
+    if pos is None:
+        # Truly numberless (`gh pr merge --squash`) → runs on the CURRENT branch.
+        # Derive the real target from the window's mandated Pre-Merge probe
+        # (`gh pr checks/view N`) and correlate against THAT. Fail closed when no
+        # probe resolves a target (No Approval Transfer, P1#2).
+        ctx_pr = _context_pr_from_window(entries, idxs[-2] + 1, len(entries))
+        correlated = ctx_pr is not None and _mentions_pr(prev_text, ctx_pr)
+    else:
+        m = _PULL_TOKEN_RE.match(pos)
+        if m:
+            correlated = _mentions_pr(prev_text, m.group(1) or m.group(2))
+        else:
+            # A NAMED branch (`gh pr merge feature-x`) targets that branch's PR —
+            # which cannot be mapped to a number without a live `gh` call, and is
+            # NOT the current branch, so the window probe does not identify it.
+            # Fail closed (round-3 P1b): a prior probe of a different PR must not
+            # be treated as this branch's target.
+            correlated = False
+
+    # The trivial-PR carve-out and the briefing-count pass apply ONLY once the
+    # merge is correlated to the briefed PR — never to an unrelated trivial /
+    # complete briefing about a different PR (P1#1).
+    if not correlated:
+        return False
+    return _is_trivial_merge(prev_text) \
+        or _briefing_item_count(prev_text) >= MERGE_BRIEFING_MIN_ITEMS
+
+
 def _merge_escalation_reason(payload: dict) -> str | None:
     """Return a deny reason when the pre-merge briefing is incomplete, else None."""
     # Background cmux-delegate agents merge autonomously — the delegation intent
@@ -601,48 +651,9 @@ def _merge_escalation_reason(payload: dict) -> str | None:
     if _briefing_item_count(current_text) >= MERGE_BRIEFING_MIN_ITEMS:
         return None
 
-    # Window extension (issue #826, window-scoping axis): the mandated flow is
-    # briefing → user approval → merge, which places the briefing in the turn
-    # BEFORE the approving user message — outside the since-last-user window.
-    # When the last user message is a short approval reply, also score the prior
-    # assistant turn — scored ALONE, so text authored AFTER the approval cannot
-    # supplement a briefing the user never saw before approving (P2#5).
-    command = (payload.get("tool_input") or {}).get("command")
-    segments = _merge_segments(command)
-    # A single approval authorizes ONE merge. A compound `merge A && merge B` (≥2
-    # segments) or a shell loop repeating one segment (`for pr in …; do merge`)
-    # must not ride a single approval (No Approval Transfer) → skip the extension.
-    single_merge = len(segments) == 1 and not _has_repetition(command)
-    if single_merge and len(idxs) >= 2 \
-            and _is_approval_reply(entries[idxs[-1]].get("message", {}).get("content")):
-        prev_text = _assistant_text(entries, idxs[-2] + 1, idxs[-1])
-        pos = segments[0]
-        if pos is None:
-            # Truly numberless (`gh pr merge --squash`) → runs on the CURRENT
-            # branch. Derive the real target from the window's mandated Pre-Merge
-            # probe (`gh pr checks/view N`) and correlate against THAT. Fail
-            # closed when no probe resolves a target (No Approval Transfer, P1#2).
-            ctx_pr = _context_pr_from_window(entries, idxs[-2] + 1, len(entries))
-            correlated = ctx_pr is not None and _mentions_pr(prev_text, ctx_pr)
-        else:
-            m = _PULL_TOKEN_RE.match(pos)
-            if m:
-                correlated = _mentions_pr(prev_text, m.group(1) or m.group(2))
-            else:
-                # A NAMED branch (`gh pr merge feature-x`) targets that branch's
-                # PR — which cannot be mapped to a number without a live `gh`
-                # call, and is NOT the current branch, so the window probe does
-                # not identify it. Fail closed (round-3 P1b): a prior probe of a
-                # different PR must not be treated as this branch's target.
-                correlated = False
-        # The trivial-PR carve-out and the briefing-count pass apply ONLY once
-        # the merge is correlated to the briefed PR — never to an unrelated
-        # trivial/complete briefing about a different PR (P1#1).
-        if correlated:
-            if _is_trivial_merge(prev_text):
-                return None
-            if _briefing_item_count(prev_text) >= MERGE_BRIEFING_MIN_ITEMS:
-                return None
+    if _prior_turn_extension_passes(
+            entries, idxs, (payload.get("tool_input") or {}).get("command")):
+        return None
 
     return format_block(
         rule_name="Pre-Merge Reporting briefing",

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -342,16 +342,34 @@ def _is_trivial_merge(text: str) -> bool:
     return any(marker in low for marker in _TRIVIAL_MERGE_MARKERS)
 
 
-def _current_turn_assistant_text(transcript_path: str) -> str | None:
-    """Concatenate assistant text emitted since the last human user message.
+# Short user acknowledgements that count as "approval reply" (EN/KO). Matched
+# by exact normalized-string equality, so a substantive short message
+# ("go fix the parser") never triggers the prior-turn window extension.
+_APPROVAL_TOKENS = frozenset({
+    "ok", "okay", "okey", "k", "kk", "yes", "yep", "yup", "y", "go", "go ahead",
+    "do it", "proceed", "proceed with the merge", "merge", "merge it", "sure",
+    "lgtm", "ship it", "sounds good",
+    "네", "넵", "응", "ㅇㅋ", "ㅇㅇ", "ㄱㄱ", "고고", "승인", "진행", "진행해",
+    "진행해줘", "진행하자", "머지", "머지해", "머지해줘", "머지 진행", "좋아",
+    "좋습니다", "그래", "ㄱ",
+})
 
-    Scans a bounded tail window (TRANSCRIPT_SCAN_LINES) so a long transcript
-    cannot blow the hook timeout. Returns:
-      • None  → transcript missing / unreadable (caller fails open, no block)
-      • ""    → transcript readable but the agent emitted no briefing text this
-                turn (the exact compound-imperative failure — caller escalates)
-      • text  → the briefing text to score
-    """
+# Recording-fidelity proxy: a current turn with this many tool_use-bearing
+# assistant entries but zero text-bearing ones signals a harness that is not
+# recording assistant narration (issue #826 blind spot) — the briefing may be
+# real yet invisible, so escalation demotes to advisory rather than deny.
+_FIDELITY_MIN_TOOLUSE = 3
+
+# PR number a `gh pr merge` targets (positional number or /pull/N URL); the
+# optional -R/--repo global flag may precede `pr`.
+_MERGE_PR_RE = re.compile(
+    r"gh\s+(?:(?:-R|--repo)\s+\S+\s+)?pr\s+merge\s+(?:\S*?/pull/(\d+)|(\d+))",
+    re.IGNORECASE,
+)
+
+
+def _load_turn_entries(transcript_path: str) -> list[dict] | None:
+    """Parse a bounded tail of the transcript into entry dicts, or None if unreadable."""
     if not transcript_path or not os.path.isfile(transcript_path):
         return None
     try:
@@ -361,7 +379,6 @@ def _current_turn_assistant_text(transcript_path: str) -> str | None:
             lines = deque(fh, maxlen=TRANSCRIPT_SCAN_LINES)
     except OSError:
         return None
-
     entries: list[dict] = []
     for line in lines:
         line = line.strip()
@@ -373,10 +390,12 @@ def _current_turn_assistant_text(transcript_path: str) -> str | None:
             continue
         if isinstance(obj, dict):
             entries.append(obj)
+    return entries
 
-    # Locate the most recent human-authored user message (skip tool_result-only
-    # user entries — those are the runtime's tool-output bridge, not input).
-    last_user_idx = -1
+
+def _human_user_indices(entries: list[dict]) -> list[int]:
+    """Indices of human-authored user messages (skip tool_result-only bridges)."""
+    idxs: list[int] = []
     for i, ev in enumerate(entries):
         msg = ev.get("message")
         if not isinstance(msg, dict) or msg.get("role") != "user" or ev.get("isSidechain"):
@@ -384,14 +403,17 @@ def _current_turn_assistant_text(transcript_path: str) -> str | None:
         content = msg.get("content", [])
         if isinstance(content, str):
             if content.strip():
-                last_user_idx = i
+                idxs.append(i)
         elif isinstance(content, list):
             if any(isinstance(b, dict) and b.get("type") != "tool_result" for b in content):
-                last_user_idx = i
+                idxs.append(i)
+    return idxs
 
-    turn = entries[last_user_idx + 1:] if last_user_idx >= 0 else entries
+
+def _assistant_text(entries: list[dict], lo: int, hi: int) -> str:
+    """Concatenate assistant text blocks in entries[lo:hi]."""
     texts: list[str] = []
-    for ev in turn:
+    for ev in entries[lo:hi]:
         msg = ev.get("message")
         if not isinstance(msg, dict) or msg.get("role") != "assistant" or ev.get("isSidechain"):
             continue
@@ -407,6 +429,60 @@ def _current_turn_assistant_text(transcript_path: str) -> str | None:
     return "\n".join(texts)
 
 
+def _fidelity_unreliable(entries: list[dict], lo: int) -> bool:
+    """True when the current turn (entries[lo:]) shows tool activity but no
+    recorded narration — a proxy for a harness that drops assistant text."""
+    n_text = n_tool = 0
+    for ev in entries[lo:]:
+        msg = ev.get("message")
+        if not isinstance(msg, dict) or msg.get("role") != "assistant" or ev.get("isSidechain"):
+            continue
+        content = msg.get("content", [])
+        if isinstance(content, str):
+            if content.strip():
+                n_text += 1
+            continue
+        if isinstance(content, list):
+            if any(isinstance(b, dict) and b.get("type") == "text"
+                   and isinstance(b.get("text"), str) and b["text"].strip() for b in content):
+                n_text += 1
+            if any(isinstance(b, dict) and b.get("type") == "tool_use" for b in content):
+                n_tool += 1
+    return n_tool >= _FIDELITY_MIN_TOOLUSE and n_text == 0
+
+
+def _user_message_text(content: object) -> str:
+    """Flatten a user message's content (str or block list) to plain text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(
+            b["text"] for b in content
+            if isinstance(b, dict) and b.get("type") == "text" and isinstance(b.get("text"), str)
+        )
+    return ""
+
+
+def _is_approval_reply(content: object) -> bool:
+    """True when a user message is a short bare approval token (ok / 진행 / 승인 …)."""
+    norm = re.sub(r"\s+", " ", _user_message_text(content).strip().lower()).strip(" .!~,·")
+    return norm in _APPROVAL_TOKENS
+
+
+def _merge_target_pr(payload: dict) -> str | None:
+    """PR number the `gh pr merge` command targets, or None (branch-name merge)."""
+    cmd = (payload.get("tool_input") or {}).get("command")
+    if not isinstance(cmd, str):
+        return None
+    m = _MERGE_PR_RE.search(cmd)
+    return (m.group(1) or m.group(2)) if m else None
+
+
+def _mentions_pr(text: str, pr: str) -> bool:
+    """True when the text references the target PR (`#N` or the bare number)."""
+    return re.search(rf"#{pr}\b|\b{pr}\b", text) is not None
+
+
 def _merge_escalation_reason(payload: dict) -> str | None:
     """Return a deny reason when the pre-merge briefing is incomplete, else None."""
     # Background cmux-delegate agents merge autonomously — the delegation intent
@@ -417,12 +493,35 @@ def _merge_escalation_reason(payload: dict) -> str | None:
     if os.environ.get(MERGE_ADVISORY_ENV) == "1":
         return None
 
-    text = _current_turn_assistant_text(payload.get("transcript_path", "") or "")
-    if text is None:
+    entries = _load_turn_entries(payload.get("transcript_path", "") or "")
+    if entries is None:
         return None  # transcript unreadable → fail open, do not block
-    if _is_trivial_merge(text):
+
+    idxs = _human_user_indices(entries)
+    lo = (idxs[-1] + 1) if idxs else 0
+    current_text = _assistant_text(entries, lo, len(entries))
+    if _is_trivial_merge(current_text):
         return None
-    if _briefing_item_count(text) >= MERGE_BRIEFING_MIN_ITEMS:
+    if _briefing_item_count(current_text) >= MERGE_BRIEFING_MIN_ITEMS:
+        return None
+
+    # Window extension (issue #826, window-scoping axis): the mandated flow is
+    # briefing → user approval → merge, which places the briefing in the turn
+    # BEFORE the approving user message — outside the since-last-user window.
+    # When the last user message is a short approval reply, also score the prior
+    # assistant turn, gated on it referencing THIS PR so a stale prior-turn
+    # briefing for a different PR cannot satisfy the gate.
+    target_pr = _merge_target_pr(payload)
+    if target_pr and len(idxs) >= 2 and _is_approval_reply(entries[idxs[-1]].get("message", {}).get("content")):
+        prev_text = _assistant_text(entries, idxs[-2] + 1, idxs[-1])
+        if _mentions_pr(prev_text, target_pr) \
+                and _briefing_item_count(current_text + "\n" + prev_text) >= MERGE_BRIEFING_MIN_ITEMS:
+            return None
+
+    # Non-recording fallback (issue #826, fidelity axis): a harness that drops
+    # assistant narration makes a real briefing invisible. Demote to advisory
+    # (fail safe) rather than hard-deny a legitimate merge.
+    if _fidelity_unreliable(entries, lo):
         return None
 
     return format_block(

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -111,19 +111,37 @@ against `_APPROVAL_TOKENS`), the immediately preceding assistant turn is scored
 before approving). Safety gates on the extension:
 
 - **PR correlation.** The prior-turn briefing must reference the PR actually
-  being merged:
-  - When the `gh pr merge <N>` command names a PR, the prior turn must reference
-    that `#N` (or the bare number). Only the *first positional* is read as the
-    target, skipping each value-flag's arity, so `gh pr merge feature-x
-    --subject 999` targets branch `feature-x` — not PR 999.
-  - A numberless branch merge (`gh pr merge --squash`, the project standard)
-    names no PR, so the real target is **derived from the window's mandated
-    Pre-Merge probe** (`gh pr checks/view <N>`, scanned from assistant tool_use
-    Bash commands) and the prior turn must reference *that* number. When no
-    probe resolves a target, the extension **fails closed** (denies) — an
-    unresolved target may differ from the briefed PR (No Approval Transfer).
+  being merged. The merge target is the segment's *first positional* token
+  (value-flag arity skipped, including trailing gh global flags like `-R
+  org/repo <N>`), classified three ways:
+  - **Numeric** (`gh pr merge 833`, `.../pull/833`) → the prior turn must
+    reference that `#N` (or bare number).
+  - **No positional** (`gh pr merge --squash`, the project standard) → a
+    current-branch merge; the real target is **derived from the window's
+    mandated Pre-Merge probe** (`gh pr checks/view <N>`, scanned from assistant
+    tool_use Bash commands) and the prior turn must reference *that* number.
+    When no probe resolves a target, the extension **fails closed** (denies).
+  - **Named branch** (`gh pr merge feature-x`) → targets that branch's PR, which
+    cannot be mapped to a number without a live `gh` call and is not the current
+    branch, so the window probe does not identify it → **fails closed** (denies).
+    A prior probe of a *different* PR must not be treated as this branch's target
+    (round-3 P1b).
   - Command parsing reuses the trigger tokenizer, so fused global flags
     (`gh --repo=o/r pr merge 833`) resolve the target correctly.
+
+  > **Accepted residual gaps (advisory-hook threat model).** This gate is a
+  > self-discipline *nudge* for an honest agent that forgets the briefing (the
+  > #795 failure), not an adversarial security boundary — `deny` merely adds
+  > teeth, and `PRAXIS_MOMENTUM_MERGE_ADVISORY=1` is a standing escape hatch. Two
+  > CLI forms that only an adversarial target-swap would use are therefore left
+  > as documented gaps rather than chased across further rounds: (a) an
+  > `xargs`-wrapped merge (`… | xargs -n1 gh pr merge`) is not recognized by the
+  > trigger tokenizer (`xargs` is not a peeled prefix), so it bypasses the gate
+  > entirely; (b) a bare-number reference is not repo-scoped, so a cross-repo
+  > `gh -R org/other pr merge 833` after briefing *this* repo's #833 (or a
+  > `Closes #833` line in a different PR's briefing) can false-correlate. Both
+  > require an explicit-signal redesign to close soundly and are out of scope for
+  > the honest-agent nudge.
 - **No multi-target / loop transfer.** A compound `gh pr merge A && gh pr merge
   B` (≥2 merge segments) OR a shell loop / `xargs` repeating one segment
   (`for pr in 833 999; do gh pr merge "$pr"; done`, detected via whole-token

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -104,33 +104,44 @@ the turn **before** the approving user message — outside the "since the last
 human user message" window. Scoring only that window would therefore penalise
 the *correct* flow (briefing → "ok" → merge) and pass only the anti-pattern
 (briefing + merge crammed into one turn, i.e. auto-proceed without waiting).
-Two mechanisms resolve this:
+The **prior-turn extension** resolves this. When the last human user message is
+a short approval reply (`ok` / `진행` / `승인` / … — exact normalized match
+against `_APPROVAL_TOKENS`), the immediately preceding assistant turn is scored
+**alone** (post-approval text must not supplement a briefing the user never saw
+before approving). Safety gates on the extension:
 
-- **Prior-turn extension.** When the last human user message is a short
-  approval reply (`ok` / `진행` / `승인` / … — exact normalized match against
-  `_APPROVAL_TOKENS`), the immediately preceding assistant turn is also scored.
-  Safety gates on the extension:
-  - **PR correlation.** When the `gh pr merge <N>` command names a PR, the prior
-    turn must reference that `#N` (or the bare number) — a stale prior-turn
-    briefing for a *different* PR cannot satisfy the gate. A numberless branch
-    merge (`gh pr merge --squash`, the project standard) has no PR to correlate,
-    so a real prior-turn briefing + approval suffices (the merge runs on the
-    current branch). Command parsing reuses the trigger tokenizer, so fused
-    global flags (`gh --repo=o/r pr merge 833`) resolve the target correctly.
-  - **No multi-target transfer.** A compound `gh pr merge A && gh pr merge B`
-    (≥2 merge segments) skips the extension entirely — one approval cannot
-    authorize two merges (No Approval Transfer Across Companion PRs).
-  - **Trivial carve-out.** A trivial-PR marker in the *prior* turn is honored
-    the same as in the current turn (the 2-line briefing sits before the "ok").
-- **Recording-fidelity fallback.** Some harnesses do not persist assistant
-  narration to the transcript, so a real briefing scores 0. When the **whole
-  scanned window** shows tool activity (≥ `_FIDELITY_MIN_TOOLUSE`, default **3**,
-  tool_use entries) but **zero** recorded text entries *anywhere*, the harness is
-  presumed to be dropping narration and escalation demotes to advisory (fail
-  safe). Scanning the whole window — not just the final turn — is what separates
-  a non-recording harness from an ordinary tool-only turn: the latter still has
-  narration in earlier turns, so a genuine briefing skip is **not** excused just
-  because the last turn happened to be tool-only.
+- **PR correlation.** The prior-turn briefing must reference the PR actually
+  being merged:
+  - When the `gh pr merge <N>` command names a PR, the prior turn must reference
+    that `#N` (or the bare number). Only the *first positional* is read as the
+    target, skipping each value-flag's arity, so `gh pr merge feature-x
+    --subject 999` targets branch `feature-x` — not PR 999.
+  - A numberless branch merge (`gh pr merge --squash`, the project standard)
+    names no PR, so the real target is **derived from the window's mandated
+    Pre-Merge probe** (`gh pr checks/view <N>`, scanned from assistant tool_use
+    Bash commands) and the prior turn must reference *that* number. When no
+    probe resolves a target, the extension **fails closed** (denies) — an
+    unresolved target may differ from the briefed PR (No Approval Transfer).
+  - Command parsing reuses the trigger tokenizer, so fused global flags
+    (`gh --repo=o/r pr merge 833`) resolve the target correctly.
+- **No multi-target / loop transfer.** A compound `gh pr merge A && gh pr merge
+  B` (≥2 merge segments) OR a shell loop / `xargs` repeating one segment
+  (`for pr in 833 999; do gh pr merge "$pr"; done`, detected via whole-token
+  match of `for`/`while`/`until`/`xargs`) skips the extension entirely — one
+  approval cannot authorize repeated merges (No Approval Transfer Across
+  Companion PRs).
+- **Trivial carve-out.** A trivial-PR marker in the *prior* turn is honored the
+  same as in the current turn (the 2-line briefing sits before the "ok"), but
+  **only once the merge is correlated to the briefed PR** — an unrelated trivial
+  briefing about a different PR cannot carve out the merge.
+
+> **Recording-fidelity axis (deferred).** A separate #826 concern — harnesses
+> that drop assistant narration so a real briefing scores 0 — is **not** handled
+> here. A text-absence heuristic cannot distinguish a non-recording harness from
+> a genuine briefing skip that happens to be tool-only (it is gameable by
+> suppressing all narration), so it was dropped from this change rather than
+> shipped as a weak gate. If needed, address it with an explicit harness signal
+> in a follow-up, not an inference.
 
 **Why `deny`, not `ask`:** the sibling `pre-merge-approval-gate` already emits
 an unconditional `ask` on *every* `gh pr merge`. A second `ask` would be
@@ -151,8 +162,9 @@ approve blindly.
 - Trivial-PR markers (`typo`, `comment-only`, `single-line`, `오타`, `주석만`,
   `trivial pr`, `2-line report`, …) in the briefing text → no escalation,
   matching CLAUDE.md's "Trivial PRs: a 2-line report is fine" carve-out.
-- Prior-turn briefing (approval reply + PR-number match) or an
-  unreliable-recording current turn → no escalation (issue #826, above).
+- Prior-turn briefing correlated to the merged PR (approval reply + PR-number
+  match, or numberless merge whose window-derived target matches) → no
+  escalation (issue #826, above).
 
 The `dispatch` and `force-push` triggers never emit a decision — escalation is
 merge-only, per the issue scope (only the merge failure was reproduced).

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -98,6 +98,28 @@ The 6 items (a single keyword hit marks each present, EN/KO): What changed /
 What was verified / What was NOT verified / Risk-blast-radius / Open items /
 explicit approve-ask.
 
+**Window scoping (issue #826).** The mandated Pre-Merge Reporting flow is
+*briefing → user approval → merge*, which necessarily places the briefing in
+the turn **before** the approving user message — outside the "since the last
+human user message" window. Scoring only that window would therefore penalise
+the *correct* flow (briefing → "ok" → merge) and pass only the anti-pattern
+(briefing + merge crammed into one turn, i.e. auto-proceed without waiting).
+Two mechanisms resolve this:
+
+- **Prior-turn extension.** When the last human user message is a short
+  approval reply (`ok` / `진행` / `승인` / … — exact normalized match against
+  `_APPROVAL_TOKENS`), the immediately preceding assistant turn is also scored.
+  To keep the extension safe, that prior turn must reference the **merge target
+  PR** (`#N` or the bare number, from the `gh pr merge <N>` command) — a stale
+  prior-turn briefing for a different PR cannot satisfy the gate. A branch-name
+  merge (no PR number) disables the extension.
+- **Recording-fidelity fallback.** Some harnesses do not persist assistant
+  narration to the transcript, so a real briefing scores 0. When the current
+  turn shows tool activity (≥ `_FIDELITY_MIN_TOOLUSE`, default **3**, tool_use
+  entries) but **zero** recorded text entries, the briefing is presumed
+  invisible-not-absent and escalation demotes to advisory (fail safe) instead of
+  a hard deny.
+
 **Why `deny`, not `ask`:** the sibling `pre-merge-approval-gate` already emits
 an unconditional `ask` on *every* `gh pr merge`. A second `ask` would be
 redundant with the exact gate that failed to prevent the #795 recurrence (the
@@ -117,6 +139,8 @@ approve blindly.
 - Trivial-PR markers (`typo`, `comment-only`, `single-line`, `오타`, `주석만`,
   `trivial pr`, `2-line report`, …) in the briefing text → no escalation,
   matching CLAUDE.md's "Trivial PRs: a 2-line report is fine" carve-out.
+- Prior-turn briefing (approval reply + PR-number match) or an
+  unreliable-recording current turn → no escalation (issue #826, above).
 
 The `dispatch` and `force-push` triggers never emit a decision — escalation is
 merge-only, per the issue scope (only the merge failure was reproduced).

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -109,16 +109,28 @@ Two mechanisms resolve this:
 - **Prior-turn extension.** When the last human user message is a short
   approval reply (`ok` / `진행` / `승인` / … — exact normalized match against
   `_APPROVAL_TOKENS`), the immediately preceding assistant turn is also scored.
-  To keep the extension safe, that prior turn must reference the **merge target
-  PR** (`#N` or the bare number, from the `gh pr merge <N>` command) — a stale
-  prior-turn briefing for a different PR cannot satisfy the gate. A branch-name
-  merge (no PR number) disables the extension.
+  Safety gates on the extension:
+  - **PR correlation.** When the `gh pr merge <N>` command names a PR, the prior
+    turn must reference that `#N` (or the bare number) — a stale prior-turn
+    briefing for a *different* PR cannot satisfy the gate. A numberless branch
+    merge (`gh pr merge --squash`, the project standard) has no PR to correlate,
+    so a real prior-turn briefing + approval suffices (the merge runs on the
+    current branch). Command parsing reuses the trigger tokenizer, so fused
+    global flags (`gh --repo=o/r pr merge 833`) resolve the target correctly.
+  - **No multi-target transfer.** A compound `gh pr merge A && gh pr merge B`
+    (≥2 merge segments) skips the extension entirely — one approval cannot
+    authorize two merges (No Approval Transfer Across Companion PRs).
+  - **Trivial carve-out.** A trivial-PR marker in the *prior* turn is honored
+    the same as in the current turn (the 2-line briefing sits before the "ok").
 - **Recording-fidelity fallback.** Some harnesses do not persist assistant
-  narration to the transcript, so a real briefing scores 0. When the current
-  turn shows tool activity (≥ `_FIDELITY_MIN_TOOLUSE`, default **3**, tool_use
-  entries) but **zero** recorded text entries, the briefing is presumed
-  invisible-not-absent and escalation demotes to advisory (fail safe) instead of
-  a hard deny.
+  narration to the transcript, so a real briefing scores 0. When the **whole
+  scanned window** shows tool activity (≥ `_FIDELITY_MIN_TOOLUSE`, default **3**,
+  tool_use entries) but **zero** recorded text entries *anywhere*, the harness is
+  presumed to be dropping narration and escalation demotes to advisory (fail
+  safe). Scanning the whole window — not just the final turn — is what separates
+  a non-recording harness from an ordinary tool-only turn: the latter still has
+  narration in earlier turns, so a genuine briefing skip is **not** excused just
+  because the last turn happened to be tool-only.
 
 **Why `deny`, not `ask`:** the sibling `pre-merge-approval-gate` already emits
 an unconditional `ask` on *every* `gh pr merge`. A second `ask` would be

--- a/tests/fixtures/momentum-merge-fidelity-unreliable.jsonl
+++ b/tests/fixtures/momentum-merge-fidelity-unreliable.jsonl
@@ -1,0 +1,6 @@
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": "머지해줘"}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "a", "name": "Bash", "input": {"command": "gh pr view 833"}}]}}
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "a", "content": "x"}]}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "b", "name": "Bash", "input": {"command": "gh pr checks 833"}}]}}
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "b", "content": "x"}]}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "c", "name": "Bash", "input": {"command": "git status"}}]}}

--- a/tests/fixtures/momentum-merge-numberless-no-probe.jsonl
+++ b/tests/fixtures/momentum-merge-numberless-no-probe.jsonl
@@ -1,6 +1,4 @@
 {"type": "user", "isSidechain": false, "message": {"role": "user", "content": "PR 833 머지 준비됐는지 보고 진행하자"}}
-{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "chk", "name": "Bash", "input": {"command": "gh pr checks 833"}}]}}
-{"type": "user", "isSidechain": false, "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "chk", "content": "all checks passing"}]}}
 {"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "PR #833 브리핑. 변경 사항: hook 파일 수정. 테스트 통과 확인(lint clean). 미검증 항목: prod 경로 미확인. 리스크: downstream 없음. 남은 항목: 없음. Approve merge?"}]}}
 {"type": "user", "isSidechain": false, "message": {"role": "user", "content": "ok"}}
 {"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "머지합니다."}]}}

--- a/tests/fixtures/momentum-merge-prior-turn-briefing.jsonl
+++ b/tests/fixtures/momentum-merge-prior-turn-briefing.jsonl
@@ -1,0 +1,4 @@
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": "PR 833 머지 준비됐는지 보고 진행하자"}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "PR #833 브리핑. 변경 사항: hook 파일 수정. 테스트 통과 확인(lint clean). 미검증 항목: prod 경로 미확인. 리스크: downstream 없음. 남은 항목: 없음. Approve merge?"}]}}
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": "ok"}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "머지합니다."}]}}

--- a/tests/fixtures/momentum-merge-prior-turn-trivial.jsonl
+++ b/tests/fixtures/momentum-merge-prior-turn-trivial.jsonl
@@ -1,0 +1,4 @@
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": "오타 수정 PR 833 머지하자"}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "PR #833 은 오타 수정만 있는 trivial PR 입니다. Approve merge?"}]}}
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": "ok"}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "머지합니다."}]}}

--- a/tests/fixtures/momentum-merge-prior-turn-wrong-pr.jsonl
+++ b/tests/fixtures/momentum-merge-prior-turn-wrong-pr.jsonl
@@ -1,0 +1,4 @@
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": "먼저 다른 PR 검토하고 이거 머지하자"}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "PR #999 브리핑. 변경 사항: 다른 hook 수정. 테스트 통과 확인. 미검증: 없음. 리스크: 없음. 남은 항목: 없음. Approve merge?"}]}}
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": "ok"}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "머지합니다."}]}}

--- a/tests/fixtures/momentum-merge-substantive-reply.jsonl
+++ b/tests/fixtures/momentum-merge-substantive-reply.jsonl
@@ -1,0 +1,4 @@
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": "PR 833 머지 준비"}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "PR #833 브리핑. 변경 사항: hook 파일 수정. 테스트 통과 확인. 미검증: 없음. 리스크: 없음. 남은 항목: 없음. Approve merge?"}]}}
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": "그 전에 파서 로직도 리팩터해줘"}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "네, 파서부터 확인하겠습니다."}]}}

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -704,10 +704,29 @@ run_merge_escalation_cmd_case "merge_escalation_prior_turn_wrong_pr_denies" \
 run_merge_escalation_cmd_case "merge_escalation_substantive_reply_denies" \
   "yes" "" "momentum-merge-substantive-reply.jsonl" "gh pr merge 833 --squash"
 
-# Recording-fidelity proxy: current turn has 3 tool_use entries, 0 recorded
+# Recording-fidelity proxy: whole window has 3 tool_use entries, 0 recorded
 # narration → demote to advisory (fail-open), no deny.
 run_merge_escalation_case "merge_escalation_fidelity_unreliable_demotes" \
   "no" "" "momentum-merge-fidelity-unreliable.jsonl"
+
+# Numberless branch merge (`gh pr merge --squash`, the project standard) with a
+# prior-turn briefing + approval → extension applies without PR correlation.
+run_merge_escalation_cmd_case "merge_escalation_numberless_prior_briefing_passes" \
+  "no" "" "momentum-merge-prior-turn-briefing.jsonl" "gh pr merge --squash --delete-branch"
+
+# Compound multi-target (`merge 833 && merge 999`) → one approval cannot cover
+# both → no extension → deny (No Approval Transfer).
+run_merge_escalation_cmd_case "merge_escalation_multi_target_denies" \
+  "yes" "" "momentum-merge-prior-turn-briefing.jsonl" "gh pr merge 833 --squash && gh pr merge 999 --squash"
+
+# Fused global flag (`gh --repo=o/r pr merge 833`) → tokenizer still extracts
+# target 833, correlation passes → no deny.
+run_merge_escalation_cmd_case "merge_escalation_fused_repo_flag_passes" \
+  "no" "" "momentum-merge-prior-turn-briefing.jsonl" "gh --repo=o/r pr merge 833 --squash"
+
+# Trivial-PR briefing in the PRIOR turn + approval → carve-out applies, no deny.
+run_merge_escalation_cmd_case "merge_escalation_prior_turn_trivial_exempt" \
+  "no" "" "momentum-merge-prior-turn-trivial.jsonl" "gh pr merge 833 --squash"
 
 # Incomplete briefing (3 of 6 items) → deny. Reproduces the #795 failure shape.
 run_merge_escalation_case "merge_escalation_incomplete_briefing" \

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -596,19 +596,23 @@ run_compound_multi_assert_force_dispatch \
 # transcript_path, so they stay advisory-only (regression-safe).
 FIXTURES_DIR="$SCRIPT_DIR/../../fixtures"
 
-# run_merge_escalation_case name expect_deny(yes|no) env_args transcript_fixture
+# run_merge_escalation_case name expect_deny(yes|no) env_args transcript_fixture [command]
+# The optional 5th arg overrides the merge command (defaults to the standard
+# numberless squash merge), letting PR-number correlation (window extension,
+# issue #826) be exercised without a second near-identical helper.
 run_merge_escalation_case() {
   local name="$1" expect_deny="$2" env_args="$3" fixture="$4"
+  local command="${5:-gh pr merge --squash --delete-branch}"
   local transcript="$FIXTURES_DIR/$fixture"
   local payload
   payload=$(python3 -c '
 import json, sys
 print(json.dumps({
     "tool_name": "Bash",
-    "tool_input": {"command": "gh pr merge --squash --delete-branch"},
+    "tool_input": {"command": sys.argv[2]},
     "transcript_path": sys.argv[1],
     "session_id": "test-momentum-merge",
-}))' "$transcript")
+}))' "$transcript" "$command")
 
   local out_file err_file
   out_file=$(mktemp); err_file=$(mktemp)
@@ -642,66 +646,19 @@ print(json.dumps({
   fi
 }
 
-# run_merge_escalation_cmd_case name expect_deny env_args transcript_fixture command
-# Variant carrying a custom merge command so the PR-number correlation
-# (window extension, issue #826) can be exercised.
-run_merge_escalation_cmd_case() {
-  local name="$1" expect_deny="$2" env_args="$3" fixture="$4" command="$5"
-  local transcript="$FIXTURES_DIR/$fixture"
-  local payload
-  payload=$(python3 -c '
-import json, sys
-print(json.dumps({
-    "tool_name": "Bash",
-    "tool_input": {"command": sys.argv[2]},
-    "transcript_path": sys.argv[1],
-    "session_id": "test-momentum-merge",
-}))' "$transcript" "$command")
-
-  local out_file err_file
-  out_file=$(mktemp); err_file=$(mktemp)
-  if [ -n "$env_args" ]; then
-    # shellcheck disable=SC2086
-    echo "$payload" | env $env_args python3 "$HOOK" >"$out_file" 2>"$err_file"
-  else
-    echo "$payload" | python3 "$HOOK" >"$out_file" 2>"$err_file"
-  fi
-  local rc=$?
-  local out err
-  out=$(cat "$out_file"); err=$(cat "$err_file")
-  rm -f "$out_file" "$err_file"
-
-  local ok=1
-  [ "$rc" -eq 0 ] || ok=0
-  echo "$err" | grep -qF "[praxis:momentum-gate]" || ok=0
-  if [ "$expect_deny" = "yes" ]; then
-    echo "$out" | grep -qF '"permissionDecision": "deny"' || ok=0
-  else
-    echo "$out" | grep -qF '"permissionDecision"' && ok=0
-  fi
-
-  if [ "$ok" -eq 1 ]; then
-    echo "PASS  [$name]"; PASS=$((PASS + 1))
-  else
-    echo "FAIL  [$name] expect_deny=$expect_deny rc=$rc"
-    [ -n "$out" ] && echo "        stdout: $(echo "$out" | head -c 200)"
-    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
-  fi
-}
-
 # Window extension (issue #826): briefing in the PRIOR turn + short approval
 # reply ("ok") + merge of the SAME PR → no deny (the mandated flow).
-run_merge_escalation_cmd_case "merge_escalation_prior_turn_briefing_passes" \
+run_merge_escalation_case "merge_escalation_prior_turn_briefing_passes" \
   "no" "" "momentum-merge-prior-turn-briefing.jsonl" "gh pr merge 833 --squash --delete-branch"
 
 # Prior-turn briefing is for a DIFFERENT PR (#999) than the merge target (833)
 # → correlation fails, extension denied → deny.
-run_merge_escalation_cmd_case "merge_escalation_prior_turn_wrong_pr_denies" \
+run_merge_escalation_case "merge_escalation_prior_turn_wrong_pr_denies" \
   "yes" "" "momentum-merge-prior-turn-wrong-pr.jsonl" "gh pr merge 833 --squash"
 
 # Last user message is a substantive instruction, not an approval reply → no
 # window extension → deny.
-run_merge_escalation_cmd_case "merge_escalation_substantive_reply_denies" \
+run_merge_escalation_case "merge_escalation_substantive_reply_denies" \
   "yes" "" "momentum-merge-substantive-reply.jsonl" "gh pr merge 833 --squash"
 
 # Tool-only turn, no recorded briefing narration, single human message (no
@@ -713,47 +670,47 @@ run_merge_escalation_case "merge_escalation_tool_only_no_briefing_denies" \
 # Numberless branch merge (`gh pr merge --squash`, the project standard): the
 # window carries the mandated Pre-Merge probe (`gh pr checks 833`), so the real
 # target (833) is derived and correlated against the prior-turn briefing → pass.
-run_merge_escalation_cmd_case "merge_escalation_numberless_context_pr_passes" \
+run_merge_escalation_case "merge_escalation_numberless_context_pr_passes" \
   "no" "" "momentum-merge-prior-turn-briefing.jsonl" "gh pr merge --squash --delete-branch"
 
 # Numberless merge but NO Pre-Merge probe in the window → target unresolvable →
 # fail closed (No Approval Transfer: an unresolved target may differ from the
 # briefed PR). Deny even though a prior-turn briefing + approval exist.
-run_merge_escalation_cmd_case "merge_escalation_numberless_no_probe_denies" \
+run_merge_escalation_case "merge_escalation_numberless_no_probe_denies" \
   "yes" "" "momentum-merge-numberless-no-probe.jsonl" "gh pr merge --squash --delete-branch"
 
 # Named-branch merge (`gh pr merge feature-for-999`) targets that branch's PR,
 # which the window probe (#833) does NOT identify → fail closed → deny (round-3
 # P1b: a prior probe of a different PR is not this branch's target). The `-for-`
 # in the branch name must also NOT be read as a loop keyword (whole-token match).
-run_merge_escalation_cmd_case "merge_escalation_named_branch_denies" \
+run_merge_escalation_case "merge_escalation_named_branch_denies" \
   "yes" "" "momentum-merge-prior-turn-briefing.jsonl" "gh pr merge feature-for-999 --squash"
 
 # Repo flag trailing the subcommand (`gh pr merge -R o/r 833`) must skip its
 # value so the target resolves to 833, not `o/r` (round-3 P1d). 833 correlates
 # with the prior-turn briefing → pass. Value-flag arity skip (`--subject 999`
 # not read as target) is exercised here too since -R sits before the positional.
-run_merge_escalation_cmd_case "merge_escalation_repo_flag_arity_passes" \
+run_merge_escalation_case "merge_escalation_repo_flag_arity_passes" \
   "no" "" "momentum-merge-prior-turn-briefing.jsonl" "gh pr merge -R o/r 833 --squash"
 
 # Shell loop repeating the merge (`for pr in 833 999; do gh pr merge "$pr"`) →
 # one approval must not ride a loop → extension disabled → deny (P1#3). The `do`
 # keyword is peeled by strip_prefix so the inner `gh pr merge` IS detected.
-run_merge_escalation_cmd_case "merge_escalation_loop_repetition_denies" \
+run_merge_escalation_case "merge_escalation_loop_repetition_denies" \
   "yes" "" "momentum-merge-prior-turn-briefing.jsonl" 'for pr in 833 999; do gh pr merge "$pr" --squash; done'
 
 # Compound multi-target (`merge 833 && merge 999`) → one approval cannot cover
 # both → no extension → deny (No Approval Transfer).
-run_merge_escalation_cmd_case "merge_escalation_multi_target_denies" \
+run_merge_escalation_case "merge_escalation_multi_target_denies" \
   "yes" "" "momentum-merge-prior-turn-briefing.jsonl" "gh pr merge 833 --squash && gh pr merge 999 --squash"
 
 # Fused global flag (`gh --repo=o/r pr merge 833`) → tokenizer still extracts
 # target 833, correlation passes → no deny.
-run_merge_escalation_cmd_case "merge_escalation_fused_repo_flag_passes" \
+run_merge_escalation_case "merge_escalation_fused_repo_flag_passes" \
   "no" "" "momentum-merge-prior-turn-briefing.jsonl" "gh --repo=o/r pr merge 833 --squash"
 
 # Trivial-PR briefing in the PRIOR turn + approval → carve-out applies, no deny.
-run_merge_escalation_cmd_case "merge_escalation_prior_turn_trivial_exempt" \
+run_merge_escalation_case "merge_escalation_prior_turn_trivial_exempt" \
   "no" "" "momentum-merge-prior-turn-trivial.jsonl" "gh pr merge 833 --squash"
 
 # Incomplete briefing (3 of 6 items) → deny. Reproduces the #795 failure shape.

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -704,15 +704,36 @@ run_merge_escalation_cmd_case "merge_escalation_prior_turn_wrong_pr_denies" \
 run_merge_escalation_cmd_case "merge_escalation_substantive_reply_denies" \
   "yes" "" "momentum-merge-substantive-reply.jsonl" "gh pr merge 833 --squash"
 
-# Recording-fidelity proxy: whole window has 3 tool_use entries, 0 recorded
-# narration → demote to advisory (fail-open), no deny.
-run_merge_escalation_case "merge_escalation_fidelity_unreliable_demotes" \
-  "no" "" "momentum-merge-fidelity-unreliable.jsonl"
+# Tool-only turn, no recorded briefing narration, single human message (no
+# approval reply) → fidelity fallback removed (issue #826), so a genuine
+# briefing skip now denies rather than demoting to advisory.
+run_merge_escalation_case "merge_escalation_tool_only_no_briefing_denies" \
+  "yes" "" "momentum-merge-fidelity-unreliable.jsonl"
 
-# Numberless branch merge (`gh pr merge --squash`, the project standard) with a
-# prior-turn briefing + approval → extension applies without PR correlation.
-run_merge_escalation_cmd_case "merge_escalation_numberless_prior_briefing_passes" \
+# Numberless branch merge (`gh pr merge --squash`, the project standard): the
+# window carries the mandated Pre-Merge probe (`gh pr checks 833`), so the real
+# target (833) is derived and correlated against the prior-turn briefing → pass.
+run_merge_escalation_cmd_case "merge_escalation_numberless_context_pr_passes" \
   "no" "" "momentum-merge-prior-turn-briefing.jsonl" "gh pr merge --squash --delete-branch"
+
+# Numberless merge but NO Pre-Merge probe in the window → target unresolvable →
+# fail closed (No Approval Transfer: an unresolved target may differ from the
+# briefed PR). Deny even though a prior-turn briefing + approval exist.
+run_merge_escalation_cmd_case "merge_escalation_numberless_no_probe_denies" \
+  "yes" "" "momentum-merge-numberless-no-probe.jsonl" "gh pr merge --squash --delete-branch"
+
+# Flag value must not be misread as the merge target (P2#6): `merge feature-x
+# --subject 999` targets branch `feature-x` (numberless), NOT PR 999. Target
+# resolves to None → context PR 833 (from the probe) correlates → pass. A
+# regression that read 999 as the target would fail correlation and wrongly deny.
+run_merge_escalation_cmd_case "merge_escalation_flag_value_not_target" \
+  "no" "" "momentum-merge-prior-turn-briefing.jsonl" "gh pr merge feature-x --subject 999 --squash"
+
+# Shell loop repeating the merge (`for pr in 833 999; do gh pr merge "$pr"`) →
+# one approval must not ride a loop → extension disabled → deny (P1#3). The `do`
+# keyword is peeled by strip_prefix so the inner `gh pr merge` IS detected.
+run_merge_escalation_cmd_case "merge_escalation_loop_repetition_denies" \
+  "yes" "" "momentum-merge-prior-turn-briefing.jsonl" 'for pr in 833 999; do gh pr merge "$pr" --squash; done'
 
 # Compound multi-target (`merge 833 && merge 999`) → one approval cannot cover
 # both → no extension → deny (No Approval Transfer).

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -642,6 +642,73 @@ print(json.dumps({
   fi
 }
 
+# run_merge_escalation_cmd_case name expect_deny env_args transcript_fixture command
+# Variant carrying a custom merge command so the PR-number correlation
+# (window extension, issue #826) can be exercised.
+run_merge_escalation_cmd_case() {
+  local name="$1" expect_deny="$2" env_args="$3" fixture="$4" command="$5"
+  local transcript="$FIXTURES_DIR/$fixture"
+  local payload
+  payload=$(python3 -c '
+import json, sys
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {"command": sys.argv[2]},
+    "transcript_path": sys.argv[1],
+    "session_id": "test-momentum-merge",
+}))' "$transcript" "$command")
+
+  local out_file err_file
+  out_file=$(mktemp); err_file=$(mktemp)
+  if [ -n "$env_args" ]; then
+    # shellcheck disable=SC2086
+    echo "$payload" | env $env_args python3 "$HOOK" >"$out_file" 2>"$err_file"
+  else
+    echo "$payload" | python3 "$HOOK" >"$out_file" 2>"$err_file"
+  fi
+  local rc=$?
+  local out err
+  out=$(cat "$out_file"); err=$(cat "$err_file")
+  rm -f "$out_file" "$err_file"
+
+  local ok=1
+  [ "$rc" -eq 0 ] || ok=0
+  echo "$err" | grep -qF "[praxis:momentum-gate]" || ok=0
+  if [ "$expect_deny" = "yes" ]; then
+    echo "$out" | grep -qF '"permissionDecision": "deny"' || ok=0
+  else
+    echo "$out" | grep -qF '"permissionDecision"' && ok=0
+  fi
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  [$name]"; PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expect_deny=$expect_deny rc=$rc"
+    [ -n "$out" ] && echo "        stdout: $(echo "$out" | head -c 200)"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+# Window extension (issue #826): briefing in the PRIOR turn + short approval
+# reply ("ok") + merge of the SAME PR → no deny (the mandated flow).
+run_merge_escalation_cmd_case "merge_escalation_prior_turn_briefing_passes" \
+  "no" "" "momentum-merge-prior-turn-briefing.jsonl" "gh pr merge 833 --squash --delete-branch"
+
+# Prior-turn briefing is for a DIFFERENT PR (#999) than the merge target (833)
+# → correlation fails, extension denied → deny.
+run_merge_escalation_cmd_case "merge_escalation_prior_turn_wrong_pr_denies" \
+  "yes" "" "momentum-merge-prior-turn-wrong-pr.jsonl" "gh pr merge 833 --squash"
+
+# Last user message is a substantive instruction, not an approval reply → no
+# window extension → deny.
+run_merge_escalation_cmd_case "merge_escalation_substantive_reply_denies" \
+  "yes" "" "momentum-merge-substantive-reply.jsonl" "gh pr merge 833 --squash"
+
+# Recording-fidelity proxy: current turn has 3 tool_use entries, 0 recorded
+# narration → demote to advisory (fail-open), no deny.
+run_merge_escalation_case "merge_escalation_fidelity_unreliable_demotes" \
+  "no" "" "momentum-merge-fidelity-unreliable.jsonl"
+
 # Incomplete briefing (3 of 6 items) → deny. Reproduces the #795 failure shape.
 run_merge_escalation_case "merge_escalation_incomplete_briefing" \
   "yes" "" "momentum-merge-incomplete.jsonl"

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -722,12 +722,19 @@ run_merge_escalation_cmd_case "merge_escalation_numberless_context_pr_passes" \
 run_merge_escalation_cmd_case "merge_escalation_numberless_no_probe_denies" \
   "yes" "" "momentum-merge-numberless-no-probe.jsonl" "gh pr merge --squash --delete-branch"
 
-# Flag value must not be misread as the merge target (P2#6): `merge feature-x
-# --subject 999` targets branch `feature-x` (numberless), NOT PR 999. Target
-# resolves to None → context PR 833 (from the probe) correlates → pass. A
-# regression that read 999 as the target would fail correlation and wrongly deny.
-run_merge_escalation_cmd_case "merge_escalation_flag_value_not_target" \
-  "no" "" "momentum-merge-prior-turn-briefing.jsonl" "gh pr merge feature-x --subject 999 --squash"
+# Named-branch merge (`gh pr merge feature-for-999`) targets that branch's PR,
+# which the window probe (#833) does NOT identify → fail closed → deny (round-3
+# P1b: a prior probe of a different PR is not this branch's target). The `-for-`
+# in the branch name must also NOT be read as a loop keyword (whole-token match).
+run_merge_escalation_cmd_case "merge_escalation_named_branch_denies" \
+  "yes" "" "momentum-merge-prior-turn-briefing.jsonl" "gh pr merge feature-for-999 --squash"
+
+# Repo flag trailing the subcommand (`gh pr merge -R o/r 833`) must skip its
+# value so the target resolves to 833, not `o/r` (round-3 P1d). 833 correlates
+# with the prior-turn briefing → pass. Value-flag arity skip (`--subject 999`
+# not read as target) is exercised here too since -R sits before the positional.
+run_merge_escalation_cmd_case "merge_escalation_repo_flag_arity_passes" \
+  "no" "" "momentum-merge-prior-turn-briefing.jsonl" "gh pr merge -R o/r 833 --squash"
 
 # Shell loop repeating the merge (`for pr in 833 999; do gh pr merge "$pr"`) →
 # one approval must not ride a loop → extension disabled → deny (P1#3). The `do`


### PR DESCRIPTION
## 배경

`momentum-rule-retrieval-gate`의 merge-briefing escalation이 **정당한 머지를 오차단**하는 문제(#826)를 해소합니다. 강제된 Pre-Merge Reporting 흐름은 *briefing → 사용자 승인 → merge*라서 briefing이 승인 메시지 **직전 턴**에 위치하는데, 기존 window("마지막 human user 메시지 이후")는 그 briefing을 제외해 올바른 흐름을 penalize하고 anti-pattern(briefing+merge를 한 턴에 몰아넣기)만 통과시켰습니다.

## 변경 (window-scoping axis)

**prior-turn extension** — 마지막 user 메시지가 짧은 승인 응답(`ok`/`진행`/`승인` …)이면 직전 assistant 턴을 **단독** 채점(승인 후 텍스트가 briefing 요건을 보충하지 못하게).

**PR correlation** (No Approval Transfer) — merge 대상을 세그먼트의 첫 positional로 분류:
- **숫자** PR(`gh pr merge 833`) → 직전 턴이 해당 `#N` 참조 필요
- **positional 없음**(`gh pr merge --squash`, 현재 브랜치 머지) → window의 mandated Pre-Merge probe(`gh pr checks/view N`)에서 실제 대상 유도 후 상관; 미해결 시 **fail-closed**
- **명명 브랜치**(`gh pr merge feature-x`) → 그 브랜치의 PR을 live `gh` 호출 없이 매핑 불가 → **fail-closed** (이전 probe의 다른 PR을 대상으로 오차용 금지)

**multi-target / loop 차단** — 복합 `merge A && merge B`(≥2 세그먼트) 또는 loop/`xargs` 반복(whole-token 매칭)은 확장 비활성 → 하나의 승인이 반복 머지를 타지 못함.

**flag-arity** — 첫 positional만 대상으로 읽고 value-flag(`--subject`, 후행 `-R org/repo` 등) 값은 skip.

## 이관 / 수용된 한계

- **Recording-fidelity axis 제외**: harness가 assistant narration을 기록하지 않는 경우(#826의 다른 축)는 이번 PR에서 다루지 않습니다. 텍스트 부재 휴리스틱은 non-recording harness와 정상 tool-only briefing-skip을 구분할 수 없고 gameable하므로, 약한 gate로 출하하는 대신 제거하고 **explicit-signal follow-up으로 이관**했습니다.
- **advisory-hook 위협모델**: 이 gate는 honest agent가 briefing을 깜빡하는 것을 잡는 self-discipline nudge(`PRAXIS_MOMENTUM_MERGE_ADVISORY=1` 탈출구 존재)이지 적대적 경계가 아닙니다. 적대적 target-swap에만 해당하는 두 CLI 형태 — (a) `xargs`-wrapped merge(trigger 미감지로 우회), (b) bare-number가 repo-scoped 아니라 크로스레포 `-R` 머지 false-correlation — 는 문서화된 수용 한계로 남깁니다.

## 검증

- 훅 shell 테스트 **77/77** (prior-turn / numberless-context / numberless-no-probe / named-branch / repo-flag-arity / loop / multi-target / fused-repo / trivial 신규·판별 케이스 포함)
- pytest **480 passed** · `ruff check .` clean · shellcheck RC=0 · manifest / hook-token-invariants OK

## 리뷰

codex-review-wrap 3라운드(각 라운드 실제 결함 발견 → 수정). 라운드-2 numberless correlation flip(round-1 허용 ↔ round-2 fail-closed)은 window 유도 target correlation 합성으로 해소, 라운드-3은 값싼 완결성 수정 + 잔여 문서화로 수렴.

Caller chain verified: N/A -- 내부 hook 로직 변경만; entry point(main)과 hooks/manifest.json 등록은 불변, 새 public symbol 없음
Pre-commit verified: ruff check clean, shellcheck RC=0, 77/77 hook shell tests + 480 pytest passed (this branch, 14da913)

Refs #826


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved merge approval handling by associating confirmations with the correct pull request.
  - Merge requests may now be denied when the required pre-merge briefing is missing or incomplete.
  - Added support for approval replies in English and Korean.
  - Prevented approvals from carrying across unrelated pull requests or repeated merge loops.
  - Preserved existing behavior for trivial changes and unreadable transcript data.

- **Documentation**
  - Clarified merge briefing requirements, target matching, limitations, and exception handling.

- **Tests**
  - Added coverage for prior briefings, incorrect targets, numberless merges, loops, and trivial pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->