### PR TITLE
feat(hooks): cover squash-merge title length

### DIFF
--- a/hooks/preflight-gate/commit-title-length-check/impl.py
+++ b/hooks/preflight-gate/commit-title-length-check/impl.py
@@ -22,20 +22,39 @@ Detection path:
 Opt-out: embed `# title-length:ack` anywhere in the command to bypass.
 Skip: Merge / Revert commits, -F - (stdin body), unreadable -F files.
 Config: CLAUDE_COMMIT_TITLE_MAX=<n> (integer ≥ 1) overrides default 50.
+
+Squash-merge path (issue #843): `gh pr merge --squash` combines the PR title
+into the squash commit title on GitHub's side — a shape this hook's `git
+commit` matcher cannot see. Detected separately below and reported via
+stderr ADVISORY (not `ask`), never blocking the merge itself:
+
+  gh [global flags] pr merge [flags] --squash|-s
+    -> `-t`/`--subject <value>` present -> that value IS the title (no
+       network call needed)
+    -> otherwise -> `gh pr view <id> [-R repo] --json title -q .title`
+       (5s timeout, fail-open on any error)
+  len(title) > MAX -> stderr advisory (exit 0, command proceeds)
+
+`gh api repos/.../pulls/N/merge` is a DELIBERATE gap, not an oversight —
+see "Ordering constraint" in spec.md. The `git commit` path is unchanged
+(still `ask`, still blocking); only the new squash-merge path is advisory.
 """
 from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    _is_gh_binary,
     compound_cascade_hint,
     iter_command_starts,
     safe_tokenize,
+    strip_prefix,
 )
 from git_commit_titles import (  # type: ignore[import-not-found]  # noqa: E402
     extract_git_titles,
@@ -50,6 +69,135 @@ OPT_OUT_MARKER = "# title-length:ack"
 
 # Prefixes that indicate auto-generated merge/revert commits — skip them.
 SKIP_PREFIXES = ("Merge ", "Revert ")
+
+# ---------------------------------------------------------------------------
+# Squash-merge path (issue #843)
+# ---------------------------------------------------------------------------
+
+_GH_TIMEOUT_SEC = 5
+
+# gh global flags that consume one separate-token argument. Same set
+# duplicated across ~11 sibling hooks in this repo (pre-merge-approval-gate,
+# gh-merge-worktree-precondition, gh-flag-verify, etc.) — established repo
+# convention keeps this local rather than extracted to _lib.
+_GH_GLOBAL_FLAGS_WITH_ARG = frozenset({
+    "-R", "--repo",
+    "--hostname",
+    "--color",
+})
+
+# `gh pr merge` flags that consume one separate-token argument (per
+# `gh help pr merge`), needed to walk past them when scanning the tail.
+_MERGE_FLAGS_WITH_ARG = frozenset({
+    "-A", "--author-email",
+    "-b", "--body",
+    "-F", "--body-file",
+    "-t", "--subject",
+    "--match-head-commit",
+})
+
+_SQUASH_FLAGS = frozenset({"-s", "--squash"})
+_SUBJECT_FLAGS = frozenset({"-t", "--subject"})
+
+_TAIL_FLAGS_WITH_ARG = _MERGE_FLAGS_WITH_ARG | _GH_GLOBAL_FLAGS_WITH_ARG
+
+
+def _gh_pr_merge_segment(argv: list[str]) -> tuple[list[str], str | None] | None:
+    """Return (argv slice after `merge`, repo), or None if not `gh pr merge`.
+
+    Mirrors `gh-merge-worktree-precondition`'s `_merge_segment` — `-R`/
+    `--repo` (and the other value-taking gh global flags) are inherited
+    cobra flags gh accepts before `pr`, between `pr` and `merge`, and after
+    `merge` (the last placement handled by the tail scan below).
+    """
+    argv = strip_prefix(argv)
+    if not argv or not _is_gh_binary(argv[0]):
+        return None
+
+    repo: str | None = None
+    words: list[str] = []
+    i = 1
+    while i < len(argv) and len(words) < 2:
+        tok = argv[i]
+        if tok == "--":
+            i += 1
+            if i < len(argv):
+                words.append(argv[i])
+                i += 1
+            continue
+        if not tok.startswith("-"):
+            words.append(tok)
+            i += 1
+            continue
+        i += 1
+        base, eq, inline = tok.partition("=")
+        if eq and base in ("-R", "--repo"):
+            repo = inline or None
+        elif not eq and tok in _GH_GLOBAL_FLAGS_WITH_ARG and i < len(argv):
+            if tok in ("-R", "--repo"):
+                repo = argv[i]
+            i += 1
+
+    if words != ["pr", "merge"]:
+        return None
+    return argv[i:], repo
+
+
+def _scan_merge_tail(tail: list[str]) -> tuple[bool, str | None, str | None, str | None]:
+    """Single walk over the post-`merge` argv:
+    (has_squash, identifier, repo, subject_override)."""
+    has_squash = False
+    identifier: str | None = None
+    repo: str | None = None
+    subject: str | None = None
+    i = 0
+    while i < len(tail):
+        tok = tail[i]
+        if tok == "--":
+            if identifier is None and i + 1 < len(tail):
+                identifier = tail[i + 1]
+            break
+        if not tok.startswith("-"):
+            if identifier is None:
+                identifier = tok
+            i += 1
+            continue
+        base, eq, inline = tok.partition("=")
+        if base in _SQUASH_FLAGS:
+            has_squash = True
+        if eq and base in ("-R", "--repo"):
+            repo = inline or None
+        elif eq and base in _SUBJECT_FLAGS:
+            subject = inline
+        i += 1
+        if not eq and base in _TAIL_FLAGS_WITH_ARG and i < len(tail):
+            if base in ("-R", "--repo"):
+                repo = tail[i]
+            elif base in _SUBJECT_FLAGS:
+                subject = tail[i]
+            i += 1
+    return has_squash, identifier, repo, subject
+
+
+def _resolve_pr_title(identifier: str | None, cwd: str | None, repo: str | None) -> str | None:
+    """`gh pr view <id> [-R repo] --json title -q .title`, fail-open on error."""
+    cmd = ["gh", "pr", "view"]
+    if identifier:
+        cmd.append(identifier)
+    if repo:
+        cmd += ["-R", repo]
+    cmd += ["--json", "title", "-q", ".title"]
+    try:
+        result = subprocess.run(
+            cmd, cwd=cwd or None, capture_output=True, text=True,
+            timeout=_GH_TIMEOUT_SEC, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    title = result.stdout.strip()
+    return title or None
 
 
 # ---------------------------------------------------------------------------
@@ -75,6 +223,13 @@ def _get_max() -> int:
 
 def _emit_ask(reason: str) -> None:
     emit_decision("ask", reason)
+
+
+def _emit_squash_advisory(reason: str) -> None:
+    """Stderr-only advisory for the squash-merge path (issue #843) — never
+    `ask`, so a `gh pr view` network hiccup or an over-eager match cannot
+    block a merge. See spec.md 'Severity: advisory, not ask' for rationale."""
+    sys.stderr.write(f"[commit-title-length-check] {reason}\n")
 
 
 # ---------------------------------------------------------------------------
@@ -108,6 +263,7 @@ def main() -> int:
         return 0
 
     max_len = _get_max()
+    cwd = payload.get("cwd") or None
 
     for argv in iter_command_starts(tokens):
         titles = extract_git_titles(argv)
@@ -123,6 +279,33 @@ def main() -> int:
                     + compound_cascade_hint(command)
                 )
                 return 0  # ask emitted; only report first violation
+
+        merge_segment = _gh_pr_merge_segment(argv)
+        if merge_segment is None:
+            continue
+        tail, repo = merge_segment
+        has_squash, identifier, tail_repo, subject = _scan_merge_tail(tail)
+        if not has_squash:
+            continue
+        repo = tail_repo or repo
+
+        # `-t`/`--subject` overrides the PR title as the squash commit
+        # title — no network call needed when present.
+        title = subject if subject is not None else _resolve_pr_title(identifier, cwd, repo)
+        if not title:
+            continue  # unresolvable (fail-open) or genuinely empty
+        if any(title.startswith(p) for p in SKIP_PREFIXES):
+            continue
+        length = len(title)
+        if length > max_len:
+            _emit_squash_advisory(
+                f"Squash-merge title too long: {length} chars (max {max_len}).\n"
+                f"Title: {title!r}\n"
+                "The PR title becomes the squash commit title on merge. Shorten "
+                "the PR title, pass `-t <title>` (≤50 chars) to override the "
+                "subject, or embed `# title-length:ack` to acknowledge."
+            )
+            return 0  # advisory emitted; only report first violation
 
     return 0
 

--- a/hooks/preflight-gate/commit-title-length-check/spec.md
+++ b/hooks/preflight-gate/commit-title-length-check/spec.md
@@ -40,6 +40,55 @@ issue #177.
 Length counting uses Python `len(str)` which counts Unicode code points — the
 correct measure for the 50-char rule in Korean/CJK mixed commit titles.
 
+### Squash-merge path (issue #843)
+
+`git commit` is not the only path a commit title reaches `main` through: `gh
+pr merge --squash` combines the PR's title into the squash commit title on
+GitHub's side, a shape the `git commit` matcher above cannot see. Two real
+squash titles already landed on `main` over the limit — #834 at 61 chars,
+#835 at 63 chars (both measured excluding any trailing `(#N)` suffix GitHub
+appends) — because the gate only ever fired on the branch's own `git commit`
+calls, never on the merge that actually produced the title landing on
+`main`.
+
+| Command shape                                        | Action |
+| ------------------------------------------------------ | -------- |
+| `gh pr merge <id> --squash` / `-s`                     | resolve PR title via `gh pr view`; **advisory** (stderr) when over limit |
+| `gh pr merge <id> --squash -t "<subject>"`             | `-t`/`--subject` value IS the title — no network call, checked directly |
+| `gh pr merge <id> --merge` / `--rebase` (no `-s`)      | silent — not a squash, title composition differs |
+| `gh -R owner/repo pr merge <id> --squash`              | `-R`/`--repo` forwarded to the `gh pr view` resolution call |
+| `gh api repos/.../pulls/N/merge -f merge_method=squash` | **NOT matched — deliberate gap**, see "Ordering constraint" below |
+
+#### Severity: advisory, not `ask`
+
+Unlike the `git commit` path (which blocks via `ask`), the squash-merge path
+only ever writes a stderr advisory and always exits 0 — it never blocks the
+merge. Two reasons: (1) this path makes a live network call (`gh pr view`)
+that the `git commit` path never needed, so a transient API failure or
+latency spike must not be able to stall a merge; (2) the issue itself
+recommends starting conservative — "1단계는 advisory로 시작 권장" — given the
+new failure surface (network dependency) this path introduces relative to
+the pure-local `git commit` check.
+
+#### Ordering constraint — `gh api .../pulls/N/merge` intentionally NOT sealed
+
+The issue body asks to also match `gh api repos/.../pulls/N/merge` (the same
+mutation via the raw API instead of the `gh pr merge` subcommand). This PR
+deliberately does **not** cover that shape. A separate, unresolved
+release-lag issue needs the `gh api` path as an escape hatch while a
+defective *cached* hook (a prior release still running in
+`~/.claude/plugins/cache/`) is in play — fully sealing both paths in the
+same change window would remove that escape hatch before its blocking issue
+resolves. Extending coverage to `gh api` is left to a follow-up once that
+ordering constraint clears.
+
+#### `-t`/`--subject` override
+
+`gh pr merge` accepts `-t`/`--subject <value>` to set the squash commit
+subject directly, overriding the PR title. When present, that value **is**
+the title — checked directly, no `gh pr view` call needed (and none of its
+fail-open/network-error paths apply).
+
 ### Configuration
 
 | Env var                   | Default | Effect                            |
@@ -80,6 +129,13 @@ script):
 git commit -m "Merge remote-tracking branch 'origin/main' into feature/long-name"  # title-length:ack
 ```
 
+The same marker suppresses the squash-merge advisory (checked once, before
+either path runs):
+
+```bash
+gh pr merge 42 --squash  # title-length:ack
+```
+
 ### Parsing guarantees
 
 Inherits `safe_tokenize` / `iter_command_starts` / `strip_prefix` from
@@ -105,13 +161,20 @@ Inherits `safe_tokenize` / `iter_command_starts` / `strip_prefix` from
   tokenizer (see `_hook_utils.py` docstring), preserved to keep
   newline-separated multi-command detection intact for sibling hooks.
 
+### Fail-open (squash-merge path)
+
+`gh pr view` failure (auth error, timeout, non-zero exit, empty output) ->
+silent pass, same fail-open contract as `gh-merge-worktree-precondition`'s
+own `gh pr view` call. The advisory only fires on a positively-resolved,
+over-limit title.
+
 ### Tests
 
 ```bash
-bash tests/test_commit_title_length_check.sh
+bash tests/hooks/preflight-gate/test_commit_title_length_check.sh
 ```
 
-Covers 47 cases: boundary (50 chars), under (49 chars), long via `-m` /
+Covers 59 cases: boundary (50 chars), under (49 chars), long via `-m` /
 `--message` / `-m=value` / `--amend` / `-am`, Korean 51-code-point title,
 Hub #1912 regression (82-char title), Merge/Revert skip, body-in-second-m
 protection, chained command, `CLAUDE_COMMIT_TITLE_MAX` override (both
@@ -120,4 +183,10 @@ marker, echo false-positive guard, non-Bash tool passthrough, malformed JSON
 fail-open, plus regression coverage for `git -C <dir>` global flags,
 attached-form `-m"value"`, `-S<keyid>` whitelist (must not be misparsed as
 combined `-m`), and `-C <dir>` + relative `-F <file>` resolution including
-stacked `-C` flags.
+stacked `-C` flags — **plus** the squash-merge path (issue #843): long/short
+PR title via a faked `gh pr view`, `-s` short flag, `-t`/`--subject`
+override (long and short, no `gh` call made), `gh pr view` error -> fail-open,
+`-R owner/repo` global-flag forwarding, opt-out marker suppressing the
+squash advisory, `gh api .../pulls/N/merge` confirmed NOT matched (the
+deliberate gap), `--merge`/`--rebase` (no `-s`) staying silent even with a
+long title, and an unrelated `gh pr view` command staying silent.

--- a/hooks/preflight-gate/commit-title-length-check/spec.md
+++ b/hooks/preflight-gate/commit-title-length-check/spec.md
@@ -7,7 +7,7 @@ Bash call and emits `permissionDecision: "ask"` when the first line of the
 commit message exceeds the configured maximum (default 50, matching the global
 global `~/.claude/CLAUDE.md` "Git Commit & Title Rules — Title: max 50 characters" rule).
 
-### Why a PreToolUse hook instead of a git commit-msg hook
+## Why a PreToolUse hook instead of a git commit-msg hook
 
 The issue body suggests a commit-msg hook because that is the natural insertion
 point. However, the praxis distribution model ships Claude Code hooks (loaded
@@ -23,43 +23,43 @@ Trade-off: the hook only catches AI-authored commits (not manual shell commits),
 which is exactly the population that produced the silent violations described in
 issue #177.
 
-### What is warned
+## What is warned
 
-| Command shape                    | Action                                |
-| -------------------------------- | ------------------------------------- |
-| `git commit -m "title"`          | ask when `len(title) > 50`            |
-| `git commit --message "title"`   | ask when `len(title) > 50`            |
-| `git commit -m="title"`          | ask when `len(title) > 50`            |
-| `git commit -am "title"`         | ask when `len(title) > 50`            |
-| `git commit --amend -m "title"`  | ask when `len(title) > 50`            |
-| `git commit -F /path/to/file`    | reads first line; ask when over limit |
-| `git commit -F -` (stdin)        | silent pass (acknowledged limitation) |
-| `Merge ...` / `Revert ...` title | silent pass (auto-generated)          |
-| `git status`, `git push`, etc.   | silent pass (not a commit)            |
+| Command shape | Action |
+| --- | --- |
+| `git commit -m "title"` | ask when `len(title) > 50` |
+| `git commit --message "title"` | ask when `len(title) > 50` |
+| `git commit -m="title"` | ask when `len(title) > 50` |
+| `git commit -am "title"` | ask when `len(title) > 50` |
+| `git commit --amend -m "title"` | ask when `len(title) > 50` |
+| `git commit -F /path/to/file` | reads first line; ask when over limit |
+| `git commit -F -` (stdin) | silent pass (acknowledged limitation) |
+| `Merge ...` / `Revert ...` title | silent pass (auto-generated) |
+| `git status`, `git push`, etc. | silent pass (not a commit) |
 
 Length counting uses Python `len(str)` which counts Unicode code points — the
 correct measure for the 50-char rule in Korean/CJK mixed commit titles.
 
-### Squash-merge path (issue #843)
+## Squash-merge path (issue #843)
 
 `git commit` is not the only path a commit title reaches `main` through: `gh
 pr merge --squash` combines the PR's title into the squash commit title on
 GitHub's side, a shape the `git commit` matcher above cannot see. Two real
-squash titles already landed on `main` over the limit — #834 at 61 chars,
-#835 at 63 chars (both measured excluding any trailing `(#N)` suffix GitHub
-appends) — because the gate only ever fired on the branch's own `git commit`
+squash titles already landed on `main` over the limit — #834 at 61
+chars, #835 at 63 chars (both measured excluding any trailing `(#N)`
+suffix GitHub appends) — because the gate only ever fired on the branch's own `git commit`
 calls, never on the merge that actually produced the title landing on
 `main`.
 
-| Command shape                                        | Action |
-| ------------------------------------------------------ | -------- |
-| `gh pr merge <id> --squash` / `-s`                     | resolve PR title via `gh pr view`; **advisory** (stderr) when over limit |
-| `gh pr merge <id> --squash -t "<subject>"`             | `-t`/`--subject` value IS the title — no network call, checked directly |
-| `gh pr merge <id> --merge` / `--rebase` (no `-s`)      | silent — not a squash, title composition differs |
-| `gh -R owner/repo pr merge <id> --squash`              | `-R`/`--repo` forwarded to the `gh pr view` resolution call |
+| Command shape | Action |
+| --- | --- |
+| `gh pr merge <id> --squash` / `-s` | resolve PR title via `gh pr view`; **advisory** (stderr) when over limit |
+| `gh pr merge <id> --squash -t "<subject>"` | `-t`/`--subject` value IS the title — no network call, checked directly |
+| `gh pr merge <id> --merge` / `--rebase` (no `-s`) | silent — not a squash, title composition differs |
+| `gh -R owner/repo pr merge <id> --squash` | `-R`/`--repo` forwarded to the `gh pr view` resolution call |
 | `gh api repos/.../pulls/N/merge -f merge_method=squash` | **NOT matched — deliberate gap**, see "Ordering constraint" below |
 
-#### Severity: advisory, not `ask`
+### Severity: advisory, not `ask`
 
 Unlike the `git commit` path (which blocks via `ask`), the squash-merge path
 only ever writes a stderr advisory and always exits 0 — it never blocks the
@@ -70,7 +70,7 @@ recommends starting conservative — "1단계는 advisory로 시작 권장" — 
 new failure surface (network dependency) this path introduces relative to
 the pure-local `git commit` check.
 
-#### Ordering constraint — `gh api .../pulls/N/merge` intentionally NOT sealed
+### Ordering constraint — `gh api .../pulls/N/merge` intentionally NOT sealed
 
 The issue body asks to also match `gh api repos/.../pulls/N/merge` (the same
 mutation via the raw API instead of the `gh pr merge` subcommand). This PR
@@ -82,23 +82,23 @@ same change window would remove that escape hatch before its blocking issue
 resolves. Extending coverage to `gh api` is left to a follow-up once that
 ordering constraint clears.
 
-#### `-t`/`--subject` override
+### `-t`/`--subject` override
 
 `gh pr merge` accepts `-t`/`--subject <value>` to set the squash commit
 subject directly, overriding the PR title. When present, that value **is**
 the title — checked directly, no `gh pr view` call needed (and none of its
 fail-open/network-error paths apply).
 
-### Configuration
+## Configuration
 
-| Env var                   | Default | Effect                            |
-| ------------------------- | ------- | --------------------------------- |
-| `CLAUDE_COMMIT_TITLE_MAX` | `50`    | Override the maximum title length |
+| Env var | Default | Effect |
+| --- | --- | --- |
+| `CLAUDE_COMMIT_TITLE_MAX` | `50` | Override the maximum title length |
 
 Setting `CLAUDE_COMMIT_TITLE_MAX=80` allows longer titles (e.g. for repos with
 a 72-char convention) without disabling the hook.
 
-### Response
+## Response
 
 ```json
 {
@@ -110,7 +110,7 @@ a 72-char convention) without disabling the hook.
 }
 ```
 
-### Compound cascade advisory (issue #229)
+## Compound cascade advisory (issue #229)
 
 When the ask fires on a compound Bash command containing a state-changing
 step (e.g. `mkdir -p /tmp/log && git commit -m "$(cat /tmp/log/very-long-..."`),
@@ -119,7 +119,7 @@ the ask reason is suffixed with the shared
 chained `mkdir`/redirect/download also did not run — retries must materialize
 those files first.
 
-### Opt-out marker
+## Opt-out marker
 
 Embed `# title-length:ack` anywhere in the command to bypass the check for
 known-intentional long titles (e.g. auto-generated merge commits handled by a
@@ -136,7 +136,7 @@ either path runs):
 gh pr merge 42 --squash  # title-length:ack
 ```
 
-### Parsing guarantees
+## Parsing guarantees
 
 Inherits `safe_tokenize` / `iter_command_starts` / `strip_prefix` from
 `_hook_utils.py` (same primitive as the sibling hooks):
@@ -161,14 +161,14 @@ Inherits `safe_tokenize` / `iter_command_starts` / `strip_prefix` from
   tokenizer (see `_hook_utils.py` docstring), preserved to keep
   newline-separated multi-command detection intact for sibling hooks.
 
-### Fail-open (squash-merge path)
+## Fail-open (squash-merge path)
 
 `gh pr view` failure (auth error, timeout, non-zero exit, empty output) ->
 silent pass, same fail-open contract as `gh-merge-worktree-precondition`'s
 own `gh pr view` call. The advisory only fires on a positively-resolved,
 over-limit title.
 
-### Tests
+## Tests
 
 ```bash
 bash tests/hooks/preflight-gate/test_commit_title_length_check.sh

--- a/tests/hooks/preflight-gate/test_commit_title_length_check.sh
+++ b/tests/hooks/preflight-gate/test_commit_title_length_check.sh
@@ -362,6 +362,130 @@ rm -f "$R4_F2_MSG" "$R4_F2_ABS_MSG"
 rmdir "$R4_F2_DIR" "$R4_F2_ABS_DIR" 2>/dev/null || true
 
 # ---------------------------------------------------------------------------
+# Squash-merge path (issue #843) — `gh pr merge --squash` resolves the PR
+# title via a live `gh pr view` call, faked here via a per-case PATH-
+# prepended fake `gh` binary. Advisory (stderr, non-blocking), never `ask`.
+# ---------------------------------------------------------------------------
+
+# make_fake_gh_title <title> — `gh pr view ... -q .title` prints <title>.
+make_fake_gh_title() {
+  local title="$1" d
+  d=$(mktemp -d)
+  cat >"$d/gh" <<EOF
+#!/usr/bin/env bash
+echo "$title"
+exit 0
+EOF
+  chmod +x "$d/gh"
+  echo "$d"
+}
+
+# make_fake_gh_error — every `gh` call exits 1 (auth-style failure).
+make_fake_gh_error() {
+  local d
+  d=$(mktemp -d)
+  cat >"$d/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "gh: authentication required" >&2
+exit 1
+EOF
+  chmod +x "$d/gh"
+  echo "$d"
+}
+
+# run_case_gh name expectation command gh_dir
+#   expectation:
+#     advisory — stdout empty, stderr contains "Squash-merge title too long", rc=0
+#     silent   — stdout empty, stderr empty, rc=0
+run_case_gh() {
+  local name="$1" expectation="$2" command="$3" gh_dir="$4"
+  local payload out_file err_file
+  payload=$(python3 -c '
+import json, sys
+print(json.dumps({"tool_name": "Bash", "tool_input": {"command": sys.argv[1]}}))
+' "$command")
+
+  out_file=$(mktemp)
+  err_file=$(mktemp)
+  echo "$payload" | env -u CLAUDE_COMMIT_TITLE_MAX PATH="$gh_dir:$PATH" python3 "$HOOK" \
+    >"$out_file" 2>"$err_file"
+  local rc=$?
+  local out err
+  out=$(cat "$out_file")
+  err=$(cat "$err_file")
+  rm -f "$out_file" "$err_file"
+
+  local ok=1
+  case "$expectation" in
+    advisory)
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$out" ]   || ok=0
+      echo "$err" | grep -q "Squash-merge title too long" || ok=0
+      ;;
+    silent)
+      [ "$rc" -eq 0 ] || ok=0
+      [ -z "$out" ]   || ok=0
+      [ -z "$err" ]   || ok=0
+      ;;
+    *)
+      echo "  internal: unknown expectation '$expectation'" >&2
+      ok=0
+      ;;
+  esac
+
+  if [ "$ok" -eq 1 ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS  $name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+    echo "  FAIL  $name (rc=$rc, expected=$expectation)"
+    [ -n "$out" ] && echo "        stdout: $(echo "$out" | head -c 400)"
+    [ -n "$err" ] && echo "        stderr: $(echo "$err" | head -c 400)"
+  fi
+}
+
+LONG_TITLE_GH=$(make_fake_gh_title "fix(momentum-gate): scope merge-briefing window to a very long prior turn")
+SHORT_TITLE_GH=$(make_fake_gh_title "fix(hook): short title")
+ERROR_GH=$(make_fake_gh_error)
+
+run_case_gh "squash + long PR title (advisory)" \
+  advisory "gh pr merge 42 --squash" "$LONG_TITLE_GH"
+
+run_case_gh "squash short flag -s + long PR title (advisory)" \
+  advisory "gh pr merge 42 -s" "$LONG_TITLE_GH"
+
+run_case_gh "squash + short PR title (silent)" \
+  silent "gh pr merge 42 --squash" "$SHORT_TITLE_GH"
+
+run_case_gh "no --squash flag at all (silent, no gh call needed)" \
+  silent "gh pr merge 42" "$ERROR_GH"
+
+run_case_gh "-t/--subject overrides PR title, long (advisory, no gh call)" \
+  advisory 'gh pr merge 42 --squash -t "this subject line is definitely far too long to pass fifty chars"' "$ERROR_GH"
+
+run_case_gh "-t/--subject overrides PR title, short (silent, no gh call)" \
+  silent 'gh pr merge 42 --squash -t "short title"' "$ERROR_GH"
+
+run_case_gh "gh pr view errors -> fail-open (silent)" \
+  silent "gh pr merge 42 --squash" "$ERROR_GH"
+
+run_case_gh "gh -R owner/repo pr merge --squash (global flag before subcommand)" \
+  advisory "gh -R owner/repo pr merge 42 --squash" "$LONG_TITLE_GH"
+
+run_case_gh "opt-out marker suppresses squash advisory too (silent)" \
+  silent "gh pr merge 42 --squash  # title-length:ack" "$LONG_TITLE_GH"
+
+run_case_gh "gh api pulls/N/merge is a deliberate gap (silent, not matched)" \
+  silent "gh api repos/o/r/pulls/42/merge -X PUT -f merge_method=squash" "$LONG_TITLE_GH"
+
+run_case_gh "gh pr merge --merge (no squash) is silent even with long title" \
+  silent "gh pr merge 42 --merge" "$LONG_TITLE_GH"
+
+run_case_gh "gh pr view (unrelated gh command) is silent" \
+  silent "gh pr view 42 --json title" "$LONG_TITLE_GH"
+
+# ---------------------------------------------------------------------------
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then


### PR DESCRIPTION
## 배경

`commit-title-length-check` 훅은 `git commit [-m|-F|...]` Bash shape 만
매칭한다. squash merge 시 GitHub 측에서 조합되는 커밋 타이틀 경로는 게이트
밖 — `gh pr merge --squash` 는 PR title 이 그대로 squash 커밋 타이틀이 된다.
실증: main 에 61/63자 squash 타이틀 실재 (#834 61자, #835 63자 — suffix
제외 실측), 게이트가 branch 의 `git commit` 호출에만 반응하고 실제 title 을
만든 merge 자체는 한 번도 검사하지 않았다.

## 변경 사항

`hooks/preflight-gate/commit-title-length-check/impl.py`:

- `gh [global flags] pr merge [flags] --squash|-s` 세그먼트를
  `gh-merge-worktree-precondition` 의 검증된 `_merge_segment`/tail-scan
  패턴을 그대로 미러링해 감지.
- `-t`/`--subject <value>` 가 있으면 그 값이 곧 타이틀 — network call
  없이 바로 검사.
- 없으면 `gh pr view <id> [-R repo] --json title -q .title` (5s timeout,
  fail-open) 로 PR title 조회 후 길이 검사.
- 초과 시 **advisory**(stderr, exit 0) — `ask`/block 아님. 기존 `git commit`
  경로(`ask`)는 변경 없음.

## 순서 구속 — `gh api .../pulls/N/merge` 의도적 미봉쇄

오케스트레이터 지시에 따라 이슈 본문이 요청한 `gh api
repos/.../pulls/N/merge` 매칭은 **이 PR에 포함하지 않았다**. 별건의 미해결
release-lag 이슈가 defective cached hook 상황에서 `gh api` 경로를
escape hatch 로 필요로 한다 — 두 경로를 같은 변경 창에서 동시에 봉쇄하면
그 이슈가 풀리기 전에 escape hatch 가 사라진다. `gh pr merge --squash`
경로만 커버하고 `gh api` 경로는 spec.md 에 "deliberate gap" 으로 명시
문서화했다.

## Severity: advisory, not ask

이슈 본문 권고("1단계는 advisory로 시작 권장")를 따랐다. 이 경로는 기존
`git commit` 검사와 달리 실시간 `gh pr view` 네트워크 호출을 수반하므로,
API 지연/일시 오류가 머지 자체를 막을 수 없어야 한다.

## 입력 표면 열거 (surface-enumeration)

- `gh pr merge <id> --squash` / `-s` (short flag)
- `-t`/`--subject "<title>"` override (long/short, gh 호출 스킵 확인)
- `--merge`/`--rebase` (squash 아님) — 무시
- `gh -R owner/repo pr merge <id> --squash` — global flag 가 `gh pr view`
  로 forward 되는지
- `gh pr view` 오류(auth 실패) → fail-open
- `gh api repos/.../pulls/N/merge` → 매칭 안 됨(의도적 gap) 확인
- opt-out 마커(`# title-length:ack`)가 squash 경로도 억제하는지
- 무관 `gh pr view` 명령 → 침묵

각 변형이 테스트 케이스(12개 신규, 총 47→59)로 대응됨.

## 검증

```
bash tests/hooks/preflight-gate/test_commit_title_length_check.sh
# Result: 59 passed, 0 failed

python3 -m pytest tests/ -q
# 500 passed

ruff check hooks/preflight-gate/commit-title-length-check/impl.py
# All checks passed!

shellcheck --severity=warning tests/hooks/preflight-gate/test_commit_title_length_check.sh
# (경고 없음)
```

Pre-commit verified: `bash tests/hooks/preflight-gate/test_commit_title_length_check.sh` → Result: 59 passed, 0 failed; `python3 -m pytest tests/ -q` → 500 passed; `ruff check` clean; `shellcheck --severity=warning` clean.

Caller chain verified: 기존 `commit-title-length-check` 확장이므로 신규 심볼 없음 — `grep -rn "commit-title-length-check" hooks/manifest.json` 로 기존 등록(PreToolUse, Bash matcher) 그대로 유지 확인, manifest 변경 없음. 새 helper 함수(`_gh_pr_merge_segment`, `_scan_merge_tail`, `_resolve_pr_title`)는 모두 동일 파일 `main()` 에서만 호출.

## 미검증 / 의도적 미완결

- `gh api repos/.../pulls/N/merge` 매칭은 오케스트레이터 지시에 따라 이번
  PR 범위에서 의도적으로 제외 — 아래 "순서 구속" 참조.
- 실제 `gh pr merge --squash` 런타임 실행 대신 fake `gh` 바이너리로만
  검증 — 실제 gh CLI 대상 canary 는 release 이후 진행.

Refs #843 (gh api 경로는 의도적으로 미포함)
