### PR TITLE
feat(telemetry): instrument impl.sh hooks

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -42,10 +42,27 @@ Design mechanisms shared by all hooks:
     a zero-arg `_entry()` instead). Rule 15 in
     `scripts/check-plugin-manifests.py` enforces this invariant.
 
+  Shell hooks (`impl.sh`) have no Python entrypoint, so neither path
+  applies to them — they carry their own `set +e` / `|| true` posture, and
+  reach the fire ledger through `_lib/record_fire.sh` instead (see the
+  instrumentation bullet below).
+
   Trade-off, stated explicitly: for *gates*, fail-open means a crashed
   guard allows the action it would have screened. That is the deliberate
   ETHOS choice — hook infrastructure failure must degrade to "no hook"
   rather than "no work".
+- **Fire-ledger instrumentation for shell hooks (issue #848).** A hook's
+  engagements land in the fire ledger via `@fail_open` (standalone) or the
+  dispatcher (Bash group) — both Python-only, so the four `impl.sh` hooks
+  recorded nothing at all while an audit reading that ledger scored the
+  silence as "never fires". A shell hook sources `_lib/record_fire.sh` and
+  calls `praxis_fire_arm <hook> <role> "$SESSION_ID" ""` right after it
+  parses its stdin payload; the armed EXIT trap writes exactly one RICH
+  record whichever branch exits, so a later-added early `exit 0` cannot
+  silently drop out of the ledger. Set `PRAXIS_FIRE_DECISION=block|advise`
+  before the emitting branch; the default is `pass`. Rule 18 in
+  `scripts/check-plugin-manifests.py` enforces that every manifest-listed
+  `impl.sh` arms it.
 - **Compound-Bash cascade advisory (issue #229).** When a PreToolUse(Bash)
   hook rejects (block) or asks-and-may-deny a compound command (`&&`, `||`,
   `;`, `|`, newline) containing a state-changing step (`> file`, `<<EOF >`,

--- a/hooks/_lib/_fire_ledger.py
+++ b/hooks/_lib/_fire_ledger.py
@@ -20,9 +20,26 @@ COVERAGE (issue #710, two tiers):
            `decision` field while exiting 0, so THEIR blocks are invisible to the
            coarse path and recorded as "pass" (PreToolUse blocks do exit 2 and
            are captured). Treat coarse Block as a lower bound.
-CEILING: a hook that does NOT use @fail_open is uninstrumented. The dispatcher
-process marks itself (mark_dispatcher_process) so its Bash-group members are not
+CEILING: a hook that reaches neither @fail_open nor an explicit
+`record_session_fire` call is uninstrumented. The dispatcher process marks
+itself (mark_dispatcher_process) so its Bash-group members are not
 double-counted by the coarse path.
+
+SHELL HOOKS (issue #848): `impl.sh` hooks run no Python `main()`, so
+@fail_open never wraps them — all four (strike-counter across its three
+events, completion-verify, retrospect-mix-check, codex-review-route) held
+zero records while an audit reading this ledger scored their absence as
+"never fires". They now source `_lib/record_fire.sh` and arm an EXIT trap
+(`praxis_fire_arm`) that writes exactly one RICH record per invocation via
+`record_session_fire`. Rich, not coarse: a shell hook has already parsed its
+own stdin payload and holds a real session_id. Because there is no coarse
+path for them, there is nothing to suppress on success and nothing to
+restore on failure — the `suppress_coarse_duplicate` contract below does not
+apply. Two deliberate gaps: guard clauses that exit BEFORE session_id is
+parsed (missing jq, unparseable stdin) are unrecorded, since a record keyed
+to an unknown session cannot be aggregated per-session; and strike-counter's
+slash-command modes (strike/status/reset) are user invocations, not hook
+engagements, so counting them would inflate the fire rate.
 
 SINGLE-EVENT RICH (issue #740): a standalone hook outside the Bash dispatch
 group that still needs real session_id/tool attribution (not the coarse

--- a/hooks/_lib/record_fire.sh
+++ b/hooks/_lib/record_fire.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Fire-ledger recording for pure-shell hooks (issue #848).
+#
+# Every Python hook reaches the ledger through `@fail_open`
+# (`record_standalone_fire`) or the Bash dispatcher (`record_group_fires`).
+# A hook written in shell runs through neither, so its engagements were
+# invisible: the four `impl.sh` hooks held 0 ledger records while the audit
+# that reads the ledger treated absence as "never fires".
+#
+# Source this file, then call praxis_record_fire at each terminal branch:
+#
+#   . "$(dirname "$0")/../../_lib/record_fire.sh"
+#   praxis_record_fire completion-verify completion-verify block "$SESSION_ID" ""
+#
+# Args (positional, all required — pass "" for an unknown value):
+#   1 hook        — manifest `name` of the firing hook
+#   2 role        — manifest `role` (preflight-gate / advisory-nudge / …)
+#   3 decision    — block | ask | advise | pass
+#   4 session_id  — from the hook's own stdin payload
+#   5 tool        — tool name for PreToolUse-family hooks; "" elsewhere
+#
+# Writes a granularity="rich" record, the same shape
+# `_fire_ledger.record_session_fire` writes for a standalone Python hook —
+# NOT the coarse shape, because a shell hook has already parsed its stdin
+# payload and holds a real session_id. Shell hooks have no coarse fallback,
+# so unlike the Python callers there is nothing to suppress on success and
+# nothing to restore on failure.
+#
+# Fail-open, unconditionally: python3 missing, _lib unreadable, ledger
+# unwritable, malformed argument — every failure is swallowed and the caller
+# continues. A telemetry write must never change a hook's decision.
+
+# praxis_fire_arm <hook> <role> <session_id> [tool]
+#
+# Records exactly one fire at process exit, whichever branch got there. A
+# shell hook exits from many places (guard clauses, early passes, the emit
+# path); arming an EXIT trap once is what keeps a later-added early `exit 0`
+# from silently dropping out of the ledger. Set PRAXIS_FIRE_DECISION before
+# the exiting branch to record something other than the "pass" default.
+#
+# Call it AFTER the hook has parsed session_id — a record keyed to an unknown
+# session cannot be aggregated per-session, which is the whole reason a shell
+# hook writes the rich shape. Guard clauses that run before parsing (missing
+# jq, unparseable stdin) are therefore deliberately unrecorded.
+praxis_fire_arm() {
+  PRAXIS_FIRE_HOOK="$1"
+  PRAXIS_FIRE_ROLE="$2"
+  PRAXIS_FIRE_SESSION="${3:-}"
+  PRAXIS_FIRE_TOOL="${4:-}"
+  PRAXIS_FIRE_DECISION="pass"
+  trap 'praxis_record_fire "$PRAXIS_FIRE_HOOK" "$PRAXIS_FIRE_ROLE" "$PRAXIS_FIRE_DECISION" "$PRAXIS_FIRE_SESSION" "$PRAXIS_FIRE_TOOL"' EXIT
+}
+
+praxis_record_fire() {
+  # CDPATH is unset inside the subshell, not prefixed on `cd` — a prefixed
+  # `CDPATH= cd` reads to shellcheck as a stray empty assignment (SC1007).
+  _rf_lib_dir="${PRAXIS_LIB_DIR:-$(unset CDPATH; cd -- "$(dirname -- "$0")/../../_lib" 2>/dev/null && pwd)}"
+  [ -n "$_rf_lib_dir" ] || return 0
+  command -v python3 >/dev/null 2>&1 || return 0
+
+  python3 -c '
+import sys
+sys.path.insert(0, sys.argv[1])
+try:
+    import _fire_ledger
+    _fire_ledger.record_session_fire(
+        hook=sys.argv[2], role=sys.argv[3], decision=sys.argv[4],
+        session_id=sys.argv[5], tool=sys.argv[6],
+    )
+except Exception:
+    pass
+' "$_rf_lib_dir" "$1" "$2" "$3" "${4:-}" "${5:-}" >/dev/null 2>&1 || true
+  return 0
+}

--- a/hooks/advisory-nudge/codex-review-route/impl.sh
+++ b/hooks/advisory-nudge/codex-review-route/impl.sh
@@ -22,6 +22,12 @@ fi
 
 INPUT=$(cat)
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)
+
+# shellcheck source=../../_lib/record_fire.sh
+. "$(dirname "$0")/../../_lib/record_fire.sh" 2>/dev/null || true
+command -v praxis_fire_arm >/dev/null 2>&1 && \
+  praxis_fire_arm codex-review-route advisory-nudge "$SESSION_ID" ""
 
 if [ -z "$PROMPT" ]; then
   exit 0
@@ -114,6 +120,7 @@ ${PR_STATE_MSG}"
   fi
 fi
 
+PRAXIS_FIRE_DECISION=advise
 jq -n --arg ctx "$COMBINED_MSG" \
   '{hookSpecificOutput: {hookEventName: "UserPromptSubmit", additionalContext: $ctx}}'
 

--- a/hooks/completion-verify/completion-verify/impl.sh
+++ b/hooks/completion-verify/completion-verify/impl.sh
@@ -23,6 +23,11 @@ TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // ""')
 STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false')
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 
+# shellcheck source=../../_lib/record_fire.sh
+. "$(dirname "$0")/../../_lib/record_fire.sh" 2>/dev/null || true
+command -v praxis_fire_arm >/dev/null 2>&1 && \
+  praxis_fire_arm completion-verify completion-verify "$SESSION_ID" ""
+
 [ "$STOP_HOOK_ACTIVE" = "true" ] && exit 0
 [ ! -f "$TRANSCRIPT_PATH" ] && exit 0
 
@@ -133,6 +138,7 @@ if [ -n "$block_reason" ]; then
   mkdir -p "${PRAXIS_HOME:-$HOME/.praxis}/scope-confirm" || true
   echo "$(date -Iseconds) session=$SESSION_ID blocked_completion_without_evidence" >> "${PRAXIS_HOME:-$HOME/.praxis}/scope-confirm/stop-triggered.log" || true
 
+  PRAXIS_FIRE_DECISION=block
   REASON="Completion claim detected without same-turn verification evidence. ${block_reason} See AGENTS.md Verification section."
   jq -n --arg r "$REASON" '{decision: "block", reason: $r}'
   exit 0

--- a/hooks/completion-verify/completion-verify/impl.sh
+++ b/hooks/completion-verify/completion-verify/impl.sh
@@ -22,11 +22,17 @@ INPUT=$(cat)
 TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // ""')
 STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false')
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
+# The log line below has always written the "unknown" placeholder, but the
+# ledger must not: aggregate_fires adds any non-empty session string to its
+# distinct-session set, so "unknown" would collapse every unattributed fire
+# into one fake session. Empty is the documented unattributed value — it
+# still counts the decision, it only forgoes per-session attribution.
+TELEMETRY_SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // ""')
 
 # shellcheck source=../../_lib/record_fire.sh
 . "$(dirname "$0")/../../_lib/record_fire.sh" 2>/dev/null || true
 command -v praxis_fire_arm >/dev/null 2>&1 && \
-  praxis_fire_arm completion-verify completion-verify "$SESSION_ID" ""
+  praxis_fire_arm completion-verify completion-verify "$TELEMETRY_SESSION_ID" ""
 
 [ "$STOP_HOOK_ACTIVE" = "true" ] && exit 0
 [ ! -f "$TRANSCRIPT_PATH" ] && exit 0

--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -37,6 +37,11 @@ TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // ""')
 STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false')
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 
+# shellcheck source=../../_lib/record_fire.sh
+. "$(dirname "$0")/../../_lib/record_fire.sh" 2>/dev/null || true
+command -v praxis_fire_arm >/dev/null 2>&1 && \
+  praxis_fire_arm retrospect-mix-check completion-verify "$SESSION_ID" ""
+
 [ "$STOP_HOOK_ACTIVE" = "true" ] && exit 0
 [ ! -f "$TRANSCRIPT_PATH" ] && exit 0
 
@@ -191,6 +196,7 @@ if [ "$RETRO_ACTIVE" = "true" ]; then
     echo "$(date -Iseconds) session=$SESSION_ID blocked_retrospect_fence_omission" \
       >> "${PRAXIS_HOME:-$HOME/.praxis}/scope-confirm/retrospect-mix-blocked.log" || true
     fence_reason="Retrospect Stage 3 distribution fence missing (issue #666). This is a retrospect-active session (the retrospect skill was invoked this turn) presenting a findings table, but the assistant message carries no '<!-- retrospect:distribution begin -->' fence and no '## Actions Executed' marker. A free-form or localized Stage 3 report bypasses every mix-check gate (Gate-1..7) because the gates key on the canonical output schema. Re-emit the Stage 3 output per the Output Schema Contract in skills/retrospect/references/stage3-reporting.md: '## Retrospect Report' header -> audit fences -> '<!-- retrospect:distribution begin/end -->' card -> unified findings table."
+    PRAXIS_FIRE_DECISION=block
     jq -n --arg r "$fence_reason" '{decision: "block", reason: $r}'
     exit 0
   fi
@@ -1010,6 +1016,7 @@ if [ "$should_block" = "true" ]; then
   done
 
   full_reason="Retrospect mix-check gate triggered. ${reason}. Fix guide: Gate-1 → relabel finding category via skills/retrospect/references/stage1-2-analysis.md; Gate-2 → supply either (a) 5-line 'not <action>: <reason>' rationale (Schema A) or (b) 1-2 'not-others: <dim-tags>' lines (Schema B, issue #285) in Stage 2.5; Gate-3 verdict → return to skills/retrospect/references/stage2.5-audit.md and re-evaluate evidence robustness for 2-action findings; Gate-3 backing_repo → return to skills/retrospect/references/stage1-2-analysis.md action assignment (step 7) and add 'backing_repo: <owner/repo>' to Rationale cell; Gate-4 → return to skills/retrospect/references/stage2.5-audit.md Gate-4 and re-run external-repo classification; ensure gate_4_verdict is emitted in the distribution card; Gate-7 → post-compaction session: emit a '<!-- retrospect:transcript_receipt begin/end -->' fence with the real full-transcript scan output (or the 'retrospect:transcript_receipt_skipped: transcript unreachable' line when the jsonl is genuinely unreachable); include both 'is_error_count: N' and 'content_error_count: N' fields; when content_error_count > 0 add a '<!-- retrospect:content_error_enum begin/end -->' block with per-signal promote/note/dismiss disposition rows (issue #670); Gate-8 → emit a '<!-- retrospect:suppression_ledger begin/end -->' fence carrying 'worst_agent_failure:', 'self_adversarial:', and 'critic_diff:' lines (the Stage 2 self-incrimination pass plus conditional externalized critic tier record, mandatory on every path incl. the clean one), and do not claim none-found/clean when live transcript signals exceed tolerance — surface or justify those signals before Stage 3. See skills/retrospect/references/stage1-2-analysis.md self-incrimination pass and skills/retrospect/references/stage3-reporting.md."
+  PRAXIS_FIRE_DECISION=block
   jq -n --arg r "$full_reason" '{decision: "block", reason: $r}'
   exit 0
 fi

--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -36,11 +36,14 @@ INPUT=$(cat)
 TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // ""')
 STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false')
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
+# "unknown" is fine for the marker filename and the log lines below, but not
+# for the ledger — see the same guard in completion-verify/impl.sh.
+TELEMETRY_SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // ""')
 
 # shellcheck source=../../_lib/record_fire.sh
 . "$(dirname "$0")/../../_lib/record_fire.sh" 2>/dev/null || true
 command -v praxis_fire_arm >/dev/null 2>&1 && \
-  praxis_fire_arm retrospect-mix-check completion-verify "$SESSION_ID" ""
+  praxis_fire_arm retrospect-mix-check completion-verify "$TELEMETRY_SESSION_ID" ""
 
 [ "$STOP_HOOK_ACTIVE" = "true" ] && exit 0
 [ ! -f "$TRANSCRIPT_PATH" ] && exit 0

--- a/hooks/completion-verify/strike-counter/impl.sh
+++ b/hooks/completion-verify/strike-counter/impl.sh
@@ -95,6 +95,18 @@ case "$MODE" in
     ;;
 esac
 
+# Fire-ledger instrumentation (issue #848). Hook modes only: the slash modes
+# are user-invoked commands, not hook engagements, so counting them would
+# inflate the fire rate this ledger exists to measure.
+case "$MODE" in
+  session-start|preprompt|stop)
+    # shellcheck source=../../_lib/record_fire.sh
+    . "$(dirname "$0")/../../_lib/record_fire.sh" 2>/dev/null || true
+    command -v praxis_fire_arm >/dev/null 2>&1 && \
+      praxis_fire_arm strike-counter completion-verify "$SID" ""
+    ;;
+esac
+
 if [ -z "$SID" ]; then
   echo "strike-counter: session_id unavailable — skipping" >&2
   exit 0
@@ -170,6 +182,7 @@ case "$MODE" in
     COUNT=$(load_count)
     if [ "$COUNT" -gt 0 ] 2>/dev/null; then
       # Emit as JSON additionalContext so Claude sees current strike state
+      PRAXIS_FIRE_DECISION=advise
       jq -n --arg ctx "Praxis strikes carried from prior activity this session: $COUNT/3" \
         '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'
     fi
@@ -187,6 +200,7 @@ case "$MODE" in
         MSG="⚠️ Praxis strike 1/3 — warning. Recorded violation:
 $REASONS
 Stay extra careful with the rules this session."
+        PRAXIS_FIRE_DECISION=advise
         jq -n --arg ctx "$MSG" \
           '{hookSpecificOutput: {hookEventName: "UserPromptSubmit", additionalContext: $ctx}}'
         ;;
@@ -195,6 +209,7 @@ Stay extra careful with the rules this session."
         MSG="🔶 Praxis strike 2/3 — review required. Cumulative violations:
 $REASONS
 Before your next action, re-read the relevant sections of ~/.claude/CLAUDE.md and explicitly state how you will avoid another violation. One more strike triggers a hard block."
+        PRAXIS_FIRE_DECISION=advise
         jq -n --arg ctx "$MSG" \
           '{hookSpecificOutput: {hookEventName: "UserPromptSubmit", additionalContext: $ctx}}'
         ;;
@@ -223,6 +238,7 @@ Before your next action, re-read the relevant sections of ~/.claude/CLAUDE.md an
 $REASONS
 
 $REQUIREMENT"
+      PRAXIS_FIRE_DECISION=block
       jq -n --arg r "$REASON_MSG" '{decision: "block", reason: $r}'
     fi
     exit 0

--- a/scripts/check-plugin-manifests.py
+++ b/scripts/check-plugin-manifests.py
@@ -1212,6 +1212,34 @@ def main() -> int:
                     f"in {source} but absent from the hook's manifest `mode` block"
                 )
 
+    # ------------------------------------------------------------------
+    # Rule 18 — impl.sh hooks must reach the fire ledger (#848)
+    #
+    # Rule 16 above exempts impl.sh bodies because they have no Python
+    # entrypoint for @fail_open to decorate — but that exemption is exactly
+    # what left four shell hooks writing zero ledger records while an audit
+    # reading the ledger scored the silence as "never fires". A shell hook
+    # instead sources `_lib/record_fire.sh` and arms the EXIT trap. The match
+    # is the ARM CALL carrying the hook's own manifest name — not a bare
+    # `praxis_fire_arm` substring, which the `command -v praxis_fire_arm`
+    # availability guard satisfies on its own even after the actual arm call
+    # is deleted. A shell hook that legitimately must not record belongs in
+    # this rule as an explicit exemption, not as silent absence.
+    # ------------------------------------------------------------------
+    for name, role in sorted(_build.hook_identities(manifest).items()):
+        sh_path = _build.HOOKS_DIR / role / name / "impl.sh"
+        if not sh_path.exists():
+            continue
+        body = sh_path.read_text(encoding="utf-8", errors="replace")
+        if not re.search(rf"praxis_fire_arm\s+{re.escape(name)}\b", body):
+            drifts.append(
+                f"FIRE-LEDGER MISSING hooks/{role}/{name}/impl.sh: shell hook "
+                "does not arm fire-ledger instrumentation — source "
+                "_lib/record_fire.sh and call praxis_fire_arm after "
+                "session_id is parsed (#848)"
+            )
+
+
     if drifts:
         print("plugin-manifest check FAILED:")
         for d in drifts:

--- a/scripts/check-plugin-manifests.py
+++ b/scripts/check-plugin-manifests.py
@@ -1231,11 +1231,21 @@ def main() -> int:
         if not sh_path.exists():
             continue
         body = sh_path.read_text(encoding="utf-8", errors="replace")
-        # The line must also be executable shell: a commented-out or
-        # heredoc-quoted arm call reads identically to the real one, so a
-        # leading `#` disqualifies the match (coderabbit, PR #892).
+        # The match must look like an executable call, not a mention of one:
+        # anchored at the start of its own line, so a comment, an `echo
+        # "praxis_fire_arm ..."`, or an assignment holding the same text no
+        # longer satisfies the rule (coderabbit + codex, PR #892). All four
+        # instrumented hooks put the call at line start, after the `command -v`
+        # guard's line continuation.
+        #
+        # Deliberately not a shell parser: a heredoc body line that itself
+        # begins with a bare call still passes. Closing that residue means
+        # tracking quoting and heredoc state, which in this codebase has
+        # repeatedly traded one corner case for the next. The rule guards
+        # against the instrumentation being dropped, not against someone
+        # disguising its absence.
         if not re.search(
-            rf"(?m)^(?!\s*#).*\bpraxis_fire_arm\s+{re.escape(name)}\b", body
+            rf"(?m)^[ \t]*praxis_fire_arm\s+{re.escape(name)}\b", body
         ):
             drifts.append(
                 f"FIRE-LEDGER MISSING hooks/{role}/{name}/impl.sh: shell hook "

--- a/scripts/check-plugin-manifests.py
+++ b/scripts/check-plugin-manifests.py
@@ -1231,7 +1231,12 @@ def main() -> int:
         if not sh_path.exists():
             continue
         body = sh_path.read_text(encoding="utf-8", errors="replace")
-        if not re.search(rf"praxis_fire_arm\s+{re.escape(name)}\b", body):
+        # The line must also be executable shell: a commented-out or
+        # heredoc-quoted arm call reads identically to the real one, so a
+        # leading `#` disqualifies the match (coderabbit, PR #892).
+        if not re.search(
+            rf"(?m)^(?!\s*#).*\bpraxis_fire_arm\s+{re.escape(name)}\b", body
+        ):
             drifts.append(
                 f"FIRE-LEDGER MISSING hooks/{role}/{name}/impl.sh: shell hook "
                 "does not arm fire-ledger instrumentation — source "

--- a/tests/hooks/_lib/test_record_fire.sh
+++ b/tests/hooks/_lib/test_record_fire.sh
@@ -28,7 +28,12 @@ rows = [json.loads(line) for line in open(path, encoding="utf-8") if line.strip(
 match = [r for r in rows
          if r["hook"] == hook and r["decision"] == decision
          and r["session_id"] == session and r["granularity"] == "rich"]
-assert match, f"no rich {hook}/{decision}/{session} record in {rows}"
+# Exactly one: a duplicate arm (say, sourcing record_fire.sh twice) would
+# double-count the engagement, and "at least one" cannot see that.
+assert len(match) == 1, (
+    f"expected exactly 1 rich {hook}/{decision}/{session} record, "
+    f"got {len(match)} in {rows}"
+)
 PY
   if [ $? -eq 0 ]; then ok "$name"; else ko "$name" "record mismatch"; fi
 }

--- a/tests/hooks/_lib/test_record_fire.sh
+++ b/tests/hooks/_lib/test_record_fire.sh
@@ -125,11 +125,23 @@ printf '{"transcript_path":"%s","session_id":"sess-rm"}' "$TMP/rm.jsonl" \
     bash "$ROOT_DIR/hooks/completion-verify/retrospect-mix-check/impl.sh" >/dev/null
 assert_record "$LEDGER" "retrospect-mix-check records pass" retrospect-mix-check pass sess-rm
 
-# codex-review-route — /codex:review advises
+# codex-review-route — /codex:review advises.
+#
+# The advisory fires on >= 2 non-bare worktrees, so it must run against a
+# repository this test builds rather than whichever checkout happens to host
+# the run: a developer machine mid-session has many worktrees and a CI runner
+# has exactly one, which would make the same assertion pass locally and fail
+# in CI.
+CR_REPO="$TMP/cr-repo"
+git init -q "$CR_REPO"
+: > "$CR_REPO/seed"
+git -C "$CR_REPO" add seed
+git -C "$CR_REPO" -c user.name=t -c user.email=t@e commit -qm seed
+git -C "$CR_REPO" worktree add -q -b second "$TMP/cr-wt2"
 LEDGER="$TMP/cr-led.jsonl"
 printf '{"prompt":"/codex:review","session_id":"sess-cr"}' \
-  | PRAXIS_FIRE_TELEMETRY_FILE="$LEDGER" \
-    bash "$ROOT_DIR/hooks/advisory-nudge/codex-review-route/impl.sh" >/dev/null
+  | (cd "$CR_REPO" && PRAXIS_FIRE_TELEMETRY_FILE="$LEDGER" \
+      bash "$ROOT_DIR/hooks/advisory-nudge/codex-review-route/impl.sh") >/dev/null
 assert_record "$LEDGER" "codex-review-route records advise" codex-review-route advise sess-cr
 
 # strike-counter — three strikes then a blocking stop

--- a/tests/hooks/_lib/test_record_fire.sh
+++ b/tests/hooks/_lib/test_record_fire.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# Tests for _lib/record_fire.sh — fire-ledger instrumentation for shell hooks
+# (issue #848). Covers the helper's own contract plus one end-to-end record
+# per instrumented impl.sh hook, because the helper working in isolation says
+# nothing about whether a hook actually armed it on the branch that fires.
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+
+ok() { PASS=$((PASS + 1)); echo "PASS  [$1]"; }
+ko() { FAIL=$((FAIL + 1)); echo "FAIL  [$1] $2"; }
+
+# assert_record <ledger> <name> <expected_hook> <expected_decision> <expected_session>
+assert_record() {
+  local ledger="$1" name="$2" hook="$3" decision="$4" session="$5"
+  if [ ! -s "$ledger" ]; then
+    ko "$name" "no ledger record written"
+    return
+  fi
+  python3 - "$ledger" "$hook" "$decision" "$session" <<'PY'
+import json, sys
+path, hook, decision, session = sys.argv[1:5]
+rows = [json.loads(line) for line in open(path, encoding="utf-8") if line.strip()]
+match = [r for r in rows
+         if r["hook"] == hook and r["decision"] == decision
+         and r["session_id"] == session and r["granularity"] == "rich"]
+assert match, f"no rich {hook}/{decision}/{session} record in {rows}"
+PY
+  if [ $? -eq 0 ]; then ok "$name"; else ko "$name" "record mismatch"; fi
+}
+
+# --- helper contract -------------------------------------------------------
+# A shell hook lives two directories below _lib, so the probe harness has to
+# reproduce that depth for the relative source path to resolve.
+PROBE_ROOT="$(mktemp -d)"
+mkdir -p "$PROBE_ROOT/_lib" "$PROBE_ROOT/role/name"
+cp "$ROOT_DIR/hooks/_lib/record_fire.sh" "$PROBE_ROOT/_lib/"
+cp "$ROOT_DIR/hooks/_lib/_fire_ledger.py" "$PROBE_ROOT/_lib/"
+cat > "$PROBE_ROOT/role/name/impl.sh" <<'EOF'
+#!/bin/sh
+. "$(dirname "$0")/../../_lib/record_fire.sh"
+praxis_fire_arm probe-hook probe-role "sess-probe" ""
+[ "${PROBE_DECIDE:-}" = "block" ] && PRAXIS_FIRE_DECISION=block
+exit 0
+EOF
+
+LEDGER="$PROBE_ROOT/led.jsonl"
+PRAXIS_FIRE_TELEMETRY_FILE="$LEDGER" sh "$PROBE_ROOT/role/name/impl.sh"
+assert_record "$LEDGER" "arm defaults to pass" probe-hook pass sess-probe
+
+rm -f "$LEDGER"
+PROBE_DECIDE=block PRAXIS_FIRE_TELEMETRY_FILE="$LEDGER" sh "$PROBE_ROOT/role/name/impl.sh"
+assert_record "$LEDGER" "decision override recorded" probe-hook block sess-probe
+
+# fail-open: telemetry disabled
+rm -f "$LEDGER"
+PRAXIS_FIRE_TELEMETRY_DISABLE=1 PRAXIS_FIRE_TELEMETRY_FILE="$LEDGER" \
+  sh "$PROBE_ROOT/role/name/impl.sh"
+rc=$?
+if [ "$rc" -eq 0 ] && [ ! -f "$LEDGER" ]; then
+  ok "disable env writes nothing, exit 0"
+else
+  ko "disable env writes nothing, exit 0" "rc=$rc ledger=$(ls "$LEDGER" 2>&1)"
+fi
+
+# fail-open: _fire_ledger.py missing from the resolved _lib
+NOLIB_ROOT="$(mktemp -d)"
+mkdir -p "$NOLIB_ROOT/_lib" "$NOLIB_ROOT/role/name"
+cp "$ROOT_DIR/hooks/_lib/record_fire.sh" "$NOLIB_ROOT/_lib/"
+cp "$PROBE_ROOT/role/name/impl.sh" "$NOLIB_ROOT/role/name/impl.sh"
+PRAXIS_FIRE_TELEMETRY_FILE="$NOLIB_ROOT/led.jsonl" sh "$NOLIB_ROOT/role/name/impl.sh"
+rc=$?
+if [ "$rc" -eq 0 ] && [ ! -f "$NOLIB_ROOT/led.jsonl" ]; then
+  ok "missing _fire_ledger fails open"
+else
+  ko "missing _fire_ledger fails open" "rc=$rc"
+fi
+
+# fail-open: unwritable ledger path
+PRAXIS_FIRE_TELEMETRY_FILE=/dev/null/nope sh "$PROBE_ROOT/role/name/impl.sh"
+rc=$?
+[ "$rc" -eq 0 ] && ok "unwritable ledger fails open" \
+  || ko "unwritable ledger fails open" "rc=$rc"
+
+# --- end-to-end: each instrumented impl.sh hook ----------------------------
+TMP="$(mktemp -d)"
+
+# completion-verify — claim without evidence blocks
+python3 - "$TMP/cv.jsonl" <<'PY'
+import json, sys
+events = [
+    {"message": {"role": "user", "content": "go"}},
+    {"message": {"role": "assistant",
+                 "content": [{"type": "text", "text": "모두 완료했습니다."}]}},
+]
+with open(sys.argv[1], "w", encoding="utf-8") as f:
+    for e in events:
+        f.write(json.dumps(e, ensure_ascii=False) + "\n")
+PY
+LEDGER="$TMP/cv-led.jsonl"
+printf '{"transcript_path":"%s","session_id":"sess-cv"}' "$TMP/cv.jsonl" \
+  | PRAXIS_FIRE_TELEMETRY_FILE="$LEDGER" \
+    bash "$ROOT_DIR/hooks/completion-verify/completion-verify/impl.sh" >/dev/null
+assert_record "$LEDGER" "completion-verify records block" completion-verify block sess-cv
+
+# retrospect-mix-check — ordinary message passes
+python3 - "$TMP/rm.jsonl" <<'PY'
+import json, sys
+events = [
+    {"message": {"role": "user", "content": "go"}},
+    {"message": {"role": "assistant",
+                 "content": [{"type": "text", "text": "평범한 응답입니다."}]}},
+]
+with open(sys.argv[1], "w", encoding="utf-8") as f:
+    for e in events:
+        f.write(json.dumps(e, ensure_ascii=False) + "\n")
+PY
+LEDGER="$TMP/rm-led.jsonl"
+printf '{"transcript_path":"%s","session_id":"sess-rm"}' "$TMP/rm.jsonl" \
+  | PRAXIS_FIRE_TELEMETRY_FILE="$LEDGER" \
+    bash "$ROOT_DIR/hooks/completion-verify/retrospect-mix-check/impl.sh" >/dev/null
+assert_record "$LEDGER" "retrospect-mix-check records pass" retrospect-mix-check pass sess-rm
+
+# codex-review-route — /codex:review advises
+LEDGER="$TMP/cr-led.jsonl"
+printf '{"prompt":"/codex:review","session_id":"sess-cr"}' \
+  | PRAXIS_FIRE_TELEMETRY_FILE="$LEDGER" \
+    bash "$ROOT_DIR/hooks/advisory-nudge/codex-review-route/impl.sh" >/dev/null
+assert_record "$LEDGER" "codex-review-route records advise" codex-review-route advise sess-cr
+
+# strike-counter — three strikes then a blocking stop
+STATE="$TMP/state"
+printf '{"session_id":"sess-sc"}' \
+  | PRAXIS_STATE_DIR="$STATE" PRAXIS_FIRE_TELEMETRY_DISABLE=1 \
+    bash "$ROOT_DIR/hooks/completion-verify/strike-counter/impl.sh" session-start >/dev/null
+for i in 1 2 3; do
+  CLAUDE_SESSION_ID=sess-sc PRAXIS_STATE_DIR="$STATE" PRAXIS_FIRE_TELEMETRY_DISABLE=1 \
+    bash "$ROOT_DIR/hooks/completion-verify/strike-counter/impl.sh" strike "v$i" >/dev/null
+done
+LEDGER="$TMP/sc-led.jsonl"
+printf '{"session_id":"sess-sc"}' \
+  | PRAXIS_STATE_DIR="$STATE" PRAXIS_FIRE_TELEMETRY_FILE="$LEDGER" \
+    bash "$ROOT_DIR/hooks/completion-verify/strike-counter/impl.sh" stop >/dev/null
+assert_record "$LEDGER" "strike-counter records block" strike-counter block sess-sc
+
+# slash modes are user commands, not hook engagements — they must stay out of
+# the ledger, otherwise the fire rate this ledger measures is inflated.
+LEDGER="$TMP/sc-slash.jsonl"
+CLAUDE_SESSION_ID=sess-sc PRAXIS_STATE_DIR="$STATE" PRAXIS_FIRE_TELEMETRY_FILE="$LEDGER" \
+  bash "$ROOT_DIR/hooks/completion-verify/strike-counter/impl.sh" status >/dev/null
+if [ ! -f "$LEDGER" ]; then
+  ok "strike-counter slash mode records nothing"
+else
+  ko "strike-counter slash mode records nothing" "$(cat "$LEDGER")"
+fi
+
+rm -rf "$PROBE_ROOT" "$NOLIB_ROOT" "$TMP"
+
+echo "----"
+echo "PASS: $PASS / FAIL: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/hooks/_lib/test_record_fire.sh
+++ b/tests/hooks/_lib/test_record_fire.sh
@@ -144,6 +144,32 @@ printf '{"prompt":"/codex:review","session_id":"sess-cr"}' \
       bash "$ROOT_DIR/hooks/advisory-nudge/codex-review-route/impl.sh") >/dev/null
 assert_record "$LEDGER" "codex-review-route records advise" codex-review-route advise sess-cr
 
+# An absent session_id must reach the ledger as "", never as the "unknown"
+# placeholder those hooks use for their log lines and marker filenames.
+# aggregate_fires adds any non-empty session string to its distinct-session
+# set, so "unknown" would collapse every unattributed fire into one fake
+# session — inflating the session count these records exist to measure.
+for probe in \
+  "completion-verify:completion-verify/completion-verify/impl.sh" \
+  "retrospect-mix-check:completion-verify/retrospect-mix-check/impl.sh"
+do
+  probe_hook="${probe%%:*}"
+  LEDGER="$TMP/${probe_hook}-nosess.jsonl"
+  printf '{"transcript_path":"%s"}' "$TMP/rm.jsonl" \
+    | PRAXIS_FIRE_TELEMETRY_FILE="$LEDGER" \
+      bash "$ROOT_DIR/hooks/${probe#*:}" >/dev/null
+  if python3 -c '
+import json, sys
+recs = [json.loads(l) for l in open(sys.argv[1], encoding="utf-8") if l.strip()]
+sys.exit(0 if recs and all(r.get("session_id") == "" for r in recs) else 1)
+' "$LEDGER" 2>/dev/null; then
+    ok "$probe_hook records an absent session as empty, not \"unknown\""
+  else
+    ko "$probe_hook records an absent session as empty, not \"unknown\"" \
+      "$(cat "$LEDGER" 2>/dev/null)"
+  fi
+done
+
 # strike-counter — three strikes then a blocking stop
 STATE="$TMP/state"
 printf '{"session_id":"sess-sc"}' \

--- a/tests/test_check_fire_ledger_arm.sh
+++ b/tests/test_check_fire_ledger_arm.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# test_check_fire_ledger_arm.sh — verify check-plugin-manifests.py Rule 18 (#848):
+# every shell hook arms fire-ledger instrumentation with an executable call.
+#
+# The rule exists so that deleting the arm call cannot pass CI. Its whole value
+# therefore rests on rejecting text that merely *looks* like the call — a
+# comment, an echoed string, an assignment — because each of those reads
+# identically to a live call while recording nothing at runtime.
+#
+# Usage: bash tests/test_check_fire_ledger_arm.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK="$ROOT_DIR/scripts/check-plugin-manifests.py"
+TARGET="$ROOT_DIR/hooks/advisory-nudge/codex-review-route/impl.sh"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+run_case() {
+  local name="$1" result="$2" expected="$3"
+  if [ "$result" = "$expected" ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expected=$expected got=$result"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+echo "test_check_fire_ledger_arm"
+
+if [ ! -f "$TARGET" ]; then
+  echo "FAIL  [target_exists] expected=yes got=no"
+  exit 1
+fi
+
+BACKUP="$(mktemp)"
+cp "$TARGET" "$BACKUP"
+trap 'cp "$BACKUP" "$TARGET"; rm -f "$BACKUP"' EXIT
+
+# The live arm call, matched exactly as it appears in the hook.
+ARM='  praxis_fire_arm codex-review-route advisory-nudge "$SESSION_ID" ""'
+
+# Replace the arm call with $1 and report the checker's exit code.
+sub_arm() {
+  python3 - "$TARGET" "$ARM" "$1" <<'PY'
+import sys
+path, old, new = sys.argv[1:4]
+body = open(path, encoding="utf-8").read()
+assert old in body, "arm call not found verbatim — fixture is stale"
+open(path, "w", encoding="utf-8").write(body.replace(old, new, 1))
+PY
+  python3 "$CHECK" >/dev/null 2>&1
+  echo "$?"
+  cp "$BACKUP" "$TARGET"
+}
+
+# 1. Baseline: the real call satisfies the rule.
+python3 "$CHECK" >/dev/null 2>&1
+run_case "baseline_check_clean" "$?" "0"
+
+# 2. Deleting the call entirely is the case the rule was written for.
+run_case "deleted_arm_call_fails" "$(sub_arm '')" "1"
+
+# 3-5. Text that mentions the call without executing it must not satisfy it.
+#      Each of these passed under the original "appears anywhere" pattern.
+run_case "commented_arm_call_fails" \
+  "$(sub_arm '  # praxis_fire_arm codex-review-route advisory-nudge "$SESSION_ID" ""')" "1"
+run_case "echoed_arm_call_fails" \
+  "$(sub_arm '  echo "praxis_fire_arm codex-review-route advisory-nudge"')" "1"
+run_case "assigned_arm_call_fails" \
+  "$(sub_arm "  MSG='praxis_fire_arm codex-review-route advisory-nudge'")" "1"
+
+# 6. A different hook's name in the call does not satisfy this hook's rule —
+#    the match is name-anchored, so a copy-paste from a sibling still fails.
+run_case "wrong_hook_name_fails" \
+  "$(sub_arm '  praxis_fire_arm completion-verify advisory-nudge "$SESSION_ID" ""')" "1"
+
+echo "----"
+echo "PASS: $PASS / FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'failed: %s\n' "${FAILED_NAMES[@]}"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 배경

fire ledger 도달 경로는 `@fail_open`(standalone)과 dispatcher(Bash 그룹) 둘뿐이고 양쪽 다 Python 전용이라, `impl.sh` 4개 훅은 레코드가 **0건**이었다. ledger 를 읽는 감사(`docs/hook-prune-audit.md`)에서는 이 침묵이 "한 번도 발화 안 함"으로 채점된다 — 실제로는 계측이 없었던 것이다.

## 변경

- **`hooks/_lib/record_fire.sh` 신규** — `praxis_fire_arm <hook> <role> "$SESSION_ID" ""` 가 EXIT trap 을 걸어, 어느 분기로 빠져나가든 rich 레코드 1건을 남긴다. 나중에 이른 `exit 0` 이 추가돼도 계측에서 조용히 빠지지 않는 것이 trap 을 쓴 이유다. `PRAXIS_FIRE_DECISION` 으로 block/advise 를 지정하고 기본값은 pass.
- **4개 훅 적용** — `strike-counter`(hook 모드 3종), `completion-verify`, `retrospect-mix-check`, `codex-review-route`.
- **rich 형태로 기록** — 셸 훅은 이미 자기 stdin 을 파싱해 실제 session_id 를 들고 있으므로 coarse(`session_id=""`) 형태는 쓸 수 없다. coarse 경로 자체가 없으므로 `suppress_coarse_duplicate` 계약은 적용되지 않는다.
- **`check-plugin-manifests.py` Rule 18** — manifest 등재 `impl.sh` 는 자기 이름으로 arm 을 호출해야 한다. `command -v praxis_fire_arm` 가용성 가드만으로 통과되지 않도록 훅 이름까지 매칭한다.
- `_fire_ledger.py` CEILING 절 + `DESIGN.md` 갱신.

## 의도적 미기록 (2가지)

| 대상 | 사유 |
| --- | --- |
| session_id 파싱 이전 guard (`jq` 부재, stdin 파싱 실패) | 알 수 없는 세션에 묶인 레코드는 per-session 집계가 불가능 |
| `strike-counter` 의 slash 모드 (strike/status/reset) | 사용자 명령이지 훅 발화가 아니며, 세면 이 ledger 가 재려는 fire rate 가 부풀려짐 |

## fail-open

python3 부재 · `_lib` 미해석 · `_fire_ledger.py` 부재 · ledger 쓰기 실패 · `PRAXIS_FIRE_TELEMETRY_DISABLE=1` — 전부 조용히 no-op 하고 훅은 그대로 진행한다. 텔레메트리 쓰기가 훅의 판정을 바꿔서는 안 된다.

## 검증

```
$ ./scripts/run-tests.sh
Passed: 42  Failed: 0        (shell)
507 passed                    (pytest)
plugin-manifest check OK
hook-token-invariant check OK (7 invariants verified)
ruff: All checks passed!
shellcheck: (clean)
ALL TESTS PASSED
```

```
$ bash tests/hooks/_lib/test_record_fire.sh
PASS: 10 / FAIL: 0
```

4개 훅 각각에 실제 stdin 을 넣어 레코드를 확인했다 (block/advise/pass):

```
{"session_id": "sess-cv", "hook": "completion-verify",    "decision": "block",  "granularity": "rich"}
{"session_id": "sess-rm", "hook": "retrospect-mix-check", "decision": "pass",   "granularity": "rich"}
{"session_id": "sess-cr", "hook": "codex-review-route",   "decision": "advise", "granularity": "rich"}
{"session_id": "sess-sc", "hook": "strike-counter",       "decision": "block",  "granularity": "rich"}
```

**Falsification** — 두 가드 모두 민감함을 확인했다:

- `completion-verify` 의 arm 호출을 제거 → `test_record_fire.sh` 가 `FAIL [completion-verify records block] no ledger record written` 로 실패
- `codex-review-route` 의 arm 호출을 제거 → Rule 18 이 `FIRE-LEDGER MISSING ...` 로 FAILED

## 검증되지 않은 것

실제 Claude Code 세션에서의 발화는 플러그인 배포 이후에만 확인할 수 있다. 위 검증은 전부 훅을 직접 실행한 것이다.

Caller chain verified: `praxis_fire_arm` / `praxis_record_fire` 는 신규 심볼로, 호출자는 이 PR 이 만드는 4개 `impl.sh` 뿐이다 (`grep -rn praxis_fire_arm hooks/` → 4개 훅 + 헬퍼 정의 + Rule 18). `_fire_ledger.record_session_fire` 는 기존 심볼이며 시그니처 변경 없음 — 기존 Python 호출자 5개는 무영향.
Pre-commit verified: `./scripts/run-tests.sh` → ALL TESTS PASSED (pytest 507 / shell 42 / manifest OK / hook-token OK / ruff clean / shellcheck clean)

Closes #848


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fail-safe fire-event telemetry for shell-based hooks, ensuring exactly one rich “fire” record per invocation with hook, session, and decision details.
  * Documented and enforced `PRAXIS_FIRE_DECISION` (`pass`/`advise`/`block`) requirements for shell `impl.sh` hooks.
* **Validation**
  * Updated manifest/check tooling to detect missing shell-hook fire instrumentation (`praxis_fire_arm` sourcing) and report drift.
* **Tests**
  * Added a shell test harness covering default, decision override, telemetry-disabled/unavailable, and end-to-end ledger assertions for multiple instrumented hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->