### PR TITLE
docs: add review-body surface to pr comment scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,12 +151,16 @@ to catch "patch landed in the wrong clone" before it bites a future session.
 ## Issue & PR Conventions
 
 - **PR comment retrieval scope**: When asked to check PR comments,
-  inspect both surfaces: Conversation comments (`gh pr view --json comments`)
-  and inline review comments/discussions (`gh api
+  inspect all three surfaces: (1) Conversation comments (`gh pr view --json
+  comments`), (2) inline review comments/discussions (`gh api
   repos/{owner}/{repo}/pulls/<PR>/comments --paginate` or the GraphQL review
-  thread equivalent). Links containing `#discussion_r...` are inline review
-  comments, not Conversation comments; do not report "no comments" or "only one
-  comment" until both surfaces have been checked.
+  thread equivalent), and (3) review bodies (`gh api
+  repos/{owner}/{repo}/pulls/<PR>/reviews --paginate -q '.[].body'`) — bots
+  like CodeRabbit place nitpick/actionable feedback in collapsible
+  review-body sections, not line comments; scan for
+  `Nitpick|Actionable|outside diff|🧹`. Links containing `#discussion_r...`
+  are inline review comments, not Conversation comments; do not report "no
+  comments" or "only one comment" until all three surfaces have been checked.
 - **Partial-scope PR**: When a PR addresses only a subset of an issue's body
   (e.g., "items 1-3 implemented, P-redesign deferred to follow-up"), use
   `Refs #N` (or `Addresses #N (items X, Y; Z deferred)`) in the PR body


### PR DESCRIPTION
## 요약

AGENTS.md의 "PR comment retrieval scope" 컨벤션을 2-surface에서 3-surface로 확장합니다. CodeRabbit 등 봇이 nitpick/actionable 피드백을 line comment가 아닌 collapsible review-body 섹션에 남기는 케이스(#716에서 실제 miss 발생)를 커버하기 위해 review bodies(`gh api repos/{owner}/{repo}/pulls/<PR>/reviews --paginate -q '.[].body'`) surface를 추가했습니다.

Closes #825

## 변경 내용

- `AGENTS.md` (CLAUDE.md는 이 파일의 symlink) — "PR comment retrieval scope" bullet 1개 교체 (9 insertions, 5 deletions)
  - "both surfaces" → "all three surfaces" + (1)/(2)/(3) 번호 부여
  - (3) review bodies surface 추가 + `Nitpick|Actionable|outside diff|🧹` 스캔 마커 명시

## 검증

```
grep -c "both surfaces" AGENTS.md        → 0
grep -c "all three surfaces" AGENTS.md   → 2
grep -n "pulls/<PR>/reviews" AGENTS.md   → 158
bash scripts/run-tests.sh                → ALL TESTS PASSED (exit 0)
```

Pre-commit verified: `bash scripts/run-tests.sh` → pytest + shell 67 pass / manifest check OK / hook-token invariant 7 verified — ALL TESTS PASSED (exit 0)

Caller chain verified: docs-only change — grep survey로 AGENTS.md가 유일한 restatement site임을 확인 (momentum spec.md의 "both surfaces"는 다른 문맥, cmux-delegate SKILL.md snippet은 컨벤션 아님)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded pull request comment retrieval guidance to include conversation comments, inline review discussions, and review-body content.
  * Clarified when to report that no comments or only one comment exists.
  * Added guidance for distinguishing inline review comments from conversation comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->