### PR TITLE
docs(contributing): qualify canary lag figures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,10 +164,22 @@ Hooks do not execute from this repository. They execute from a versioned copy
 under `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/praxis/praxis/<version>/`
 — note the config dir is relocatable, so `~/.claude` is the default, not a
 given — and a merged change is not live until
-`release → plugin update → session reload` completes. Measured
-lead time from merge to release is a median of **33.7 hours** (max observed:
-201 hours, n=44 — see issue #841). Treat that lag as a permanent property of
-the repo, not an incident: the release cadence is deliberate.
+`release → plugin update → session reload` completes.
+
+Both hops were measured on 2026-07-28 (issue #841). They are not comparable in
+size, so quote the window along with the number — an unqualified median invites
+the reader to apply a 14-day figure to a 7-week history:
+
+| Hop | Window | Result |
+| ---- | ------- | ------- |
+| merge → release | trailing 14 days (n=46) | median **22.6h**, max 90.8h |
+| merge → release | since the first release (n=120) | median **50.0h**, max 469.2h |
+| release → adoption | v7.6.0, both config dirs | **~2 minutes** |
+
+Merge → release is therefore the whole of the lag; the plugin-cache hop is
+effectively instant, so a stale cache is a symptom to investigate rather than
+the expected state. Treat the release lag itself as a permanent property of the
+repo, not an incident: the release cadence is deliberate.
 
 The consequence is that **you cannot validate a hook change in the session that
 wrote it by simply triggering the hook.** Triggering it runs the *previous*


### PR DESCRIPTION
## 배경

이슈 #841 의 문서 요구는 이미 머지된 PR #851 (제목 동일)이 충족했습니다 — canary 절, procedure A/B, 3종 프로브, advisory stderr 주의가 모두 `CONTRIBUTING.md` 에 있습니다. `Refs` 로 참조돼 이슈만 열려 있었을 뿐입니다.

남은 결함은 그 절이 인용한 수치 하나입니다: `median 33.7h (max 201h, n=44)` 에 **측정 창이 붙어 있지 않습니다.**

## 재측 (2026-07-28)

`gh release list` publishedAt 과 `gh pr list --state merged` mergedAt 을 대조해, 릴리즈 PR 을 제외한 각 머지 PR 의 다음 릴리즈까지 시간을 계산했습니다.

| 창 | n | median | max |
| --- | --- | --- | --- |
| 최근 14일 | 46 | 22.6h | 90.8h |
| 첫 릴리즈 이후 전체 | 120 | 50.0h | 469.2h |

기존 수치는 **틀린 게 아니라 최근 창 스냅샷**이었습니다 (n=44 ↔ 지금 14일 창 n=46, 같은 규모). 창이 없으면 독자가 2주 스냅샷을 7주 이력에 적용하게 되므로, 두 창을 모두 명시하도록 고쳤습니다.

## 두 번째 홉 추가

절이 `release → plugin update → session reload` 를 지연 경로로 서술하면서 두 번째 홉은 한 번도 측정하지 않았습니다. 실측:

```
CLAUDE_CONFIG_DIR=[unset]
~/.claude    praxis 7.6.0  lastUpdated 2026-07-27T02:39:23Z
~/.claude-2  praxis 7.6.0  lastUpdated 2026-07-27T02:39:23Z
gh release   v7.6.0        published   2026-07-27T02:37:28Z
```

release → 채택 ≈ **2분**. 즉 지연의 전부가 merge → release 이고, 캐시가 낡아 있다면 그것은 기대 상태가 아니라 조사 대상입니다. 이슈 본문이 지배 성분으로 지목했던 "활성 config 가 6.1.3 에 49일 고정" 은 현재 상태에서 falsify 됩니다.

## 검증

```
$ npx markdownlint-cli2 CONTRIBUTING.md
5 issues   # 변경 전과 동일 (라인 18/39/71/130/135, 전부 기존 항목)
```

변경 전 파일(`git show HEAD:CONTRIBUTING.md`)과 동일한 지적 수임을 대조 확인했습니다.

## 검증되지 않은 것

수치는 시점 측정이라 시간이 지나면 다시 어긋납니다. 자동 갱신은 넣지 않았습니다 — 창을 명시했으므로 다음 독자가 재측 방법을 그대로 재현할 수 있습니다.

Caller chain verified: N/A — 문서(`CONTRIBUTING.md`) 단일 파일 변경, 코드 심볼 추가·변경 없음.
Pre-commit verified: `npx markdownlint-cli2 CONTRIBUTING.md` → 5 issues (변경 전과 동일)

Closes #841
