### PR TITLE
docs(worktree-merge-cleanup): add squash merged-ness oracle

### DIFF
--- a/skills/worktree-merge-cleanup/SKILL.md
+++ b/skills/worktree-merge-cleanup/SKILL.md
@@ -175,6 +175,64 @@ earlier step is easily misread as "cleanup done". Run steps separately; after a
 fragile step (worktree remove / pull) fails, re-verify primitive state with
 `git worktree list` / `git branch | grep`.
 
+## Squash merge under bulk cleanup — the merged-ness oracle
+
+The unified sequence above cleans up **one** worktree right after its own PR
+merge, where `gh pr merge` itself is the merged-ness proof. Bulk cleanup of N
+already-merged local branches (no `gh pr merge` call in the loop) needs its
+own oracle, and under a squash-merge repo the obvious ones are wrong.
+
+- **`git branch --merged` is invalid.** It answers "is this branch's tip an
+  ancestor of `<base>`?" — true for a fast-forward or merge-commit, but a
+  squash merge creates a brand-new commit on `<base>` that is never an
+  ancestor of the original branch tip. A genuinely merged squash branch shows
+  up as **not** merged by this check.
+- **`git diff base...branch` (or `--stat`) is equally invalid**, for the
+  mirror reason: 3-dot diff shows the branch's unique commits relative to
+  their merge-base with `<base>`, and squash does not rewrite or remove those
+  commits from the branch ref — it only adds a new, unrelated commit to
+  `<base>`. A squash-merged branch still reports the same non-empty diff a
+  never-merged branch would, so an empty-diff check can never fire true and a
+  non-empty one can never rule the branch out.
+- **Valid oracle — tip SHA vs `headRefOid`, plus PR `state`.** Compare the
+  branch's local tip against the PR's recorded head SHA, then check the PR
+  closed as merged:
+
+  ```bash
+  git rev-parse <branch>
+  gh pr list --search "head:<branch>" --json number,headRefOid,state,mergedAt
+  ```
+
+  (`gh pr view <N> --json headRefOid,state,mergedAt` works the same way when
+  the PR number is already known.) The branch is safe to delete only when
+  **both** hold: the local tip SHA equals `headRefOid`, **and** `state` is
+  `MERGED` (not `OPEN`/`CLOSED`). `state` alone is insufficient — a PR can be
+  merged and the local branch since amended with unpushed commits, in which
+  case the tip SHA no longer matches the merged head and the extra commits
+  would be lost by deleting it.
+- Do not write verdict language ("safe to delete", "confirmed merged") before
+  this two-step check has actually run against live `gh` output — a plausible
+  guess from branch name or commit message is not evidence.
+
+### Bulk branch-delete procedure
+
+1. **Enumerate candidates**: list local branches to review (e.g.
+   `git branch --format='%(refname:short)'`, excluding the base branch).
+2. **Look up each branch's PR** with
+   `gh pr list --search "head:<branch>" --json number,headRefOid,state,mergedAt`.
+   - **No PR found** (never pushed, or pushed to a fork/deleted remote): this
+     branch is not tracked by the oracle above — fall back to a separate,
+     manual path (inspect the branch's own commits / confirm with the user)
+     rather than assuming it is safe or unsafe.
+3. **Confirm `state == "MERGED"`.** `OPEN` or `CLOSED` (without `mergedAt`)
+   means do not delete.
+4. **Compare tip SHA**: `git rev-parse <branch>` must equal the PR's
+   `headRefOid`. A mismatch means the local branch has commits the merged PR
+   never saw — do not delete without inspecting the difference first.
+5. Only after both checks pass, `git branch -D <branch>` (`-D` because the
+   squash commit is not an ancestor of the branch tip, so `-d` refuses with
+   "not fully merged" even though the PR is in fact merged).
+
 ## Relationship to enforcement
 
 | Layer | Home | Covers |
@@ -194,3 +252,8 @@ does not (and structurally cannot) enforce.
   out of scope here.
 - Worktree-recovery after an accidental removal is a separate concern (recover
   via `git worktree add`, never `git clone`).
+- The bulk branch-delete oracle covers branches with a discoverable PR only
+  (`gh pr list --search "head:<branch>"` returns a result). A branch pushed to
+  a fork, or whose PR/remote was deleted, has no `headRefOid` to compare
+  against — that case is out of scope here and needs a separate, manual
+  review path.

--- a/skills/worktree-merge-cleanup/SKILL.md
+++ b/skills/worktree-merge-cleanup/SKILL.md
@@ -194,22 +194,38 @@ own oracle, and under a squash-merge repo the obvious ones are wrong.
   `<base>`. A squash-merged branch still reports the same non-empty diff a
   never-merged branch would, so an empty-diff check can never fire true and a
   non-empty one can never rule the branch out.
-- **Valid oracle — tip SHA vs `headRefOid`, plus PR `state`.** Compare the
-  branch's local tip against the PR's recorded head SHA, then check the PR
-  closed as merged:
+- **Valid oracle — tip SHA vs `headRefOid`, plus PR `state` and `baseRefName`.**
+  Compare the branch's local tip against the PR's recorded head SHA, then check
+  the PR closed as merged *into the base you are cleaning up*:
 
   ```bash
   git rev-parse <branch>
-  gh pr list --search "head:<branch>" --json number,headRefOid,state,mergedAt
+  gh pr list --search "head:<branch>" --state merged \
+    --json number,headRefOid,state,mergedAt,baseRefName
   ```
 
-  (`gh pr view <N> --json headRefOid,state,mergedAt` works the same way when
-  the PR number is already known.) The branch is safe to delete only when
-  **both** hold: the local tip SHA equals `headRefOid`, **and** `state` is
-  `MERGED` (not `OPEN`/`CLOSED`). `state` alone is insufficient — a PR can be
-  merged and the local branch since amended with unpushed commits, in which
-  case the tip SHA no longer matches the merged head and the extra commits
-  would be lost by deleting it.
+  `--state merged` is **not optional**. `gh pr list` defaults to `--state open`
+  (`gh pr list --help`), so without it a squash-merged branch — the only kind
+  this procedure ever looks at — comes back as `[]` and the `state == MERGED`
+  check can never be reached. The failure is silent and looks exactly like "no
+  PR found", which routes every merged branch into the manual fallback path.
+
+  (`gh pr view <N> --json headRefOid,state,mergedAt,baseRefName` works the same
+  way when the PR number is already known, and needs no `--state` because it
+  addresses one PR directly.)
+
+  The branch is safe to delete only when **all three** hold:
+
+  1. the local tip SHA equals `headRefOid`;
+  2. `state` is `MERGED` (not `OPEN`/`CLOSED`);
+  3. `baseRefName` equals the `<base>` you are cleaning up.
+
+  `state` alone is insufficient — a PR can be merged and the local branch since
+  amended with unpushed commits, in which case the tip SHA no longer matches the
+  merged head and the extra commits would be lost by deleting it. `baseRefName`
+  matters because this skill covers `main`/`dev`/`prod` bases: a branch merged
+  into `dev` but not yet into `prod` satisfies conditions 1 and 2 while cleaning
+  up `prod`, and deleting it there discards work `prod` has never seen.
 - Do not write verdict language ("safe to delete", "confirmed merged") before
   this two-step check has actually run against live `gh` output — a plausible
   guess from branch name or commit message is not evidence.
@@ -219,17 +235,23 @@ own oracle, and under a squash-merge repo the obvious ones are wrong.
 1. **Enumerate candidates**: list local branches to review (e.g.
    `git branch --format='%(refname:short)'`, excluding the base branch).
 2. **Look up each branch's PR** with
-   `gh pr list --search "head:<branch>" --json number,headRefOid,state,mergedAt`.
+   `gh pr list --search "head:<branch>" --state merged --json number,headRefOid,state,mergedAt,baseRefName`.
+   - `--state merged` is required; the default is `open`, which returns `[]`
+     for exactly the branches this procedure exists to clean up.
    - **No PR found** (never pushed, or pushed to a fork/deleted remote): this
      branch is not tracked by the oracle above — fall back to a separate,
      manual path (inspect the branch's own commits / confirm with the user)
-     rather than assuming it is safe or unsafe.
+     rather than assuming it is safe or unsafe. If *every* branch reports "no
+     PR found", suspect the query before suspecting the branches — a dropped
+     `--state merged` produces precisely that pattern.
 3. **Confirm `state == "MERGED"`.** `OPEN` or `CLOSED` (without `mergedAt`)
    means do not delete.
 4. **Compare tip SHA**: `git rev-parse <branch>` must equal the PR's
    `headRefOid`. A mismatch means the local branch has commits the merged PR
    never saw — do not delete without inspecting the difference first.
-5. Only after both checks pass, `git branch -D <branch>` (`-D` because the
+5. **Confirm `baseRefName == <base>`** — the branch must have merged into the
+   base you are cleaning up, not a sibling base.
+6. Only after all three checks pass, `git branch -D <branch>` (`-D` because the
    squash commit is not an ancestor of the branch tip, so `-d` refuses with
    "not fully merged" even though the PR is in fact merged).
 

--- a/tests/test_worktree_merge_cleanup.sh
+++ b/tests/test_worktree_merge_cleanup.sh
@@ -212,6 +212,31 @@ assert_present \
   "never \`git clone\`"
 
 # ---------------------------------------------------------------------------
+# 7. Squash merged-ness oracle states every condition it depends on
+#
+# The oracle is a delete gate, so a silently weakened one is worse than none:
+# dropping --state merged makes it match nothing (every branch reads as
+# "no PR found"), and dropping baseRefName lets a branch merged into a sibling
+# base pass while cleaning this one.
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "oracle query filters to merged PRs" \
+  "--state merged"
+
+assert_present \
+  "oracle explains why --state merged is required" \
+  "defaults to \`--state open\`"
+
+assert_present \
+  "oracle checks the merge base, not just state" \
+  "\`baseRefName\` equals the \`<base>\` you are cleaning up"
+
+assert_present \
+  "3-dot diff is named as an invalid oracle" \
+  "\`git diff base...branch\`"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Background

2026-07-27 세션 retrospect finding #3 (HIGH). 26개 머지된 로컬 브랜치를 정리하면서
`git diff --stat main...<branch>` 를 안전 판정 오라클로 쓰고 "진짜 안전 판정" 이라 서술했으나,
squash merge 하에서 이 오라클은 원리적으로 mergedness 를 증명할 수 없다 — 3-dot diff 는 squash
된 브랜치의 고유 변경을 여전히 표시한다. 같은 이유로 `git branch --merged` 도 무효다. 이 사실이
`worktree-merge-cleanup` 스킬에는 반영되어 있지 않았다 (`grep -n "headRefOid\|merged"` → `git
branch -D` 두 줄만 존재).

## Base 브랜치 안내

이 PR 은 `main` 이 아니라 `issue-872-test-wrap-insensitive` (#872, PR #877) 위에서 브랜치했다.
같은 `SKILL.md` 파일을 다루므로, #872 가 먼저 머지되면 diff 충돌 없이 순서대로 rebase 될 것이다.
#871 자체는 #872 의 파일을 수정하지 않으므로(같은 파일의 다른 섹션 추가) 기능적 의존은 없지만,
두 PR 이 같은 파일을 건드리는 만큼 머지 순서를 #872 → #871 로 유지해 달라는 팀 지침을 따랐다.

## 변경 사항

`skills/worktree-merge-cleanup/SKILL.md` 에 새 절 추가:

1. **Squash merge 하의 merged-ness 오라클** — `git branch --merged` / `git diff base...branch`
   가 무효인 이유(둘 다 원본 브랜치 tip 의 ancestry/diff 를 보는데, squash 는 그 tip 을 재작성하지
   않음)와 유효 오라클(로컬 tip SHA vs PR `headRefOid`, 그리고 PR `state == MERGED`)을 문서화.
2. **bulk 브랜치 삭제 절차** — 후보 열거 → PR 조회 → `state == MERGED` 확인 → tip SHA 대조 →
   `git branch -D`. PR 없는(추적 불가) 브랜치는 별도 경로로 분리.
3. **Limitations** 에 오라클이 "PR 이 있는 브랜치"로만 스코프된다는 점 명시.

## 검증

Pre-commit verified: `bash tests/test_worktree_merge_cleanup.sh` → Passed: 38 Failed: 0 (기존 어서션 전부 유지, 신규 절이 wrap-insensitive 헬퍼(#872) 하에서도 문제 없음 확인); `python3 -m pytest tests/ -q` → 500 passed; 라이브 검증 — `gh pr list --search "head:issue-872-test-wrap-insensitive" --json number,headRefOid,state,mergedAt` 실행 결과 `headRefOid` 가 `git rev-parse issue-872-test-wrap-insensitive` 값과 정확히 일치함을 확인 (오라클이 문서대로 동작).

Caller chain verified: N/A -- docs-only change, no code caller. 새 섹션을 참조하는 테스트는 없음(라이브 확인은 위 명령 실행으로 대체).

## 미검증

- 이슈 본문에 명시된 대로, 이 섹션에 대한 정적 문서 테스트는 별도 이슈에서 추가 예정(wrap-insensitive 헬퍼가 안정화된 뒤).

Closes #871

Refs #865 (background context; #865 자체는 별도 스코프)
