### PR TITLE
docs(hooks): formalize canary verification steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,8 +218,10 @@ LIVE=$(jq -r '.plugins["praxis@praxis"][0].installPath' "$CFG/plugins/installed_
 echo "$LIVE"
 
 # Diff the live copy against your working tree.
-# Use the hook's actual body from the manifest — impl.sh for the shell hooks.
-diff "$LIVE/hooks/<role>/<name>/impl.py" hooks/<role>/<name>/impl.py
+# Use the hook's actual body from the manifest — impl.sh for the shell hooks,
+# and diff the generated wrapper (hooks/<name>.sh) separately for those.
+BODY=$(python3 -c "import json;print(next(h.get('body','impl.py') for h in json.load(open('hooks/manifest.json'))['hooks'] if h['name']=='<name>'))")
+diff "$LIVE/hooks/<role>/<name>/$BODY" "hooks/<role>/<name>/$BODY"
 ```
 
 `CLAUDE_CONFIG_DIR` is easy to miss and the failure is silent: both config
@@ -246,10 +248,15 @@ mutation. Each is a real probe used during the 2026-07-22 release-lag incident.
 
    ```bash
    LEDGER=$(mktemp)
-   printf '%s' "$PAYLOAD" | PRAXIS_FIRE_TELEMETRY_FILE="$LEDGER" \
-     python3 hooks/<role>/<name>/impl.py
+   # Unset the opt-out — if PRAXIS_FIRE_TELEMETRY_DISABLE=1 is inherited the
+   # writer is a no-op, and the empty ledger reads as "hook never fired".
+   printf '%s' "$PAYLOAD" | env -u PRAXIS_FIRE_TELEMETRY_DISABLE \
+     PRAXIS_FIRE_TELEMETRY_FILE="$LEDGER" python3 hooks/<role>/<name>/impl.py
    jq -r 'select(.hook=="<name>") | "\(.decision) \(.granularity)"' "$LEDGER"
    ```
+
+   Use the invocation surface from procedure A — `hooks/<name>.sh <args...>`
+   for `impl.sh` hooks — not a bare `impl.py` for every hook.
 
    Two caveats when reading the result:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,140 @@ and the canonical registry is `hooks/manifest.json` (not `hooks.json`).
    directory↔manifest cross-check, role↔dirname agreement, impl existence,
    Stop ordering, byte-equivalent generated artifacts, and 5+ more
    invariants (see the script preamble).
+9. Canary the change — see
+   [Verifying a hook change at runtime](#verifying-a-hook-change-at-runtime-canary)
+   below. A green test suite does not tell you what the runtime is executing.
+
+### Verifying a hook change at runtime (canary)
+
+Hooks do not execute from this repository. They execute from a versioned copy
+under `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/praxis/praxis/<version>/`
+— note the config dir is relocatable, so `~/.claude` is the default, not a
+given — and a merged change is not live until
+`release → plugin update → session reload` completes. Measured
+lead time from merge to release is a median of **33.7 hours** (max observed:
+201 hours, n=44 — see issue #841). Treat that lag as a permanent property of
+the repo, not an incident: the release cadence is deliberate.
+
+The consequence is that **you cannot validate a hook change in the session that
+wrote it by simply triggering the hook.** Triggering it runs the *previous*
+release. Two separate questions need two separate procedures — conflating them
+is the failure this section exists to prevent.
+
+#### A. Is the new logic correct?
+
+Invoke the working-tree impl directly with a synthetic payload. This is the same
+surface the tests use, so mirror an existing test rather than inventing one.
+
+The invocation surface depends on the hook's manifest entry — read `body` and
+`args` before assuming `impl.py` with no arguments:
+
+```bash
+# Default: body omitted (impl.py), no args
+printf '%s' "$PAYLOAD" | python3 hooks/<role>/<name>/impl.py; echo "rc=$?"
+
+# body: "impl.sh" (codex-review-route, completion-verify,
+# retrospect-mix-check, strike-counter) — the generated wrapper is the
+# invocation surface, and args are part of the registration
+printf '%s' "$PAYLOAD" | hooks/<name>.sh <args...>; echo "rc=$?"
+```
+
+A hook can hold several manifest entries that differ only by `args` —
+`strike-counter` registers `session-start`, `preprompt`, and `stop` — and
+`pre-edit-md-escape-advisory` splits into `-pre` / `-post` wrappers via
+`wrapper_suffix`. Probing the wrong entry exercises a different mode than the
+one you changed:
+
+```bash
+python3 -c "import json;[print(h['name'], h.get('body','impl.py'), h.get('args'), h.get('wrapper_suffix','')) for h in json.load(open('hooks/manifest.json'))['hooks'] if h['name']=='<name>']"
+```
+
+This proves the logic. It proves nothing about the runtime.
+
+#### B. Is the runtime executing the new logic?
+
+Compare against the cache copy that is actually registered:
+
+```bash
+# Resolve the config dir FIRST — CLAUDE_CONFIG_DIR relocates it, and reading
+# the wrong one silently reports a different (often stale) install.
+CFG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+
+# Which version is live right now
+LIVE=$(jq -r '.plugins["praxis@praxis"][0].installPath' "$CFG/plugins/installed_plugins.json")
+echo "$LIVE"
+
+# Diff the live copy against your working tree.
+# Use the hook's actual body from the manifest — impl.sh for the shell hooks.
+diff "$LIVE/hooks/<role>/<name>/impl.py" hooks/<role>/<name>/impl.py
+```
+
+`CLAUDE_CONFIG_DIR` is easy to miss and the failure is silent: both config
+dirs can hold a populated `plugins/cache/praxis/praxis/<version>/` tree, so
+hardcoding `$HOME/.claude` returns a plausible version that is simply not the
+one running. Verify against the config dir the session actually loaded — the
+`praxis:*` skill header printed at invocation names it directly.
+
+A non-empty diff means the runtime is still on the old logic — any behaviour you
+observe in-session is evidence about the *old* hook, and must not be reported as
+verification of the change.
+
+#### Canary probes
+
+Use these to confirm a hook is wired and discriminating, without performing any
+mutation. Each is a real probe used during the 2026-07-22 release-lag incident.
+
+1. **Fire-ledger probe** — confirm the hook fired at all, and with which
+   decision. `@fail_open` hooks append JSONL records to
+   `~/.praxis/telemetry/fire-events-YYYY-MM-DD.jsonl`. Isolate the probe with
+   `PRAXIS_FIRE_TELEMETRY_FILE` so it never pollutes the production ledger
+   (see issue #849) — and **query the same path you set**, or you will be
+   reading pre-existing production rows and mistaking them for your probe:
+
+   ```bash
+   LEDGER=$(mktemp)
+   printf '%s' "$PAYLOAD" | PRAXIS_FIRE_TELEMETRY_FILE="$LEDGER" \
+     python3 hooks/<role>/<name>/impl.py
+   jq -r 'select(.hook=="<name>") | "\(.decision) \(.granularity)"' "$LEDGER"
+   ```
+
+   Two caveats when reading the result:
+
+   - **`granularity` first.** `coarse` records collapse `ask`/`advise`/`pass`
+     together, and Stop / UserPromptSubmit hooks that block via a stdout
+     `decision` field while exiting 0 are recorded as `pass`. A `coarse`
+     "pass" is therefore **not** evidence the hook allowed the call.
+   - **One fire can produce two rows.** A hook that calls
+     `record_session_fire` directly (`pr-report-destination-gate`,
+     `askuserquestion-loop-signal`) still passes through `@fail_open`, so a
+     `rich` row and a `coarse` duplicate are both written for a single
+     invocation — see `_fire_ledger.record_session_fire`'s docstring. Filter
+     to `granularity=="rich"` rather than counting rows, or a single fire
+     reads as two.
+
+2. **Non-existent-target probe** — for any gate that queries external state
+   (`gh pr view`, `gh issue view`), drive it with an identifier that does not
+   exist. A correct gate fails open or blocks explicitly; a defective one
+   fabricates a verdict from an empty response. This costs nothing and mutates
+   nothing.
+
+3. **Negative-discrimination probe** — feed an input the hook is specified to
+   *ignore* and confirm silence. For `model-routing-advisory`, a non-Claude
+   provider prefix (`--model gemini:pro`) must stay silent per its spec. A hook
+   that fires on its documented no-op input is over-triggering, which a
+   positive-only test will not catch.
+
+   Silence alone is not a pass: a malformed payload is also silent. Pair every
+   negative probe with a positive one that differs *only* in the discriminating
+   field, and confirm the positive case fires. Without that pair you are
+   verifying your payload shape, not the hook.
+
+#### Advisory output is not visible to the model
+
+`advisory-nudge` hooks emit on stderr, which the model does not see. Never infer
+that an advisory fired from the absence of a reaction in the transcript, and
+never report an advisory as verified on that basis. Confirm through the
+fire-ledger (probe 1) or by invoking the impl directly (procedure A).
 
 ## Reviewing or auditing a PR
 


### PR DESCRIPTION
## 배경

훅은 이 레포가 아니라 `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/praxis/praxis/<version>/`
의 버전별 사본에서 실행된다. 따라서 main 에 머지된 훅 변경은
`release → plugin update → session reload` 가 끝나기 전까지 런타임에 반영되지 않는다.

#841 에서 실측한 두 구간:

| 구간 | 실측 |
|---|---|
| merge → release | 중앙값 33.7h (min 0.1h / max 201.4h, n=44) |
| release → 채택 (본 작업의 활성 config) | 49일 경과, 미채택 (`6.1.3` 고정 / main 은 `7.5.0`) |

릴리즈 주기 단축은 범위에서 제외됐다 (사용자 결정). 랙은 제거 대상이 아니라
**상시 전제** 이므로, 이 PR 은 *랙 구간에서도 훅 변경을 검증하는 절차* 를
CONTRIBUTING.md 에 공식화한다.

## 변경 내용

`CONTRIBUTING.md` → `Adding or modifying a hook` 에 step 9 추가 + 신규 절
`Verifying a hook change at runtime (canary)` (+134줄, 1 파일).

핵심은 두 질문을 분리한 것이다 — 이 둘을 뭉개는 것이 이 절이 막으려는 실패다.

- **A. 새 로직이 맞는가** — 워킹트리 impl 을 합성 payload 로 직접 호출.
  manifest 의 `body` / `args` / `wrapper_suffix` 를 먼저 읽어야 한다
  (`impl.sh` 6 엔트리, `args` 보유 5 엔트리는 `impl.py` 호출로 재현되지 않음).
- **B. 런타임이 그 로직을 실행 중인가** — 등록된 cache 사본과 diff.
  `CLAUDE_CONFIG_DIR` 를 먼저 해석해야 하며, 하드코딩하면 **다른 (대개 오래된)
  install 을 조용히 조회** 하게 된다.

비-mutation canary probe 3종:

1. **fire-ledger probe** — `PRAXIS_FIRE_TELEMETRY_FILE` 로 격리하고 **그 경로를
   그대로 조회**. `granularity` 를 먼저 읽을 것 (coarse 는 ask/advise/pass 를
   뭉개고, Stop/UPS 의 block 은 exit 0 이라 `pass` 로 기록됨). 1 회 발화가
   rich + coarse **2 행** 을 남길 수 있음.
2. **non-existent-target probe** — 외부 상태를 조회하는 게이트에 존재하지 않는
   식별자를 넣어, 빈 응답으로 판정을 날조하지 않는지 확인.
3. **negative-discrimination probe** — 명세상 무시해야 할 입력에 침묵하는지 확인.
   침묵만으로는 통과가 아니며(잘못된 payload 도 침묵함), 판별 필드만 다른
   양성 케이스와 반드시 쌍으로 돌려야 한다.

advisory stderr 는 모델에 보이지 않으므로, 반응이 없다는 사실은 advisory 가
발화했다는 증거가 될 수 없다는 점도 명시했다.

## 검증

문서에 실은 모든 명령을 게재 전 실제 실행했다.

- `installed_plugins.json` resolver → `CFG=/Users/nathan.song/.claude-2`,
  `LIVE=.../praxis/6.1.3`
- 위 `LIVE` 로 diff → non-empty (런타임이 구버전이라는 신호를 실제로 검출)
- manifest `body`/`args` 조회 one-liner → `strike-counter` 3 엔트리 출력 확인
- `hooks/strike-counter.sh stop` wrapper 호출 → rc=0
- 격리 ledger probe → 1 행 기록, `pass coarse` (advisory 를 냈음에도 coarse 로
  붕괴되는 것을 실증 — 문서의 경고가 그대로 재현됨)
- negative/positive 쌍: `--model gemini:pro` 침묵 / `architect` + `--model haiku`
  발화 확인

테스트·린트:

```
./scripts/run-tests.sh        → ALL TESTS PASSED (exit 0)
scripts/check-plugin-manifests.py → plugin-manifest check OK
markdownlint CONTRIBUTING.md  → 추가분(157행 이후) 위반 0건
```

`markdownlint` 는 라인 18/39/71/130/135 에 기존 위반 5건을 보고하지만 모두 이
PR 의 diff 밖이며, reviewdog 는 추가된 라인만 필터하므로 CI 에 영향 없다.
범위 규율상 손대지 않았다.

## codex-review-wrap

1 라운드, P2 4건. 전부 fact-modifying 으로 분류해 Step 5b 전제 검증 후 반영했다.
flip 없음.

| # | 지적 | 전제 검증 | 조치 |
|---|---|---|---|
| 1 | `CLAUDE_CONFIG_DIR` 미반영 | `CLAUDE_CONFIG_DIR=~/.claude-2`, 두 config 가 서로 다른 버전을 보고 | 도입부 prose + resolver 모두 수정 |
| 2 | `impl.sh` / `args` 훅 미지원 | manifest 스캔 → `body=impl.sh` 6 엔트리, `args` 5 엔트리 | wrapper + args 분기 추가 |
| 3 | telemetry override 경로 불일치 | writer 는 override 경로, 예제 jq 는 기본 ledger 조회 | 동일 경로 사용하도록 수정 |
| 4 | rich/coarse 중복 레코드 | `_fire_ledger.py:267-271` — "a COARSE duplicate is also recorded ... must filter to `granularity=="rich"`" | 중복 가능성 명시 |

지적 1 은 이 PR 의 초안이 **이 절이 경고하는 실패를 그대로 저지른** 사례다 —
`$HOME/.claude` 를 하드코딩해 7.5.0 을 보고했으나 실제 활성 install 은 6.1.3
이었다. 커밋 본문에 그대로 기록했다.

## 미검증 / 후속

- 이 절차는 **아직 실제 미릴리즈 훅 변경에 적용해 본 적이 없다.** 최초 적용은
  #843 / #844 / #846 중 하나에서 이뤄진다.
- 활성 config 의 install 포인터가 `6.1.3` 에 고정된 원인은 규명하지 않았다
  (cache 에 `7.5.0` 이 이미 있으므로 활성화 단계에서 멈춘 것으로 보임).
  #841 에 별도 작업 항목으로 남겼다.

Refs #841

Pre-commit verified: 이 레포에는 pre-commit 훅이 설정돼 있지 않다
(`core.hooksPath` unset, `.git/hooks` 에 sample 외 실행 파일 없음, `.pre-commit-config.yaml`
부재). 동등 검증을 수동 실행했다 — `./scripts/run-tests.sh` → ALL TESTS PASSED (exit 0),
`scripts/check-plugin-manifests.py` → plugin-manifest check OK,
`markdownlint-cli@0.49.0 CONTRIBUTING.md` → diff 범위(157행 이후) 위반 0건.

Caller chain verified: n/a — 문서 전용 변경이다. 코드 심볼·런타임 경로·manifest
엔트리를 건드리지 않으며 (`git diff --cached --name-status` → `M CONTRIBUTING.md` 단일),
따라서 호출자 체인이 존재하지 않는다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a canary validation procedure for hook changes.
  * Documented how to verify working-tree logic and confirm that the runtime is using the latest released version.
  * Added guidance for interpreting differences between local and installed logic.
  * Included recommended probes for validating hook execution and advisory behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->