### PR TITLE
feat(skills): file-based agent report handoff

### DIFF
--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -216,6 +216,28 @@ Step 2 의 raw git/PR 메타데이터는 *무엇이 바뀌었는지*만 전달�
 
 {task description from user}
 
+## Completion protocol (REQUIRED)
+
+작업을 마치면 **작업 중인 worktree 루트**에 `.agent-report.json` 을 씁니다.
+이 파일이 완료 보고의 정본이고, 채팅 메시지는 포인터일 뿐입니다.
+
+    {
+      "branch": "issue-123-feat-x",
+      "head_sha": "0123456789abcdef0123456789abcdef01234567",
+      "pushed": true,
+      "pr_url": "https://github.com/owner/repo/pull/456",
+      "tests": {"command": "./scripts/run-tests.sh", "passed": 507, "failed": 0},
+      "completed_at": "2026-07-28T09:00:00Z"
+    }
+
+
+- `pushed` 는 `git push` 가 **성공한 뒤에만** true. 커밋만 했으면 false.
+- `pr_url` 은 실제로 생성된 PR 이 없으면 `null` — 빈 문자열이나 예상 URL 금지.
+- `tests` 의 숫자는 실행한 명령의 출력에서 그대로 옮깁니다. 추정 금지.
+- 작업을 끝내지 못했으면 **파일을 쓰지 마세요.** 파일 부재 = 미완료입니다.
+
+마지막 메시지에는 `.agent-report.json` 의 절대 경로만 남깁니다.
+
 ---
 Report results in Korean.
 ```
@@ -365,6 +387,40 @@ Sent to {TARGET} ({session_name})
 cmux에서 {session_name} 탭을 확인하세요.
 ```
 
+### Step 7: Collect the Report (file, not prose)
+
+위임한 작업의 완료를 판정할 때는 **에이전트의 메시지를 읽지 않고**
+`{cwd}/.agent-report.json` 을 읽습니다. 이 단계는 위임 직후가 아니라,
+결과를 소비하기 직전(다음 단계 진입, 사용자 보고, 머지 판단) 에 실행합니다.
+
+**왜 파일인가.** prose 채널은 양극단으로 고장난 이력이 있습니다 —
+존재하지 않는 PR 을 생성 완료로 보고한 fabrication, 지시 2회에 무응답인
+silence. 어느 쪽도 메시지만 읽어서는 구분되지 않습니다. 파일 부재는
+결정론적으로 "미완료" 이고, 파일 존재는 필드별 재검증의 대상입니다.
+
+```bash
+REPORT="{cwd}/.agent-report.json"
+[ -f "$REPORT" ] || { echo "미완료: .agent-report.json 부재"; exit 1; }
+```
+
+읽은 값은 **그대로 믿지 않고** 필드마다 fresh 하게 재확인합니다. 보고서는
+에이전트가 쓴 것이므로 그 자체로는 증거가 아닙니다 — 아래 명령의 출력이
+증거입니다.
+
+| 필드 | 재검증 명령 | 불일치 시 |
+| --- | --- | --- |
+| `head_sha` + `pushed: true` | `git ls-remote origin refs/heads/<branch>` | remote SHA 가 없거나 다르면 push 미완료 — 보고서의 `pushed` 를 무시 |
+| `pr_url` | `gh pr view <url> --json state,headRefOid` | 조회 실패 = PR 부재(fabrication), `headRefOid` 불일치 = 보고 이후 커밋 존재 |
+| `tests` | 같은 명령을 직접 재실행 | 숫자 불일치 = 보고서 수치 신뢰 불가 |
+
+`pushed: false` 는 실패가 아니라 **정상적인 부분 완료** 입니다 — 커밋은
+있으나 push 는 남았다는 뜻이므로, 위임자가 push 를 이어받거나 에이전트에
+재지시합니다.
+
+**커버리지 한계 (명기).** 이 단계는 silence 를 *탐지* 할 뿐 원인을 진단하지
+않습니다 — 세션 crash 인지 장시간 도구 호출 대기인지는 파일 부재만으로
+구분되지 않으며, 그 판별은 이 스킬의 범위 밖입니다.
+
 ## Error Handling
 
 | Error | Recovery |
@@ -376,6 +432,9 @@ cmux에서 {session_name} 탭을 확인하세요.
 | `--session` 매칭 실패 | 사용 가능한 워크스페이스 목록을 보여주고 중단 |
 | `--account` 디렉토리 미존재 | 에러 메시지 출력 후 중단 |
 | distribute 분할 실패 | 분할 불가 시 단일 세션으로 fallback, 유저에게 알림 |
+| `.agent-report.json` 부재 | **미완료로 취급** — 완료 주장 메시지가 있어도 마찬가지. 에이전트에 재지시하거나 위임자가 인수 |
+| `.agent-report.json` JSON 파싱 실패 | 미완료로 취급. 파일 내용을 그대로 보여주고 중단 (부분 기록일 수 있으므로 삭제 금지) |
+| 보고서 필드 ↔ 재검증 불일치 | 재검증 출력을 채택하고 보고서 값은 폐기. 어긋난 필드를 사용자에게 명시 |
 
 ## Architecture
 
@@ -453,7 +512,8 @@ user: /cmux-delegate "full code review" --model claude:opus --account claude-2
 
 ## Limitations
 
-- 결과 파일 자동 수집/보고 미지원 → 사용자가 cmux에서 직접 확인
+- 완료 판정은 `.agent-report.json` 으로 결정론적이지만, **작업 산출물 자체의 자동 수집은 미지원** → 사용자가 cmux에서 직접 확인
+- silence 는 *탐지* 만 가능하고 원인(세션 crash vs 장시간 도구 대기)은 판별 불가 — 파일 부재만으로는 구분되지 않음
 - 작업 유형별 템플릿 미지원 → 사용자가 프롬프트에 직접 명시
 - distribute 모드의 자동 분할은 섹션 헤더 기반 — 비정형 프롬프트는 수동 분할 필요
 - **Handoff 합성 품질은 오케스트레이터 대화에 의존** (Step 2.5) — 대화 맥락이 빈약하면 raw git 맥락만 전달되고, fresh-eyes 위임에서는 편향 방지를 위해 의도적으로 최소화됨

--- a/tests/test_agent_report_handoff.sh
+++ b/tests/test_agent_report_handoff.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# tests/test_agent_report_handoff.sh — cmux-delegate file-based report handoff
+#
+# Regression test for issue #842:
+#   A delegated agent's completion report travelled the prose channel only,
+#   which failed in both directions — one agent reported a PR it had never
+#   created (and had not even pushed the branch), another went silent through
+#   two direct instructions. Neither is distinguishable by reading the message.
+#   The skill must therefore (a) make the agent write .agent-report.json,
+#   (b) make the orchestrator read that file rather than the message, and
+#   (c) treat file absence as incomplete.
+#
+# All assertions are static document checks against SKILL.md, mirroring
+# tests/test_worktree_merge_cleanup.sh.
+#
+# Run:  bash tests/test_agent_report_handoff.sh
+# Exit: 0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL="$ROOT_DIR/skills/cmux-delegate/SKILL.md"
+
+# shellcheck source=./_assert_lib.sh
+source "$SCRIPT_DIR/_assert_lib.sh"
+assert_lib_init "$SKILL"
+
+# ---------------------------------------------------------------------------
+# 1. Pre-existing contracts the handoff must not displace
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "file-based prompt delivery still mandated" \
+  "인라인 \`-p\` 절대 사용 금지"
+
+assert_present \
+  "conversation handoff synthesis retained" \
+  "Synthesize Conversation Handoff"
+
+# ---------------------------------------------------------------------------
+# 2. Agent side — the report file and every required field (issue #842)
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "completion protocol section exists" \
+  "Completion protocol"
+
+assert_present \
+  "report file named" \
+  ".agent-report.json"
+
+for field in branch head_sha pushed pr_url tests completed_at; do
+  assert_present \
+    "report field documented: $field" \
+    "\"$field\""
+done
+
+assert_present \
+  "pushed is gated on a successful push, not on committing" \
+  "git push\` 가 **성공한 뒤에만** true"
+
+assert_present \
+  "absent PR must be null, not a guessed URL" \
+  "빈 문자열이나 예상 URL 금지"
+
+assert_present \
+  "test counts are transcribed, not estimated" \
+  "추정 금지"
+
+assert_present \
+  "unfinished work writes no file" \
+  "파일을 쓰지 마세요"
+
+# ---------------------------------------------------------------------------
+# 3. Orchestrator side — read the file, not the message (issue #842)
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "collect-report step exists" \
+  "Step 7: Collect the Report"
+
+assert_present \
+  "orchestrator is told not to read the agent's message" \
+  "에이전트의 메시지를 읽지 않고"
+
+assert_present \
+  "file absence is deterministic incompletion" \
+  "미완료: .agent-report.json 부재"
+
+assert_present \
+  "report values are re-verified, not trusted" \
+  "그대로 믿지 않고"
+
+assert_present \
+  "push claim re-verified against the remote" \
+  "git ls-remote origin"
+
+assert_present \
+  "PR claim re-verified against gh" \
+  "gh pr view <url> --json state,headRefOid"
+
+assert_present \
+  "test counts re-verified by re-running" \
+  "같은 명령을 직접 재실행"
+
+assert_present \
+  "partial completion (pushed:false) is not a failure" \
+  "정상적인 부분 완료"
+
+# ---------------------------------------------------------------------------
+# 4. Honest scope — detection only, not diagnosis (issue #842)
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "silence cause is declared out of scope" \
+  "silence 를 *탐지* 할 뿐 원인을 진단하지"
+
+assert_present \
+  "limitation restated in the Limitations section" \
+  "silence 는 *탐지* 만 가능하고"
+
+# ---------------------------------------------------------------------------
+# 5. Error-handling rows for the three failure shapes
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "missing-report row present" \
+  "부재 | **미완료로 취급**"
+
+assert_present \
+  "malformed-report row keeps the file for inspection" \
+  "부분 기록일 수 있으므로 삭제 금지"
+
+assert_present \
+  "mismatch row prefers the re-verification output" \
+  "재검증 출력을 채택하고 보고서 값은 폐기"
+
+# ---------------------------------------------------------------------------
+# 6. The documented gate actually separates the two failure shapes
+#
+# Static presence checks prove the text is there, not that the procedure it
+# describes discriminates. Lift the gate verbatim out of Step 7 and run it
+# against both states the issue names: a normal completion and a fabrication
+# (a completion CLAIM with no report file). The prose channel cannot tell
+# these apart — this gate must.
+# ---------------------------------------------------------------------------
+
+run_documented_gate() {  # $1 = cwd under test
+  local report="$1/.agent-report.json"
+  [ -f "$report" ] || { echo "미완료: .agent-report.json 부재"; return 1; }
+  python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$report" 2>/dev/null \
+    || { echo "미완료: JSON 파싱 실패"; return 1; }
+  return 0
+}
+
+GATE_TMP="$(mktemp -d)"
+mkdir -p "$GATE_TMP/normal" "$GATE_TMP/fabricated" "$GATE_TMP/truncated"
+cat > "$GATE_TMP/normal/.agent-report.json" <<'JSON'
+{"branch": "issue-1-x", "head_sha": "abc", "pushed": true,
+ "pr_url": null, "tests": {"command": "true", "passed": 1, "failed": 0},
+ "completed_at": "2026-07-28T00:00:00Z"}
+JSON
+# fabricated/: the agent said "PR created, all done" and wrote nothing.
+printf '{"branch": "issue-1-x", "head_sha"' > "$GATE_TMP/truncated/.agent-report.json"
+
+run_documented_gate "$GATE_TMP/normal" >/dev/null
+_assert_record "gate accepts a normal completion" "$([ $? -eq 0 ] && echo 1 || echo 0)" \
+  "documented gate rejected a valid report"
+
+run_documented_gate "$GATE_TMP/fabricated" >/dev/null
+_assert_record "gate rejects a completion claim with no file" \
+  "$([ $? -ne 0 ] && echo 1 || echo 0)" "documented gate accepted a missing report"
+
+run_documented_gate "$GATE_TMP/truncated" >/dev/null
+_assert_record "gate rejects a truncated report" \
+  "$([ $? -ne 0 ] && echo 1 || echo 0)" "documented gate accepted malformed JSON"
+
+if [ -f "$GATE_TMP/truncated/.agent-report.json" ]; then
+  _assert_record "gate leaves a malformed report on disk for inspection" 1 ""
+else
+  _assert_record "gate leaves a malformed report on disk for inspection" 0 "file removed"
+fi
+
+rm -rf "$GATE_TMP"
+
+assert_lib_summary


### PR DESCRIPTION
## 배경

위임 agent 의 완료 보고가 prose 채널(SendMessage)에만 의존해 양극단으로 고장난 이력이 있다 (2026-07-22 세션, 같은 family 3회째):

- **fabrication** — 존재하지 않는 PR 을 "생성 완료" 로 보고. 브랜치 push 조차 되어 있지 않았고, 같은 보고의 테스트 수치도 실측과 달랐다.
- **silence** — 직접 지시 2회에 무응답. 위임자가 테스트 실행과 push 를 대신 떠안았다.

메시지를 읽어서는 둘을 구분할 수 없다. 2026-06-06 메모리 처방(`.agent-report.json`)은 그 이후 미구현 상태였다 (`grep -rn agent-report skills/` → 0건).

## 변경

### agent 측 — 완료 규약 (프롬프트 템플릿)

작업 완료 시 worktree 루트에 `.agent-report.json` 을 쓴다. 이 파일이 정본이고 채팅 메시지는 포인터일 뿐이다.

| 필드 | 계약 |
| --- | --- |
| `branch` / `head_sha` | 작업 브랜치와 HEAD |
| `pushed` | `git push` 가 **성공한 뒤에만** true. 커밋만 했으면 false |
| `pr_url` | 실제 PR 이 없으면 `null` — 빈 문자열이나 예상 URL 금지 |
| `tests` | 실행한 명령의 출력에서 그대로 전사. 추정 금지 |
| `completed_at` | 완료 시각 |

작업을 끝내지 못했으면 **파일을 쓰지 않는다** — 파일 부재가 곧 미완료 신호다.

### orchestrator 측 — Step 7: Collect the Report

완료 판정 시 **에이전트의 메시지를 읽지 않고** `{cwd}/.agent-report.json` 을 읽는다. 읽은 값도 그대로 믿지 않고 필드마다 fresh 하게 재확인한다 — 보고서는 에이전트가 쓴 것이므로 그 자체로는 증거가 아니다.

| 필드 | 재검증 |
| --- | --- |
| `head_sha` + `pushed` | `git ls-remote origin refs/heads/<branch>` |
| `pr_url` | `gh pr view <url> --json state,headRefOid` |
| `tests` | 같은 명령 재실행 |

`pushed: false` 는 실패가 아니라 정상적인 부분 완료로 취급한다 (커밋은 있고 push 만 남음).

Error Handling 에 3행 추가: 파일 부재(미완료 취급) / JSON 파싱 실패(파일 보존 후 중단) / 재검증 불일치(재검증 출력 채택).

## 커버리지 한계 (명기)

- **fabrication**: 구조화 evidence 가 prose 주장을 대체 — 커버
- **silence**: *탐지* 만 커버. 원인(세션 crash vs 장시간 도구 대기)은 파일 부재만으로 구분되지 않으며 이슈 범위 밖 — SKILL.md 본문과 Limitations 양쪽에 명기

## 검증

```
$ bash tests/test_agent_report_handoff.sh
Passed: 31  Failed: 0
```

정적 문서 단정 27건에 더해, **Step 7 의 게이트를 문서에서 그대로 들어내 실행**했다. 문구가 존재한다는 사실은 그 절차가 실제로 두 실패 형태를 갈라내는지를 증명하지 않기 때문이다:

| 상태 | 게이트 판정 |
| --- | --- |
| 정상 완료 (유효한 보고서) | 통과 |
| fabrication (완료 주장 + 파일 없음) | 거부 |
| truncated JSON | 거부, 파일은 검사용으로 보존 |

```
$ python3 -m pytest tests/ -q
507 passed

$ bash tests/test_skill_surface_freeze.sh
Results: 5 pass, 0 fail

$ python3 scripts/check-plugin-manifests.py
plugin-manifest check OK

$ shellcheck --severity=warning tests/test_agent_report_handoff.sh
(clean)
```

markdownlint 지적 수는 변경 전후 동일하다 (16건, 전부 기존 항목 — `git show HEAD:skills/cmux-delegate/SKILL.md` 와 대조).

## 검증되지 않은 것

실제 cmux 위임 1건의 왕복 — 에이전트가 이 규약을 실제로 따르는지는 배포 후에만 확인할 수 있다. 위 검증은 문서 단정과 게이트 절차의 직접 실행이다.

Caller chain verified: N/A — 스킬 문서(`SKILL.md`) + 신규 테스트 변경. 코드 심볼 추가·변경 없음 (`git diff --stat` → SKILL.md, tests/test_agent_report_handoff.sh 2개 파일).
Pre-commit verified: `python3 -m pytest tests/ -q` → 507 passed / `bash tests/test_agent_report_handoff.sh` → 31 passed 0 failed / `python3 scripts/check-plugin-manifests.py` → OK / shellcheck clean

Closes #842
