### PR TITLE
refactor(hook): extract shared external-write body module

### DIFF
--- a/hooks/_lib/_external_write_body.py
+++ b/hooks/_lib/_external_write_body.py
@@ -45,12 +45,19 @@ GH_BODY_FLAGS_WITH_ARG = frozenset({"-b", "--body", "-F", "--body-file"})
 
 
 def resolve_body(flag: str, value: str) -> str:
-    """Read body content. For --body-file, read file contents (best effort)."""
+    """Read body content. For --body-file, read file contents (best effort).
+
+    A non-UTF-8 file raises UnicodeDecodeError, which is not an OSError. Left
+    uncaught it escapes to the hook's `fail_open` wrapper, so ONE undecodable
+    body silently skips the whole call's scan — including sibling writes
+    chained in the same command. Same category as an unreadable file, so it
+    takes the same empty-body fallback and the other bodies still get scanned.
+    """
     if flag in {"-F", "--body-file"}:
         try:
             with open(value, encoding="utf-8") as fh:
                 return fh.read()
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             return ""  # treat unreadable file as empty body — advisory-only hooks
     return value
 

--- a/hooks/_lib/_external_write_body.py
+++ b/hooks/_lib/_external_write_body.py
@@ -1,0 +1,167 @@
+"""Shared external-write body extraction for PreToolUse hooks.
+
+Two hooks (`external-write-falsify-check`, `source-citation-probe-gate`)
+each carried a byte-identical copy of this surface detection + body
+extraction. Both specs recorded the repo's 2-copy convention with the
+same directive: extract to `_lib/_external_write_body.py` at the third
+consumer. This module is that extraction; the copies were semantically
+identical (comment wording aside), so migration is behavior-preserving
+and each hook's existing test suite is the parity oracle.
+
+What lives here is only "which tool calls write to an external surface,
+and what is the body text" — every claim-detection heuristic stays in the
+consuming hook, since that is what distinguishes them.
+"""
+from __future__ import annotations
+
+import re
+
+from _hook_utils import strip_prefix  # type: ignore[import-not-found]
+
+# ---------------------------------------------------------------------------
+# Bash gh detection
+# ---------------------------------------------------------------------------
+
+GH_GLOBAL_FLAGS_WITH_ARG = frozenset({
+    "-R", "--repo",
+    "--hostname",
+    "--color",
+})
+
+# `gh <obj> <sub>` pairs that write to external surfaces.
+# `pr review` accepts --body / -b / --body-file / -F and posts a public
+# review comment, so it belongs here alongside the comment/create/edit forms.
+GH_WRITE_SUBCOMMANDS = frozenset({
+    ("issue", "comment"),
+    ("pr", "comment"),
+    ("issue", "create"),
+    ("pr", "create"),
+    ("issue", "edit"),
+    ("pr", "edit"),
+    ("pr", "review"),
+})
+
+GH_BODY_FLAGS_WITH_ARG = frozenset({"-b", "--body", "-F", "--body-file"})
+
+
+def resolve_body(flag: str, value: str) -> str:
+    """Read body content. For --body-file, read file contents (best effort)."""
+    if flag in {"-F", "--body-file"}:
+        try:
+            with open(value, encoding="utf-8") as fh:
+                return fh.read()
+        except OSError:
+            return ""  # treat unreadable file as empty body — advisory-only hooks
+    return value
+
+
+def extract_gh_body(argv: list[str]) -> str | None:
+    """Pull body text from --body / --body-file in a gh argv. None if absent."""
+    for i, tok in enumerate(argv):
+        if "=" in tok:
+            key, _, val = tok.partition("=")
+            if key in GH_BODY_FLAGS_WITH_ARG:
+                return resolve_body(key, val)
+            continue
+        if tok in GH_BODY_FLAGS_WITH_ARG and i + 1 < len(argv):
+            return resolve_body(tok, argv[i + 1])
+    return None
+
+
+def is_gh_external_write(argv: list[str]) -> bool:
+    """Return True iff argv invokes a gh subcommand that writes to a public surface."""
+    argv = strip_prefix(argv)
+    if not argv or argv[0] != "gh":
+        return False
+
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        if tok == "--":
+            i += 1
+            break
+        if not tok.startswith("-"):
+            break
+        i += 1
+        if "=" not in tok and tok in GH_GLOBAL_FLAGS_WITH_ARG and i < len(argv):
+            i += 1
+
+    if i + 1 >= len(argv):
+        return False
+    obj, sub = argv[i], argv[i + 1]
+    return (obj, sub) in GH_WRITE_SUBCOMMANDS
+
+
+# ---------------------------------------------------------------------------
+# MCP detection
+# ---------------------------------------------------------------------------
+
+MCP_EXTERNAL_WRITE_PATTERNS = (
+    re.compile(r".*slack.*send.*", re.IGNORECASE),
+    re.compile(r".*slack.*post.*", re.IGNORECASE),
+    re.compile(r".*slack.*update.*", re.IGNORECASE),
+    re.compile(r".*notion.*create.*page.*", re.IGNORECASE),
+    re.compile(r".*notion.*update.*page.*", re.IGNORECASE),
+    re.compile(r".*notion.*append.*block.*", re.IGNORECASE),
+)
+
+
+def is_mcp_external_write(tool_name: str) -> bool:
+    return any(p.match(tool_name) for p in MCP_EXTERNAL_WRITE_PATTERNS)
+
+
+# Leaf keys whose value is body content (collect descendant strings).
+BODY_LEAF_KEYS = frozenset({
+    "text", "content", "body", "message", "page_content",
+})
+
+# Container keys that wrap block/rich-text lists. Inside a container we
+# traverse wrapper dicts (paragraph, heading_1, section, ...) until we hit
+# a body leaf or another container.
+BODY_CONTAINER_KEYS = frozenset({
+    "children", "blocks", "rich_text",
+})
+
+
+def _collect_under_leaf(node, parts: list[str]) -> None:
+    """Collect every string descendant. Called once a leaf key is entered."""
+    if isinstance(node, str):
+        parts.append(node)
+    elif isinstance(node, list):
+        for item in node:
+            _collect_under_leaf(item, parts)
+    elif isinstance(node, dict):
+        for val in node.values():
+            _collect_under_leaf(val, parts)
+
+
+def _walk_in_container(node, parts: list[str]) -> None:
+    """Inside `children` / `blocks` / `rich_text`: traverse wrapper dicts
+    transparently, switching to leaf-collection only at body keys."""
+    if isinstance(node, list):
+        for item in node:
+            _walk_in_container(item, parts)
+    elif isinstance(node, dict):
+        for key, val in node.items():
+            if isinstance(key, str) and key.lower() in BODY_LEAF_KEYS:
+                _collect_under_leaf(val, parts)
+            else:
+                _walk_in_container(val, parts)
+
+
+def extract_mcp_body(tool_input: dict) -> str:
+    """Body extraction from MCP tool_input gated by recognized entry points.
+
+    Gating on recognized container/leaf entry points keeps property metadata
+    (`properties.{name}.title[].text.content`) from surfacing as body.
+    """
+    parts: list[str] = []
+    for key, val in tool_input.items():
+        if not isinstance(key, str):
+            continue
+        kl = key.lower()
+        if kl in BODY_LEAF_KEYS:
+            _collect_under_leaf(val, parts)
+        elif kl in BODY_CONTAINER_KEYS:
+            _walk_in_container(val, parts)
+    return "\n".join(parts)

--- a/hooks/advisory-nudge/external-write-falsify-check/impl.py
+++ b/hooks/advisory-nudge/external-write-falsify-check/impl.py
@@ -56,7 +56,6 @@ from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     iter_command_starts,
     safe_tokenize,
-    strip_prefix,
 )
 from _transcript import TRANSCRIPT_SCAN_LINES  # type: ignore[import-not-found]  # noqa: E402
 
@@ -79,170 +78,16 @@ HYPOTHESIS_MARKERS_KO = (
 )
 
 
-# ---------------------------------------------------------------------------
-# Bash gh detection
-# ---------------------------------------------------------------------------
-
-GH_GLOBAL_FLAGS_WITH_ARG = frozenset({
-    "-R", "--repo",
-    "--hostname",
-    "--color",
-})
-
-# `gh <obj> <sub>` pairs that write to external surfaces.
-GH_WRITE_SUBCOMMANDS = frozenset({
-    ("issue", "comment"),
-    ("pr", "comment"),
-    ("issue", "create"),
-    ("pr", "create"),
-    ("issue", "edit"),
-    ("pr", "edit"),
-    ("pr", "review"),  # accepts --body / -b / --body-file / -F; posts public review comment
-})
-
-GH_BODY_FLAGS_WITH_ARG = frozenset({"-b", "--body", "-F", "--body-file"})
-
-
-def _resolve_body(flag: str, value: str) -> str:
-    """Read body content. For --body-file, read file contents (best effort)."""
-    if flag in {"-F", "--body-file"}:
-        try:
-            with open(value, encoding="utf-8") as fh:
-                return fh.read()
-        except OSError:
-            return ""  # treat unreadable file as empty body — advisory-only hook
-    return value
-
-
-def _extract_gh_body(argv: list[str]) -> str | None:
-    """Pull body text from --body / --body-file in a gh argv. None if absent.
-
-    `gh issue/pr comment` and friends only accept body via flags (--body / -b
-    / --body-file / -F per `gh <subcmd> --help`); positional form
-    `gh issue comment <num> "body"` is rejected by gh itself with
-    `accepts 1 arg(s)`. Detecting positional shape would only add noise on
-    already-invalid invocations, so this extractor is flag-only.
-    """
-    for i, tok in enumerate(argv):
-        if "=" in tok:
-            key, _, val = tok.partition("=")
-            if key in GH_BODY_FLAGS_WITH_ARG:
-                return _resolve_body(key, val)
-            continue
-        if tok in GH_BODY_FLAGS_WITH_ARG and i + 1 < len(argv):
-            return _resolve_body(tok, argv[i + 1])
-    return None
-
-
-def _is_gh_external_write(argv: list[str]) -> bool:
-    """Return True iff argv invokes a gh subcommand that writes to a public surface."""
-    argv = strip_prefix(argv)
-    if not argv or argv[0] != "gh":
-        return False
-
-    i = 1
-    while i < len(argv):
-        tok = argv[i]
-        if tok == "--":
-            i += 1
-            break
-        if not tok.startswith("-"):
-            break
-        i += 1
-        if "=" not in tok and tok in GH_GLOBAL_FLAGS_WITH_ARG and i < len(argv):
-            i += 1
-
-    if i + 1 >= len(argv):
-        return False
-    obj, sub = argv[i], argv[i + 1]
-    return (obj, sub) in GH_WRITE_SUBCOMMANDS
-
-
-# ---------------------------------------------------------------------------
-# MCP detection
-# ---------------------------------------------------------------------------
-
-MCP_EXTERNAL_WRITE_PATTERNS = (
-    re.compile(r".*slack.*send.*", re.IGNORECASE),
-    re.compile(r".*slack.*post.*", re.IGNORECASE),
-    re.compile(r".*slack.*update.*", re.IGNORECASE),
-    re.compile(r".*notion.*create.*page.*", re.IGNORECASE),
-    re.compile(r".*notion.*update.*page.*", re.IGNORECASE),
-    re.compile(r".*notion.*append.*block.*", re.IGNORECASE),
+# Shared surface detection + body extraction now lives in
+# `_lib/_external_write_body.py` (extracted at the 3rd consumer per repo
+# convention — see that module's docstring). Aliased to the previous
+# private names so call sites and tests stay unchanged.
+from _external_write_body import (  # type: ignore[import-not-found]  # noqa: E402
+    extract_gh_body as _extract_gh_body,
+    extract_mcp_body as _extract_mcp_body,
+    is_gh_external_write as _is_gh_external_write,
+    is_mcp_external_write as _is_mcp_external_write,
 )
-
-
-def _is_mcp_external_write(tool_name: str) -> bool:
-    return any(p.match(tool_name) for p in MCP_EXTERNAL_WRITE_PATTERNS)
-
-
-# Leaf keys whose value is body content (collect descendant strings).
-BODY_LEAF_KEYS = frozenset({
-    "text", "content", "body", "message", "page_content",
-})
-
-# Container keys that wrap block/rich-text lists. Inside a container we
-# traverse wrapper dicts (paragraph, heading_1, section, ...) until we hit
-# a body leaf or another container.
-BODY_CONTAINER_KEYS = frozenset({
-    "children", "blocks", "rich_text",
-})
-
-
-# [PR #179] P2: MCP payloads nest body text under shapes like Notion's
-# `children[].paragraph.rich_text[].text.content` (3 levels deep) and Slack's
-# `blocks[].text.text`. A flat top-level scan missed both. An unconstrained
-# recursive walk (earlier revision) over-collected siblings — page property
-# titles like `properties.Name.title[].text.content` would surface and trip
-# markers like "potential" / "likely" inside legitimate titles. So entry into
-# body subtrees is gated: top level accepts BODY_LEAF_KEYS or BODY_CONTAINER_KEYS;
-# inside containers, wrapper dicts (paragraph / section / heading_X) are
-# transparent — recursion continues until a leaf is reached.
-def _collect_under_leaf(node, parts: list[str]) -> None:
-    """Collect every string descendant. Called once a leaf key is entered."""
-    if isinstance(node, str):
-        parts.append(node)
-    elif isinstance(node, list):
-        for item in node:
-            _collect_under_leaf(item, parts)
-    elif isinstance(node, dict):
-        for val in node.values():
-            _collect_under_leaf(val, parts)
-
-
-def _walk_in_container(node, parts: list[str]) -> None:
-    """Inside `children` / `blocks` / `rich_text`: traverse wrapper dicts
-    (paragraph / section / heading_X) and nested containers transparently,
-    switching to leaf-collection only at body keys."""
-    if isinstance(node, list):
-        for item in node:
-            _walk_in_container(item, parts)
-    elif isinstance(node, dict):
-        for key, val in node.items():
-            if isinstance(key, str) and key.lower() in BODY_LEAF_KEYS:
-                _collect_under_leaf(val, parts)
-            else:
-                _walk_in_container(val, parts)
-
-
-def _extract_mcp_body(tool_input: dict) -> str:
-    """Body extraction from MCP tool_input gated by recognized entry points.
-
-    At the top level only BODY_LEAF_KEYS and BODY_CONTAINER_KEYS are
-    entered — sibling keys like `properties`, `parent`, `channel`, `title`
-    are ignored so that property metadata (e.g. Notion page property
-    titles under `properties.Name.title`) does not surface as body.
-    """
-    parts: list[str] = []
-    for key, val in tool_input.items():
-        if not isinstance(key, str):
-            continue
-        kl = key.lower()
-        if kl in BODY_LEAF_KEYS:
-            _collect_under_leaf(val, parts)
-        elif kl in BODY_CONTAINER_KEYS:
-            _walk_in_container(val, parts)
-    return "\n".join(parts)
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/advisory-nudge/source-citation-probe-gate/impl.py
+++ b/hooks/advisory-nudge/source-citation-probe-gate/impl.py
@@ -38,10 +38,9 @@ Exits 0 by default — advisory, not block. Set
 `PRAXIS_SOURCE_CITATION_STRICT=1` (literal "1" only) to convert into a
 hard block (exit 2).
 
-Body extraction (gh argv walk + MCP nested container/leaf walk) is copied
-from external-write-falsify-check (2 copies — DRY extraction to
-`_lib/_external_write_body.py` deferred to a 3rd consumer per repo
-convention).
+Body extraction (gh argv walk + MCP nested container/leaf walk) is shared
+with external-write-falsify-check via `_lib/_external_write_body.py`
+(extracted at the 3rd consumer per repo convention — issue #907).
 """
 from __future__ import annotations
 
@@ -56,150 +55,20 @@ from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     iter_command_starts,
     safe_tokenize,
-    strip_prefix,
 )
 from _transcript import TRANSCRIPT_SCAN_LINES  # type: ignore[import-not-found]  # noqa: E402
 
 
-# ---------------------------------------------------------------------------
-# Bash gh detection — copied from external-write-falsify-check (2nd copy)
-# ---------------------------------------------------------------------------
-
-GH_GLOBAL_FLAGS_WITH_ARG = frozenset({
-    "-R", "--repo",
-    "--hostname",
-    "--color",
-})
-
-# `gh <obj> <sub>` pairs that write to external surfaces.
-GH_WRITE_SUBCOMMANDS = frozenset({
-    ("issue", "comment"),
-    ("pr", "comment"),
-    ("issue", "create"),
-    ("pr", "create"),
-    ("issue", "edit"),
-    ("pr", "edit"),
-    ("pr", "review"),
-})
-
-GH_BODY_FLAGS_WITH_ARG = frozenset({"-b", "--body", "-F", "--body-file"})
-
-
-def _resolve_body(flag: str, value: str) -> str:
-    """Read body content. For --body-file, read file contents (best effort)."""
-    if flag in {"-F", "--body-file"}:
-        try:
-            with open(value, encoding="utf-8") as fh:
-                return fh.read()
-        except OSError:
-            return ""  # treat unreadable file as empty body — advisory-only hook
-    return value
-
-
-def _extract_gh_body(argv: list[str]) -> str | None:
-    """Pull body text from --body / --body-file in a gh argv. None if absent."""
-    for i, tok in enumerate(argv):
-        if "=" in tok:
-            key, _, val = tok.partition("=")
-            if key in GH_BODY_FLAGS_WITH_ARG:
-                return _resolve_body(key, val)
-            continue
-        if tok in GH_BODY_FLAGS_WITH_ARG and i + 1 < len(argv):
-            return _resolve_body(tok, argv[i + 1])
-    return None
-
-
-def _is_gh_external_write(argv: list[str]) -> bool:
-    """Return True iff argv invokes a gh subcommand that writes to a public surface."""
-    argv = strip_prefix(argv)
-    if not argv or argv[0] != "gh":
-        return False
-
-    i = 1
-    while i < len(argv):
-        tok = argv[i]
-        if tok == "--":
-            i += 1
-            break
-        if not tok.startswith("-"):
-            break
-        i += 1
-        if "=" not in tok and tok in GH_GLOBAL_FLAGS_WITH_ARG and i < len(argv):
-            i += 1
-
-    if i + 1 >= len(argv):
-        return False
-    obj, sub = argv[i], argv[i + 1]
-    return (obj, sub) in GH_WRITE_SUBCOMMANDS
-
-
-# ---------------------------------------------------------------------------
-# MCP detection — copied from external-write-falsify-check (2nd copy)
-# ---------------------------------------------------------------------------
-
-MCP_EXTERNAL_WRITE_PATTERNS = (
-    re.compile(r".*slack.*send.*", re.IGNORECASE),
-    re.compile(r".*slack.*post.*", re.IGNORECASE),
-    re.compile(r".*slack.*update.*", re.IGNORECASE),
-    re.compile(r".*notion.*create.*page.*", re.IGNORECASE),
-    re.compile(r".*notion.*update.*page.*", re.IGNORECASE),
-    re.compile(r".*notion.*append.*block.*", re.IGNORECASE),
+# Shared surface detection + body extraction now lives in
+# `_lib/_external_write_body.py` (extracted at the 3rd consumer per repo
+# convention — see that module's docstring). Aliased to the previous
+# private names so call sites and tests stay unchanged.
+from _external_write_body import (  # type: ignore[import-not-found]  # noqa: E402
+    extract_gh_body as _extract_gh_body,
+    extract_mcp_body as _extract_mcp_body,
+    is_gh_external_write as _is_gh_external_write,
+    is_mcp_external_write as _is_mcp_external_write,
 )
-
-
-def _is_mcp_external_write(tool_name: str) -> bool:
-    return any(p.match(tool_name) for p in MCP_EXTERNAL_WRITE_PATTERNS)
-
-
-# Leaf keys whose value is body content (collect descendant strings).
-BODY_LEAF_KEYS = frozenset({
-    "text", "content", "body", "message", "page_content",
-})
-
-# Container keys that wrap block/rich-text lists.
-BODY_CONTAINER_KEYS = frozenset({
-    "children", "blocks", "rich_text",
-})
-
-
-def _collect_under_leaf(node, parts: list[str]) -> None:
-    """Collect every string descendant. Called once a leaf key is entered."""
-    if isinstance(node, str):
-        parts.append(node)
-    elif isinstance(node, list):
-        for item in node:
-            _collect_under_leaf(item, parts)
-    elif isinstance(node, dict):
-        for val in node.values():
-            _collect_under_leaf(val, parts)
-
-
-def _walk_in_container(node, parts: list[str]) -> None:
-    """Inside `children` / `blocks` / `rich_text`: traverse wrapper dicts
-    transparently, switching to leaf-collection only at body keys."""
-    if isinstance(node, list):
-        for item in node:
-            _walk_in_container(item, parts)
-    elif isinstance(node, dict):
-        for key, val in node.items():
-            if isinstance(key, str) and key.lower() in BODY_LEAF_KEYS:
-                _collect_under_leaf(val, parts)
-            else:
-                _walk_in_container(val, parts)
-
-
-def _extract_mcp_body(tool_input: dict) -> str:
-    """Body extraction from MCP tool_input gated by recognized entry points."""
-    parts: list[str] = []
-    for key, val in tool_input.items():
-        if not isinstance(key, str):
-            continue
-        kl = key.lower()
-        if kl in BODY_LEAF_KEYS:
-            _collect_under_leaf(val, parts)
-        elif kl in BODY_CONTAINER_KEYS:
-            _walk_in_container(val, parts)
-    return "\n".join(parts)
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/advisory-nudge/source-citation-probe-gate/spec.md
+++ b/hooks/advisory-nudge/source-citation-probe-gate/spec.md
@@ -33,9 +33,9 @@ author-exempt Check 2 territory.
 | T2 | exact call syntax | inside **inline code spans (single backticks) only**: `name(...)` whose argument list contains `.` or `[` — the weakest detector by design |
 | T3 | test-semantics claim | `test*` token + `assert*` / `raise(s)` / `expect*` within an 80-char same-sentence window (case-insensitive) |
 
-Surfaces scanned (same extraction as `external-write-falsify-check` — gh
-argv walk + MCP nested container/leaf walk, 2nd copy per repo 2-copy
-convention):
+Surfaces scanned (shared with `external-write-falsify-check` — gh argv walk
++ MCP nested container/leaf walk, extracted to `_lib/_external_write_body.py`
+at the 3rd consumer per repo 2-copy convention, issue #907):
 
 - `gh issue|pr comment|create|edit`, `gh pr review` with `--body` / `-b` /
   `--body=` / `--body-file` / `-F` (file contents read best-effort)

--- a/hooks/advisory-nudge/source-citation-probe-gate/spec.md
+++ b/hooks/advisory-nudge/source-citation-probe-gate/spec.md
@@ -34,8 +34,9 @@ author-exempt Check 2 territory.
 | T3 | test-semantics claim | `test*` token + `assert*` / `raise(s)` / `expect*` within an 80-char same-sentence window (case-insensitive) |
 
 Surfaces scanned (shared with `external-write-falsify-check` — gh argv walk
-+ MCP nested container/leaf walk, extracted to `_lib/_external_write_body.py`
-at the 3rd consumer per repo 2-copy convention, issue #907):
+plus MCP nested container/leaf walk, extracted to
+`_lib/_external_write_body.py` at the 3rd consumer per repo 2-copy
+convention, issue #907):
 
 - `gh issue|pr comment|create|edit`, `gh pr review` with `--body` / `-b` /
   `--body=` / `--body-file` / `-F` (file contents read best-effort)


### PR DESCRIPTION
Closes #907

## 배경

`external-write-falsify-check` 와 `source-citation-probe-gate` 가 외부 쓰기 표면 감지 + body 추출 코드를 각각 사본으로 들고 있었습니다. 두 spec 이 레포의 2-copy 규약과 함께 동일한 지시를 기록해 두었고, #906 (caller-probe-gate) 이 3번째 소비자가 되면서 그 지시가 발동했습니다.

> 2 copies — DRY extraction to `_lib/_external_write_body.py` deferred to a 3rd consumer per repo convention

## 이관 전 확인

두 사본의 공유 함수·상수 13개를 대조했습니다. 차이는 **주석 문구뿐**이었습니다.

| 항목 | 차이 |
|---|---|
| `GH_WRITE_SUBCOMMANDS` | `pr review` 항목의 인라인 주석 유무 |
| `BODY_CONTAINER_KEYS` | 위쪽 설명 주석 3줄 유무 |
| 나머지 11개 | 완전 동일 |

실행 경로가 같으므로 동작 보존 리팩터이며, 각 훅의 기존 테스트 스위트가 그대로 parity 오라클이 됩니다.

## 변경

- `hooks/_lib/_external_write_body.py` 신설 — `is_gh_external_write` / `extract_gh_body` / `resolve_body` / `is_mcp_external_write` / `extract_mcp_body` + 관련 상수
- 두 훅 impl 에서 해당 구간 제거 후 import. **기존 private 이름으로 alias** 하여 호출부·테스트 무변경
- 이관 후 미사용이 된 `strip_prefix` import 제거 (F401)
- `source-citation-probe-gate` 의 spec/docstring 에서 "2 copies ... deferred to a 3rd consumer" 문구를 추출 완료 상태로 갱신

옮긴 범위는 "어떤 도구 호출이 외부 표면에 쓰는가 + body 텍스트는 무엇인가" 까지입니다. 각 훅을 구분짓는 주장 탐지 휴리스틱(가설 마커, 인용 tier, 해제 팔)은 소비하는 훅에 그대로 남겼습니다.

`_hook_utils` 를 `_lib` 모듈 안에서 import 하는 패턴은 `_lib/git_commit_titles.py:33` 의 기존 선례를 따랐습니다.

## 검증 (실제 출력)

```
$ bash tests/hooks/advisory-nudge/test_source_citation_probe_gate.sh
passed: 34, failed: 0

$ bash tests/hooks/advisory-nudge/test_external_write_falsify_check.sh
Result: 60 passed, 0 failed

$ ruff check hooks/_lib/_external_write_body.py \
    hooks/advisory-nudge/source-citation-probe-gate/impl.py \
    hooks/advisory-nudge/external-write-falsify-check/impl.py
All checks passed!
```

두 스위트 모두 **테스트 파일을 수정하지 않은 채** 통과했습니다 — 이것이 동작 동일성의 근거입니다.

codex-review-wrap 통과 (findings 0건). Codex 는 read-only 샌드박스의 `mktemp` 차단으로 shell 스위트를 직접 실행하지 못했고, ruff / diff check / dispatcher 실행 / 대표 입력 parity 비교로 검증했습니다. shell 스위트는 위와 같이 별도로 실행했습니다.

## 검증하지 않은 것

- 다른 플랫폼(codex / cursor / gemini / opencode) 빌드 산출물 재생성 — `_lib` 모듈 추가는 훅 엔트리 변경이 아니므로 `hooks/manifest.json` 무변경, 따라서 재생성 대상이 아니라고 판단했으나 실제 빌드는 돌리지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * External write checks now consistently recognize supported GitHub CLI actions and configured integrations.
  * Request content is extracted from direct text, container fields, and body files, including gracefully handling unreadable files.
* **Documentation**
  * Updated source-citation documentation to reflect the consolidated external-write handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->