### PR TITLE
refactor(hooks): consolidate runtime files under PRAXIS_HOME

### DIFF
--- a/docs/runtime-state-layout.md
+++ b/docs/runtime-state-layout.md
@@ -1,6 +1,6 @@
 # Praxis runtime state layout
 
-Praxis hooks and skills write four kinds of runtime files. Since praxis is
+Praxis hooks and skills write runtime files under six roots. Since praxis is
 multi-platform (Claude, Codex, Cursor, Gemini, OpenCode), these live under a
 **host-neutral** `~/.praxis` root rather than the Claude-nested legacy location.
 The resolver is [`hooks/_lib/_paths.py`](../hooks/_lib/_paths.py), mirrored for

--- a/docs/runtime-state-layout.md
+++ b/docs/runtime-state-layout.md
@@ -10,14 +10,14 @@ on opposite sides of that split.
 
 ## Roots
 
-| Root                       | Purpose                                            | Resolver                                | Override                                 |
-| -------------------------- | -------------------------------------------------- | --------------------------------------- | ---------------------------------------- |
-| `~/.praxis/state/`         | Durable, cross-session state                       | `praxis_state_dir()`                    | `PRAXIS_STATE_DIR` (base), `PRAXIS_HOME` |
-| `~/.praxis/cache/`         | Regenerable, session-scoped caches / dedup markers | `praxis_cache_dir()`, `resolve_cache_file()` | `PRAXIS_HOME`, per-file env         |
-| `~/.praxis/logs/`          | Diagnostics                                        | `resolve_writable("logs", …)`           | `PRAXIS_HOME`, per-file env              |
-| `~/.praxis/agent-reports/` | cmux-delegate completion reports                   | `skills/cmux-delegate/agent-report-path.sh` | `PRAXIS_HOME`                        |
-| `~/.praxis/telemetry/`     | fire / bypass event ledgers (daily rotation)       | `hooks/_lib/_fire_ledger.py`            | `PRAXIS_FIRE_TELEMETRY_FILE`, `PRAXIS_HOME` |
-| `~/.praxis/scope-confirm/` | Stop-gate block logs                               | `praxis_resolve_writable scope-confirm …` | `PRAXIS_HOME`                          |
+| Root                       | Purpose                                            | Resolver                                     | Override                                    |
+| -------------------------- | -------------------------------------------------- | -------------------------------------------- | ------------------------------------------- |
+| `~/.praxis/state/`         | Durable, cross-session state                       | `praxis_state_dir()`                         | `PRAXIS_STATE_DIR` (base), `PRAXIS_HOME`    |
+| `~/.praxis/cache/`         | Regenerable, session-scoped caches / dedup markers | `praxis_cache_dir()`, `resolve_cache_file()` | `PRAXIS_HOME`, per-file env                 |
+| `~/.praxis/logs/`          | Diagnostics                                        | `resolve_writable("logs", …)`                | `PRAXIS_HOME`, per-file env                 |
+| `~/.praxis/agent-reports/` | cmux-delegate completion reports                   | `skills/cmux-delegate/agent-report-path.sh`  | `PRAXIS_HOME`                               |
+| `~/.praxis/telemetry/`     | fire / bypass event ledgers (daily rotation)       | `hooks/_lib/_fire_ledger.py`                 | `PRAXIS_FIRE_TELEMETRY_FILE`, `PRAXIS_HOME` |
+| `~/.praxis/scope-confirm/` | Stop-gate block logs                               | `praxis_resolve_writable scope-confirm …`    | `PRAXIS_HOME`                               |
 
 `PRAXIS_HOME` relocates the whole tree — that is the single knob, and every
 runtime path praxis writes goes through one of the resolvers above so it stays
@@ -57,19 +57,19 @@ dir is not writable, and never raises.
 Session-scoped dedup and state files. All of these lived under `${TMPDIR}`
 before #903, which meant `PRAXIS_HOME` did not move them:
 
-| Entry                                  | Producer                          |
-| -------------------------------------- | --------------------------------- |
-| `session-intent-<sid>.json`            | `preflight-gate/session-intent`   |
+| Entry                                                              | Producer                                                                                     |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `session-intent-<sid>.json`                                        | `preflight-gate/session-intent`                                                              |
 | `retrospect-active-<sid>.json`, `retrospect-candidates-<sid>.json` | `preflight-gate/retrospect-active-marker` (read by `completion-verify/retrospect-mix-check`) |
-| `md-read-history-<sid>.json`           | `postuse-correction/pre-edit-md-escape-advisory` |
-| `postcompact-context-<sid>.json`       | `advisory-nudge/postcompact-context` |
-| `jq-config-advisory-<sid>.json`        | `advisory-nudge/jq-config-empty-dict-advisory` |
-| `path-probe-gate/`                     | `advisory-nudge/path-probe-gate`  |
-| `pre-output-falsification-gate/`       | `advisory-nudge/pre-output-falsification-gate` |
-| `bulk-write-checkpoint/`               | `advisory-nudge/bulk-write-memory-checkpoint` |
-| `bash-worktree-advisory/`              | `advisory-nudge/bash-worktree-existence-advisory` |
-| `gh-json-<sid>/`                       | `preflight-gate/gh-json-validator` |
-| `worktree-prune-snapshot-<sid>.json`   | `preflight-gate/worktree-prune-snapshot-gate` |
+| `md-read-history-<sid>.json`                                       | `postuse-correction/pre-edit-md-escape-advisory`                                             |
+| `postcompact-context-<sid>.json`                                   | `advisory-nudge/postcompact-context`                                                         |
+| `jq-config-advisory-<sid>.json`                                    | `advisory-nudge/jq-config-empty-dict-advisory`                                               |
+| `path-probe-gate/`                                                 | `advisory-nudge/path-probe-gate`                                                             |
+| `pre-output-falsification-gate/`                                   | `advisory-nudge/pre-output-falsification-gate`                                               |
+| `bulk-write-checkpoint/`                                           | `advisory-nudge/bulk-write-memory-checkpoint`                                                |
+| `bash-worktree-advisory/`                                          | `advisory-nudge/bash-worktree-existence-advisory`                                            |
+| `gh-json-<sid>/`                                                   | `preflight-gate/gh-json-validator`                                                           |
+| `worktree-prune-snapshot-<sid>.json`                               | `preflight-gate/worktree-prune-snapshot-gate`                                                |
 
 ### Sweeping
 

--- a/docs/runtime-state-layout.md
+++ b/docs/runtime-state-layout.md
@@ -1,21 +1,28 @@
 # Praxis runtime state layout
 
-Praxis hooks write three kinds of runtime files. Since praxis is multi-platform
-(Claude, Codex, Cursor, Gemini, OpenCode), these live under a **host-neutral**
-`~/.praxis` root rather than the Claude-nested legacy location. The resolver is
-[`hooks/_lib/_paths.py`](../hooks/_lib/_paths.py).
+Praxis hooks and skills write four kinds of runtime files. Since praxis is
+multi-platform (Claude, Codex, Cursor, Gemini, OpenCode), these live under a
+**host-neutral** `~/.praxis` root rather than the Claude-nested legacy location.
+The resolver is [`hooks/_lib/_paths.py`](../hooks/_lib/_paths.py), mirrored for
+pure-shell hooks by [`hooks/_lib/_paths.sh`](../hooks/_lib/_paths.sh) — the two
+must stay in agreement, since the writer and reader halves of a protocol can sit
+on opposite sides of that split.
 
 ## Roots
 
-| Root               | Purpose                                            | Resolver                      | Override                                 |
-| ------------------ | -------------------------------------------------- | ----------------------------- | ---------------------------------------- |
-| `~/.praxis/state/` | Durable, cross-session state                       | `praxis_state_dir()`          | `PRAXIS_STATE_DIR` (base), `PRAXIS_HOME` |
-| `~/.praxis/cache/` | Regenerable, session-scoped caches / dedup markers | `praxis_cache_dir()`          | `PRAXIS_HOME`                            |
-| `~/.praxis/logs/`  | Diagnostics                                        | `resolve_writable("logs", …)` | `PRAXIS_HOME`, per-file env              |
+| Root                       | Purpose                                            | Resolver                                | Override                                 |
+| -------------------------- | -------------------------------------------------- | --------------------------------------- | ---------------------------------------- |
+| `~/.praxis/state/`         | Durable, cross-session state                       | `praxis_state_dir()`                    | `PRAXIS_STATE_DIR` (base), `PRAXIS_HOME` |
+| `~/.praxis/cache/`         | Regenerable, session-scoped caches / dedup markers | `praxis_cache_dir()`, `resolve_cache_file()` | `PRAXIS_HOME`, per-file env         |
+| `~/.praxis/logs/`          | Diagnostics                                        | `resolve_writable("logs", …)`           | `PRAXIS_HOME`, per-file env              |
+| `~/.praxis/agent-reports/` | cmux-delegate completion reports                   | `skills/cmux-delegate/agent-report-path.sh` | `PRAXIS_HOME`                        |
+| `~/.praxis/telemetry/`     | fire / bypass event ledgers (daily rotation)       | `hooks/_lib/_fire_ledger.py`            | `PRAXIS_FIRE_TELEMETRY_FILE`, `PRAXIS_HOME` |
+| `~/.praxis/scope-confirm/` | Stop-gate block logs                               | `praxis_resolve_writable scope-confirm …` | `PRAXIS_HOME`                          |
 
-`PRAXIS_HOME` relocates the whole tree (used by tests for isolation).
-`resolve_writable` falls back to `${TMPDIR}/praxis-<file>` when the home dir is
-not writable, and never raises.
+`PRAXIS_HOME` relocates the whole tree — that is the single knob, and every
+runtime path praxis writes goes through one of the resolvers above so it stays
+true. `resolve_writable` falls back to `${TMPDIR}/praxis-<file>` when the home
+dir is not writable, and never raises.
 
 ## Durable state (`~/.praxis/state/`)
 
@@ -45,11 +52,48 @@ not writable, and never raises.
   [`hooks/_lib/_hook_runtime.py`](../hooks/_lib/_hook_runtime.py).
 - bypass telemetry — see [`bypass-telemetry.md`](bypass-telemetry.md).
 
-## Volatile caches (`~/.praxis/cache/`) — follow-up
+## Volatile caches (`~/.praxis/cache/`)
 
-The session-scoped `${TMPDIR}/praxis-*` dedup files (jq-config, path-probe,
-bulk-write, pre-output-falsification, bash-worktree, session-intent,
-postcompact-context, md-read-history, gh-json) are tracked for migration onto
-`praxis_cache_dir()` / `resolve_writable("cache", …)` in #527's follow-up. The
-foundation (`praxis_cache_dir()`) is in place; the consumers are swept
-separately to keep each hook's dedup-behaviour change reviewable in isolation.
+Session-scoped dedup and state files. All of these lived under `${TMPDIR}`
+before #903, which meant `PRAXIS_HOME` did not move them:
+
+| Entry                                  | Producer                          |
+| -------------------------------------- | --------------------------------- |
+| `session-intent-<sid>.json`            | `preflight-gate/session-intent`   |
+| `retrospect-active-<sid>.json`, `retrospect-candidates-<sid>.json` | `preflight-gate/retrospect-active-marker` (read by `completion-verify/retrospect-mix-check`) |
+| `md-read-history-<sid>.json`           | `postuse-correction/pre-edit-md-escape-advisory` |
+| `postcompact-context-<sid>.json`       | `advisory-nudge/postcompact-context` |
+| `jq-config-advisory-<sid>.json`        | `advisory-nudge/jq-config-empty-dict-advisory` |
+| `path-probe-gate/`                     | `advisory-nudge/path-probe-gate`  |
+| `pre-output-falsification-gate/`       | `advisory-nudge/pre-output-falsification-gate` |
+| `bulk-write-checkpoint/`               | `advisory-nudge/bulk-write-memory-checkpoint` |
+| `bash-worktree-advisory/`              | `advisory-nudge/bash-worktree-existence-advisory` |
+| `gh-json-<sid>/`                       | `preflight-gate/gh-json-validator` |
+| `worktree-prune-snapshot-<sid>.json`   | `preflight-gate/worktree-prune-snapshot-gate` |
+
+### Sweeping
+
+`${TMPDIR}` came with an OS janitor; `~/.praxis/cache/` does not, and these
+entries are session-keyed — one per session, indefinitely. `prune_stale` runs
+opportunistically from `resolve_writable("cache", …)` and drops entries past
+`PRAXIS_CACHE_TTL_DAYS` (default 7; `0` disables).
+
+### Back-compat (#903)
+
+`resolve_cache_file()` performs a one-time move of a pre-#903
+`${TMPDIR}/praxis-<name>` file into the cache root. Without it, a session that
+was already retrospect-active or intent-anchored when the upgrade landed would
+read the new path as "no state" and silently disarm its gate mid-session.
+
+## Agent reports (`~/.praxis/agent-reports/`)
+
+`cmux-delegate` writes one completion report per delegated task, named
+`<sha1(worktree absolute path)>.json`. Before #903 this was `.agent-report.json`
+at the worktree root — inside whatever repository the task happened to target.
+The delegator derives the same path from `{cwd}` via the shared helper and
+checks the report's own `worktree` field before trusting it.
+
+Reports are deliberately **not** swept by `prune_stale`. Absence of a report is
+the deterministic "incomplete" signal, so deleting one a delegator has not yet
+collected would manufacture exactly the false negative the file-based handoff
+exists to eliminate. They are small and one per delegated task.

--- a/hooks/_lib/_paths.py
+++ b/hooks/_lib/_paths.py
@@ -12,14 +12,22 @@ Layout (#527):
 
 Durable state migrated off the Claude-nested ${PRAXIS_STATE_DIR:-~/.claude/state/
 praxis} default reads back from `legacy_state_dir()` when the new location is
-empty so existing strike/phantom state survives the move. The volatile
-${TMPDIR}/praxis-* dedup files are tracked separately in #527's follow-up.
+empty so existing strike/phantom state survives the move.
+
+#903 finished the move: the volatile ${TMPDIR}/praxis-* dedup files #527 left
+behind now resolve through `resolve_writable("cache", ...)`, so PRAXIS_HOME
+relocates every runtime file praxis writes. `prune_stale` supplies the janitor
+TMPDIR used to provide for free. `_paths.sh` mirrors this module for pure-shell
+hooks — keep the two in agreement.
 """
 from __future__ import annotations
 
 import os
+import shutil
+import time
 
 _LEGACY_STATE_DIRNAME = ("~", ".claude", "state", "praxis")
+_DEFAULT_CACHE_TTL_DAYS = 7.0
 
 
 def praxis_home() -> str:
@@ -61,8 +69,83 @@ def resolve_writable(subdir: str, filename: str) -> str:
         d = os.path.join(praxis_home(), subdir)
         os.makedirs(d, exist_ok=True)
         if os.access(d, os.W_OK):
+            if subdir == "cache":
+                _ = prune_stale(d)
             return os.path.join(d, filename)
     except Exception:
         pass
     return os.path.join(_tmp_root(), "praxis-" + filename)
+
+
+def legacy_tmp_path(filename: str) -> str:
+    """The pre-#903 ${TMPDIR}/praxis-<filename> location for a cache entry."""
+    return os.path.join(_tmp_root().rstrip("/") or "/", "praxis-" + filename)
+
+
+def resolve_cache_file(filename: str) -> str:
+    """Cache path for `filename`, adopting the pre-#903 ${TMPDIR} file if present.
+
+    Session-scoped state (retrospect marker, session intent, dedup markers) is
+    written mid-session. Upgrading praxis while such a session is live would
+    otherwise strand the old file and read the new path as "no state" — for the
+    retrospect marker that means the Stop gate silently stops firing, the exact
+    failure #666 was opened for. The adoption is a one-time move, mirroring the
+    #527 strike-state migration in strike-counter/impl.sh.
+    """
+    path = resolve_writable("cache", filename)
+    legacy = legacy_tmp_path(filename)
+    if legacy != path and not os.path.exists(path) and os.path.exists(legacy):
+        try:
+            _ = shutil.move(legacy, path)
+        except (OSError, shutil.Error):
+            return legacy
+    return path
+
+
+def cache_ttl_days() -> float:
+    """Age past which a cache entry is swept. PRAXIS_CACHE_TTL_DAYS overrides;
+    0 or a malformed value disables the sweep."""
+    raw = os.environ.get("PRAXIS_CACHE_TTL_DAYS")
+    if raw is None:
+        return _DEFAULT_CACHE_TTL_DAYS
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return 0.0
+
+
+def prune_stale(directory: str, ttl_days: float | None = None) -> int:
+    """Delete entries in `directory` older than the cache TTL; return the count.
+
+    TMPDIR had an OS janitor behind it. ~/.praxis/cache does not, and these
+    files are session-keyed — one per session, forever — so the move off TMPDIR
+    (#903) trades a leak-free location for one that needs sweeping. Called
+    opportunistically from `resolve_writable`, which is already on the write
+    path of every cache consumer. Never raises: a failed sweep must not take a
+    hook down with it.
+    """
+    ttl = cache_ttl_days() if ttl_days is None else ttl_days
+    if ttl <= 0:
+        return 0
+
+    cutoff = time.time() - ttl * 86400
+    removed = 0
+    try:
+        entries = os.scandir(directory)
+    except OSError:
+        return 0
+
+    with entries:
+        for entry in entries:
+            try:
+                if entry.stat().st_mtime >= cutoff:
+                    continue
+                if entry.is_dir(follow_symlinks=False):
+                    shutil.rmtree(entry.path, ignore_errors=True)
+                else:
+                    os.unlink(entry.path)
+                removed += 1
+            except OSError:
+                continue
+    return removed
 

--- a/hooks/_lib/_paths.py
+++ b/hooks/_lib/_paths.py
@@ -98,7 +98,12 @@ def resolve_cache_file(filename: str) -> str:
         try:
             _ = shutil.move(legacy, path)
         except (OSError, shutil.Error):
-            return legacy
+            # The move usually fails because a concurrent hook process won the
+            # race and already moved it. Returning `legacy` unconditionally
+            # would send this process on writing to the old location that
+            # every later reader has stopped consulting.
+            if os.path.exists(legacy) and not os.path.exists(path):
+                return legacy
     return path
 
 
@@ -138,9 +143,11 @@ def prune_stale(directory: str, ttl_days: float | None = None) -> int:
     with entries:
         for entry in entries:
             try:
-                if entry.stat().st_mtime >= cutoff:
+                is_dir = entry.is_dir(follow_symlinks=False)
+                mtime = _newest_mtime(entry.path) if is_dir else entry.stat().st_mtime
+                if mtime >= cutoff:
                     continue
-                if entry.is_dir(follow_symlinks=False):
+                if is_dir:
                     shutil.rmtree(entry.path, ignore_errors=True)
                 else:
                     os.unlink(entry.path)
@@ -148,4 +155,26 @@ def prune_stale(directory: str, ttl_days: float | None = None) -> int:
             except OSError:
                 continue
     return removed
+
+
+def _newest_mtime(directory: str) -> float:
+    """Newest mtime among `directory` and everything below it.
+
+    A directory's own mtime tracks only its direct entries, so the session
+    trees the dedup hooks keep (`<cache>/path-probe-gate/<sid>/<key>`) look
+    untouched to the parent while a live session writes into them. Judging the
+    parent by its own mtime therefore deletes active state.
+    """
+    newest = 0.0
+    try:
+        newest = os.stat(directory).st_mtime
+    except OSError:
+        return newest
+    for root, _dirs, files in os.walk(directory):
+        for name in (root, *(os.path.join(root, f) for f in files)):
+            try:
+                newest = max(newest, os.stat(name).st_mtime)
+            except OSError:
+                continue
+    return newest
 

--- a/hooks/_lib/_paths.sh
+++ b/hooks/_lib/_paths.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# Host-neutral path resolver for praxis runtime files (issue #903).
+#
+# Shell equivalent of hooks/_lib/_paths.py. The two must agree: a hook ported
+# between languages, and the writer/reader halves of a protocol split across
+# them, resolve the same file. Layout and PRAXIS_HOME semantics are documented
+# in the Python module.
+#
+#   . "$(dirname "$0")/../../_lib/_paths.sh"
+#   log_dir="$(praxis_home)/scope-confirm"
+#   state="$(praxis_resolve_writable cache "retrospect-mix-$SESSION_ID")"
+#
+# Every function writes its result to stdout and never exits non-zero.
+
+# PRAXIS_HOME override, else ~/.praxis. Not created.
+praxis_home() {
+    if [ -n "${PRAXIS_HOME:-}" ]; then
+        printf '%s\n' "${PRAXIS_HOME%/}"
+    else
+        printf '%s\n' "$HOME/.praxis"
+    fi
+}
+
+# Durable, cross-session state root. An explicit PRAXIS_STATE_DIR always wins,
+# for back-compat with the pre-#527 convention. Not created.
+praxis_state_dir() {
+    if [ -n "${PRAXIS_STATE_DIR:-}" ]; then
+        printf '%s\n' "${PRAXIS_STATE_DIR%/}"
+    else
+        printf '%s\n' "$(praxis_home)/state"
+    fi
+}
+
+# Volatile, regenerable, session-scoped cache root. Not created.
+praxis_cache_dir() {
+    printf '%s\n' "$(praxis_home)/cache"
+}
+
+# Diagnostics root (hook errors, bypass telemetry). Not created.
+praxis_logs_dir() {
+    printf '%s\n' "$(praxis_home)/logs"
+}
+
+# Path under <praxis_home>/$1/$2, creating the directory. Falls back to
+# ${TMPDIR}/praxis-$2 when the home dir cannot be written, so a hook on a
+# read-only or unwritable HOME degrades instead of failing.
+praxis_resolve_writable() {
+    _prw_subdir="$1"
+    _prw_name="$2"
+    _prw_dir="$(praxis_home)/$_prw_subdir"
+
+    if mkdir -p "$_prw_dir" 2>/dev/null && [ -w "$_prw_dir" ]; then
+        printf '%s\n' "$_prw_dir/$_prw_name"
+    else
+        _prw_tmp="${TMPDIR:-/tmp}"
+        printf '%s\n' "${_prw_tmp%/}/praxis-$_prw_name"
+    fi
+
+    unset _prw_subdir _prw_name _prw_dir _prw_tmp
+}

--- a/hooks/_lib/_paths.sh
+++ b/hooks/_lib/_paths.sh
@@ -13,9 +13,23 @@
 # Every function writes its result to stdout and never exits non-zero.
 
 # PRAXIS_HOME override, else ~/.praxis. Not created.
+#
+# The tilde is expanded explicitly: an unquoted PRAXIS_HOME=~/praxis is expanded
+# by the assigning shell, but a quoted or exported-from-config one arrives here
+# literally, while _paths.py runs os.path.expanduser on the same value. Left
+# alone, shell and Python halves of one protocol resolve different directories.
 praxis_home() {
     if [ -n "${PRAXIS_HOME:-}" ]; then
-        printf '%s\n' "${PRAXIS_HOME%/}"
+        _ph_raw="${PRAXIS_HOME%/}"
+        # Held in a variable so the tilde stays a literal to match against
+        # rather than something the shell might try to expand here.
+        _ph_tilde='~'
+        case "$_ph_raw" in
+            "$_ph_tilde") _ph_raw="$HOME" ;;
+            "$_ph_tilde"/*) _ph_raw="$HOME/${_ph_raw#"$_ph_tilde"/}" ;;
+        esac
+        printf '%s\n' "$_ph_raw"
+        unset _ph_raw _ph_tilde
     else
         printf '%s\n' "$HOME/.praxis"
     fi

--- a/hooks/advisory-nudge/bash-worktree-existence-advisory/impl.py
+++ b/hooks/advisory-nudge/bash-worktree-existence-advisory/impl.py
@@ -42,7 +42,7 @@ Silent cases (no output emitted):
 
 Deduplication:
   Per-session marker files in
-  `${TMPDIR:-/tmp}/praxis-bash-worktree-advisory/<session_id>.<path-hash>.<state>`
+  `<PRAXIS_HOME>/cache/bash-worktree-advisory/<session_id>.<path-hash>.<state>`
   suppress repeat advisories for the same (session, path, state) triple.
   State is `missing`. If path state changes (e.g. directory is created),
   the old marker does not suppress the new state's advisory.
@@ -84,6 +84,7 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     filter_argv,
     tokenize_with_roles,
 )
+from _paths import praxis_cache_dir  # type: ignore[import-not-found]  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -95,7 +96,7 @@ OPT_OUT_MARKER = "# worktree-advisory:ack"
 # Dedupe dir — per-session markers suppress repeat advisories for the same
 # (path, state) pair. State is encoded in the marker filename suffix so that
 # a path transitioning from missing → exists triggers a fresh advisory.
-_DEDUPE_BASE = os.path.join(os.environ.get("TMPDIR", "/tmp"), "praxis-bash-worktree-advisory")
+_DEDUPE_BASE = os.path.join(praxis_cache_dir(), "bash-worktree-advisory")
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/advisory-nudge/bulk-write-memory-checkpoint/impl.py
+++ b/hooks/advisory-nudge/bulk-write-memory-checkpoint/impl.py
@@ -36,7 +36,7 @@ Bulk definition (mirrors path-probe-gate session-state keying):
 
   Session state is keyed on `session_id` from the stdin payload (the canonical
   session identity per Claude Code), stored under
-  `${TMPDIR:-/tmp}/praxis-bulk-write-checkpoint/<session_id_hash>/`.
+  `<PRAXIS_HOME>/cache/bulk-write-checkpoint/<session_id_hash>/`.
   This mirrors path-probe-gate's (session_id, parent_hash) dedup pattern.
 
 Behavior:
@@ -60,6 +60,7 @@ import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
+from _paths import praxis_cache_dir  # type: ignore[import-not-found]  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Advisory message
@@ -155,9 +156,7 @@ def _extract_file_path(payload: dict) -> str:
 # Session-scoped write counter (keyed on session_id + SOT bucket)
 # ---------------------------------------------------------------------------
 
-_STATE_BASE = os.path.join(
-    os.environ.get("TMPDIR", "/tmp"), "praxis-bulk-write-checkpoint"
-)
+_STATE_BASE = os.path.join(praxis_cache_dir(), "bulk-write-checkpoint")
 
 # Per-session global write counter across all SOT paths (tracks total SOT writes).
 # Stored as a simple touch-marker per (session_hash, bucket_hash).

--- a/hooks/advisory-nudge/jq-config-empty-dict-advisory/impl.py
+++ b/hooks/advisory-nudge/jq-config-empty-dict-advisory/impl.py
@@ -37,7 +37,7 @@ Actions:
 
 Deduplicated per session_id + path so the nudge fires at most once per
 advisory-emitting invocation per session. Session-state file:
-  ${TMPDIR:-/tmp}/praxis-jq-config-advisory-<session_id>.json
+  <PRAXIS_HOME>/cache/jq-config-advisory-<session_id>.json
 
 Fail-open contract:
   • malformed JSON / non-Bash payload → exit 0
@@ -63,6 +63,7 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     strip_prefix,
     _coalesce_subst_runs,
 )
+from _paths import resolve_cache_file  # type: ignore[import-not-found]  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -349,11 +350,8 @@ def _extract_session_id(payload: dict) -> Optional[str]:
 
 
 def _resolve_dedup_path(session_id: Optional[str]) -> str:
-    tmp = os.environ.get("TMPDIR", "/tmp").rstrip("/") or "/tmp"
-    if session_id:
-        return os.path.join(tmp, f"praxis-jq-config-advisory-{session_id}.json")
-    ppid = os.getppid()
-    return os.path.join(tmp, f"praxis-jq-config-advisory-{ppid}.json")
+    key = session_id or str(os.getppid())
+    return resolve_cache_file(f"jq-config-advisory-{key}.json")
 
 
 def _load_seen(path: str) -> set:

--- a/hooks/advisory-nudge/path-probe-gate/impl.py
+++ b/hooks/advisory-nudge/path-probe-gate/impl.py
@@ -43,7 +43,7 @@ Bypass:
 
 State:
   Session-scoped enumeration markers under:
-    ${TMPDIR:-/tmp}/praxis-path-probe-gate/<session_id_hash>/<parent_hash>
+    <PRAXIS_HOME>/cache/path-probe-gate/<session_id_hash>/<parent_hash>
   A marker's presence means the parent was enumerated this session.
   Stale markers are cleaned up by the OS tmp purge policy.
 
@@ -66,6 +66,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
+from _paths import praxis_cache_dir  # type: ignore[import-not-found]  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -102,9 +103,7 @@ _DENY_TMPL = (
     "  NotebookEdit are monitored by this hook.\n"
 )
 
-_STATE_BASE = os.path.join(
-    os.environ.get("TMPDIR", "/tmp"), "praxis-path-probe-gate"
-)
+_STATE_BASE = os.path.join(praxis_cache_dir(), "path-probe-gate")
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/advisory-nudge/postcompact-context/impl.py
+++ b/hooks/advisory-nudge/postcompact-context/impl.py
@@ -41,7 +41,7 @@ On every `UserPromptSubmit`:
 State file
 ==========
 
-`${TMPDIR:-/tmp}/praxis-postcompact-context-${session_id}.json`
+`<PRAXIS_HOME>/cache/postcompact-context-${session_id}.json`
 
 Path resolution: `PRAXIS_POSTCOMPACT_CONTEXT_FILE` env override → session_id
 keyed file. The PPID fallback used by sibling `preflight-gate/session-intent`
@@ -75,7 +75,11 @@ import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
-from _paths import praxis_state_dir, legacy_state_dir  # type: ignore[import-not-found]  # noqa: E402
+from _paths import (  # type: ignore[import-not-found]  # noqa: E402
+    legacy_state_dir,
+    praxis_state_dir,
+    resolve_cache_file,
+)
 
 DEFAULT_TAIL_LINES = 100
 BYPASS_ENV = "PRAXIS_HOOK_BYPASS_POSTCOMPACT_CONTEXT"
@@ -98,7 +102,7 @@ def resolve_state_path(session_id: str) -> str:
     """Resolve the dedup state file path.
 
     Priority: `PRAXIS_POSTCOMPACT_CONTEXT_FILE` env override → `session_id`
-    keyed file under `${TMPDIR:-/tmp}`. The caller is responsible for
+    keyed file under `<PRAXIS_HOME>/cache`. The caller is responsible for
     rejecting missing session_id BEFORE calling this — `main()` already
     does so, so no PPID fallback is needed (the session-intent hook keeps
     one only to support direct CLI / test invocation without a payload).
@@ -106,8 +110,7 @@ def resolve_state_path(session_id: str) -> str:
     explicit = os.environ.get(STATE_FILE_ENV, "").strip()
     if explicit:
         return explicit
-    tmp = os.environ.get("TMPDIR", "/tmp").rstrip("/")
-    return os.path.join(tmp, f"praxis-postcompact-context-{session_id}.json")
+    return resolve_cache_file(f"postcompact-context-{session_id}.json")
 
 
 def read_state(path: str) -> dict:

--- a/hooks/advisory-nudge/pre-output-falsification-gate/impl.py
+++ b/hooks/advisory-nudge/pre-output-falsification-gate/impl.py
@@ -66,6 +66,7 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
 )
 from ask_option_text import collect_option_texts  # type: ignore[import-not-found]  # noqa: E402
 from _transcript import TRANSCRIPT_SCAN_LINES  # type: ignore[import-not-found]  # noqa: E402
+from _paths import praxis_cache_dir  # type: ignore[import-not-found]  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -127,9 +128,7 @@ REPEAT_THRESHOLD = 3
 # is reset (codex review #487: monotonic counter nagged on legitimate repeats).
 _REPEAT_WINDOW_SECONDS = 300
 
-_STATE_BASE = os.path.join(
-    os.environ.get("TMPDIR", "/tmp"), "praxis-pre-output-falsification-gate"
-)
+_STATE_BASE = os.path.join(praxis_cache_dir(), "pre-output-falsification-gate")
 
 # ---------------------------------------------------------------------------
 # Lane A — AskUserQuestion evaluative-option gate

--- a/hooks/completion-verify/completion-verify/impl.sh
+++ b/hooks/completion-verify/completion-verify/impl.sh
@@ -32,12 +32,24 @@ TELEMETRY_SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // ""')
 # shellcheck source=../../_lib/record_fire.sh
 . "$(dirname "$0")/../../_lib/record_fire.sh" 2>/dev/null || true
 # shellcheck source=../../_lib/_paths.sh
-. "$(dirname "$0")/../../_lib/_paths.sh"
+# A POSIX shell aborts outright when `.` cannot find the file, so the guard
+# below is unreachable without this — the degraded path must stay reachable.
+. "$(dirname "$0")/../../_lib/_paths.sh" 2>/dev/null || true
 # A missing _paths.sh must not read as "no state" — that silently disarms the
-# gate below, which is the failure mode this hook exists to prevent. Surface it.
+# gate below. Exit 0 means "pass" here, so bailing out on a broken install
+# would drop completion verification entirely; degrade to the pre-#903 inline
+# expansion instead and keep verifying.
 if ! command -v praxis_resolve_writable >/dev/null 2>&1; then
-  echo "praxis: hooks/_lib/_paths.sh unreadable — broken install, completion-verify disarmed" >&2
-  exit 0
+  echo "praxis: hooks/_lib/_paths.sh unreadable — broken install, completion-verify running on the inline path default" >&2
+  praxis_resolve_writable() {
+    _prw_dir="${PRAXIS_HOME:-$HOME/.praxis}/$1"
+    if mkdir -p "$_prw_dir" 2>/dev/null && [ -w "$_prw_dir" ]; then
+      printf '%s\n' "$_prw_dir/$2"
+    else
+      printf '%s\n' "${TMPDIR:-/tmp}/praxis-$2"
+    fi
+    unset _prw_dir
+  }
 fi
 command -v praxis_fire_arm >/dev/null 2>&1 && \
   praxis_fire_arm completion-verify completion-verify "$TELEMETRY_SESSION_ID" ""

--- a/hooks/completion-verify/completion-verify/impl.sh
+++ b/hooks/completion-verify/completion-verify/impl.sh
@@ -31,6 +31,14 @@ TELEMETRY_SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // ""')
 
 # shellcheck source=../../_lib/record_fire.sh
 . "$(dirname "$0")/../../_lib/record_fire.sh" 2>/dev/null || true
+# shellcheck source=../../_lib/_paths.sh
+. "$(dirname "$0")/../../_lib/_paths.sh"
+# A missing _paths.sh must not read as "no state" — that silently disarms the
+# gate below, which is the failure mode this hook exists to prevent. Surface it.
+if ! command -v praxis_resolve_writable >/dev/null 2>&1; then
+  echo "praxis: hooks/_lib/_paths.sh unreadable — broken install, completion-verify disarmed" >&2
+  exit 0
+fi
 command -v praxis_fire_arm >/dev/null 2>&1 && \
   praxis_fire_arm completion-verify completion-verify "$TELEMETRY_SESSION_ID" ""
 
@@ -141,8 +149,8 @@ else
 fi
 
 if [ -n "$block_reason" ]; then
-  mkdir -p "${PRAXIS_HOME:-$HOME/.praxis}/scope-confirm" || true
-  echo "$(date -Iseconds) session=$SESSION_ID blocked_completion_without_evidence" >> "${PRAXIS_HOME:-$HOME/.praxis}/scope-confirm/stop-triggered.log" || true
+  _log="$(praxis_resolve_writable scope-confirm stop-triggered.log)"
+  echo "$(date -Iseconds) session=$SESSION_ID blocked_completion_without_evidence" >> "$_log" || true
 
   PRAXIS_FIRE_DECISION=block
   REASON="Completion claim detected without same-turn verification evidence. ${block_reason} See AGENTS.md Verification section."

--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -42,6 +42,14 @@ TELEMETRY_SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // ""')
 
 # shellcheck source=../../_lib/record_fire.sh
 . "$(dirname "$0")/../../_lib/record_fire.sh" 2>/dev/null || true
+# shellcheck source=../../_lib/_paths.sh
+. "$(dirname "$0")/../../_lib/_paths.sh"
+# A missing _paths.sh must not read as "no state" — that silently disarms the
+# gate below, which is the failure mode this hook exists to prevent. Surface it.
+if ! command -v praxis_resolve_writable >/dev/null 2>&1; then
+  echo "praxis: hooks/_lib/_paths.sh unreadable — broken install, retrospect-mix-check disarmed" >&2
+  exit 0
+fi
 command -v praxis_fire_arm >/dev/null 2>&1 && \
   praxis_fire_arm retrospect-mix-check completion-verify "$TELEMETRY_SESSION_ID" ""
 
@@ -181,8 +189,20 @@ printf '%s\n' "$LAST_TEXT" | grep -qE '^[[:space:]]*\|[[:space:]:|-]*-[[:space:]
 # gate (incl. Gate-7) — "the gate exists but does not fire". Close that here,
 # BEFORE the format-keyed pass-throughs run.
 RETRO_ACTIVE=false
-_RM_TMP="${TMPDIR:-/tmp}"; _RM_TMP="${_RM_TMP%/}"
-MARKER_FILE="${PRAXIS_RETROSPECT_ACTIVE_FILE:-${_RM_TMP}/praxis-retrospect-active-${SESSION_ID}.json}"
+# [#903] The marker moved from ${TMPDIR} to <praxis_home>/cache. A session that
+# was already retrospect-active when the upgrade landed still has its marker at
+# the old path, so fall back to it for reads — otherwise the gate goes silent
+# mid-retrospect, which is the failure #666 was opened for.
+if [ -n "${PRAXIS_RETROSPECT_ACTIVE_FILE:-}" ]; then
+  MARKER_FILE="$PRAXIS_RETROSPECT_ACTIVE_FILE"
+else
+  MARKER_FILE="$(praxis_resolve_writable cache "retrospect-active-${SESSION_ID}.json")"
+  if [ ! -f "$MARKER_FILE" ]; then
+    _RM_TMP="${TMPDIR:-/tmp}"; _RM_TMP="${_RM_TMP%/}"
+    _RM_LEGACY="${_RM_TMP}/praxis-retrospect-active-${SESSION_ID}.json"
+    [ -f "$_RM_LEGACY" ] && MARKER_FILE="$_RM_LEGACY"
+  fi
+fi
 [ -f "$MARKER_FILE" ] && RETRO_ACTIVE=true
 
 if [ "$RETRO_ACTIVE" = "true" ]; then
@@ -195,9 +215,9 @@ if [ "$RETRO_ACTIVE" = "true" ]; then
     # no Stage-4 marker, distribution fence absent. The mix-check gates cannot
     # evaluate the report. Block. (A retrospect-active stop WITHOUT a table is a
     # legitimate pre-Stage-3 prose clarification — not gated.)
-    mkdir -p "${PRAXIS_HOME:-$HOME/.praxis}/scope-confirm" || true
+    _log="$(praxis_resolve_writable scope-confirm retrospect-mix-blocked.log)"
     echo "$(date -Iseconds) session=$SESSION_ID blocked_retrospect_fence_omission" \
-      >> "${PRAXIS_HOME:-$HOME/.praxis}/scope-confirm/retrospect-mix-blocked.log" || true
+      >> "$_log" || true
     fence_reason="Retrospect Stage 3 distribution fence missing (issue #666). This is a retrospect-active session (the retrospect skill was invoked this turn) presenting a findings table, but the assistant message carries no '<!-- retrospect:distribution begin -->' fence and no '## Actions Executed' marker. A free-form or localized Stage 3 report bypasses every mix-check gate (Gate-1..7) because the gates key on the canonical output schema. Re-emit the Stage 3 output per the Output Schema Contract in skills/retrospect/references/stage3-reporting.md: '## Retrospect Report' header -> audit fences -> '<!-- retrospect:distribution begin/end -->' card -> unified findings table."
     PRAXIS_FIRE_DECISION=block
     jq -n --arg r "$fence_reason" '{decision: "block", reason: $r}'
@@ -1005,8 +1025,8 @@ if [ "${#GATE10_VIOLATIONS[@]}" -gt 0 ]; then
 fi
 
 if [ "$should_block" = "true" ]; then
-  mkdir -p "${PRAXIS_HOME:-$HOME/.praxis}/scope-confirm" || true
-  echo "$(date -Iseconds) session=$SESSION_ID blocked_retrospect_mix_check" >> "${PRAXIS_HOME:-$HOME/.praxis}/scope-confirm/retrospect-mix-blocked.log" || true
+  _log="$(praxis_resolve_writable scope-confirm retrospect-mix-blocked.log)"
+  echo "$(date -Iseconds) session=$SESSION_ID blocked_retrospect_mix_check" >> "$_log" || true
 
   # Build reason string with ' | ' separator.
   reason=""

--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -43,12 +43,24 @@ TELEMETRY_SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // ""')
 # shellcheck source=../../_lib/record_fire.sh
 . "$(dirname "$0")/../../_lib/record_fire.sh" 2>/dev/null || true
 # shellcheck source=../../_lib/_paths.sh
-. "$(dirname "$0")/../../_lib/_paths.sh"
+# A POSIX shell aborts outright when `.` cannot find the file, so the guard
+# below is unreachable without this — the degraded path must stay reachable.
+. "$(dirname "$0")/../../_lib/_paths.sh" 2>/dev/null || true
 # A missing _paths.sh must not read as "no state" — that silently disarms the
-# gate below, which is the failure mode this hook exists to prevent. Surface it.
+# gate below. Exit 0 means "pass" here, so bailing out on a broken install
+# would drop the check entirely; degrade to the pre-#903 inline expansion
+# instead and keep checking.
 if ! command -v praxis_resolve_writable >/dev/null 2>&1; then
-  echo "praxis: hooks/_lib/_paths.sh unreadable — broken install, retrospect-mix-check disarmed" >&2
-  exit 0
+  echo "praxis: hooks/_lib/_paths.sh unreadable — broken install, retrospect-mix-check running on the inline path default" >&2
+  praxis_resolve_writable() {
+    _prw_dir="${PRAXIS_HOME:-$HOME/.praxis}/$1"
+    if mkdir -p "$_prw_dir" 2>/dev/null && [ -w "$_prw_dir" ]; then
+      printf '%s\n' "$_prw_dir/$2"
+    else
+      printf '%s\n' "${TMPDIR:-/tmp}/praxis-$2"
+    fi
+    unset _prw_dir
+  }
 fi
 command -v praxis_fire_arm >/dev/null 2>&1 && \
   praxis_fire_arm retrospect-mix-check completion-verify "$TELEMETRY_SESSION_ID" ""

--- a/hooks/completion-verify/strike-counter/impl.sh
+++ b/hooks/completion-verify/strike-counter/impl.sh
@@ -44,12 +44,18 @@ fi
 # (PRAXIS_HOME-aware); PRAXIS_STATE_DIR still overrides the base (back-compat).
 # [#903] Resolution moved into _paths.sh so shell and Python agree on one rule.
 # shellcheck source=../../_lib/_paths.sh
-. "$(dirname "$0")/../../_lib/_paths.sh"
+# A POSIX shell aborts outright when `.` cannot find the file, so the guard
+# below is unreachable without this — the degraded path must stay reachable.
+. "$(dirname "$0")/../../_lib/_paths.sh" 2>/dev/null || true
 # A missing _paths.sh must not read as "no state" — that silently disarms the
-# gate below, which is the failure mode this hook exists to prevent. Surface it.
-if ! command -v praxis_resolve_writable >/dev/null 2>&1; then
-  echo "praxis: hooks/_lib/_paths.sh unreadable — broken install, strike-counter disarmed" >&2
-  exit 0
+# gate below. Exit 0 means "pass" here, so bailing out on a broken install
+# would drop strike enforcement entirely; degrade to the pre-#903 inline
+# expansion instead and keep enforcing.
+if ! command -v praxis_state_dir >/dev/null 2>&1; then
+  echo "praxis: hooks/_lib/_paths.sh unreadable — broken install, strike-counter running on the inline path default" >&2
+  praxis_state_dir() {
+    printf '%s\n' "${PRAXIS_STATE_DIR:-${PRAXIS_HOME:-$HOME/.praxis}/state}"
+  }
 fi
 STATE_DIR="$(praxis_state_dir)/strikes"
 # One-time migration: if no override is set and the new location does not yet

--- a/hooks/completion-verify/strike-counter/impl.sh
+++ b/hooks/completion-verify/strike-counter/impl.sh
@@ -42,7 +42,16 @@ fi
 # cleanup/uninstall.
 # [#527] Durable state lives under the host-neutral ~/.praxis/state by default
 # (PRAXIS_HOME-aware); PRAXIS_STATE_DIR still overrides the base (back-compat).
-STATE_DIR="${PRAXIS_STATE_DIR:-${PRAXIS_HOME:-$HOME/.praxis}/state}/strikes"
+# [#903] Resolution moved into _paths.sh so shell and Python agree on one rule.
+# shellcheck source=../../_lib/_paths.sh
+. "$(dirname "$0")/../../_lib/_paths.sh"
+# A missing _paths.sh must not read as "no state" — that silently disarms the
+# gate below, which is the failure mode this hook exists to prevent. Surface it.
+if ! command -v praxis_resolve_writable >/dev/null 2>&1; then
+  echo "praxis: hooks/_lib/_paths.sh unreadable — broken install, strike-counter disarmed" >&2
+  exit 0
+fi
+STATE_DIR="$(praxis_state_dir)/strikes"
 # One-time migration: if no override is set and the new location does not yet
 # exist but the pre-#527 ~/.claude/state/praxis/strikes does, move the strike
 # state across so existing counters/latches survive the relocation.

--- a/hooks/postuse-correction/pre-edit-md-escape-advisory/impl.py
+++ b/hooks/postuse-correction/pre-edit-md-escape-advisory/impl.py
@@ -41,8 +41,8 @@ Resolution order:
      tests for isolation.
   2. `session_id` from the hook payload (primary key — stable across
      PreToolUse / PostToolUse invocations within a single Claude Code
-     session) → `${TMPDIR:-/tmp}/praxis-md-read-history-<session_id>.json`.
-  3. `${TMPDIR:-/tmp}/praxis-md-read-history-${PPID}.json` — last-resort
+     session) → `<PRAXIS_HOME>/cache/md-read-history-<session_id>.json`.
+  3. `<PRAXIS_HOME>/cache/md-read-history-${PPID}.json` — last-resort
      back-compat fallback when the payload does not carry a `session_id`
      (e.g., direct CLI / test invocation).
 
@@ -110,6 +110,7 @@ from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
+from _paths import resolve_cache_file  # type: ignore[import-not-found]  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -168,11 +169,8 @@ def resolve_history_path(session_id: str | None = None) -> str:
     if override:
         return override
 
-    tmp = os.environ.get("TMPDIR", "/tmp").rstrip("/") or "/tmp"
-    if session_id:
-        return os.path.join(tmp, f"praxis-md-read-history-{session_id}.json")
-    ppid = os.getppid()
-    return os.path.join(tmp, f"praxis-md-read-history-{ppid}.json")
+    key = session_id or str(os.getppid())
+    return resolve_cache_file(f"md-read-history-{key}.json")
 
 
 def load_history(path: str) -> dict:

--- a/hooks/preflight-gate/gh-json-validator/impl.py
+++ b/hooks/preflight-gate/gh-json-validator/impl.py
@@ -42,6 +42,7 @@ from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
+from _paths import praxis_cache_dir  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     iter_command_starts,
     safe_tokenize,
@@ -69,7 +70,7 @@ _EXCLUDED_FIRST_TOKENS: frozenset[str] = frozenset({"api"})
 
 def _session_cache_dir(session_id: str) -> Path:
     """Return per-session cache directory for gh JSON field sets."""
-    return Path(f"/tmp/praxis-gh-json-{session_id}")
+    return Path(praxis_cache_dir()) / f"gh-json-{session_id}"
 
 
 def _cache_key(subcommand_tokens: tuple[str, ...]) -> str:

--- a/hooks/preflight-gate/gh-json-validator/spec.md
+++ b/hooks/preflight-gate/gh-json-validator/spec.md
@@ -63,13 +63,14 @@ Available fields:
 ### Caching
 
 Field sets are cached per subcommand under
-`/tmp/praxis-gh-json-<session_id>/` as JSON files (one per subcommand
-shape). Cache is session-scoped — a new session starts with a fresh
-cache. `PPID` is used as the session_id fallback for direct CLI / test
-invocation.
+`<PRAXIS_HOME>/cache/gh-json-<session_id>/` as JSON files (one per
+subcommand shape). Cache is session-scoped — a new session starts with a
+fresh cache. `PPID` is used as the session_id fallback for direct CLI /
+test invocation.
 
-Override `PRAXIS_GH_JSON_CACHE_DIR` is not required; the `/tmp/` path is
-sufficient for session-scoped state.
+The location follows `praxis_cache_dir()` (#903), so `PRAXIS_HOME`
+relocates it along with every other praxis runtime file; entries are
+swept by `prune_stale` once past the cache TTL.
 
 ### Closest-match suggestion
 

--- a/hooks/preflight-gate/retrospect-active-marker/impl.py
+++ b/hooks/preflight-gate/retrospect-active-marker/impl.py
@@ -41,11 +41,12 @@ that still routes through the Skill tool.
 
 State file (priority order)
   1. `PRAXIS_RETROSPECT_ACTIVE_FILE` env var (explicit override for tests).
-  2. `${TMPDIR:-/tmp}/praxis-retrospect-active-${session_id}.json` — the
-     canonical praxis hook session key (same field consumed by
-     `session-intent`, `retrospect-mix-check.sh`, `strike-counter.sh`).
-  3. `${TMPDIR:-/tmp}/praxis-retrospect-active-${PPID}.json` back-compat
-     fallback when no `session_id` is supplied (direct CLI / test usage).
+  2. `<PRAXIS_HOME>/cache/retrospect-active-${session_id}.json` — the canonical
+     praxis hook session key (same field consumed by `session-intent`,
+     `retrospect-mix-check.sh`, `strike-counter.sh`). Pre-#903 this lived in
+     `${TMPDIR}`; `resolve_cache_file` adopts that file if it is still there.
+  3. `${PPID}` replaces `${session_id}` in the filename when no `session_id`
+     is supplied (direct CLI / test usage).
 
 Fail-open everywhere — malformed payloads / unwritable state exit 0 silently.
 The hook never blocks; it only records side-effect state for the Stop gate.
@@ -64,6 +65,7 @@ _sys_path = str(_Path(__file__).resolve().parent.parent.parent / "_lib")
 if _sys_path not in sys.path:
     sys.path.insert(0, _sys_path)
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
+from _paths import resolve_cache_file  # type: ignore[import-not-found]  # noqa: E402
 
 # Explicit retrospect slash-command invocation at the start of the prompt.
 # `/retrospect`, `/praxis:retrospect` (the plugin-namespaced form). A trailing
@@ -94,13 +96,8 @@ def resolve_state_path(session_id: str | None = None) -> str:
     if explicit:
         return explicit
 
-    # Root-safe: `"/".rstrip("/")` is "", which would yield a *relative*
-    # marker path. Fall back to "/" so the path stays absolute and the sh
-    # consumer (which computes the same path) agrees.
-    tmp = os.environ.get("TMPDIR", "/tmp").rstrip("/") or "/"
-    if session_id:
-        return os.path.join(tmp, f"praxis-retrospect-active-{session_id}.json")
-    return os.path.join(tmp, f"praxis-retrospect-active-{os.getppid()}.json")
+    key = session_id or str(os.getppid())
+    return resolve_cache_file(f"retrospect-active-{key}.json")
 
 
 def set_marker(path: str, source: str) -> None:
@@ -164,15 +161,14 @@ def resolve_candidates_path(session_id: str | None = None) -> str:
     Mirrors resolve_state_path's location logic with a distinct filename so the
     hint file and the marker are always separate files. Under an explicit marker
     override the override path is opaque, so the sibling is that path plus a
-    `.candidates.json` suffix; otherwise it is the TMPDIR
-    `praxis-retrospect-candidates-<session>.json` companion of the marker.
+    `.candidates.json` suffix; otherwise it is the cache-dir
+    `retrospect-candidates-<session>.json` companion of the marker.
     """
     explicit = os.environ.get("PRAXIS_RETROSPECT_ACTIVE_FILE", "").strip()
     if explicit:
         return explicit + ".candidates.json"
-    tmp = os.environ.get("TMPDIR", "/tmp").rstrip("/") or "/"
     token = session_id if session_id else str(os.getppid())
-    return os.path.join(tmp, f"praxis-retrospect-candidates-{token}.json")
+    return resolve_cache_file(f"retrospect-candidates-{token}.json")
 
 
 def write_candidate_hints(payload: dict, session_id: str | None) -> None:

--- a/hooks/preflight-gate/session-intent/impl.py
+++ b/hooks/preflight-gate/session-intent/impl.py
@@ -24,12 +24,13 @@ Two event handlers share a session state file:
 
 Session state location (in priority order):
   1. `PRAXIS_SESSION_INTENT_FILE` env var (test override; explicit path)
-  2. `${TMPDIR:-/tmp}/praxis-session-intent-${session_id}.json` when the
-     hook payload carries a `session_id` field (the canonical praxis hook
-     pattern — same key used by `completion-verify.sh`,
-     `retrospect-mix-check.sh`, `strike-counter.sh`)
-  3. `${TMPDIR:-/tmp}/praxis-session-intent-${PPID}.json` (back-compat
-     fallback when the payload does not include `session_id`)
+  2. `<PRAXIS_HOME>/cache/session-intent-${session_id}.json` when the hook
+     payload carries a `session_id` field (the canonical praxis hook pattern —
+     same key used by `completion-verify.sh`, `retrospect-mix-check.sh`,
+     `strike-counter.sh`). Pre-#903 this lived under `${TMPDIR}`;
+     `resolve_cache_file` adopts that file if it is still there.
+  3. `${PPID}` replaces `${session_id}` in the filename (back-compat fallback
+     when the payload does not include `session_id`)
 
 The `$CLAUDE_PROJECT_DIR/.praxis-session-intent.json` branch was removed
 intentionally (codex P1 review on PR #190): a project-rooted state file
@@ -83,6 +84,7 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     safe_tokenize,
     strip_prefix,
 )
+from _paths import resolve_cache_file  # type: ignore[import-not-found]  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Lexical signal sets — module-level constants (Korean + English).
@@ -265,11 +267,8 @@ def resolve_state_path(session_id: str | None = None) -> str:
     if explicit:
         return explicit
 
-    tmp = os.environ.get("TMPDIR", "/tmp").rstrip("/")
-    if session_id:
-        return os.path.join(tmp, f"praxis-session-intent-{session_id}.json")
-    ppid = os.getppid()
-    return os.path.join(tmp, f"praxis-session-intent-{ppid}.json")
+    key = session_id or str(os.getppid())
+    return resolve_cache_file(f"session-intent-{key}.json")
 
 
 def read_state(path: str) -> dict:

--- a/hooks/preflight-gate/worktree-prune-snapshot-gate/impl.py
+++ b/hooks/preflight-gate/worktree-prune-snapshot-gate/impl.py
@@ -66,6 +66,7 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     iter_command_starts,
     safe_tokenize,
 )
+from _paths import resolve_cache_file  # type: ignore[import-not-found]  # noqa: E402
 from block_message import emit_block  # type: ignore[import-not-found]  # noqa: E402
 
 _BYPASS_ENV = "PRAXIS_HOOK_BYPASS_WORKTREE_PRUNE_SNAPSHOT"
@@ -150,11 +151,8 @@ def resolve_state_path(session_id: str | None = None) -> str:
     explicit = os.environ.get(_STATE_FILE_ENV, "").strip()
     if explicit:
         return explicit
-    tmp = os.environ.get("TMPDIR", "/tmp").rstrip("/")
-    if session_id:
-        return os.path.join(tmp, f"praxis-worktree-prune-snapshot-{session_id}.json")
-    ppid = os.getppid()
-    return os.path.join(tmp, f"praxis-worktree-prune-snapshot-{ppid}.json")
+    key = session_id or str(os.getppid())
+    return resolve_cache_file(f"worktree-prune-snapshot-{key}.json")
 
 
 def read_state(path: str) -> dict:

--- a/hooks/preflight-gate/worktree-prune-snapshot-gate/spec.md
+++ b/hooks/preflight-gate/worktree-prune-snapshot-gate/spec.md
@@ -37,10 +37,11 @@ State file location (priority order):
 
 1. `PRAXIS_WORKTREE_PRUNE_SNAPSHOT_FILE` env var (explicit override; used by
    tests).
-2. `${TMPDIR:-/tmp}/praxis-worktree-prune-snapshot-${session_id}.json` when
-   the payload carries `session_id` (primary key).
-3. `${TMPDIR:-/tmp}/praxis-worktree-prune-snapshot-${PPID}.json` (back-compat
-   fallback for direct CLI/test invocation without a payload).
+2. `<PRAXIS_HOME>/cache/worktree-prune-snapshot-${session_id}.json` when the
+   payload carries `session_id` (primary key). Pre-#903 this lived under
+   `${TMPDIR}`; `resolve_cache_file` adopts that file if it is still there.
+3. `${PPID}` replaces `${session_id}` in the filename (back-compat fallback
+   for direct CLI/test invocation without a payload).
 
 State file shape: `{"snapshot_taken": true}`. The flag is sticky once set —
 it never resets within a session (mirrors `session-intent`'s

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -23,6 +23,14 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 cd "$REPO_ROOT"
 
+# Run against a throwaway PRAXIS_HOME (#903). Hooks now resolve their runtime
+# files through it, so without this the suite would write into — and let
+# prune_stale sweep — the developer's own ~/.praxis. Individual cases that care
+# about the default still unset it themselves (see tests/test_paths.sh).
+PRAXIS_HOME="$(mktemp -d)" || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+export PRAXIS_HOME
+trap 'rm -rf "$PRAXIS_HOME"' EXIT
+
 FAILED=0
 
 # ---------------------------------------------------------------------------

--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -223,11 +223,9 @@ Step 2 의 raw git/PR 메타데이터는 *무엇이 바뀌었는지*만 전달�
 루트가 아니라 `PRAXIS_HOME` 아래입니다. worktree 는 대개 남의 repo 이고,
 praxis 가 거기에 파일을 남길 이유가 없습니다.
 
-```bash
-ARP="${CLAUDE_PLUGIN_ROOT}/skills/cmux-delegate/agent-report-path.sh"
-WORKTREE="$(sh "$ARP" --worktree "$PWD")"   # ← 보고서의 worktree 필드에 그대로
-REPORT="$(sh "$ARP" "$PWD")"
-```
+    ARP="${CLAUDE_PLUGIN_ROOT}/skills/cmux-delegate/agent-report-path.sh"
+    WORKTREE="$(sh "$ARP" --worktree "$PWD")"   # ← 보고서의 worktree 필드에
+    REPORT="$(sh "$ARP" "$PWD")"
 
 `$PWD` 가 worktree 하위 디렉터리여도 됩니다 — 헬퍼가 worktree 루트로
 정규화하므로 위임자와 같은 경로가 나옵니다.
@@ -241,7 +239,6 @@ REPORT="$(sh "$ARP" "$PWD")"
       "tests": {"command": "./scripts/run-tests.sh", "passed": 507, "failed": 0},
       "completed_at": "2026-07-28T09:00:00Z"
     }
-
 
 - `worktree` 는 위 `$WORKTREE` 값을 그대로 넣습니다. 파일명이 해시라서 이
   필드가 없으면 위임자가 자기 것인지 확인할 수 없습니다.

--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -218,10 +218,22 @@ Step 2 의 raw git/PR 메타데이터는 *무엇이 바뀌었는지*만 전달�
 
 ## Completion protocol (REQUIRED)
 
-작업을 마치면 **작업 중인 worktree 루트**에 `.agent-report.json` 을 씁니다.
-이 파일이 완료 보고의 정본이고, 채팅 메시지는 포인터일 뿐입니다.
+작업을 마치면 완료 보고서를 씁니다. 이 파일이 완료 보고의 정본이고,
+채팅 메시지는 포인터일 뿐입니다. 경로는 아래 명령으로 구합니다 — worktree
+루트가 아니라 `PRAXIS_HOME` 아래입니다. worktree 는 대개 남의 repo 이고,
+praxis 가 거기에 파일을 남길 이유가 없습니다.
+
+```bash
+ARP="${CLAUDE_PLUGIN_ROOT}/skills/cmux-delegate/agent-report-path.sh"
+WORKTREE="$(sh "$ARP" --worktree "$PWD")"   # ← 보고서의 worktree 필드에 그대로
+REPORT="$(sh "$ARP" "$PWD")"
+```
+
+`$PWD` 가 worktree 하위 디렉터리여도 됩니다 — 헬퍼가 worktree 루트로
+정규화하므로 위임자와 같은 경로가 나옵니다.
 
     {
+      "worktree": "/abs/path/to/worktree",
       "branch": "issue-123-feat-x",
       "head_sha": "0123456789abcdef0123456789abcdef01234567",
       "pushed": true,
@@ -231,12 +243,14 @@ Step 2 의 raw git/PR 메타데이터는 *무엇이 바뀌었는지*만 전달�
     }
 
 
+- `worktree` 는 위 `$WORKTREE` 값을 그대로 넣습니다. 파일명이 해시라서 이
+  필드가 없으면 위임자가 자기 것인지 확인할 수 없습니다.
 - `pushed` 는 `git push` 가 **성공한 뒤에만** true. 커밋만 했으면 false.
 - `pr_url` 은 실제로 생성된 PR 이 없으면 `null` — 빈 문자열이나 예상 URL 금지.
 - `tests` 의 숫자는 실행한 명령의 출력에서 그대로 옮깁니다. 추정 금지.
 - 작업을 끝내지 못했으면 **파일을 쓰지 마세요.** 파일 부재 = 미완료입니다.
 
-마지막 메시지에는 `.agent-report.json` 의 절대 경로만 남깁니다.
+마지막 메시지에는 그 보고서의 절대 경로만 남깁니다.
 
 ---
 Report results in Korean.
@@ -389,9 +403,11 @@ cmux에서 {session_name} 탭을 확인하세요.
 
 ### Step 7: Collect the Report (file, not prose)
 
-위임한 작업의 완료를 판정할 때는 **에이전트의 메시지를 읽지 않고**
-`{cwd}/.agent-report.json` 을 읽습니다. 이 단계는 위임 직후가 아니라,
-결과를 소비하기 직전(다음 단계 진입, 사용자 보고, 머지 판단) 에 실행합니다.
+위임한 작업의 완료를 판정할 때는 **에이전트의 메시지를 읽지 않고** 보고서
+파일을 읽습니다. 경로는 writer 와 **같은 헬퍼**로 구합니다 — 스니펫을 양쪽에
+복붙하면 한쪽만 고쳐질 때 판정이 조용히 깨집니다. 이 단계는 위임 직후가
+아니라, 결과를 소비하기 직전(다음 단계 진입, 사용자 보고, 머지 판단) 에
+실행합니다.
 
 **왜 파일인가.** prose 채널은 양극단으로 고장난 이력이 있습니다 —
 존재하지 않는 PR 을 생성 완료로 보고한 fabrication, 지시 2회에 무응답인
@@ -399,8 +415,12 @@ silence. 어느 쪽도 메시지만 읽어서는 구분되지 않습니다. 파�
 결정론적으로 "미완료" 이고, 파일 존재는 필드별 재검증의 대상입니다.
 
 ```bash
-REPORT="{cwd}/.agent-report.json"
-[ -f "$REPORT" ] || { echo "미완료: .agent-report.json 부재"; exit 1; }
+ARP="${CLAUDE_PLUGIN_ROOT}/skills/cmux-delegate/agent-report-path.sh"
+WORKTREE="$(sh "$ARP" --worktree "{cwd}")"
+REPORT="$(sh "$ARP" "{cwd}")"
+[ -f "$REPORT" ] || { echo "미완료: 완료 보고서 부재 ($REPORT)"; exit 1; }
+[ "$(jq -r '.worktree // ""' "$REPORT")" = "$WORKTREE" ] \
+  || { echo "미완료: 보고서의 worktree 가 $WORKTREE 와 불일치"; exit 1; }
 ```
 
 읽은 값은 **그대로 믿지 않고** 필드마다 fresh 하게 재확인합니다. 보고서는
@@ -409,6 +429,7 @@ REPORT="{cwd}/.agent-report.json"
 
 | 필드 | 재검증 명령 | 불일치 시 |
 | --- | --- | --- |
+| `worktree` | 위 `jq` 비교 | 불일치 = 다른 작업의 보고서. 미완료로 취급 |
 | `head_sha` + `pushed: true` | `git ls-remote origin refs/heads/<branch>` | remote SHA 가 없거나 다르면 push 미완료 — 보고서의 `pushed` 를 무시 |
 | `pr_url` | `gh pr view <url> --json state,headRefOid` | 조회 실패 = PR 부재(fabrication), `headRefOid` 불일치 = 보고 이후 커밋 존재 |
 | `tests` | 같은 명령을 직접 재실행 | 숫자 불일치 = 보고서 수치 신뢰 불가 |
@@ -432,8 +453,8 @@ REPORT="{cwd}/.agent-report.json"
 | `--session` 매칭 실패 | 사용 가능한 워크스페이스 목록을 보여주고 중단 |
 | `--account` 디렉토리 미존재 | 에러 메시지 출력 후 중단 |
 | distribute 분할 실패 | 분할 불가 시 단일 세션으로 fallback, 유저에게 알림 |
-| `.agent-report.json` 부재 | **미완료로 취급** — 완료 주장 메시지가 있어도 마찬가지. 에이전트에 재지시하거나 위임자가 인수 |
-| `.agent-report.json` JSON 파싱 실패 | 미완료로 취급. 파일 내용을 그대로 보여주고 중단 (부분 기록일 수 있으므로 삭제 금지) |
+| 완료 보고서 부재 | **미완료로 취급** — 완료 주장 메시지가 있어도 마찬가지. 에이전트에 재지시하거나 위임자가 인수 |
+| 완료 보고서 JSON 파싱 실패 | 미완료로 취급. 파일 내용을 그대로 보여주고 중단 (부분 기록일 수 있으므로 삭제 금지) |
 | 보고서 필드 ↔ 재검증 불일치 | 재검증 출력을 채택하고 보고서 값은 폐기. 어긋난 필드를 사용자에게 명시 |
 
 ## Architecture
@@ -512,7 +533,7 @@ user: /cmux-delegate "full code review" --model claude:opus --account claude-2
 
 ## Limitations
 
-- 완료 판정은 `.agent-report.json` 으로 결정론적이지만, **작업 산출물 자체의 자동 수집은 미지원** → 사용자가 cmux에서 직접 확인
+- 완료 판정은 완료 보고서 파일로 결정론적이지만, **작업 산출물 자체의 자동 수집은 미지원** → 사용자가 cmux에서 직접 확인
 - silence 는 *탐지* 만 가능하고 원인(세션 crash vs 장시간 도구 대기)은 판별 불가 — 파일 부재만으로는 구분되지 않음
 - 작업 유형별 템플릿 미지원 → 사용자가 프롬프트에 직접 명시
 - distribute 모드의 자동 분할은 섹션 헤더 기반 — 비정형 프롬프트는 수동 분할 필요

--- a/skills/cmux-delegate/agent-report-path.sh
+++ b/skills/cmux-delegate/agent-report-path.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Agent-report path derivation for cmux-delegate (issue #903).
+#
+# The delegated agent writes its completion report and the delegator reads it
+# back in Step 7. Both must land on the same file, and the only thing the two
+# share is the worktree path — so the key is derived from that, here, once.
+# Inlining the derivation in both halves of SKILL.md is how one half gets
+# fixed and the completion judgment silently stops finding anything.
+#
+#   report="$(sh path/to/agent-report-path.sh "$PWD")"
+#
+# Reports live under <PRAXIS_HOME>/agent-reports/ rather than the worktree
+# root: the worktree usually belongs to an unrelated repository, and praxis
+# has no business leaving files in it.
+#
+# Hashing goes through python3 rather than shasum/sha1sum — praxis hooks
+# already require python3, and the two checksum binaries are not both present
+# across the platforms praxis targets.
+
+set -eu
+
+_ARP_MODE=path
+if [ "${1:-}" = "--worktree" ]; then
+    _ARP_MODE=worktree
+    shift
+fi
+
+if [ $# -ne 1 ] || [ -z "$1" ]; then
+    echo "usage: agent-report-path.sh [--worktree] <path-inside-worktree>" >&2
+    exit 2
+fi
+
+_ARP_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../../hooks/_lib/_paths.sh
+. "$_ARP_DIR/../../hooks/_lib/_paths.sh"
+
+# Normalize to the worktree ROOT before hashing. The agent writing the report
+# and the delegator reading it are rarely standing in the same directory — the
+# agent commonly works from a package subdir (`<worktree>/analytics_backend`)
+# while the delegator holds the path it passed to `--cwd`. Hashing the raw
+# argument would give the two different files, and the reader would report a
+# finished task as incomplete. A path outside any repo hashes as given.
+_ARP_TARGET="$(git -C "$1" rev-parse --show-toplevel 2>/dev/null || printf '%s' "${1%/}")"
+
+# `--worktree` exposes that same normalization, so the value the agent records
+# in the report's `worktree` field and the value the delegator compares it
+# against come from one implementation rather than two hand-written commands.
+if [ "$_ARP_MODE" = worktree ]; then
+    printf '%s\n' "$_ARP_TARGET"
+    exit 0
+fi
+
+_ARP_KEY="$(python3 -c 'import hashlib,sys; print(hashlib.sha1(sys.argv[1].rstrip("/").encode()).hexdigest())' "$_ARP_TARGET")"
+
+praxis_resolve_writable agent-reports "$_ARP_KEY.json"

--- a/tests/hooks/postuse-correction/test_pre_edit_md_escape_advisory.sh
+++ b/tests/hooks/postuse-correction/test_pre_edit_md_escape_advisory.sh
@@ -452,10 +452,11 @@ run_case "missing tool_input → silent" silent \
 # ---------------------------------------------------------------------------
 
 # Build a payload with explicit session_id and verify the post-hook writes
-# under ${TMPDIR}/praxis-md-read-history-<session_id>.json.
+# under <PRAXIS_HOME>/cache/md-read-history-<session_id>.json (#903 — the file
+# used to live in ${TMPDIR}; PRAXIS_HOME now relocates it).
 sid="test-session-$$-$RANDOM"
-expected_path="${TMPDIR:-/tmp}/praxis-md-read-history-${sid}.json"
-rm -f "$expected_path"
+SID_HOME="$(mktemp -d)" || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+expected_path="$SID_HOME/cache/md-read-history-${sid}.json"
 
 payload_with_sid=$(python3 -c '
 import json, sys
@@ -467,16 +468,16 @@ print(json.dumps({
 }))
 ' "$sid" "/Users/test/session-id.md")
 
-printf '%s' "$payload_with_sid" | "$POST_HOOK" >/dev/null 2>&1
+printf '%s' "$payload_with_sid" | PRAXIS_HOME="$SID_HOME" "$POST_HOOK" >/dev/null 2>&1
 
 if [ -f "$expected_path" ] && python3 -c "
 import json
 data = json.load(open('$expected_path'))
 assert '/Users/test/session-id.md' in data.get('read', []), data
 " 2>/dev/null; then
-  echo "PASS [state] session_id resolves to ${TMPDIR:-/tmp}/praxis-md-read-history-<sid>.json"
+  echo "PASS [state] session_id resolves to <PRAXIS_HOME>/cache/md-read-history-<sid>.json"
   ((PASS++))
-  rm -f "$expected_path"
+  rm -rf "$SID_HOME"
 else
   echo "FAIL [state] session_id-based path resolution"
   ((FAIL++)); FAILED_NAMES+=("session_id-based path resolution")

--- a/tests/hooks/preflight-gate/test_session_intent.sh
+++ b/tests/hooks/preflight-gate/test_session_intent.sh
@@ -427,8 +427,9 @@ case_run "19. explicit env wins over CLAUDE_PROJECT_DIR seeded state → ask" "a
 # Without PRAXIS_SESSION_INTENT_FILE override, the resolver must derive
 # the path from session_id and produce distinct paths for distinct ids.
 # -----------------------------------------------------------------------
+SI_HOME="$(mktemp -d)" || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
 PATH_A=$(
-  env -u PRAXIS_SESSION_INTENT_FILE -u CLAUDE_PROJECT_DIR \
+  env -u PRAXIS_SESSION_INTENT_FILE -u CLAUDE_PROJECT_DIR PRAXIS_HOME="$SI_HOME" \
     python3 -c "
 import os, sys
 sys.path.insert(0, '$ROOT_DIR/hooks')
@@ -439,7 +440,7 @@ spec.loader.exec_module(mod)
 print(mod.resolve_state_path('sess-A'))
 ")
 PATH_B=$(
-  env -u PRAXIS_SESSION_INTENT_FILE -u CLAUDE_PROJECT_DIR \
+  env -u PRAXIS_SESSION_INTENT_FILE -u CLAUDE_PROJECT_DIR PRAXIS_HOME="$SI_HOME" \
     python3 -c "
 import os, sys
 sys.path.insert(0, '$ROOT_DIR/hooks')
@@ -450,8 +451,8 @@ spec.loader.exec_module(mod)
 print(mod.resolve_state_path('sess-B'))
 ")
 if [ -n "$PATH_A" ] && [ -n "$PATH_B" ] && [ "$PATH_A" != "$PATH_B" ] \
-  && echo "$PATH_A" | grep -q "praxis-session-intent-sess-A.json" \
-  && echo "$PATH_B" | grep -q "praxis-session-intent-sess-B.json"; then
+  && echo "$PATH_A" | grep -q "cache/session-intent-sess-A.json" \
+  && echo "$PATH_B" | grep -q "cache/session-intent-sess-B.json"; then
   case_run "20. different session_id routes to different state files" "silent" "" "0"
 else
   case_run "20. different session_id routes to different state files" "silent" "PATH_A=$PATH_A PATH_B=$PATH_B" "1"
@@ -464,7 +465,7 @@ fi
 # -----------------------------------------------------------------------
 CURRENT_PPID=$$
 PATH_SID=$(
-  env -u PRAXIS_SESSION_INTENT_FILE -u CLAUDE_PROJECT_DIR \
+  env -u PRAXIS_SESSION_INTENT_FILE -u CLAUDE_PROJECT_DIR PRAXIS_HOME="$SI_HOME" \
     python3 -c "
 import os, sys
 sys.path.insert(0, '$ROOT_DIR/hooks')
@@ -475,8 +476,8 @@ spec.loader.exec_module(mod)
 print(mod.resolve_state_path('my-session-key'))
 ")
 # The resolved path should contain 'my-session-key' (not the PPID).
-if echo "$PATH_SID" | grep -q "praxis-session-intent-my-session-key.json" \
-  && ! echo "$PATH_SID" | grep -q "praxis-session-intent-${CURRENT_PPID}.json"; then
+if echo "$PATH_SID" | grep -q "cache/session-intent-my-session-key.json" \
+  && ! echo "$PATH_SID" | grep -q "session-intent-${CURRENT_PPID}.json"; then
   case_run "21. session_id present → state file derived from session_id, not PPID" "silent" "" "0"
 else
   case_run "21. session_id present → state file derived from session_id, not PPID" "silent" "PATH_SID=$PATH_SID PPID=$CURRENT_PPID" "1"
@@ -489,7 +490,7 @@ fi
 # without a payload remains functional.
 # -----------------------------------------------------------------------
 PATH_FALLBACK=$(
-  env -u PRAXIS_SESSION_INTENT_FILE -u CLAUDE_PROJECT_DIR \
+  env -u PRAXIS_SESSION_INTENT_FILE -u CLAUDE_PROJECT_DIR PRAXIS_HOME="$SI_HOME" \
     python3 -c "
 import os, sys
 sys.path.insert(0, '$ROOT_DIR/hooks')
@@ -500,14 +501,15 @@ spec.loader.exec_module(mod)
 # Call with no argument — exercises the PPID fallback branch.
 print(mod.resolve_state_path())
 ")
-# Should look like /tmp/praxis-session-intent-<ppid>.json — extract numeric ppid
-PPID_PATTERN=$(echo "$PATH_FALLBACK" | sed -n 's/.*praxis-session-intent-\([0-9][0-9]*\)\.json$/\1/p')
+# Should look like <home>/cache/session-intent-<ppid>.json — extract numeric ppid
+PPID_PATTERN=$(echo "$PATH_FALLBACK" | sed -n 's/.*session-intent-\([0-9][0-9]*\)\.json$/\1/p')
 if [ -n "$PPID_PATTERN" ]; then
   case_run "22. missing session_id → PPID fallback path" "silent" "" "0"
 else
   case_run "22. missing session_id → PPID fallback path" "silent" "PATH_FALLBACK=$PATH_FALLBACK" "1"
 fi
 
+rm -rf "$SI_HOME"
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/tests/test_agent_report_handoff.sh
+++ b/tests/test_agent_report_handoff.sh
@@ -6,12 +6,16 @@
 #   which failed in both directions — one agent reported a PR it had never
 #   created (and had not even pushed the branch), another went silent through
 #   two direct instructions. Neither is distinguishable by reading the message.
-#   The skill must therefore (a) make the agent write .agent-report.json,
+#   The skill must therefore (a) make the agent write a completion report,
 #   (b) make the orchestrator read that file rather than the message, and
 #   (c) treat file absence as incomplete.
 #
-# All assertions are static document checks against SKILL.md, mirroring
-# tests/test_worktree_merge_cleanup.sh.
+# Issue #903 moved the report out of the worktree root into
+# <PRAXIS_HOME>/agent-reports/<sha1(worktree)>.json, so §6 additionally
+# exercises the shipped path helper both halves of the protocol call.
+#
+# Assertions are static document checks against SKILL.md (mirroring
+# tests/test_worktree_merge_cleanup.sh) plus an executable gate in §6.
 #
 # Run:  bash tests/test_agent_report_handoff.sh
 # Exit: 0 = all pass; 1 = at least one fail
@@ -47,10 +51,14 @@ assert_present \
   "Completion protocol"
 
 assert_present \
-  "report file named" \
-  ".agent-report.json"
+  "report path comes from the shared helper, not a literal path (#903)" \
+  "agent-report-path.sh"
 
-for field in branch head_sha pushed pr_url tests completed_at; do
+assert_present \
+  "report no longer lands in the worktree root (#903)" \
+  "worktree 루트가 아니라"
+
+for field in worktree branch head_sha pushed pr_url tests completed_at; do
   assert_present \
     "report field documented: $field" \
     "\"$field\""
@@ -86,7 +94,11 @@ assert_present \
 
 assert_present \
   "file absence is deterministic incompletion" \
-  "미완료: .agent-report.json 부재"
+  "미완료: 완료 보고서 부재"
+
+assert_present \
+  "reader confirms the report belongs to its own worktree (#903)" \
+  "보고서의 worktree 가"
 
 assert_present \
   "report values are re-verified, not trusted" \
@@ -126,7 +138,7 @@ assert_present \
 
 assert_present \
   "missing-report row present" \
-  "부재 | **미완료로 취급**"
+  "완료 보고서 부재 | **미완료로 취급**"
 
 assert_present \
   "malformed-report row keeps the file for inspection" \
@@ -137,51 +149,119 @@ assert_present \
   "재검증 출력을 채택하고 보고서 값은 폐기"
 
 # ---------------------------------------------------------------------------
-# 6. The documented gate actually separates the two failure shapes
+# 6. The documented gate actually separates the failure shapes
 #
 # Static presence checks prove the text is there, not that the procedure it
-# describes discriminates. Lift the gate verbatim out of Step 7 and run it
-# against both states the issue names: a normal completion and a fabrication
-# (a completion CLAIM with no report file). The prose channel cannot tell
-# these apart — this gate must.
+# describes discriminates. Run the gate against every state the issues name: a
+# normal completion, a fabrication (a completion CLAIM with no report file), a
+# truncated write, and — since #903 keys reports by worktree hash rather than
+# location — a report belonging to a different worktree.
+#
+# The path comes from the shipped helper, not a transcription of it. A
+# transcription passes even when writer and reader have drifted apart, which
+# is the failure the shared helper exists to prevent.
 # ---------------------------------------------------------------------------
 
-run_documented_gate() {  # $1 = cwd under test
-  local report="$1/.agent-report.json"
-  [ -f "$report" ] || { echo "미완료: .agent-report.json 부재"; return 1; }
+HELPER="$ROOT_DIR/skills/cmux-delegate/agent-report-path.sh"
+GATE_TMP="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
+export PRAXIS_HOME="$GATE_TMP/praxis-home"
+
+report_path_for() { sh "$HELPER" "$1"; }
+worktree_for() { sh "$HELPER" --worktree "$1"; }
+
+run_documented_gate() {  # $1 = path the delegator holds (worktree or a subdir)
+  local report worktree
+  report="$(report_path_for "$1")" || return 1
+  worktree="$(worktree_for "$1")" || return 1
+  [ -f "$report" ] || { echo "미완료: 완료 보고서 부재 ($report)"; return 1; }
   python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$report" 2>/dev/null \
     || { echo "미완료: JSON 파싱 실패"; return 1; }
+  [ "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("worktree",""))' "$report")" = "$worktree" ] \
+    || { echo "미완료: 보고서의 worktree 불일치"; return 1; }
   return 0
 }
 
-GATE_TMP="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
-mkdir -p "$GATE_TMP/normal" "$GATE_TMP/fabricated" "$GATE_TMP/truncated"
-cat > "$GATE_TMP/normal/.agent-report.json" <<'JSON'
-{"branch": "issue-1-x", "head_sha": "abc", "pushed": true,
+WT_NORMAL="$GATE_TMP/normal"
+WT_FABRICATED="$GATE_TMP/fabricated"
+WT_TRUNCATED="$GATE_TMP/truncated"
+WT_FOREIGN="$GATE_TMP/foreign"
+
+cat > "$(report_path_for "$WT_NORMAL")" <<JSON
+{"worktree": "$WT_NORMAL", "branch": "issue-1-x", "head_sha": "abc", "pushed": true,
  "pr_url": null, "tests": {"command": "true", "passed": 1, "failed": 0},
  "completed_at": "2026-07-28T00:00:00Z"}
 JSON
-# fabricated/: the agent said "PR created, all done" and wrote nothing.
-printf '{"branch": "issue-1-x", "head_sha"' > "$GATE_TMP/truncated/.agent-report.json"
+# fabricated: the agent said "PR created, all done" and wrote nothing.
+printf '{"worktree": "%s", "head_sha"' "$WT_TRUNCATED" > "$(report_path_for "$WT_TRUNCATED")"
+# foreign: a well-formed report that belongs to some other worktree.
+cat > "$(report_path_for "$WT_FOREIGN")" <<JSON
+{"worktree": "$GATE_TMP/somewhere-else", "branch": "issue-2-y", "head_sha": "def",
+ "pushed": true, "pr_url": null, "tests": {"command": "true", "passed": 1, "failed": 0},
+ "completed_at": "2026-07-28T00:00:00Z"}
+JSON
 
-run_documented_gate "$GATE_TMP/normal" >/dev/null
+# Writer and reader independently derive the same path — the property the
+# shared helper exists to guarantee.
+_assert_record "writer and reader derive the same path" \
+  "$([ "$(report_path_for "$WT_NORMAL")" = "$(report_path_for "$WT_NORMAL/")" ] && echo 1 || echo 0)" \
+  "trailing slash changed the derived report path"
+
+case "$(report_path_for "$WT_NORMAL")" in
+  "$PRAXIS_HOME"/agent-reports/*) _assert_record "report lands under PRAXIS_HOME" 1 "" ;;
+  *) _assert_record "report lands under PRAXIS_HOME" 0 "path escaped PRAXIS_HOME" ;;
+esac
+
+_assert_record "report does not land in the worktree" \
+  "$([ ! -e "$WT_NORMAL" ] && echo 1 || echo 0)" \
+  "the worktree dir was created/written to"
+
+run_documented_gate "$WT_NORMAL" >/dev/null
 _assert_record "gate accepts a normal completion" "$([ $? -eq 0 ] && echo 1 || echo 0)" \
   "documented gate rejected a valid report"
 
-run_documented_gate "$GATE_TMP/fabricated" >/dev/null
+run_documented_gate "$WT_FABRICATED" >/dev/null
 _assert_record "gate rejects a completion claim with no file" \
   "$([ $? -ne 0 ] && echo 1 || echo 0)" "documented gate accepted a missing report"
 
-run_documented_gate "$GATE_TMP/truncated" >/dev/null
+run_documented_gate "$WT_TRUNCATED" >/dev/null
 _assert_record "gate rejects a truncated report" \
   "$([ $? -ne 0 ] && echo 1 || echo 0)" "documented gate accepted malformed JSON"
 
-if [ -f "$GATE_TMP/truncated/.agent-report.json" ]; then
+run_documented_gate "$WT_FOREIGN" >/dev/null
+_assert_record "gate rejects a report from another worktree" \
+  "$([ $? -ne 0 ] && echo 1 || echo 0)" "documented gate accepted a foreign report"
+
+if [ -f "$(report_path_for "$WT_TRUNCATED")" ]; then
   _assert_record "gate leaves a malformed report on disk for inspection" 1 ""
 else
   _assert_record "gate leaves a malformed report on disk for inspection" 0 "file removed"
 fi
 
+# The case that motivated the normalization: the agent writes from a package
+# subdirectory while the delegator holds the path it passed to `--cwd`. Hashing
+# the raw argument would send the two to different files, and a finished task
+# would read as incomplete.
+GIT_WT="$GATE_TMP/real-repo"
+mkdir -p "$GIT_WT/pkg/nested"
+git -C "$GIT_WT" init -q 2>/dev/null
+
+_assert_record "agent in a subdir derives the delegator's report path" \
+  "$([ "$(report_path_for "$GIT_WT/pkg/nested")" = "$(report_path_for "$GIT_WT")" ] && echo 1 || echo 0)" \
+  "subdirectory hashed to a different report than the worktree root"
+
+cat > "$(report_path_for "$GIT_WT/pkg/nested")" <<JSON
+{"worktree": "$(worktree_for "$GIT_WT/pkg/nested")", "branch": "issue-3-z",
+ "head_sha": "abc", "pushed": true, "pr_url": null,
+ "tests": {"command": "true", "passed": 1, "failed": 0},
+ "completed_at": "2026-07-28T00:00:00Z"}
+JSON
+
+run_documented_gate "$GIT_WT" >/dev/null
+_assert_record "gate accepts a report written from a subdirectory" \
+  "$([ $? -eq 0 ] && echo 1 || echo 0)" \
+  "gate rejected a report the agent wrote from a package subdir"
+
+unset PRAXIS_HOME
 rm -rf "$GATE_TMP"
 
 assert_lib_summary

--- a/tests/test_paths.sh
+++ b/tests/test_paths.sh
@@ -107,6 +107,122 @@ PYEOF
 )
 assert_eq "legacy_state_dir = ~/.claude/state/praxis" "/tmp/fakehome-527/.claude/state/praxis" "$legacy"
 
+# 8. prune_stale removes entries past the TTL and keeps fresh ones (#903)
+prune_result=$(python3 - "$LIB" << 'PYEOF'
+import os, sys, tempfile, time
+sys.path.insert(0, sys.argv[1])
+from _paths import prune_stale
+
+d = tempfile.mkdtemp()
+old, fresh = os.path.join(d, "old.json"), os.path.join(d, "fresh.json")
+for p in (old, fresh):
+    open(p, "w").close()
+stale = time.time() - 8 * 86400
+os.utime(old, (stale, stale))
+
+olddir = os.path.join(d, "olddir")
+os.makedirs(olddir)
+open(os.path.join(olddir, "inner"), "w").close()
+os.utime(olddir, (stale, stale))
+
+removed = prune_stale(d, ttl_days=7)
+print(f"{removed}:{os.path.exists(old)}:{os.path.exists(fresh)}:{os.path.exists(olddir)}")
+PYEOF
+)
+assert_eq "prune_stale sweeps stale files and dirs, keeps fresh" "2:False:True:False" "$prune_result"
+
+# 9. PRAXIS_CACHE_TTL_DAYS=0 disables the sweep
+prune_disabled=$(PRAXIS_CACHE_TTL_DAYS=0 python3 - "$LIB" << 'PYEOF'
+import os, sys, tempfile, time
+sys.path.insert(0, sys.argv[1])
+from _paths import prune_stale
+d = tempfile.mkdtemp()
+p = os.path.join(d, "old.json")
+open(p, "w").close()
+stale = time.time() - 400 * 86400
+os.utime(p, (stale, stale))
+print(f"{prune_stale(d)}:{os.path.exists(p)}")
+PYEOF
+)
+assert_eq "PRAXIS_CACHE_TTL_DAYS=0 disables the sweep" "0:True" "$prune_disabled"
+
+# 10. prune_stale on a missing directory returns 0 rather than raising
+prune_missing=$(python3 - "$LIB" << 'PYEOF'
+import sys
+sys.path.insert(0, sys.argv[1])
+from _paths import prune_stale
+print(prune_stale("/nonexistent-praxis-903", ttl_days=1))
+PYEOF
+)
+assert_eq "prune_stale on missing dir returns 0" "0" "$prune_missing"
+
+# 10b. resolve_cache_file adopts a pre-#903 ${TMPDIR} file (#903)
+# A session already holding intent/marker state when praxis upgrades must not
+# read the new path as "no state" — that silently disarms the Stop gate.
+adopt=$(python3 - "$LIB" << 'PYEOF'
+import os, sys, tempfile
+sys.path.insert(0, sys.argv[1])
+home, tmp = tempfile.mkdtemp(), tempfile.mkdtemp()
+os.environ["PRAXIS_HOME"], os.environ["TMPDIR"] = home, tmp
+from _paths import resolve_cache_file
+legacy = os.path.join(tmp, "praxis-session-intent-x.json")
+with open(legacy, "w") as fh:
+    fh.write('{"mutation_verb_seen": true}')
+p = resolve_cache_file("session-intent-x.json")
+print(f"{p.startswith(home)}:{open(p).read()}:{os.path.exists(legacy)}")
+PYEOF
+)
+assert_eq "resolve_cache_file adopts the legacy TMPDIR file" \
+  'True:{"mutation_verb_seen": true}:False' "$adopt"
+
+# 10c. With no legacy file, resolve_cache_file just returns the new path
+fresh=$(python3 - "$LIB" << 'PYEOF'
+import os, sys, tempfile
+sys.path.insert(0, sys.argv[1])
+home, tmp = tempfile.mkdtemp(), tempfile.mkdtemp()
+os.environ["PRAXIS_HOME"], os.environ["TMPDIR"] = home, tmp
+from _paths import resolve_cache_file
+p = resolve_cache_file("session-intent-y.json")
+print(f"{p == os.path.join(home, 'cache', 'session-intent-y.json')}:{os.path.exists(p)}")
+PYEOF
+)
+assert_eq "resolve_cache_file with no legacy file creates nothing" "True:False" "$fresh"
+
+# --- _paths.sh must agree with _paths.py (#903) -----------------------------
+# The writer/reader halves of a protocol are split across the two languages, so
+# a divergence here silently sends them to different files.
+
+sh_eval() {  # sh_eval <shell-expression>
+  sh -c ". \"$LIB/_paths.sh\"; $1"
+}
+
+# 11. shell praxis_home honors PRAXIS_HOME and defaults to ~/.praxis
+assert_eq "sh praxis_home: PRAXIS_HOME override" "/tmp/ph-903" \
+  "$(PRAXIS_HOME=/tmp/ph-903 sh_eval 'praxis_home')"
+assert_eq "sh praxis_home: default" "/tmp/fakehome-903/.praxis" \
+  "$(unset PRAXIS_HOME; HOME=/tmp/fakehome-903 sh_eval 'praxis_home')"
+
+# 12. shell state/cache dirs match the Python resolver, override precedence included
+assert_eq "sh praxis_state_dir default" "/tmp/ph-903/state" \
+  "$(unset PRAXIS_STATE_DIR; PRAXIS_HOME=/tmp/ph-903 sh_eval 'praxis_state_dir')"
+assert_eq "sh PRAXIS_STATE_DIR override wins" "/custom/state" \
+  "$(PRAXIS_STATE_DIR=/custom/state PRAXIS_HOME=/tmp/ph-903 sh_eval 'praxis_state_dir')"
+assert_eq "sh praxis_cache_dir" "/tmp/ph-903/cache" \
+  "$(PRAXIS_HOME=/tmp/ph-903 sh_eval 'praxis_cache_dir')"
+
+# 13. shell resolve_writable creates the subdir, and falls back like Python
+SH_HOME=$(mktemp -d) || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+assert_eq "sh praxis_resolve_writable path" "$SH_HOME/cache/x.json" \
+  "$(PRAXIS_HOME="$SH_HOME" sh_eval 'praxis_resolve_writable cache x.json')"
+if [ -d "$SH_HOME/cache" ]; then
+  echo "PASS  [sh praxis_resolve_writable created the subdir]"; PASS=$((PASS + 1))
+else
+  echo "FAIL  [sh praxis_resolve_writable did not create subdir]"; FAIL=$((FAIL + 1)); FAILED_NAMES+=("sh subdir created")
+fi
+rm -rf "$SH_HOME"
+assert_eq "sh unwritable home falls back to TMPDIR" "/tmp/praxis-hook-errors.jsonl" \
+  "$(PRAXIS_HOME=/proc/nonexistent-praxis-home TMPDIR=/tmp sh_eval 'praxis_resolve_writable logs hook-errors.jsonl')"
+
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/tests/test_paths.sh
+++ b/tests/test_paths.sh
@@ -122,7 +122,11 @@ os.utime(old, (stale, stale))
 
 olddir = os.path.join(d, "olddir")
 os.makedirs(olddir)
-open(os.path.join(olddir, "inner"), "w").close()
+inner = os.path.join(olddir, "inner")
+open(inner, "w").close()
+# Backdate the contents too: a directory is judged by its newest descendant,
+# so backdating only the dir would (correctly) spare it. Case 15 covers that.
+os.utime(inner, (stale, stale))
 os.utime(olddir, (stale, stale))
 
 removed = prune_stale(d, ttl_days=7)
@@ -222,6 +226,65 @@ fi
 rm -rf "$SH_HOME"
 assert_eq "sh unwritable home falls back to TMPDIR" "/tmp/praxis-hook-errors.jsonl" \
   "$(PRAXIS_HOME=/proc/nonexistent-praxis-home TMPDIR=/tmp sh_eval 'praxis_resolve_writable logs hook-errors.jsonl')"
+
+# 14. A literal tilde in PRAXIS_HOME must expand the same way on both sides.
+# Python runs os.path.expanduser; shell left alone does not, so a quoted or
+# config-exported PRAXIS_HOME='~/praxis' would split the two resolvers apart.
+TILDE='~'   # kept in a variable so the literal never sits inside quotes
+assert_eq "sh praxis_home expands a literal ~/" "/tmp/fakehome-903/praxis" \
+  "$(HOME=/tmp/fakehome-903 PRAXIS_HOME="$TILDE/praxis" sh_eval 'praxis_home')"
+assert_eq "sh praxis_home expands a bare ~" "/tmp/fakehome-903" \
+  "$(HOME=/tmp/fakehome-903 PRAXIS_HOME="$TILDE" sh_eval 'praxis_home')"
+assert_eq "sh/py agree on a literal ~/ PRAXIS_HOME" \
+  "$(HOME=/tmp/fakehome-903 PRAXIS_HOME="$TILDE/praxis" python3 -c "import sys; sys.path.insert(0, '$LIB'); import _paths; print(_paths.praxis_home())")" \
+  "$(HOME=/tmp/fakehome-903 PRAXIS_HOME="$TILDE/praxis" sh_eval 'praxis_home')"
+assert_eq "sh praxis_home leaves a mid-path tilde alone" "/tmp/a~b" \
+  "$(PRAXIS_HOME='/tmp/a~b' sh_eval 'praxis_home')"
+
+# 15. prune_stale must judge a directory by its newest descendant, not its own
+# mtime. The dedup hooks nest state two levels down, and writing there does not
+# touch the top-level dir — so an mtime-only check deletes live session state.
+PRUNE_HOME=$(mktemp -d) || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+mkdir -p "$PRUNE_HOME/tree/session-a"
+: > "$PRUNE_HOME/tree/session-a/live"
+: > "$PRUNE_HOME/loose-old"
+# Backdate the parent dir and the loose file; leave the nested file fresh.
+touch -t 202001010000 "$PRUNE_HOME/tree" "$PRUNE_HOME/tree/session-a" "$PRUNE_HOME/loose-old"
+python3 -c "import sys; sys.path.insert(0, '$LIB'); import _paths; _paths.prune_stale('$PRUNE_HOME', 7.0)" >/dev/null
+if [ -f "$PRUNE_HOME/tree/session-a/live" ]; then
+  echo "PASS  [prune_stale keeps a stale dir holding fresh nested state]"; PASS=$((PASS + 1))
+else
+  echo "FAIL  [prune_stale deleted active nested state]"; FAIL=$((FAIL + 1)); FAILED_NAMES+=("prune nested state")
+fi
+if [ -f "$PRUNE_HOME/loose-old" ]; then
+  echo "FAIL  [prune_stale left a genuinely stale file]"; FAIL=$((FAIL + 1)); FAILED_NAMES+=("prune stale file")
+else
+  echo "PASS  [prune_stale still removes a genuinely stale file]"; PASS=$((PASS + 1))
+fi
+# A tree that is stale all the way down still goes.
+mkdir -p "$PRUNE_HOME/dead/session-b"
+: > "$PRUNE_HOME/dead/session-b/old"
+touch -t 202001010000 "$PRUNE_HOME/dead/session-b/old" "$PRUNE_HOME/dead/session-b" "$PRUNE_HOME/dead"
+python3 -c "import sys; sys.path.insert(0, '$LIB'); import _paths; _paths.prune_stale('$PRUNE_HOME', 7.0)" >/dev/null
+if [ -d "$PRUNE_HOME/dead" ]; then
+  echo "FAIL  [prune_stale left a fully stale tree]"; FAIL=$((FAIL + 1)); FAILED_NAMES+=("prune stale tree")
+else
+  echo "PASS  [prune_stale removes a fully stale tree]"; PASS=$((PASS + 1))
+fi
+rm -rf "$PRUNE_HOME"
+
+# 16. A concurrent migration must not hand back the abandoned legacy path.
+# Two processes can both see the new path absent; the loser's move fails, and
+# returning `legacy` then writes where no later reader looks.
+RACE_HOME=$(mktemp -d) || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+RACE_TMP=$(mktemp -d) || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+mkdir -p "$RACE_HOME/cache"
+printf '{"winner": true}' > "$RACE_HOME/cache/race.json"
+printf '{"stale": true}' > "$RACE_TMP/praxis-race.json"
+assert_eq "resolve_cache_file prefers the new path when both exist" \
+  "$RACE_HOME/cache/race.json" \
+  "$(PRAXIS_HOME="$RACE_HOME" TMPDIR="$RACE_TMP" python3 -c "import sys; sys.path.insert(0, '$LIB'); import _paths; print(_paths.resolve_cache_file('race.json'))")"
+rm -rf "$RACE_HOME" "$RACE_TMP"
 
 echo ""
 echo "Result: $PASS passed, $FAIL failed"

--- a/tests/test_skill_runtime_metadata.py
+++ b/tests/test_skill_runtime_metadata.py
@@ -572,7 +572,9 @@ def test_current_repo_runtime_sensitive_skill_set_is_stable():
         if check._skill_runtime_verification_reasons(skill_dir)
     }
     assert actual == {
-        "cmux-delegate": ("external-cli-wrapper",),
+        # helper-executable since #903: agent-report-path.sh derives the
+        # completion-report path for both halves of the handoff protocol.
+        "cmux-delegate": ("external-cli-wrapper", "helper-executable"),
         "cmux-recover-sessions": (
             "AskUserQuestion",
             "external-cli-wrapper",


### PR DESCRIPTION
## 요약

praxis 가 쓰는 런타임 파일이 세 군데로 흩어져 있어 `PRAXIS_HOME` 이 실제로는 위치를 통제하지 못했습니다. 전부 `PRAXIS_HOME` 아래로 모으고, 그 변수 하나로 전체가 움직이게 합니다.

## 문제

1. **워크스페이스 루트** — `cmux-delegate` 가 위임 완료 보고서를 *작업 대상 repo* 의 worktree 루트에 `.agent-report.json` 으로 씁니다. praxis 내부 파일이 남의 레포 안에 생기고 repo 마다 gitignore 가 필요합니다. 이번 세션의 hub-4609 위임에서 실제로 발생했습니다.
2. **`${TMPDIR}` 산재** — 훅 12곳이 각자 `os.environ.get("TMPDIR", "/tmp")` (2곳은 `/tmp` 하드코딩) 로 경로를 만듭니다. `PRAXIS_HOME` 을 바꿔도 하나도 안 따라옵니다.
3. **`~/.praxis`** — #527 이 durable state / cache / logs 만 옮겨 놨습니다.

`_paths.py:15` 가 남긴 문장 그대로입니다 — *"The volatile `${TMPDIR}/praxis-*` dedup files are tracked separately in #527's follow-up."* 그 후속 이슈는 존재하지 않았습니다 (`gh issue list --state all` → 0건).

## 변경 사항

### 1. 셸 경로 리졸버 (`hooks/_lib/_paths.sh`)

`_paths.py` 의 대응물. `${PRAXIS_HOME:-$HOME/.praxis}` 인라인 표현이 3개 `impl.sh` 에 반복돼 있었습니다. 프로토콜의 writer 와 reader 가 언어 경계 양쪽에 앉을 수 있으므로 정의는 언어당 하나여야 합니다.

`resolve_cache_file` (구 `${TMPDIR}` 파일 일회성 이관) 과 `prune_stale` 도 추가했습니다 — `${TMPDIR}` 엔 OS 청소부가 있었지만 `~/.praxis/cache` 엔 없고, 이 파일들은 세션 키라 그대로 두면 무한 증가합니다. `PRAXIS_CACHE_TTL_DAYS` (기본 7, `0` 이면 비활성).

### 2. 런타임 파일 12곳 이관

| 이관 | 대상 |
|---|---|
| `${TMPDIR}` → `<PRAXIS_HOME>/cache/` | session-intent, retrospect-active-marker(+candidates), md-read-history, postcompact-context, jq-config-advisory, path-probe-gate, pre-output-falsification-gate, bulk-write-checkpoint, bash-worktree-advisory, worktree-prune-snapshot |
| `/tmp` 하드코딩 → 동일 | gh-json-validator |

`_paths.py` 의 docstring 은 이 중 9개만 후속 대상으로 적어 두고 있었습니다. `gh-json-validator` 와 `worktree-prune-snapshot-gate` 는 그 목록에 없었고, 목록을 믿는 대신 트리를 전수 조사해서 찾았습니다.

명시적 per-file env override (`PRAXIS_SESSION_INTENT_FILE` 등) 는 최우선 순위를 유지합니다.

### 3. 완료 보고서 재배치

`.agent-report.json` → `<PRAXIS_HOME>/agent-reports/<sha1(worktree)>.json`.

- writer(완료 프로토콜) 와 reader(Step 7 판정) 가 **같은 헬퍼** `agent-report-path.sh` 를 호출합니다. 스니펫을 양쪽에 복붙하면 한쪽만 고쳐질 때 판정이 조용히 깨집니다.
- 헬퍼가 해시 전에 **worktree 루트로 정규화**합니다. 에이전트는 보통 패키지 서브디렉터리에서 작업하고 위임자는 `--cwd` 로 넘긴 경로를 들고 있어서, 인자를 그대로 해시하면 둘이 다른 파일을 보고 **끝난 작업이 미완료로 읽힙니다**.
- 보고서에 `worktree` 필수 필드. 파일명이 해시라 눈으로 확인할 수 없으므로 위임자가 이 값을 대조합니다.
- 보고서는 `prune_stale` 대상이 **아닙니다**. 부재가 곧 "미완료" 신호이므로, 아직 수거되지 않은 보고서를 지우면 이 handoff 가 없애려던 false negative 를 그대로 만들어냅니다.

## 검증

`./scripts/run-tests.sh` → **ALL TESTS PASSED / EXIT=0**. pytest 508 passed, 셸 테스트 PASS 2777 / FAIL 0. `origin/main` 리베이스 후 재실행한 결과입니다.

**경로 변경 가능성 실증** — 단위 테스트가 아니라 훅 실제 실행:

```
$ PRAXIS_HOME=$H python3 hooks/preflight-gate/session-intent/impl.py
$ PRAXIS_HOME=$H python3 hooks/preflight-gate/retrospect-active-marker/impl.py
$ find "$H" -type f
<PRAXIS_HOME>/cache/session-intent-probe-903.json
<PRAXIS_HOME>/cache/retrospect-active-probe-903.json
$ ls ${TMPDIR}praxis-session-intent-probe-903.json
No such file or directory
```

**레거시 이관 실증** — 구 `${TMPDIR}` 경로에 `{"mutation_verb_seen": true, "read_intent_anchored": true}` 를 심고 훅 실행 → 그 값이 새 경로에서 읽혔고 구 파일은 사라졌습니다.

**정규화 실증** — `report_path_for <worktree>/hooks/_lib` 와 `report_path_for <worktree>` 가 동일 경로. `--worktree` 는 서브디렉터리에서도 루트를 반환하고, repo 밖 경로는 그대로 통과.

**이관 훅 12곳 전수 실증** — 임시 `PRAXIS_HOME` + 임시 `TMPDIR` 아래에서 각 훅을 매니페스트의 이벤트에 맞는 페이로드로 실제 실행했습니다. 12곳 모두 상태 파일이 `<PRAXIS_HOME>/cache/` 에 생겼고, 구 `${TMPDIR}/praxis-*` 위치의 파일 수는 0 이었습니다.

첫 회차에서 `jq-config` / `path-probe` / `bash-worktree` / `pre-output-falsification` / `postcompact-context` 5곳이 아무 파일도 남기지 않았는데, 이건 이관 실패가 아니라 **제가 발화하지 않는 페이로드를 준 것**이었습니다. 이 훅들은 어드바이저리가 실제로 뜰 때만 dedup 파일을 씁니다. 조건을 맞춰 재실행했습니다 — 실제 git worktree 안의 미열람 중간 디렉터리(path-probe), 존재하지 않는 `cd` 대상(bash-worktree), `.claude/` 아래 빈 `settings.json`(jq-config), 동일 read-only 프로브 3회 반복(falsification gate), `isCompactSummary` 레코드가 있는 트랜스크립트(postcompact). 전부 발화했고 파일은 `<PRAXIS_HOME>` 아래에 생겼습니다.

```
<PRAXIS_HOME>/cache/session-intent-<sid>.json
<PRAXIS_HOME>/cache/retrospect-active-<sid>.json
<PRAXIS_HOME>/cache/md-read-history-<sid>.json
<PRAXIS_HOME>/cache/worktree-prune-snapshot-<sid>.json
<PRAXIS_HOME>/cache/postcompact-context-<sid>.json
<PRAXIS_HOME>/cache/jq-config-advisory-<sid>.json
<PRAXIS_HOME>/cache/gh-json-<sid>/pr_list.json
<PRAXIS_HOME>/cache/bulk-write-checkpoint/counts/<h>/<h>
<PRAXIS_HOME>/cache/path-probe-gate/<h>/<h>
<PRAXIS_HOME>/cache/pre-output-falsification-gate/<h>/<h>
<PRAXIS_HOME>/cache/bash-worktree-advisory/<sid>.<h>.missing
```

**handoff 왕복 실증** — 테스트 하네스가 아니라 `SKILL.md` 에 적힌 writer/reader 스니펫을 그대로 실행했습니다. 픽스처 git repo 를 만들고, 에이전트 역할로 `<repo>/analytics_backend/app` 에서 writer 를, 위임자 역할로 `cd /` 한 뒤 worktree 루트 경로만으로 reader 를 돌렸습니다. 서브디렉터리에서 쓴 보고서를 루트 경로만으로 찾아냈고, `head_sha` 는 `git rev-parse HEAD` 와 일치했으며, 대상 worktree 최상위에는 `.git` 과 소스 디렉터리만 남았습니다 — `.agent-report.json` 없음. 실패 3형태도 각각 구분됐습니다: 보고서 부재 → "완료 보고서 부재", 타 worktree 보고서 → "worktree 불일치", 잘린 보고서 → "JSON 파싱 실패".

신규 테스트: `test_paths.sh` 8 → 21 케이스 (prune, 레거시 이관, 셸↔파이썬 리졸버 일치), `test_agent_report_handoff.sh` 30 → 40 케이스 (PRAXIS_HOME 하위 확인, 타 worktree 보고서 거부, 서브디렉터리 왕복). handoff 게이트는 스니펫을 전사하지 않고 **배포되는 헬퍼를 그대로 실행**합니다 — 전사본은 writer/reader 가 갈라져도 통과하는데, 그게 공유 헬퍼가 막으려는 실패입니다.

## 리뷰 중 스스로 잡은 회귀 2건

1. **`_paths.sh` 부재 시 게이트 무음 해제** — `impl.sh` 가 source 하게 되면서 생긴 신규 실패 모드입니다. `set -e` 가 없어 source 실패가 조용히 지나가고, `MARKER_FILE` 이 빈 문자열이 되어 retrospect 게이트가 아무 소리 없이 풀립니다(#666 이 열렸던 실패 형태). 세 소비자 모두 함수 존재를 확인하고 stderr 로 표면화합니다.
2. **서브디렉터리 해시 불일치** — 위 "정규화" 항목.

## 부수 변경

`run-tests.sh` 가 임시 `PRAXIS_HOME` 을 export 합니다. 훅이 이제 그걸 통해 파일을 만들므로, 없으면 스위트가 개발자 본인의 `~/.praxis` 에 쓰고 `prune_stale` 이 거기를 쓸어버립니다.

## 검증하지 않은 것

- **실제 cmux 위임을 이 브랜치가 설치된 상태로 돌려 보지는 않았습니다.** 위 handoff 왕복은 `SKILL.md` 스니펫을 사람이 실행한 것이지, cmux 워커가 스킬을 읽고 스스로 수행한 것이 아닙니다. 검증된 것은 프로토콜의 경로 산출·판정 로직이고, 에이전트가 그 지시를 따르는지는 아닙니다.
- 레거시 `${TMPDIR}` 읽기 폴백은 `session-intent` 한 곳에서만 실제 파일을 심어 확인했습니다. 나머지는 같은 `resolve_cache_file` 을 거치지만 개별 실증은 안 했습니다.

Pre-commit verified: `./scripts/run-tests.sh` → ALL TESTS PASSED (pytest 508 passed, shell FAIL 0, manifest / hook-token invariant / ruff / shellcheck 전부 통과, markdownlint 는 미설치로 SKIPPED).

Caller chain verified: `resolve_cache_file` / `praxis_cache_dir` 의 호출자를 전수 확인 — `grep -rn 'os.environ.get("TMPDIR"' hooks/ --include="*.py"` 결과 잔여 지점은 `_paths.py`(정의부) 와 `_hook_runtime.py`(쓰기 불가 홈 폴백) 둘뿐이고, `grep -rn 'Path(f*"/tmp\|"/tmp/praxis' hooks/ skills/` 는 0건입니다. `_paths.sh` 의 소비자는 `hooks/completion-verify/{strike-counter,completion-verify,retrospect-mix-check}/impl.sh` 와 `skills/cmux-delegate/agent-report-path.sh` 4곳이며 모두 함수 존재 가드를 거칩니다. `agent-report-path.sh` 의 호출자는 `skills/cmux-delegate/SKILL.md` 의 writer(완료 프로토콜)·reader(Step 7) 두 지점과 `tests/test_agent_report_handoff.sh` 입니다.

Closes #903


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent runtime path handling for durable state, caches, logs, and agent reports.
  * Added cache migration, configurable expiration, and automatic cleanup for stale entries.
  * Added worktree-aware agent-report discovery and validation.
  * Added safe fallback behavior when writable locations are unavailable.

* **Documentation**
  * Updated runtime, cache, session-state, and completion-report documentation.

* **Tests**
  * Expanded coverage for path resolution, migration, cleanup, isolation, and report validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
