### PR TITLE
docs(worktree-merge-cleanup): guard prune blast radius

### DIFF
--- a/skills/worktree-merge-cleanup/SKILL.md
+++ b/skills/worktree-merge-cleanup/SKILL.md
@@ -97,11 +97,20 @@ git pull origin <base-branch>                              # resolve squash-ance
 git branch -d <feature-branch> 2>/dev/null \
   || git branch -D <feature-branch>                        # fallback (may already be deleted)
 git worktree list --porcelain \
-  > "$(git rev-parse --git-common-dir)/wt-before-<N>.txt"   # snapshot BEFORE prune (see below)
+  > "$(git rev-parse --path-format=absolute --git-common-dir)/wt-before-<N>.txt"
 git worktree prune --dry-run -v                             # what would go — read it
+```
+
+**STOP here and read the dry-run output.** `--dry-run` reports candidates; it
+is not a confirmation barrier, so the two commands below must not be pasted
+together with the block above. If anything other than your own worktree
+appears, surface it to the user before continuing. Only then:
+
+```bash
 git worktree prune
 git worktree list --porcelain | grep '^worktree ' \
-  | diff <(grep '^worktree ' "$(git rev-parse --git-common-dir)/wt-before-<N>.txt") -
+  | diff <(grep '^worktree ' \
+      "$(git rev-parse --path-format=absolute --git-common-dir)/wt-before-<N>.txt") -
 ```
 
 Even if stdout shows only "deleted remote branch" or is empty, verify local
@@ -111,7 +120,9 @@ the same way — the plain `git worktree list` output is a different format from
 `--porcelain`, so comparing one against the other never matches. Your own
 worktree left the registry back at checklist item 2, so it is already absent
 from the snapshot: when the dry-run printed nothing, the `diff` must print
-nothing either. Any entry it reports as removed belonged to someone else.
+nothing either — assuming no one added or removed a worktree in this
+repository while the sequence was running. Any entry it reports as removed
+belonged to someone else.
 
 ### `prune` is repository-wide — snapshot before running it
 
@@ -126,12 +137,16 @@ fact unless you captured evidence first.
 - **Before**: `git worktree list --porcelain` records every registration and
   marks the already-missing, unlocked ones `prunable` (a locked entry shows
   `locked` instead and is not a prune target). Park it at
-  `$(git rev-parse --git-common-dir)/wt-before-<N>.txt`, substituting the PR
-  number you are cleaning up for `<N>`. Not a shell variable and not a bare
-  `wt-before.txt`: the steps run as separate Bash calls so a `snap=$(mktemp)`
-  variable is gone by the next call, while the common dir recomputes to the
-  same path every time — and the `<N>` suffix keeps two concurrent cleanups in
-  the same repository from overwriting each other's baseline. This snapshot is
+  `$(git rev-parse --path-format=absolute --git-common-dir)/wt-before-<N>.txt`,
+  substituting the PR number you are cleaning up for `<N>`. Not a shell
+  variable and not a bare `wt-before.txt`: the steps run as separate Bash calls
+  so a `snap=$(mktemp)` variable is gone by the next call, while the common dir
+  recomputes to the same path every time — and the `<N>` suffix keeps two
+  concurrent cleanups in the same repository from overwriting each other's
+  baseline. `--path-format=absolute` is not optional: a bare
+  `git rev-parse --git-common-dir` answers `.git` in the main worktree and
+  `../.git` one directory down, so without it the snapshot and the diff can
+  resolve to different files. This snapshot is
   the only thing that later answers "was that sibling worktree already gone, or
   did I break it?" — without it the question is unanswerable, which is worse
   than the removal itself. Write the **unfiltered** porcelain output: the

--- a/skills/worktree-merge-cleanup/SKILL.md
+++ b/skills/worktree-merge-cleanup/SKILL.md
@@ -73,8 +73,9 @@ fatal: 'main' is already used by worktree at /Users/.../<main-worktree>
    on remote (gh order: remote merge → local sync). Manual cleanup — run each as
    a **separate** Bash call, never chained (a failure in one step must not
    short-circuit the rest): `git worktree remove <path>`, then
-   `git branch -D <branch>`, then `git worktree prune`, then
-   `git pull origin <base>`.
+   `git branch -D <branch>`, then `git worktree prune` (snapshot and dry-run
+   it first — see [prune is repository-wide](#prune-is-repository-wide--snapshot-before-running-it)),
+   then `git pull origin <base>`.
 5. **Squash-ancestry stale HEAD guard (post-merge sync mandatory)**: immediately
    after `gh pr merge --squash --delete-branch`, run `git pull origin
    <base-branch>` as a **separate step**. gh merges remote then deletes local
@@ -95,11 +96,62 @@ gh pr merge <N> --squash --delete-branch
 git pull origin <base-branch>                              # resolve squash-ancestry gap
 git branch -d <feature-branch> 2>/dev/null \
   || git branch -D <feature-branch>                        # fallback (may already be deleted)
+git worktree list --porcelain \
+  > "$(git rev-parse --git-common-dir)/wt-before-<N>.txt"   # snapshot BEFORE prune (see below)
+git worktree prune --dry-run -v                             # what would go — read it
 git worktree prune
+git worktree list --porcelain | grep '^worktree ' \
+  | diff <(grep '^worktree ' "$(git rev-parse --git-common-dir)/wt-before-<N>.txt") -
 ```
 
 Even if stdout shows only "deleted remote branch" or is empty, verify local
-cleanup separately: confirm with `git branch | grep <feature-branch>`.
+cleanup separately: confirm with `git branch | grep <feature-branch>` **and**
+diff the post-prune registry against the snapshot. Both sides must be filtered
+the same way — the plain `git worktree list` output is a different format from
+`--porcelain`, so comparing one against the other never matches. Your own
+worktree left the registry back at checklist item 2, so it is already absent
+from the snapshot: when the dry-run printed nothing, the `diff` must print
+nothing either. Any entry it reports as removed belonged to someone else.
+
+### `prune` is repository-wide — snapshot before running it
+
+`git worktree prune` takes no target. It drops the registration of **every**
+unlocked worktree whose directory is gone, including worktrees belonging to
+other issues that you never touched. Two bounds on that blast radius: it only
+removes registrations for directories that are already missing — it never
+deletes a live worktree — and a registration held by `git worktree lock`
+survives even when its directory is gone. Neither bound is visible after the
+fact unless you captured evidence first.
+
+- **Before**: `git worktree list --porcelain` records every registration and
+  marks the already-missing, unlocked ones `prunable` (a locked entry shows
+  `locked` instead and is not a prune target). Park it at
+  `$(git rev-parse --git-common-dir)/wt-before-<N>.txt`, substituting the PR
+  number you are cleaning up for `<N>`. Not a shell variable and not a bare
+  `wt-before.txt`: the steps run as separate Bash calls so a `snap=$(mktemp)`
+  variable is gone by the next call, while the common dir recomputes to the
+  same path every time — and the `<N>` suffix keeps two concurrent cleanups in
+  the same repository from overwriting each other's baseline. This snapshot is
+  the only thing that later answers "was that sibling worktree already gone, or
+  did I break it?" — without it the question is unanswerable, which is worse
+  than the removal itself. Write the **unfiltered** porcelain output: the
+  `prunable` and `locked` lines are precisely the forensic evidence, and a
+  snapshot filtered at write time cannot answer the question it exists for.
+- **Dry run**: `git worktree prune --dry-run -v` (`-n` / `-v`, confirmed via
+  `git worktree prune -h`) prints what it would remove without touching
+  anything. If anything other than your own worktree appears, stop and surface
+  it to the user before running the real prune.
+- **After**: diff `git worktree list --porcelain` against the snapshot — the
+  same format on both sides, or the comparison is meaningless. Filter both
+  through `grep '^worktree '` **at compare time**: the question is only which
+  *registrations* vanished, and an unfiltered diff also reports the `HEAD` /
+  `branch` lines that any parallel worktree changes by committing or switching,
+  which reads as a removal that never happened. The existing `git branch | grep` check only
+  proves *your* branch is gone; a sibling registration can disappear and still
+  pass it.
+
+Recovering a registration removed this way is out of scope here — see
+[Limitations](#limitations) (`git worktree add`, never `git clone`).
 
 ⚠️ Do NOT collapse the sequence into a single `&&`-chain. A git hard error
 mid-sequence (submodule worktree missing `--force`, divergent pull)

--- a/tests/test_worktree_merge_cleanup.sh
+++ b/tests/test_worktree_merge_cleanup.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# tests/test_worktree_merge_cleanup.sh — worktree-merge-cleanup prune guards
+#
+# Regression test for issue #865:
+#   The cleanup sequence prescribes `git worktree prune`, which is a
+#   repository-wide operation — it drops the registration of every worktree
+#   whose directory is gone, including siblings the merge never touched.
+#   The skill must tell the reader to snapshot and dry-run before pruning and
+#   to diff the list afterwards, because without the snapshot a later "did I
+#   break that?" question is unanswerable.
+#
+# All assertions are static document checks against SKILL.md, mirroring
+# tests/test_critic_pre_lock_probe.sh.
+#
+# Run:  bash tests/test_worktree_merge_cleanup.sh
+# Exit: 0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL="$ROOT_DIR/skills/worktree-merge-cleanup/SKILL.md"
+
+if [ ! -f "$SKILL" ]; then
+  echo "FAIL: SKILL.md not found at $SKILL" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+# Assert that a fixed-string pattern appears at least once in SKILL.md.
+assert_present() {
+  local name="$1"
+  local pattern="$2"
+  local hits
+  hits=$(grep -Fc -- "$pattern" "$SKILL" 2>/dev/null)
+  hits=${hits:-0}
+  if [ "$hits" -gt 0 ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] — pattern not found: $pattern"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+# Assert that pattern A appears before pattern B in the file.  The snapshot /
+# dry-run guards are worthless if the document lists them after the prune.
+assert_order() {
+  local name="$1"
+  local first="$2"
+  local second="$3"
+  local line_first line_second
+  line_first=$(grep -Fn -m1 -- "$first" "$SKILL" 2>/dev/null | cut -d: -f1)
+  line_second=$(grep -Fn -m1 -- "$second" "$SKILL" 2>/dev/null | cut -d: -f1)
+  if [ -z "$line_first" ] || [ -z "$line_second" ]; then
+    echo "FAIL  [$name] — one of the patterns is absent (first=${line_first:-none} second=${line_second:-none})"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  elif [ "$line_first" -lt "$line_second" ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] — '$first' (line $line_first) must precede '$second' (line $line_second)"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+# Same as assert_order, but both anchors are extended regexes.  Needed for the
+# bare `git worktree prune` line, which is a prefix of the dry-run line and so
+# cannot be anchored with a fixed string.
+assert_order_re() {
+  local name="$1"
+  local first="$2"
+  local second="$3"
+  local line_first line_second
+  line_first=$(grep -En -m1 -- "$first" "$SKILL" 2>/dev/null | cut -d: -f1)
+  line_second=$(grep -En -m1 -- "$second" "$SKILL" 2>/dev/null | cut -d: -f1)
+  if [ -z "$line_first" ] || [ -z "$line_second" ]; then
+    echo "FAIL  [$name] — one of the patterns is absent (first=${line_first:-none} second=${line_second:-none})"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  elif [ "$line_first" -lt "$line_second" ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] — '$first' (line $line_first) must precede '$second' (line $line_second)"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 1. Pre-existing contracts the prune guards must not displace
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "base-worktree call site documented" \
+  "called from the worktree that"
+
+assert_present \
+  "squash-ancestry stale HEAD guard documented" \
+  "Squash-ancestry stale HEAD guard"
+
+assert_present \
+  "no-&&-chain rule documented" \
+  "Do NOT collapse the sequence into a single"
+
+assert_present \
+  "submodule --force caveat documented" \
+  "git worktree remove --force"
+
+# ---------------------------------------------------------------------------
+# 2. prune blast radius is stated (issue #865)
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "prune section heading present" \
+  "### \`prune\` is repository-wide — snapshot before running it"
+
+assert_present \
+  "prune takes no target" \
+  "takes no target"
+
+assert_present \
+  "sibling worktrees named as collateral" \
+  "including worktrees belonging to"
+
+assert_present \
+  "prune never deletes a live worktree" \
+  "deletes a live worktree"
+
+assert_present \
+  "locked registrations survive prune" \
+  "survives even when its directory is gone"
+
+assert_present \
+  "snapshot path is repository-scoped, not a fixed /tmp name" \
+  "\$(git rev-parse --git-common-dir)/wt-before-<N>.txt"
+
+assert_present \
+  "snapshot path survives the separate-Bash-call rule" \
+  "variable is gone by the next call"
+
+assert_present \
+  "snapshot name is unique per concurrent cleanup" \
+  "from overwriting each other's baseline"
+
+assert_present \
+  "comparison is filtered to registration lines only" \
+  "grep '^worktree '"
+
+assert_present \
+  "snapshot itself is written unfiltered" \
+  "Write the **unfiltered** porcelain output"
+
+assert_present \
+  "prunable/locked markers named as the forensic evidence" \
+  "are precisely the forensic evidence"
+
+assert_present \
+  "unfiltered diff false-positive explained" \
+  "a removal that never happened"
+
+# ---------------------------------------------------------------------------
+# 3. Snapshot / dry-run / diff steps are prescribed
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "snapshot command prescribed" \
+  "git worktree list --porcelain"
+
+assert_present \
+  "prunable marker explained" \
+  "marks the already-missing, unlocked ones \`prunable\`"
+
+assert_present \
+  "dry-run command prescribed" \
+  "git worktree prune --dry-run -v"
+
+assert_present \
+  "dry-run flags verified against the binary" \
+  "confirmed via"
+
+assert_present \
+  "unexpected dry-run entry escalates to the user" \
+  "stop and surface"
+
+assert_present \
+  "post-prune diff prescribed" \
+  "diff \`git worktree list --porcelain\` against the snapshot"
+
+assert_present \
+  "both sides of the comparison use the same format" \
+  "Both sides must be filtered"
+
+assert_present \
+  "branch-grep alone declared insufficient" \
+  "proves *your* branch is gone"
+
+assert_present \
+  "empty dry-run implies an empty post-prune diff" \
+  "when the dry-run printed nothing, the \`diff\` must print"
+
+assert_present \
+  "own worktree already absent from the snapshot" \
+  "so it is already absent"
+
+# ---------------------------------------------------------------------------
+# 4. Ordering — guards must appear before the prune they guard
+# ---------------------------------------------------------------------------
+
+assert_order \
+  "snapshot precedes prune in the cleanup block" \
+  "> \"\$(git rev-parse --git-common-dir)/wt-before-<N>.txt\"" \
+  "git worktree prune --dry-run -v"
+
+assert_order \
+  "dry-run precedes the post-prune comparison in the cleanup block" \
+  "git worktree prune --dry-run -v" \
+  "| diff <(grep '^worktree ' \"\$(git rev-parse --git-common-dir)/wt-before-<N>.txt\") -"
+
+# The bare prune is the destructive step; both guards are worthless unless it
+# sits between them.  Anchor on the line that is exactly `git worktree prune`.
+assert_order_re \
+  "dry-run precedes the real prune in the cleanup block" \
+  "^git worktree prune --dry-run -v" \
+  "^git worktree prune\$"
+
+assert_order_re \
+  "real prune precedes the post-prune comparison in the cleanup block" \
+  "^git worktree prune\$" \
+  "^ *\| diff <\(grep '\^worktree ' \"\\\$\(git rev-parse --git-common-dir\)/wt-before-<N>\.txt\"\) -"
+
+# ---------------------------------------------------------------------------
+# 5. Checklist item 4 points at the new guards
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "manual-cleanup checklist references the prune guards" \
+  "snapshot and dry-run"
+
+# ---------------------------------------------------------------------------
+# 6. Recovery stays a pointer, not a duplicated procedure
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "recovery pointer retained" \
+  "never \`git clone\`"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed tests:"
+  for t in "${FAILED_NAMES[@]}"; do
+    echo "  - $t"
+  done
+  exit 1
+fi
+exit 0

--- a/tests/test_worktree_merge_cleanup.sh
+++ b/tests/test_worktree_merge_cleanup.sh
@@ -140,7 +140,7 @@ assert_present \
 
 assert_present \
   "snapshot path is repository-scoped, not a fixed /tmp name" \
-  "\$(git rev-parse --git-common-dir)/wt-before-<N>.txt"
+  "\$(git rev-parse --path-format=absolute --git-common-dir)/wt-before-<N>.txt"
 
 assert_present \
   "snapshot path survives the separate-Bash-call rule" \
@@ -148,7 +148,23 @@ assert_present \
 
 assert_present \
   "snapshot name is unique per concurrent cleanup" \
-  "from overwriting each other's baseline"
+  "from overwriting each other's"
+
+assert_present \
+  "absolute path format is declared mandatory" \
+  "\`--path-format=absolute\` is not optional"
+
+assert_present \
+  "relative-path failure mode spelled out" \
+  "resolve to different files"
+
+assert_present \
+  "dry-run is an explicit stop, not a barrier" \
+  "is not a confirmation barrier"
+
+assert_present \
+  "concurrent-worktree assumption stated" \
+  "removed a worktree in this"
 
 assert_present \
   "comparison is filtered to registration lines only" \
@@ -216,13 +232,13 @@ assert_present \
 
 assert_order \
   "snapshot precedes prune in the cleanup block" \
-  "> \"\$(git rev-parse --git-common-dir)/wt-before-<N>.txt\"" \
+  "> \"\$(git rev-parse --path-format=absolute --git-common-dir)/wt-before-<N>.txt\"" \
   "git worktree prune --dry-run -v"
 
 assert_order \
   "dry-run precedes the post-prune comparison in the cleanup block" \
   "git worktree prune --dry-run -v" \
-  "| diff <(grep '^worktree ' \"\$(git rev-parse --git-common-dir)/wt-before-<N>.txt\") -"
+  "| diff <(grep '^worktree ' \\"
 
 # The bare prune is the destructive step; both guards are worthless unless it
 # sits between them.  Anchor on the line that is exactly `git worktree prune`.
@@ -234,7 +250,19 @@ assert_order_re \
 assert_order_re \
   "real prune precedes the post-prune comparison in the cleanup block" \
   "^git worktree prune\$" \
-  "^ *\| diff <\(grep '\^worktree ' \"\\\$\(git rev-parse --git-common-dir\)/wt-before-<N>\.txt\"\) -"
+  "^ *\| diff <\(grep '\^worktree ' \\\\\$"
+
+# The stop-and-read instruction only works if it sits between the dry-run and
+# the destructive prune — inside the block it would be a comment nobody honours.
+assert_order_re \
+  "stop-and-read gate sits between the dry-run and the real prune" \
+  "^git worktree prune --dry-run -v" \
+  "STOP here and read the dry-run output"
+
+assert_order_re \
+  "stop-and-read gate precedes the real prune" \
+  "STOP here and read the dry-run output" \
+  "^git worktree prune\$"
 
 # ---------------------------------------------------------------------------
 # 5. Checklist item 4 points at the new guards


### PR DESCRIPTION
## 배경

`worktree-merge-cleanup` 의 정리 시퀀스는 `git worktree prune` 을 무조건 실행하는
단계로 처방했다. 그러나 `prune` 은 대상을 받지 않는 **저장소 전역** 동작이라,
디렉터리가 사라진 다른 이슈의 worktree 등록까지 함께 제거한다. 스킬은 이 blast
radius 를 언급하지 않았고, 유일한 사후 검증인 `git branch | grep <feature-branch>`
는 형제 등록이 사라져도 통과한다.

PR #863 정리 중 이번 작업과 무관한 `issue-862-verdict-evidence-gate` 등록이
사라졌다. 커밋 유실은 없었다(로컬·리모트 tip 모두 `6e89fe5`, PR #864 OPEN 유지).
핵심 문제는 소실 자체보다 **사후에 원인을 단정할 수 없다는 점** — prune 직전
스냅샷을 남기라는 지시가 없어 `prunable` 표시 여부를 확인할 수 없었다.

## 변경

**`skills/worktree-merge-cleanup/SKILL.md`**

- cleanup 시퀀스에 스냅샷 → `--dry-run -v` → prune → `diff` 4단계 배치
- 스냅샷은 **필터 없는** 전체 porcelain 으로 저장 — `prunable` / `locked` 행이
  포렌식 증거 자체이므로 쓰기 시점 필터링은 스냅샷의 존재 이유를 무너뜨린다
- 비교 시점에만 양쪽을 `grep '^worktree '` 로 좁힘 — 병렬 worktree 의 커밋/브랜치
  전환이 `HEAD` / `branch` 행을 바꿔 "제거되지 않았는데 제거된 것처럼" 보이는
  false positive 차단
- 스냅샷 경로 `$(git rev-parse --git-common-dir)/wt-before-<N>.txt` — 이 스킬이
  강제하는 **단계별 별도 Bash 호출** 사이에서 재계산 가능하고(shell 변수는 소실),
  `<N>` 접미로 동시 정리 세션 간 baseline 덮어쓰기 방지
- 신규 섹션 "`prune` is repository-wide" — 저장소 전역 동작, 형제 등록 영향,
  두 가지 경계(살아있는 worktree 는 지우지 않음 / `git worktree lock` 등록은 생존)
- 체크리스트 항목 4 에서 신규 섹션으로 크로스 링크

**`tests/test_worktree_merge_cleanup.sh`** (신규) — 이 스킬의 첫 테스트

정적 문서 검증으로 `tests/test_critic_pre_lock_probe.sh` 패턴 미러. 신규 가드뿐
아니라 기존 계약(base-worktree 호출 지점, submodule `--force`, squash-ancestry
가드, no-`&&`-chain)도 함께 고정. `assert_order` / `assert_order_re` 로 스냅샷과
dry-run 이 모두 bare `git worktree prune` 앞에 온다는 순서 속성 검증.

## 검증

- `bash scripts/run-tests.sh` → **ALL TESTS PASSED** (신규 테스트 러너 수집 확인, 로그 3795-3796행)
- `bash tests/test_worktree_merge_cleanup.sh` → **32 PASS / 0 FAIL**
- `shellcheck tests/test_worktree_merge_cleanup.sh` → clean
- 라이브 프로브 (git 2.50.1):
  - `git worktree prune -h` → `-n` / `-v` / `--expire` 존재 확인
  - lock 프로브: `git worktree lock` → 디렉터리 삭제 → `prune --dry-run -v` 무출력
    (잠긴 등록은 prune 대상 아님), unlock 후 즉시 `Removing worktrees/...` 출력
  - `man git-config` → `gc.worktreePruneExpire` 는 `git gc` 가 `--expire 3.months.ago`
    로 호출할 때만 적용 — 수동 prune 에는 grace period 없음
  - 문서화한 시퀀스를 **분리된 Bash 호출**로 실제 실행 → 스냅샷에 `locked` 행 보존,
    `diff` exit 0
- 순서 assertion 반증 검증: bare prune 을 dry-run 앞으로 이동 → `FAIL [dry-run
  precedes the real prune in the cleanup block]` 발생 확인 후 원상 복구
- codex 리뷰 6 라운드 / 8 건 — 7 건 반영, 1 건(expiration grace period 주장) 5b
  프리미스 검증에서 반증되어 기각. 각 건은 `codex-review-wrap` Step 5i 게이트로
  사용자 승인을 받아 반영했다

Pre-commit verified: bash scripts/run-tests.sh -> ALL TESTS PASSED; tests/test_worktree_merge_cleanup.sh 32/32; shellcheck clean

Caller chain verified: 변경은 SKILL.md 산문 + 신규 정적 테스트뿐이며 실행 코드 호출자 없음 — `grep -rn "worktree-merge-cleanup" --include="*.md" --include="*.py" --include="*.sh" --include="*.json" .` 로 참조처를 전수 확인: README.md:33 / AGENTS.md:50 (스킬 목록 행), scripts/constants.py:69 + tests/test_skill_runtime_metadata.py:614 (스킬 이름 문자열, 본문 무관), hooks/preflight-gate/gh-merge-worktree-precondition/spec.md:15,80,91 (섹션 제목 "Unified post-merge cleanup sequence" 와 no-`&&`-chain 규칙 인용). 인용된 섹션 제목(SKILL.md:88)과 no-`&&`-chain 규칙은 이번 변경에서 손대지 않았음을 확인. 신규 테스트는 scripts/run-tests.sh 의 `tests/test_*.sh` 글롭으로 수집됨을 실행 로그(3795-3796행)로 확인

## 미검증

- 형제 등록이 실제로 정리 도중 사라지는 저장소에서의 재현은 없음 — collateral
  removal 경로는 위에서 프로브한 prune 시맨틱으로부터 추론했고 end-to-end 재현은
  하지 않았다

Closes #865


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded worktree cleanup guidance with snapshot, dry-run, verification, and repository-wide scope details.
  * Clarified how to confirm expected cleanup results and interpret worktree listings.

* **Tests**
  * Added regression checks to verify cleanup instructions, required safety steps, ordering, and recovery guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->