### PR TITLE
fix(hooks): honor CLAUDE_CONFIG_DIR in memory resolver

### DIFF
--- a/hooks/_lib/_memory_dir.py
+++ b/hooks/_lib/_memory_dir.py
@@ -16,7 +16,11 @@ Both hooks now import from here so the resolution semantics cannot drift.
 Resolution order:
   1. `PRAXIS_MEMORY_DIR` env var — when set, it is authoritative: return it
      if it is an existing directory, else None (no fallback attempt)
-  2. fallback `~/.claude/projects/{slugified-cwd}/memory` if it exists
+  2. fallback `${CLAUDE_CONFIG_DIR:-~/.claude}/projects/{slugified-cwd}/memory`
+     if it exists (#853: `CLAUDE_CONFIG_DIR` relocates Claude Code's config
+     root off the `~/.claude` default — a hardcoded `~/.claude` silently
+     reads the wrong/stale store on any host where that var is set and not
+     symlinked back to `~/.claude`)
   3. linked-worktree fallback (#824): when 2 misses, resolve the main
      worktree via `git rev-parse --git-common-dir` (its parent dir is the
      main worktree) and retry with THAT path's slug — Claude Code keys the
@@ -53,6 +57,16 @@ def slugify_project_path(path: str) -> str:
     return SLUG_CHAR_RE.sub("-", path)
 
 
+def _claude_config_dir(home: str) -> str:
+    """Claude Code's config root: `CLAUDE_CONFIG_DIR` override, else `~/.claude`.
+
+    #853: this resolver previously hardcoded `home + "/.claude"`, silently
+    ignoring `CLAUDE_CONFIG_DIR` when Claude Code's config root is relocated.
+    """
+    override = os.environ.get("CLAUDE_CONFIG_DIR", "").strip()
+    return override if override else os.path.join(home, ".claude")
+
+
 def _main_worktree_path() -> str | None:
     """Return the main worktree's absolute path, or None outside git.
 
@@ -86,9 +100,10 @@ def resolve_memory_dir() -> str | None:
         return env_dir if os.path.isdir(env_dir) else None
 
     home = os.path.expanduser("~")
+    config_dir = _claude_config_dir(home)
     cwd = os.getcwd()
     slug = slugify_project_path(cwd)
-    fallback = os.path.join(home, ".claude", "projects", slug, "memory")
+    fallback = os.path.join(config_dir, "projects", slug, "memory")
     if os.path.isdir(fallback):
         return fallback
 
@@ -98,7 +113,7 @@ def resolve_memory_dir() -> str | None:
     main_path = _main_worktree_path()
     if main_path and main_path != cwd:
         main_fallback = os.path.join(
-            home, ".claude", "projects", slugify_project_path(main_path), "memory"
+            config_dir, "projects", slugify_project_path(main_path), "memory"
         )
         if os.path.isdir(main_fallback):
             return main_fallback

--- a/hooks/advisory-nudge/memory-hint/impl.py
+++ b/hooks/advisory-nudge/memory-hint/impl.py
@@ -25,7 +25,7 @@ sibling hook blocked the command.
 
 Memory directory discovery:
   1. `PRAXIS_MEMORY_DIR` env var (when set + exists)
-  2. fallback to `~/.claude/projects/{slugified-cwd}/memory/`
+  2. fallback to `${CLAUDE_CONFIG_DIR:-~/.claude}/projects/{slugified-cwd}/memory/`
      (slugify rule: replace every non-alphanumeric character with `-`,
      per-character — see `hooks/_lib/_memory_dir.py`, the shared SoT)
   3. missing dir → exit 0 silently

--- a/tests/hooks/_lib/test_memory_dir.py
+++ b/tests/hooks/_lib/test_memory_dir.py
@@ -152,6 +152,27 @@ def test_worktree_cwd_resolves_to_main_project_memory(tmp_path, monkeypatch):
     assert _memory_dir.resolve_memory_dir() == str(memory)
 
 
+def test_worktree_cwd_honors_relocated_config_dir(tmp_path, monkeypatch):
+    # The two #853 fixes above only exercise the cwd-slug branch, and the #824
+    # test above only exercises the ~/.claude default — so the crossing of the
+    # two (relocated config root reached via the main-worktree slug) was the
+    # one path no test covered, even though it is the shape this repo actually
+    # runs in. ~/.claude is left empty so only the relocated root can answer.
+    monkeypatch.delenv("PRAXIS_MEMORY_DIR", raising=False)
+    relocated = tmp_path / "relocated-config"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(relocated))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(_memory_dir.os, "getcwd", lambda: WORKTREE_CWD)
+    monkeypatch.setattr(
+        _memory_dir.subprocess,
+        "run",
+        lambda *a, **k: _FakeGitProc(f"{FAKE_CWD}/.git\n"),
+    )
+    memory = relocated / "projects" / FAKE_SLUG / "memory"
+    memory.mkdir(parents=True)
+    assert _memory_dir.resolve_memory_dir() == str(memory)
+
+
 def test_worktree_fallback_git_absent_returns_none(tmp_path, monkeypatch):
     # Fail-safe: any git error (binary absent, not a repo) → current behavior.
     monkeypatch.delenv("PRAXIS_MEMORY_DIR", raising=False)

--- a/tests/hooks/_lib/test_memory_dir.py
+++ b/tests/hooks/_lib/test_memory_dir.py
@@ -58,6 +58,7 @@ def test_slugify_adjacent_specials_not_collapsed():
 def _fallback_fixture(tmp_path, monkeypatch):
     """Point HOME/cwd at a fake tree whose cwd contains a `.` (bug trigger)."""
     monkeypatch.delenv("PRAXIS_MEMORY_DIR", raising=False)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr(_memory_dir.os, "getcwd", lambda: FAKE_CWD)
     memory = tmp_path / ".claude" / "projects" / FAKE_SLUG / "memory"
@@ -74,6 +75,7 @@ def test_fallback_resolves_cwd_with_dot(tmp_path, monkeypatch):
 
 def test_fallback_dir_absent_returns_none(tmp_path, monkeypatch):
     monkeypatch.delenv("PRAXIS_MEMORY_DIR", raising=False)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr(_memory_dir.os, "getcwd", lambda: FAKE_CWD)
     assert _memory_dir.resolve_memory_dir() is None
@@ -89,10 +91,35 @@ def test_env_override_existing_dir(tmp_path, monkeypatch):
 def test_env_override_missing_dir_returns_none(tmp_path, monkeypatch):
     # Env var is authoritative when set: no fallback attempt on a missing dir.
     monkeypatch.setenv("PRAXIS_MEMORY_DIR", str(tmp_path / "does-not-exist"))
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr(_memory_dir.os, "getcwd", lambda: FAKE_CWD)
     (tmp_path / ".claude" / "projects" / FAKE_SLUG / "memory").mkdir(parents=True)
     assert _memory_dir.resolve_memory_dir() is None
+
+
+# --------------------------------------------------------------------------- #
+# CLAUDE_CONFIG_DIR relocation (#853)
+# --------------------------------------------------------------------------- #
+
+def test_claude_config_dir_relocates_fallback(tmp_path, monkeypatch):
+    # #853 core regression: when CLAUDE_CONFIG_DIR points off ~/.claude, the
+    # fallback must read from THAT root, not the hardcoded ~/.claude default
+    # (which is left empty here to prove the relocated path is what resolves).
+    monkeypatch.delenv("PRAXIS_MEMORY_DIR", raising=False)
+    relocated = tmp_path / "relocated-config"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(relocated))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(_memory_dir.os, "getcwd", lambda: FAKE_CWD)
+    memory = relocated / "projects" / FAKE_SLUG / "memory"
+    memory.mkdir(parents=True)
+    assert _memory_dir.resolve_memory_dir() == str(memory)
+
+
+def test_claude_config_dir_unset_falls_back_to_home_claude(tmp_path, monkeypatch):
+    # No CLAUDE_CONFIG_DIR → default remains ~/.claude (back-compat).
+    memory = _fallback_fixture(tmp_path, monkeypatch)
+    assert _memory_dir.resolve_memory_dir() == str(memory)
 
 
 # --------------------------------------------------------------------------- #
@@ -112,6 +139,7 @@ def test_worktree_cwd_resolves_to_main_project_memory(tmp_path, monkeypatch):
     # Core #824 regression: from a linked-worktree cwd the cwd-slug dir does
     # not exist, but the main worktree (parent of --git-common-dir) does.
     monkeypatch.delenv("PRAXIS_MEMORY_DIR", raising=False)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr(_memory_dir.os, "getcwd", lambda: WORKTREE_CWD)
     monkeypatch.setattr(
@@ -127,6 +155,7 @@ def test_worktree_cwd_resolves_to_main_project_memory(tmp_path, monkeypatch):
 def test_worktree_fallback_git_absent_returns_none(tmp_path, monkeypatch):
     # Fail-safe: any git error (binary absent, not a repo) → current behavior.
     monkeypatch.delenv("PRAXIS_MEMORY_DIR", raising=False)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr(_memory_dir.os, "getcwd", lambda: WORKTREE_CWD)
 
@@ -140,6 +169,7 @@ def test_worktree_fallback_git_absent_returns_none(tmp_path, monkeypatch):
 
 def test_worktree_fallback_git_error_returns_none(tmp_path, monkeypatch):
     monkeypatch.delenv("PRAXIS_MEMORY_DIR", raising=False)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr(_memory_dir.os, "getcwd", lambda: WORKTREE_CWD)
     monkeypatch.setattr(
@@ -156,6 +186,7 @@ def test_main_worktree_same_as_cwd_skips_retry(tmp_path, monkeypatch):
     # the `!= cwd` guard must skip the redundant retry and return None when
     # the (identical) slug dir is absent.
     monkeypatch.delenv("PRAXIS_MEMORY_DIR", raising=False)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr(_memory_dir.os, "getcwd", lambda: FAKE_CWD)
     monkeypatch.setattr(


### PR DESCRIPTION
## 배경

`hooks/_lib/_memory_dir.py`의 `resolve_memory_dir()`이 fallback/linked-worktree
경로 산출 시 `$HOME/.claude`를 하드코딩하고 있었다. Claude Code의 config 루트는
`$HOME/.claude`가 기본값일 뿐, `CLAUDE_CONFIG_DIR`로 재배치될 수 있다.
`PRAXIS_MEMORY_DIR`가 설정된 경우엔 문제없지만, 미설정 상태에서 config 루트가
재배치된 호스트에서는 `memory-hint` 훅이 엉뚱한(빈/오래된) store를 읽게 된다.

## 변경 사항

- `hooks/_lib/_memory_dir.py`: `_claude_config_dir(home)` 헬퍼 추가
  (`CLAUDE_CONFIG_DIR` env var 우선, 없으면 기존 `~/.claude` 기본값). fallback과
  linked-worktree 재시도 경로 모두 이 헬퍼를 사용하도록 교체.
- `hooks/advisory-nudge/memory-hint/impl.py`: docstring의 경로 설명을
  `${CLAUDE_CONFIG_DIR:-~/.claude}/...`로 갱신 (코드 변경 없음, 문서 정합성).
- `tests/hooks/_lib/test_memory_dir.py`: 회귀 테스트 2건 추가
  (`CLAUDE_CONFIG_DIR` 설정 시 그 경로로 resolve / 미설정 시 기존 `~/.claude` 유지),
  기존 테스트들에 `CLAUDE_CONFIG_DIR` delenv 보강(실제 호스트 env 누수 방지).

## 이슈 작업 항목 대비

- [x] `_memory_dir.py:91,101` 하드코딩 교체 (라인 번호는 구현 전 재확인, 변경 후 이동)
- [x] praxis 전반 `.claude` 하드코딩 audit — `_paths.py`의 `legacy_state_dir()`는
      pre-#527 back-compat 마이그레이션 소스(항상 리터럴 `~/.claude/state`)로,
      CLAUDE_CONFIG_DIR 인지 여부와 무관한 의도된 레거시 고정값이라 범위 밖으로 판단.
      나머지 히트는 문서/메시지 또는 리터럴 `.claude` 경로 패턴매칭(경로 구성 아님).
- [x] `CLAUDE_CONFIG_DIR` tmp 픽스처 테스트 추가
- [x] symlink 없는 격리 tmp 환경에서 회귀 검증 (테스트가 매번 tmp_path 사용, symlink 비의존)

## 검증

```
$ python3 -m pytest tests/ -q
502 passed in 9.47s

$ python3 -m pytest tests/hooks/_lib/test_memory_dir.py -q
14 passed in 0.13s

$ bash tests/hooks/advisory-nudge/test_memory_hint.sh
Passed: 36  Failed: 0

$ ruff check hooks/_lib/_memory_dir.py hooks/advisory-nudge/memory-hint/impl.py tests/hooks/_lib/test_memory_dir.py
All checks passed!
```

수정 전/후 재현 (이슈 본문의 검증 레시피와 동일한 방식, env-var injection):

```
$ CLAUDE_CONFIG_DIR=<tmp> python3 -c "... resolve_memory_dir() ..."
resolved: <tmp>/projects/-Users-.../memory   # 수정 후 — 재배치된 경로 반환
```

## 검증하지 못한 것

- 실제 `CLAUDE_CONFIG_DIR`가 symlink 없이 분리된 라이브 호스트는 이 세션에서
  이용 불가 — env-var injection 기반 tmp 픽스처로 대체 검증.

Pre-commit verified: `python3 -m pytest tests/ -q` → 502 passed; `ruff check` → All checks passed
Caller chain verified: `grep -rn "from _memory_dir import\|import _memory_dir" hooks/` → memory-hint/impl.py, momentum-rule-retrieval-gate/impl.py 둘 다 공유 resolver import (dual-SoT 없음), 이번 PR로 시그니처/동작 변경 없이 내부 경로 산출만 교체

Closes #853


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory storage fallback locations now respect the `CLAUDE_CONFIG_DIR` setting.
  * Linked-worktree memory paths also use the configured location.

* **Bug Fixes**
  * Restored fallback behavior to `~/.claude` when no custom configuration directory is set.
  * Preserved the existing memory directory override behavior.

* **Tests**
  * Added coverage for relocated and default memory directory resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->