### PR TITLE
fix(hook): downgrade Recommended T1 deny back to ask

### DIFF
--- a/docs/hook/INDEX.md
+++ b/docs/hook/INDEX.md
@@ -60,9 +60,10 @@ confirmation-prompt layer.
 Pre-tool stderr hints. **Default: never block** — emit reminders for recurrent
 patterns so the agent can self-correct. Documented exceptions escalate beyond
 stderr: hooks marked "opt-in strict" in the table emit `ask`/`deny`/block only
-when their strict-mode env var is set, and `output-block-falsify-advisory`'s
-T1 tier hard-denies — without any env gate — when the exact `(Recommended)`
-marker appears without an accompanying `Falsified:` line (issue #393).
+when their strict-mode env var is set, and `output-block-falsify-advisory`
+emits `ask` — without any env gate — when a `(Recommended)`/anchoring option
+appears without an accompanying `Falsified:` line (issue #393 made the T1
+tier a hard deny; #899 restored it to `ask`).
 Fail-open on infrastructure errors by design.
 
 | Hook | Trigger | Purpose |
@@ -78,7 +79,7 @@ Fail-open on infrastructure errors by design.
 | [memory-hint](../../hooks/advisory-nudge/memory-hint/spec.md) | PreToolUse | Surface hookable memory entries by keyword at decision-construction time |
 | [external-write-falsify-check](../../hooks/advisory-nudge/external-write-falsify-check/spec.md) | PreToolUse (opt-in) | Warn before posting hypothesis-stage text or unverified applied-on-branch claims (#656) to PR / issue / Slack / Notion |
 | [external-api-literal-trigger](../../hooks/advisory-nudge/external-api-literal-trigger/spec.md) | PreToolUse | Advisory nudge when ALL_CAPS enum candidates or 3-part SQL identifiers are written without prior retrieval verification |
-| [output-block-falsify-advisory](../../hooks/advisory-nudge/output-block-falsify-advisory/spec.md) | PreToolUse | Output-block falsification gate before surfacing `(Recommended)` options or bulk-action commands — T1 (exact `(Recommended)` marker without `Falsified:` line) hard-denies; T2 (confidence-anchoring tokens) emits `ask` |
+| [output-block-falsify-advisory](../../hooks/advisory-nudge/output-block-falsify-advisory/spec.md) | PreToolUse | Output-block falsification gate before surfacing `(Recommended)` options or bulk-action commands — T1 (exact `(Recommended)` marker without `Falsified:` line) and T2 (confidence-anchoring tokens) both emit `ask` (T1 was a hard deny until #899) |
 | [source-citation-probe-gate](../../hooks/advisory-nudge/source-citation-probe-gate/spec.md) | PreToolUse | Advisory when an external-write body (gh / Slack / Notion) cites source facts (file:line, inline-code call syntax, test-semantics claims) with no read-probe in the recent transcript and no in-body `Probe:` / `[verified]` basis — issue #830 |
 | [advisory-wrapper-signature-verify](../../hooks/advisory-nudge/advisory-wrapper-signature-verify/spec.md) | PreToolUse | Advisory nudge to verify wrapped function signatures before writing wrapper/client code |
 | [jq-config-empty-dict-advisory](../../hooks/advisory-nudge/jq-config-empty-dict-advisory/spec.md) | PreToolUse | Advisory nudge when `jq` reads a config file (settings.json, hooks.json, ~/.claude/*.json, ~/.codex/*.json) that is empty or invalid JSON |

--- a/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
@@ -14,14 +14,17 @@ This hook adds a structural enforcement point at two surfaces:
      lacks a `Falsified:` line (exact prefix at line start):
 
      T1. Label contains exact `(Recommended)` or `(추천)` (case-sensitive)
-         — original literal-marker path. **Emits `permissionDecision: deny`
-         (hard block)** — issue #393 upgrade. Rationale: the explicit
-         marker is a high-confidence false-positive-free signal; soft
-         `ask` permitted acknowledge-and-proceed and within-session
-         recurrence was observed (retrospect 2026-05-23, 3 calls in
-         a single codex-review-wrap chain). False-positive rate of
-         a literal `(Recommended)` label without `Falsified:` is low
-         enough to justify hard block.
+         — original literal-marker path. **Emits `permissionDecision: ask`
+         (soft gate)** — issue #899 restores the pre-#393 tier. #393 raised
+         this to `deny` because compliance was absent (retrospect
+         2026-05-23: 3 calls, 0 `Falsified:` lines). That premise no
+         longer holds — 90-day transcript census shows `Falsified:` lines
+         (221/wk) now exceed `(Recommended)` labels (184/wk), i.e. the
+         template is over-applied. Under `deny` the surviving cost was a
+         forced re-author round trip: 306 blocks / 30 days, 48% of all
+         AskUserQuestion blocks, up to 14 in one session — which pushed
+         questions onto the ungated prose surface instead (AQ per 1k
+         assistant turns 9.25 → 6.36; prose-ask/AQ 1.71 → 2.08).
 
      T2. Label OR description contains a confidence-anchoring framing
          token (issue #369). EN tokens (case-insensitive, ASCII word
@@ -584,9 +587,9 @@ def _emit_ask(message: str) -> None:
     emit_decision("ask", message)
 
 
-def _emit_deny(message: str) -> None:
-    """T1 path: hard block (issue #393 upgrade)."""
-    emit_decision("deny", message)
+def _emit_t1_ask(message: str) -> None:
+    """T1 path: soft gate (issue #899 — restores the pre-#393 tier)."""
+    emit_decision("ask", message)
 
 
 # ---------------------------------------------------------------------------
@@ -824,12 +827,12 @@ def main() -> int:
                 advisory_needed = True
 
         if any_t1_violation:
-            # T1 deny is final — overrides any T2 ask — but the scaffold
-            # still aggregates T2 labels too so a question that only
-            # violates T2 doesn't reblock on the very next retry. No
-            # cross-question dedup here (see comment above).
-            _record_block_telemetry(payload.get("session_id"), _fire_ledger.DECISION_BLOCK)
-            _emit_deny(_build_ask_msg(t1_labels + t2_labels))
+            # T1 takes precedence over T2 (its message is the stricter one)
+            # — but the scaffold still aggregates T2 labels too so a
+            # question that only violates T2 doesn't regate on the very
+            # next retry. No cross-question dedup here (see comment above).
+            _record_block_telemetry(payload.get("session_id"), _fire_ledger.DECISION_ASK)
+            _emit_t1_ask(_build_ask_msg(t1_labels + t2_labels))
         elif any_t2_violation:
             _record_block_telemetry(payload.get("session_id"), _fire_ledger.DECISION_ASK)
             _emit_ask(_build_anchoring_ask_msg(t2_labels))

--- a/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
@@ -31,7 +31,7 @@ Text rules and MEMORY.md entries alone have proven insufficient to prevent
 recurrence. A structural hook moves the gate to the tool-call use-site.
 
 References: issue [#221](https://github.com/devseunggwan/praxis/issues/221) (advisory),
-[#290](https://github.com/devseunggwan/praxis/issues/290) (T1 ask escalation),
+[#290](https://github.com/devseunggwan/praxis/issues/290) (T1 ask escalation), [#899](https://github.com/devseunggwan/praxis/issues/899) (T1 deny → ask restore),
 [#369](https://github.com/devseunggwan/praxis/issues/369) (T2 confidence-anchoring extension).
 
 ### Source rule detail (always-loaded SoT reference)
@@ -86,7 +86,7 @@ edits the user requested, reversible exploration commands.
 
 | Tool | Trigger condition | Decision |
 | ------ | ----------------- | ---------- |
-| `AskUserQuestion` (T1) | Option `label` contains exact `(Recommended)` or `(추천)` AND no `Falsified:` line in the question body or that triggering option's own `description` | `permissionDecision: deny` (ASK_MSG) |
+| `AskUserQuestion` (T1) | Option `label` contains exact `(Recommended)` or `(추천)` AND no `Falsified:` line in the question body or that triggering option's own `description` | `permissionDecision: ask` (ASK_MSG) |
 | `AskUserQuestion` (T1) | Option `label` contains exact `(Recommended)` or `(추천)` AND a `Falsified:` line is present (question body OR that triggering option's own `description`, issue #828) | Silent pass |
 | `AskUserQuestion` (T2, issue #369) | Option `label` OR `description` contains a confidence-anchoring framing token AND no `Falsified:` line in the question body or that triggering option's own `description` | `permissionDecision: ask` (ANCHORING_ASK_MSG) |
 | `AskUserQuestion` (T2) | Same as above + `Falsified:` present (question body OR that triggering option's own `description`, issue #828) | Silent pass |
@@ -107,8 +107,21 @@ checked no existing PR — none found`).
 
 - **`Falsified:` present** → silent pass. The model has provided verifiable
   evidence of a disconfirming test.
-- **`Falsified:` absent** → `permissionDecision: deny` with ASK_MSG (hard block — issue #393). The model
-  must add the falsification line and retry.
+- **`Falsified:` absent** → `permissionDecision: ask` with ASK_MSG (soft gate — issue #393
+  raised this to `deny`, issue #899 restored it). The scaffold still names the
+  missing line, but the decision is acknowledge-and-proceed rather than a forced
+  re-author round trip.
+
+  Why the downgrade: #393's premise was systematic non-compliance (retrospect
+  2026-05-23 — 3 calls, 0 `Falsified:` lines). A 90-day Claude Code transcript
+  census no longer supports it — `Falsified:` lines (221/wk) now outnumber
+  `(Recommended)` labels (184/wk), i.e. the template is applied even where the
+  hook would not fire. What `deny` still cost was the retry tax: 306 blocks over
+  30 days, 48% of all `AskUserQuestion` blocks, up to 14 in a single session.
+  That tax displaced questions onto the ungated prose surface (AskUserQuestion
+  per 1k assistant turns 9.25 → 6.36; prose-ask/AskUserQuestion 1.71 → 2.08),
+  reproducing the very defect the gate exists to catch, where the gate cannot
+  see it.
 
 T1's *marker* scan (is `(Recommended)`/`(추천)` present at all) reads
 `options[].label` ONLY — description is scanned for the marker by T2
@@ -121,7 +134,7 @@ not stylistic.
 #### AskUserQuestion T1/T2 evidence location: question body OR option description (issue #828)
 
 **Why this exists**: praxis skill `praxis:cmux-delegate` (and this hook
-itself) require a `Falsified:` line to satisfy T1/T2 before the deny/ask
+itself) require a `Falsified:` line to satisfy T1/T2 before the ask
 decision clears. Before issue #828 the only place `_has_falsified_line`
 scanned was `questions[].question` — the single string field carrying the
 literal user-facing question text. In practice this pushed the model to
@@ -216,7 +229,7 @@ does not have this problem: T1's marker scan reads `label` only (never
 without also being the very marker the evidence is supposed to falsify.
 The fix (see `impl.py` `q_texts` construction) collects only `o.get("description")`
 per option, never `o.get("label")`. Regression test: "AskUserQuestion:
-label itself crafted as a Falsified: line, no description → still T1 deny
+label itself crafted as a Falsified: line, no description → still T1 gates
 (issue #828 codex P2)" in the test suite.
 
 **Why evidence is scoped to TRIGGERING options only, never every option in
@@ -247,7 +260,7 @@ non-triggering option's description is never evidence for anything; only
 a triggering option's own description can supply its own evidence.
 Regression test: "AskUserQuestion: non-triggering option's unrelated
 Falsified: description does not cover a different triggering option →
-still T1 deny (issue #828 codex round-2 P2)" in the test suite.
+still T1 gates (issue #828 codex round-2 P2)" in the test suite.
 
 **Why matching must key on option identity (index), not normalized label
 text (codex review round-3, third in-vivo P2 catch)**: the round-2 fix
@@ -279,7 +292,7 @@ covers the wrong evidence slot by omission; round-3 closes the case where
 label TEXT COLLISION, not omission, misroutes a different option's
 description into the wrong slot. The pre-existing label-based
 `t1_triggering` / `t2_triggering` / `combined_triggering` machinery used
-for messaging (scaffold text, deny/ask reason) is unchanged — only the
+for messaging (scaffold text, ask reason) is unchanged — only the
 evidence-collection step now reads option identity directly. Regression
 test: "AskUserQuestion: non-triggering option sharing a normalized label
 with the triggering option does not supply its evidence → still T2 ask
@@ -345,7 +358,7 @@ matched; read-only commands (`git log --all`, `gh pr list`) do not fire.
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "deny",
+    "permissionDecision": "ask",
     "permissionDecisionReason": "(Recommended) 라벨이 있으나 question body 또는 해당 옵션의 description 필드 어디에도 'Falsified: <disconfirming test 결과>' 가 없음. CLAUDE.md Self-Falsify Before Recommendation Lock 룰. [pre-author-template] 이번 호출뿐 아니라 앞으로 (Recommended) 라벨을 붙일 때마다 AskUserQuestion 작성 직전(도구 호출 전) 에 첫 칼럼 시작 'Falsified: <검증 결과>' 줄을 템플릿에 포함하라 — 인스턴스 수정이 아닌 템플릿 수정이 필요하다. 'Falsified:' 는 자기 줄 첫 칼럼에서 시작해야 한다 (startswith 검사) — 질문문 중간/불릿/코드펜스 내부 배치는 미검출. [trigger-reduction] question 은 짧게 유지하고, Falsified: 줄은 해당 옵션 (Recommended) 의 description 필드에 넣는 것을 권장 — 두 위치 모두 검증됨."
   }
 }
@@ -372,7 +385,7 @@ matched; read-only commands (`git log --all`, `gh pr list`) do not fire.
 
 #### Ready-to-fill `Falsified:` scaffold (issue #787)
 
-Both the T1 deny and T2 ask `permissionDecisionReason` above end with a
+Both the T1 and T2 ask `permissionDecisionReason` above end with a
 `[scaffold]` marker followed by one copy-paste-ready `Falsified:` line per
 triggering option label, parsed straight from the blocked `tool_input`:
 
@@ -475,7 +488,7 @@ independently per question (not via `if`/`elif`) and pooled into one
 combined `required_count` — the prior `if`/`elif` skipped the T2 check
 entirely once T1 matched for the question, so a retry that only supplied
 evidence for the T1 option silent-passed with the T2 option's claim never
-verified. T1 still decides the final deny-vs-ask precedence (unchanged);
+verified. T1 still decides the final message precedence (unchanged);
 only the per-question evidence requirement changed.
 
 T2's bare `recommend(?:ed|s)?` pattern also matches the literal word
@@ -484,7 +497,7 @@ incidentally also matches T2's check. Labels already present in
 `t1_triggering` are excluded from `t2_triggering` before pooling — without
 this, a pure-T1 2-option question would double-count each label into both
 `t1_labels` and `t2_labels`, producing duplicate scaffold lines in the
-final deny message for a case with no genuine T2-only option at all.
+final gate message for a case with no genuine T2-only option at all.
 
 **Real-delimiter anchoring + whitespace-normalized dedup (issue #787 codex
 round-8 P2, two findings):**
@@ -573,7 +586,7 @@ in practice.
 `_falsified_scaffold` interpolates each triggering option's raw label
 verbatim into a single f-string line (`f"Falsified: {label} — probe:
 ..."`). If the label itself contains a literal newline, that single
-logical line prints as two PHYSICAL lines in the deny/ask message. A
+logical line prints as two PHYSICAL lines in the ask message. A
 verbatim copy-paste of that unfilled scaffold then has its `Falsified:`
 prefix on the first physical line and its placeholder-bearing evidence
 (`<command>`, `<observed>`, `<...>`) on the second — which does not start
@@ -651,13 +664,14 @@ instead of surfacing the proposal.
 
 ### Block-event telemetry (issue #787)
 
-Every T1 deny / T2 ask decision also appends one RICH record to the shared
+Every T1 / T2 ask decision also appends one RICH record to the shared
 fire-ledger (`hooks/_lib/_fire_ledger.py`, `record_session_fire`) — hook
-`output-block-falsify-advisory`, role `advisory-nudge`, `decision` = `block`
-(T1) or `ask` (T2), `tool` = `AskUserQuestion`, `session_id` from the hook
+`output-block-falsify-advisory`, role `advisory-nudge`, `decision` = `ask`
+for both tiers since issue #899 (T1 recorded `block` while it emitted
+`deny`), `tool` = `AskUserQuestion`, `session_id` from the hook
 payload. Skipped when `session_id` is missing or empty (cannot attribute).
 
-This exists because this hook signals deny/ask via a stdout JSON
+This exists because this hook signals its decision via a stdout JSON
 `permissionDecision`, not exit code 2 — so the universal `@fail_open` coarse
 recorder (which only inspects the return code) always logs `pass` for these
 calls. Before issue #787, cross-session block-rate measurement had to fall
@@ -690,34 +704,34 @@ bash tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
 ```
 
 **Harness isolation (issue #787 codex round-6 P2)**: every `run_case`
-invocation calls the hook directly, and the T1/T2 deny/ask cases each write
+invocation calls the hook directly, and the T1/T2 ask cases each write
 a RICH telemetry record. The script exports a throwaway
 `PRAXIS_FIRE_TELEMETRY_FILE` default at the top so these dozens of test
 invocations never land in the real `~/.praxis/telemetry/` store — the
 telemetry-content-checking cases further down still override the var
 per-call to their own `TEL_DIR` paths, which wins for that one invocation.
 Separately, the `pass` expectation in `run_case` now checks stdout is empty
-in addition to stderr — a deny/ask decision also exits 0 with empty
+in addition to stderr — an ask decision also exits 0 with empty
 stderr (it signals via stdout JSON, not stderr), so a stderr-only check
 could not actually distinguish a real silent pass from an undetected
-deny/ask.
+the ask decision.
 
 Covers 97 cases (91 pre-#828 + 6 new — description-field satisfaction, per-label coverage regression via description, T2 via description, label-only self-referential bypass regression, cross-option unrelated-description bypass regression, same-normalized-label index-identity bypass regression):
 
-**T1 deny-escalation (AskUserQuestion, issue #290/#393):**
+**T1 ask-escalation (AskUserQuestion, issue #290 / #393 / #899):**
 
-- Option label `(Recommended)` + no `Falsified:` in question body → `permissionDecision: deny` (ASK_MSG)
-- Option label `(추천)` + no `Falsified:` → `permissionDecision: deny`
+- Option label `(Recommended)` + no `Falsified:` in question body → `permissionDecision: ask` (ASK_MSG)
+- Option label `(추천)` + no `Falsified:` → `permissionDecision: ask`
 - Option label `(Recommended)` + `Falsified:` line present → silent pass
 - Non-recommended option labels → silent pass
 
 **Description-field evidence location (issue #828):**
 
 - Option label `(Recommended)` + `Falsified:` line in that option's own `description` (not `question`) → silent pass, `question` stays short
-- 2 triggering `(Recommended)` options, only one covered via `description`, the other has no `Falsified:` line anywhere → still `deny` (per-label coverage still enforced across mixed sources)
+- 2 triggering `(Recommended)` options, only one covered via `description`, the other has no `Falsified:` line anywhere → still gates (`ask`) (per-label coverage still enforced across mixed sources)
 - T2 anchoring token (`safer`) + `Falsified:` line in the same option's `description` → `ask` → silent pass once evidence supplied
-- Single `(Recommended)` option with no `description` at all, whose own `label` is crafted to read as a clean `Falsified:` line → still `deny` (regression for the self-referential label-as-evidence bypass caught by codex review — see spec detail above)
-- Single triggering `(Recommended)` option with no `description` of its own, paired with a different non-triggering option whose unrelated `description` reads a clean `Falsified:` line → still `deny` (regression for the cross-option unrelated-description bypass caught by codex review round-2 — see spec detail above)
+- Single `(Recommended)` option with no `description` at all, whose own `label` is crafted to read as a clean `Falsified:` line → still gates (`ask`) (regression for the self-referential label-as-evidence bypass caught by codex review — see spec detail above)
+- Single triggering `(Recommended)` option with no `description` of its own, paired with a different non-triggering option whose unrelated `description` reads a clean `Falsified:` line → still gates (`ask`) (regression for the cross-option unrelated-description bypass caught by codex review round-2 — see spec detail above)
 
 **T2 ask-escalation (AskUserQuestion, issue #369):**
 
@@ -727,7 +741,7 @@ Covers 97 cases (91 pre-#828 + 6 new — description-field satisfaction, per-lab
 - Mixed Hangul/ASCII (`prefer this 옵션`) → `ask` — word-boundary regression
 - `(Recommended)` in description-only (no marker in label) → `ask` (replaces former false-positive-guard pass)
 - T2 anchoring + `Falsified:` line → silent pass
-- T1 precedence: literal `(Recommended)` + anchoring description → `deny` with ASK_MSG (T1 wins, issue #393)
+- T1 precedence: literal `(Recommended)` + anchoring description → `ask` with ASK_MSG (T1 wins, issue #393)
 
 **T2 negative cases (must not fire):**
 
@@ -756,61 +770,61 @@ Covers 97 cases (91 pre-#828 + 6 new — description-field satisfaction, per-lab
 
 **Template-level message cases (issue #682):**
 
-- `(Recommended)` + no `Falsified:` → deny message contains `pre-author-template` ASCII marker
+- `(Recommended)` + no `Falsified:` → gate message contains `pre-author-template` ASCII marker
 - confidence-anchoring (`safer`) + no `Falsified:` → ask message contains `pre-author-template` ASCII marker
 - `(Recommended)` + column-0 `Falsified:` present → silent pass (regression — template-level message change must not break satisfaction)
 
 **Ready-to-fill scaffold cases (issue #787):**
 
-- T1 deny message embeds `Falsified: <label>` seeded from the triggering option label
-- T1 deny message contains the `[scaffold]` marker
+- T1 gate message embeds `Falsified: <label>` seeded from the triggering option label
+- T1 gate message contains the `[scaffold]` marker
 - T2 ask message embeds `Falsified: <label>` seeded from the anchoring-token-carrying label
 - 2 options both carrying `(Recommended)` → 2 scaffold `Falsified:` lines (one per label)
 - `(Recommended)` + `Falsified:` already present → no scaffold needed (silent pass, regression)
 
 **Block-event telemetry cases (issue #787):**
 
-- T1 deny → 1 RICH fire-ledger record with `decision=block`, correct `hook`/`role`/`tool`/`session_id`
-- T1 deny → the automatic COARSE `pass` duplicate is suppressed (1 total line in the telemetry file, not 2)
+- T1 ask → 1 RICH fire-ledger record with `decision=ask`, correct `hook`/`role`/`tool`/`session_id`
+- T1 ask → the automatic COARSE `pass` duplicate is suppressed (1 total line in the telemetry file, not 2)
 - T2 ask → 1 RICH fire-ledger record with `decision=ask`
 - T2 ask → COARSE duplicate suppressed (1 total line)
 - Silent pass → no RICH record written
-- Missing `session_id` → deny still fires on stdout, but no RICH record (cannot attribute)
+- Missing `session_id` → the ask decision still fires on stdout, but no RICH record (cannot attribute)
 
 **Multi-question aggregation cases (issue #787 codex round-1 P2 fix):**
 
-- 2 separate questions, each with its own T1 violation, no `Falsified:` in either → both labels appear in the deny scaffold (not just the first)
+- 2 separate questions, each with its own T1 violation, no `Falsified:` in either → both labels appear in the ask scaffold (not just the first)
 - 2 separate questions, each with its own T2-only (anchoring) violation → both labels appear in the ask scaffold
 
 **Anti-bypass placeholder-rejection cases (issue #787 codex round-2/3/4/5/6/7/8/9/10/11/12 + PR #796 CodeRabbit review fixes):**
 
-- T1: copying the unfilled scaffold line verbatim into the question body does NOT satisfy the gate → still deny
+- T1: copying the unfilled scaffold line verbatim into the question body does NOT satisfy the gate → still gates
 - T2: same unfilled-copy-paste check → still ask
 - T1: scaffold line with all placeholders replaced by real probe output → silent pass (regression — the fix must not make legitimate filled-in evidence unsatisfiable)
-- T1: 1 of 2 scaffold lines filled in, the other still carries a placeholder → still deny (round-3 P1 — a sibling clean line must not let an unfilled one ride along)
+- T1: 1 of 2 scaffold lines filled in, the other still carries a placeholder → still gates (round-3 P1 — a sibling clean line must not let an unfilled one ride along)
 - T1: both scaffold lines for a 2-option question fully filled in → silent pass (regression)
 - 2 different questions presenting the identical triggering label → 2 separate scaffold lines, not collapsed by dedup (round-3 P2)
-- T1: 1 of 2 triggering options has a `Falsified:` line, the other is omitted entirely (no placeholder left anywhere) → still deny (round-4 P1 — placeholder-token rejection alone cannot catch a deleted line; fixed via `required_count`-based counting)
+- T1: 1 of 2 triggering options has a `Falsified:` line, the other is omitted entirely (no placeholder left anywhere) → still gates (round-4 P1 — placeholder-token rejection alone cannot catch a deleted line; fixed via `required_count`-based counting)
 - T1: single triggering label with its one clean `Falsified:` line → silent pass (regression — `required_count` defaults to 1, preserving the original single-label contract)
 - T1: option label literally contains `<command>`, evidence past `— probe:` genuinely filled in → silent pass (round-5 P2 — the label prefix is never evidence-bearing, so it must not be scanned for placeholder tokens)
-- T1: option label literally contains `<command>` AND the evidence past `— probe:` is still unfilled → still deny (regression — round-5's narrowed scan window must not disable the guard itself)
+- T1: option label literally contains `<command>` AND the evidence past `— probe:` is still unfilled → still gates (regression — round-5's narrowed scan window must not disable the guard itself)
 - T1: legacy free-form line with no `— probe:` marker whose own wording contains `<command>` → silent pass (round-6 P2 — round-5 still scanned marker-less lines whole; marker-less lines are excluded from placeholder scanning entirely since they are not scaffold-shaped)
-- T1: same clean `Falsified:` line pasted twice for a 2-option question → still deny (round-6 P2 — raw line-count could be satisfied by duplicating one option's evidence; lines are now deduped by exact text before counting)
+- T1: same clean `Falsified:` line pasted twice for a 2-option question → still gates (round-6 P2 — raw line-count could be satisfied by duplicating one option's evidence; lines are now deduped by exact text before counting)
 - T1: 2 genuinely distinct clean lines for 2 options → silent pass (regression — dedup must reject only exact-text duplicates, not require exact label-text matching)
-- Mixed T1+T2 in one question, only the T1 option's evidence provided → still deny (round-7 P2 — the prior `if`/`elif` skipped the T2 check entirely once T1 matched, so the T2 option's claim never entered `required_count`)
+- Mixed T1+T2 in one question, only the T1 option's evidence provided → still gates (round-7 P2 — the prior `if`/`elif` skipped the T2 check entirely once T1 matched, so the T2 option's claim never entered `required_count`)
 - Mixed T1+T2 in one question, both options' evidence provided → silent pass (regression)
 - Pure-T1 2-option question → scaffold shows each label exactly once, no duplication (regression — round-7's self-catch: T2's bare `recommend` pattern also matches inside `(Recommended)`, so T1-covered labels must be excluded from `t2_triggering` or they double-count into both `t1_labels` and `t2_labels`)
-- T1: option label itself embeds the `— probe:` delimiter substring plus a placeholder token, real evidence supplied after the actual (rightmost) delimiter → silent pass (round-8 P2 — `find()`'s leftmost match anchored on the label-internal marker instead of the real, last-inserted one, pulling the label's own placeholder text into `evidence_region` and permanently hard-denying; fixed via `rfind()`)
-- T1: same real evidence line pasted twice for a 2-option question with only a whitespace difference (internal double-space) on the second copy → still deny (round-8 P2 — exact-text dedup treated the two as distinct, satisfying `required_count=2` while the second option had zero real evidence; fixed via whitespace normalization before dedup)
-- T1: 2 differently-worded `Falsified:` lines, both prefixed with the SAME triggering label, the other triggering label never addressed → still deny (round-9 P1 — raw distinct-line count satisfied `required_count=2` without checking which option each line actually addressed; fixed via per-label prefix matching and coverage)
+- T1: option label itself embeds the `— probe:` delimiter substring plus a placeholder token, real evidence supplied after the actual (rightmost) delimiter → silent pass (round-8 P2 — `find()`'s leftmost match anchored on the label-internal marker instead of the real, last-inserted one, pulling the label's own placeholder text into `evidence_region` and permanently hard-gating; fixed via `rfind()`)
+- T1: same real evidence line pasted twice for a 2-option question with only a whitespace difference (internal double-space) on the second copy → still gates (round-8 P2 — exact-text dedup treated the two as distinct, satisfying `required_count=2` while the second option had zero real evidence; fixed via whitespace normalization before dedup)
+- T1: 2 differently-worded `Falsified:` lines, both prefixed with the SAME triggering label, the other triggering label never addressed → still gates (round-9 P1 — raw distinct-line count satisfied `required_count=2` without checking which option each line actually addressed; fixed via per-label prefix matching and coverage)
 - T1: 2 triggering options, each addressed by its own distinctly-worded `Falsified:` line → silent pass (regression — the round-9 P1 fix maps lines to labels by prefix, it does not require identical wording or more than one line per label)
-- T1: evidence text (after the real `— probe:` delimiter) itself contains a second `— probe:` substring, with an unfilled `<command>` placeholder sitting before that spurious second marker → still deny (round-9 P2 — `rfind()` anchored on the spurious, later marker instead of the real one, pushing the leading placeholder outside the scanned region; fixed via `find()` seeded right after the matched label prefix)
+- T1: evidence text (after the real `— probe:` delimiter) itself contains a second `— probe:` substring, with an unfilled `<command>` placeholder sitting before that spurious second marker → still gates (round-9 P2 — `rfind()` anchored on the spurious, later marker instead of the real one, pushing the leading placeholder outside the scanned region; fixed via `find()` seeded right after the matched label prefix)
 - T1: same evidence-embeds-a-second-marker shape, but with the evidence genuinely filled in (no placeholder anywhere) → silent pass (regression — the round-9 P2 fix narrows the anchor point, it does not forbid legitimate evidence from containing the word sequence `— probe:` again)
-- T1+T2: a bare (no-marker) triggering label is a literal string-prefix of unrelated evidence text on a sibling line (e.g. `"Rerun"` inside `"Rerunning without confirmation"`) → still deny (round-10 P2 — `startswith()` matched the label as a bare substring prefix without a boundary check, crediting an option that line never actually addresses)
+- T1+T2: a bare (no-marker) triggering label is a literal string-prefix of unrelated evidence text on a sibling line (e.g. `"Rerun"` inside `"Rerunning without confirmation"`) → still gates (round-10 P2 — `startswith()` matched the label as a bare substring prefix without a boundary check, crediting an option that line never actually addresses)
 - T1+T2: same bare-label-is-a-prefix shape, but the label is genuinely addressed by its own whole-token line → silent pass (regression — the round-10 fix requires a boundary after the label, it does not forbid the label from ever matching)
-- An option label contains a literal embedded newline → the deny message's scaffold hint still renders as exactly one physical `Falsified:` line (round-11 P2 — the raw label is normalized before scaffold generation, so the artifact this whole guard depends on can no longer split across lines)
-- Same newline-bearing label, the (now-guaranteed single-line) scaffold copied verbatim and left unfilled → still deny (regression — the fix must not make the placeholder guard unreachable for labels that originally contained a newline)
-- A triggering label (`"Run"`) is the string-prefix of a genuinely different, unrelated evidence line's own text (`"Run now"`) separated by a space → still deny (round-12 P2 — round-10's non-alphanumeric boundary check was too permissive; the boundary must be the exact scaffold delimiter or end-of-line, not any non-alphanumeric character)
+- An option label contains a literal embedded newline → the gate message's scaffold hint still renders as exactly one physical `Falsified:` line (round-11 P2 — the raw label is normalized before scaffold generation, so the artifact this whole guard depends on can no longer split across lines)
+- Same newline-bearing label, the (now-guaranteed single-line) scaffold copied verbatim and left unfilled → still gates (regression — the fix must not make the placeholder guard unreachable for labels that originally contained a newline)
+- A triggering label (`"Run"`) is the string-prefix of a genuinely different, unrelated evidence line's own text (`"Run now"`) separated by a space → still gates (round-12 P2 — round-10's non-alphanumeric boundary check was too permissive; the boundary must be the exact scaffold delimiter or end-of-line, not any non-alphanumeric character)
 - Same near-miss shape, but the triggering label is genuinely addressed by its own line ending exactly at the scaffold's delimiter → silent pass (regression — the round-12 fix must not forbid the label from ever matching)
-- T1: the `— probe:` marker is present, but nothing (or only whitespace) follows it on the same line → still deny (PR #796 CodeRabbit review — an empty `evidence_region` vacuously satisfied the placeholder-token scan since `any()` over an empty string is `False`)
+- T1: the `— probe:` marker is present, but nothing (or only whitespace) follows it on the same line → still gates (PR #796 CodeRabbit review — an empty `evidence_region` vacuously satisfied the placeholder-token scan since `any()` over an empty string is `False`)
 - Missing `session_id` → the RICH telemetry record is still written, with `session_id=""`, and the COARSE "pass" duplicate remains suppressed (PR #796 CodeRabbit review — the prior early-return dropped the decision from `aggregate_fires()`'s totals entirely rather than merely mislabeling it)

--- a/hooks/completion-verify/negative-existence-verdict-gate/spec.md
+++ b/hooks/completion-verify/negative-existence-verdict-gate/spec.md
@@ -130,8 +130,10 @@ kill branch, and (c) the same mechanism blocked 4/4 on the adjacent
 | `PRAXIS_HOOK_BYPASS_NEGATIVE_EXISTENCE_GATE=1` | Silent pass (full bypass) |
 
 Default is **block** (not advisory): the issue's v3 design was built
-specifically to justify a hard block at 0.10 fires/session, and the
-`Falsified:` precedent (`output-block-falsify-advisory` T1) is a hard deny.
+specifically to justify a hard block at 0.10 fires/session. The
+`Falsified:` precedent it originally cited (`output-block-falsify-advisory`
+T1) no longer supports it — that tier was downgraded to `ask` in #899 —
+so this gate's default now rests on the fire-rate argument alone.
 `PRAXIS_NEGATIVE_EXISTENCE_ADVISORY=1` demotes to advisory for callers who
 want the nudge without the block.
 

--- a/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
@@ -48,7 +48,7 @@ FAILED_NAMES=()
 #   expectation:
 #     "advisory:<substring>" — exit 0 + stderr contains <substring>
 #     "ask:<substring>"       — exit 0 + stdout JSON has permissionDecision:ask + substring
-#     "deny:<substring>"      — exit 0 + stdout JSON has permissionDecision:deny + substring  (issue #393)
+#     "ask:<substring>"      — exit 0 + stdout JSON has permissionDecision:ask + substring  (issue #899)
 #     "pass"                  — exit 0 + stderr empty
 run_case() {
   local name="$1" expectation="$2" payload="$3"
@@ -268,12 +268,12 @@ print(json.dumps(payload))
 # AskUserQuestion positive cases
 # ---------------------------------------------------------------------------
 
-run_case "AskUserQuestion: (Recommended) English — no Falsified: — T1 blocks (issue #393)" \
-  "deny:Falsified:" \
+run_case "AskUserQuestion: (Recommended) English — no Falsified: — T1 gates (issue #899)" \
+  "ask:Falsified:" \
   "$(make_ask_payload '["Option A (Recommended)", "Option B"]')"
 
-run_case "AskUserQuestion: (추천) Korean — no Falsified: — T1 blocks (issue #393)" \
-  "deny:Falsified:" \
+run_case "AskUserQuestion: (추천) Korean — no Falsified: — T1 gates (issue #899)" \
+  "ask:Falsified:" \
   "$(make_ask_payload '["옵션 A (추천)", "옵션 B"]')"
 
 run_case "AskUserQuestion: (recommended) lowercase — T2 escalates to ask (issue #369)" \
@@ -385,8 +385,8 @@ run_case "AskUserQuestion: (Recommended) + Falsified: line in question body → 
 What should we do?")"
 
 # Case 2 (updated by issue #393): (Recommended) label + no Falsified: → DENY (block)
-run_case "AskUserQuestion: (Recommended) + no Falsified: → T1 deny (issue #393)" \
-  "deny:Falsified:" \
+run_case "AskUserQuestion: (Recommended) + no Falsified: → T1 ask (issue #393)" \
+  "ask:Falsified:" \
   "$(make_ask_payload '["Best option (Recommended)", "Alternative"]')"
 
 # Case 2b (issue #828): Falsified: line in the triggering option's OWN
@@ -403,9 +403,9 @@ run_case "AskUserQuestion: (Recommended) + Falsified: in option description (not
 # Case 2c (issue #828 regression): per-label coverage still enforced when
 # evidence is supplied via description — 2 triggering options, only one
 # covered (via its own description), the other has no Falsified: line
-# anywhere → still deny.
-run_case "AskUserQuestion: 2x (Recommended), only one covered via description → still T1 deny (issue #828)" \
-  "deny:Falsified:" \
+# anywhere → still gates.
+run_case "AskUserQuestion: 2x (Recommended), only one covered via description → still T1 gates (issue #828)" \
+  "ask:Falsified:" \
   "$(make_ask_payload_with_descriptions \
       '["Option A (Recommended)", "Option B (Recommended)"]' \
       '["Falsified: Option A (Recommended) — probe: grep → none found; premise survives because none.", "plain description, no evidence"]' \
@@ -431,8 +431,8 @@ run_case "T2: 'safer' + Falsified: line in same description field → pass (issu
 # premise. Regression for a real bypass caught by codex review (single-
 # label mode: "any clean Falsified: line anywhere" previously included
 # `collect_option_texts()`'s label text).
-run_case "AskUserQuestion: label itself crafted as a Falsified: line, no description → still T1 deny (issue #828 codex P2)" \
-  "deny:Falsified:" \
+run_case "AskUserQuestion: label itself crafted as a Falsified: line, no description → still T1 gates (issue #828 codex P2)" \
+  "ask:Falsified:" \
   "$(make_ask_payload \
       '["Falsified: Option A (Recommended) (Recommended) — probe: fake → fake; premise survives because fake"]')"
 
@@ -444,8 +444,8 @@ run_case "AskUserQuestion: label itself crafted as a Falsified: line, no descrip
 # line anywhere satisfies") accept evidence that never addressed the
 # actual triggering option at all — the triggering option's premise was
 # never falsified. Only a triggering option's OWN description counts.
-run_case "AskUserQuestion: non-triggering option's unrelated Falsified: description does not cover a different triggering option → still T1 deny (issue #828 codex round-2 P2)" \
-  "deny:Falsified:" \
+run_case "AskUserQuestion: non-triggering option's unrelated Falsified: description does not cover a different triggering option → still T1 gates (issue #828 codex round-2 P2)" \
+  "ask:Falsified:" \
   "$(make_ask_payload_with_descriptions \
       '["Option A (Recommended)", "Option B"]' \
       '[null, "Falsified: totally unrelated evidence about something else — probe: n/a → n/a; premise survives because n/a"]' \
@@ -477,8 +477,8 @@ run_case "AskUserQuestion: (Recommended) in description only — T2 escalates to
   "$(make_ask_payload_description_only)"
 
 # Case 4 (updated by issue #393): (추천) Korean label + no Falsified: → DENY (block)
-run_case "AskUserQuestion: (추천) Korean label + no Falsified: → T1 deny (issue #393)" \
-  "deny:Falsified:" \
+run_case "AskUserQuestion: (추천) Korean label + no Falsified: → T1 ask (issue #393)" \
+  "ask:Falsified:" \
   "$(make_ask_payload '["권장 방법 (추천)", "대안"]')"
 
 # Case 5: Non-recommended option — no (Recommended) label — silent pass (no advisory)
@@ -489,8 +489,8 @@ run_case "AskUserQuestion: non-recommended option labels — silent pass" \
 # Case 6 (regression for P2 fix; updated by issue #393): multi-question payload
 # where Q1 has (Recommended) but no Falsified:, and Q2 has Falsified: in its own
 # question text — Q1 still fires T1 → DENY (block).
-run_case "AskUserQuestion: multi-question — Falsified: in Q2 does not cover Q1 (Recommended) → T1 deny" \
-  "deny:Falsified:" \
+run_case "AskUserQuestion: multi-question — Falsified: in Q2 does not cover Q1 (Recommended) → T1 ask" \
+  "ask:Falsified:" \
   "$(make_ask_payload_multi_question_bypass)"
 
 # ---------------------------------------------------------------------------
@@ -575,11 +575,12 @@ run_case "T2: KO '안전한' triggers ANCHORING_ASK_MSG (not ASK_MSG)" \
 
 # T1 precedence over T2 — when label has literal (Recommended) AND
 # description has confidence-anchoring, T1 fires first.
-# Updated by issue #393: T1 now emits deny (not ask). The T1 message
+# Issue #393 raised T1 to deny; issue #899 restored it to ask. T1 still
+# takes precedence over T2, so the T1 message
 # (ASK_MSG content, "Self-Falfify" marker) is still emitted, but the
-# decision is deny instead of ask.
-run_case "T1>T2 precedence: literal (Recommended) + anchoring desc → T1 deny (issue #393)" \
-  "deny:Self-Falsify" \
+# is the one emitted.
+run_case "T1>T2 precedence: literal (Recommended) + anchoring desc → T1 ask (issue #393)" \
+  "ask:Self-Falsify" \
   "$(make_ask_payload_with_descriptions \
       '["X (Recommended)", "Y"]' \
       '["가장 안전한 path", "alt"]' \
@@ -588,7 +589,7 @@ run_case "T1>T2 precedence: literal (Recommended) + anchoring desc → T1 deny (
 # Multi-question T2-then-T1 precedence — Q1 fires T2 (confidence-anchoring),
 # Q2 fires T1 (literal Recommended). Pre-fix bug: loop broke on Q1's T2 and
 # emitted ask, allowing user to bypass the T1 hard block. Post-fix: T2 records
-# but keeps scanning; Q2's T1 upgrades the decision to deny.
+# but keeps scanning; Q2's T1 takes precedence over the T2 message.
 make_ask_payload_t2_then_t1() {
   python3 - <<'PYEOF'
 import json
@@ -618,8 +619,8 @@ payload = {
 print(json.dumps(payload))
 PYEOF
 }
-run_case "T2→T1 multi-question: Q1 anchoring, Q2 literal (Recommended) → deny (issue #393 fix)" \
-  "deny:Self-Falsify" \
+run_case "T2→T1 multi-question: Q1 anchoring, Q2 literal (Recommended) → ask (issue #393 fix, downgraded #899)" \
+  "ask:Self-Falsify" \
   "$(make_ask_payload_t2_then_t1)"
 
 # ---------------------------------------------------------------------------
@@ -627,11 +628,11 @@ run_case "T2→T1 multi-question: Q1 anchoring, Q2 literal (Recommended) → den
 # ---------------------------------------------------------------------------
 
 # T1: (Recommended) label + Falsified: appears MID-LINE (not at column 0)
-# → hook must still block (deny) AND the message must contain the line-start hint.
+# → hook must still gate (ask) AND the message must contain the line-start hint.
 # Needle uses the ASCII word "startswith" which appears literally in the JSON output
 # (Korean is Unicode-escaped by json.dumps, so Korean needle won't match in shell).
-run_case "T1: Falsified: mid-line does not satisfy startswith check — still deny + hint" \
-  "deny:startswith" \
+run_case "T1: Falsified: mid-line does not satisfy startswith check — still gates + hint" \
+  "ask:startswith" \
   "$(make_ask_payload_with_question \
       '["Option A (Recommended)", "Option B"]' \
       "이 선택이 A가 B의 선행. Falsified: checked prior PRs — none exist. 계속?")"
@@ -649,11 +650,11 @@ run_case "T2: Falsified: mid-line does not satisfy startswith check — still as
 # Template-level guidance cases — issue #682
 # ---------------------------------------------------------------------------
 
-# T1: (Recommended) without Falsified: → deny message must contain the
+# T1: (Recommended) without Falsified: → gate message must contain the
 # [pre-author-template] marker, proving the message is template-level
 # (instructs Claude to fix the compose template, not just this instance).
-run_case "T1 (issue #682): (Recommended) + no Falsified: → deny contains pre-author-template" \
-  "deny:pre-author-template" \
+run_case "T1 (issue #682): (Recommended) + no Falsified: → ask contains pre-author-template" \
+  "ask:pre-author-template" \
   "$(make_ask_payload '["Option A (Recommended)", "Option B"]')"
 
 # T2: confidence-anchoring without Falsified: → ask message must contain the
@@ -675,14 +676,14 @@ What should we do?")"
 # Ready-to-fill scaffold cases — issue #787
 # ---------------------------------------------------------------------------
 
-# T1: deny message must embed a copy-paste-ready Falsified: line seeded with
+# T1: gate message must embed a copy-paste-ready Falsified: line seeded with
 # the triggering option label, not just the generic instruction text.
-run_case "T1 (issue #787): (Recommended) + no Falsified: → deny embeds ready-to-fill scaffold" \
-  "deny:Falsified: Best option (Recommended)" \
+run_case "T1 (issue #787): (Recommended) + no Falsified: → ask embeds ready-to-fill scaffold" \
+  "ask:Falsified: Best option (Recommended)" \
   "$(make_ask_payload '["Best option (Recommended)", "Alternative"]')"
 
 run_case "T1 (issue #787): scaffold section is marked with [scaffold]" \
-  "deny:[scaffold]" \
+  "ask:[scaffold]" \
   "$(make_ask_payload '["Best option (Recommended)", "Alternative"]')"
 
 # T2: ask message must embed the same ready-to-fill scaffold, seeded with the
@@ -726,8 +727,8 @@ What should we do?")"
 # line VERBATIM (placeholders unfilled) into the question body must NOT
 # silently satisfy the gate — the placeholder line itself starts with
 # "Falsified:", so a naive prefix check would let a probe-free retry through.
-run_case "T1 (issue #787 round-2 P1): unfilled scaffold copy-paste does not satisfy gate — still deny" \
-  "deny:Falsified:" \
+run_case "T1 (issue #787 round-2 P1): unfilled scaffold copy-paste does not satisfy gate — still gates" \
+  "ask:Falsified:" \
   "$(make_ask_payload_with_question \
       '["Best option (Recommended)", "Alternative"]' \
       "Falsified: Best option (Recommended) — probe: <command> → <observed>; premise survives because <...>
@@ -757,8 +758,8 @@ What should we do?")"
 # leaving the second with unfilled placeholders must NOT satisfy the gate —
 # _has_falsified_line's old "return True on first clean line" let a sibling
 # option's fake evidence ride along unchecked.
-run_case "T1 (issue #787 round-3 P1): 1 of 2 scaffold lines filled, other still placeholder → still deny" \
-  "deny:Falsified:" \
+run_case "T1 (issue #787 round-3 P1): 1 of 2 scaffold lines filled, other still placeholder → still gates" \
+  "ask:Falsified:" \
   "$(make_ask_payload_with_question \
       '["Option A (Recommended)", "Option B (Recommended)"]' \
       "Falsified: Option A (Recommended) — probe: gh pr list --search a → none found; premise survives because none found
@@ -783,8 +784,8 @@ Which one?")"
 # fix only rejected leftover placeholder tokens, but a deleted line has no
 # placeholder to reject, so clean_count (1) must be compared against the
 # number of triggering labels (2), not treated as boolean-satisfied.
-run_case "T1 (issue #787 round-4 P1): 1 of 2 lines provided, other omitted → still deny" \
-  "deny:Falsified:" \
+run_case "T1 (issue #787 round-4 P1): 1 of 2 lines provided, other omitted → still gates" \
+  "ask:Falsified:" \
   "$(make_ask_payload_with_question \
       '["Option A (Recommended)", "Option B (Recommended)"]' \
       "Falsified: Option A (Recommended) — probe: gh pr list --search a → none found; premise survives because none found
@@ -819,8 +820,8 @@ What should we do?")"
 # region (after "— probe:") is the unfilled part, even though the label
 # prefix also happens to contain a placeholder-looking substring — proves
 # round-5's fix narrowed the scan window without disabling it.
-run_case "T1 (issue #787 round-5): label contains <command> AND evidence unfilled → still deny" \
-  "deny:Falsified:" \
+run_case "T1 (issue #787 round-5): label contains <command> AND evidence unfilled → still gates" \
+  "ask:Falsified:" \
   "$(make_ask_payload_with_question \
       '["Run <command> manually (Recommended)", "Alternative"]' \
       "Falsified: Run <command> manually (Recommended) — probe: <command> → <observed>; premise survives because <...>
@@ -848,8 +849,8 @@ What should we do?")"
 # the check without ever addressing Option B. Falsified lines are now
 # deduped by exact text before counting, so the duplicate contributes
 # nothing and the question still denies.
-run_case "T1 (issue #787 round-6 P2): same clean line pasted twice for 2 options → still deny" \
-  "deny:Falsified:" \
+run_case "T1 (issue #787 round-6 P2): same clean line pasted twice for 2 options → still gates" \
+  "ask:Falsified:" \
   "$(make_ask_payload_with_question \
       '["Option A (Recommended)", "Option B (Recommended)"]' \
       "Falsified: Option A (Recommended) — probe: gh pr list --search a → none found; premise survives because none found
@@ -873,8 +874,8 @@ Which one?")"
 # entirely once T1 matched for the question, so the T2 option's label
 # never entered required_count — a retry providing evidence for ONLY the
 # T1 option silent-passed with the T2 option's claim never verified.
-run_case "T1 (issue #787 round-7 P2): mixed T1+T2 in one question, only T1 evidence → still deny" \
-  "deny:Falsified: Option B" \
+run_case "T1 (issue #787 round-7 P2): mixed T1+T2 in one question, only T1 evidence → still gates" \
+  "ask:Falsified: Option B" \
   "$(make_ask_payload_with_descriptions \
       '["Option A (Recommended)", "Option B"]' \
       '["", "This is the safer choice overall"]' \
@@ -899,7 +900,7 @@ Which one?")"
 # anchoring check. Without excluding t1_triggering labels from
 # t2_triggering, this double-counted each label into both t1_labels and
 # t2_labels, producing 4 scaffold lines (2 duplicated) instead of 2 in the
-# deny message for a case that has no genuine T2-only option at all.
+# gate message for a case that has no genuine T2-only option at all.
 _scaffold_no_dup_result=$(make_ask_payload '["Option A (Recommended)", "Option B (Recommended)"]' | "$HOOK" 2>/dev/null | python3 -c "
 import json, sys
 d = json.loads(sys.stdin.read())
@@ -920,7 +921,7 @@ fi
 # placeholder-looking token (e.g. quoting another probe's shape) used to
 # shift the scan to that label-internal, leftmost marker occurrence via
 # find(), pulling trailing label text — including the placeholder token —
-# into evidence_region and permanently hard-denying even after real
+# into evidence_region and permanently hard-gating even after real
 # evidence was filled in after the actual (rightmost) scaffold delimiter.
 # rfind() now anchors on the real, last-inserted delimiter.
 run_case "T1 (issue #787 round-8 P2): label itself embeds marker+placeholder, real evidence after real delimiter → silent pass" \
@@ -937,8 +938,8 @@ Which one?")"
 # zero real evidence. Lines are now whitespace-normalized before dedup, so
 # the whitespace-only copy still collapses to 1 clean line and the
 # question still denies.
-run_case "T1 (issue #787 round-8 P2): whitespace-only duplicate line does not satisfy 2nd option → still deny" \
-  "deny:Falsified:" \
+run_case "T1 (issue #787 round-8 P2): whitespace-only duplicate line does not satisfy 2nd option → still gates" \
+  "ask:Falsified:" \
   "$(make_ask_payload_with_question \
       '["Option A (Recommended)", "Option B (Recommended)"]' \
       "Falsified: Option A (Recommended) — probe: gh pr list --search a → none found; premise  survives because none found
@@ -953,8 +954,8 @@ Which one?")"
 # Each clean line is now matched to a specific triggering label by its
 # "Falsified: {label}" prefix, so 2 lines both prefixed with "Option A"
 # leave Option B uncovered and the question still denies.
-run_case "T1 (issue #787 round-9 P1): 2 differently-worded lines, both Option A, Option B uncovered → still deny" \
-  "deny:Falsified:" \
+run_case "T1 (issue #787 round-9 P1): 2 differently-worded lines, both Option A, Option B uncovered → still gates" \
+  "ask:Falsified:" \
   "$(make_ask_payload_with_question \
       '["Option A (Recommended)", "Option B (Recommended)"]' \
       "Falsified: Option A (Recommended) — probe: gh pr list --search a -> none found; premise survives (first check)
@@ -984,8 +985,8 @@ Which one?")"
 # "— probe:" after the label (the real, scaffold-inserted one) is used
 # regardless of how many more "— probe:"-shaped substrings appear later in
 # the evidence text — the leading placeholder is caught.
-run_case "T1 (issue #787 round-9 P2): evidence embeds a second marker, unfilled placeholder before it → still deny" \
-  "deny:Falsified:" \
+run_case "T1 (issue #787 round-9 P2): evidence embeds a second marker, unfilled placeholder before it → still gates" \
+  "ask:Falsified:" \
   "$(make_ask_payload_with_question \
       '["Option A (Recommended)", "Alternative"]' \
       "Falsified: Option A (Recommended) — probe: <command> ran — probe: actually done
@@ -1011,8 +1012,8 @@ What should we do?")"
 # "Rerunning" both continue the shorter label with more letters), wrongly
 # crediting "Rerun" as covered even though that line never actually
 # addresses it — the real "Rerun" claim stayed unverified.
-run_case "T1+T2 (issue #787 round-10 P2): bare label is a string-prefix of unrelated evidence text → still deny" \
-  "deny:Falsified:" \
+run_case "T1+T2 (issue #787 round-10 P2): bare label is a string-prefix of unrelated evidence text → still gates" \
+  "ask:Falsified:" \
   "$(make_ask_payload_with_descriptions \
       '["Merge (Recommended)", "Rerun"]' \
       '["", "This is the safer choice overall"]' \
@@ -1036,13 +1037,13 @@ Which one?")"
 
 # Anti-bypass regression (codex round-11 P2 fix): an option LABEL itself
 # contains a literal embedded newline. `_falsified_scaffold` previously
-# interpolated the raw label verbatim, so the deny message's scaffold hint
+# interpolated the raw label verbatim, so the gate message's scaffold hint
 # split across two printed lines — a verbatim copy-paste of that unfilled
 # scaffold then had its placeholder tokens (`<command>` etc.) land on the
 # SECOND physical line, which does not start with `Falsified:` and is
 # invisible to the per-line scan, silently passing. Labels are now
 # whitespace-normalized (embedded newlines collapsed to spaces) at the
-# point they enter the triggering pipeline, so the deny message's scaffold
+# point they enter the triggering pipeline, so the gate message's scaffold
 # is guaranteed to stay a single physical line regardless of what the raw
 # option label contains — verified here by checking the scaffold segment
 # contains the newline-joined label as ONE line, with no bare "Falsified:
@@ -1070,10 +1071,10 @@ fi
 
 # Regression: the SAME newline-bearing label, with the (now-guaranteed
 # single-line) scaffold copy-pasted verbatim and left unfilled, must still
-# deny — the round-11 fix must not accidentally make the placeholder guard
+# gate — the round-11 fix must not accidentally make the placeholder guard
 # unreachable for labels that originally contained a newline.
-run_case "T1 (issue #787 round-11 P2): newline-bearing label, unfilled single-line scaffold copy-paste → still deny" \
-  "deny:Falsified:" \
+run_case "T1 (issue #787 round-11 P2): newline-bearing label, unfilled single-line scaffold copy-paste → still gates" \
+  "ask:Falsified:" \
   "$(make_ask_payload_with_question \
       '["Multi\nline label (Recommended)", "Alternative"]' \
       "Falsified: Multi line label (Recommended) — probe: <command> → <observed>; premise survives because <...>
@@ -1086,8 +1087,8 @@ What should we do?")"
 # evidence text "Run now"), also has a non-alphanumeric boundary. The
 # "Run" option's real claim is never addressed even though the line
 # gets credited toward it.
-run_case "T1+T2 (issue #787 round-12 P2): near-miss label prefix (triggering \"Run\" vs. evidence \"Run now\") → still deny" \
-  "deny:Falsified:" \
+run_case "T1+T2 (issue #787 round-12 P2): near-miss label prefix (triggering \"Run\" vs. evidence \"Run now\") → still gates" \
+  "ask:Falsified:" \
   "$(make_ask_payload_with_descriptions \
       '["Merge (Recommended)", "Run"]' \
       '["", "This is the safer choice overall"]' \
@@ -1139,16 +1140,16 @@ payload = {
 print(json.dumps(payload))
 PYEOF
 )
-if [ "$_empty_evidence_decision" = "deny" ]; then
-  echo "  PASS  marker present, empty evidence after it -> still deny (PR #796 CodeRabbit review)"
+if [ "$_empty_evidence_decision" = "ask" ]; then
+  echo "  PASS  marker present, empty evidence after it -> still gates (PR #796 CodeRabbit review)"
   PASS=$((PASS + 1))
 else
-  echo "  FAIL  marker present, empty evidence after it -> still deny (PR #796 CodeRabbit review) (got '$_empty_evidence_decision')"
-  FAIL=$((FAIL + 1)); FAILED_NAMES+=("marker present, empty evidence after it -> still deny")
+  echo "  FAIL  marker present, empty evidence after it -> still gates (PR #796 CodeRabbit review) (got '$_empty_evidence_decision')"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("marker present, empty evidence after it -> still gates")
 fi
 
 # Regression variant: whitespace-only evidence (not merely zero-length)
-# must also still deny — the fix strips the evidence region before
+# must also still gate — the fix strips the evidence region before
 # checking emptiness, not just checking for a zero-length string.
 _whitespace_evidence_decision=$(python3 - <<'PYEOF' | "$HOOK" 2>/dev/null | python3 -c "
 import json, sys
@@ -1173,12 +1174,12 @@ payload = {
 print(json.dumps(payload))
 PYEOF
 )
-if [ "$_whitespace_evidence_decision" = "deny" ]; then
-  echo "  PASS  marker present, whitespace-only evidence -> still deny (PR #796 CodeRabbit review)"
+if [ "$_whitespace_evidence_decision" = "ask" ]; then
+  echo "  PASS  marker present, whitespace-only evidence -> still gates (PR #796 CodeRabbit review)"
   PASS=$((PASS + 1))
 else
-  echo "  FAIL  marker present, whitespace-only evidence -> still deny (PR #796 CodeRabbit review) (got '$_whitespace_evidence_decision')"
-  FAIL=$((FAIL + 1)); FAILED_NAMES+=("marker present, whitespace-only evidence -> still deny")
+  echo "  FAIL  marker present, whitespace-only evidence -> still gates (PR #796 CodeRabbit review) (got '$_whitespace_evidence_decision')"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("marker present, whitespace-only evidence -> still gates")
 fi
 
 # Cross-question label preservation (codex round-3 P2 fix): 2 DIFFERENT
@@ -1318,7 +1319,7 @@ with open('$file') as f:
 "
 }
 
-# T1 deny fires -> 1 RICH record, decision=block, correct hook/role/session/tool.
+# T1 ask fires -> 1 RICH record, decision=ask, correct hook/role/session/tool.
 TEL_T1="$TEL_DIR/t1.jsonl"
 make_ask_payload '["Best option (Recommended)", "Alternative"]' \
   | PRAXIS_FIRE_TELEMETRY_FILE="$TEL_T1" "$HOOK" >/dev/null 2>&1
@@ -1327,7 +1328,7 @@ import json, sys
 lines = [json.loads(l) for l in sys.stdin if l.strip()]
 ok = (
     len(lines) == 1
-    and lines[0].get('decision') == 'block'
+    and lines[0].get('decision') == 'ask'
     and lines[0].get('hook') == 'output-block-falsify-advisory'
     and lines[0].get('role') == 'advisory-nudge'
     and lines[0].get('tool') == 'AskUserQuestion'
@@ -1336,24 +1337,24 @@ ok = (
 print('ok' if ok else 'fail_' + str(lines))
 ")
 if [ "$_t1_tel" = "ok" ]; then
-  echo "  PASS  T1 deny -> 1 RICH telemetry record (decision=block, issue #787)"
+  echo "  PASS  T1 ask -> 1 RICH telemetry record (decision=ask, issue #787)"
   PASS=$((PASS + 1))
 else
-  echo "  FAIL  T1 deny -> 1 RICH telemetry record (decision=block, issue #787) ($_t1_tel)"
-  FAIL=$((FAIL + 1)); FAILED_NAMES+=("T1 deny -> 1 RICH telemetry record")
+  echo "  FAIL  T1 ask -> 1 RICH telemetry record (decision=ask, issue #787) ($_t1_tel)"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("T1 ask -> 1 RICH telemetry record")
 fi
 
-# T1 deny -> the automatic COARSE "pass" duplicate from @fail_open must be
+# T1 ask -> the automatic COARSE "pass" duplicate from @fail_open must be
 # suppressed (issue #787 codex round-1 P2): without suppression the file
 # would have 2 lines (RICH block + COARSE pass), corrupting aggregate_fires()
 # block-rate counts. Reusing the same TEL_T1 file/call from the case above.
 _t1_total_lines=$(wc -l < "$TEL_T1" 2>/dev/null | tr -d ' ')
 if [ "${_t1_total_lines:-0}" -eq 1 ]; then
-  echo "  PASS  T1 deny -> coarse duplicate suppressed (1 total line, issue #787)"
+  echo "  PASS  T1 ask -> coarse duplicate suppressed (1 total line, issue #787)"
   PASS=$((PASS + 1))
 else
-  echo "  FAIL  T1 deny -> coarse duplicate suppressed (1 total line, issue #787) (got $_t1_total_lines lines)"
-  FAIL=$((FAIL + 1)); FAILED_NAMES+=("T1 deny -> coarse duplicate suppressed")
+  echo "  FAIL  T1 ask -> coarse duplicate suppressed (1 total line, issue #787) (got $_t1_total_lines lines)"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("T1 ask -> coarse duplicate suppressed")
 fi
 
 # T2 ask fires -> 1 RICH record, decision=ask.
@@ -1397,7 +1398,7 @@ else
   FAIL=$((FAIL + 1)); FAILED_NAMES+=("silent pass -> no RICH telemetry record")
 fi
 
-# Missing session_id -> deny still fires (stdout unaffected). PR #796
+# Missing session_id -> the ask decision still fires (stdout unaffected). PR #796
 # CodeRabbit review: previously this early-returned before the RICH write,
 # dropping the decision from aggregate_fires()'s fires/block/ask totals
 # entirely. record_session_fire coerces a non-str session_id to "", and
@@ -1426,7 +1427,7 @@ import json, sys
 lines = [json.loads(l) for l in sys.stdin if l.strip()]
 ok = (
     len(lines) == 1
-    and lines[0].get('decision') == 'block'
+    and lines[0].get('decision') == 'ask'
     and lines[0].get('hook') == 'output-block-falsify-advisory'
     and lines[0].get('session_id') == ''
 )

--- a/tests/test_ask_option_text.py
+++ b/tests/test_ask_option_text.py
@@ -145,11 +145,11 @@ def _decision(stdout: str) -> str | None:
     return obj.get("hookSpecificOutput", {}).get("permissionDecision")
 
 
-def test_output_block_recommended_without_falsified_denies():
+def test_output_block_recommended_without_falsified_asks():
     payload = _make_ask_payload(["Option A (Recommended)", "Option B"])
     proc = _run_hook(OUTPUT_BLOCK, payload)
     assert proc.returncode == 0
-    assert _decision(proc.stdout) == "deny"
+    assert _decision(proc.stdout) == "ask"
 
 
 def test_output_block_recommended_with_falsified_line_silent():


### PR DESCRIPTION
Closes #899

## 배경

`output-block-falsify-advisory` 의 T1 — `(Recommended)`/`(추천)` 라벨에 `Falsified:` 줄이 없을 때 — 은 #393 에서 `ask` → `deny` 로 승격됐습니다. 근거는 **체계적 미준수**였습니다 (retrospect 2026-05-23: 3 콜, `Falsified:` 0건).

## 그 전제가 소멸했다는 실측

Claude Code 트랜스크립트 90일 전수 집계 (uuid 중복 제거):

| 주 | AQ 호출 | `(Recommended)` | `Falsified:` 줄 |
|---|---|---|---|
| 2026-W27 | 447 | 138 | 87 |
| 2026-W29 | 524 | 279 | 219 |
| 2026-W31 | 343 | 184 | **221** |

`Falsified:` 부착(221)이 `(Recommended)` 개수(184)를 초과합니다 — 훅이 발화하지 않는 호출에도 템플릿이 적용되는 과잉준수 상태.

## deny 가 남긴 비용

최근 30일 AskUserQuestion 결과 (트랜스크립트 이중기록 보정):

- **Falsified 줄 누락 차단 306건 — 전체 AQ 차단 사유의 48%**
- 224개 세션이 1건 이상 경험, 한 세션 최대 14회
- deny 는 재작성 후 재호출을 강제 → 차단 1건 = 왕복 1회

부작용으로 질문이 게이트 없는 산문 표면으로 이동했습니다 — AQ/1k 어시스턴트턴 9.25 → 6.36, 산문질문/AQ 1.71 → 2.08. 훅이 잡으려던 결함이 훅이 못 보는 곳에서 재생산됩니다.

## 변경

- T1 → `permissionDecision: ask` (#393 이전 복원). T2 `ask` 유지, T3 advisory 유지 → 티어 사다리 순서 보존
- fire-ledger 의 T1 기록도 `block` → `ask`
- T1 을 stderr advisory 까지 내리지 않은 이유: T2 가 `ask` 인데 T1 만 advisory 면 더 엄격해야 할 티어가 더 약해집니다

### 문서 정정 4곳

`spec.md` telemetry 서술 · `docs/hook/INDEX.md` 2곳(서문 + 표) · `hooks/completion-verify/negative-existence-verdict-gate/spec.md`.

마지막 항목은 주의가 필요합니다 — 그 훅의 `block` 기본값 근거 중 하나가 "`Falsified:` 선례(T1)가 hard deny"였습니다. 이 선례가 사라졌으므로 해당 기본값은 이제 **fire-rate 논거 하나에만** 의존합니다. 동작은 변경하지 않고 서술만 정정했습니다.

## 검증

```
$ python3 -m pytest tests/ -q
508 passed in 8.95s

$ bash tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
Results: 97 passed, 0 failed
```

실환경 기능 검증 (실제 훅에 실제 payload 투입):

```
$ echo '{"tool_name":"AskUserQuestion",...,"options":[{"label":"A안 (Recommended)"}]}' | python3 impl.py
permissionDecision = ask          # Falsified 없음 → soft gate

$ echo '{... "question":"Falsified: ...\n어느 방향?" ...}' | python3 impl.py
(빈 출력, exit 0)                  # Falsified 있음 → silent pass
```

- [x] T1 + `Falsified:` 부재 → `ask`
- [x] T1 + `Falsified:` 존재 → silent
- [x] T2 + `Falsified:` 부재 → `ask` (회귀 없음)
- [x] 둘 다 없음 → silent
- [x] 테스트 갱신 + 실행 출력 첨부
- [x] spec tier matrix 갱신

## 미검증 / 후속

준수율(221건)은 **deny 체제 하에서 측정된 값**이라 강제력 제거 후 감쇠할 가능성이 남습니다. 4주 뒤 `Falsified:` 부착률과 AQ/1k 를 재측정해 하락 시 재승격을 검토합니다.

## 리뷰 이력

Codex 리뷰 1라운드에서 P1 1건(pytest 계약 미갱신 → CI red) + P2 1건(잔존 hard-deny 문서) 지적, 둘 다 라이브 프로브로 확정 후 적용. 자체 sweep 에서 Codex 가 놓친 4번째 문서 사이트를 추가 발견해 함께 정정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Behavior Changes**
  - Updated recommended-case advisory handling to request confirmation instead of automatically blocking.
  - Retained confirmation prompts for confidence-anchoring cases.
  - Improved validation for falsification evidence, including placement, formatting, and completeness checks.

- **Documentation**
  - Updated guidance to reflect the revised confirmation behavior and block rationale.

- **Tests**
  - Expanded regression coverage for evidence validation, multiple questions, edge cases, and telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->