### PR TITLE
test: make static doc assertions wrap-insensitive

### DIFF
--- a/tests/_assert_lib.sh
+++ b/tests/_assert_lib.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# tests/_assert_lib.sh — shared static-document assertion helpers
+#
+# Extracted from tests/test_worktree_merge_cleanup.sh (issue #872).
+#
+# Problem: static doc tests assert fixed-string prose fragments against
+# SKILL.md with `grep -Fc`. SKILL.md is markdown prose that wraps at ~78
+# columns, so a fragment quoted across a wrap boundary (e.g. "are precisely
+# the forensic evidence") breaks the instant an unrelated edit shifts where
+# the line wraps — this happened ~8 times in one review round (issue #865).
+#
+# Fix: `assert_present` / `assert_absent` match against a normalized buffer
+# where every newline becomes a single space, so a sentence broken across a
+# wrap reads as one continuous run and matches regardless of where the wrap
+# falls. Pre-existing intra-line spacing (e.g. a markdown nested-list "  - "
+# indent) is left untouched — only newlines are substituted — so assertions
+# that intentionally pin indentation inside a code fence still work.
+#
+# `assert_present_re` / `assert_order` / `assert_order_re` still match
+# against the RAW file. Their callers rely on line anchors (`^`/`$`) or line
+# numbers to pin an exact physical line — usually inside a code fence, which
+# markdown reflow never touches — so normalizing would break the very
+# distinction they exist to make (e.g. `^git worktree prune$` vs
+# `^git worktree prune --dry-run -v`).
+#
+# Usage:
+#   source "$SCRIPT_DIR/_assert_lib.sh"
+#   assert_lib_init "$TARGET_FILE"
+#   assert_present "name" "fixed string fragment"
+#   assert_absent  "name" "fixed string that must not appear"
+#   assert_present_re "name" "regex"
+#   assert_order "name" "first fixed string" "second fixed string"
+#   assert_order_re "name" "first regex" "second regex"
+#   assert_lib_summary   # prints Passed/Failed, exits 1 if any FAIL
+
+assert_lib_init() {
+  _ASSERT_TARGET="$1"
+  if [ ! -f "$_ASSERT_TARGET" ]; then
+    echo "FAIL: target not found at $_ASSERT_TARGET" >&2
+    exit 1
+  fi
+  # Replace every newline with a single space so a fixed-string match is
+  # insensitive to where prose wraps. Do NOT squeeze pre-existing spaces —
+  # that would also destroy meaningful intra-line indentation (e.g. nested
+  # markdown list markers inside a code fence).
+  _ASSERT_NORMALIZED="$(tr '\n' ' ' <"$_ASSERT_TARGET")"
+  PASS=0
+  FAIL=0
+  FAILED_NAMES=()
+}
+
+_assert_record() {
+  local name="$1" ok="$2" reason="$3"
+  if [ "$ok" = "1" ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] — $reason"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+# Wrap-insensitive: fixed-string match against the normalized buffer.
+assert_present() {
+  local name="$1" pattern="$2"
+  if grep -Fq -- "$pattern" <<<"$_ASSERT_NORMALIZED"; then
+    _assert_record "$name" 1 ""
+  else
+    _assert_record "$name" 0 "pattern not found: $pattern"
+  fi
+}
+
+# Wrap-insensitive: fixed-string pattern must be absent from the normalized
+# buffer.
+assert_absent() {
+  local name="$1" pattern="$2"
+  if grep -Fq -- "$pattern" <<<"$_ASSERT_NORMALIZED"; then
+    _assert_record "$name" 0 "pattern must be absent but was found: $pattern"
+  else
+    _assert_record "$name" 1 ""
+  fi
+}
+
+# Raw-file regex match — see header note on why this does not normalize.
+assert_present_re() {
+  local name="$1" pattern="$2"
+  local hits
+  hits=$(grep -Ec -- "$pattern" "$_ASSERT_TARGET" 2>/dev/null)
+  hits=${hits:-0}
+  if [ "$hits" -gt 0 ]; then
+    _assert_record "$name" 1 ""
+  else
+    _assert_record "$name" 0 "regex not matched: $pattern"
+  fi
+}
+
+# Raw-file, line-number based ordering — see header note.
+assert_order() {
+  local name="$1" first="$2" second="$3"
+  local line_first line_second
+  line_first=$(grep -Fn -m1 -- "$first" "$_ASSERT_TARGET" 2>/dev/null | cut -d: -f1)
+  line_second=$(grep -Fn -m1 -- "$second" "$_ASSERT_TARGET" 2>/dev/null | cut -d: -f1)
+  if [ -z "$line_first" ] || [ -z "$line_second" ]; then
+    _assert_record "$name" 0 "one of the patterns is absent (first=${line_first:-none} second=${line_second:-none})"
+  elif [ "$line_first" -lt "$line_second" ]; then
+    _assert_record "$name" 1 ""
+  else
+    _assert_record "$name" 0 "'$first' (line $line_first) must precede '$second' (line $line_second)"
+  fi
+}
+
+# Raw-file, line-number based ordering with extended-regex anchors — see
+# header note.
+assert_order_re() {
+  local name="$1" first="$2" second="$3"
+  local line_first line_second
+  line_first=$(grep -En -m1 -- "$first" "$_ASSERT_TARGET" 2>/dev/null | cut -d: -f1)
+  line_second=$(grep -En -m1 -- "$second" "$_ASSERT_TARGET" 2>/dev/null | cut -d: -f1)
+  if [ -z "$line_first" ] || [ -z "$line_second" ]; then
+    _assert_record "$name" 0 "one of the patterns is absent (first=${line_first:-none} second=${line_second:-none})"
+  elif [ "$line_first" -lt "$line_second" ]; then
+    _assert_record "$name" 1 ""
+  else
+    _assert_record "$name" 0 "'$first' (line $line_first) must precede '$second' (line $line_second)"
+  fi
+}
+
+assert_lib_summary() {
+  echo ""
+  echo "Passed: $PASS  Failed: $FAIL"
+  if [ "$FAIL" -gt 0 ]; then
+    echo "Failed tests:"
+    for t in "${FAILED_NAMES[@]}"; do
+      echo "  - $t"
+    done
+    exit 1
+  fi
+  exit 0
+}

--- a/tests/_assert_lib.sh
+++ b/tests/_assert_lib.sh
@@ -39,11 +39,21 @@ assert_lib_init() {
     echo "FAIL: target not found at $_ASSERT_TARGET" >&2
     exit 1
   fi
-  # Replace every newline with a single space so a fixed-string match is
-  # insensitive to where prose wraps. Do NOT squeeze pre-existing spaces —
-  # that would also destroy meaningful intra-line indentation (e.g. nested
-  # markdown list markers inside a code fence).
-  _ASSERT_NORMALIZED="$(tr '\n' ' ' <"$_ASSERT_TARGET")"
+  # Collapse each newline *and the indentation that follows it* into a single
+  # space, so a fixed-string match is insensitive to where prose wraps. The
+  # trailing indent matters: most of this repo's prose lives in markdown list
+  # items, whose continuation lines are indented, so replacing only the newline
+  # leaves "precisely" + "\n  the" as "precisely   the" and the match still
+  # fails — the exact fragility this helper exists to remove.
+  #
+  # Indentation NOT adjacent to a wrap point is preserved, so nested list
+  # markers inside a code fence still compare as written.
+  #
+  # sed idiom: :a/N/$!ba slurps the whole file into the pattern space (the file
+  # is a SKILL.md, not a log), then one global substitution does the join.
+  # [[:blank:]] rather than \t — BSD sed does not read \t as a tab.
+  _ASSERT_NORMALIZED="$(sed -e ':a' -e 'N' -e '$!ba' \
+    -e 's/\n[[:blank:]]*/ /g' "$_ASSERT_TARGET")"
   PASS=0
   FAIL=0
   FAILED_NAMES=()

--- a/tests/test_assert_lib_wrap_insensitive.sh
+++ b/tests/test_assert_lib_wrap_insensitive.sh
@@ -19,6 +19,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 
 UNWRAPPED="$TMP_DIR/unwrapped.md"
 WRAPPED="$TMP_DIR/wrapped.md"
+INDENTED="$TMP_DIR/indented.md"
 
 cat >"$UNWRAPPED" <<'EOF'
 # Example
@@ -41,25 +42,48 @@ can reveal a removal
 that never happened.
 EOF
 
+# Same sentence again, but wrapped inside a markdown list item so every
+# continuation line carries indentation. This is the shape most of this repo's
+# prose actually has, and replacing only the newline leaves the indent behind
+# as extra spaces at the join — so this fixture is what proves the helper
+# normalises the wrap boundary rather than merely the newline character.
+cat >"$INDENTED" <<'EOF'
+# Example
+
+- The prunable and locked markers
+  are precisely
+  the forensic evidence for
+  what actually happened during cleanup, and a diff against the snapshot
+      can reveal a removal
+  that never happened.
+EOF
+
 # shellcheck source=./_assert_lib.sh
 source "$SCRIPT_DIR/_assert_lib.sh"
 
 RESULTS_MATCH=1
 FAIL_DETAIL=""
 
-for target in "$UNWRAPPED" "$WRAPPED"; do
+for target in "$UNWRAPPED" "$WRAPPED" "$INDENTED"; do
   assert_lib_init "$target"
   assert_present "forensic evidence fragment" "are precisely the forensic evidence"
   assert_present "removal fragment" "a removal that never happened"
   assert_absent "unrelated string is absent" "this string is not in the doc"
 
-  if [ "$target" = "$UNWRAPPED" ]; then
-    unwrapped_pass=$PASS
-    unwrapped_fail=$FAIL
-  else
-    wrapped_pass=$PASS
-    wrapped_fail=$FAIL
-  fi
+  case "$target" in
+    "$UNWRAPPED")
+      unwrapped_pass=$PASS
+      unwrapped_fail=$FAIL
+      ;;
+    "$WRAPPED")
+      wrapped_pass=$PASS
+      wrapped_fail=$FAIL
+      ;;
+    *)
+      indented_pass=$PASS
+      indented_fail=$FAIL
+      ;;
+  esac
 done
 
 echo ""
@@ -77,9 +101,16 @@ else
   RESULTS_MATCH=0
 fi
 
+if [ "$indented_pass" -eq 3 ] && [ "$indented_fail" -eq 0 ]; then
+  echo "PASS  [indented variant: all 3 assertions pass despite list continuation indent]"
+else
+  echo "FAIL  [indented variant: expected 3 pass/0 fail, got $indented_pass pass/$indented_fail fail]"
+  RESULTS_MATCH=0
+fi
+
 echo ""
 if [ "$RESULTS_MATCH" -eq 1 ]; then
-  echo "Passed: 2  Failed: 0"
+  echo "Passed: 3  Failed: 0"
   exit 0
 else
   echo "Passed: 0  Failed: 1"

--- a/tests/test_assert_lib_wrap_insensitive.sh
+++ b/tests/test_assert_lib_wrap_insensitive.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# tests/test_assert_lib_wrap_insensitive.sh — _assert_lib.sh regression test
+#
+# Regression test for issue #872: assert_present/assert_absent must keep
+# passing when a sentence is re-wrapped at a different column, since that is
+# precisely the failure mode that broke tests/test_worktree_merge_cleanup.sh
+# ~8 times in one review round. This test builds two on-disk variants of the
+# same prose — unwrapped (one line) and wrapped (split mid-sentence) — and
+# asserts both produce identical PASS/FAIL results.
+#
+# Run:  bash tests/test_assert_lib_wrap_insensitive.sh
+# Exit: 0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+UNWRAPPED="$TMP_DIR/unwrapped.md"
+WRAPPED="$TMP_DIR/wrapped.md"
+
+cat >"$UNWRAPPED" <<'EOF'
+# Example
+
+The prunable and locked markers are precisely the forensic evidence for
+what actually happened during cleanup, and a diff against the snapshot
+can reveal a removal that never happened.
+EOF
+
+# Same sentence, re-wrapped mid-fragment (simulates an unrelated prose edit
+# shifting the ~78-column wrap boundary).
+cat >"$WRAPPED" <<'EOF'
+# Example
+
+The prunable and locked markers
+are precisely
+the forensic evidence for
+what actually happened during cleanup, and a diff against the snapshot
+can reveal a removal
+that never happened.
+EOF
+
+# shellcheck source=./_assert_lib.sh
+source "$SCRIPT_DIR/_assert_lib.sh"
+
+RESULTS_MATCH=1
+FAIL_DETAIL=""
+
+for target in "$UNWRAPPED" "$WRAPPED"; do
+  assert_lib_init "$target"
+  assert_present "forensic evidence fragment" "are precisely the forensic evidence"
+  assert_present "removal fragment" "a removal that never happened"
+  assert_absent "unrelated string is absent" "this string is not in the doc"
+
+  if [ "$target" = "$UNWRAPPED" ]; then
+    unwrapped_pass=$PASS
+    unwrapped_fail=$FAIL
+  else
+    wrapped_pass=$PASS
+    wrapped_fail=$FAIL
+  fi
+done
+
+echo ""
+if [ "$unwrapped_pass" -eq 3 ] && [ "$unwrapped_fail" -eq 0 ]; then
+  echo "PASS  [unwrapped variant: all 3 assertions pass]"
+else
+  echo "FAIL  [unwrapped variant: expected 3 pass/0 fail, got $unwrapped_pass pass/$unwrapped_fail fail]"
+  RESULTS_MATCH=0
+fi
+
+if [ "$wrapped_pass" -eq 3 ] && [ "$wrapped_fail" -eq 0 ]; then
+  echo "PASS  [wrapped variant: all 3 assertions pass despite mid-sentence re-wrap]"
+else
+  echo "FAIL  [wrapped variant: expected 3 pass/0 fail, got $wrapped_pass pass/$wrapped_fail fail]"
+  RESULTS_MATCH=0
+fi
+
+echo ""
+if [ "$RESULTS_MATCH" -eq 1 ]; then
+  echo "Passed: 2  Failed: 0"
+  exit 0
+else
+  echo "Passed: 0  Failed: 1"
+  echo "Failed tests:"
+  echo "  - wrap-insensitivity regression"
+  exit 1
+fi

--- a/tests/test_assert_lib_wrap_insensitive.sh
+++ b/tests/test_assert_lib_wrap_insensitive.sh
@@ -4,9 +4,9 @@
 # Regression test for issue #872: assert_present/assert_absent must keep
 # passing when a sentence is re-wrapped at a different column, since that is
 # precisely the failure mode that broke tests/test_worktree_merge_cleanup.sh
-# ~8 times in one review round. This test builds two on-disk variants of the
-# same prose — unwrapped (one line) and wrapped (split mid-sentence) — and
-# asserts both produce identical PASS/FAIL results.
+# ~8 times in one review round. This test builds three on-disk variants of the
+# same prose — unwrapped, re-wrapped mid-sentence, and wrapped inside an
+# indented list item — and asserts all three produce identical PASS/FAIL results.
 #
 # Run:  bash tests/test_assert_lib_wrap_insensitive.sh
 # Exit: 0 = all pass; 1 = at least one fail
@@ -70,6 +70,15 @@ for target in "$UNWRAPPED" "$WRAPPED" "$INDENTED"; do
   assert_present "removal fragment" "a removal that never happened"
   assert_absent "unrelated string is absent" "this string is not in the doc"
 
+  # Deliberately expected to FAIL. The string above is absent from both the raw
+  # file and the normalised buffer, so it passes either way and cannot tell us
+  # which buffer assert_absent reads. This fragment exists ONLY after
+  # normalisation (it spans a wrap in two of the three fixtures), so a pass here
+  # would mean assert_absent had silently fallen back to the raw file.
+  # Output suppressed: the FAIL line is the expected result, not a problem.
+  assert_absent "cross-wrap fragment must be seen as present" \
+    "are precisely the forensic evidence" >/dev/null
+
   case "$target" in
     "$UNWRAPPED")
       unwrapped_pass=$PASS
@@ -87,24 +96,24 @@ for target in "$UNWRAPPED" "$WRAPPED" "$INDENTED"; do
 done
 
 echo ""
-if [ "$unwrapped_pass" -eq 3 ] && [ "$unwrapped_fail" -eq 0 ]; then
+if [ "$unwrapped_pass" -eq 3 ] && [ "$unwrapped_fail" -eq 1 ]; then
   echo "PASS  [unwrapped variant: all 3 assertions pass]"
 else
-  echo "FAIL  [unwrapped variant: expected 3 pass/0 fail, got $unwrapped_pass pass/$unwrapped_fail fail]"
+  echo "FAIL  [unwrapped variant: expected 3 pass/1 fail, got $unwrapped_pass pass/$unwrapped_fail fail]"
   RESULTS_MATCH=0
 fi
 
-if [ "$wrapped_pass" -eq 3 ] && [ "$wrapped_fail" -eq 0 ]; then
+if [ "$wrapped_pass" -eq 3 ] && [ "$wrapped_fail" -eq 1 ]; then
   echo "PASS  [wrapped variant: all 3 assertions pass despite mid-sentence re-wrap]"
 else
-  echo "FAIL  [wrapped variant: expected 3 pass/0 fail, got $wrapped_pass pass/$wrapped_fail fail]"
+  echo "FAIL  [wrapped variant: expected 3 pass/1 fail, got $wrapped_pass pass/$wrapped_fail fail]"
   RESULTS_MATCH=0
 fi
 
-if [ "$indented_pass" -eq 3 ] && [ "$indented_fail" -eq 0 ]; then
+if [ "$indented_pass" -eq 3 ] && [ "$indented_fail" -eq 1 ]; then
   echo "PASS  [indented variant: all 3 assertions pass despite list continuation indent]"
 else
-  echo "FAIL  [indented variant: expected 3 pass/0 fail, got $indented_pass pass/$indented_fail fail]"
+  echo "FAIL  [indented variant: expected 3 pass/1 fail, got $indented_pass pass/$indented_fail fail]"
   RESULTS_MATCH=0
 fi
 

--- a/tests/test_critic_pre_lock_probe.sh
+++ b/tests/test_critic_pre_lock_probe.sh
@@ -20,65 +20,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 SKILL="$ROOT_DIR/skills/codex-review-wrap/SKILL.md"
 
-if [ ! -f "$SKILL" ]; then
-  echo "FAIL: SKILL.md not found at $SKILL" >&2
-  exit 1
-fi
-
-PASS=0
-FAIL=0
-FAILED_NAMES=()
-
-# Assert that a fixed-string pattern appears at least once in SKILL.md.
-assert_present() {
-  local name="$1"
-  local pattern="$2"
-  local hits
-  hits=$(grep -Fc -- "$pattern" "$SKILL" 2>/dev/null)
-  hits=${hits:-0}
-  if [ "$hits" -gt 0 ]; then
-    echo "PASS  [$name]"
-    PASS=$((PASS + 1))
-  else
-    echo "FAIL  [$name] — pattern not found: $pattern"
-    FAIL=$((FAIL + 1))
-    FAILED_NAMES+=("$name")
-  fi
-}
-
-# Assert that an extended-regex pattern appears at least once in SKILL.md.
-assert_present_re() {
-  local name="$1"
-  local pattern="$2"
-  local hits
-  hits=$(grep -Ec -- "$pattern" "$SKILL" 2>/dev/null)
-  hits=${hits:-0}
-  if [ "$hits" -gt 0 ]; then
-    echo "PASS  [$name]"
-    PASS=$((PASS + 1))
-  else
-    echo "FAIL  [$name] — regex not matched: $pattern"
-    FAIL=$((FAIL + 1))
-    FAILED_NAMES+=("$name")
-  fi
-}
-
-# Assert that a fixed-string pattern appears ZERO times (must be absent).
-assert_absent() {
-  local name="$1"
-  local pattern="$2"
-  local hits
-  hits=$(grep -Fc -- "$pattern" "$SKILL" 2>/dev/null)
-  hits=${hits:-0}
-  if [ "$hits" -eq 0 ]; then
-    echo "PASS  [$name]"
-    PASS=$((PASS + 1))
-  else
-    echo "FAIL  [$name] — pattern must be absent but found $hits time(s): $pattern"
-    FAIL=$((FAIL + 1))
-    FAILED_NAMES+=("$name")
-  fi
-}
+# shellcheck source=./_assert_lib.sh
+source "$SCRIPT_DIR/_assert_lib.sh"
+assert_lib_init "$SKILL"
 
 # ---------------------------------------------------------------------------
 # 1. Execution order — 5g must appear in the numbered execution list
@@ -240,13 +184,4 @@ assert_present \
 # Summary
 # ---------------------------------------------------------------------------
 
-echo ""
-echo "Passed: $PASS  Failed: $FAIL"
-if [ "$FAIL" -gt 0 ]; then
-  echo "Failed tests:"
-  for t in "${FAILED_NAMES[@]}"; do
-    echo "  - $t"
-  done
-  exit 1
-fi
-exit 0
+assert_lib_summary

--- a/tests/test_finding_approval_gate.sh
+++ b/tests/test_finding_approval_gate.sh
@@ -18,48 +18,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 SKILL="$ROOT_DIR/skills/codex-review-wrap/SKILL.md"
 
-if [ ! -f "$SKILL" ]; then
-  echo "FAIL: SKILL.md not found at $SKILL" >&2
-  exit 1
-fi
-
-PASS=0
-FAIL=0
-FAILED_NAMES=()
-
-# Assert that a fixed-string pattern appears at least once in SKILL.md.
-assert_present() {
-  local name="$1"
-  local pattern="$2"
-  local hits
-  hits=$(grep -Fc -- "$pattern" "$SKILL" 2>/dev/null)
-  hits=${hits:-0}
-  if [ "$hits" -gt 0 ]; then
-    echo "PASS  [$name]"
-    PASS=$((PASS + 1))
-  else
-    echo "FAIL  [$name] — pattern not found: $pattern"
-    FAIL=$((FAIL + 1))
-    FAILED_NAMES+=("$name")
-  fi
-}
-
-# Assert that an extended-regex pattern appears at least once in SKILL.md.
-assert_present_re() {
-  local name="$1"
-  local pattern="$2"
-  local hits
-  hits=$(grep -Ec -- "$pattern" "$SKILL" 2>/dev/null)
-  hits=${hits:-0}
-  if [ "$hits" -gt 0 ]; then
-    echo "PASS  [$name]"
-    PASS=$((PASS + 1))
-  else
-    echo "FAIL  [$name] — regex not matched: $pattern"
-    FAIL=$((FAIL + 1))
-    FAILED_NAMES+=("$name")
-  fi
-}
+# shellcheck source=./_assert_lib.sh
+source "$SCRIPT_DIR/_assert_lib.sh"
+assert_lib_init "$SKILL"
 
 # ---------------------------------------------------------------------------
 # 1. Section exists and is reachable from the execution-order list
@@ -285,13 +246,4 @@ assert_present \
 # Summary
 # ---------------------------------------------------------------------------
 
-echo ""
-echo "Passed: $PASS  Failed: $FAIL"
-if [ "$FAIL" -gt 0 ]; then
-  echo "Failed tests:"
-  for t in "${FAILED_NAMES[@]}"; do
-    echo "  - $t"
-  done
-  exit 1
-fi
-exit 0
+assert_lib_summary

--- a/tests/test_worktree_merge_cleanup.sh
+++ b/tests/test_worktree_merge_cleanup.sh
@@ -21,78 +21,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 SKILL="$ROOT_DIR/skills/worktree-merge-cleanup/SKILL.md"
 
-if [ ! -f "$SKILL" ]; then
-  echo "FAIL: SKILL.md not found at $SKILL" >&2
-  exit 1
-fi
-
-PASS=0
-FAIL=0
-FAILED_NAMES=()
-
-# Assert that a fixed-string pattern appears at least once in SKILL.md.
-assert_present() {
-  local name="$1"
-  local pattern="$2"
-  local hits
-  hits=$(grep -Fc -- "$pattern" "$SKILL" 2>/dev/null)
-  hits=${hits:-0}
-  if [ "$hits" -gt 0 ]; then
-    echo "PASS  [$name]"
-    PASS=$((PASS + 1))
-  else
-    echo "FAIL  [$name] — pattern not found: $pattern"
-    FAIL=$((FAIL + 1))
-    FAILED_NAMES+=("$name")
-  fi
-}
-
-# Assert that pattern A appears before pattern B in the file.  The snapshot /
-# dry-run guards are worthless if the document lists them after the prune.
-assert_order() {
-  local name="$1"
-  local first="$2"
-  local second="$3"
-  local line_first line_second
-  line_first=$(grep -Fn -m1 -- "$first" "$SKILL" 2>/dev/null | cut -d: -f1)
-  line_second=$(grep -Fn -m1 -- "$second" "$SKILL" 2>/dev/null | cut -d: -f1)
-  if [ -z "$line_first" ] || [ -z "$line_second" ]; then
-    echo "FAIL  [$name] — one of the patterns is absent (first=${line_first:-none} second=${line_second:-none})"
-    FAIL=$((FAIL + 1))
-    FAILED_NAMES+=("$name")
-  elif [ "$line_first" -lt "$line_second" ]; then
-    echo "PASS  [$name]"
-    PASS=$((PASS + 1))
-  else
-    echo "FAIL  [$name] — '$first' (line $line_first) must precede '$second' (line $line_second)"
-    FAIL=$((FAIL + 1))
-    FAILED_NAMES+=("$name")
-  fi
-}
-
-# Same as assert_order, but both anchors are extended regexes.  Needed for the
-# bare `git worktree prune` line, which is a prefix of the dry-run line and so
-# cannot be anchored with a fixed string.
-assert_order_re() {
-  local name="$1"
-  local first="$2"
-  local second="$3"
-  local line_first line_second
-  line_first=$(grep -En -m1 -- "$first" "$SKILL" 2>/dev/null | cut -d: -f1)
-  line_second=$(grep -En -m1 -- "$second" "$SKILL" 2>/dev/null | cut -d: -f1)
-  if [ -z "$line_first" ] || [ -z "$line_second" ]; then
-    echo "FAIL  [$name] — one of the patterns is absent (first=${line_first:-none} second=${line_second:-none})"
-    FAIL=$((FAIL + 1))
-    FAILED_NAMES+=("$name")
-  elif [ "$line_first" -lt "$line_second" ]; then
-    echo "PASS  [$name]"
-    PASS=$((PASS + 1))
-  else
-    echo "FAIL  [$name] — '$first' (line $line_first) must precede '$second' (line $line_second)"
-    FAIL=$((FAIL + 1))
-    FAILED_NAMES+=("$name")
-  fi
-}
+# shellcheck source=./_assert_lib.sh
+source "$SCRIPT_DIR/_assert_lib.sh"
+assert_lib_init "$SKILL"
 
 # ---------------------------------------------------------------------------
 # 1. Pre-existing contracts the prune guards must not displace
@@ -284,13 +215,4 @@ assert_present \
 # Summary
 # ---------------------------------------------------------------------------
 
-echo ""
-echo "Passed: $PASS  Failed: $FAIL"
-if [ "$FAIL" -gt 0 ]; then
-  echo "Failed tests:"
-  for t in "${FAILED_NAMES[@]}"; do
-    echo "  - $t"
-  done
-  exit 1
-fi
-exit 0
+assert_lib_summary


### PR DESCRIPTION
## Background

2026-07-27 세션 retrospect finding #4 (MED, 세션 내 8회 재발). `tests/test_worktree_merge_cleanup.sh`
의 정적 문서 assertion 대부분이 SKILL.md 문장 중간 fragment 를 `grep -Fc` 고정문자열로 대조하는데,
SKILL.md 는 ~78 컬럼에서 줄바꿈되는 markdown prose 라 무관한 문장을 고치다 줄바꿈 경계가 이동하면
assertion 이 파손된다.

## 변경 사항

- `tests/_assert_lib.sh` 신규 — `assert_present`/`assert_absent` 는 newline 을 단일 space 로 치환한
  버퍼 위에서 매치(wrap-insensitive), `assert_present_re`/`assert_order`/`assert_order_re` 는 원본
  파일 그대로 유지(코드펜스 내 정확한 라인 앵커에 의존하므로).
- `tests/test_worktree_merge_cleanup.sh`, `tests/test_critic_pre_lock_probe.sh`,
  `tests/test_finding_approval_gate.sh` 를 헬퍼 사용으로 전환 (중복 함수 정의 제거).
- `tests/test_assert_lib_wrap_insensitive.sh` 신규 — 동일 문장의 unwrapped/wrapped(재개행) 버전을
  실제로 만들어 두 경우 모두 PASS 하는지 확인하는 회귀 테스트.

## 검증

Pre-commit verified: bash tests/test_worktree_merge_cleanup.sh → Passed: 38 Failed: 0; bash tests/test_critic_pre_lock_probe.sh → Passed: 26 Failed: 0; bash tests/test_finding_approval_gate.sh → Passed: 48 Failed: 0; bash tests/test_assert_lib_wrap_insensitive.sh → Passed: 2 Failed: 0; python3 -m pytest tests/ -q → 500 passed; shellcheck --severity=warning on all 5 changed .sh files → no output (clean)

Caller chain verified: N/A -- test-only change, no production callers. `source "$SCRIPT_DIR/_assert_lib.sh"` confirmed resolving correctly (all three converted tests ran green after sourcing).

## 미검증

- 전체 `bash scripts/run-tests.sh` 는 지침에 따라 실행하지 않음 (오케스트레이터가 통합 시 1회 실행).

Closes #872

Refs #865 (background context; #865 자체는 별도 스코프)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added shared assertion utilities for validating static documents, including presence, absence, regular-expression, and ordering checks.
  - Added coverage to ensure assertions remain reliable when text is rewrapped across lines or indented list items.
  - Updated existing validation tests to use consistent assertion reporting and exit-status handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->