### PR TITLE
fix(momentum-gate): add in-band briefing-surfaced bypass marker

### DIFF
--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -39,7 +39,6 @@ from __future__ import annotations
 import json
 import os
 import re
-import shlex
 import sys
 from collections import deque
 from pathlib import Path
@@ -283,38 +282,58 @@ MERGE_ADVISORY_ENV = "PRAXIS_MOMENTUM_MERGE_ADVISORY"
 _BRIEFING_MARKER_RE = re.compile(r"#\s*briefing-surfaced\b", re.IGNORECASE)
 
 
-def _tokenize_code_only(command: str) -> list[str]:
-    """Tokenize with `#` as a shell comment starter, so unquoted `# …` comments
-    are DROPPED while a quoted `'# …'` argument is KEPT as a token. Mirrors
-    `safe_tokenize` (per-line, punctuation_chars) but with commenters='#'."""
-    tokens: list[str] = []
+def _split_shell_comment(command: str) -> tuple[str, str]:
+    """Split each line into (code, comment) at an UNQUOTED, word-boundary `#`,
+    matching Bash semantics: `#` starts a comment only at the start of a word
+    (preceded by whitespace or a command separator, or at line start) and outside
+    quotes. A mid-word `x#` or a quoted `'#'` is literal data, not a comment.
+
+    Returns (code_without_comments, joined_comment_text). Used so the marker is
+    detected only in a real comment (round-1/2 P2) AND so segment/repetition
+    analysis never sees the comment's reason text (round-2 P2b)."""
+    code_lines: list[str] = []
+    comment_parts: list[str] = []
     for line in command.split("\n"):
-        if not line.strip():
-            continue
-        try:
-            lex = shlex.shlex(line, posix=True, punctuation_chars=";|&")
-            lex.whitespace_split = True
-            lex.commenters = "#"
-            tokens.extend(list(lex))
-        except ValueError:
-            continue
-    return tokens
+        in_single = in_double = False
+        prev_is_boundary = True  # line start is a word boundary
+        cut = None
+        for i, c in enumerate(line):
+            if in_single:
+                in_single = c != "'"
+                prev_is_boundary = False
+            elif in_double:
+                in_double = c != '"'
+                prev_is_boundary = False
+            elif c == "'":
+                in_single = True
+                prev_is_boundary = False
+            elif c == '"':
+                in_double = True
+                prev_is_boundary = False
+            elif c == "#" and prev_is_boundary:
+                cut = i
+                break
+            else:
+                prev_is_boundary = c.isspace() or c in ";|&("
+        if cut is None:
+            code_lines.append(line)
+        else:
+            code_lines.append(line[:cut])
+            comment_parts.append(line[cut:])
+    return "\n".join(code_lines), "\n".join(comment_parts)
 
 
 def _has_briefing_marker(command: object) -> bool:
     """True when the command carries the in-band `# briefing-surfaced` marker in
-    an UNQUOTED shell comment (not inside a quoted argument or other data).
+    an UNQUOTED shell comment (not a quoted argument, not a mid-word `#`).
 
-    The marker must be a real shell comment — a quoted occurrence (e.g.
-    `grep '# briefing-surfaced' spec.md && gh pr merge …`) is data, not an
-    attestation, and must not bypass the gate (round-1 P2). Detection: the marker
-    is present in the raw command but ABSENT once `#` comments are stripped by the
-    lexer; a marker that survives comment-stripping is quoted data.
-    """
-    if not isinstance(command, str) or _BRIEFING_MARKER_RE.search(command) is None:
+    A quoted occurrence (`grep '# briefing-surfaced' … && gh pr merge …`) or a
+    mid-word `#` (`echo x# briefing-surfaced`) is data, not an attestation, and
+    must not bypass the gate (round-1/2 P2)."""
+    if not isinstance(command, str):
         return False
-    code_only = " ".join(_tokenize_code_only(command))
-    return _BRIEFING_MARKER_RE.search(code_only) is None
+    _, comment = _split_shell_comment(command)
+    return _BRIEFING_MARKER_RE.search(comment) is not None
 
 # Distinct Pre-Merge Reporting items must be present in the pre-merge assistant
 # text. The documented failure surfaced only 3 of 6 (What changed / verified /
@@ -689,6 +708,10 @@ def _merge_escalation_reason(payload: dict) -> str | None:
         return None
 
     command = (payload.get("tool_input") or {}).get("command")
+    # Analyze only the EXECUTABLE portion (unquoted shell comment stripped) for
+    # segments/repetition, so a `# briefing-surfaced: … for …` reason text never
+    # trips the loop guard (round-2 P2b).
+    code = _split_shell_comment(command)[0] if isinstance(command, str) else command
     # In-band bypass (issue #826): a `# briefing-surfaced` marker in an UNQUOTED
     # shell comment demotes to advisory where the env bypass cannot reach the
     # hook process — but only for a SINGLE merge with no loop. One
@@ -696,7 +719,7 @@ def _merge_escalation_reason(payload: dict) -> str | None:
     # looped merge (round-1 P1: same No-Approval-Transfer guard the prior-turn
     # extension applies).
     if _has_briefing_marker(command) \
-            and len(_merge_segments(command)) == 1 and not _has_repetition(command):
+            and len(_merge_segments(code)) == 1 and not _has_repetition(code):
         return None
 
     entries = _load_turn_entries(payload.get("transcript_path", "") or "")
@@ -711,7 +734,7 @@ def _merge_escalation_reason(payload: dict) -> str | None:
     if _briefing_item_count(current_text) >= MERGE_BRIEFING_MIN_ITEMS:
         return None
 
-    if _prior_turn_extension_passes(entries, idxs, command):
+    if _prior_turn_extension_passes(entries, idxs, code):
         return None
 
     return format_block(

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -283,44 +283,71 @@ _BRIEFING_MARKER_RE = re.compile(r"#\s*briefing-surfaced\b", re.IGNORECASE)
 
 
 def _split_shell_comment(command: str) -> tuple[str, str]:
-    """Split each line into (code, comment) at an UNQUOTED, word-boundary `#`,
+    """Split a command into (code, comment) at each UNQUOTED, word-boundary `#`,
     matching Bash semantics: `#` starts a comment only at the start of a word
-    (preceded by whitespace or a command separator, or at line start) and outside
-    quotes. A mid-word `x#` or a quoted `'#'` is literal data, not a comment.
+    (preceded by whitespace / a command separator / line start) and outside
+    quotes; it runs to the end of that physical line. A mid-word `x#`, a quoted
+    `'#'`, or a backslash-escaped `\\#` is literal data, not a comment.
+
+    Lexical state (quote + backslash escape) is tracked continuously across
+    physical lines so a single-quoted string spanning newlines (e.g.
+    `printf 'a\\n# x\\n'`) is not misread as a comment (round-3 P2). Heredoc
+    bodies are NOT parsed — a `# briefing-surfaced` inside a `<<EOF` body would
+    be treated as a comment; under this gate's non-adversarial threat model
+    (self-discipline nudge, not a security boundary) that residual is accepted.
 
     Returns (code_without_comments, joined_comment_text). Used so the marker is
     detected only in a real comment (round-1/2 P2) AND so segment/repetition
     analysis never sees the comment's reason text (round-2 P2b)."""
-    code_lines: list[str] = []
-    comment_parts: list[str] = []
-    for line in command.split("\n"):
-        in_single = in_double = False
-        prev_is_boundary = True  # line start is a word boundary
-        cut = None
-        for i, c in enumerate(line):
-            if in_single:
-                in_single = c != "'"
-                prev_is_boundary = False
-            elif in_double:
-                in_double = c != '"'
-                prev_is_boundary = False
-            elif c == "'":
-                in_single = True
-                prev_is_boundary = False
-            elif c == '"':
-                in_double = True
-                prev_is_boundary = False
-            elif c == "#" and prev_is_boundary:
-                cut = i
-                break
+    code_chars: list[str] = []
+    comment_chars: list[str] = []
+    in_single = in_double = escaped = in_comment = False
+    prev_is_boundary = True  # command start is a word boundary
+    for c in command:
+        if in_comment:
+            if c == "\n":
+                in_comment = False
+                prev_is_boundary = True
+                code_chars.append(c)
             else:
-                prev_is_boundary = c.isspace() or c in ";|&("
-        if cut is None:
-            code_lines.append(line)
+                comment_chars.append(c)
+        elif escaped:  # backslash-escaped char is literal data
+            code_chars.append(c)
+            escaped = False
+            prev_is_boundary = False
+        elif in_single:
+            code_chars.append(c)
+            in_single = c != "'"
+            prev_is_boundary = False
+        elif in_double:
+            code_chars.append(c)
+            if c == "\\":
+                escaped = True
+            else:
+                in_double = c != '"'
+            prev_is_boundary = False
+        elif c == "\\":
+            code_chars.append(c)
+            escaped = True
+            prev_is_boundary = False
+        elif c == "'":
+            code_chars.append(c)
+            in_single = True
+            prev_is_boundary = False
+        elif c == '"':
+            code_chars.append(c)
+            in_double = True
+            prev_is_boundary = False
+        elif c == "#" and prev_is_boundary:
+            in_comment = True
+            comment_chars.append(c)
+        elif c == "\n":
+            code_chars.append(c)
+            prev_is_boundary = True
         else:
-            code_lines.append(line[:cut])
-            comment_parts.append(line[cut:])
-    return "\n".join(code_lines), "\n".join(comment_parts)
+            code_chars.append(c)
+            prev_is_boundary = c.isspace() or c in ";|&("
+    return "".join(code_chars), "".join(comment_chars)
 
 
 def _has_briefing_marker(command: object) -> bool:

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -262,10 +262,29 @@ def _emit_for_trigger(trigger: str, directory: str | None) -> str:
 #   • no readable transcript                 → no escalation (fail open)
 #   • CMUX_DELEGATE=1 (background agent)      → no escalation (mirror sibling)
 #   • PRAXIS_MOMENTUM_MERGE_ADVISORY=1        → demote back to advisory only
+#   • `# briefing-surfaced` in the command    → demote back to advisory only
 #   • trivial-PR markers in the briefing text → no escalation (CLAUDE.md carve-out)
 # ---------------------------------------------------------------------------
 
 MERGE_ADVISORY_ENV = "PRAXIS_MOMENTUM_MERGE_ADVISORY"
+
+# In-band bypass marker (issue #826). The env bypass above is read from the hook
+# process `os.environ` and is NOT reachable via a Bash inline `VAR=1 cmd` prefix
+# — the hook is spawned by the harness, not as a child of the command. In a
+# bridge-session harness that ALSO drops assistant text from the transcript, a
+# legitimate briefing-surfaced merge is otherwise permanently blocked with no
+# in-band way to release it (observed live: #826, and again merging #834). A
+# marker embedded in the command string (a shell `#` comment, harmless at exec —
+# bash ignores everything after `#`) IS reachable in-band and demotes escalation
+# to advisory. This is a conscious self-attestation, appropriate for a
+# self-discipline nudge rather than an adversarial boundary: the agent asserts
+# the briefing was surfaced, exactly as the env bypass would.
+_BRIEFING_MARKER_RE = re.compile(r"#\s*briefing-surfaced\b", re.IGNORECASE)
+
+
+def _has_briefing_marker(command: object) -> bool:
+    """True when the command carries the in-band `# briefing-surfaced` marker."""
+    return isinstance(command, str) and _BRIEFING_MARKER_RE.search(command) is not None
 
 # Distinct Pre-Merge Reporting items must be present in the pre-merge assistant
 # text. The documented failure surfaced only 3 of 6 (What changed / verified /
@@ -639,6 +658,12 @@ def _merge_escalation_reason(payload: dict) -> str | None:
     if os.environ.get(MERGE_ADVISORY_ENV) == "1":
         return None
 
+    command = (payload.get("tool_input") or {}).get("command")
+    # In-band bypass (issue #826): a `# briefing-surfaced` marker in the command
+    # demotes to advisory where the env bypass cannot reach the hook process.
+    if _has_briefing_marker(command):
+        return None
+
     entries = _load_turn_entries(payload.get("transcript_path", "") or "")
     if entries is None:
         return None  # transcript unreadable → fail open, do not block
@@ -651,8 +676,7 @@ def _merge_escalation_reason(payload: dict) -> str | None:
     if _briefing_item_count(current_text) >= MERGE_BRIEFING_MIN_ITEMS:
         return None
 
-    if _prior_turn_extension_passes(
-            entries, idxs, (payload.get("tool_input") or {}).get("command")):
+    if _prior_turn_extension_passes(entries, idxs, command):
         return None
 
     return format_block(
@@ -664,6 +688,9 @@ def _merge_escalation_reason(payload: dict) -> str | None:
         correct_path="surface the 6-item briefing and an explicit 'Approve "
             "merge?' question, then re-run the merge",
         bypass_env=MERGE_ADVISORY_ENV,
+        bypass_reason_hint="with a one-line reason — or, where the env var "
+            "cannot reach the hook (bridge-session harness), append "
+            "`# briefing-surfaced: <reason>` to the merge command",
         reference="CLAUDE.md → Pre-Merge Reporting; "
             "hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md",
     )

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import sys
 from collections import deque
 from pathlib import Path
@@ -282,9 +283,38 @@ MERGE_ADVISORY_ENV = "PRAXIS_MOMENTUM_MERGE_ADVISORY"
 _BRIEFING_MARKER_RE = re.compile(r"#\s*briefing-surfaced\b", re.IGNORECASE)
 
 
+def _tokenize_code_only(command: str) -> list[str]:
+    """Tokenize with `#` as a shell comment starter, so unquoted `# …` comments
+    are DROPPED while a quoted `'# …'` argument is KEPT as a token. Mirrors
+    `safe_tokenize` (per-line, punctuation_chars) but with commenters='#'."""
+    tokens: list[str] = []
+    for line in command.split("\n"):
+        if not line.strip():
+            continue
+        try:
+            lex = shlex.shlex(line, posix=True, punctuation_chars=";|&")
+            lex.whitespace_split = True
+            lex.commenters = "#"
+            tokens.extend(list(lex))
+        except ValueError:
+            continue
+    return tokens
+
+
 def _has_briefing_marker(command: object) -> bool:
-    """True when the command carries the in-band `# briefing-surfaced` marker."""
-    return isinstance(command, str) and _BRIEFING_MARKER_RE.search(command) is not None
+    """True when the command carries the in-band `# briefing-surfaced` marker in
+    an UNQUOTED shell comment (not inside a quoted argument or other data).
+
+    The marker must be a real shell comment — a quoted occurrence (e.g.
+    `grep '# briefing-surfaced' spec.md && gh pr merge …`) is data, not an
+    attestation, and must not bypass the gate (round-1 P2). Detection: the marker
+    is present in the raw command but ABSENT once `#` comments are stripped by the
+    lexer; a marker that survives comment-stripping is quoted data.
+    """
+    if not isinstance(command, str) or _BRIEFING_MARKER_RE.search(command) is None:
+        return False
+    code_only = " ".join(_tokenize_code_only(command))
+    return _BRIEFING_MARKER_RE.search(code_only) is None
 
 # Distinct Pre-Merge Reporting items must be present in the pre-merge assistant
 # text. The documented failure surfaced only 3 of 6 (What changed / verified /
@@ -659,9 +689,14 @@ def _merge_escalation_reason(payload: dict) -> str | None:
         return None
 
     command = (payload.get("tool_input") or {}).get("command")
-    # In-band bypass (issue #826): a `# briefing-surfaced` marker in the command
-    # demotes to advisory where the env bypass cannot reach the hook process.
-    if _has_briefing_marker(command):
+    # In-band bypass (issue #826): a `# briefing-surfaced` marker in an UNQUOTED
+    # shell comment demotes to advisory where the env bypass cannot reach the
+    # hook process — but only for a SINGLE merge with no loop. One
+    # self-attestation must not release a compound `merge A && merge B` or a
+    # looped merge (round-1 P1: same No-Approval-Transfer guard the prior-turn
+    # extension applies).
+    if _has_briefing_marker(command) \
+            and len(_merge_segments(command)) == 1 and not _has_repetition(command):
         return None
 
     entries = _load_turn_entries(payload.get("transcript_path", "") or "")

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -177,6 +177,19 @@ approve blindly.
   is the approval, mirroring `pre-merge-approval-gate`.
 - `PRAXIS_MOMENTUM_MERGE_ADVISORY=1` → demote back to advisory only (keeps the
   stderr reminder, skips the deny). The escape hatch for a mis-scored briefing.
+- `# briefing-surfaced` in the merge command (an **in-band** marker, issue #826)
+  → demote back to advisory only. The env bypass above is read from the hook
+  process `os.environ` and is **not** reachable via a Bash inline `VAR=1 cmd`
+  prefix — the hook is spawned by the harness, not as a child of the command. In
+  a bridge-session harness that *also* drops assistant text from the transcript
+  (so the briefing scores 0), a legitimate briefing-surfaced merge would be
+  permanently blocked with no in-band release. A shell-comment marker embedded in
+  the command (harmless at exec — bash ignores everything after `#`) is reachable
+  in-band. Matched case-insensitively as `#\s*briefing-surfaced`; a trailing
+  `: <reason>` is recommended but not required. This is a conscious
+  self-attestation, appropriate for a self-discipline nudge (not an adversarial
+  boundary): the agent asserts the briefing was surfaced, exactly as the env
+  bypass would.
 - Trivial-PR markers (`typo`, `comment-only`, `single-line`, `오타`, `주석만`,
   `trivial pr`, `2-line report`, …) in the briefing text → no escalation,
   matching CLAUDE.md's "Trivial PRs: a 2-line report is fine" carve-out.
@@ -192,7 +205,7 @@ merge-only, per the issue scope (only the merge failure was reproduced).
 | Variable | Effect |
 | ---------- | -------- |
 | `PRAXIS_MOMENTUM_BYPASS=1` | Skip all output and exit 0 immediately (for scripted batch operations) |
-| `PRAXIS_MOMENTUM_MERGE_ADVISORY=1` | Demote the merge-briefing escalation to advisory only (stderr reminder still fires, no `deny`) |
+| `PRAXIS_MOMENTUM_MERGE_ADVISORY=1` | Demote the merge-briefing escalation to advisory only (stderr reminder still fires, no `deny`). See also the in-band `# briefing-surfaced` command marker (issue #826) for harnesses where this env var cannot reach the hook |
 | `PRAXIS_MOMENTUM_STRICT=1` | Exit 2 (block) instead of exit 0, unless `PRAXIS_MOMENTUM_ACK=1` is also set |
 | `PRAXIS_MOMENTUM_ACK=1` | Acknowledge the surface in strict mode; exit 0 after emitting the advisory |
 

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -189,7 +189,15 @@ approve blindly.
   `: <reason>` is recommended but not required. This is a conscious
   self-attestation, appropriate for a self-discipline nudge (not an adversarial
   boundary): the agent asserts the briefing was surfaced, exactly as the env
-  bypass would.
+  bypass would. The marker is honored only in a **real** unquoted shell comment,
+  parsed with a continuous quote/escape scanner (`_split_shell_comment`): a
+  quoted `'# briefing-surfaced'`, a mid-word `x#`, a backslash-escaped `\#`, or a
+  `#` inside a single-quoted string spanning newlines is data, not an
+  attestation, and does not demote (round-1/2/3 codex findings). It is honored
+  only for a **single** merge segment with no loop (No Approval Transfer). A
+  `# briefing-surfaced` inside a heredoc body (`<<EOF … EOF`) is the one residual
+  the scanner does not exclude — accepted under the non-adversarial threat model,
+  as with the `xargs`/cross-repo gaps above.
 - Trivial-PR markers (`typo`, `comment-only`, `single-line`, `오타`, `주석만`,
   `trivial pr`, `2-line report`, …) in the briefing text → no escalation,
   matching CLAUDE.md's "Trivial PRs: a 2-line report is fine" carve-out.

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -799,6 +799,18 @@ run_merge_escalation_case "merge_escalation_marker_loop_denies" \
 run_merge_escalation_case "merge_escalation_marker_quoted_denies" \
   "yes" "" "momentum-merge-incomplete.jsonl" "grep '# briefing-surfaced' spec.md && gh pr merge --squash"
 
+# round-2 P2a: a mid-word `#` (no preceding word boundary) is NOT a shell
+# comment in Bash. `echo x# briefing-surfaced` is an argument, not an
+# attestation → must still deny (shlex commenters="#" wrongly stripped this).
+run_merge_escalation_case "merge_escalation_marker_midword_hash_denies" \
+  "yes" "" "momentum-merge-incomplete.jsonl" "echo x# briefing-surfaced && gh pr merge --squash"
+
+# round-2 P2b: a reason clause containing a loop keyword ("for") must not trip
+# the repetition guard — segment/repetition run on the comment-stripped code
+# only, so the single merge still demotes.
+run_merge_escalation_case "merge_escalation_marker_reason_with_for_demotes" \
+  "no" "" "momentum-merge-incomplete.jsonl" "gh pr merge --squash # briefing-surfaced: required for bridge harness"
+
 # Full bypass silences everything, including the escalation.
 merge_escalation_bypass_silent_case() {
   local name="merge_escalation_full_bypass_silent"

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -811,6 +811,16 @@ run_merge_escalation_case "merge_escalation_marker_midword_hash_denies" \
 run_merge_escalation_case "merge_escalation_marker_reason_with_for_demotes" \
   "no" "" "momentum-merge-incomplete.jsonl" "gh pr merge --squash # briefing-surfaced: required for bridge harness"
 
+# round-3 P2: a `# briefing-surfaced` inside a single-quoted string that spans
+# physical lines is DATA, not a comment. Quote state must persist across the
+# newline so the marker is not misdetected → incomplete briefing still denies.
+run_merge_escalation_case "merge_escalation_marker_multiline_quoted_denies" \
+  "yes" "" "momentum-merge-incomplete.jsonl" $'gh pr merge --squash\nprintf \'line\n# briefing-surfaced\n\''
+
+# round-3: a backslash-escaped `\#` is a literal, not a comment start → deny.
+run_merge_escalation_case "merge_escalation_marker_escaped_hash_denies" \
+  "yes" "" "momentum-merge-incomplete.jsonl" "gh pr merge --squash \\# briefing-surfaced"
+
 # Full bypass silences everything, including the escalation.
 merge_escalation_bypass_silent_case() {
   local name="merge_escalation_full_bypass_silent"

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -769,6 +769,21 @@ run_merge_escalation_case "merge_escalation_delegate_skips" \
 run_merge_escalation_case "merge_escalation_advisory_env_demotes" \
   "no" "PRAXIS_MOMENTUM_MERGE_ADVISORY=1" "momentum-merge-incomplete.jsonl"
 
+# In-band bypass marker (issue #826): `# briefing-surfaced` in the command
+# demotes to advisory where the env var cannot reach the hook. Incomplete
+# briefing fixture would otherwise deny → marker present → no deny.
+run_merge_escalation_case "merge_escalation_briefing_marker_demotes" \
+  "no" "" "momentum-merge-incomplete.jsonl" "gh pr merge --squash # briefing-surfaced: env unreachable in this harness"
+
+# Marker with no reason still demotes (reason is recommended, not required).
+run_merge_escalation_case "merge_escalation_briefing_marker_bare_demotes" \
+  "no" "" "momentum-merge-incomplete.jsonl" "gh pr merge --squash --delete-branch # briefing-surfaced"
+
+# Sanity: WITHOUT the marker the same incomplete briefing still denies (the
+# marker, not the fixture, is what demotes).
+run_merge_escalation_case "merge_escalation_no_marker_still_denies" \
+  "yes" "" "momentum-merge-incomplete.jsonl" "gh pr merge --squash --delete-branch"
+
 # Full bypass silences everything, including the escalation.
 merge_escalation_bypass_silent_case() {
   local name="merge_escalation_full_bypass_silent"

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -784,6 +784,21 @@ run_merge_escalation_case "merge_escalation_briefing_marker_bare_demotes" \
 run_merge_escalation_case "merge_escalation_no_marker_still_denies" \
   "yes" "" "momentum-merge-incomplete.jsonl" "gh pr merge --squash --delete-branch"
 
+# round-1 P1: one self-attestation must not release a compound multi-merge.
+# Marker present but TWO merge segments → not demoted → deny.
+run_merge_escalation_case "merge_escalation_marker_multi_merge_denies" \
+  "yes" "" "momentum-merge-incomplete.jsonl" "gh pr merge 833 --squash && gh pr merge 999 --squash # briefing-surfaced"
+
+# round-1 P1: a looped merge with the marker also stays denied.
+run_merge_escalation_case "merge_escalation_marker_loop_denies" \
+  "yes" "" "momentum-merge-incomplete.jsonl" 'for pr in 833 999; do gh pr merge "$pr" --squash; done # briefing-surfaced'
+
+# round-1 P2: the marker inside a QUOTED argument is data, not an attestation
+# comment → must NOT bypass. `grep '# briefing-surfaced' …` before the merge
+# still denies on the incomplete briefing.
+run_merge_escalation_case "merge_escalation_marker_quoted_denies" \
+  "yes" "" "momentum-merge-incomplete.jsonl" "grep '# briefing-surfaced' spec.md && gh pr merge --squash"
+
 # Full bypass silences everything, including the escalation.
 merge_escalation_bypass_silent_case() {
   local name="merge_escalation_full_bypass_silent"


### PR DESCRIPTION
## 배경

`momentum-rule-retrieval-gate`의 merge-briefing escalation은 두 가지 우회로를 갖습니다: `PRAXIS_MOMENTUM_MERGE_ADVISORY=1` 환경변수와 trivial-PR 마커. 그러나 이 env는 **hook 프로세스의 `os.environ`에서 읽히므로** Bash 인라인 `VAR=1 cmd` prefix로는 도달하지 않습니다. hook은 command의 자식이 아니라 harness가 spawn하기 때문입니다.

bridge-session harness가 assistant narration까지 transcript에서 누락시키는 경우(briefing이 0점 채점됨), 정당하게 briefing을 마친 머지가 **in-band 해제 수단 없이 영구 차단**됩니다(#826의 availability/bypass 결함). 이 PR은 명령어에 임베드하는 **in-band 마커**를 도입해 이 공백을 메웁니다.

## 변경

`# briefing-surfaced` 셸 주석 마커를 머지 명령에 붙이면 escalation을 advisory로 강등합니다(exec 시 무해 — bash가 `#` 이후를 무시). 이는 self-attestation으로, env bypass와 동일한 의미의 self-discipline nudge에 적합합니다(적대적 경계 아님).

**마커 인식은 실제 unquoted 셸 주석에서만** — `_split_shell_comment` 연속 스캐너가 quote/backslash-escape 상태를 명령 전체에 걸쳐 추적합니다:
- quoted `'# briefing-surfaced'` → 데이터(우회 안 됨)
- mid-word `x#` → 데이터
- backslash-escaped `\#` → 데이터
- 여러 줄에 걸친 single-quote 내부 `#` → 데이터

**No Approval Transfer** — 단일 머지 세그먼트 + loop 없음일 때만 강등. 복합 `merge A && merge B`나 loop/`xargs` 반복은 하나의 attestation으로 해제되지 않습니다. segment/repetition 분석은 주석을 제거한 code 부분에만 적용되어, `# briefing-surfaced: required for bridge harness` 같은 reason의 "for"가 loop guard를 오발화시키지 않습니다.

## 수용된 잔여

- **heredoc body 내 마커**: `<<EOF … EOF` 본문 안의 `# briefing-surfaced`는 스캐너가 배제하지 못하는 유일한 잔여 — 비적대적 위협모델(self-discipline nudge) 하에 기존 xargs/cross-repo 공백과 함께 문서화된 수용 한계로 남깁니다.

## 검증

- 훅 shell 테스트 **87/87** (신규: midword-hash-denies, reason-with-for-demotes, multiline-quoted-denies, escaped-hash-denies)
- `ruff check` clean · shellcheck RC=0 · markdownlint(MD013 off) OK

## 리뷰

codex-review-wrap 3라운드 — 각 라운드가 실제 shell-lexing edge case 발견 → 수정:
- round-1: 마커가 segment/repetition 검사 전에 실행됨(복합/loop 우회) + quoted 마커 오인 → 단일-머지 게이팅 + dual-tokenize
- round-2: shlex `commenters="#"`가 mid-word `#` strip(P2a) + 주석 reason이 repetition 분석에 포함(P2b) → bash word-boundary 스캐너 + code-only 분석
- round-3: per-line quote 상태 리셋으로 multi-line quoted 마커 오인(P2) → 연속 스캔(quote/escape 줄 경계 넘어 추적)

flip 없음(shlex → line-scanner → continuous-scanner는 같은 방향 정밀화). round-3에서 파서 lexically 완결(heredoc 제외) → 수렴.

Caller chain verified: N/A -- 내부 hook 로직 변경만; entry point(main)과 hooks/manifest.json 등록은 불변, 새 public symbol 없음(_split_shell_comment/_has_briefing_marker는 _merge_escalation_reason 내부에서만 호출)
Pre-commit verified: ruff check clean, shellcheck RC=0, 87/87 hook shell tests passed (this branch, aa04b3c)

Closes #826


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an inline `# briefing-surfaced` marker that can convert eligible merge escalations into advisory notices.
  * Added support for specifying a reason alongside the marker.
  * Updated guidance for environments where the standard advisory setting is unavailable.

* **Bug Fixes**
  * Improved marker recognition to avoid false matches in quoted, escaped, or unrelated command text.
  * Preserved escalation behavior for repeated or multi-step merge commands.

* **Documentation**
  * Documented the inline bypass behavior, limitations, and supported usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->