### PR TITLE
fix(hooks): extract shared memory-dir resolver

### DIFF
--- a/hooks/_lib/_memory_dir.py
+++ b/hooks/_lib/_memory_dir.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Shared memory-directory resolver — single source of truth (#823).
+
+Previously this resolver was re-implemented per hook:
+
+  - memory-hint carried the fixed per-character slugify (#800)
+  - momentum-rule-retrieval-gate kept a stale private copy still using
+    `cwd.replace("/", "-")`, so on any host whose absolute cwd contains a
+    non-alphanumeric character beyond `/` (e.g. a literal `.` in the
+    username) its fallback path never resolved and the gate's dynamic
+    memory cites silently never fired — the exact dual-SoT drift the #800
+    fix was supposed to eliminate.
+
+Both hooks now import from here so the resolution semantics cannot drift.
+
+Resolution order:
+  1. `PRAXIS_MEMORY_DIR` env var — when set, it is authoritative: return it
+     if it is an existing directory, else None (no fallback attempt)
+  2. fallback `~/.claude/projects/{slugified-cwd}/memory` if it exists
+  3. otherwise None
+
+Public API:
+  SLUG_CHAR_RE                       — per-character slugify pattern
+  slugify_project_path(path) -> str  — Claude Code project-slug rule
+  resolve_memory_dir() -> str | None — resolved memory dir or None
+"""
+from __future__ import annotations
+
+import os
+import re
+
+SLUG_CHAR_RE = re.compile(r"[^a-zA-Z0-9]")
+
+
+def slugify_project_path(path: str) -> str:
+    """Slugify an absolute path per Claude Code's project-slug rule.
+
+    Claude Code replaces every non-alphanumeric character individually
+    (not collapsed runs) — e.g. /Users/nathan.song/.claude slugs to
+    -Users-nathan-song--claude (double dash, since "/." is two chars).
+    A prior cwd.replace("/", "-") only touched slashes, so any other
+    special character (a literal "." in a username, for one) left the
+    fallback path permanently unresolvable — this fallback ran, found
+    None, and the entire hookable/hookKeywords surface silently never
+    fired for any memory in the store.
+    """
+    return SLUG_CHAR_RE.sub("-", path)
+
+
+def resolve_memory_dir() -> str | None:
+    """Return the resolved memory directory path or None if missing."""
+    env_dir = os.environ.get("PRAXIS_MEMORY_DIR", "").strip()
+    if env_dir:
+        return env_dir if os.path.isdir(env_dir) else None
+
+    home = os.path.expanduser("~")
+    cwd = os.getcwd()
+    slug = slugify_project_path(cwd)
+    fallback = os.path.join(home, ".claude", "projects", slug, "memory")
+    return fallback if os.path.isdir(fallback) else None

--- a/hooks/advisory-nudge/memory-hint/impl.py
+++ b/hooks/advisory-nudge/memory-hint/impl.py
@@ -26,7 +26,8 @@ sibling hook blocked the command.
 Memory directory discovery:
   1. `PRAXIS_MEMORY_DIR` env var (when set + exists)
   2. fallback to `~/.claude/projects/{slugified-cwd}/memory/`
-     (slugify rule: replace `/` with `-` on the absolute cwd)
+     (slugify rule: replace every non-alphanumeric character with `-`,
+     per-character — see `hooks/_lib/_memory_dir.py`, the shared SoT)
   3. missing dir → exit 0 silently
 
 Frontmatter parser is pure regex (no PyYAML dependency). Supported shapes:
@@ -52,6 +53,7 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     safe_tokenize,
     strip_prefix,
 )
+from _memory_dir import resolve_memory_dir  # type: ignore[import-not-found]  # noqa: E402
 
 
 HIT_LIMIT = 3
@@ -170,30 +172,6 @@ def parse_frontmatter(raw: str) -> dict | None:
         "description": description,
         "events": events,
     }
-
-
-_SLUG_CHAR_RE = re.compile(r"[^a-zA-Z0-9]")
-
-
-def resolve_memory_dir() -> str | None:
-    """Return the resolved memory directory path or None if missing."""
-    env_dir = os.environ.get("PRAXIS_MEMORY_DIR", "").strip()
-    if env_dir:
-        return env_dir if os.path.isdir(env_dir) else None
-
-    home = os.path.expanduser("~")
-    cwd = os.getcwd()
-    # Claude Code replaces every non-alphanumeric character individually
-    # (not collapsed runs) — e.g. /Users/nathan.song/.claude slugs to
-    # -Users-nathan-song--claude (double dash, since "/." is two chars).
-    # A prior cwd.replace("/", "-") only touched slashes, so any other
-    # special character (a literal "." in a username, for one) left the
-    # fallback path permanently unresolvable — this fallback ran, found
-    # None, and the entire hookable/hookKeywords surface silently never
-    # fired for any memory in the store.
-    slug = _SLUG_CHAR_RE.sub("-", cwd)
-    fallback = os.path.join(home, ".claude", "projects", slug, "memory")
-    return fallback if os.path.isdir(fallback) else None
 
 
 def index_memories(directory: str) -> list[tuple[str, dict, float]]:

--- a/hooks/advisory-nudge/memory-hint/spec.md
+++ b/hooks/advisory-nudge/memory-hint/spec.md
@@ -89,17 +89,17 @@ clarify *why* a block fired.
 
 ### Discovery and fail-safe
 
-Memory directory resolution order:
+Memory directory resolution is delegated to the shared resolver
+`hooks/_lib/_memory_dir.py` (`resolve_memory_dir()`) — hoisted there as the
+single source of truth in #823 after `momentum-rule-retrieval-gate`'s private
+copy drifted from the #799/#800 per-character slugify fix. Resolution order:
 1. `PRAXIS_MEMORY_DIR` env var (when set + points to an existing directory)
 2. fallback `~/.claude/projects/{slugified-cwd}/memory/` — slugify rule:
    replace every non-alphanumeric character in the absolute cwd with `-`
    (per-character, not collapsed) — matches Claude Code's own project-slug
    convention, e.g. `/Users/nathan.song/.claude` → `-Users-nathan-song--claude`
-   (double dash from the adjacent `/` and `.`). A naive `cwd.replace("/", "-")`
-   left any other special character (such as a literal `.` in a home-directory
-   segment) un-slugified, permanently desyncing the fallback path from the
-   real project directory and silently disabling this hook end-to-end for
-   affected users (issue #799).
+   (double dash from the adjacent `/` and `.`). The full #799 drift story
+   lives in the `_memory_dir.py` module docstring.
 3. neither resolves → exit 0 silently (no fallback attempt, no error)
 
 Five exit-0 fail-safe paths:

--- a/hooks/advisory-nudge/memory-hint/spec.md
+++ b/hooks/advisory-nudge/memory-hint/spec.md
@@ -93,6 +93,7 @@ Memory directory resolution is delegated to the shared resolver
 `hooks/_lib/_memory_dir.py` (`resolve_memory_dir()`) — hoisted there as the
 single source of truth in #823 after `momentum-rule-retrieval-gate`'s private
 copy drifted from the #799/#800 per-character slugify fix. Resolution order:
+
 1. `PRAXIS_MEMORY_DIR` env var (when set + points to an existing directory)
 2. fallback `~/.claude/projects/{slugified-cwd}/memory/` — slugify rule:
    replace every non-alphanumeric character in the absolute cwd with `-`

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -50,6 +50,7 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     safe_tokenize,
     strip_prefix,
 )
+from _memory_dir import resolve_memory_dir  # type: ignore[import-not-found]  # noqa: E402
 from _transcript import TRANSCRIPT_SCAN_LINES  # type: ignore[import-not-found]  # noqa: E402
 from block_message import format_block  # type: ignore[import-not-found]  # noqa: E402
 
@@ -172,17 +173,6 @@ def _parse_momentum_frontmatter(raw: str) -> dict | None:
         )
 
     return {"triggers": triggers, "description": description}
-
-
-def _resolve_memory_dir() -> str | None:
-    env_dir = os.environ.get("PRAXIS_MEMORY_DIR", "").strip()
-    if env_dir:
-        return env_dir if os.path.isdir(env_dir) else None
-    home = os.path.expanduser("~")
-    cwd = os.getcwd()
-    slug = cwd.replace("/", "-")
-    fallback = os.path.join(home, ".claude", "projects", slug, "memory")
-    return fallback if os.path.isdir(fallback) else None
 
 
 def _load_momentum_memories(directory: str, trigger: str) -> list[tuple[str, str, float]]:
@@ -968,7 +958,7 @@ def main() -> int:
     if not triggers:
         return 0
 
-    directory = _resolve_memory_dir()
+    directory = resolve_memory_dir()
 
     # Emit each surface to stderr — static rule text + dynamic memory cites.
     for trigger in triggers:

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -42,9 +42,11 @@ N merges occur in rapid succession) is deferred to Phase 2 (separate issue).
 ### Dynamic memory loading
 
 Memory cites are no longer hardcoded — they are loaded at hook fire time
-from the same user-scoped memory directory used by `memory-hint`
-(`PRAXIS_MEMORY_DIR` env var when set, otherwise
-`~/.claude/projects/{slugified-cwd}/memory/`). A memory file participates
+from the same user-scoped memory directory used by `memory-hint`, resolved
+via the shared `hooks/_lib/_memory_dir.py` resolver (#823): `PRAXIS_MEMORY_DIR`
+env var when set, otherwise `~/.claude/projects/{slugified-cwd}/memory/` —
+slugify replaces every non-alphanumeric character with `-`, per-character
+(Claude Code's own project-slug rule). A memory file participates
 by adding a flat single-line `momentum:` list to its frontmatter:
 
 ```yaml

--- a/tests/hooks/_lib/test_memory_dir.py
+++ b/tests/hooks/_lib/test_memory_dir.py
@@ -1,0 +1,118 @@
+"""Tests for hooks/_lib/_memory_dir.py — shared memory-dir resolver (#823).
+
+Coverage:
+  - slugify_project_path: per-character non-alphanumeric substitution
+    (Claude Code project-slug rule — a `.` in a path segment must slug to `-`)
+  - resolve_memory_dir fallback: the #823 core regression — a cwd containing
+    a `.` resolves to the per-character slug directory
+  - PRAXIS_MEMORY_DIR env override (existing dir wins, missing dir → None)
+  - fallback dir absent → None
+  - both consumer hooks (memory-hint, momentum-rule-retrieval-gate) import
+    the shared resolver — identity check blocks dual-SoT reintroduction
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LIB = REPO_ROOT / "hooks" / "_lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+import _memory_dir  # noqa: E402
+
+FAKE_CWD = "/Users/nathan.song/projects/praxis"
+FAKE_SLUG = "-Users-nathan-song-projects-praxis"
+
+
+def _load_impl(name: str, rel_path: str):
+    """Load a hook impl.py by file path (hook dirs contain `-`)."""
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / rel_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# --------------------------------------------------------------------------- #
+# slugify_project_path
+# --------------------------------------------------------------------------- #
+
+def test_slugify_per_character_substitution():
+    assert _memory_dir.slugify_project_path(FAKE_CWD) == FAKE_SLUG
+
+
+def test_slugify_adjacent_specials_not_collapsed():
+    # "/." is two characters → two dashes, never collapsed into one.
+    assert (
+        _memory_dir.slugify_project_path("/Users/nathan.song/.claude")
+        == "-Users-nathan-song--claude"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# resolve_memory_dir
+# --------------------------------------------------------------------------- #
+
+def _fallback_fixture(tmp_path, monkeypatch):
+    """Point HOME/cwd at a fake tree whose cwd contains a `.` (bug trigger)."""
+    monkeypatch.delenv("PRAXIS_MEMORY_DIR", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(_memory_dir.os, "getcwd", lambda: FAKE_CWD)
+    memory = tmp_path / ".claude" / "projects" / FAKE_SLUG / "memory"
+    memory.mkdir(parents=True)
+    return memory
+
+
+def test_fallback_resolves_cwd_with_dot(tmp_path, monkeypatch):
+    # Core #823 regression: `.` in the cwd must slug to `-` so the fallback
+    # path resolves; the drifted replace("/", "-") copy returned None here.
+    memory = _fallback_fixture(tmp_path, monkeypatch)
+    assert _memory_dir.resolve_memory_dir() == str(memory)
+
+
+def test_fallback_dir_absent_returns_none(tmp_path, monkeypatch):
+    monkeypatch.delenv("PRAXIS_MEMORY_DIR", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(_memory_dir.os, "getcwd", lambda: FAKE_CWD)
+    assert _memory_dir.resolve_memory_dir() is None
+
+
+def test_env_override_existing_dir(tmp_path, monkeypatch):
+    env_dir = tmp_path / "custom-memory"
+    env_dir.mkdir()
+    monkeypatch.setenv("PRAXIS_MEMORY_DIR", str(env_dir))
+    assert _memory_dir.resolve_memory_dir() == str(env_dir)
+
+
+def test_env_override_missing_dir_returns_none(tmp_path, monkeypatch):
+    # Env var is authoritative when set: no fallback attempt on a missing dir.
+    monkeypatch.setenv("PRAXIS_MEMORY_DIR", str(tmp_path / "does-not-exist"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(_memory_dir.os, "getcwd", lambda: FAKE_CWD)
+    (tmp_path / ".claude" / "projects" / FAKE_SLUG / "memory").mkdir(parents=True)
+    assert _memory_dir.resolve_memory_dir() is None
+
+
+# --------------------------------------------------------------------------- #
+# consumer hooks share the single resolver (dual-SoT guard)
+# --------------------------------------------------------------------------- #
+
+def test_memory_hint_uses_shared_resolver(tmp_path, monkeypatch):
+    memory = _fallback_fixture(tmp_path, monkeypatch)
+    impl = _load_impl(
+        "memory_hint_impl", "hooks/advisory-nudge/memory-hint/impl.py"
+    )
+    assert impl.resolve_memory_dir is _memory_dir.resolve_memory_dir
+    assert impl.resolve_memory_dir() == str(memory)
+
+
+def test_momentum_gate_uses_shared_resolver(tmp_path, monkeypatch):
+    memory = _fallback_fixture(tmp_path, monkeypatch)
+    impl = _load_impl(
+        "momentum_gate_impl",
+        "hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py",
+    )
+    assert impl.resolve_memory_dir is _memory_dir.resolve_memory_dir
+    assert impl.resolve_memory_dir() == str(memory)


### PR DESCRIPTION
Closes #823

## 변경 내용

`momentum-rule-retrieval-gate`의 private `_resolve_memory_dir` 사본이 #800의 per-character slugify 수정을 반영하지 못한 채 `cwd.replace("/", "-")`를 유지하고 있어, cwd에 `.` 등 비영숫자 문자가 포함된 호스트(예: username에 `.`)에서 fallback 경로가 영구히 미해석 → dynamic memory cite가 조용히 전혀 발화하지 않는 회귀를 수정합니다.

- **`hooks/_lib/_memory_dir.py` 신설** — `SLUG_CHAR_RE` / `slugify_project_path()` / `resolve_memory_dir()`를 단일 SoT로 hoist. #800 버그 설명 주석을 memory-hint에서 verbatim 이동.
- **`hooks/advisory-nudge/memory-hint/impl.py`** — 로컬 정의 삭제, `_lib`에서 import. 모듈 docstring의 stale slugify 설명(`replace / with -`)도 수정.
- **`hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py`** — drift된 `_resolve_memory_dir` 삭제, 공유 `resolve_memory_dir` import 및 호출부(impl.py:971) 갱신.
- **spec 2건 갱신** — 두 spec.md 모두 공유 resolver(`hooks/_lib/_memory_dir.py`)와 per-character slugify 규칙을 명시.
- **`tests/hooks/_lib/test_memory_dir.py` 신설 (8 tests)** — slug 단위 검증, fallback 핵심 회귀(cwd에 `.` 포함), env override, dir 부재 → None, 그리고 두 소비 hook 모두에 대한 identity check(`impl.resolve_memory_dir is _memory_dir.resolve_memory_dir`)로 dual-SoT 재도입 차단.

## before/after 라이브 프로브 (실제 버그 호스트, username에 `.` 포함)

```
# before (drift된 momentum-gate 사본, cwd=~/projects/praxis)
before (main clone, cwd=~/projects/praxis): None

# after (공유 resolver, 동일 cwd)
after (cwd=~/projects/praxis): /Users/nathan.song/.claude/projects/-Users-nathan-song-projects-praxis/memory
```

## 검증

```
git grep 'replace("/", "-")' hooks/   → 0 hits
python3 -m pytest tests/hooks/_lib/test_memory_dir.py -v → 8 passed
bash scripts/run-tests.sh → ALL TESTS PASSED
ruff check hooks/ tests/ → All checks passed!
codex review → 결함 0건
```

Pre-commit verified: python3 -m pytest tests/hooks/_lib/test_memory_dir.py -v (8 passed); bash scripts/run-tests.sh (ALL TESTS PASSED); ruff check hooks/ tests/ (All checks passed); live probe before=None / after=resolves

Caller chain verified: git grep으로 resolve_memory_dir 호출부 전수 열거 — memory-hint impl.py:335, momentum-rule-retrieval-gate impl.py:971, 두 곳 모두 공유 resolver로 갱신
