### PR TITLE
feat(hooks): guard force-push in bash commands

### DIFF
--- a/hooks/advisory-nudge/destructive-bash-guard/impl.py
+++ b/hooks/advisory-nudge/destructive-bash-guard/impl.py
@@ -33,6 +33,9 @@ Detected surfaces (issue #463 enumeration):
     (NOT `> /dev/null` or `> /dev/stderr`)
   • `git clean -fdx` / `git clean -fd` / `git clean -fx` etc.
   • `git reset --hard`
+  • `git push --force` / `-f` / `--force-with-lease[=<refspec>]` (issue #844
+    — rewrites a published ref; advisory only, MED severity, message
+    suggests a fixup commit as the non-destructive alternative)
   • `find ... -delete`
   • `truncate -s 0` / `truncate --size 0`
   • `shred` (overwrite-and-delete)
@@ -302,6 +305,45 @@ def _is_git_reset_hard(argv: list[str]) -> bool:
     return any(tok == "--hard" for tok in argv[i + 1:])
 
 
+def _is_git_push_force(argv: list[str]) -> bool:
+    """True iff argv invokes `git push` with `-f`/`--force` or
+    `--force-with-lease[=<refspec>]`.
+
+    Mirrors `_is_git_reset_hard`'s subcommand-skip loop for `-C dir` /
+    `-c key=val` global flags. Matches exact tokens only (no bundled-short-
+    flag handling like `_is_rm_recursive_force`) — `git push` has few short
+    flags and bundling a force flag with others is not an idiomatic form, so
+    the conservative-false-negative trade-off documented for this module
+    applies here too (see spec.md Known limitations).
+
+    Issue #844: `git push --force*` rewrites a published ref, distinct from
+    the local-only `git reset --hard` above.
+    """
+    if not argv or os.path.basename(argv[0]) != "git":
+        return False
+    i = 1
+    n = len(argv)
+    while i < n:
+        tok = argv[i]
+        if tok in {"-C", "-c"} and i + 1 < n:
+            i += 2
+            continue
+        if tok.startswith("-"):
+            i += 1
+            continue
+        break
+    if i >= n or argv[i] != "push":
+        return False
+    for tok in argv[i + 1:]:
+        if tok == "--":
+            break
+        if tok in {"-f", "--force"}:
+            return True
+        if tok == "--force-with-lease" or tok.startswith("--force-with-lease="):
+            return True
+    return False
+
+
 def _is_find_delete(argv: list[str]) -> bool:
     if not argv or os.path.basename(argv[0]) != "find":
         return False
@@ -438,6 +480,8 @@ def _classify_segment(raw_argv: list[str]) -> str | None:
         return "`git clean -f` — force-delete untracked files"
     if _is_git_reset_hard(argv):
         return "`git reset --hard` — discard working-tree changes"
+    if _is_git_push_force(argv):
+        return "`git push --force`/`--force-with-lease`/`-f` — rewrites published ref history"
     if _is_find_delete(argv):
         return "`find ... -delete` — bulk filesystem delete"
     if _is_truncate_zero(argv):
@@ -474,6 +518,17 @@ _SIGNAL_HEADER = "[destructive-bash-guard] outcome-proxy signal detected"
 def _advisory_text(reasons: list[str], strict: bool) -> str:
     mode = "BLOCKED-for-ask (strict mode)" if strict else "ADVISORY"
     body_lines = "\n".join(f"    - {r}" for r in reasons)
+    is_force_push = any("git push" in r for r in reasons)
+    force_push_hint = ""
+    if is_force_push:
+        force_push_hint = (
+            "\n"
+            "  Force-pushing rewrites a published ref other agents/reviewers may\n"
+            "  already be looking at. If the branch already has an open PR, prefer\n"
+            "  a fixup commit instead: `git commit --fixup=<sha>` — squash merge\n"
+            "  (this repo's convention) absorbs it automatically, no rewrite needed.\n"
+        )
+    reference = "issue #463, #844" if is_force_push else "issue #463"
     return (
         f"{_ADVISORY_HEADER} — {mode}\n"
         "\n"
@@ -482,12 +537,13 @@ def _advisory_text(reasons: list[str], strict: bool) -> str:
         "  Destructive commands can permanently delete files, overwrite\n"
         "  partitions, or escalate privileges. Verify the target path and\n"
         "  scope before proceeding.\n"
+        f"{force_push_hint}"
         "\n"
         "  Bypass options:\n"
         "    • Skip this single call: PRAXIS_HOOK_BYPASS_DESTRUCTIVE_BASH=1\n"
         "    • Soften strict mode: unset PRAXIS_DESTRUCTIVE_BASH_STRICT\n"
         "\n"
-        "  Reference: issue #463"
+        f"  Reference: {reference}"
     )
 
 

--- a/hooks/advisory-nudge/destructive-bash-guard/spec.md
+++ b/hooks/advisory-nudge/destructive-bash-guard/spec.md
@@ -42,6 +42,7 @@ Fires when **both** are true:
 | Block-device redirect | `>` or `>>` targeting `/dev/sd*`, `/dev/nvme*`, `/dev/disk*`, `/dev/hd*` | `cat foo > /dev/sda`, `tar c . > /dev/nvme0n1` |
 | `git clean -f` | `git clean` with `-f` or `--force` (any bundled form) | `git clean -fd`, `git clean -fdx`, `git clean --force .` |
 | `git reset --hard` | `git reset` with `--hard` | `git reset --hard HEAD~1` |
+| `git push --force` | `git push` with `-f`, `--force`, or `--force-with-lease[=<refspec>]` | `git push --force origin branch`, `git push -f origin branch`, `git push --force-with-lease origin branch` |
 | `find … -delete` | `find` with `-delete` or `--delete` | `find /tmp -name '*.bak' -delete` |
 | `truncate -s 0` | `truncate -s 0` / `--size 0` / `-s0` / `--size=0` | `truncate -s 0 logfile` |
 | `shred` | argv[0] is `shred` | `shred sensitive.dat` |
@@ -52,6 +53,46 @@ Fires when **both** are true:
 These device targets are NOT flagged when used as redirect targets:
 
 `/dev/null`, `/dev/stdout`, `/dev/stderr`, `/dev/zero`, `/dev/tty`
+
+### `git push --force*` — force-history-rewrite mutation (issue #844)
+
+`git push --force` / `-f` / `--force-with-lease[=<refspec>]` rewrites a
+published ref — the memory rule `force-history-rewrite-mutation` requires
+individual, explicit approval for this class of mutation, but until this
+issue there was no structural enforcement (`destructive-bash-guard` covered
+only `rm -rf` and `git clean -f`; a 2026-07-22 retrospect found the
+recurrence: two force-with-lease pushes executed without a prior surface,
+once from a delegated agent instruction and once directly, both bypassing
+the memory-only rule under an "unresponsive agent recovery" narrative).
+
+**Extend, not new sibling** — decided after surveying ≥2 sibling hooks
+(`gh-merge-worktree-precondition`, `commit-title-length-check` — both
+preflight-gate, ask/block severity) plus this hook's own existing `git
+clean -f` / `git reset --hard` rules. `destructive-bash-guard` already hosts
+git-subcommand-shape classifiers with the exact severity this issue asks
+for (advisory-by-default, MED severity, self-service bypass) — adding a new
+sibling hook would duplicate the tokenization/dispatch scaffold for a rule
+that fits the existing dispatch table's shape (one more `_is_git_*`
+classifier feeding `_classify_segment`). A new hook would be justified only
+if the severity needed to default to `ask`/`deny` (it does not — see
+"Task" §3 of the issue: "blast radius 참고: 자기 PR branch 대상이 대부분이라
+severity MED — advisory 우선").
+
+Detection: `git [-C <dir>|-c <k=v>|<bare flag>]* push ... (-f|--force|
+--force-with-lease[=<refspec>])`, scanning the tail after the `push` token
+and stopping at a literal `--` separator (so `git push -- --force` — a
+positional refspec named `--force` — does not false-positive). Matches exact
+tokens only, not bundled short flags — `git push` has few short flags and
+bundling a force flag with others is not an idiomatic form, so this mirrors
+the module's existing conservative-false-negative trade-off (see Known
+limitations).
+
+The advisory message conditionally appends a fixup-commit alternative
+(`git commit --fixup=<sha>` — squash merge absorbs it automatically, no
+force-push needed) and a `#844` reference **only** when a force-push reason
+is present — other destructive-command advisories are unaffected. This is
+the only rule in the module whose message body is reason-dependent; every
+other rule shares the same generic body.
 
 ### Outcome-proxy signal detection (issue #737)
 
@@ -115,6 +156,12 @@ bypass); the strict-mode env var has no effect on them.
 | `git clean -dn` | **SILENT** | dry-run (`-n`), no force |
 | `git reset --hard HEAD` | **ADVISORY** | git reset --hard |
 | `git reset HEAD foo` | **SILENT** | not --hard |
+| `git push --force origin branch` | **ADVISORY** | git push force (message includes fixup-commit alternative) |
+| `git push -f origin branch` | **ADVISORY** | short-flag force |
+| `git push --force-with-lease origin branch` | **ADVISORY** | force-with-lease |
+| `git push origin branch` | **SILENT** | no force flag |
+| `git push --no-force origin branch` | **SILENT** | explicit no-force |
+| `git push -- --force` | **SILENT** | `--force` is a positional refspec after `--` |
 | `find /tmp -name '*.tmp' -delete` | **ADVISORY** | find -delete |
 | `truncate -s 0 log.txt` | **ADVISORY** | truncate zero |
 | `truncate -s 100M file` | **SILENT** | non-zero size |
@@ -180,9 +227,15 @@ bash tests/hooks/advisory-nudge/test_destructive_bash_guard.sh
 ```
 
 Cases cover: every detection rule, false-positive guards (`rm -i`, `removed/`
-path, `git clean -n`, safe device targets, non-recursive chmod), compound
-command decomposition (`mkdir x && rm -rf x`), strict-mode JSON output,
-bypass env var, infrastructure fail-open, and the outcome-proxy signal rules
-(`git revert`, `gh pr close`, `gh issue reopen` — including that strict mode
-does NOT escalate them to `ask`, and that a compound command mixing a
+path, `git clean -n`, safe device targets, non-recursive chmod), the
+`git push --force`/`-f`/`--force-with-lease[=<refspec>]` rule (bare, short
+flag, inline-refspec form, global `-C` flag, flag positioned after the
+refspec) plus its negative cases (`--no-force`, a lookalike
+`--force-with-lease-typo`, `--force` as a positional after `--`), the
+reason-dependent fixup-commit hint appearing only on force-push advisories
+(never on `rm -rf`), compound command decomposition (`mkdir x && rm -rf x`),
+strict-mode JSON output, bypass env var, infrastructure fail-open, and the
+outcome-proxy signal rules (`git revert`, `gh pr close`, `gh issue reopen` —
+including that strict mode does NOT escalate them to `ask`, and that a
+compound command mixing a
 destructive match with a signal match emits both).

--- a/tests/hooks/advisory-nudge/test_destructive_bash_guard.sh
+++ b/tests/hooks/advisory-nudge/test_destructive_bash_guard.sh
@@ -209,6 +209,22 @@ run_case "git -C /tmp reset --hard" advisory "git -C /tmp reset --hard HEAD~1"
 run_case "git reset HEAD foo" silent "git reset HEAD foo"
 run_case "git reset --mixed" silent "git reset --mixed"
 
+# === ADVISORY — git push --force (issue #844) ==============================
+
+run_case "git push --force origin branch" advisory "git push --force origin branch"
+run_case "git push -f origin branch" advisory "git push -f origin branch"
+run_case "git push --force-with-lease origin branch" advisory "git push --force-with-lease origin branch"
+run_case "git push --force-with-lease=branch:sha origin branch (inline refspec)" advisory "git push --force-with-lease=branch:sha origin branch"
+run_case "git -C /tmp push --force (global flag)" advisory "git -C /tmp push --force origin branch"
+run_case "git push origin branch --force (flag after refspec)" advisory "git push origin branch --force"
+
+# === SILENT — git push without a force flag ================================
+
+run_case "git push origin branch" silent "git push origin branch"
+run_case "git push --no-force origin branch" silent "git push --no-force origin branch"
+run_case "git push --force-with-lease-typo (not the real flag)" silent "git push --force-with-lease-typo origin branch"
+run_case "git push -- --force (positional after --)" silent "git push -- --force"
+
 # === ADVISORY — find -delete ===============================================
 
 run_case "find /tmp -delete" advisory "find /tmp -name '*.bak' -delete"
@@ -364,6 +380,32 @@ if [ "$_uncaught_rc" -eq 0 ] && [ -z "$_uncaught_out" ]; then
 else
   echo "  FAIL  main() not wrapped by @fail_open (rc=$_uncaught_rc, out=$(echo "$_uncaught_out" | head -c 200))"
   FAIL=$((FAIL + 1)); FAILED_NAMES+=("main() is wrapped by the shared @fail_open guard")
+fi
+
+# === ADVISORY — fixup-commit alternative appears only for force-push =======
+
+_fp_out=$(python3 -c '
+import json, sys
+print(json.dumps({"tool_name": "Bash", "tool_input": {"command": "git push --force origin branch"}}))' \
+  | python3 "$HOOK" 2>&1 1>/dev/null)
+if echo "$_fp_out" | grep -q "git commit --fixup="; then
+  echo "PASS  [git push --force message includes fixup-commit alternative]"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL  [git push --force message includes fixup-commit alternative]"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("git push --force message includes fixup-commit alternative")
+fi
+
+_rm_out=$(python3 -c '
+import json, sys
+print(json.dumps({"tool_name": "Bash", "tool_input": {"command": "rm -rf /tmp/x"}}))' \
+  | python3 "$HOOK" 2>&1 1>/dev/null)
+if echo "$_rm_out" | grep -q "git commit --fixup="; then
+  echo "FAIL  [rm -rf message does NOT include the fixup-commit hint]"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("rm -rf message does NOT include fixup-commit hint")
+else
+  echo "PASS  [rm -rf message does NOT include the fixup-commit hint]"
+  PASS=$((PASS + 1))
 fi
 
 # === Summary ==============================================================


### PR DESCRIPTION
## 배경

`git push --force`/`--force-with-lease`/`-f` 는 published ref 를 다시 쓰는
mutation(`force-history-rewrite-mutation` 메모리 룰)인데 구조 enforcement 가
없었다. `destructive-bash-guard` 는 `rm -rf` 와 `git clean -f` 만 커버 (spec/impl
grep 확인). 2026-07-22 세션에서 `--force-with-lease` 를 사전 surface 없이 2회
실행("unresponsive agent recovery" 서사가 룰 retrieval 우회)한 재발 실측이
있음.

## Extend vs 신규 sibling 결정

`hooks/preflight-gate/gh-merge-worktree-precondition`,
`hooks/preflight-gate/commit-title-length-check` (둘 다 preflight-gate,
ask/block severity) 와 `destructive-bash-guard` 자신의 기존
`git clean -f`/`git reset --hard` 룰을 서베이한 뒤 **확장**으로 결정했다.
`destructive-bash-guard` 는 이미 이 이슈가 요구하는 정확한 severity
(advisory-by-default, MED, self-service bypass)를 가진 git-subcommand
classifier 디스패치 테이블을 갖고 있어, 새 sibling 훅은 동일한 tokenize/
dispatch scaffold 를 중복시킬 뿐이다. 신규 훅은 severity 가 기본 ask/deny
여야 정당화되는데, 이슈 본문 자체가 "blast radius 참고: 자기 PR branch 대상이
대부분이라 severity MED — advisory 우선"이라고 명시한다.

## 변경 사항

`hooks/advisory-nudge/destructive-bash-guard/impl.py`:

- `_is_git_push_force(argv)` 신설 — `git [-C/-c 등 global flag]* push` 뒤
  tail 을 스캔해 `-f`/`--force`/`--force-with-lease[=<refspec>]` 매칭,
  리터럴 `--` 이후는 스캔 중단(positional refspec 오탐 방지).
- `_classify_segment` dispatch 에 추가.
- 메시지: force-push 사유가 있을 때만(다른 destructive 룰에는 영향 없음)
  fixup-commit 대안(`git commit --fixup=<sha>` → squash merge 가 흡수)과
  `#844` reference 를 조건부로 append.

## 입력 표면 열거 (surface-enumeration)

- `git push --force` / `-f` / `--force-with-lease` (bare)
- `--force-with-lease=<branch:sha>` (inline refspec, glued `=`)
- `git -C <dir> push --force` (global flag 우회 방지)
- flag 가 refspec 뒤에 오는 형태 (`git push origin branch --force`)
- negative: `git push origin branch` (플래그 없음), `--no-force`,
  `--force-with-lease-typo`(lookalike, 오탐 방지), `git push -- --force`
  (positional refspec 이름이 `--force`인 경우 — `--` 이후는 검사 안 함)
- 기존 `rm -rf` 메시지에 fixup-commit 힌트가 섞여 나오지 않는지 negative 확인

각 변형이 테스트 케이스(총 10개 신규 케이스 + 기존 129→139)로 대응됨.

## 검증

```
bash tests/hooks/advisory-nudge/test_destructive_bash_guard.sh
# Results: 139 passed, 0 failed

python3 -m pytest tests/ -q
# 500 passed

ruff check hooks/advisory-nudge/destructive-bash-guard/impl.py
# All checks passed!

shellcheck --severity=warning tests/hooks/advisory-nudge/test_destructive_bash_guard.sh
# (경고 없음)
```

Pre-commit verified: `bash tests/hooks/advisory-nudge/test_destructive_bash_guard.sh` → Results: 139 passed, 0 failed; `python3 -m pytest tests/ -q` → 500 passed; `ruff check` clean; `shellcheck --severity=warning` clean.

Caller chain verified: 기존 `destructive-bash-guard` 확장이므로 신규 심볼 없음 — `grep -rn "destructive-bash-guard" hooks/manifest.json` 로 기존 등록(PreToolUse, Bash matcher) 그대로 유지 확인, manifest 변경 없음.

## 미검증 / 미포함

- 실제 Claude Code 런타임 canary 미실행 — release-please 배포 후 진행.
- manifest/hooks.json/INDEX.md/ARCHITECTURE.md 변경 없음(기존 훅 확장이라
  등록 변경 불필요).

Closes #844
