### PR TITLE
ci: add lint tier to run-tests.sh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -430,9 +430,17 @@ This is the single entry point. It runs pytest, all shell-based hook tests,
 `ruff check`, and `shellcheck` under one exit code gate, plus an advisory
 markdownlint pass over the markdown files your branch changed.
 
-`ruff` and `shellcheck` skip with an explicit `SKIPPED:` line when the tool is
-not installed, so a missing toolchain does not block you — but the
-corresponding CI job still runs, so install them if you want local parity.
+All three static checks — `ruff`, `shellcheck`, and `markdownlint` — skip with
+an explicit `SKIPPED:` line when the tool is not installed, so a missing
+toolchain does not block you. The corresponding CI job still runs either way,
+so install them if you want local parity.
+
+The markdownlint pass normally covers only the markdown your branch changed,
+measured against `origin/main`. When `origin/main` is not available — a shallow
+clone, or a fork that has not fetched upstream — it prints
+`NOTE: origin/main unavailable` and falls back to linting every tracked
+markdown file, which surfaces the repo's existing backlog. It stays advisory in
+both modes and never fails the run.
 
 CI invokes this runner from the `test` job in `.github/workflows/ci.yml`. It is
 not the whole of CI: `ci.yml` additionally runs `ruff`, `shellcheck`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -421,15 +421,26 @@ artifacts in sync.
 ## Testing
 
 ```bash
-# Run the full test suite (pytest + shell tests + manifest check) from the repo root
+# Run the full test suite (tests + manifest checks + static lint) from the repo root
 bash scripts/run-tests.sh
 ```
 
-This is the single entry point. It runs pytest, all shell-based hook tests, and
-`scripts/check-plugin-manifests.py` under one exit code gate.
+This is the single entry point. It runs pytest, all shell-based hook tests,
+`scripts/check-plugin-manifests.py`, `scripts/check-hook-token-invariants.py`,
+`ruff check`, and `shellcheck` under one exit code gate, plus an advisory
+markdownlint pass over the markdown files your branch changed.
 
-CI runs the same command on every push and pull request via
-`.github/workflows/test.yml`.
+`ruff` and `shellcheck` skip with an explicit `SKIPPED:` line when the tool is
+not installed, so a missing toolchain does not block you — but the
+corresponding CI job still runs, so install them if you want local parity.
+
+CI invokes this runner from the `test` job in `.github/workflows/ci.yml`. It is
+not the whole of CI: `ci.yml` additionally runs `ruff`, `shellcheck`,
+`markdownlint`, `actionlint`, `gitleaks`, and `link-check` as separate jobs,
+and CodeQL's `analyze` job runs from its own `.github/workflows/codeql.yml`.
+Those jobs are authoritative. The runner mirrors `ruff`, `shellcheck`, and
+`markdownlint` so they surface before you open a PR; the rest stay CI-only
+because they depend on network access, tokens, or a full-history scan.
 
 New hooks must ship with a test under `tests/hooks/<role>/`:
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -6,6 +6,14 @@
 #   2. shell    — shell tests at tests/hooks/*/test_*.sh and tests/test_*.sh
 #   3. manifest — scripts/check-plugin-manifests.py
 #   4. invariants — scripts/check-hook-token-invariants.py
+#   5. ruff     — static Python lint (mirrors the ci.yml `ruff` job)
+#   6. shellcheck — static shell lint (mirrors the ci.yml `shellcheck` job)
+#   7. markdownlint — advisory markdown lint (mirrors the ci.yml `markdownlint` job)
+#
+# Steps 5-7 mirror CI jobs that used to have no local equivalent, so a change
+# could pass here and still be flagged on the PR (issue #866). Each skips with
+# an explicit SKIPPED line when its tool is absent, so a contributor without
+# the toolchain is not blocked — CI remains authoritative either way.
 #
 # Exit code is non-zero if any step fails.
 set -euo pipefail
@@ -76,6 +84,98 @@ echo ""
 echo "=== hook-token invariant check ==="
 if ! python3 ./scripts/check-hook-token-invariants.py; then
   FAILED=1
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Ruff (mirrors ci.yml `ruff` job — blocking there, blocking here)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== ruff ==="
+if command -v ruff >/dev/null 2>&1; then
+  RUFF=(ruff)
+elif python3 -m ruff --version >/dev/null 2>&1; then
+  RUFF=(python3 -m ruff)
+else
+  RUFF=()
+fi
+
+if [[ ${#RUFF[@]} -eq 0 ]]; then
+  echo "SKIPPED: ruff (not installed — pip install 'ruff==0.15.8')"
+elif ! "${RUFF[@]}" check .; then
+  FAILED=1
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Shellcheck (mirrors ci.yml `shellcheck` job — same find/severity)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== shellcheck ==="
+if ! command -v shellcheck >/dev/null 2>&1; then
+  echo "SKIPPED: shellcheck (not installed — brew install shellcheck)"
+else
+  # Mirrors the CI invocation verbatim so severity and file set cannot drift.
+  if ! find . -name '*.sh' -not -path './.git/*' -print0 \
+    | xargs -0 shellcheck --severity=warning; then
+    FAILED=1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Markdownlint (mirrors ci.yml `markdownlint` job)
+#
+# CI runs this with filter_mode:added and never fails the check, so the repo's
+# existing backlog stays untouched. The advisory half is mirrored exactly — a
+# violation warns without setting FAILED. The scope is deliberately WIDER than
+# CI: reviewdog filters to added *lines*, this filters to changed *files*, so
+# pre-existing violations in a file you touched will also print. Reproducing
+# per-line filtering would need the reviewdog diff machinery; since nothing
+# here can fail the run, the extra noise is the cheaper trade.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== markdownlint (advisory) ==="
+if command -v markdownlint-cli2 >/dev/null 2>&1; then
+  MDL=(markdownlint-cli2)
+elif command -v markdownlint >/dev/null 2>&1; then
+  MDL=(markdownlint)
+elif [[ -x node_modules/.bin/markdownlint-cli2 ]]; then
+  # Probed by path, not by invoking npx: `npx --no-install <pkg>` still hits the
+  # registry to resolve the manifest before refusing to install, so on an
+  # offline or proxy-blocked host the detection itself stalls the runner.
+  MDL=(node_modules/.bin/markdownlint-cli2)
+else
+  MDL=()
+fi
+
+if [[ ${#MDL[@]} -eq 0 ]]; then
+  echo "SKIPPED: markdownlint (not installed — npm i -g markdownlint-cli2)"
+else
+  # Diff base: the merge-base with origin/main when it is known, else the whole
+  # tracked set. `git merge-base` failing (no origin/main in a fresh clone) must
+  # not abort the runner, hence the guarded assignment under `set -e`.
+  MD_BASE=""
+  if git rev-parse --verify --quiet origin/main >/dev/null; then
+    MD_BASE="$(git merge-base HEAD origin/main 2>/dev/null || true)"
+  fi
+
+  # Collected with a read loop, not `mapfile`: macOS ships bash 3.2, which has
+  # no mapfile, and local/CI parity is the whole point of this step.
+  MD_FILES=()
+  if [[ -n "$MD_BASE" ]]; then
+    while IFS= read -r f; do
+      [[ -n "$f" ]] && MD_FILES+=("$f")
+    done < <(git diff --name-only --diff-filter=d "$MD_BASE" -- '*.md')
+  else
+    echo "NOTE: origin/main unavailable — linting all tracked markdown"
+    while IFS= read -r f; do
+      [[ -n "$f" ]] && MD_FILES+=("$f")
+    done < <(git ls-files -- '*.md')
+  fi
+
+  if [[ ${#MD_FILES[@]} -eq 0 ]]; then
+    echo "no changed markdown files"
+  elif ! "${MDL[@]}" "${MD_FILES[@]}"; then
+    echo "WARNING: markdownlint findings above are advisory (CI does not fail on them)" >&2
+  fi
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 배경

`scripts/run-tests.sh` 는 CONTRIBUTING 에서 "the single entry point" 로 문서화돼
있지만 CI 가 강제하는 검증의 부분집합만 돌린다. 로컬 통과 후 PR 을 열면 CI 가
잡고, 수정 커밋이 한 번 더 붙는다 (PR #864 — `spec.md` 한 파일에 markdownlint
위반 23건, `style(hook): ...` 커밋 1건 추가 소요).

부수적으로 CONTRIBUTING 이 존재하지 않는 `.github/workflows/test.yml` 을 가리키고
있었고, "CI runs the same command" 라는 문장이 "로컬 러너 통과 = CI 통과" 오독을
직접 유도하고 있었다.

## 변경

**`scripts/run-tests.sh`** — 기존 4단계 뒤에 정적 검사 3단계 추가

| 단계 | 성격 | CI 대응 잡 |
| --- | --- | --- |
| `ruff check .` | blocking | `ci.yml` `ruff` |
| `shellcheck --severity=warning` | blocking | `ci.yml` `shellcheck` |
| `markdownlint` | advisory (실패시키지 않음) | `ci.yml` `markdownlint` |

- 각 단계는 도구 부재 시 `SKIPPED: <tool> (not installed — <설치법>)` 을 명시
  출력하고 통과한다. 도구 미설치 기여자를 막지 않되, "로컬 통과"의 의미가 흐려지지
  않도록 skip 사실을 숨기지 않는다.
- markdownlint 를 advisory 로 둔 이유: CI 가 `filter_mode: added` + never-fail 로
  돌리고 레포에 기존 위반 백로그가 있다. 로컬에서 blocking 으로 만들면 CI 가
  의도적으로 무시하는 위반을 실패로 승격시킨다.
- markdownlint 의 스코프는 `origin/main` 대비 **변경된 파일**로, reviewdog 의
  **추가된 줄** 필터보다 의도적으로 넓다. 실패시키지 않으므로 노이즈가 per-line
  필터 재구현보다 싼 거래.

**`CONTRIBUTING.md`** — `test.yml` → `ci.yml` 정정, "same command" 문장을 실제 잡
구성으로 교체, 신규 lint 단계와 skip 동작 문서화.

## 호스트 이식성 — 두 가지 함정을 피했다

1. **`mapfile` 미사용** — macOS 기본 bash 는 3.2 이고 `mapfile` 이 없다. 로컬/CI
   패리티가 이 변경의 본질이므로 read 루프로 수집한다.
   (`bash --version` → 3.2.57, `command -v mapfile` → 없음)
2. **`npx --no-install` 미사용** — npx 는 설치를 거부하기 전에 레지스트리에서
   manifest 를 해석하므로 오프라인·프록시 차단 환경에서 감지 자체가 러너를 멈춘다.
   `node_modules/.bin/markdownlint-cli2` 경로 확인으로 대체 (네트워크 무의존).

## 검증

Pre-commit verified: bash scripts/run-tests.sh → ALL TESTS PASSED (RUNNER_EXIT=0; pytest 500 passed, shell tests 실패 0건, ruff clean, shellcheck clean, markdownlint 는 이 호스트에서 설계대로 SKIPPED)

Caller chain verified: grep -rn 'run-tests.sh' → 호출부 2곳 (.github/workflows/ci.yml:97 의 `- run: bash scripts/run-tests.sh`, CONTRIBUTING.md:425 의 문서 예시). 둘 다 인자 없이 호출하고 종료 코드만 소비하므로 단계 추가는 호출 규약을 바꾸지 않는다. 함수·심볼 시그니처 변경 없음.

수용 기준별 실증:

- [x] **PR #864 위반 3종 로컬 검출** — 임시 fixture 파일로 세 위반을 재현한 뒤
      러너가 `MD060` (표 구분줄), `MD038` (코드 스팬 후행 공백), `MD040` (펜스 언어
      미지정) 을 모두 보고하는 것을 확인했다. 확인 후 fixture 는 삭제했고 추적
      잔여는 0 이다 (`git status --short` → 수정 파일 2개뿐).
- [x] **도구 미설치 시 crash 없이 skip 명시** — 실행 로그에
      `SKIPPED: markdownlint (not installed — npm i -g markdownlint-cli2)`
- [x] **워크플로 경로가 실재 파일과 일치** —
      Probe: grep -n 'analyze:' .github/workflows/codeql.yml → `25:  analyze:`
      (같은 grep 을 `.github/workflows/*.yml` 로 넓혀도 `ci.yml` 매치 없음) [verified]
      따라서 `analyze` 는 `ci.yml` 잡이 아니므로 별도 표기.
- [x] **"same command" 문장이 실제 잡 구성과 일치** — `ci.yml` 잡 7개
      (ruff/shellcheck/gitleaks/test/link-check/actionlint/markdownlint) 전부 반영,
      CodeQL 은 별도 워크플로로 분리 표기.

코드 리뷰: codex review 1라운드, 지적 2건(`npx` 네트워크 조회 / `analyze` 잡 위치)
전제 검증 후 모두 적용. 두 번째 지적은 이 PR 이 새로 쓴 문장의 사실 오류였다.

## 검증하지 못한 것

- `ruff` / `shellcheck` 의 SKIPPED 분기 — 두 도구 모두 이 호스트에 설치돼 있어
  markdownlint 의 skip 경로만 실제로 탔다.
- 오프라인 환경에서의 `npx` 지연 — 리뷰 샌드박스에서 관측됐을 뿐 직접 재현하지
  않았다. 경로 기반 감지로 바꾼 것은 그 조건을 반증하지 못했기 때문이다.

## 범위 밖 (별건)

- `gitleaks` / `link-check` / `analyze` / `actionlint` 는 네트워크·토큰·전체 트리
  스캔 의존이라 로컬 러너 편입 대상에서 제외.
- **shell test 실행 시간** — 이번 작업 중 러너 전체가 10분을 넘는 것이 확인됐다.
  개별 측정에서 10초 이상 걸리는 shell test 가 21개 이상, 그중 4개는 25초 캡에서도
  미완이었다. `origin/main` 기존 조건이며 이 PR 의 변경과 무관하다 (변경 파일은
  `scripts/run-tests.sh` 와 `CONTRIBUTING.md` 뿐). 별도 이슈 대상.

Closes #866


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing guidance to use the full test runner and describe its checks, CI alignment, and skipped-tool behavior.

* **Chores**
  * Expanded the test runner with Python linting, shell script checks, and advisory Markdown linting.
  * Added clear `SKIPPED:` messages when optional local tools are unavailable.
  * Markdown checks now focus on changed files when possible and report warnings without failing the run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->