### PR TITLE
feat(hooks): record stop-lane block/advise fires

### DIFF
--- a/docs/hook-prune-audit.md
+++ b/docs/hook-prune-audit.md
@@ -85,6 +85,17 @@ until a user opts into strict mode — a 0-block count for these is the designed
 default, not evidence of dead code, so they're also excluded from a "drop"
 read (though still listed below for completeness).
 
+> **Update (issue #847):** the coarse Stop-lane blind spot this restriction
+> works around is now closed for the five completion-verify Stop gates
+> (`completion-signal-gate`, `merge-state-claim-gate`,
+> `negative-existence-verdict-gate`, `runtime-state-claim-gate`,
+> `readonly-verify-deferral-gate`). Each now calls `record_session_fire` at
+> its emit point with the real decision (block/advise), so future audits can
+> score them on this axis directly by filtering `granularity="rich"`. Before
+> #847 the Stop lane recorded structurally zero non-pass fires — every
+> block/advise collapsed to coarse "pass" — so any pre-#847 "never escalates"
+> read on these hooks is measurement-absent, not evidence of dead code.
+
 Remaining `PreToolUse`/`PostToolUse` hooks with **zero block AND zero advise**
 across 49 sessions / 30 days (i.e., every fire resolved to a silent Pass):
 

--- a/hooks/_lib/_fire_ledger.py
+++ b/hooks/_lib/_fire_ledger.py
@@ -37,9 +37,12 @@ negative-existence-verdict-gate, runtime-state-claim-gate,
 readonly-verify-deferral-gate) close the coarse block-invisibility gap
 above by calling `record_session_fire` at their emit point with the real
 decision (block under their strict env var, else advise), then
-`suppress_coarse_duplicate()` to drop the redundant coarse "pass" that
-`aggregate_fires` would otherwise sum into `fires=2, block=1, pass=1` for
-a single emit. One rich record is written per genuine emit — no
+`suppress_coarse_duplicate()` — GATED on record_session_fire returning True —
+to drop the redundant coarse "pass" that `aggregate_fires` would otherwise
+sum into `fires=2, block=1, pass=1` for a single emit. Suppression is
+conditional: on a failed rich append (returns False) the coarse fallback is
+left in place, so a transient ledger-write error never drops the fire from
+both streams. One rich record is written per genuine emit — no
 session-level dedup (each hook's `stop_hook_active` early-return already
 guards re-entrant re-fires, so distinct per-turn engagements are counted,
 not collapsed). session_id attribution is kept when the payload carries
@@ -270,8 +273,15 @@ def record_standalone_fire(hook: str, role: str, rc: int) -> None:
         pass  # fail-open — never break the hook
 
 
-def record_session_fire(hook: str, role: str, decision: str, session_id: str, tool: str) -> None:
+def record_session_fire(hook: str, role: str, decision: str, session_id: str, tool: str) -> bool:
     """Append a single RICH fire record with a caller-supplied session_id/tool.
+
+    Returns True iff the rich record was actually appended, False otherwise
+    (telemetry disabled, or a write error swallowed by the fail-open guard). A
+    caller that suppresses its coarse @fail_open fallback after a rich record
+    MUST gate the suppression on this return: suppressing after a FAILED rich
+    append would drop the engagement from both streams (no rich, no coarse) —
+    a silently-unrecorded fire. On False, leave the coarse fallback in place.
 
     Companion to record_standalone_fire (coarse, session_id/tool always "").
     For a standalone (non-Bash-dispatched) hook that has already parsed its own
@@ -288,10 +298,11 @@ def record_session_fire(hook: str, role: str, decision: str, session_id: str, to
     per-session counts must filter to granularity=="rich" (see
     skills/bypass-review/bypass-review's compute_reclarification_loop_counts).
 
-    Fail-open: any error → silently no-op, mirrors every other writer here.
+    Fail-open: any error → silently no-op (returns False), mirrors every other
+    writer here.
     """
     if _disabled():
-        return
+        return False
     try:
         record = {
             "timestamp": datetime.now(tz=timezone.utc).isoformat(),
@@ -303,8 +314,9 @@ def record_session_fire(hook: str, role: str, decision: str, session_id: str, to
             "granularity": "rich",
         }
         _atomic_append(resolve_path(), [json.dumps(record, ensure_ascii=False)])
+        return True
     except Exception:
-        pass  # fail-open — never break the hook
+        return False  # fail-open — never break the hook
 
 
 def count_session_fires(hook: str, session_id: str, decision: str | None = None) -> int:

--- a/hooks/_lib/_fire_ledger.py
+++ b/hooks/_lib/_fire_ledger.py
@@ -31,6 +31,24 @@ main() after parsing its own stdin payload. It still also goes through
 @fail_open's coarse recording for the same hook name — see
 `record_session_fire`'s docstring for the resulting dedup contract.
 
+STOP-LANE BLOCK RECOVERY (issue #847): the five completion-verify Stop
+hooks (completion-signal-gate, merge-state-claim-gate,
+negative-existence-verdict-gate, runtime-state-claim-gate,
+readonly-verify-deferral-gate) close the coarse block-invisibility gap
+above by calling `record_session_fire` at their emit point with the real
+decision (block under their strict env var, else advise), then
+`suppress_coarse_duplicate()` to drop the redundant coarse "pass" that
+`aggregate_fires` would otherwise sum into `fires=2, block=1, pass=1` for
+a single emit. One rich record is written per genuine emit — no
+session-level dedup (each hook's `stop_hook_active` early-return already
+guards re-entrant re-fires, so distinct per-turn engagements are counted,
+not collapsed). session_id attribution is kept when the payload carries
+one and forgone otherwise (`record_session_fire` normalizes a missing id
+to ""), so the decision is never dropped just because the id is absent.
+Before #847 the Stop lane recorded structurally zero non-pass fires
+(every block/advise collapsed to coarse "pass"), which mis-scored these
+gates in the fire-ledger prune audit.
+
 Record fields (JSONL, one line per hook fire):
   timestamp    UTC ISO-8601
   session_id   from payload (rich only; "" for coarse)

--- a/hooks/completion-verify/completion-signal-gate/impl.py
+++ b/hooks/completion-verify/completion-signal-gate/impl.py
@@ -45,6 +45,7 @@ import subprocess
 import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "_lib"))
+import _fire_ledger  # type: ignore[import-not-found]  # noqa: E402
 from _hook_io import emit_stop_advisory  # type: ignore[import-not-found]  # noqa: E402
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
@@ -59,6 +60,9 @@ from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
 # ---------------------------------------------------------------------------
 
 PREFIX = "[praxis:completion-signal-gate]"
+
+_HOOK_NAME = "completion-signal-gate"
+_ROLE = "completion-verify"
 
 # ---------------------------------------------------------------------------
 # Rule 1 — completion-signal tokens
@@ -369,6 +373,19 @@ def main() -> int:
     if messages:
         # Single JSON object per invocation — both rules can fire in one stop.
         emit_stop_advisory("\n".join(messages))
+        # Rich fire record (issue #847): this advisory exits 0, so @fail_open's
+        # coarse path records only "pass" — indistinguishable from a silent
+        # allow. Record the real decision (one rich record per genuine emit;
+        # stop_hook_active already guards re-entrant re-fires), keeping session
+        # attribution when present and forgoing it otherwise.
+        # suppress_coarse_duplicate() drops the redundant coarse "pass" so
+        # aggregate_fires() does not count one emit as fires=2.
+        session_id = payload.get("session_id")
+        _fire_ledger.record_session_fire(
+            _HOOK_NAME, _ROLE, _fire_ledger.DECISION_ADVISE,
+            session_id if isinstance(session_id, str) else "", "Stop",
+        )
+        _fire_ledger.suppress_coarse_duplicate()
 
     return 0
 

--- a/hooks/completion-verify/completion-signal-gate/impl.py
+++ b/hooks/completion-verify/completion-signal-gate/impl.py
@@ -381,11 +381,14 @@ def main() -> int:
         # suppress_coarse_duplicate() drops the redundant coarse "pass" so
         # aggregate_fires() does not count one emit as fires=2.
         session_id = payload.get("session_id")
-        _fire_ledger.record_session_fire(
+        if _fire_ledger.record_session_fire(
             _HOOK_NAME, _ROLE, _fire_ledger.DECISION_ADVISE,
             session_id if isinstance(session_id, str) else "", "Stop",
-        )
-        _fire_ledger.suppress_coarse_duplicate()
+        ):
+            # Suppress the coarse fallback ONLY when the rich record actually
+            # landed — else a failed rich append would drop the fire from both
+            # streams (coderabbit finding on PR #855).
+            _fire_ledger.suppress_coarse_duplicate()
 
     return 0
 

--- a/hooks/completion-verify/merge-state-claim-gate/impl.py
+++ b/hooks/completion-verify/merge-state-claim-gate/impl.py
@@ -306,11 +306,14 @@ def main() -> int:
     # and forgoing it otherwise. suppress_coarse_duplicate() drops the redundant
     # coarse "pass" so aggregate_fires() does not count one emit as fires=2.
     session_id = payload.get("session_id")
-    _fire_ledger.record_session_fire(
+    if _fire_ledger.record_session_fire(
         _HOOK_NAME, _ROLE, decision,
         session_id if isinstance(session_id, str) else "", "Stop",
-    )
-    _fire_ledger.suppress_coarse_duplicate()
+    ):
+        # Suppress the coarse fallback ONLY when the rich record actually
+        # landed — else a failed rich append would drop the fire from both
+        # streams (coderabbit finding on PR #855).
+        _fire_ledger.suppress_coarse_duplicate()
     return 0
 
 

--- a/hooks/completion-verify/merge-state-claim-gate/impl.py
+++ b/hooks/completion-verify/merge-state-claim-gate/impl.py
@@ -29,6 +29,7 @@ import sys
 from pathlib import Path as _Path
 
 sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
+import _fire_ledger  # type: ignore[import-not-found]  # noqa: E402
 from _hook_io import (  # type: ignore[import-not-found]  # noqa: E402
     emit_stop_advisory,
     emit_stop_block,
@@ -44,6 +45,8 @@ _PREFIX = "[merge-state-claim-gate]"
 _BYPASS_ENV = "PRAXIS_MERGE_CLAIM_BYPASS"
 _STRICT_ENV = "PRAXIS_MERGE_CLAIM_STRICT"
 _EVIDENCE_WINDOW = 80  # how many recent transcript events to scan for evidence
+_HOOK_NAME = "merge-state-claim-gate"
+_ROLE = "completion-verify"
 
 # ---------------------------------------------------------------------------
 # Claim detection — a claim needs a SUBJECT token and a COMPLETED-state token
@@ -292,8 +295,22 @@ def main() -> int:
 
     if os.environ.get(_STRICT_ENV, "").strip() == "1":
         emit_stop_block(_advisory(unbacked))
+        decision = _fire_ledger.DECISION_BLOCK
     else:
         emit_stop_advisory(_advisory(unbacked))
+        decision = _fire_ledger.DECISION_ADVISE
+    # Rich fire record (issue #847): Stop hooks signal block/advise via a stdout
+    # decision while exiting 0, so @fail_open's coarse path records only "pass".
+    # Record the real decision (one rich record per genuine emit; stop_hook_active
+    # already guards re-entrant re-fires), keeping session attribution when present
+    # and forgoing it otherwise. suppress_coarse_duplicate() drops the redundant
+    # coarse "pass" so aggregate_fires() does not count one emit as fires=2.
+    session_id = payload.get("session_id")
+    _fire_ledger.record_session_fire(
+        _HOOK_NAME, _ROLE, decision,
+        session_id if isinstance(session_id, str) else "", "Stop",
+    )
+    _fire_ledger.suppress_coarse_duplicate()
     return 0
 
 

--- a/hooks/completion-verify/negative-existence-verdict-gate/impl.py
+++ b/hooks/completion-verify/negative-existence-verdict-gate/impl.py
@@ -78,6 +78,7 @@ from _hook_io import (  # type: ignore[import-not-found]  # noqa: E402
     emit_stop_advisory,
     emit_stop_block,
 )
+import _fire_ledger  # type: ignore[import-not-found]  # noqa: E402
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
     extract_last_assistant_text,
@@ -86,6 +87,8 @@ from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
 )
 
 _PREFIX = "[negative-existence-verdict-gate]"
+_HOOK_NAME = "negative-existence-verdict-gate"
+_ROLE = "completion-verify"
 _BYPASS_ENV = "PRAXIS_HOOK_BYPASS_NEGATIVE_EXISTENCE_GATE"
 _ADVISORY_ENV = "PRAXIS_NEGATIVE_EXISTENCE_ADVISORY"
 
@@ -219,8 +222,22 @@ def main() -> int:
     advisory_env = os.environ.get(_ADVISORY_ENV, "")
     if advisory_env not in ("", "0", "false", "False"):
         emit_stop_advisory(_MESSAGE)
+        decision = _fire_ledger.DECISION_ADVISE
     else:
         emit_stop_block(_MESSAGE)
+        decision = _fire_ledger.DECISION_BLOCK
+    # Rich fire record (issue #847): Stop hooks signal block/advise via a stdout
+    # decision while exiting 0, so @fail_open's coarse path records only "pass".
+    # Record the real decision (one rich record per genuine emit; stop_hook_active
+    # already guards re-entrant re-fires), keeping session attribution when present
+    # and forgoing it otherwise. suppress_coarse_duplicate() drops the redundant
+    # coarse "pass" so aggregate_fires() does not count one emit as fires=2.
+    session_id = payload.get("session_id")
+    _fire_ledger.record_session_fire(
+        _HOOK_NAME, _ROLE, decision,
+        session_id if isinstance(session_id, str) else "", "Stop",
+    )
+    _fire_ledger.suppress_coarse_duplicate()
     return 0
 
 

--- a/hooks/completion-verify/negative-existence-verdict-gate/impl.py
+++ b/hooks/completion-verify/negative-existence-verdict-gate/impl.py
@@ -233,11 +233,14 @@ def main() -> int:
     # and forgoing it otherwise. suppress_coarse_duplicate() drops the redundant
     # coarse "pass" so aggregate_fires() does not count one emit as fires=2.
     session_id = payload.get("session_id")
-    _fire_ledger.record_session_fire(
+    if _fire_ledger.record_session_fire(
         _HOOK_NAME, _ROLE, decision,
         session_id if isinstance(session_id, str) else "", "Stop",
-    )
-    _fire_ledger.suppress_coarse_duplicate()
+    ):
+        # Suppress the coarse fallback ONLY when the rich record actually
+        # landed — else a failed rich append would drop the fire from both
+        # streams (coderabbit finding on PR #855).
+        _fire_ledger.suppress_coarse_duplicate()
     return 0
 
 

--- a/hooks/completion-verify/readonly-verify-deferral-gate/impl.py
+++ b/hooks/completion-verify/readonly-verify-deferral-gate/impl.py
@@ -367,11 +367,14 @@ def main() -> int:
     # and forgoing it otherwise. suppress_coarse_duplicate() drops the redundant
     # coarse "pass" so aggregate_fires() does not count one emit as fires=2.
     session_id = payload.get("session_id")
-    _fire_ledger.record_session_fire(
+    if _fire_ledger.record_session_fire(
         _HOOK_NAME, _ROLE, decision,
         session_id if isinstance(session_id, str) else "", "Stop",
-    )
-    _fire_ledger.suppress_coarse_duplicate()
+    ):
+        # Suppress the coarse fallback ONLY when the rich record actually
+        # landed — else a failed rich append would drop the fire from both
+        # streams (coderabbit finding on PR #855).
+        _fire_ledger.suppress_coarse_duplicate()
     return 0
 
 

--- a/hooks/completion-verify/readonly-verify-deferral-gate/impl.py
+++ b/hooks/completion-verify/readonly-verify-deferral-gate/impl.py
@@ -64,6 +64,7 @@ from _hook_io import (  # type: ignore[import-not-found]  # noqa: E402
     emit_stop_advisory,
     emit_stop_block,
 )
+import _fire_ledger  # type: ignore[import-not-found]  # noqa: E402
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
     extract_last_assistant_text,
@@ -80,6 +81,8 @@ PREFIX = "[praxis:readonly-verify-deferral-gate]"
 _BYPASS_ENV = "PRAXIS_READONLY_VERIFY_BYPASS"
 _STRICT_ENV = "PRAXIS_READONLY_VERIFY_STRICT"
 _SIGNALS_ENV = "PRAXIS_READONLY_VERIFY_SIGNALS"
+_HOOK_NAME = "readonly-verify-deferral-gate"
+_ROLE = "completion-verify"
 
 # ---------------------------------------------------------------------------
 # Signal A — read-only verification intent
@@ -353,8 +356,22 @@ def main() -> int:
 
     if os.environ.get(_STRICT_ENV, "").strip() == "1":
         emit_stop_block(ADVISORY)
+        decision = _fire_ledger.DECISION_BLOCK
     else:
         emit_stop_advisory(ADVISORY)
+        decision = _fire_ledger.DECISION_ADVISE
+    # Rich fire record (issue #847): Stop hooks signal block/advise via a stdout
+    # decision while exiting 0, so @fail_open's coarse path records only "pass".
+    # Record the real decision (one rich record per genuine emit; stop_hook_active
+    # already guards re-entrant re-fires), keeping session attribution when present
+    # and forgoing it otherwise. suppress_coarse_duplicate() drops the redundant
+    # coarse "pass" so aggregate_fires() does not count one emit as fires=2.
+    session_id = payload.get("session_id")
+    _fire_ledger.record_session_fire(
+        _HOOK_NAME, _ROLE, decision,
+        session_id if isinstance(session_id, str) else "", "Stop",
+    )
+    _fire_ledger.suppress_coarse_duplicate()
     return 0
 
 

--- a/hooks/completion-verify/runtime-state-claim-gate/impl.py
+++ b/hooks/completion-verify/runtime-state-claim-gate/impl.py
@@ -40,6 +40,7 @@ from _hook_io import (  # type: ignore[import-not-found]  # noqa: E402
     emit_stop_advisory,
     emit_stop_block,
 )
+import _fire_ledger  # type: ignore[import-not-found]  # noqa: E402
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
     extract_last_assistant_text,
@@ -50,6 +51,8 @@ from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
 _PREFIX = "[runtime-state-claim-gate]"
 _BYPASS_ENV = "PRAXIS_RUNTIME_CLAIM_BYPASS"
 _STRICT_ENV = "PRAXIS_RUNTIME_CLAIM_STRICT"
+_HOOK_NAME = "runtime-state-claim-gate"
+_ROLE = "completion-verify"
 
 # ---------------------------------------------------------------------------
 # Claim detection — a claim needs a runtime SUBJECT token and a present-state
@@ -233,8 +236,22 @@ def main() -> int:
 
     if os.environ.get(_STRICT_ENV, "").strip() == "1":
         emit_stop_block(_advisory(kinds))
+        decision = _fire_ledger.DECISION_BLOCK
     else:
         emit_stop_advisory(_advisory(kinds))
+        decision = _fire_ledger.DECISION_ADVISE
+    # Rich fire record (issue #847): Stop hooks signal block/advise via a stdout
+    # decision while exiting 0, so @fail_open's coarse path records only "pass".
+    # Record the real decision (one rich record per genuine emit; stop_hook_active
+    # already guards re-entrant re-fires), keeping session attribution when present
+    # and forgoing it otherwise. suppress_coarse_duplicate() drops the redundant
+    # coarse "pass" so aggregate_fires() does not count one emit as fires=2.
+    session_id = payload.get("session_id")
+    _fire_ledger.record_session_fire(
+        _HOOK_NAME, _ROLE, decision,
+        session_id if isinstance(session_id, str) else "", "Stop",
+    )
+    _fire_ledger.suppress_coarse_duplicate()
     return 0
 
 

--- a/hooks/completion-verify/runtime-state-claim-gate/impl.py
+++ b/hooks/completion-verify/runtime-state-claim-gate/impl.py
@@ -247,11 +247,14 @@ def main() -> int:
     # and forgoing it otherwise. suppress_coarse_duplicate() drops the redundant
     # coarse "pass" so aggregate_fires() does not count one emit as fires=2.
     session_id = payload.get("session_id")
-    _fire_ledger.record_session_fire(
+    if _fire_ledger.record_session_fire(
         _HOOK_NAME, _ROLE, decision,
         session_id if isinstance(session_id, str) else "", "Stop",
-    )
-    _fire_ledger.suppress_coarse_duplicate()
+    ):
+        # Suppress the coarse fallback ONLY when the rich record actually
+        # landed — else a failed rich append would drop the fire from both
+        # streams (coderabbit finding on PR #855).
+        _fire_ledger.suppress_coarse_duplicate()
     return 0
 
 

--- a/skills/bypass-review/bypass-review
+++ b/skills/bypass-review/bypass-review
@@ -850,14 +850,17 @@ def aggregate_fires(events: list[dict]) -> dict[str, dict]:
         row = by_hook.setdefault(hook, {
             "role": ev.get(F_FIRE_ROLE) or UNKNOWN,
             "fires": 0, "block": 0, "ask": 0, "advise": 0, "pass": 0,
-            "sessions": set(), "last_seen": "", "coarse": False,
+            "sessions": set(), "last_seen": "", "coarse": False, "rich": False,
         })
         row["fires"] += 1
         decision = ev.get(F_FIRE_DECISION)
         if decision in _FIRE_DECISIONS:
             row[decision] += 1
-        if ev.get(F_FIRE_GRANULARITY) == "coarse":
+        gran = ev.get(F_FIRE_GRANULARITY)
+        if gran == "coarse":
             row["coarse"] = True
+        elif gran == "rich":
+            row["rich"] = True
         session = ev.get(F_FIRE_SESSION)
         if isinstance(session, str) and session:
             row["sessions"].add(session)
@@ -1607,13 +1610,16 @@ def render_fire_report(
     today = datetime.now(tz=timezone.utc).date()
     since = today - timedelta(days=days - 1)
 
-    coarse_count = sum(1 for r in by_hook.values() if r.get("coarse"))
+    coarse_count = sum(1 for r in by_hook.values() if r.get("coarse") and not r.get("rich"))
+    mixed_count = sum(1 for r in by_hook.values() if r.get("coarse") and r.get("rich"))
     lines.append(_render_header("bypass-review: Hook Fire-Rate Report (issue #710)"))
     lines.append(f"  Period : {since} → {today} (last {days} day{'s' if days != 1 else ''})")
     lines.append(f"  Source : {telemetry_dir}")
-    lines.append(f"  Hooks fired : {len(by_hook)}  ({coarse_count} coarse)")
+    lines.append(f"  Hooks fired : {len(by_hook)}  ({coarse_count} coarse, {mixed_count} mixed)")
     lines.append("  Scope  : Bash dispatch group = rich (block/ask/advise/pass);")
-    lines.append("           other @fail_open hooks = coarse (block/pass only)")
+    lines.append("           other @fail_open hooks = coarse (block/pass only);")
+    lines.append("           single-event-rich Stop hooks = mixed (rich escalations")
+    lines.append("           + coarse passes)")
 
     if not by_hook:
         # Empty window: nothing fired. Intentionally NOT listing the whole roster
@@ -1634,7 +1640,12 @@ def render_fire_report(
     for hook in sorted(by_hook, key=lambda h: by_hook[h]["fires"], reverse=True):
         r = by_hook[hook]
         last_seen = (r["last_seen"] or "")[:10] or "(unknown)"
-        g = "C" if r.get("coarse") else "R"
+        if r.get("coarse") and r.get("rich"):
+            g = "M"
+        elif r.get("coarse"):
+            g = "C"
+        else:
+            g = "R"
         lines.append(
             f"  {hook:<{col}}  {g:>1}  {r['fires']:>5}  {r['block']:>5}  {r['ask']:>4}  "
             f"{r['advise']:>6}  {r['pass']:>5}  {len(r['sessions']):>4}  {last_seen}"
@@ -1647,7 +1658,11 @@ def render_fire_report(
         "     `decision` field while exiting 0 — those blocks are invisible here\n"
         "     and fold into Pass (so coarse Block is a lower bound). ask/advise\n"
         "     also fold into Pass; session id is absent. A coarse 'Fires' count\n"
-        "     ≈ how often the hook's matcher matched, not how often it engaged."
+        "     ≈ how often the hook's matcher matched, not how often it engaged.\n"
+        "     M=mixed (single-event-rich Stop hook, issue #847): escalations\n"
+        "     (Block/Advise) are recorded rich with the real decision; silent\n"
+        "     passes stay coarse. So Block/Advise here are exact, but Pass is the\n"
+        "     coarse matcher-match count, and 'Fires' sums both granularities."
     )
 
     # ── issue #710 remaining scope: advise_ignored_rate / bypass_count / outcome-proxy ──

--- a/skills/bypass-review/bypass-review
+++ b/skills/bypass-review/bypass-review
@@ -886,10 +886,23 @@ def aggregate_fires(events: list[dict]) -> dict[str, dict]:
 # denominator, not silently counted either way.
 # ---------------------------------------------------------------------------
 
-def compute_advise_ignored(fire_events: list[dict]) -> dict[str, dict]:
+def compute_advise_ignored(
+    fire_events: list[dict], full_rich_hooks: set[str] | None = None
+) -> dict[str, dict]:
     """Return dict[hook] -> {advise_fires, observed, ignored, rate}.
 
     `rate` is `ignored / observed`, or None when `observed == 0`.
+
+    `full_rich_hooks` scopes the calculation to hooks whose ENTIRE decision
+    stream (including silent `pass`) is recorded at rich granularity — the
+    PreToolUse(Bash) dispatch group (see `bash_group_roster`). The "next
+    decision == pass ⇒ heeded" inference at the core of this metric is only
+    sound when passes are observable in the rich stream. Single-event-rich
+    Stop hooks (issue #847: they call `record_session_fire` only when they
+    escalate; a silent pass stays a coarse, session_id-less record) would
+    otherwise show a run of `advise, advise, …` with the intervening heeded
+    passes invisible, mis-scoring them as ignored=100%. When `None` (roster
+    unreadable), fall back to the unscoped legacy behavior.
     """
     by_session_hook: dict[tuple[str, str], list[dict]] = {}
     for ev in fire_events:
@@ -897,6 +910,8 @@ def compute_advise_ignored(fire_events: list[dict]) -> dict[str, dict]:
         sid = ev.get(F_FIRE_SESSION)
         if not (isinstance(hook, str) and hook and isinstance(sid, str) and sid):
             continue
+        if full_rich_hooks is not None and hook not in full_rich_hooks:
+            continue  # partial rich stream — pass is not observable, skip
         by_session_hook.setdefault((sid, hook), []).append(ev)
 
     result: dict[str, dict] = {}
@@ -1697,7 +1712,10 @@ def run_fire_rate(args: argparse.Namespace, telemetry_dir: Path) -> int:
     # ~/.praxis/telemetry by default — see hooks/_lib/_fire_ledger.py and
     # hooks/postuse-correction/bypass-telemetry/impl.py resolve_*_path()).
     bypass_events = load_events(telemetry_dir, args.days)
-    advise_ignored = compute_advise_ignored(events)
+    # Scope advise-ignored to full-rich hooks: single-event-rich Stop hooks
+    # (issue #847) record only escalations, so their silent passes are invisible
+    # and the "next == pass ⇒ heeded" inference would mis-score them.
+    advise_ignored = compute_advise_ignored(events, bash_group_roster(manifest_path))
     exact_map = bypass_env_exact_map(manifest_path)
     bypass_join = join_bypass_to_hooks(events, bypass_events, exact_map=exact_map)
     state_dir = Path(args.state_dir) if args.state_dir else default_strike_state_dir()

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -313,6 +313,37 @@ def test_record_session_fire_non_string_session_and_tool_default_empty(tmp_path,
     assert rec["session_id"] == "" and rec["tool"] == ""
 
 
+def test_record_session_fire_returns_true_on_success(tmp_path, monkeypatch):
+    """Callers gate coarse suppression on this return (coderabbit finding on
+    PR #855): a successful rich append reports True."""
+    out = tmp_path / "fire.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    assert fl.record_session_fire("h", "r", "advise", "s1", "Stop") is True
+
+
+def test_record_session_fire_returns_false_when_disabled(tmp_path, monkeypatch):
+    out = tmp_path / "fire.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_DISABLE", "1")
+    assert fl.record_session_fire("h", "r", "advise", "s1", "Stop") is False
+
+
+def test_record_session_fire_returns_false_on_write_error(tmp_path, monkeypatch):
+    """A swallowed write failure must report False so the caller keeps its
+    coarse fallback instead of suppressing it — else the fire is dropped from
+    both streams."""
+    out = tmp_path / "fire.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+
+    def _boom(*_a, **_k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(fl, "_atomic_append", _boom)
+    assert fl.record_session_fire("h", "r", "advise", "s1", "Stop") is False
+
+
 # ---------------------------------------------------------------------------
 # Reader: count_session_fires (issue #805 — in-session read path for a preflight
 # gate to consume its own repeated-block signal)
@@ -577,6 +608,28 @@ def test_aggregate_marks_coarse_hooks():
     agg = cli.aggregate_fires(events)
     assert agg["c"]["coarse"] is True
     assert agg["r"]["coarse"] is False
+
+
+def test_aggregate_marks_mixed_granularity_stop_hook():
+    """issue #847: a single-event-rich Stop hook records its escalation rich
+    (real Block/Advise) but its silent passes stay coarse — the row carries
+    BOTH flags and must render as G=M, not G=C (which the legend says folds
+    Block into Pass, contradicting a visible Block=1)."""
+    events = [
+        {"hook": "merge-state-claim-gate", "role": "completion-verify", "decision": "block",
+         "granularity": "rich", "session_id": "s1", "timestamp": "2026-06-26T01:00:00+00:00"},
+        {"hook": "merge-state-claim-gate", "role": "completion-verify", "decision": "pass",
+         "granularity": "coarse", "session_id": "", "timestamp": "2026-06-26T01:00:10+00:00"},
+    ]
+    agg = cli.aggregate_fires(events)
+    assert agg["merge-state-claim-gate"]["coarse"] is True
+    assert agg["merge-state-claim-gate"]["rich"] is True
+    assert agg["merge-state-claim-gate"]["block"] == 1
+
+    report = cli.render_fire_report(agg, 30, Path("/tmp"), None)
+    # The row's G column is M (mixed), and the summary/legend name it.
+    assert "1 mixed" in report
+    assert "M=mixed" in report
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -654,6 +654,32 @@ def test_advise_ignored_pass_after_advise_is_heeded_not_ignored():
     assert row["rate"] == 0.0
 
 
+def test_advise_ignored_excludes_partial_rich_stop_hook_when_scoped():
+    """issue #847: a single-event-rich Stop hook records only escalations —
+    its silent passes never reach the rich stream, so advise, advise (the
+    intervening heeded pass invisible) would mis-score as ignored=100%. When a
+    full-rich roster is supplied, the partial-stream hook is excluded entirely
+    while a genuine full-rich hook is still scored."""
+    events = [
+        # partial-rich Stop hook: two advises, the heeded pass between them is
+        # never recorded rich, so leaving it in would read as ignored.
+        {"hook": "merge-state-claim-gate", "session_id": "s1", "decision": "advise", "timestamp": "2026-06-26T00:00:00+00:00"},
+        {"hook": "merge-state-claim-gate", "session_id": "s1", "decision": "advise", "timestamp": "2026-06-26T00:00:20+00:00"},
+        # full-rich Bash-group hook: advise then pass (heeded) — still scored.
+        {"hook": "destructive-bash-guard", "session_id": "s1", "decision": "advise", "timestamp": "2026-06-26T00:00:00+00:00"},
+        {"hook": "destructive-bash-guard", "session_id": "s1", "decision": "pass", "timestamp": "2026-06-26T00:00:10+00:00"},
+    ]
+    scoped = cli.compute_advise_ignored(events, {"destructive-bash-guard"})
+    assert "merge-state-claim-gate" not in scoped  # partial stream — excluded
+    assert scoped["destructive-bash-guard"]["observed"] == 1
+    assert scoped["destructive-bash-guard"]["ignored"] == 0  # pass = heeded
+
+    # None (roster unreadable) falls back to legacy unscoped behavior — the
+    # partial-rich hook reappears and its advise, advise reads as ignored.
+    legacy = cli.compute_advise_ignored(events)
+    assert legacy["merge-state-claim-gate"]["ignored"] == 1
+
+
 # ---------------------------------------------------------------------------
 # issue #710 remaining scope: bypass_count join
 # ---------------------------------------------------------------------------
@@ -1223,19 +1249,22 @@ def test_fire_rate_report_includes_remaining_scope_sections(tmp_path, monkeypatc
     monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
 
     # Two dispatches of the same hook in the same session: advise then advise
-    # again (ignored), via the real writer.
-    members = [("advisory-nudge", "protected-paths-guard", Path("x"))]
-    fl.record_group_fires(members, [(0, "", "nudge")], _payload("s1", "Write"))
-    fl.record_group_fires(members, [(0, "", "nudge")], _payload("s1", "Write"))
+    # again (ignored), via the real writer. Uses a genuine PreToolUse(Bash)
+    # group hook so it survives the advise-ignored roster scoping (issue #847):
+    # single-event-rich Stop hooks are excluded because their passes are not
+    # rich, so the fixture must be a full-rich Bash-group hook.
+    members = [("preflight-gate", "destructive-bash-guard", Path("x"))]
+    fl.record_group_fires(members, [(0, "", "advise")], _payload("s1", "Bash"))
+    fl.record_group_fires(members, [(0, "", "advise")], _payload("s1", "Bash"))
 
     # bypass-events file uses the real writer's own field schema (session_id,
     # tool, bypass_env_vars, tool_input, tool_result_status).
     bypass_record = {
         "timestamp": datetime.now(tz=timezone.utc).isoformat(),
         "session_id": "s1",
-        "tool": "Write",
-        "bypass_env_vars": ["PRAXIS_HOOK_BYPASS_PROTECTED_PATHS"],
-        "tool_input": "echo hi",
+        "tool": "Bash",
+        "bypass_env_vars": ["PRAXIS_HOOK_BYPASS_DESTRUCTIVE_BASH"],
+        "tool_input": "rm -rf x",
         "tool_result_status": "ok",
     }
     bypass_out.write_text(json.dumps(bypass_record) + "\n")
@@ -1252,7 +1281,7 @@ def test_fire_rate_report_includes_remaining_scope_sections(tmp_path, monkeypatc
 
     assert rc == 0
     assert "Advise-Ignored Detail" in report
-    assert "protected-paths-guard" in report
+    assert "destructive-bash-guard" in report
     assert "100%" in report  # both advise fires ignored (no escalation)
     assert "Bypass Attribution" in report
     assert "Outcome Proxy" in report


### PR DESCRIPTION
## 배경

5개 completion-verify Stop 훅은 stdout JSON `decision` 으로 차단/권고하면서 **exit
code 는 0** 이라, coarse 계측 경로(`_hook_runtime.fail_open`, 반환 코드만 관측)가
모든 fire 를 `"pass"` 로 기록했다. Stop 층은 구조적으로 non-pass 0건이 되어
`docs/hook-prune-audit.md` (#713) 의 keep/drop 판정에서 prune 후보로 오분류됐다.

## 변경

각 훅의 emit 지점에서 `record_session_fire` 로 실제 decision(strict env → `block`,
else `advise`)을 rich 레코드로 기록하고, 곧바로 `suppress_coarse_duplicate()` 로
중복 coarse `"pass"` 를 억제한다.

| 훅 | decision |
|---|---|
| `completion-signal-gate` | advise 전용 |
| `merge-state-claim-gate` | strict → block, else advise |
| `negative-existence-verdict-gate` | 기본 block, opt-out → advise |
| `runtime-state-claim-gate` | strict → block, else advise |
| `readonly-verify-deferral-gate` | strict → block, else advise |

설계 포인트 (codex round-1 리뷰 반영):
- **coarse 중복 억제** — `aggregate_fires` 는 granularity 무관 합산이라, 억제 없이는
  1 emit 이 `fires=2, block=1, pass=1` 로 왜곡됨 (`suppress_coarse_duplicate`, #787).
- **세션-dedup 미적용** — emit 마다 rich 레코드 1건 (coarse 카디널리티와 일치).
  재진입 중복은 각 훅의 `stop_hook_active` early-return 이 이미 차단하므로, 별개 turn
  의 실제 재발 위반이 collapse 되지 않음.
- **session_id 부재 시에도 기록** — attribution 만 포기(`""` 정규화), decision 은
  유지 → id 없다고 blind spot 재현하지 않음.

`_fire_ledger.py` COVERAGE docstring 에 STOP-LANE BLOCK RECOVERY 문단, 그리고
`docs/hook-prune-audit.md` Axis 4 에 해석 주의 문구를 추가했다.

**advise-ignored 스코핑 (codex round-2):** 이 훅들은 escalation 만 rich 로 기록하고
silent pass 는 coarse(session_id 없음)로 남으므로, `compute_advise_ignored` 의
"next == pass ⇒ heeded" 추론이 성립하지 않는다 (중간 heeded pass 가 안 보여
advise→advise 가 ignored=100% 로 오집계). `compute_advise_ignored` 를
`bash_group_roster`(full block/ask/advise/pass rich 집합)로 스코프 제한해 이
partial-stream 훅들을 제외한다. `aggregate_fires`(fire-count) 는 계속 포함.

## 검증

- `./scripts/run-tests.sh` green (ALL TESTS PASSED)
- Canary (mutation 0, 격리 `PRAXIS_FIRE_TELEMETRY_FILE`): 12/12 PASS
  - 5개 훅 × (advise/block) 9 케이스 rich decision 정확
  - F1: 5개 훅 coarse 중복 0건 (suppress 동작)
  - F2: 같은 세션 2회 engagement 둘 다 기록 (dedup 제거)
  - F3: session_id 부재 시에도 rich decision 기록
- fire_ledger 88 tests green (advise-ignored 스코핑 테스트 + e2e 실제 full-rich 훅으로 교정 포함)
Pre-commit verified: ./scripts/run-tests.sh → ALL TESTS PASSED; canary 12/12 PASS

Caller chain verified: grep confirmed aggregate_fires (skills/bypass-review/bypass-review:855) sums both granularities; suppress_coarse_duplicate / record_session_fire / stop_hook_active consumers read directly

## 한계

라이브 Stop block 은 실제 세션 동작이라 단위 테스트로는 mechanism-reproduction
까지만 가능하다. artifact 검증은 canary 로 대체한다.

## 후속 (별도, 이 PR 범위 밖)

`pr-report-destination-gate` 는 rich 기록 후 `suppress_coarse_duplicate()` 를 호출하지
않아 동일한 coarse-중복 왜곡이 잠재한다 (단, 그 훅의 세션-dedup 은 emit 자체를
gate 하는 의도적 설계). SRP 상 이 PR 에 번들하지 않음.

Closes #847
