### PR TITLE
fix(telemetry): isolate test writes from ledger

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+"""Global pytest fixtures — test-write isolation from production state (#849).
+
+Autouse, session-independent: every test gets its OWN per-test fire-ledger
+path, so a test that (directly or transitively, e.g. via
+`_dispatch.run_group`/`run_one`) exercises a real hook impl can never leak a
+record into the production ledger
+(`~/.praxis/telemetry/fire-events-YYYY-MM-DD.jsonl`).
+
+Root cause this closes: `tests/hooks/_lib/test_dispatch.py` calls
+`_dispatch.run_group(...)` and `_dispatch.run_one(...)` directly against the
+REAL hook roster with no `PRAXIS_FIRE_TELEMETRY_FILE`/`_DISABLE` override, so
+every parametrized member run wrote a real coarse/rich record — the exact
+9,476-record pollution (`_lib`/`boom`/`adv`/`ask`/`deny`/`pass`/`p1`/`p2`/
+`real_block`/`allow`) found across 14 production ledger dates. The `_lib`
+bucket specifically comes from `_dispatch.run_one`'s intentional
+double-`fail_open`-wrap (see its docstring, "double-wrapping an already-
+`@fail_open` main is harmless") — the second wrapper function is physically
+defined in `hooks/_lib/_hook_runtime.py`, so `_hook_identity()`'s
+parent-dir-of-`__code__.co_filename` rule resolves it to `hook="_lib",
+role="hooks"` when `run_one` is called standalone (outside `run_group`, whose
+`mark_dispatcher_process()` call would otherwise suppress that coarse
+record). This is a real attribution quirk of the double-wrap, not a second
+bug to fix — it only ever fires this way in tests that skip `run_group`.
+
+A test that needs to assert on ledger CONTENT still sets its own
+`PRAXIS_FIRE_TELEMETRY_FILE` (e.g. `tests/test_fire_ledger.py`) — safe to
+override here because `monkeypatch` is the same function-scoped stack the
+test body's own `monkeypatch.setenv(...)` call also uses; the test's own
+value simply wins (last write).
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolate_fire_telemetry(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "PRAXIS_FIRE_TELEMETRY_FILE", str(tmp_path / "fire-events-test.jsonl")
+    )


### PR DESCRIPTION
## 배경

프로덕션 fire-ledger(`~/.praxis/telemetry/fire-events-YYYY-MM-DD.jsonl`)에
manifest 미등록 훅명 레코드 16,796건이 있고, 그중 9,476건(`_lib`, `boom*`,
`adv`/`ask`/`deny`, `pass`/`p1`/`p2`, `real_block`/`allow`)은 테스트 아티팩트다.

## 근본 원인

`tests/hooks/_lib/test_dispatch.py`가 `_dispatch.run_group()` /
`_dispatch.run_one()`를 실제 훅 로스터에 대해 직접 호출하면서
`PRAXIS_FIRE_TELEMETRY_FILE`/`PRAXIS_FIRE_TELEMETRY_DISABLE`를 전혀 설정하지
않는다:

- fake-member 테스트(`test_deny_wins_over_ask_and_advisory`,
  `test_ask_when_no_deny`, `test_crash_isolated_as_pass` 류)가
  `run_group()`을 호출 → `_record_fires`(rich)가 `adv`/`ask`/`deny`/`pass`/
  `p1`/`p2` 같은 fake hook 이름으로 실제 ledger에 기록.
- `test_run_one_matches_subprocess_for_noop`(38개 멤버 parametrize)와
  `test_run_one_matches_subprocess_for_firing_payload`가 `run_one()`을
  **`run_group()`을 거치지 않고 직접** 호출 → `mark_dispatcher_process()`가
  선행되지 않아 `run_one()`의 의도된 이중 `fail_open` wrap(자체 docstring에
  "double-wrapping an already-`@fail_open` main is harmless"로 문서화된
  동작)의 두 번째 wrapper가 실행됨. 그 wrapper 함수 자체가
  `hooks/_lib/_hook_runtime.py`에 물리적으로 정의돼 있어
  `_hook_identity()`(= `__code__.co_filename`의 부모 디렉토리명)가
  `hook="_lib", role="hooks"`로 귀속 — **두 번째 버그가 아니라, `run_group()`을
  건너뛰는 테스트에서만 드러나는 귀속 특이 케이스**임을 코드로 확인.

## 변경 사항

- `tests/conftest.py` 신규: autouse fixture `isolate_fire_telemetry`가 모든
  pytest 테스트의 `PRAXIS_FIRE_TELEMETRY_FILE`을 테스트별 `tmp_path`로 강제.
  개별 테스트가 (지금처럼, 혹은 앞으로) 깜빡해도 conftest 레벨에서 새지 않음.
  `tests/test_fire_ledger.py`처럼 자체적으로 `monkeypatch.setenv(...)`를
  호출하는 테스트는 같은 function-scoped `monkeypatch` 스택을 공유하므로
  테스트 자신의 값이 그대로 우선(override) — 충돌 없음.

## 이슈 작업 항목 대비

- [x] 테스트 격리: conftest 레벨 autouse fixture 추가 (1번 항목)
- [x] `_lib` 귀속 경로 확인 — 위 근본 원인 참조, 별도 수정 불필요 판정 (2번 항목)
- [ ] **기존 14개 파일 오염 레코드 9,476건 소급 제거 — 미실행, 사용자 승인 필요**
      (3번 항목). `~/.praxis/telemetry/`는 저장소 밖 사용자 실제 머신 상태이고,
      현재 이 세션 시점 기준 today 파일 하나만도 16만+ 줄의 실사용 데이터다.
      이슈 코드 PR 안에서 판단할 사안이 아니라고 보아 보류 — 별도 승인 하에
      백업 후 진행을 권장.
- [ ] **분석 층 opt-in 훅 개념 도입 — 미착수** (4번 항목). `docs/hook-prune-audit.md`
      는 `bypass-review fire-rate` 1회성 호출 결과를 손으로 정리한 문서이고,
      manifest-ledger join을 수행하는 커밋된 스크립트가 현재 존재하지 않는다
      (grep 확인: `fire-events` 참조 3곳 — `bypass-review` 본체, 이 문서,
      retrospect-prune-audit.md뿐). 고칠 코드 사이트가 없어 후속 이슈로 남김.

## 검증

```
$ python3 -m pytest tests/ -q
500 passed in 12.65s

$ ruff check tests/conftest.py
All checks passed!
```

라이브 재현(수정 전/후, 실제 프로덕션 ledger 대상):

```
$ wc -l ~/.praxis/telemetry/fire-events-<today>.jsonl   # before
$ python3 -m pytest tests/hooks/_lib/test_dispatch.py -q   # 52 passed
$ wc -l ~/.praxis/telemetry/fire-events-<today>.jsonl   # after
$ sed -n '<before_line+1>,<after_line>p' ... | python3 -c "... hook name 카운트 ..."
# → adv/ask/deny/pass/p1/p2/real_block/allow/boom/_lib 계열 레코드 0건
#   (증가분은 전부 이 세션 자신의 실제 Bash 툴콜에서 나온 정상 훅명)
```

## 검증하지 못한 것 / 의도적 보류

- 위 3, 4번 항목 — 사유는 위 체크리스트 참조.

Pre-commit verified: `python3 -m pytest tests/ -q` → 500 passed; `ruff check tests/conftest.py` → All checks passed
Caller chain verified: `grep -n "PRAXIS_FIRE_TELEMETRY_FILE" tests/hooks/_lib/test_dispatch.py` → 0건 (조건 확인 완료, 이번 conftest fixture로만 격리됨을 검증)

Refs #849 (3, 4번 항목 미해결 — 위 사유로 보류, 이슈 유지)
