### PR TITLE
feat(hook): cover negative-polarity PR state claims

### DIFF
--- a/hooks/completion-verify/merge-state-claim-gate/impl.py
+++ b/hooks/completion-verify/merge-state-claim-gate/impl.py
@@ -159,6 +159,9 @@ def detect_unchanged_claims(text: str) -> list[str]:
 
 _GH_EVIDENCE_RE = re.compile(r"\bgh\b[^|;&\n]*\b(pr|issue)\b\s+[a-z]", re.IGNORECASE)
 _MCP_GH_EVIDENCE_RE = re.compile(r"pull_request|issue|merge|pr_", re.IGNORECASE)
+# Digit runs bounded on both sides: `864` must not be cleared by a query for
+# `1864` (`digits in cmd` substring matching cleared that collision).
+_STANDALONE_NUM_RE = re.compile(r"(?<![0-9])[0-9]+(?![0-9])")
 
 # Reachability evidence for "applied" claims (#656). A generic state query
 # (`gh pr view --json state`) is NOT sufficient — the 2026-05-15 incident ran
@@ -270,6 +273,12 @@ def has_reachability_evidence(events: list[dict]) -> bool:
     return False
 
 
+def _cites_number(text: str, digits: str) -> bool:
+    """True if `digits` appears in `text` as a whole number, not as a
+    substring of a longer one — `1864` must not clear a claim about `864`."""
+    return digits in _STANDALONE_NUM_RE.findall(text)
+
+
 def has_fresh_query_for_number(events: list[dict], number: str) -> bool:
     """True if a recent assistant `gh pr|issue` Bash command or GitHub MCP
     call explicitly references `number` (e.g. `gh pr view 864 --json state`
@@ -293,11 +302,11 @@ def has_fresh_query_for_number(events: list[dict], number: str) -> bool:
             if name == "Bash":
                 inp = block.get("input", {})
                 cmd = inp.get("command", "") if isinstance(inp, dict) else ""
-                if cmd and _GH_EVIDENCE_RE.search(cmd) and digits in cmd:
+                if cmd and _GH_EVIDENCE_RE.search(cmd) and _cites_number(cmd, digits):
                     return True
             elif name.startswith("mcp__github__") and _MCP_GH_EVIDENCE_RE.search(name):
                 inp = block.get("input", {})
-                if isinstance(inp, dict) and digits in json.dumps(inp):
+                if isinstance(inp, dict) and _cites_number(json.dumps(inp), digits):
                     return True
     return False
 

--- a/hooks/completion-verify/merge-state-claim-gate/impl.py
+++ b/hooks/completion-verify/merge-state-claim-gate/impl.py
@@ -159,9 +159,22 @@ def detect_unchanged_claims(text: str) -> list[str]:
 
 _GH_EVIDENCE_RE = re.compile(r"\bgh\b[^|;&\n]*\b(pr|issue)\b\s+[a-z]", re.IGNORECASE)
 _MCP_GH_EVIDENCE_RE = re.compile(r"pull_request|issue|merge|pr_", re.IGNORECASE)
-# Digit runs bounded on both sides: `864` must not be cleared by a query for
-# `1864` (`digits in cmd` substring matching cleared that collision).
-_STANDALONE_NUM_RE = re.compile(r"(?<![0-9])[0-9]+(?![0-9])")
+# The queried number must sit at the TARGET position of a READ subcommand.
+# Whole-command scanning cleared `#864` off `gh pr view 111 --repo org/p-864`
+# (number in an unrelated slug) and off `gh pr merge 864` (a mutation, which
+# tells you nothing about the post-merge state the claim asserts).
+_GH_READ_VERBS = frozenset({"view", "list", "status", "checks", "diff"})
+_GH_TARGET_RE = re.compile(
+    r"\bgh\b(?P<mid>[^|;&\n]*?)\b(?:pr|issue)\s+(?P<verb>[a-z-]+)(?P<rest>[^|;&\n]*)",
+    re.IGNORECASE,
+)
+_TARGET_NUM_RE = re.compile(r"(?:^|/)(?P<n>[0-9]+)$")
+# GitHub MCP reads only — a merge/create/close tool is a mutation, same
+# exclusion as the CLI verb allow-list above.
+_MCP_GH_READ_RE = re.compile(r"^mcp__github__(?:get|list|search|read)_|_read$", re.IGNORECASE)
+_MCP_NUMBER_KEY_RE = re.compile(
+    r"^(?:number|pull_?number|issue_?number|pr_?number)$", re.IGNORECASE
+)
 
 # Reachability evidence for "applied" claims (#656). A generic state query
 # (`gh pr view --json state`) is NOT sufficient — the 2026-05-15 incident ran
@@ -273,10 +286,39 @@ def has_reachability_evidence(events: list[dict]) -> bool:
     return False
 
 
-def _cites_number(text: str, digits: str) -> bool:
-    """True if `digits` appears in `text` as a whole number, not as a
-    substring of a longer one — `1864` must not clear a claim about `864`."""
-    return digits in _STANDALONE_NUM_RE.findall(text)
+def _bash_reads_number(cmd: str, digits: str) -> bool:
+    """True if `cmd` is a gh READ of exactly `digits`.
+
+    Positional, not substring: the number must appear as a bare argument or
+    a PR/issue URL ending in `/864`, and the subcommand must be a read verb.
+    `gh pr view 1864`, `gh pr view 111 --repo org/project-864` (digits inside
+    a slug never follow a `/`) and `gh pr merge 864 --squash` all fail.
+    Flag *values* are scanned too rather than assuming the target is the
+    first positional — `gh pr view --json state 864` is a real shape and a
+    value-taking-flag table would be its own drift surface.
+    """
+    for m in _GH_TARGET_RE.finditer(cmd):
+        if m.group("verb").lower() not in _GH_READ_VERBS:
+            continue
+        for token in m.group("rest").split():
+            if token.startswith("-"):
+                continue
+            hit = _TARGET_NUM_RE.search(token.rstrip("/"))
+            if hit and hit.group("n") == digits:
+                return True
+    return False
+
+
+def _mcp_reads_number(name: str, inp: dict, digits: str) -> bool:
+    """True if a GitHub MCP READ tool was called with `digits` in a
+    PR/issue *number* field. An owner/repo slug carrying the digits, and any
+    mutation tool (merge/create/close), do not count."""
+    if not _MCP_GH_READ_RE.search(name):
+        return False
+    for key, value in inp.items():
+        if _MCP_NUMBER_KEY_RE.match(str(key)) and str(value) == digits:
+            return True
+    return False
 
 
 def has_fresh_query_for_number(events: list[dict], number: str) -> bool:
@@ -302,11 +344,11 @@ def has_fresh_query_for_number(events: list[dict], number: str) -> bool:
             if name == "Bash":
                 inp = block.get("input", {})
                 cmd = inp.get("command", "") if isinstance(inp, dict) else ""
-                if cmd and _GH_EVIDENCE_RE.search(cmd) and _cites_number(cmd, digits):
+                if cmd and _bash_reads_number(cmd, digits):
                     return True
-            elif name.startswith("mcp__github__") and _MCP_GH_EVIDENCE_RE.search(name):
+            elif name.startswith("mcp__github__"):
                 inp = block.get("input", {})
-                if isinstance(inp, dict) and _cites_number(json.dumps(inp), digits):
+                if isinstance(inp, dict) and _mcp_reads_number(name, inp, digits):
                     return True
     return False
 

--- a/hooks/completion-verify/merge-state-claim-gate/impl.py
+++ b/hooks/completion-verify/merge-state-claim-gate/impl.py
@@ -103,6 +103,57 @@ _NEGATION_RE = re.compile(
 )
 
 # ---------------------------------------------------------------------------
+# Negative-polarity state claims (issue #869). "PR #864 는 여전히 OPEN, 커밋
+# 유실 없음" is a genuine state claim, but it is neither caught by
+# `_CLAIM_KINDS` (no merged/created/closed/cleaned/applied verb — "OPEN" and
+# "no loss" are not in that vocabulary at all) nor rescued by `_NEGATION_RE`
+# (which would silence it anyway, since "없음" matches). The original
+# negative-polarity design intentionally treated any negated line as safe —
+# but "여전히 OPEN" and "유실 없음" are exactly the persistence-of-state /
+# no-change claims that go stale across turns and were never re-verified in
+# the #869 incident (pre-compaction snapshot repeated across several turns;
+# the PR had actually merged 9ac8fa3 in the interim).
+#
+# Scope is deliberately narrow to avoid widening false positives (mirrors the
+# issue's own scoping note): this path fires ONLY when a PR/issue NUMBER
+# (`#123`) co-occurs with unchanged/still-open/no-loss vocabulary on the SAME
+# LINE. A numberless line ("the branch still has no open PR") is left to the
+# existing (silent) negation path — same trade-off style as the `applied`
+# kind's narrower negation set above.
+_UNCHANGED_STATE_RE = re.compile(
+    r"여전히\s*(?:OPEN|open|열려\s*있)|그대로|유실\s*(?:없|없음|없다)"
+    r"|남아있|변경\s*(?:없|되지\s*않)"
+    r"|(?<![A-Za-z0-9_])still\s+open(?![A-Za-z0-9_])"
+    r"|no\s+commits?\s+(?:were\s+)?lost|nothing\s+(?:was\s+)?lost"
+    r"|(?:hasn't|has\s+not|wasn't|was\s+not)\s+been\s+merged"
+    r"|remains?\s+open",
+    re.IGNORECASE,
+)
+_NUMBER_RE = re.compile(r"#(\d+)")
+
+
+def detect_unchanged_claims(text: str) -> list[str]:
+    """Return distinct `#N` tokens asserted as unchanged/still-open/no-loss,
+    ON THE SAME LINE as the number (co-occurrence narrowing per #869 scope).
+    Unlike `detect_claims`, this path is NOT skipped by `_NEGATION_RE` — the
+    negative surface form (없음/not merged/still open) IS the claim, mirroring
+    `runtime-state-claim-gate`'s "isolation" kind, which matches negative
+    surface forms directly instead of treating negation as a generic
+    suppressor."""
+    numbers: list[str] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if not _UNCHANGED_STATE_RE.search(line):
+            continue
+        for m in _NUMBER_RE.finditer(line):
+            tag = f"#{m.group(1)}"
+            if tag not in numbers:
+                numbers.append(tag)
+    return numbers
+
+# ---------------------------------------------------------------------------
 # Evidence detection — a fresh state query in the recent transcript.
 # ---------------------------------------------------------------------------
 
@@ -219,7 +270,39 @@ def has_reachability_evidence(events: list[dict]) -> bool:
     return False
 
 
-def _advisory(kinds: list[str]) -> str:
+def has_fresh_query_for_number(events: list[dict], number: str) -> bool:
+    """True if a recent assistant `gh pr|issue` Bash command or GitHub MCP
+    call explicitly references `number` (e.g. `gh pr view 864 --json state`
+    for claim `#864`). Narrower than `has_fresh_state_query`: a query for a
+    DIFFERENT PR/issue does not back a negative-polarity claim about THIS
+    number (#869) — a blanket "any gh query fires recently" check would have
+    let the incident's stale re-assertion pass if any unrelated `gh pr view`
+    call happened to appear in the window."""
+    digits = number.lstrip("#")
+    for ev in events[-_EVIDENCE_WINDOW:]:
+        msg = ev.get("message", {})
+        if msg.get("role") != "assistant" or ev.get("isSidechain"):
+            continue
+        content = msg.get("content", [])
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "tool_use":
+                continue
+            name = block.get("name", "") or ""
+            if name == "Bash":
+                inp = block.get("input", {})
+                cmd = inp.get("command", "") if isinstance(inp, dict) else ""
+                if cmd and _GH_EVIDENCE_RE.search(cmd) and digits in cmd:
+                    return True
+            elif name.startswith("mcp__github__") and _MCP_GH_EVIDENCE_RE.search(name):
+                inp = block.get("input", {})
+                if isinstance(inp, dict) and digits in json.dumps(inp):
+                    return True
+    return False
+
+
+def _advisory(kinds: list[str], stale_unchanged: list[str] | None = None) -> str:
     # The "no fresh state query" sentence is only true for the non-applied
     # kinds — an "applied" claim can be unbacked even when a state query
     # exists (that is exactly the incident shape), so the generic sentence
@@ -245,6 +328,19 @@ def _advisory(kinds: list[str]) -> str:
             "`gh pr view <N> --json state,baseRefName` or "
             "`git merge-base --is-ancestor <sha> origin/<target>` and cite the "
             "output before asserting applied/deployed/blocked-since.\n"
+        )
+    if stale_unchanged:
+        msg += (
+            f"{_PREFIX} final message asserts {', '.join(stale_unchanged)} is "
+            "still-open / unchanged / no-loss (여전히 OPEN / 유실 없음 / not "
+            "merged) but no fresh `gh pr|issue` query FOR THAT NUMBER appears "
+            "in the recent transcript.\n"
+            f"{_PREFIX} Rule: a persistence claim goes stale exactly like a "
+            "change claim — re-fetch the specific number "
+            "(`gh pr view <N> --json state` / `gh issue view <N>`) before "
+            "repeating a pre-compaction snapshot (issue #869: \"PR #864 는 "
+            "여전히 OPEN\" was repeated across turns while the PR had already "
+            "merged).\n"
         )
     return msg + f"{_PREFIX} bypass: {_BYPASS_ENV}=1\n"
 
@@ -278,7 +374,8 @@ def main() -> int:
         return 0
 
     kinds = detect_claims(last_text)
-    if not kinds:
+    unchanged_numbers = detect_unchanged_claims(last_text)
+    if not kinds and not unchanged_numbers:
         return 0
 
     # "applied" claims are cleared only by reachability evidence; the other
@@ -290,14 +387,22 @@ def main() -> int:
         unbacked = []
     if "applied" in kinds and not has_reachability_evidence(events):
         unbacked.append("applied")
-    if not unbacked:
+
+    # Negative-polarity persistence claims (#869): cleared per-NUMBER, not by
+    # any generic gh query — a query about a different PR/issue must not
+    # clear a stale claim about this one.
+    stale_unchanged = [
+        n for n in unchanged_numbers if not has_fresh_query_for_number(events, n)
+    ]
+
+    if not unbacked and not stale_unchanged:
         return 0
 
     if os.environ.get(_STRICT_ENV, "").strip() == "1":
-        emit_stop_block(_advisory(unbacked))
+        emit_stop_block(_advisory(unbacked, stale_unchanged))
         decision = _fire_ledger.DECISION_BLOCK
     else:
-        emit_stop_advisory(_advisory(unbacked))
+        emit_stop_advisory(_advisory(unbacked, stale_unchanged))
         decision = _fire_ledger.DECISION_ADVISE
     # Rich fire record (issue #847): Stop hooks signal block/advise via a stdout
     # decision while exiting 0, so @fail_open's coarse path records only "pass".

--- a/hooks/completion-verify/merge-state-claim-gate/spec.md
+++ b/hooks/completion-verify/merge-state-claim-gate/spec.md
@@ -144,6 +144,25 @@ the applied-kind's stricter-evidence precedent (#656): a looser generic
 check would have let the incident's exact stale re-assertion pass had any
 unrelated `gh pr view` call happened to appear nearby.
 
+The reference must be **positional and read-only**, not a substring of the
+command text:
+
+| Evidence shape | Clears `#864`? |
+| --- | --- |
+| `gh pr view 864 --json state` / `gh issue view 864` / `gh -R o/r pr view 864` | yes |
+| `gh pr view https://github.com/o/r/pull/864` | yes (URL target ends in `/864`) |
+| MCP read (`pull_request_read`, `get_issue`, …) with `pullNumber`/`issue_number` = `864` | yes |
+| `gh pr view 1864` | no — digits must be a whole number, not a longer one's prefix |
+| `gh pr view 111 --repo org/project-864` | no — the digits sit in a slug, not at the target position |
+| MCP read with `owner: team864`, `pullNumber: 111` | no — only PR/issue *number* fields count |
+| `gh pr merge 864 --squash`, MCP `merge_pull_request` | no — a mutation does not report the post-mutation state the claim asserts |
+
+**Known gap (deliberate).** A combined line ("PR #864 는 OPEN이고 커밋 유실
+없음") is cleared as a whole by a state-only read, even though `--json state`
+cannot witness a force-push that dropped commits. Requiring commit/head
+history evidence for the no-loss subtype specifically would change the
+gate's contract beyond issue #869's scope; it is left to a follow-up.
+
 ## Relationship to sibling hooks
 
 | Hook | Scope | Overlap |

--- a/hooks/completion-verify/merge-state-claim-gate/spec.md
+++ b/hooks/completion-verify/merge-state-claim-gate/spec.md
@@ -36,6 +36,10 @@ the model to verify before stopping.
 | Same, but a fresh `gh pr\|issue …` command or GitHub MCP pull_request/issue/merge tool is present in the recent transcript                                                                                     | silent (claim is backed)                                       |
 | Final message asserts an **applied-on-branch** state (`applied`/`deployed`/`적용됨`/`배포됨` …) AND no **reachability probe** in the recent transcript — a generic state query does NOT clear this kind (#656) | `[merge-state-claim-gate]` advisory with reachability guidance |
 | Applied-on-branch claim WITH a reachability probe (`git merge-base --is-ancestor`, `--json state,baseRefName` query, `git branch --contains`) in the recent transcript                                         | silent (claim is backed)                                       |
+| Final message asserts a **still-open / unchanged / no-loss** state for a specific `#N` (`PR #864 는 여전히 OPEN`, `no commits were lost from PR #864`) AND no fresh `gh pr\|issue` query FOR THAT NUMBER (#869)  | `[merge-state-claim-gate]` advisory                             |
+| Same unchanged claim, cleared by a `gh pr\|issue view <N>` or GitHub MCP call referencing THAT SAME number                                                                                                      | silent (claim is backed)                                       |
+| Same unchanged claim, a query for a DIFFERENT `#M` is present — does NOT clear                                                                                                                                  | `[merge-state-claim-gate]` advisory (per-number specificity)    |
+| Unchanged claim with no `#N` on the line (`the branch still has no open PR`)                                                                                                                                    | silent (deliberate narrowing — #869 scope, see below)           |
 | Final message has no such claim                                                                                                                                                                                | silent                                                         |
 | Claim line is negated (`not`, `yet`, `아직`, `않`, …)                                                                                                                                                          | silent                                                         |
 | Future intent only (`I'll create a PR`, `ready to merge`)                                                                                                                                                      | silent (completion tokens are past/perfective)                 |
@@ -102,6 +106,44 @@ This is deliberately CLI-only: an MCP `pull_request_read` *returns*
 mirrored in `hooks/advisory-nudge/external-write-falsify-check` (2 copies —
 DRY extraction deferred to a 3rd consumer per repo convention).
 
+### Negative-polarity persistence claims (issue #869)
+
+2026-07-27 session retrospect finding #2 (HIGH). Across several turns, the
+assistant repeated "PR #864 는 여전히 OPEN, 커밋 유실 없음" (still open, no
+commits lost) — a pre-compaction snapshot. The PR had actually merged as
+`9ac8fa3` and that commit was the base of the in-progress work. Re-query
+count over the affected turns: zero.
+
+`_NEGATION_RE` originally treated ANY negated line as safe to silence (a
+deliberate false-positive-avoidance choice). But "여전히 OPEN" / "유실 없음"
+were never even reaching that check — `_CLAIM_KINDS`' vocabulary
+(`merged`/`created`/`closed`/`cleaned`/`applied`) has no token for "OPEN" or
+"no loss" at all, so the line was invisible to the hook, negation aside.
+
+A second, independent claim path (`detect_unchanged_claims` /
+`_UNCHANGED_STATE_RE`) now recognizes persistence-of-state assertions —
+`여전히 OPEN`, `그대로`, `유실 없음`, `남아있`, `변경 없`, EN `still open`,
+`no commits lost`, `hasn't been merged`, `remains open` — and, mirroring
+`runtime-state-claim-gate`'s "isolation" kind, does **not** run the generic
+negation suppressor: the negative surface form (`없음`, `not merged`) IS the
+claim, not evidence that the assistant is reporting incompletion.
+
+**Scope narrowing (deliberate, per issue).** This path fires ONLY when a
+`#N` token co-occurs with the persistence vocabulary on the SAME LINE. A
+numberless line ("the branch still has no open PR", "여전히 열려
+있습니다") is left to the existing (silent) generic-negation path — widening
+to numberless lines was explicitly rejected to avoid reopening the original
+false-positive concern that motivated blanket negation suppression.
+
+**Per-number evidence (`has_fresh_query_for_number`).** Unlike the
+positive-kind evidence check (any recent `gh pr|issue` query clears any
+positive kind), an unchanged claim about `#864` is cleared ONLY by a query
+that itself references `864` — a `gh pr view 111 --json state` call sitting
+in the same window does NOT clear a stale claim about `#864`. This mirrors
+the applied-kind's stricter-evidence precedent (#656): a looser generic
+check would have let the incident's exact stale re-assertion pass had any
+unrelated `gh pr view` call happened to appear nearby.
+
 ### Relationship to sibling hooks
 
 | Hook                                                                       | Scope                                                         | Overlap                                                                  |
@@ -121,7 +163,7 @@ transcript, and any uncaught exception (via the shared `@fail_open` decorator in
 bash tests/hooks/completion-verify/test_merge_state_claim_gate.sh
 ```
 
-39 cases: English/Korean claim without evidence (advisory), claim with `gh`
+50 cases: English/Korean claim without evidence (advisory), claim with `gh`
 evidence / GitHub MCP evidence (silent), neutral message (silent), negated claim
 (silent), future intent (silent), strict mode (decision: block), bypass (silent),
 `stop_hook_active` loop guard (silent), worktree-cleanup claim (advisory),
@@ -137,3 +179,14 @@ regressions: `grep baseRefName` does not clear, long-flag
 `released the lock` prose stays silent, baseRefName-only query does not
 clear (codex P2), applied-only advisory drops the (false) generic
 "no fresh state query" sentence when a state query exists (CodeRabbit).
+
+Plus 11 negative-polarity persistence cases (#869): motivating incident
+verbatim (KR still-open + no-loss, zero re-query → advisory), cleared by a
+matching-number `gh pr view 864` / GitHub MCP `pullNumber: 864` query
+(silent, 2 cases), NOT cleared by a different-number query (advisory — the
+per-number specificity guard), EN "has not been merged" without/with a
+matching query (advisory / silent), "no commits lost" phrasing (advisory),
+two numberless claims EN/KR that stay silent (deliberate scope narrowing),
+a mixed message where a generic query clears a "merged" claim but does NOT
+clear an unchanged claim for a different number (advisory — number
+specificity), and strict mode on an unchanged-only claim (decision: block).

--- a/hooks/completion-verify/merge-state-claim-gate/spec.md
+++ b/hooks/completion-verify/merge-state-claim-gate/spec.md
@@ -7,7 +7,7 @@ event. It scans the **final assistant message** for a completed merge / PR /
 issue / worktree state assertion and, when no fresh state query appears in the
 recent transcript, emits a **stdout `{"systemMessage": ...}` JSON advisory**.
 
-### Why this exists
+## Why this exists
 
 A praxis ultrawork session (#487/#489) hallucinated review/merge state four
 times in one session: "PR #495/#497 created, merged, issue closed, worktree
@@ -21,7 +21,7 @@ they cannot gate a *claim*. The Stop hook is the exact complement: it sees the
 final assistant output and can cross-check it against what the session actually
 did.
 
-### What is emitted
+## What is emitted
 
 Advisory by default — exit 0 + stdout `{"systemMessage": ...}` JSON (issue #647
 H3; the old exit-0 stderr form only reached the debug log). The model has
@@ -30,24 +30,24 @@ the model). `PRAXIS_MERGE_CLAIM_STRICT=1`
 escalates to a `{"decision": "block", "reason": ...}` JSON, which re-prompts
 the model to verify before stopping.
 
-| Condition                                                                                                                                                                                                      | Result                                                         |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| Final message asserts a completed merge/PR/issue/worktree state AND no fresh state query in the recent transcript                                                                                              | `[merge-state-claim-gate]` advisory                            |
-| Same, but a fresh `gh pr\|issue …` command or GitHub MCP pull_request/issue/merge tool is present in the recent transcript                                                                                     | silent (claim is backed)                                       |
+| Condition | Result |
+| --- | --- |
+| Final message asserts a completed merge/PR/issue/worktree state AND no fresh state query in the recent transcript | `[merge-state-claim-gate]` advisory |
+| Same, but a fresh `gh pr\|issue …` command or GitHub MCP pull_request/issue/merge tool is present in the recent transcript | silent (claim is backed) |
 | Final message asserts an **applied-on-branch** state (`applied`/`deployed`/`적용됨`/`배포됨` …) AND no **reachability probe** in the recent transcript — a generic state query does NOT clear this kind (#656) | `[merge-state-claim-gate]` advisory with reachability guidance |
-| Applied-on-branch claim WITH a reachability probe (`git merge-base --is-ancestor`, `--json state,baseRefName` query, `git branch --contains`) in the recent transcript                                         | silent (claim is backed)                                       |
-| Final message asserts a **still-open / unchanged / no-loss** state for a specific `#N` (`PR #864 는 여전히 OPEN`, `no commits were lost from PR #864`) AND no fresh `gh pr\|issue` query FOR THAT NUMBER (#869)  | `[merge-state-claim-gate]` advisory                             |
-| Same unchanged claim, cleared by a `gh pr\|issue view <N>` or GitHub MCP call referencing THAT SAME number                                                                                                      | silent (claim is backed)                                       |
-| Same unchanged claim, a query for a DIFFERENT `#M` is present — does NOT clear                                                                                                                                  | `[merge-state-claim-gate]` advisory (per-number specificity)    |
-| Unchanged claim with no `#N` on the line (`the branch still has no open PR`)                                                                                                                                    | silent (deliberate narrowing — #869 scope, see below)           |
-| Final message has no such claim                                                                                                                                                                                | silent                                                         |
-| Claim line is negated (`not`, `yet`, `아직`, `않`, …)                                                                                                                                                          | silent                                                         |
-| Future intent only (`I'll create a PR`, `ready to merge`)                                                                                                                                                      | silent (completion tokens are past/perfective)                 |
-| `stop_hook_active` is true                                                                                                                                                                                     | silent (re-entry loop guard)                                   |
-| Missing/unreadable transcript, malformed stdin                                                                                                                                                                 | silent (fail-open)                                             |
-| `PRAXIS_MERGE_CLAIM_BYPASS` set                                                                                                                                                                                | silent (opt-out)                                               |
+| Applied-on-branch claim WITH a reachability probe (`git merge-base --is-ancestor`, `--json state,baseRefName` query, `git branch --contains`) in the recent transcript | silent (claim is backed) |
+| Final message asserts a **still-open / unchanged / no-loss** state for a specific `#N` (`PR #864 는 여전히 OPEN`, `no commits were lost from PR #864`) AND no fresh `gh pr\|issue` query FOR THAT NUMBER (#869) | `[merge-state-claim-gate]` advisory |
+| Same unchanged claim, cleared by a `gh pr\|issue view <N>` or GitHub MCP call referencing THAT SAME number | silent (claim is backed) |
+| Same unchanged claim, a query for a DIFFERENT `#M` is present — does NOT clear | `[merge-state-claim-gate]` advisory (per-number specificity) |
+| Unchanged claim with no `#N` on the line (`the branch still has no open PR`) | silent (deliberate narrowing — #869 scope, see below) |
+| Final message has no such claim | silent |
+| **Completed-state** claim line is negated (`not`, `yet`, `아직`, `않`, …) — persistence claims (`has not been merged`, `유실 없음`) are covered by the unchanged rows above, not silenced here | silent |
+| Future intent only (`I'll create a PR`, `ready to merge`) | silent (completion tokens are past/perfective) |
+| `stop_hook_active` is true | silent (re-entry loop guard) |
+| Missing/unreadable transcript, malformed stdin | silent (fail-open) |
+| `PRAXIS_MERGE_CLAIM_BYPASS` set | silent (opt-out) |
 
-### Claim detection
+## Claim detection
 
 A claim requires, **on the same line**, both:
 
@@ -73,7 +73,7 @@ narrower negation set with `without` dropped — "Deployed to prod without
 incident" is a genuine claim and must still fire (`fail` stays; the
 applied-claim-next-to-failing-prose miss is an accepted, documented trade-off).
 
-### Evidence detection
+## Evidence detection
 
 The recent transcript (last 80 events) is scanned for an assistant `tool_use`
 that is either:
@@ -106,7 +106,7 @@ This is deliberately CLI-only: an MCP `pull_request_read` *returns*
 mirrored in `hooks/advisory-nudge/external-write-falsify-check` (2 copies —
 DRY extraction deferred to a 3rd consumer per repo convention).
 
-### Negative-polarity persistence claims (issue #869)
+## Negative-polarity persistence claims (issue #869)
 
 2026-07-27 session retrospect finding #2 (HIGH). Across several turns, the
 assistant repeated "PR #864 는 여전히 OPEN, 커밋 유실 없음" (still open, no
@@ -144,20 +144,20 @@ the applied-kind's stricter-evidence precedent (#656): a looser generic
 check would have let the incident's exact stale re-assertion pass had any
 unrelated `gh pr view` call happened to appear nearby.
 
-### Relationship to sibling hooks
+## Relationship to sibling hooks
 
-| Hook                                                                       | Scope                                                         | Overlap                                                                  |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `completion-signal-gate`                                                   | Stop advisory on completion phrases without an evidence block | Complementary — generic "done" claims vs. specific merge/PR state claims |
-| `block-pr-without-caller-evidence` / `block-pr-without-precommit-evidence` | PreToolUse gate on PR *creation*                              | None — those gate the action; this gates the *assertion* of state        |
+| Hook | Scope | Overlap |
+| --- | --- | --- |
+| `completion-signal-gate` | Stop advisory on completion phrases without an evidence block | Complementary — generic "done" claims vs. specific merge/PR state claims |
+| `block-pr-without-caller-evidence` / `block-pr-without-precommit-evidence` | PreToolUse gate on PR *creation* | None — those gate the action; this gates the *assertion* of state |
 
-### Parsing guarantees (fail-open)
+## Parsing guarantees (fail-open)
 
 Returns exit 0 on every infrastructure error — malformed stdin, missing/unreadable
 transcript, and any uncaught exception (via the shared `@fail_open` decorator in
 `hooks/_lib/_hook_runtime.py`). It never blocks a normal Stop in the default mode.
 
-### Tests
+## Tests
 
 ```bash
 bash tests/hooks/completion-verify/test_merge_state_claim_gate.sh

--- a/tests/hooks/completion-verify/test_merge_state_claim_gate.sh
+++ b/tests/hooks/completion-verify/test_merge_state_claim_gate.sh
@@ -41,6 +41,15 @@ elif evidence == "baserefname-only":
 elif evidence == "branch-contains-long":
     asst_blocks.append({"type": "tool_use", "name": "Bash",
                         "input": {"command": "git branch --merged --contains abc123"}})
+elif evidence == "gh-864":
+    asst_blocks.append({"type": "tool_use", "name": "Bash",
+                        "input": {"command": "gh pr view 864 --json state"}})
+elif evidence == "gh-other":
+    asst_blocks.append({"type": "tool_use", "name": "Bash",
+                        "input": {"command": "gh pr view 111 --json state"}})
+elif evidence == "mcp-864":
+    asst_blocks.append({"type": "tool_use", "name": "mcp__github__pull_request_read",
+                        "input": {"pullNumber": 864}})
 if asst_blocks:
     events.append({"message": {"role": "assistant", "content": asst_blocks}})
 events.append({"message": {"role": "assistant",
@@ -319,6 +328,54 @@ if [ "$rc" -eq 0 ] && [ -z "$err" ]; then
 else
   echo "FAIL  [malformed-json] rc=$rc err=<$err>"; FAIL=$((FAIL + 1))
 fi
+
+# =====================================================================
+# Negative-polarity persistence claims (issue #869)
+# =====================================================================
+
+# --- motivating incident verbatim: still-open + no-loss, zero re-query -----
+build_transcript "PR #864 는 여전히 OPEN, 커밋 유실 없음." none
+run_case advisory "unchanged-incident-verbatim-kr" '{}'
+
+# --- same claim, cleared by a per-number gh query --------------------------
+build_transcript "PR #864 는 여전히 OPEN, 커밋 유실 없음." gh-864
+run_case silent "unchanged-cleared-by-matching-number-query" '{}'
+
+# --- same claim, a DIFFERENT number's query does NOT clear it -------------
+build_transcript "PR #864 는 여전히 OPEN, 커밋 유실 없음." gh-other
+run_case advisory "unchanged-not-cleared-by-other-number-query" '{}'
+
+# --- cleared by a per-number GitHub MCP read -------------------------------
+build_transcript "PR #864 는 여전히 OPEN, 커밋 유실 없음." mcp-864
+run_case silent "unchanged-cleared-by-mcp-number-read" '{}'
+
+# --- EN "has not been merged" persistence claim ----------------------------
+build_transcript "PR #864 has not been merged yet." none
+run_case advisory "unchanged-en-not-merged-no-query" '{}'
+
+build_transcript "PR #864 has not been merged yet." gh-864
+run_case silent "unchanged-en-not-merged-cleared" '{}'
+
+# --- "no commits lost" phrasing --------------------------------------------
+build_transcript "No commits were lost from PR #864." none
+run_case advisory "unchanged-no-commits-lost" '{}'
+
+# --- numberless unchanged claim -> silent (deliberate narrowing, #869 scope)
+build_transcript "The branch still has no open PR." none
+run_case silent "unchanged-numberless-out-of-scope" '{}'
+
+build_transcript "여전히 열려 있습니다." none
+run_case silent "unchanged-numberless-kr-out-of-scope" '{}'
+
+# --- mixed message: a cleared "merged" claim alongside an uncleared --------
+# unchanged claim for a DIFFERENT number -> advisory carries only the
+# unchanged sentence (the generic query clears "merged" but not #864).
+build_transcript "PR #497 merged. PR #864 는 여전히 OPEN, 커밋 유실 없음." gh
+run_case advisory "mixed-merged-cleared-unchanged-not" '{}'
+
+# --- strict mode on an unchanged-only claim --------------------------------
+build_transcript "PR #864 는 여전히 OPEN, 커밋 유실 없음." none
+run_case advisory-strict "unchanged-strict-mode" '{}' PRAXIS_MERGE_CLAIM_STRICT=1
 
 echo "----"
 echo "PASS: $PASS / FAIL: $FAIL"

--- a/tests/hooks/completion-verify/test_merge_state_claim_gate.sh
+++ b/tests/hooks/completion-verify/test_merge_state_claim_gate.sh
@@ -56,6 +56,21 @@ elif evidence == "gh-1864":
 elif evidence == "mcp-1864":
     asst_blocks.append({"type": "tool_use", "name": "mcp__github__pull_request_read",
                         "input": {"pullNumber": 1864}})
+elif evidence == "gh-864-in-slug":
+    asst_blocks.append({"type": "tool_use", "name": "Bash",
+                        "input": {"command": "gh pr view 111 --repo org/project-864 --json state"}})
+elif evidence == "mcp-864-in-owner":
+    asst_blocks.append({"type": "tool_use", "name": "mcp__github__pull_request_read",
+                        "input": {"owner": "team864", "pullNumber": 111}})
+elif evidence == "gh-864-merge":
+    asst_blocks.append({"type": "tool_use", "name": "Bash",
+                        "input": {"command": "gh pr merge 864 --squash"}})
+elif evidence == "mcp-864-merge":
+    asst_blocks.append({"type": "tool_use", "name": "mcp__github__merge_pull_request",
+                        "input": {"pullNumber": 864}})
+elif evidence == "gh-864-url":
+    asst_blocks.append({"type": "tool_use", "name": "Bash",
+                        "input": {"command": "gh pr view https://github.com/o/r/pull/864 --json state"}})
 if asst_blocks:
     events.append({"message": {"role": "assistant", "content": asst_blocks}})
 events.append({"message": {"role": "assistant",
@@ -405,6 +420,25 @@ run_case advisory "unchanged-not-cleared-by-longer-number" '{}'
 
 build_transcript "PR #864 는 여전히 OPEN." mcp-1864
 run_case advisory "unchanged-not-cleared-by-longer-number-mcp" '{}'
+
+# --- the number must sit at the READ subcommand's target position ----------
+# (codex review on #884): whole-command scanning cleared #864 off an
+# unrelated PR whose repo slug carried the digits, and off a mutation that
+# says nothing about the post-merge state the claim asserts.
+build_transcript "PR #864 는 여전히 OPEN." gh-864-in-slug
+run_case advisory "unchanged-not-cleared-by-digits-in-repo-slug" '{}'
+
+build_transcript "PR #864 는 여전히 OPEN." mcp-864-in-owner
+run_case advisory "unchanged-not-cleared-by-digits-in-owner" '{}'
+
+build_transcript "PR #864 는 여전히 OPEN." gh-864-merge
+run_case advisory "unchanged-not-cleared-by-cli-mutation" '{}'
+
+build_transcript "PR #864 는 여전히 OPEN." mcp-864-merge
+run_case advisory "unchanged-not-cleared-by-mcp-mutation" '{}'
+
+build_transcript "PR #864 는 여전히 OPEN." gh-864-url
+run_case silent "unchanged-cleared-by-pr-url-read" '{}'
 
 # --- strict mode on an unchanged-only claim --------------------------------
 build_transcript "PR #864 는 여전히 OPEN, 커밋 유실 없음." none

--- a/tests/hooks/completion-verify/test_merge_state_claim_gate.sh
+++ b/tests/hooks/completion-verify/test_merge_state_claim_gate.sh
@@ -50,6 +50,12 @@ elif evidence == "gh-other":
 elif evidence == "mcp-864":
     asst_blocks.append({"type": "tool_use", "name": "mcp__github__pull_request_read",
                         "input": {"pullNumber": 864}})
+elif evidence == "gh-1864":
+    asst_blocks.append({"type": "tool_use", "name": "Bash",
+                        "input": {"command": "gh pr view 1864 --json state"}})
+elif evidence == "mcp-1864":
+    asst_blocks.append({"type": "tool_use", "name": "mcp__github__pull_request_read",
+                        "input": {"pullNumber": 1864}})
 if asst_blocks:
     events.append({"message": {"role": "assistant", "content": asst_blocks}})
 events.append({"message": {"role": "assistant",
@@ -60,7 +66,7 @@ with open(path, "w", encoding="utf-8") as f:
 PY
 }
 
-# run_case <advisory|advisory-strict|silent> <name> <stop_payload_extra_json> [ENV=v ...]
+# run_case <advisory|advisory-unchanged-only|advisory-strict|silent> <name> <stop_payload_extra_json> [ENV=v ...]
 run_case() {
   local expected="$1" name="$2" extra="$3"
   shift 3
@@ -84,6 +90,22 @@ import json, sys
 d = json.load(sys.stdin)
 assert "[merge-state-claim-gate]" in d["systemMessage"]
 assert "decision" not in d
+' || ok=0
+      ;;
+    advisory-unchanged-only)
+      # the advisory carries ONLY the per-number persistence guidance — the
+      # generic "no fresh state query" sentence belongs to the merged claim,
+      # which the generic query already cleared.
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$err" ] || ok=0
+      printf '%s' "$out" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+m = d["systemMessage"]
+assert "[merge-state-claim-gate]" in m
+assert "decision" not in d
+assert "still-open / unchanged / no-loss" in m
+assert "asserts a" not in m, m
 ' || ok=0
       ;;
     advisory-strict)
@@ -370,8 +392,19 @@ run_case silent "unchanged-numberless-kr-out-of-scope" '{}'
 # --- mixed message: a cleared "merged" claim alongside an uncleared --------
 # unchanged claim for a DIFFERENT number -> advisory carries only the
 # unchanged sentence (the generic query clears "merged" but not #864).
-build_transcript "PR #497 merged. PR #864 는 여전히 OPEN, 커밋 유실 없음." gh
-run_case advisory "mixed-merged-cleared-unchanged-not" '{}'
+# The two claims MUST sit on separate lines: `detect_claims()` is line-scoped
+# and the `유실 없음` negation would otherwise disqualify the merged claim
+# sharing that line, so the intended path would never be exercised.
+build_transcript "PR #497 merged.
+PR #864 는 여전히 OPEN, 커밋 유실 없음." gh
+run_case advisory-unchanged-only "mixed-merged-cleared-unchanged-not" '{}'
+
+# --- number-collision regressions: a query for #1864 must NOT clear #864 ---
+build_transcript "PR #864 는 여전히 OPEN." gh-1864
+run_case advisory "unchanged-not-cleared-by-longer-number" '{}'
+
+build_transcript "PR #864 는 여전히 OPEN." mcp-1864
+run_case advisory "unchanged-not-cleared-by-longer-number-mcp" '{}'
 
 # --- strict mode on an unchanged-only claim --------------------------------
 build_transcript "PR #864 는 여전히 OPEN, 커밋 유실 없음." none


### PR DESCRIPTION
## 배경

2026-07-27 세션 retrospect finding #2 (HIGH). "PR #864 는 여전히 OPEN, 커밋 유실 없음" 이라는 pre-compaction snapshot 이 여러 턴에 걸쳐 재발화됐다. 실제로 #864 는 `9ac8fa3` 으로 이미 머지되어 있었고, 그 커밋이 진행 중이던 작업의 base 였다. 재조회는 0회.

## Base 선택

이 PR 은 **`origin/main`** 에서 직접 브랜치했다 (`#868` 브랜치 위가 아님). `#868` 은 신규 파일 `hooks/completion-verify/pr-claim-mutation-gate/` 를 추가하고, 이 PR 은 기존 `hooks/completion-verify/merge-state-claim-gate/impl.py` 를 확장한다 — 파일 충돌이 없고, 이슈 본문에서도 "확장 대상은 merge-state-claim-gate" 라고 명시되어 있어 두 이슈 사이에 실질적 의존관계가 없다고 판단했다.

## 왜 기존 `_NEGATION_RE` 가 놓쳤는가

`_CLAIM_KINDS` 어휘(`merged`/`created`/`closed`/`cleaned`/`applied`)에는 애초에 "OPEN" 이나 "유실 없음" 에 해당하는 토큰이 없어서, negation 검사에 도달하기 전에 이미 해당 줄이 클레임으로 인식되지 않았다.

## 변경 사항

`hooks/completion-verify/merge-state-claim-gate/impl.py` 에 독립적인 2번째 클레임 경로 추가:

- `_UNCHANGED_STATE_RE` + `detect_unchanged_claims()`: `여전히 OPEN`, `유실 없음`, `그대로`, `남아있`, EN `still open`/`no commits lost`/`hasn't been merged` 등 지속-상태 주장을 인식. `runtime-state-claim-gate` 의 "isolation" kind 선례를 따라 **generic negation suppressor 를 적용하지 않음** — 부정 표면형 자체가 주장이므로.
- **스코프 의도적 축소**: `#N` 번호가 같은 줄에 함께 있을 때만 발화 (이슈 본문의 "번호+상태어휘 동시조건"). 번호 없는 줄("여전히 열려 있습니다")은 기존 silent 경로 그대로 — 오탐 확대 방지를 위해 명시적으로 제외.
- `has_fresh_query_for_number()`: 기존 `has_fresh_state_query()`(임의의 gh 조회면 통과)와 달리, 주장된 번호와 **동일한 번호**를 참조하는 `gh pr|issue` 조회 또는 GitHub MCP 호출만 증거로 인정. 다른 번호 조회로는 clear 되지 않음.

## 입력 표면 enumeration (praxis:surface-enumeration)

| 축 | 커버된 변형 |
| --- | --- |
| polarity | 긍정형 없음(이 경로는 태생적으로 부정 표면형), EN/KR 부정 claim(2) |
| 번호 유무 | 번호 있음(발화, 5), 번호 없음 EN/KR(2, 의도적 silent) |
| 증거 specificity | 동일 번호 gh query/MCP(2, silent), 다른 번호 query(1, 여전히 발화) |
| mixed | 기존 positive kind(merged)는 generic query 로 clear, unchanged(다른 번호)는 미clear — 동일 메시지 내 혼재(1) |
| strict mode | unchanged-only claim 도 strict 승격 대상(1) |

11개 신규 fixture case 전부 `tests/hooks/completion-verify/test_merge_state_claim_gate.sh` 에 추가 (기존 39 + 신규 11 = 50).

## 검증

```
$ bash tests/hooks/completion-verify/test_merge_state_claim_gate.sh
... (50 cases, 기존 39건 회귀 없음 + 신규 11건)
PASS: 50 / FAIL: 0

$ ruff check hooks/completion-verify/merge-state-claim-gate/
All checks passed!

$ shellcheck --severity=warning tests/hooks/completion-verify/test_merge_state_claim_gate.sh
(no output)

$ python3 -m pytest tests/ -q
500 passed
```

## 검증하지 못한 것

- 실제 라이브 세션에서의 fire 여부(오탐률)는 관측하지 못함 — fixture 기반 unit 검증만 수행. 이슈 Task 의 "오탐률을 기존 ledger 로 측정" 항목은 이 세션에 fire-ledger 실측 데이터가 없어 수행 불가 — 배포 후 실측 필요.
- `docs/hook/INDEX.md` 갱신은 스코프 밖 (기존 훅 확장이라 신규 등록 불필요; 오케스트레이터 Phase 2 통합 지침에서 문서 인덱스 변경 금지).

Pre-commit verified: `bash tests/hooks/completion-verify/test_merge_state_claim_gate.sh` → PASS=50 FAIL=0; `python3 -m pytest tests/ -q` → 500 passed
Caller chain verified: N/A -- extends existing Stop hook already registered in hooks/manifest.json; no new caller wiring needed

Closes #869


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of negative-polarity “unchanged/still-open/no-loss” completion claims.
  * Added per-PR-number evidence handling so claims clear only when there’s a fresh query referencing the same number.
  * Strict verification now blocks unsupported unchanged-state persistence and shows targeted re-query guidance.

* **Documentation**
  * Expanded the `merge-state-claim-gate` spec with vocabulary, same-line number requirements, evidence-window rules, and strict-mode behavior.

* **Tests**
  * Added coverage for matching vs mismatched evidence, mixed-message scenarios, numberless out-of-scope claims, and number-collision regressions (including issue `#869` cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->