### PR TITLE
feat(codex-review-wrap): per-finding approval gate

### DIFF
--- a/RUNTIME_CONSTRAINTS.md
+++ b/RUNTIME_CONSTRAINTS.md
@@ -38,6 +38,18 @@ user that the list was truncated.
 failure: `codex-review-wrap` Step 2 attempted to surface all 8 active worktrees
 as options, which is impossible per the `maxItems: 4` JSON schema constraint.
 
+### 1a. `AskUserQuestion.questions` — same hard cap of 4 items
+
+**Constraint**: the `questions` array carries its own `minItems: 1` /
+`maxItems: 4`. A step that needs a decision on more than 4 items must issue
+consecutive calls of at most 4 questions each, not one large call.
+
+**Verified**: 2026-07-26 / Claude Code (Opus 5) / Issue #861 — a 4-question
+call (each with 3 explicit options plus the runtime's automatic `Other` slot)
+round-tripped successfully and returned all four answers keyed by question
+text; `codex-review-wrap` Step 5i batches its per-finding approval questions
+against this cap.
+
 ---
 
 ## 2. `Skill(...)` cannot invoke a skill that declares `disable-model-invocation: true`

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -11,16 +11,18 @@ description: >
   in the session ledger. Step 5f tracks rounds-per-region and surfaces a non-blocking
   diminishing-returns advisory when the same file:region accumulates more than N rounds
   (default 4, configurable via PRAXIS_DIMINISHING_RETURNS_N).
+  Step 5i asks the user, per finding, whether to apply it — no finding is edited
+  on the agent's judgement alone.
   At phase end it reaps leaked openai-codex app-server brokers via a co-located
   idle-gated reaper (GC by default; opt-in running-broker kill via
   PRAXIS_CODEX_REAP=1) to prevent the kernel_task memory-pressure spike caused
   by brokers that outlive their owning session.
   Triggers on "codex review", "review codex", "safe review", "/codex-review-wrap",
   "premise verification", "flip detection", "sibling defect", "sibling cross-check",
-  "diminishing returns", "broker reap".
+  "diminishing returns", "broker reap", "finding approval", "적용 승인".
 verified-against-runtime: true
-runtime-verified-at: 2026-05-13
-runtime-verified-note: "codex-companion 1.0.4 — ARGUMENTS rejected for non-flag string; AskUserQuestion maxItems:4 blocks worktree list >3 items; Skill() cannot delegate to disable-model-invocation skill. Step 4 hardened to a MUST NOT directive in issue #237 (2026-05-16) — directive-only change, no new runtime claim. Step 5f (PR #329) adds procedural prose only (rounds_per_region ledger + advisory text); no runtime hook code changed — existing verification evidence remains valid. Step 6 (issue #683) adds codex-broker-reaper.sh; idle-gate functionally verified 2026-06-18 via synthetic broker — fresh-log SKIP, stale-log REAP, concurrent real brokers untouched (scanned=3 reaped=1 skipped=2)."
+runtime-verified-at: 2026-07-26
+runtime-verified-note: "codex-companion 1.0.4 — ARGUMENTS rejected for non-flag string; AskUserQuestion maxItems:4 blocks worktree list >3 items; Skill() cannot delegate to disable-model-invocation skill. Step 4 hardened to a MUST NOT directive in issue #237 (2026-05-16) — directive-only change, no new runtime claim. Step 5f (PR #329) adds procedural prose only (rounds_per_region ledger + advisory text); no runtime hook code changed — existing verification evidence remains valid. Step 6 (issue #683) adds codex-broker-reaper.sh; idle-gate functionally verified 2026-06-18 via synthetic broker — fresh-log SKIP, stale-log REAP, concurrent real brokers untouched (scanned=3 reaped=1 skipped=2). Step 5i (issue #861) verified 2026-07-26 against the live AskUserQuestion runtime — 3-question and 4-question calls, each question carrying 3 explicit options, round-tripped and returned every answer keyed by question text; the runtime appended its own Other slot, confirming both the 4-question batch size and the 적용/미적용/후속이슈 shape against the 4-option cap (RUNTIME_CONSTRAINTS.md §1a)."
 ---
 
 # codex-review-wrap
@@ -46,7 +48,10 @@ sibling PR or repo, Step 5d additionally cross-checks each verified finding
 against the sibling and records the result. Step 5f tracks how many rounds
 have touched each `{file}:{region}` pair and emits a one-time non-blocking
 advisory when the count exceeds the configured threshold (default: 4 rounds,
-env var `PRAXIS_DIMINISHING_RETURNS_N`).
+env var `PRAXIS_DIMINISHING_RETURNS_N`). Step 5i then puts every finding
+that survived 5b and 5c — fact-modifying, structural, or stylistic — in
+front of the user via `AskUserQuestion` before any edit lands: the agent's
+verdict is a recommendation, the user's answer is the decision.
 See **Step 5** for the full gate.
 
 A third responsibility runs at phase end: **Step 6** reaps openai-codex
@@ -216,6 +221,11 @@ add commentary. This matches `/codex:review`'s contract.
 
 If `{{ARGUMENTS}}` includes `--background`, run via `Bash(..., run_in_background: true)`
 and tell the user: "Codex review started in the background. Check `/codex:status` for progress."
+Backgrounding defers Step 5, it does not skip it: when the run completes,
+collect its findings in this same session and enter Step 5 from the top
+(interactivity check → 5f → …). A background review whose findings never
+reach 5i has produced no applicable result — never apply its findings from
+the completion notification alone.
 
 ### Step 5: Apply Findings — Premise Verification Gate
 
@@ -237,27 +247,43 @@ session, not just the first. Terminology used below:
 Sub-sections below are numbered for cross-reference, not execution order.
 The execution order each round is:
 
+0. **Interactivity check** — if the run cannot reach a user
+   (`claude -p`, background worker, any context where `AskUserQuestion` has
+   no recipient), skip every question step (5d-i and 5i) and take the
+   non-interactive path in *Error Handling*: classify and verify findings
+   (5a–5c) but apply nothing, deferring the survivors. Doing this first is
+   what keeps the unconditional 5d-i question from stalling the round before
+   classification happens.
 1. **5f counter update + advisory check** — increment `rounds_per_region:`
    ledger for each region touched; emit the diminishing-returns advisory if
    `cumulative = N + 1`.
 2. **5d-i sibling-identification question** — `AskUserQuestion` to confirm
-   whether the PR is a port / parallel hotfix / A/B implementation.
+   whether the PR is a port / parallel hotfix / A/B implementation
+   (interactive runs only, per step 0).
 3. **5a classify findings** — fact-modifying vs structural vs stylistic.
 4. **5b verify premises** — falsify each fact-modifying finding's premise
    before applying.
 5. **5c flip detection during apply** — scan ledger for `applied:` /
    `rejected:` collisions before each edit.
-6. **5d-ii / 5d-iii sibling cross-check + propose** — only when 5d-i
-   identified a sibling.
-7. **5e commit-message trailer** — `Premise-Verified:` trailer on the
-   committed edit.
-8. **5g critic pre-lock probe check** — before any critic finding that
+6. **5g critic pre-lock probe check** — before any critic finding that
    contains a negative claim is surfaced to the user, verify the claim
-   with a live probe and cite it inline.
-9. **5h parent-truncates-child SoT audit** — after all findings are
-   applied, scan the parent doc for inline transcriptions of sibling
-   SoT enumerations and emit synthesized findings for any truncation
-   detected.
+   with a live probe and cite it inline. Runs **before** 5i, because 5i
+   surfaces every finding — including structural and stylistic ones,
+   whose 5i question body is allowed to carry `Probe: n/a`.
+7. **5i per-finding user approval gate** — ask the user, in batches of 4,
+   whether to apply each finding; edits are applied only for `적용`
+   answers. Runs **after** classification/verification/flip-scan/probe
+   check (so the question carries evidence) and **before** the first edit
+   of the round.
+8. **5d-ii / 5d-iii sibling cross-check + propose** — only when 5d-i
+   identified a sibling.
+9. **5e commit-message trailer** — `Premise-Verified:` trailer on the
+   committed fact-modifying edit.
+10. **5h parent-truncates-child SoT audit** — after all approved findings
+    are applied, scan the parent doc for inline transcriptions of sibling
+    SoT enumerations and emit synthesized findings for any truncation
+    detected. Synthesized findings re-enter 5g and 5i as their own
+    approval batch before their edits are applied.
 
 #### 5a. Classify each finding
 
@@ -308,22 +334,23 @@ global `~/.claude/CLAUDE.md` "External-Surface Write Requires Falsification".
 #### 5c. Flip detection — halt A→B→A oscillation
 
 Maintain a per-session ledger across all rounds in the same session.
-The ledger has **four record shapes** — `applied`/`rejected` (flip
+The ledger has **five record shapes** — `applied`/`rejected` (flip
 detection input), `sibling-applied` (Step 5d cross-check),
-`rounds_per_region` (Step 5f diminishing-returns) — all must be tracked
-because a finding rejected in round N can re-appear in round N+M and
-would otherwise look novel:
+`rounds_per_region` (Step 5f diminishing-returns), `deferred` (Step 5i
+follow-up issue) — all must be tracked because a finding rejected in
+round N can re-appear in round N+M and would otherwise look novel:
 
 ```
 applied:          {file}:{line-or-region} | round={N} | {value-before} → {value-after}
 rejected:         {file}:{line-or-region} | round={N} | {value-before} → {value-after} | reason: {falsifying evidence}
 sibling-applied:  {sibling-repo}#{PR-or-branch} | round={N} | finding={brief-label} | result={same defect | different | does not apply}
 rounds_per_region: {file}:{region} | round={N} | cumulative={C}
+deferred:         {file}:{line-or-region} | round={N} | finding={brief-label} | issue={URL or "pending"}
 ```
 
 Before applying any new edit, scan records whose prefix token is exactly
-**`applied:`** or **`rejected:`** (NOT `sibling-applied:` or
-`rounds_per_region:`) in the ledger.
+**`applied:`** or **`rejected:`** (NOT `sibling-applied:`,
+`rounds_per_region:`, or `deferred:`) in the ledger.
 A flip fires when:
 
 1. **Applied flip** — the new edit would revert a previously-applied
@@ -340,6 +367,20 @@ In either case, STOP and surface to the user:
    Round N+M now suggests:     {B} → {A}    (or same A → B for re-proposal)
 Both findings cannot be simultaneously correct.
 Resolve before applying further edits.
+```
+
+**Evidence rejection vs user decision.** A `rejected:` row whose reason
+starts with `user:` (written by 5i for a `미적용` / `후속이슈` answer) records
+a *decision*, not a disproved premise — the finding may well be correct. When
+the colliding row is one of those, do not claim a factual contradiction; use
+this message instead:
+
+```
+⚠ Re-proposal of a user-declined finding: {file}:{region}
+   Round N: user chose {미적용|후속이슈} — {A} → {B}
+   Round N+M proposes the same change again.
+Confirm before re-applying; the earlier answer was a decision, not a
+disproved premise.
 ```
 
 Do not apply either side of a flip without explicit user direction. The
@@ -677,8 +718,9 @@ enumeration is a systematic failure mode that round-by-round external review
 catches one missing row at a time. This step collapses that N-round sequence
 into a single pre-merge sweep.
 
-Run this step **once per invocation, after all Codex findings have been
-applied (after 5g)**, before the reviewer session ends.
+Run this step **once per invocation, after every approved finding has been
+applied** — findings the user left at `미적용` or `후속이슈` do not hold it
+back — before the reviewer session ends.
 
 ##### Trigger — does the parent doc cite a sibling SoT?
 
@@ -738,7 +780,8 @@ The synthesized finding is treated as a **structural** finding (not
 fact-modifying): it describes an omission in documentation, not a runtime
 predicate. Apply Step 5a classification accordingly — it does not require a
 premise check via 5b, but **does** flow through the normal apply/commit cycle
-(5c flip detection, 5e trailer if the edit is structural-significant).
+(5c flip detection, 5i approval). Being structural, it takes no
+`Premise-Verified:` trailer — 5e is the single rule for trailer scope.
 
 ##### Unresolved advisory (sibling SoT not locatable)
 
@@ -783,6 +826,134 @@ The SoT audit is distinct from the per-finding premise verification in 5b:
 
 The two steps are complementary: 5b prevents bad fixes; 5h prevents missed
 enumerations from reaching the next reviewer.
+
+#### 5i. Per-finding user approval gate <!-- [#861] -->
+
+Steps 5a–5c decide whether a finding is *correct*. Whether it should be
+applied **in this PR, now** is a separate judgement that belongs to the
+user. This sub-step surfaces that decision explicitly.
+
+**No finding may be edited on the agent's judgement alone.**
+There is no auto-apply path — not for stylistic findings, not for
+"obviously right" one-liners, not for findings the agent already verified
+in 5b. Applying an edit without a recorded `적용` answer is a violation of
+this gate, and the briefing-style disclosure ("I applied these, tell me if
+wrong") is not a substitute for asking first.
+
+##### Scope and ordering
+
+The gate covers **every finding of the round that survives 5b and 5c**:
+fact-modifying, structural, and stylistic alike, plus any finding
+synthesized by 5h. A finding whose premise 5b actively disproved is **not**
+offered as an `적용` option — applying a value already shown to be false is
+never a decision worth surfacing. Report those in one line instead
+("N findings rejected on evidence: …") so the user still sees them.
+Present the surviving findings in a deterministic order so the same round
+always produces the same question sequence:
+
+1. fact-modifying findings (5a row 1)
+2. structural findings (5a row 2)
+3. stylistic findings (5a row 3)
+
+Ties inside a group keep Codex's own output order. Findings already halted
+by 5c flip detection are **not** put through the gate in that state — a flip
+is surfaced on its own per 5c first. Once the user resolves it, the surviving
+side re-enters 5i as a normal finding and needs its own `적용` answer before
+it is edited; the flip-resolution direction is not itself that answer.
+
+If the round produced zero applicable findings, skip 5i entirely and say so
+in one line.
+
+##### Batching
+
+On the Claude host, `AskUserQuestion` accepts at most **4 questions per
+call** and **4 options per question** (see `RUNTIME_CONSTRAINTS.md` §1 and
+§1a). Emit one question per finding, **4 findings per call**, and repeat the
+call until every finding has an answer. Do not compress two findings into
+one question — a single answer cannot carry two decisions.
+
+`skills/` ships to other hosts too (see `manifests/platforms/` and
+`plugins/praxis/.codex-plugin/plugin.json`), and their ask-user tools have
+their own caps. Batch against **the cap of the host actually running** —
+read it from that host's tool schema rather than assuming 4 — and never
+above 4. If the running host exposes **no callable ask-user tool at all**
+(or the one it has is unavailable in the current mode), the run counts as
+non-interactive: take the step-0 path — verify, apply nothing, defer the
+survivors — rather than applying findings without a recorded answer.
+
+Each question's `question` text must start with a stable finding ID
+(`F1`, `F2`, …). Answers come back keyed by question text, so two duplicate
+findings on the same `{file}:{region}` with the same transition would
+otherwise collide on one key and share (or overwrite) a single answer.
+
+##### Question body — required elements
+
+Each question body must let the user decide without re-reading the diff:
+
+```
+{file}:{region}
+변경: {value-before} → {value-after}
+판정: {apply | reject} — {one-line reason}
+Probe: {command} → {one-line output}
+flip: none
+```
+
+- `Probe:` carries the 5b verification evidence verbatim. `Probe: n/a
+  (structural)` / `Probe: n/a (stylistic)` is allowed **only** when the
+  finding is not fact-modifying **and** carries no 5g negative claim; a
+  structural finding that asserts "symbol X is unused / does not exist"
+  still carries its 5g probe output here. The line is never omitted.
+- `flip:` reports the 5c scan result for that region (`none`, or the
+  colliding ledger row).
+- When the agent's verdict option is labelled `(Recommended)`, a line
+  starting at column 0 with the literal prefix `Falsified:` must carry the
+  disconfirming-test result — either in the question body or in that
+  option's `description` (global CLAUDE.md → *Self-Falsify Before
+  Recommendation Lock*; enforced by
+  `hooks/advisory-nudge/output-block-falsify-advisory/impl.py`, which does a
+  `startswith` check, so a mid-sentence or fenced `Falsified:` does not
+  count). The 5b probe usually supplies that line; when it does not, run one
+  and cite it.
+
+##### Options
+
+Exactly three options, plus the runtime's automatic `Other` slot:
+
+| Option | Action |
+| --- | --- |
+| `적용` | Apply the edit → ledger `applied:` row → 5e `Premise-Verified:` trailer **if the edit is fact-modifying** (structural and stylistic edits take no trailer, per 5e) |
+| `미적용` | Do not edit → ledger `rejected: … \| reason: user: declined (round N)` |
+| `후속이슈` | Do not edit → ledger `rejected: … \| reason: user: deferred to follow-up` **and** a `deferred:` row |
+| `Other` (free text) | If the instruction is a plain decline or defer, record the matching row above. If it proposes a **different** edit than the finding did, that is a new proposal: re-run 5a classification, 5b premise verification, and the 5c flip scan on it, then ask again — an `Other` answer is never itself an `적용` answer for the modified edit |
+
+Put the agent's recommended option first and mark it `(Recommended)`.
+
+Both `미적용` and `후속이슈` write a `rejected:` row with a `user:` reason
+prefix, so a finding the user declined in round N still fires 5c if Codex
+re-proposes the same transition in round N+M — but 5c reports it as a
+re-proposal of a *decision*, not as a factual contradiction (see 5c →
+*Evidence rejection vs user decision*).
+
+##### Follow-up issues (`후속이슈` answers)
+
+Do **not** create an issue per answer. Collect all `후속이슈` findings of the
+round and, once the batch is complete, surface a single implementation-approach
+review — scope, target repo(s), expected PR count, verification plan — and
+create issues only after the user approves that approach (global CLAUDE.md →
+*Implementation-approach review BEFORE issue creation*). Append the resulting
+URL to each `deferred:` row; leave `issue=pending` if the user declines.
+
+##### Relationship to 5d-iii (sibling PRs)
+
+An `적용` answer authorizes the edit **on the current PR only**. The sibling
+fix in 5d-iii keeps its own separate approval — approval never transfers
+across PRs.
+
+##### Cancellation
+
+If the user cancels a batch or gives no answer, stop applying findings for
+the round. Report which findings were already applied, which remain
+undecided, and end the round without further edits.
 
 ### Step 6: Reap leaked codex brokers (phase end)
 
@@ -842,6 +1013,10 @@ keeps the count below the compressor threshold.
 | Region label cannot be determined (binary file, empty file) | Use the file path alone as the region label |
 | Critic negative claim emitted without `Probe:` citation (5g) | Halt the finding; prompt the critic to re-run with probe citation before surfacing |
 | Probe command for 5g returns unexpected output or exits with an error code that signals a command failure (e.g. exit=2 "command not found", permission denied) — distinct from `grep` exit=1 (no match), which is the expected signal for verified absence | Surface probe failure to the user; do not auto-retract the claim — let the user decide |
+| Approval gate (5i) — user cancels a batch or gives no answer | Stop applying for the round; report applied / undecided findings; no further edits |
+| Approval gate (5i) — round produced zero applicable findings | Skip 5i; state "no findings to approve" in one line |
+| Approval gate (5i) — user declines the follow-up issue approach review | Keep the `deferred:` rows with `issue=pending`; create nothing |
+| Approval gate (5i) — non-interactive run (`claude -p`, background) where `AskUserQuestion` cannot reach a user | Apply nothing; record every finding that survived 5b/5c as `deferred:` (evidence-rejected and flip-halted findings stay out, same as the interactive path) and report the full list for a later interactive round |
 | SoT audit (5h) — sibling document not locatable | Emit unresolved advisory; do not block review completion |
 | SoT audit (5h) — parent citation site ambiguous (multiple tables at same heading) | Use all tables at the heading as candidate SoT sources; report each comparison separately |
 | Reaper (Step 6) — running broker has no readable `broker.log` | Idle is indeterminate → broker is KEPT (logged as `SKIP ... no logFile`); never reaped on a guess |
@@ -880,14 +1055,40 @@ user selects: 1
   → sibling identified: praxis#199 on branch issue-199-hook-shell
 
 [Step 5 — Round 1 — classify + verify (5a → 5b)] Codex returned 3 findings:
-  - F1: rename `query()` → `run_query()`           [structural — apply directly]
+  - F1: rename `query()` → `run_query()`           [structural — no premise check, still gated by 5i]
   - F2: change WHERE col_a = 1 → col_b = 1         [fact-modifying — verify column exists]
   - F3: drop the `--state all` flag                [fact-modifying — verify CLI accepts the value]
   Verify F2: DESCRIBE my_table → col_b not present
     → ledger: rejected: query.sql:L42 | round=1 | col_a → col_b | reason: col_b absent in DESCRIBE
+    (evidence-rejected → not put through the 5i gate)
   Verify F3: gh search issues --help → --state accepts only {open, closed}
-    → apply; ledger: applied: cli.sh:L10 | round=1 | "--state all" → "--state open"
+
+[Step 5i — approval gate] 2 findings survive to the gate (F3 fact-modifying, F1 structural)
+  1 finding rejected on evidence: F2 (col_b absent) — reported, not offered as 적용
+  AskUserQuestion (1 call, 2 questions):
+    Q1 "F3 — cli.sh:L10 --state 값 수정"   (question text starts with the finding ID)
+       body: cli.sh:parse_prompt
+             변경: "--state all" → "--state open"
+             판정: apply — 현재 값은 CLI 가 거부함
+             Probe: gh search issues --help → --state {open|closed}  ("all" 미지원)
+             flip: none
+       options: 적용 (Recommended) / 미적용 / 후속이슈
+       적용 description: "Falsified: '--state all 도 허용된다' 가설 반증 — probe 출력에 all 없음"
+    Q2 "F1 — query() → run_query() 리네임"
+       body: query.sql:query
+             변경: query() → run_query()
+             판정: apply — 호출부 3곳 동시 수정 필요
+             Probe: n/a (structural)
+             flip: none
+       options: 적용 (Recommended) / 미적용 / 후속이슈
+       적용 description: "Falsified: '호출부가 이미 run_query 를 쓴다' 가설 반증 —
+         grep -n 'query(' src/ → 3곳 모두 구 이름 사용"
+  User: Q1=적용, Q2=후속이슈
+  → apply F3; ledger: applied: cli.sh:L10 | round=1 | "--state all" → "--state open"
+  → skip F1;  ledger: rejected: query.sql:query | round=1 | query() → run_query() | reason: user: deferred to follow-up
+               ledger: deferred: query.sql:query | round=1 | finding=F1(rename) | issue=pending
   Commit F3 with trailer:  Premise-Verified: gh search issues --help (excerpt)
+  Round 종료 시 deferred 1건에 대해 구현 접근안 리뷰 surface → 승인 시에만 이슈 생성
 
 [Step 5d] Cross-check sibling: praxis#199 (branch issue-199-hook-shell)
   Apply same test for F3 against sibling:
@@ -987,6 +1188,9 @@ user selects: 1
 - Step 5h SoT audit detects truncation only for inline-transcribed enumerations; reference-link citations (sibling SoT referenced but not transcribed) are inherently safe and are not audited
 - Step 5h citation-signal scanning is keyword-based; enumerations that use non-standard labels (e.g., custom matrix row identifiers) may not be detected — when authoring, prefer the standard labels listed in the trigger table
 - Step 5h requires the sibling SoT document to be locally readable; remote-only or external URLs are flagged as unresolved advisories and require manual verification
+- Step 5i requires an interactive session — `AskUserQuestion` has no reachable user under `claude -p` or a background worker, so those runs apply nothing and defer every finding
+- Step 5i costs one `AskUserQuestion` round-trip per 4 findings; a round with many stylistic findings trades throughput for control, by design
+- Step 5i decisions live in the same per-session ledger as 5c — a finding declined in one session is not remembered in the next
 - Step 6 reaper is macOS-only (launchd reparenting + `/var/folders` sessionDirs); it is a no-op on other platforms
 - Step 6 idle detection uses `broker.log` mtime as an activity proxy — a broker mid-operation that stays silent longer than `--max-age` could be misjudged idle and reaped; the cost is a benign respawn on the next codex call, never a correctness break
 - Step 6 phase-end reaping keeps the broker count below the compressor threshold but does not reclaim every running orphan; the session-independent launchd job (`LAUNCHD.md`) is what reaps orphans whose owning session is already gone

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -221,11 +221,18 @@ add commentary. This matches `/codex:review`'s contract.
 
 If `{{ARGUMENTS}}` includes `--background`, run via `Bash(..., run_in_background: true)`
 and tell the user: "Codex review started in the background. Check `/codex:status` for progress."
-Backgrounding defers Step 5, it does not skip it: when the run completes,
-collect its findings in this same session and enter Step 5 from the top
-(interactivity check → 5f → …). A background review whose findings never
-reach 5i has produced no applicable result — never apply its findings from
-the completion notification alone.
+Backgrounding defers Step 5, it does not skip it. Which path the findings
+take depends on where the session is when the run completes:
+
+- **User is back in an interactive foreground turn** — collect the findings
+  and enter Step 5 from the top (interactivity check → 5f → …); the
+  interactivity check passes and 5i can ask.
+- **No user is reachable** (unattended worker, `-p` run, session already
+  ended) — the interactivity check fails and the findings take the
+  non-interactive path: verified, applied to nothing, deferred.
+
+Either way, never apply a background review's findings from the completion
+notification alone.
 
 ### Step 5: Apply Findings — Premise Verification Gate
 
@@ -924,7 +931,7 @@ Exactly three options, plus the runtime's automatic `Other` slot:
 | `적용` | Apply the edit → ledger `applied:` row → 5e `Premise-Verified:` trailer **if the edit is fact-modifying** (structural and stylistic edits take no trailer, per 5e) |
 | `미적용` | Do not edit → ledger `rejected: … \| reason: user: declined (round N)` |
 | `후속이슈` | Do not edit → ledger `rejected: … \| reason: user: deferred to follow-up` **and** a `deferred:` row |
-| `Other` (free text) | If the instruction is a plain decline or defer, record the matching row above. If it proposes a **different** edit than the finding did, that is a new proposal: re-run 5a classification, 5b premise verification, and the 5c flip scan on it, then ask again — an `Other` answer is never itself an `적용` answer for the modified edit |
+| `Other` (free text) | If the instruction is a plain decline or defer, record the matching row above. If it proposes a **different** edit than the finding did, that is a new proposal: re-run 5a classification, 5b premise verification, and the 5c flip scan on it, then ask again — an `Other` answer is never itself an `적용` answer for the modified edit. If it reads as approval of the **unchanged** edit ("그대로 적용해", "yes, apply this"), do not treat the paraphrase as the answer either: re-ask the same finding with the three options and apply only on a literal `적용` |
 
 Put the agent's recommended option first and mark it `(Recommended)`.
 
@@ -1087,7 +1094,7 @@ user selects: 1
   → apply F3; ledger: applied: cli.sh:L10 | round=1 | "--state all" → "--state open"
   → skip F1;  ledger: rejected: query.sql:query | round=1 | query() → run_query() | reason: user: deferred to follow-up
                ledger: deferred: query.sql:query | round=1 | finding=F1(rename) | issue=pending
-  Commit F3 with trailer:  Premise-Verified: gh search issues --help (excerpt)
+  (아직 커밋하지 않음 — 실행 순서상 5d-ii/iii 가 5e 앞에 온다)
   Round 종료 시 deferred 1건에 대해 구현 접근안 리뷰 surface → 승인 시에만 이슈 생성
 
 [Step 5d] Cross-check sibling: praxis#199 (branch issue-199-hook-shell)
@@ -1100,6 +1107,9 @@ user selects: 1
      현재 PR: praxis#200 — finding: F3 (--state all)
      형제 PR:  praxis#199 — 동일 결함 확인 근거: hook.sh:L8에서 "--state all" 사용 확인
   → surface to user for separate approval before applying sibling fix
+
+[Step 5e — commit, after 5d completes]
+  Commit F3 with trailer:  Premise-Verified: gh search issues --help (excerpt)
 
 [Step 5 — Round 2] Codex now re-suggests changing WHERE col_a = 1 → col_b = 1
   Scan ledger: rejected entry on query.sql:L42 with same A → B transition exists

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -375,7 +375,7 @@ a *decision*, not a disproved premise — the finding may well be correct. When
 the colliding row is one of those, do not claim a factual contradiction; use
 this message instead:
 
-```
+```text
 ⚠ Re-proposal of a user-declined finding: {file}:{region}
    Round N: user chose {미적용|후속이슈} — {A} → {B}
    Round N+M proposes the same change again.
@@ -890,7 +890,7 @@ otherwise collide on one key and share (or overwrite) a single answer.
 
 Each question body must let the user decide without re-reading the diff:
 
-```
+```text
 {file}:{region}
 변경: {value-before} → {value-after}
 판정: {apply | reject} — {one-line reason}

--- a/tests/test_finding_approval_gate.sh
+++ b/tests/test_finding_approval_gate.sh
@@ -146,6 +146,14 @@ assert_present \
   "Backgrounding defers Step 5, it does not skip it"
 
 assert_present \
+  "background handoff branches on whether a user is reachable" \
+  "User is back in an interactive foreground turn"
+
+assert_present \
+  "Other approval paraphrase is re-asked, not accepted" \
+  "apply only on a literal \`적용\`"
+
+assert_present \
   "resolved flips re-enter 5i for their own 적용 answer" \
   "re-enters 5i as a normal finding"
 

--- a/tests/test_finding_approval_gate.sh
+++ b/tests/test_finding_approval_gate.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# tests/test_finding_approval_gate.sh — Step 5i per-finding user approval gate
+#
+# Regression test for issue #861:
+#   codex-review-wrap SKILL.md Step 5i must require an explicit per-finding
+#   AskUserQuestion answer before any edit is applied.  The gate is prose-only
+#   (no hook binary), so the spec text is the enforcement surface — pin it here
+#   so drift surfaces in CI instead of during a review round.
+#
+# All assertions are static document checks against SKILL.md.
+#
+# Run:  bash tests/test_finding_approval_gate.sh
+# Exit: 0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL="$ROOT_DIR/skills/codex-review-wrap/SKILL.md"
+
+if [ ! -f "$SKILL" ]; then
+  echo "FAIL: SKILL.md not found at $SKILL" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+# Assert that a fixed-string pattern appears at least once in SKILL.md.
+assert_present() {
+  local name="$1"
+  local pattern="$2"
+  local hits
+  hits=$(grep -Fc -- "$pattern" "$SKILL" 2>/dev/null)
+  hits=${hits:-0}
+  if [ "$hits" -gt 0 ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] — pattern not found: $pattern"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+# Assert that an extended-regex pattern appears at least once in SKILL.md.
+assert_present_re() {
+  local name="$1"
+  local pattern="$2"
+  local hits
+  hits=$(grep -Ec -- "$pattern" "$SKILL" 2>/dev/null)
+  hits=${hits:-0}
+  if [ "$hits" -gt 0 ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] — regex not matched: $pattern"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 1. Section exists and is reachable from the execution-order list
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "5i section heading present" \
+  "#### 5i. Per-finding user approval gate"
+
+assert_present \
+  "execution-order lists 5i" \
+  "5i per-finding user approval gate"
+
+# ---------------------------------------------------------------------------
+# 2. No-auto-apply directive — the core guarantee of the gate
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "no finding edited on agent judgement alone" \
+  "No finding may be edited on the agent's judgement alone"
+
+assert_present \
+  "explicitly denies an auto-apply path" \
+  "There is no auto-apply path"
+
+# ---------------------------------------------------------------------------
+# 3. Scope — every finding class is gated
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "scope covers every finding surviving 5b/5c" \
+  "every finding of the round that survives 5b and 5c"
+
+assert_present \
+  "evidence-rejected findings are not offered as 적용" \
+  "never a decision worth surfacing"
+
+assert_present \
+  "evidence-rejected findings get a one-line report" \
+  "N findings rejected on evidence"
+
+assert_present \
+  "scope names all three 5a classes" \
+  "fact-modifying, structural,"
+
+assert_present \
+  "5h synthesized findings re-enter the gate" \
+  "Synthesized findings re-enter 5g and 5i"
+
+# ---------------------------------------------------------------------------
+# 4. Batching rule — 4 findings per AskUserQuestion call
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "batch size is 4 findings per call" \
+  "**4 findings per call**"
+
+assert_present \
+  "runtime cap cited" \
+  "accepts at most **4 questions per"
+
+assert_present \
+  "one question per finding (no compression)" \
+  "Do not compress two findings into"
+
+assert_present \
+  "batch size follows the running host's own cap" \
+  "the cap of the host"
+
+assert_present \
+  "host without a callable ask-user tool takes the non-interactive path" \
+  "no callable ask-user tool at all"
+
+assert_present \
+  "question text carries a stable finding ID" \
+  "must start with a stable finding ID"
+
+assert_present \
+  "interactivity check runs before the 5d-i question" \
+  "**Interactivity check**"
+
+assert_present \
+  "background runs re-enter Step 5 rather than skipping it" \
+  "Backgrounding defers Step 5, it does not skip it"
+
+assert_present \
+  "resolved flips re-enter 5i for their own 적용 answer" \
+  "re-enters 5i as a normal finding"
+
+assert_present \
+  "5h runs after approved findings, not after all findings" \
+  "after every approved finding has been"
+
+# ---------------------------------------------------------------------------
+# 5. Options — 적용 / 미적용 / 후속이슈
+# ---------------------------------------------------------------------------
+
+assert_present "option 적용 present"    "\`적용\`"
+assert_present "option 미적용 present"  "\`미적용\`"
+assert_present "option 후속이슈 present" "\`후속이슈\`"
+
+assert_present \
+  "Other free-text slot handled" \
+  "\`Other\` (free text)"
+
+assert_present \
+  "Other proposing a different edit re-enters 5a/5b/5c" \
+  "re-run 5a classification, 5b premise verification, and the 5c flip scan"
+
+assert_present \
+  "Other is never itself an 적용 answer for a modified edit" \
+  "never itself an \`적용\` answer"
+
+# ---------------------------------------------------------------------------
+# 6. Question body carries evidence
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "question body requires Probe: line" \
+  "Probe: {command} → {one-line output}"
+
+assert_present \
+  "non-fact-modifying findings still carry a Probe: line" \
+  "Probe: n/a (structural)"
+
+assert_present \
+  "question body requires flip scan result" \
+  "flip: none"
+
+assert_present \
+  "Recommended label requires a column-0 Falsified: line" \
+  "the literal prefix \`Falsified:\`"
+
+assert_present \
+  "Falsified: contract cites the enforcing hook" \
+  "hooks/advisory-nudge/output-block-falsify-advisory/impl.py"
+
+assert_present \
+  "5g runs before 5i in the execution order" \
+  "Runs **before** 5i"
+
+assert_present \
+  "적용 writes the Premise-Verified trailer only for fact-modifying edits" \
+  "trailer **if the edit is fact-modifying**"
+
+# ---------------------------------------------------------------------------
+# 7. Ledger integration — five record shapes including deferred
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "ledger declares five record shapes" \
+  "**five record shapes**"
+
+assert_present_re \
+  "deferred: record shape defined" \
+  "^deferred: +\{file\}"
+
+assert_present \
+  "deferred: excluded from flip scan prefixes" \
+  "or \`deferred:\`) in the ledger"
+
+assert_present \
+  "user declines write a rejected: row with a user: prefix" \
+  "reason: user: declined (round N)"
+
+assert_present \
+  "5c branches user decisions away from evidence conflicts" \
+  "Re-proposal of a user-declined finding"
+
+assert_present \
+  "Probe: n/a barred when the finding carries a 5g negative claim" \
+  "carries no 5g negative claim"
+
+assert_present \
+  "Overview summary scoped to 5b/5c survivors" \
+  "that survived 5b and 5c"
+
+assert_present \
+  "5h synthesized edits take no Premise-Verified trailer" \
+  "5e is the single rule for trailer scope"
+
+# ---------------------------------------------------------------------------
+# 8. Follow-up issue handling and approval-scope boundaries
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "follow-up issues batched behind an approach review" \
+  "Do **not** create an issue per answer"
+
+assert_present \
+  "적용 does not transfer to sibling PR" \
+  "on the current PR only"
+
+# ---------------------------------------------------------------------------
+# 9. Error handling + limitations coverage
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "error-handling: cancellation row" \
+  "Stop applying for the round"
+
+assert_present \
+  "error-handling: non-interactive run row defers only 5b/5c survivors" \
+  "record every finding that survived 5b/5c as"
+
+assert_present \
+  "worked example: structural question carries a Falsified: line" \
+  "Falsified: '호출부가 이미 run_query 를 쓴다'"
+
+assert_present \
+  "limitations: interactive-session requirement" \
+  "Step 5i requires an interactive session"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed tests:"
+  for t in "${FAILED_NAMES[@]}"; do
+    echo "  - $t"
+  done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 배경

`codex-review-wrap` Step 5 는 finding 을 분류(5a) → premise 검증(5b) → flip 검사(5c)
한 뒤 **에이전트 단독 판단으로 편집을 적용**했다. 사용자에게 노출되는 승인 지점은
형제 PR 수정(5d-iii) 하나뿐이라, 현재 PR 에 들어가는 편집은 사후에 diff 를 읽어야만
파악됐다. codex 출력이 5b 를 통과해도 "이 PR 범위에서 지금 고칠 일인가" 는 별개
판단이며, 그 판단이 사용자에게 오지 않는 것이 갭이었다.

## 변경

**Step 5i — finding 별 사용자 승인 게이트 신설**

- 5b/5c 를 통과한 모든 finding(fact-modifying / structural / stylistic + 5h 합성분)에
  대해 `AskUserQuestion` 으로 개별 질의. 승인 없는 자동 적용 경로 없음
- 호출당 4 개씩 배치 (`RUNTIME_CONSTRAINTS.md` §1·§1a), question text 는 고유 finding
  ID 로 시작 — 답변이 question text 를 key 로 오므로 중복 finding 키 충돌 방지
- 선택지 `적용` / `미적용` / `후속이슈` (+ 런타임 Other). Other 가 다른 편집을 제안하면
  5a–5c 재검증 후 재질의 — Other 자체는 `적용` 답변이 아님
- 질문 본문에 `{file}:{region}` / before→after / 판정 / `Probe:` / `flip:` 필수.
  `(Recommended)` 라벨에는 첫 칼럼 `Falsified:` 줄 필수
  (`hooks/advisory-nudge/output-block-falsify-advisory/impl.py` 가 startswith 로 강제)
- 비대화형(`claude -p`, background, ask-user 도구가 없는 host)은 검증만 하고 적용 없이
  survivor 를 defer

**기존 sub-step 정합화**

- 실행 순서: 5g(critic probe)를 5i 앞으로 이동 — 5i 는 `Probe: n/a` 를 허용하므로 5g
  보장이 깨지던 경로 차단. step 0 에 interactivity check 추가
- 5c ledger: record shape 4 종 → 5 종(`deferred:` 추가). 사용자 보류는 `user:` 접두사
  rejection 으로 기록되고, 5c 는 이를 사실 충돌이 아닌 "결정 재제안"으로 분기 보고
- 5e trailer 범위 통일: structural/stylistic 편집은 `Premise-Verified:` 없음 (5h 예외 제거)
- 5h 실행 조건: "승인된 finding 적용 후" — 미적용/후속이슈가 SoT audit 을 막지 않음
- `--background` 는 Step 5 를 건너뛰지 않고 같은 세션에서 재진입

**RUNTIME_CONSTRAINTS.md §1a** — `questions` maxItems:4 를 검증 항목으로 신설
(2026-07-26 Opus 5 에서 4-question 호출 실왕복 확인).

## 검증

- `bash scripts/run-tests.sh` → **ALL TESTS PASSED** (신규 테스트 CI 수집 확인)
- `bash tests/test_finding_approval_gate.sh` → 46 PASS / 0 FAIL (신규)
- `bash tests/test_critic_pre_lock_probe.sh` → 26 PASS / 0 FAIL (5g 무회귀)
- `python3 -m pytest tests/test_skill_runtime_metadata.py` → 34 passed
- `shellcheck tests/test_finding_approval_gate.sh`, `ruff check .` → clean
- codex 리뷰 8 라운드 / 19 건 — 18 건 반영, 1 건 사용자 미적용
  (비대화형 skip 목록에 5d-iii 포함 건). 각 건은 신규 5i 게이트 그대로 사용자
  승인을 받아 반영했다

Pre-commit verified: bash scripts/run-tests.sh → ALL TESTS PASSED (2448 PASS lines, 0 FAIL; includes tests/test_finding_approval_gate.sh 46/46 and tests/test_critic_pre_lock_probe.sh 26/26)

Caller chain verified: 변경은 SKILL.md 산문 + RUNTIME_CONSTRAINTS.md 문서 + 신규 정적 테스트뿐이며 실행 코드 호출자 없음 — `grep -rn "5g\|5h\|Step 5" --include="*.md" --include="*.py" --include="*.sh" .` 로 codex-review-wrap Step 5 하위 단계를 인용하는 외부 파일을 전수 확인했고, 인용처는 hooks/advisory-nudge/exclusion-probe-gate(5g probe 형식)와 hooks/completion-verify/negative-existence-verdict-gate(5g 참조)뿐으로 이번 변경이 건드리지 않는 5g 형식만 참조한다. 신규 테스트는 scripts/run-tests.sh 의 `tests/test_*.sh` 글롭으로 수집됨을 실행 로그(line 3428)로 확인

## 미검증

- 비-Claude host 실행 경로는 spec-only — codex host 에서의 실왕복은 없음

Closes #861


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that interactive question prompts support up to four questions per request.
  * Updated the review workflow with explicit approval requirements before applying findings.
  * Documented handling for backgrounded or non-interactive review sessions, batching, deferred items, and follow-up outcomes.

* **Tests**
  * Added regression coverage to verify approval-gate rules, prompt behavior, finding classification, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->