### PR TITLE
fix(tests): guard mktemp -d failure across suite

### DIFF
--- a/scripts/check-plugin-manifests.py
+++ b/scripts/check-plugin-manifests.py
@@ -1254,6 +1254,43 @@ def main() -> int:
                 "session_id is parsed (#848)"
             )
 
+    # ------------------------------------------------------------------
+    # Rule 19 — test temp-dir creation must be guarded (#897)
+    #
+    # The suite runs under `set +e`, so an unguarded `mktemp -d` failure
+    # leaves its variable empty and every path built from it re-anchors at
+    # the filesystem root: `$TMP/cr-repo` becomes `/cr-repo`, and
+    # `mkdir -p "$PROBE_ROOT/_lib"` becomes `mkdir -p /_lib`. Observed for
+    # real in a codex sandbox that blocks DARWIN_USER_TEMP_DIR — one
+    # unusable temp dir surfaced as eleven unrelated assertion failures,
+    # which reads as a defect in the code under test.
+    # ------------------------------------------------------------------
+    # Matches the call shape only — an assignment whose value is a command
+    # substitution running `mktemp -d`. Anything else mentioning the text (a
+    # comment, or this rule's own fixture passing candidate lines as string
+    # arguments) is not an invocation and must not be flagged.
+    mktemp_site_re = re.compile(
+        r"^[ \t]*(?:local [A-Za-z_][A-Za-z0-9_]*; *)?"
+        r"[A-Za-z_][A-Za-z0-9_]*=\"?\$\(.*mktemp -d.*"
+    )
+    for sh_file in sorted((REPO_ROOT / "tests").rglob("*.sh")):
+        for lineno, line in enumerate(
+            sh_file.read_text(encoding="utf-8", errors="replace").splitlines(), 1
+        ):
+            if not mktemp_site_re.match(line):
+                continue
+            # The guard has to sit on the same line: `VAR=$(mktemp -d)`
+            # returns the substitution's status, and that status is the only
+            # signal available before the empty value is used.
+            if "||" not in line:
+                rel = sh_file.relative_to(REPO_ROOT)
+                drifts.append(
+                    f"UNGUARDED MKTEMP {rel}:{lineno}: `mktemp -d` failure is "
+                    "not checked — append "
+                    '`|| { echo "FATAL: mktemp -d failed" >&2; exit 1; }` so a '
+                    "missing temp dir fails once instead of re-anchoring every "
+                    "derived path at / (#897)"
+                )
 
     if drifts:
         print("plugin-manifest check FAILED:")

--- a/tests/hooks/_lib/test_record_fire.sh
+++ b/tests/hooks/_lib/test_record_fire.sh
@@ -41,7 +41,7 @@ PY
 # --- helper contract -------------------------------------------------------
 # A shell hook lives two directories below _lib, so the probe harness has to
 # reproduce that depth for the relative source path to resolve.
-PROBE_ROOT="$(mktemp -d)"
+PROBE_ROOT="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 mkdir -p "$PROBE_ROOT/_lib" "$PROBE_ROOT/role/name"
 cp "$ROOT_DIR/hooks/_lib/record_fire.sh" "$PROBE_ROOT/_lib/"
 cp "$ROOT_DIR/hooks/_lib/_fire_ledger.py" "$PROBE_ROOT/_lib/"
@@ -73,7 +73,7 @@ else
 fi
 
 # fail-open: _fire_ledger.py missing from the resolved _lib
-NOLIB_ROOT="$(mktemp -d)"
+NOLIB_ROOT="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 mkdir -p "$NOLIB_ROOT/_lib" "$NOLIB_ROOT/role/name"
 cp "$ROOT_DIR/hooks/_lib/record_fire.sh" "$NOLIB_ROOT/_lib/"
 cp "$PROBE_ROOT/role/name/impl.sh" "$NOLIB_ROOT/role/name/impl.sh"
@@ -92,7 +92,7 @@ rc=$?
   || ko "unwritable ledger fails open" "rc=$rc"
 
 # --- end-to-end: each instrumented impl.sh hook ----------------------------
-TMP="$(mktemp -d)"
+TMP="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 
 # completion-verify — claim without evidence blocks
 python3 - "$TMP/cv.jsonl" <<'PY'

--- a/tests/hooks/advisory-nudge/test_bash_worktree_existence_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_bash_worktree_existence_advisory.sh
@@ -87,7 +87,7 @@ print(json.dumps(d))
 # ---------------------------------------------------------------------------
 
 # Existing directory that is NOT a registered git worktree.
-NON_WT_DIR=$(mktemp -d)
+NON_WT_DIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 
 # Path that does not exist at all.
 MISSING_PATH="$NON_WT_DIR/does-not-exist-$$"
@@ -243,7 +243,7 @@ run_case "compact subshell trailing-paren does not cause false advisory" \
 # pollute the outer effective_cwd. In `(cd /tmp && cd /usr) && cd bin`, the
 # outer relative `cd bin` must resolve against the original cwd, not /usr.
 # Run with a controlled outer cwd (a temp dir guaranteed to lack `bin/`).
-DEF1_OUTER=$(mktemp -d)
+DEF1_OUTER=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 {
   payload_def1=$(python3 -c '
 import json

--- a/tests/hooks/advisory-nudge/test_block_personal_asset_leak.sh
+++ b/tests/hooks/advisory-nudge/test_block_personal_asset_leak.sh
@@ -221,7 +221,7 @@ run_case "gh issue create --body-file unreadable path (silent)" \
   '{"tool_name":"Bash","tool_input":{"command":"gh issue create --title t --body-file /nonexistent/does-not-exist-12345.md"}}'
 
 # --- relative --body-file resolved against payload cwd (codex P2 round 2) ---
-REL_DIR=$(mktemp -d)
+REL_DIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 printf 'cfg at /Users/grace/.claude/hooks/impl.py\n' > "$REL_DIR/body.md"
 run_case "relative --body-file resolved against payload cwd (warn)" \
   "warn" "advisory" \
@@ -237,12 +237,12 @@ rm -rf "$REL_DIR"
 # Two local git fixtures stand in for a team repo (origin owner != personal)
 # and a personal repo (origin owner ∈ PRAXIS_PERSONAL_REPO_OWNERS). No network
 # access — only the remote URL string matters to the hook.
-TEAM_REPO=$(mktemp -d)
+TEAM_REPO=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 git -C "$TEAM_REPO" init -q
 git -C "$TEAM_REPO" remote add origin https://github.com/exampleorg/team-wiki.git
 printf '.omc/\n' > "$TEAM_REPO/.gitignore"
 
-PERSONAL_REPO=$(mktemp -d)
+PERSONAL_REPO=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 git -C "$PERSONAL_REPO" init -q
 git -C "$PERSONAL_REPO" remote add origin git@github.com:testowner/scratchpad.git
 
@@ -350,7 +350,7 @@ run_case "heredoc-var body with owner ref (warn)" \
   '{"tool_name":"Bash","tool_input":{"command":"BODY=$(cat <<EOF\nsee testowner/scratchpad#5\nEOF\n)\ngh issue create --repo exampleorg/team --title t --body \"$BODY\""}}' \
   "testowner"
 
-INTERNAL_PERSONAL_REPO=$(mktemp -d)
+INTERNAL_PERSONAL_REPO=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 git -C "$INTERNAL_PERSONAL_REPO" init -q
 git -C "$INTERNAL_PERSONAL_REPO" remote add origin git@internalhost:testowner/scratchpad.git
 run_case "Write owner-ref into TLD-less scp-origin personal repo (silent)" \

--- a/tests/hooks/advisory-nudge/test_codex_review_route.sh
+++ b/tests/hooks/advisory-nudge/test_codex_review_route.sh
@@ -166,7 +166,7 @@ print(json.dumps({"prompt": sys.argv[1], "session_id": "test-sid"}))' "$prompt")
 }
 
 # --- setup fixture repos -----------------------------------------------------
-TMPROOT=$(mktemp -d)
+TMPROOT=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 MULTI="$TMPROOT/multi"
 SINGLE="$TMPROOT/single"
 BARE_LINKED="$TMPROOT/bare-plus-linked"
@@ -233,7 +233,7 @@ malformed_json_test
 not_in_repo_test() {
   local name="13 silent: cwd not a git repo"
   local nogit
-  nogit=$(mktemp -d)
+  nogit=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
   local payload
   payload=$(python3 -c '
 import json, sys

--- a/tests/hooks/advisory-nudge/test_cwd_relative_exec_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_cwd_relative_exec_advisory.sh
@@ -29,7 +29,7 @@ FAILED_NAMES=()
 # separate scratch git repo with exactly 1 worktree (no ambiguity).
 # ---------------------------------------------------------------------------
 
-MULTI_BASE=$(mktemp -d)
+MULTI_BASE=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 git -c init.defaultBranch=main init -q "$MULTI_BASE/main"
 (
   cd "$MULTI_BASE/main" || exit 1
@@ -37,7 +37,7 @@ git -c init.defaultBranch=main init -q "$MULTI_BASE/main"
 )
 git -C "$MULTI_BASE/main" worktree add -q -b other-wt "$MULTI_BASE/other" >/dev/null 2>&1
 
-SINGLE_BASE=$(mktemp -d)
+SINGLE_BASE=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 git -c init.defaultBranch=main init -q "$SINGLE_BASE/solo"
 (
   cd "$SINGLE_BASE/solo" || exit 1
@@ -229,7 +229,7 @@ fi
 # === SILENT: non-git cwd ===
 # ---------------------------------------------------------------------------
 
-NON_GIT_DIR=$(mktemp -d)
+NON_GIT_DIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 run_case "non-git cwd is silent" \
   "silent" \
   "./scripts/foo.sh" \

--- a/tests/hooks/advisory-nudge/test_exclusion_probe_gate.sh
+++ b/tests/hooks/advisory-nudge/test_exclusion_probe_gate.sh
@@ -201,7 +201,7 @@ DELIBERATELY EXCLUDED (verified via HMS)
 #   A pre-existing directive + an Edit that adds only the claim (adjacent line)
 #   must fire; the same Edit on a non-existent file (claim fragment only,
 #   directive absent) must stay silent.
-P2_DIR=$(mktemp -d)
+P2_DIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 printf '# notes\nDELIBERATELY EXCLUDED these two tables\n- table_a\n' > "$P2_DIR/notes.md"
 printf '%s' "{\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$P2_DIR/notes.md\",\"old_string\":\"- table_a\",\"new_string\":\"- table_a (this exclusion confirmed via prod)\"}}" \
   | "$HOOK" >/dev/null 2>/tmp/p2e

--- a/tests/hooks/advisory-nudge/test_jq_config_empty_dict_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_jq_config_empty_dict_advisory.sh
@@ -103,7 +103,7 @@ print(json.dumps(d))
 # Setup: temp directory for fixture files
 # ---------------------------------------------------------------------------
 
-TMPDIR_TEST=$(mktemp -d)
+TMPDIR_TEST=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$TMPDIR_TEST"' EXIT
 
 # Create fixture files
@@ -297,7 +297,7 @@ run_case "multi-file: both valid config paths are silent" \
 # We simulate this by running the hook with PATH set to an empty directory.
 # ---------------------------------------------------------------------------
 
-EMPTY_BIN_DIR=$(mktemp -d)
+EMPTY_BIN_DIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 # Resolve the real python3 binary (not a pyenv shim) so it remains callable
 # after we strip PATH down to EMPTY_BIN_DIR (which removes the shim layer).
 PYTHON3_BIN="$(python3 -c 'import sys; print(sys.executable)')"

--- a/tests/hooks/advisory-nudge/test_memory_hint.sh
+++ b/tests/hooks/advisory-nudge/test_memory_hint.sh
@@ -218,7 +218,7 @@ run_case "25 hit: undecodable peer does not break sibling matches" "hit:hook_kub
 undecodable_silent_test() {
   local name="26 silent: undecodable memory alone exits 0 silently"
   local tmpdir
-  tmpdir=$(mktemp -d)
+  tmpdir=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
   cp "$FIXTURES_MAIN/non_utf8.md" "$tmpdir/non_utf8.md"
   local payload
   payload=$(python3 -c '
@@ -286,7 +286,7 @@ run_input_case "34 hit: ASCII keyword adjacent to Hangul splits as separate toke
 # not "-Users-nathan.song-.claude") — any home path containing a special
 # character other than "/" left the fallback path permanently unresolvable
 # for that user, silently disabling every hookable memory unconditionally.
-FALLBACK_HOME=$(cd "$(mktemp -d)" && pwd -P)
+FALLBACK_HOME=$(cd "$(mktemp -d)" && pwd -P) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 # cwd containing a literal "." mirrors the real-world failure (a "." inside
 # a path segment, as in a username like "nathan.song"). Resolve via `pwd -P`
 # (physical path) so this test is immune to macOS's /var -> /private/var

--- a/tests/hooks/advisory-nudge/test_merge_menu_review_options.sh
+++ b/tests/hooks/advisory-nudge/test_merge_menu_review_options.sh
@@ -195,7 +195,7 @@ run_case "KO 머지할까요 still triggers"               advisory default "$(b
 # on a feature branch over a `main` base. git identity is injected inline
 # (no global config dependency); no 2>/dev/null on setup (surface real errors).
 setup_git_repo() {
-  local tmp; tmp=$(mktemp -d)
+  local tmp; tmp=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
   git -C "$tmp" init -q -b main
   git -C "$tmp" -c user.name=t -c user.email=t@t.io commit -q --allow-empty -m "chore: base"
   git -C "$tmp" checkout -q -b feature
@@ -273,7 +273,7 @@ route_absent  "getlist.py is not data (etl)"   "src/getlist.py"
 # also exists. Nearest-fork-point resolution must pick `dev`, so the diff is the
 # branch's OWN change (a .tsx → ux) — NOT dev's auth file (would mis-route to
 # security with naive first-resolvable base selection).
-MB_REPO=$(mktemp -d)
+MB_REPO=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 git -C "$MB_REPO" init -q -b main
 git -C "$MB_REPO" -c user.name=t -c user.email=t@t.io commit -q --allow-empty -m "chore: base"
 git -C "$MB_REPO" checkout -q -b dev
@@ -293,7 +293,7 @@ else
 fi
 
 # fail-open: cwd is a non-git directory → static fallback (no routed line)
-NONGIT_TMP=$(mktemp -d)
+NONGIT_TMP=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 NONGIT_ERR=$(payload_with_cwd "$NONGIT_TMP" | "$HOOK" 2>&1 >/dev/null)
 rm -rf "$NONGIT_TMP"
 if printf '%s' "$NONGIT_ERR" | grep -q 'touches'; then

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -304,7 +304,7 @@ negative_no_momentum_case
 empty_memory_dir_case() {
   local name="empty_memory_dir_static_only"
   local tmpdir
-  tmpdir=$(mktemp -d)
+  tmpdir=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
   local payload
   payload=$(build_payload "Bash" "gh pr merge --squash")
   local err_file
@@ -340,7 +340,7 @@ empty_memory_dir_case
 empty_memory_dir_force_push_case() {
   local name="empty_memory_dir_force_push_actionable"
   local tmpdir
-  tmpdir=$(mktemp -d)
+  tmpdir=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
   local payload
   payload=$(build_payload "Bash" "git push --force origin main")
   local err_file

--- a/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
@@ -1298,7 +1298,7 @@ fi
 # Block-event telemetry cases — issue #787
 # ---------------------------------------------------------------------------
 
-TEL_DIR="$(mktemp -d)"
+TEL_DIR="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$TEL_DIR"; rm -f "$DEFAULT_TEL_FILE"' EXIT
 
 rich_records() {

--- a/tests/hooks/advisory-nudge/test_path_probe_gate.sh
+++ b/tests/hooks/advisory-nudge/test_path_probe_gate.sh
@@ -107,7 +107,7 @@ print(json.dumps(d))
 #   <wt_root>/repo-subdir/                  ← intermediate dir (depth=1)
 #   <wt_root>/repo-subdir/content-root/     ← deeper dir (depth=2)
 
-WT_ROOT=$(mktemp -d)
+WT_ROOT=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 mkdir -p "$WT_ROOT/repo-subdir/content-root"
 
 # Initialize a git repo at WT_ROOT so git worktree list returns it.
@@ -123,7 +123,7 @@ if ! git -C "$WT_ROOT" log --oneline -1 >/dev/null 2>&1; then
 fi
 
 # Outside dir: a directory NOT in any git worktree.
-OUTSIDE_DIR=$(mktemp -d)
+OUTSIDE_DIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 mkdir -p "$OUTSIDE_DIR/subdir"
 
 # ---------------------------------------------------------------------------

--- a/tests/hooks/advisory-nudge/test_perf_multiplier_evidence_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_perf_multiplier_evidence_advisory.sh
@@ -174,7 +174,7 @@ run_case "non-gh command with 3x is silent" \
 # === --body-file handling ===
 # ---------------------------------------------------------------------------
 
-BODY_FILE_DIR=$(mktemp -d)
+BODY_FILE_DIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 echo '3x speedup expected, no measurement yet' > "$BODY_FILE_DIR/body.md"
 run_case "--body-file relative, unreadable timing -> advisory" \
   "advisory:[perf-multiplier-evidence-advisory]" \

--- a/tests/hooks/advisory-nudge/test_postcompact_context.sh
+++ b/tests/hooks/advisory-nudge/test_postcompact_context.sh
@@ -199,7 +199,7 @@ print(json.dumps({
 # and PRAXIS_* env vars are inlined per-case.
 
 new_case_dir() {
-  T=$(mktemp -d)
+  T=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
   TRANSCRIPT="$T/transcript.jsonl"
   STATE_FILE="$T/state.json"
   MOCK_BIN="$T/bin"

--- a/tests/hooks/advisory-nudge/test_pre_commit_staged_file_enumeration.sh
+++ b/tests/hooks/advisory-nudge/test_pre_commit_staged_file_enumeration.sh
@@ -192,7 +192,7 @@ print(json.dumps({"tool_name": "Bash",
 # ---------------------------------------------------------------------------
 # Fixture repo
 # ---------------------------------------------------------------------------
-REPO=$(mktemp -d)
+REPO=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 git -C "$REPO" init -q
 git -C "$REPO" config user.email test@example.com
 git -C "$REPO" config user.name "Test User"
@@ -328,7 +328,7 @@ run_repo_case "assignment command-substitution commit is not detected (boundary)
 
 # Modify a tracked file (staged M, no A). Reset the index of the additions
 # first so only a modification is staged.
-MODREPO=$(mktemp -d)
+MODREPO=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 git -C "$MODREPO" init -q
 git -C "$MODREPO" config user.email test@example.com
 git -C "$MODREPO" config user.name "Test User"
@@ -356,7 +356,7 @@ rm -rf "$MODREPO" 2>/dev/null || true
 # ---------------------------------------------------------------------------
 
 # --amend with a CLEAN index (no staged additions) → silent.
-AMENDREPO=$(mktemp -d)
+AMENDREPO=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 git -C "$AMENDREPO" init -q
 git -C "$AMENDREPO" config user.email test@example.com
 git -C "$AMENDREPO" config user.name "Test User"
@@ -369,7 +369,7 @@ rm -rf "$AMENDREPO" 2>/dev/null || true
 
 # A staged symlink whose TARGET was Write-seen must NOT be suppressed:
 # canonical() preserves the final component so alias != target.
-SYMREPO=$(mktemp -d)
+SYMREPO=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 git -C "$SYMREPO" init -q
 git -C "$SYMREPO" config user.email test@example.com
 git -C "$SYMREPO" config user.name "Test User"
@@ -388,7 +388,7 @@ rm -f "$TRANSCRIPT_SYM" 2>/dev/null || true
 
 # A FAILED Write (tool_result is_error) must not count its target as seen —
 # a bash-staged file at that path is surfaced.
-FAILREPO=$(mktemp -d)
+FAILREPO=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 git -C "$FAILREPO" init -q
 git -C "$FAILREPO" config user.email test@example.com
 git -C "$FAILREPO" config user.name "Test User"
@@ -412,7 +412,7 @@ rm -f "$TRANSCRIPT_FAIL" 2>/dev/null || true
 # #1 single-call create+add+commit: at PreToolUse the file is not yet in the
 # index, so the additions list is empty → SILENT (documented miss). Fresh repo
 # with a clean index isolates the boundary.
-SINGLEREPO=$(mktemp -d)
+SINGLEREPO=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 git -C "$SINGLEREPO" init -q
 git -C "$SINGLEREPO" config user.email test@example.com
 git -C "$SINGLEREPO" config user.name "Test User"
@@ -427,7 +427,7 @@ rm -rf "$SINGLEREPO" 2>/dev/null || true
 
 # #3a partial commit (`--only <path>`) over-lists ALL staged additions, not
 # just the pathspec — pin by asserting the EXCLUDED file is still surfaced.
-ONLYREPO=$(mktemp -d)
+ONLYREPO=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 git -C "$ONLYREPO" init -q
 git -C "$ONLYREPO" config user.email test@example.com
 git -C "$ONLYREPO" config user.name "Test User"
@@ -444,7 +444,7 @@ rm -rf "$ONLYREPO" 2>/dev/null || true
 
 # #3b a `git commit` literal inside a heredoc body is data, not a command, but
 # the shared tokenizer line-splits it → false-surface. Pin the boundary.
-HEREREPO=$(mktemp -d)
+HEREREPO=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 git -C "$HEREREPO" init -q
 git -C "$HEREREPO" config user.email test@example.com
 git -C "$HEREREPO" config user.name "Test User"
@@ -518,7 +518,7 @@ ok=1; [ "$empty_rc" -eq 0 ] || ok=0; [ -z "$empty_content" ] || ok=0
 record "empty command is silent" "$ok" "$empty_rc" "$empty_content" "silent"
 
 # Not inside a git repo → silent (run from a non-repo temp dir).
-NONREPO=$(mktemp -d)
+NONREPO=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 nonrepo_err=$(mktemp)
 nonrepo_payload=$(python3 -c '
 import json, sys

--- a/tests/hooks/advisory-nudge/test_pre_output_falsification_gate.sh
+++ b/tests/hooks/advisory-nudge/test_pre_output_falsification_gate.sh
@@ -23,7 +23,7 @@ if [ ! -x "$HOOK" ]; then
 fi
 
 PASS=0; FAIL=0; FAILED_NAMES=()
-WORK=$(mktemp -d)
+WORK=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$WORK"' EXIT
 
 # A dedicated TMPDIR so Lane B counters never leak into the real tmp tree and

--- a/tests/hooks/advisory-nudge/test_push_remote_ref_verify.sh
+++ b/tests/hooks/advisory-nudge/test_push_remote_ref_verify.sh
@@ -17,7 +17,7 @@ FAIL=0
 # setup_repo -> sets globals WORK (work tree) and REMOTE (bare repo)
 setup_repo() {
   local base
-  base="$(mktemp -d)"
+  base="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
   REMOTE="$base/remote.git"
   WORK="$base/work"
   git init --bare -q "$REMOTE"

--- a/tests/hooks/completion-verify/test_completion_verify.sh
+++ b/tests/hooks/completion-verify/test_completion_verify.sh
@@ -22,7 +22,7 @@ PASS=0
 FAIL=0
 FAILED_NAMES=()
 
-TMPDIR=$(mktemp -d)
+TMPDIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$TMPDIR"' EXIT
 
 # Build a JSONL transcript file from $3 (multi-line content) and run the hook.

--- a/tests/hooks/completion-verify/test_retrospect_mix_check.sh
+++ b/tests/hooks/completion-verify/test_retrospect_mix_check.sh
@@ -24,7 +24,7 @@ PASS=0
 FAIL=0
 FAILED_NAMES=()
 
-TMPDIR=$(mktemp -d)
+TMPDIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$TMPDIR"' EXIT
 
 # Build a JSONL transcript file from $3 and run the hook.

--- a/tests/hooks/completion-verify/test_retrospect_replay_silent_pass.sh
+++ b/tests/hooks/completion-verify/test_retrospect_replay_silent_pass.sh
@@ -34,7 +34,7 @@ FIXTURE="$REPO_ROOT/tests/fixtures/retrospect-replay-silent-pass.jsonl"
 
 PASS=0
 FAIL=0
-TMP="$(mktemp -d)"
+TMP="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$TMP"' EXIT
 
 mk_assistant() {

--- a/tests/hooks/completion-verify/test_silent_pass_catalog.sh
+++ b/tests/hooks/completion-verify/test_silent_pass_catalog.sh
@@ -37,7 +37,7 @@ run_case() {
   fi
 }
 
-TMP="$(mktemp -d)"
+TMP="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$TMP"' EXIT
 
 # A fabricated, NON-allowlisted 40-char secret-shaped value used across cases.

--- a/tests/hooks/completion-verify/test_strike_counter.sh
+++ b/tests/hooks/completion-verify/test_strike_counter.sh
@@ -36,7 +36,7 @@ run() {
 # Isolated sandbox per test invocation
 fresh_env() {
   local dir
-  dir=$(mktemp -d)
+  dir=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
   export PRAXIS_STATE_DIR="$dir"
   export CLAUDE_SESSION_ID="test-$$-${RANDOM}"
 }
@@ -208,7 +208,7 @@ test_ac10_latch_fallback() {
 # ---- AC11: missing session_id fails cleanly --------------------------------
 test_ac11_missing_session_id() {
   local dir
-  dir=$(mktemp -d)
+  dir=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
   PRAXIS_STATE_DIR="$dir" env -u CLAUDE_SESSION_ID "$STRIKE" strike "x" >/tmp/out.$$ 2>/tmp/err.$$
   local code=$?
   local out err
@@ -452,8 +452,8 @@ test_ac17_ttl_cleanup() {
 # pointing $CLAUDE_PLUGIN_DATA at a sibling dir must NOT cause writes there.
 test_ac25_state_isolated_from_claude_plugin_data() {
   local praxis_dir sibling_dir
-  praxis_dir=$(mktemp -d)
-  sibling_dir=$(mktemp -d)
+  praxis_dir=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
+  sibling_dir=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
   export PRAXIS_STATE_DIR="$praxis_dir"
   export CLAUDE_PLUGIN_DATA="$sibling_dir"
   export CLAUDE_SESSION_ID="ac25-$$-${RANDOM}"
@@ -478,7 +478,7 @@ test_ac25_state_isolated_from_claude_plugin_data() {
 # PRAXIS_STATE_DIR override set.
 test_ac26_legacy_state_migration() {
   local home sid out migrated
-  home=$(mktemp -d)
+  home=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
   sid="migrate-$$-${RANDOM}"
   mkdir -p "$home/.claude/state/praxis/strikes"
   printf '{"count":2,"reasons":["legacy a","legacy b"]}' \
@@ -497,8 +497,8 @@ test_ac26_legacy_state_migration() {
 # counter must be read from the override dir (empty → 0 strikes).
 test_ac26b_no_migration_when_override_set() {
   local home override_dir legacy_dir sid out migrated
-  home=$(mktemp -d)
-  override_dir=$(mktemp -d)
+  home=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
+  override_dir=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
   sid="no-migrate-$$-${RANDOM}"
   # Seed legacy location with a non-zero strike count
   legacy_dir="$home/.claude/state/praxis/strikes"

--- a/tests/hooks/postuse-correction/test_askuserquestion_loop_signal.sh
+++ b/tests/hooks/postuse-correction/test_askuserquestion_loop_signal.sh
@@ -40,7 +40,7 @@ PASS=0
 FAIL=0
 FAILED_NAMES=()
 
-TMP_DIR="$(mktemp -d)"
+TMP_DIR="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 # ---------------------------------------------------------------------------

--- a/tests/hooks/postuse-correction/test_bypass_telemetry.sh
+++ b/tests/hooks/postuse-correction/test_bypass_telemetry.sh
@@ -45,7 +45,7 @@ FAIL=0
 FAILED_NAMES=()
 
 # Shared temp dir -- cleaned up on exit
-TMP_DIR="$(mktemp -d)"
+TMP_DIR="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 # Scrub any bypass env vars that might be present in the developer's shell or CI.

--- a/tests/hooks/preflight-gate/test_block_ask_end_option.sh
+++ b/tests/hooks/preflight-gate/test_block_ask_end_option.sh
@@ -25,7 +25,7 @@ if [ ! -x "$HOOK" ]; then
 fi
 
 PASS=0; FAIL=0; FAILED_NAMES=()
-WORK=$(mktemp -d)
+WORK=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$WORK"' EXIT
 
 # Build a transcript JSONL file from a single user message.

--- a/tests/hooks/preflight-gate/test_block_commit_without_codex_review.sh
+++ b/tests/hooks/preflight-gate/test_block_commit_without_codex_review.sh
@@ -50,7 +50,7 @@ NONEXISTENT_TX="/tmp/does-not-exist-praxis-425-$$.jsonl"
 # <project-dir>/<session_id>/subagents/agent-*.jsonl next to the root
 # <project-dir>/<session_id>.jsonl — reproduce that layout under a temp dir so
 # the root path's `.jsonl` suffix + stem-dir lookup resolves correctly.
-SUB_TX_ROOT_DIR=$(mktemp -d)
+SUB_TX_ROOT_DIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 SUB_SESSION_ID="session-$$"
 SUB_ROOT_TX="$SUB_TX_ROOT_DIR/$SUB_SESSION_ID.jsonl"
 SUB_AGENTS_DIR="$SUB_TX_ROOT_DIR/$SUB_SESSION_ID/subagents"
@@ -65,7 +65,7 @@ printf '%s\n' '{"parentUuid":null,"isSidechain":true,"type":"assistant","message
 
 # A second, sibling temp-dir layout where the subagents dir exists but no
 # agent transcript invokes codex-review-wrap — must still BLOCK.
-SUB_TX_ROOT_DIR_NOINVOKE=$(mktemp -d)
+SUB_TX_ROOT_DIR_NOINVOKE=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 SUB_SESSION_ID_NOINVOKE="session-noinvoke-$$"
 SUB_ROOT_TX_NOINVOKE="$SUB_TX_ROOT_DIR_NOINVOKE/$SUB_SESSION_ID_NOINVOKE.jsonl"
 SUB_AGENTS_DIR_NOINVOKE="$SUB_TX_ROOT_DIR_NOINVOKE/$SUB_SESSION_ID_NOINVOKE/subagents"
@@ -78,7 +78,7 @@ printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"ty
 # genuine human slash-command keystroke (subagent "user" turns are
 # Task-dispatch prompts / tool_results), so it must NOT satisfy the gate.
 # Regression guard for the root-only slash-scoping fix (code-review MEDIUM).
-SUB_TX_ROOT_DIR_SLASH=$(mktemp -d)
+SUB_TX_ROOT_DIR_SLASH=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 SUB_SESSION_ID_SLASH="session-slash-$$"
 SUB_ROOT_TX_SLASH="$SUB_TX_ROOT_DIR_SLASH/$SUB_SESSION_ID_SLASH.jsonl"
 SUB_AGENTS_DIR_SLASH="$SUB_TX_ROOT_DIR_SLASH/$SUB_SESSION_ID_SLASH/subagents"

--- a/tests/hooks/preflight-gate/test_block_gh_issue_create_without_dup_search.sh
+++ b/tests/hooks/preflight-gate/test_block_gh_issue_create_without_dup_search.sh
@@ -23,7 +23,7 @@ PASS=0
 FAIL=0
 FAILED_NAMES=()
 
-TMPDIR=$(mktemp -d)
+TMPDIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$TMPDIR"' EXIT
 
 TX_EMPTY="$TMPDIR/tx-empty.jsonl"

--- a/tests/hooks/preflight-gate/test_block_manufactured_action_menu.sh
+++ b/tests/hooks/preflight-gate/test_block_manufactured_action_menu.sh
@@ -25,7 +25,7 @@ if [ ! -x "$HOOK" ]; then
 fi
 
 PASS=0; FAIL=0; FAILED_NAMES=()
-WORK=$(mktemp -d)
+WORK=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$WORK"' EXIT
 
 # Build a transcript JSONL file from a single user message.

--- a/tests/hooks/preflight-gate/test_block_rename_sweep_survivors.sh
+++ b/tests/hooks/preflight-gate/test_block_rename_sweep_survivors.sh
@@ -113,7 +113,7 @@ run_case "empty_command_passes" "silent" \
 
 setup_repo() {
   local repo
-  repo=$(mktemp -d)
+  repo=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
   cd "$repo" || return 1
   git init -q
   git config user.email "test@example.com"

--- a/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
+++ b/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
@@ -23,7 +23,7 @@ PASS=0
 FAIL=0
 FAILED_NAMES=()
 
-TMPDIR=$(mktemp -d)
+TMPDIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$TMPDIR"' EXIT
 
 # Transcript fixtures use the REAL Claude Code transcript JSONL schema

--- a/tests/hooks/preflight-gate/test_block_unmatched_glob.sh
+++ b/tests/hooks/preflight-gate/test_block_unmatched_glob.sh
@@ -38,7 +38,7 @@ fi
 SHELL=$(command -v zsh)
 export SHELL
 
-FIXTURE=$(mktemp -d)
+FIXTURE=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$FIXTURE"' EXIT
 mkdir -p "$FIXTURE/logs" "$FIXTURE/nested/deep"
 : >"$FIXTURE/logs/alpha.log"

--- a/tests/hooks/preflight-gate/test_commit_title_length_check.sh
+++ b/tests/hooks/preflight-gate/test_commit_title_length_check.sh
@@ -339,10 +339,10 @@ run_case "R4-F1: -am long (preserves -am combined behavior, ask)" \
 # into _title_from_file.
 # ---------------------------------------------------------------------------
 
-R4_F2_DIR=$(mktemp -d)
+R4_F2_DIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 R4_F2_MSG="$R4_F2_DIR/.gitmsg"
 echo "fix(very-very-long-scope): include description that easily exceeds fifty" >"$R4_F2_MSG"
-R4_F2_ABS_DIR=$(mktemp -d)
+R4_F2_ABS_DIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 R4_F2_ABS_MSG="$R4_F2_ABS_DIR/.gitmsg"
 echo "fix(very-very-long-scope): absolute path with 73 chars title for boundary" >"$R4_F2_ABS_MSG"
 
@@ -370,7 +370,7 @@ rmdir "$R4_F2_DIR" "$R4_F2_ABS_DIR" 2>/dev/null || true
 # make_fake_gh_title <title> — `gh pr view ... -q .title` prints <title>.
 make_fake_gh_title() {
   local title="$1" d
-  d=$(mktemp -d)
+  d=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
   cat >"$d/gh" <<EOF
 #!/usr/bin/env bash
 echo "$title"
@@ -383,7 +383,7 @@ EOF
 # make_fake_gh_error — every `gh` call exits 1 (auth-style failure).
 make_fake_gh_error() {
   local d
-  d=$(mktemp -d)
+  d=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
   cat >"$d/gh" <<'EOF'
 #!/usr/bin/env bash
 echo "gh: authentication required" >&2

--- a/tests/hooks/preflight-gate/test_gh_json_validator.sh
+++ b/tests/hooks/preflight-gate/test_gh_json_validator.sh
@@ -37,7 +37,7 @@ FAILED_NAMES=()
 # differently). Shadow gh with a fixed-field stub so the test exercises the
 # hook's PARSING logic rather than whichever gh happens to be installed.
 # ---------------------------------------------------------------------------
-GH_STUB_DIR=$(mktemp -d)
+GH_STUB_DIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 cat >"$GH_STUB_DIR/gh" <<'STUB'
 #!/usr/bin/env bash
 # Deterministic stand-in for `gh <subcmd> --json help`. Emits the real
@@ -93,7 +93,7 @@ chmod +x "$GH_STUB_DIR/gh"
 # Symlink the REAL interpreter (sys.executable), not `command -v python3`: the
 # latter can resolve to a pyenv/asdf shim (a `#!/usr/bin/env bash` script) that
 # fails to launch under the restricted PATH ("env: bash: No such file").
-NO_GH_DIR=$(mktemp -d)
+NO_GH_DIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 ln -sf "$(python3 -c 'import sys; print(sys.executable)')" "$NO_GH_DIR/python3"
 
 trap 'rm -rf "$GH_STUB_DIR" "$NO_GH_DIR"' EXIT

--- a/tests/hooks/preflight-gate/test_gh_label_verify.sh
+++ b/tests/hooks/preflight-gate/test_gh_label_verify.sh
@@ -26,7 +26,7 @@ PASS=0
 FAIL=0
 FAILED_NAMES=()
 
-TMPDIR=$(mktemp -d)
+TMPDIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$TMPDIR"' EXIT
 
 # ---------------------------------------------------------------------------

--- a/tests/hooks/preflight-gate/test_gh_merge_worktree_precondition.sh
+++ b/tests/hooks/preflight-gate/test_gh_merge_worktree_precondition.sh
@@ -44,7 +44,7 @@ PASS=0; FAIL=0; FAILED_NAMES=()
 make_fake_gh() {
   local mode="$1" branch="${2:-}" repo="${3:-}"
   local d
-  d=$(mktemp -d)
+  d=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
   case "$mode" in
     branch)
       cat >"$d/gh" <<EOF
@@ -102,14 +102,14 @@ EOF
 # Real git repo (worktree state needs a real .git)
 # ---------------------------------------------------------------------------
 
-REPO=$(cd "$(mktemp -d)" && pwd -P)
+REPO=$(cd "$(mktemp -d)" && pwd -P) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 git -C "$REPO" init -q -b main
 git -C "$REPO" -c user.name=test -c user.email=test@example.com \
   commit -q --allow-empty -m init
 git -C "$REPO" branch feature-checked-out
 git -C "$REPO" branch feature-not-checked-out
 
-WT=$(mktemp -d)
+WT=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 rm -rf "$WT"
 git -C "$REPO" worktree add -q "$WT" feature-checked-out >/dev/null 2>&1
 

--- a/tests/hooks/preflight-gate/test_pr_state_refetch_gate.sh
+++ b/tests/hooks/preflight-gate/test_pr_state_refetch_gate.sh
@@ -60,7 +60,7 @@ print(json.dumps({
 make_fake_gh() {
   local mode="$1" map_content="${2:-}"
   local d
-  d=$(mktemp -d)
+  d=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
   case "$mode" in
     absent)
       ;;

--- a/tests/hooks/preflight-gate/test_pre_gh_pr_create_dedup_gate.sh
+++ b/tests/hooks/preflight-gate/test_pre_gh_pr_create_dedup_gate.sh
@@ -39,7 +39,7 @@ PASS=0; FAIL=0; FAILED_NAMES=()
 make_fake_bin() {
   local scenario="$1"
   local d
-  d=$(mktemp -d)
+  d=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 
   # git shim — returns origin URL unless `no-git` scenario.
   if [ "$scenario" = "no-git" ]; then

--- a/tests/hooks/preflight-gate/test_retrospect_active_marker.sh
+++ b/tests/hooks/preflight-gate/test_retrospect_active_marker.sh
@@ -28,7 +28,7 @@ PASS=0
 FAIL=0
 FAILED_NAMES=()
 
-WORK_DIR=$(mktemp -d)
+WORK_DIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$WORK_DIR"' EXIT
 
 CASE_N=0

--- a/tests/hooks/preflight-gate/test_retrospect_front_load.sh
+++ b/tests/hooks/preflight-gate/test_retrospect_front_load.sh
@@ -17,7 +17,7 @@ CATALOG="$ROOT_DIR/hooks/_lib/silent-pass-catalog.json"
 
 PASS=0
 FAIL=0
-WORK_DIR=$(mktemp -d)
+WORK_DIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$WORK_DIR"' EXIT
 
 ok()   { PASS=$((PASS + 1)); printf 'PASS  %s\n' "$1"; }

--- a/tests/hooks/preflight-gate/test_session_intent.sh
+++ b/tests/hooks/preflight-gate/test_session_intent.sh
@@ -27,7 +27,7 @@ PASS=0
 FAIL=0
 FAILED_NAMES=()
 
-WORK_DIR=$(mktemp -d)
+WORK_DIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$WORK_DIR"' EXIT
 
 # run_hook state_file mode_env payload

--- a/tests/hooks/preflight-gate/test_worktree_edit_gate.sh
+++ b/tests/hooks/preflight-gate/test_worktree_edit_gate.sh
@@ -25,7 +25,7 @@ PASS=0; FAIL=0; FAILED_NAMES=()
 # Real git repo fixture
 # ---------------------------------------------------------------------------
 
-TMPDIR_BASE=$(mktemp -d)
+TMPDIR_BASE=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 REPO_DIR="$TMPDIR_BASE/myorg/myrepo"
 mkdir -p "$REPO_DIR"
 

--- a/tests/hooks/preflight-gate/test_worktree_prune_snapshot_gate.sh
+++ b/tests/hooks/preflight-gate/test_worktree_prune_snapshot_gate.sh
@@ -25,7 +25,7 @@ fi
 
 PASS=0; FAIL=0; FAILED_NAMES=()
 
-STATE_DIR=$(mktemp -d)
+STATE_DIR=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$STATE_DIR"' EXIT
 _case_n=0
 

--- a/tests/test_agent_report_handoff.sh
+++ b/tests/test_agent_report_handoff.sh
@@ -154,7 +154,7 @@ run_documented_gate() {  # $1 = cwd under test
   return 0
 }
 
-GATE_TMP="$(mktemp -d)"
+GATE_TMP="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 mkdir -p "$GATE_TMP/normal" "$GATE_TMP/fabricated" "$GATE_TMP/truncated"
 cat > "$GATE_TMP/normal/.agent-report.json" <<'JSON'
 {"branch": "issue-1-x", "head_sha": "abc", "pushed": true,

--- a/tests/test_assert_lib_wrap_insensitive.sh
+++ b/tests/test_assert_lib_wrap_insensitive.sh
@@ -14,7 +14,7 @@
 set +e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-TMP_DIR="$(mktemp -d)"
+TMP_DIR="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 UNWRAPPED="$TMP_DIR/unwrapped.md"

--- a/tests/test_build_hosts_filter.sh
+++ b/tests/test_build_hosts_filter.sh
@@ -39,7 +39,7 @@ run_case() {
 # ---------------------------------------------------------------------------
 
 setup_fixture() {
-  FIXTURE_DIR="$(mktemp -d)"
+  FIXTURE_DIR="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 
   # Minimal hooks.json fixture with three hooks:
   #   - hook-no-hosts: no hosts field  (= all platforms)

--- a/tests/test_bypass_review.sh
+++ b/tests/test_bypass_review.sh
@@ -50,7 +50,7 @@ PASS=0
 FAIL=0
 FAILED_NAMES=()
 
-TMP_DIR="$(mktemp -d)"
+TMP_DIR="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 # ---------------------------------------------------------------------------

--- a/tests/test_check_mktemp_guard.sh
+++ b/tests/test_check_mktemp_guard.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# test_check_mktemp_guard.sh — verify check-plugin-manifests.py Rule 19 (#897):
+# every `mktemp -d` in the test suite checks its own failure.
+#
+# The rule exists because the suite runs under `set +e`: an unchecked failure
+# leaves the variable empty, and every path derived from it re-anchors at the
+# filesystem root. The observed cost was eleven unrelated assertion failures
+# from one unusable temp dir, plus an attempted `mkdir -p /_lib`.
+#
+# Usage: bash tests/test_check_mktemp_guard.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK="$ROOT_DIR/scripts/check-plugin-manifests.py"
+TARGET="$ROOT_DIR/tests/hooks/_lib/test_record_fire.sh"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+run_case() {
+  local name="$1" result="$2" expected="$3"
+  if [ "$result" = "$expected" ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expected=$expected got=$result"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+echo "test_check_mktemp_guard"
+
+if [ ! -f "$TARGET" ]; then
+  echo "FAIL  [target_exists] expected=yes got=no"
+  exit 1
+fi
+
+BACKUP="$(mktemp)" || { echo "FATAL: mktemp failed" >&2; exit 1; }
+cp "$TARGET" "$BACKUP"
+trap 'cp "$BACKUP" "$TARGET"; rm -f "$BACKUP"' EXIT
+
+# Rewrite the first guarded site to $1 and report the checker's exit code.
+sub_first_site() {
+  python3 - "$TARGET" "$1" <<'PY'
+import re, sys
+path, new = sys.argv[1:3]
+body = open(path, encoding="utf-8").read()
+line = re.search(r'(?m)^.*mktemp -d.*$', body)
+assert line, "no mktemp -d site found — fixture is stale"
+open(path, "w", encoding="utf-8").write(
+    body[: line.start()] + new + body[line.end() :]
+)
+PY
+  python3 "$CHECK" >/dev/null 2>&1
+  echo "$?"
+  cp "$BACKUP" "$TARGET"
+}
+
+# 1. Baseline: every site in the suite is guarded.
+python3 "$CHECK" >/dev/null 2>&1
+run_case "baseline_check_clean" "$?" "0"
+
+# 2. Dropping the guard is the regression the rule was written for.
+run_case "unguarded_site_fails" "$(sub_first_site 'PROBE_ROOT="$(mktemp -d)"')" "1"
+
+# 3. The bare-substitution form is equally unguarded.
+run_case "unguarded_bare_form_fails" "$(sub_first_site 'PROBE_ROOT=$(mktemp -d)')" "1"
+
+# 4. A template argument does not exempt the site.
+run_case "unguarded_template_form_fails" \
+  "$(sub_first_site 'PROBE_ROOT=$(mktemp -d "$HOME/x.XXXXXX")')" "1"
+
+# 5. A commented-out site is not a call and must not be flagged — otherwise
+#    the rule blocks documenting the very pattern it enforces.
+run_case "commented_site_ignored" \
+  "$(sub_first_site '# PROBE_ROOT=$(mktemp -d)  — see Rule 19')" "0"
+
+echo "----"
+echo "PASS: $PASS / FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'failed: %s\n' "${FAILED_NAMES[@]}"
+  exit 1
+fi
+exit 0

--- a/tests/test_cli_scripts_behavior.sh
+++ b/tests/test_cli_scripts_behavior.sh
@@ -43,7 +43,7 @@ echo "test_cli_scripts_behavior"
 # Fixture: mini-clone with one tracked CLI ("foo"), fresh bin dir per stanza.
 # ---------------------------------------------------------------------------
 
-TMP_ROOT=$(mktemp -d)
+TMP_ROOT=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
 CLONE="$TMP_ROOT/clone"
@@ -60,7 +60,7 @@ printf '#!/bin/sh\necho foo\n' > "$CLONE/skills/foo/foo"
 chmod +x "$CLONE/skills/foo/foo"
 
 fresh_bin() {
-  BIN=$(mktemp -d "$TMP_ROOT/bin.XXXXXX")
+  BIN=$(mktemp -d "$TMP_ROOT/bin.XXXXXX") || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 }
 
 install_sh() { PRAXIS_BIN_DIR="$BIN" bash "$CLONE/scripts/install.sh" "$@" 2>&1; }

--- a/tests/test_cli_scripts_parity.sh
+++ b/tests/test_cli_scripts_parity.sh
@@ -68,7 +68,7 @@ run_case "verify_sources_canonical"  "$([ "$VERIFY_SOURCES" -ge 1 ] && echo yes 
 # 4. Functional parity: install into a temp bin dir, then verify reports OK
 #    for bypass-review (the previously-omitted entry), both exit 0.
 # ---------------------------------------------------------------------------
-TMP_BIN="$(mktemp -d)"
+TMP_BIN="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 trap 'rm -rf "$TMP_BIN"' EXIT
 INSTALL_OUT="$(PRAXIS_BIN_DIR="$TMP_BIN" bash "$INSTALL" 2>&1)"
 INSTALL_RC=$?

--- a/tests/test_hook_runtime.sh
+++ b/tests/test_hook_runtime.sh
@@ -114,7 +114,7 @@ fi
 rm -f "$TMP_LOG"
 
 # Default placement (no PRAXIS_HOOK_ERROR_LOG): lands under <PRAXIS_HOME>/logs.
-TMP_HOME=$(mktemp -d)
+TMP_HOME=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 rc_default=$(env -u PRAXIS_HOOK_ERROR_LOG PRAXIS_HOME="$TMP_HOME" python3 - "$LIB" << 'PYEOF'
 import sys
 sys.path.insert(0, sys.argv[1])

--- a/tests/test_paths.sh
+++ b/tests/test_paths.sh
@@ -39,7 +39,7 @@ PYEOF
 assert_eq "default home = ~/.praxis (expanded)" "yes" "$default_home"
 
 # 2. PRAXIS_HOME override honored + a real file created under <home>/logs
-TMP_HOME=$(mktemp -d)
+TMP_HOME=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 override_path=$(PRAXIS_HOME="$TMP_HOME" python3 - "$LIB" << 'PYEOF'
 import sys
 sys.path.insert(0, sys.argv[1])

--- a/tests/test_recover_scan_display_name.sh
+++ b/tests/test_recover_scan_display_name.sh
@@ -12,7 +12,7 @@ if [[ ! -f "$SCAN" ]]; then
   exit 1
 fi
 
-TMPHOME=$(mktemp -d)
+TMPHOME=$(mktemp -d) || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 PROJ="$TMPHOME/.claude/projects/-tmp-fake-cwd"
 mkdir -p "$PROJ"
 

--- a/tests/test_skill_surface_freeze.sh
+++ b/tests/test_skill_surface_freeze.sh
@@ -25,7 +25,7 @@ PASS=0
 FAIL=0
 GHOST="$ROOT_DIR/skills/ghost-skill-fixture"
 GHOST_UNDERSCORE="$ROOT_DIR/skills/_internal-fixture"
-BACKUP_DIR="$(mktemp -d)"
+BACKUP_DIR="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 BACKUP="$BACKUP_DIR/strikes"
 
 cleanup() {


### PR DESCRIPTION
## 배경

PR #892 리뷰 중 codex 가 실행한 `bash tests/hooks/_lib/test_record_fire.sh` 가 exit 1 로 실패했습니다. 로컬 bash·zsh 로그인 셸·CI(ubuntu) 는 전부 12/0 exit 0 이라 훅 결함으로 오인할 뻔했고, 원인 규명에 별도 라운드가 들었습니다.

재현:

```
$ codex exec --sandbox read-only "bash tests/hooks/_lib/test_record_fire.sh"
git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR
fatal: cannot change to '/cr-repo': No such file or directory
PASS: 1 / FAIL: 11
```

훅은 정상입니다. 샌드박스가 `DARWIN_USER_TEMP_DIR` 을 막아 `mktemp -d` 가 실패했고, 스위트가 `set +e` 로 돌기 때문에 `TMP=""` 인 채로 진행해 `$TMP/cr-repo` 가 `/cr-repo` 로 해석된 것입니다.

피해는 둘입니다.

1. **진단 불가능한 cascade** — 원인은 임시 디렉터리 하나인데 무관한 단정 11건이 실패합니다.
2. **루트 쓰기 시도** — `PROBE_ROOT=""` 이면 `mkdir -p "$PROBE_ROOT/_lib"` 는 `mkdir -p /_lib` 입니다. 이번엔 샌드박스가 막았지만 쓰기 권한이 있으면 실제로 생성됩니다.

`grep -rn 'mktemp -d' tests/` → 90곳 전부가 가드 없이 같은 성질을 갖고 있었습니다.

## 변경

### 90곳 전수 가드

```sh
TMP="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
```

가드는 반드시 호출 라인에 있어야 합니다. `VAR=$(...)` 는 치환의 종료 상태를 그대로 갖고, 그 상태가 빈 값이 쓰이기 전에 얻을 수 있는 유일한 신호입니다. 공유 헬퍼(`mktemp_d`)로 빼면 헬퍼의 `exit` 이 자신이 실행되는 치환 서브셸을 벗어나지 못해 가드가 성립하지 않습니다 — 그래서 채택하지 않았습니다.

### Rule 19 (check-plugin-manifests.py)

새 사이트가 가드 없이 들어오는 것을 차단합니다. 텍스트가 아니라 **호출 형태**(치환으로부터의 할당)를 매치하므로, 주석과 이 룰 자신의 픽스처(후보 라인을 문자열 인자로 넘김)는 걸리지 않습니다.

### 회귀 픽스처

`tests/test_check_mktemp_guard.sh` — `test_check_stub_parity.sh` 컨벤션. 가드 제거 / bare 형태 / 템플릿 인자 형태가 전부 FAILED 를 내고, 주석 처리된 사이트는 통과하는지 5케이스.

## 검증

원래 실패한 환경에서 직접 확인했습니다 — 메커니즘 재현이 아니라 같은 샌드박스입니다.

```
$ codex exec --sandbox read-only --cd <worktree> "bash tests/hooks/_lib/test_record_fire.sh"
mktemp: mkdtemp failed on /var/folders/...: Operation not permitted
FATAL: mktemp -d failed — no writable temp dir
exit code: 1
```

11건 cascade 가 1줄 진단으로 바뀌었습니다. exit 1 은 여전한데, 그 환경에서는 실제로 실행이 불가능한 것이 맞기 때문입니다.

로컬 강제 실패 프로브(PATH 앞단에 `exit 1` 하는 mktemp stub) 결과도 동일합니다.

```
$ bash scripts/run-tests.sh
ALL TESTS PASSED            # exit 0

$ bash tests/test_check_mktemp_guard.sh
PASS: 5 / FAIL: 0

$ ruff check scripts/check-plugin-manifests.py
All checks passed!

$ git diff --name-only | grep '\.sh$' | xargs shellcheck --severity=warning
(clean)
```

## 검증되지 않은 것

`mktemp` 이 성공했지만 반환된 경로가 실제로는 쓸 수 없는 환경. 이 가드는 종료 상태만 보므로 그 경우는 잡지 못합니다.

Caller chain verified: N/A — 테스트 90곳의 가드 추가 + 검사기 룰 1건 추가. 런타임 훅/스킬 코드 심볼 변경 없음 (`git diff --stat` → tests/ 53개 + scripts/check-plugin-manifests.py).
Pre-commit verified: `bash scripts/run-tests.sh` → ALL TESTS PASSED (exit 0) / `bash tests/test_check_mktemp_guard.sh` → 5 passed 0 failed / ruff + shellcheck clean

Closes #897
