### PR TITLE
fix(codex-review-wrap): gate reap on owner death

### DIFF
--- a/skills/codex-review-wrap/codex-broker-reaper.sh
+++ b/skills/codex-review-wrap/codex-broker-reaper.sh
@@ -155,48 +155,66 @@ is_safe_session_dir() {
 # two positive orphan signals — a broker is reaped only when one of them fires:
 #   C  workspaceRoot is known (from the state dir's jobs/*.json) and that
 #      directory no longer exists → the worktree is gone → orphan.
-#   D  workspaceRoot still exists but NO live process has it as its cwd →
-#      nothing is working in that workspace → orphan.
-# Every indeterminate path (no state dir for the pid, no jobs file, lsof or
-# shasum failure) reports "unknown" and the broker is KEPT.
+#   D  workspaceRoot still exists but no live process OUTSIDE the broker's own
+#      tree has it as its cwd → nothing is working in that workspace → orphan.
+# Every indeterminate path (no unambiguous state dir for the pid, no jobs file,
+# lsof or shasum failure) reports "unknown" and the broker is KEPT.
 
-# sha256-16 of every live process cwd, computed once per scan. Empty list =>
-# the scan failed or is not yet run; LIVE_CWD_SCAN_OK distinguishes the two.
-LIVE_CWD_HASHES=""
+# "<pid> <sha256-16 of its cwd>" per live process. The pid is retained because
+# the broker itself is started IN its workspace root and never chdirs — so is
+# its app-server child. Counting those as "someone is working here" would make
+# signal D unfirable, so the caller subtracts the tree it is judging.
+#
+# owner_status() runs inside a command substitution, so this snapshot lives for
+# exactly one judgement — which is what the pre-kill re-check needs anyway.
+# Empty map => the scan failed; LIVE_CWD_SCAN_OK distinguishes it from unrun.
+LIVE_CWD_MAP=""
 LIVE_CWD_SCAN_OK=false
 scan_live_cwds() {
   if [[ "$LIVE_CWD_SCAN_OK" == "true" ]]; then return 0; fi
-  local paths p h
-  paths="$(lsof -a -d cwd -Fn -w 2>/dev/null | sed -n 's/^n//p' | sort -u)"
-  [[ -n "$paths" ]] || return 0
-  while IFS= read -r p; do
-    [[ -n "$p" ]] || continue
-    h="$(printf '%s' "$p" | shasum -a 256 2>/dev/null | cut -c1-16)"
-    [[ -n "$h" ]] && LIVE_CWD_HASHES="$LIVE_CWD_HASHES $h"
-  done <<< "$paths"
-  [[ -n "$LIVE_CWD_HASHES" ]] && LIVE_CWD_SCAN_OK=true
+  local raw line cur="" h
+  raw="$(lsof -a -d cwd -Fpn -w 2>/dev/null)"
+  [[ -n "$raw" ]] || return 0
+  while IFS= read -r line; do
+    case "$line" in
+      p*) cur="${line#p}" ;;
+      n*)
+        [[ -n "$cur" ]] || continue
+        h="$(printf '%s' "${line#n}" | shasum -a 256 2>/dev/null | cut -c1-16)"
+        [[ -n "$h" ]] && LIVE_CWD_MAP="$LIVE_CWD_MAP$cur $h"$'\n'
+        ;;
+    esac
+  done <<< "$raw"
+  [[ -n "$LIVE_CWD_MAP" ]] && LIVE_CWD_SCAN_OK=true
   return 0
 }
 
-# The state dir whose broker.json claims this pid, or empty. grep narrows the
-# candidates so the jq confirmation runs on one file, not all ~400.
+# The one state dir that belongs to this broker, or empty when that cannot be
+# decided. pid alone is not a key: broker.json files left behind by crashed
+# brokers are never GC'd, and pids get reused (observed: two state dirs claiming
+# pid 17869). The live broker's own command line carries the authoritative
+# sessionDir, so a candidate must match on pid AND sessionDir — and if that
+# still leaves 0 or several candidates, the caller must treat the owner as
+# undetermined rather than trust an arbitrary one.
 state_dir_of_broker() {
-  local pid="$1" bj
+  local pid="$1" want="$2" bj found="" n=0
+  [[ -n "$want" ]] || return 0
   for bj in $(grep -lE "\"pid\"[[:space:]]*:[[:space:]]*$pid([^0-9]|\$)" "$STATE_DIR"/*/broker.json 2>/dev/null || true); do
-    if [[ "$(jq -r '.pid // empty' "$bj" 2>/dev/null || true)" == "$pid" ]]; then
-      dirname "$bj"; return 0
-    fi
+    [[ "$(jq -r '.pid // empty' "$bj" 2>/dev/null || true)" == "$pid" ]] || continue
+    [[ "$(jq -r '.sessionDir // empty' "$bj" 2>/dev/null || true)" == "$want" ]] || continue
+    found="$(dirname "$bj")"; n=$(( n + 1 ))
   done
+  (( n == 1 )) && printf '%s' "$found"
   return 0
 }
 
 # "<status>:<reason>" where status is dead | alive | unknown. Only `dead`
-# licenses a kill.
+# licenses a kill. $2 is the sessionDir read off the broker's command line.
 owner_status() {
-  local pid="$1" sdir suffix wroot
-  sdir="$(state_dir_of_broker "$pid")"
+  local pid="$1" want="$2" sdir suffix wroot own lpid lhash
+  sdir="$(state_dir_of_broker "$pid" "$want")"
   if [[ -z "$sdir" ]]; then
-    printf 'unknown:no state dir claims this pid'; return 0
+    printf 'unknown:no single state dir matches this pid and sessionDir'; return 0
   fi
   suffix="$(basename "$sdir")"; suffix="${suffix##*-}"
   if [[ ! "$suffix" =~ ^[0-9a-f]{16}$ ]]; then
@@ -213,10 +231,16 @@ owner_status() {
   if [[ "$LIVE_CWD_SCAN_OK" != "true" ]]; then
     printf 'unknown:live-cwd scan produced nothing'; return 0
   fi
-  case " $LIVE_CWD_HASHES " in
-    *" $suffix "*) printf 'alive:a live process is working in %s' "$wroot"; return 0 ;;
-  esac
-  printf 'dead:no live process has %s as its cwd' "$wroot"
+  # The broker and its app-server child sit in the workspace themselves, so they
+  # are subtracted before the match — otherwise every broker would vouch for its
+  # own owner and D could never fire.
+  own=" $(collect_tree "$pid")"
+  while read -r lpid lhash; do
+    [[ "$lhash" == "$suffix" ]] || continue
+    case "$own" in *" $lpid "*) continue ;; esac
+    printf 'alive:pid %s is working in %s' "$lpid" "$wroot"; return 0
+  done <<< "$LIVE_CWD_MAP"
+  printf 'dead:no live process outside the broker tree has %s as its cwd' "$wroot"
 }
 
 # Best-effort single instance: the opt-in phase-end reaper and the launchd job
@@ -257,7 +281,7 @@ if [[ "$MODE" == "reap" ]]; then
 
     # Owner-liveness gate (#919). Idleness only says the broker is not serving
     # right now; the kill needs positive evidence that its workspace is gone.
-    owner="$(owner_status "$pid")"
+    owner="$(owner_status "$pid" "$sdir")"
     if [[ "${owner%%:*}" != "dead" ]]; then
       echo "SKIP   pid=$pid (owner ${owner%%:*}: ${owner#*:})"
       skipped=$(( skipped + 1 )); continue
@@ -275,9 +299,8 @@ if [[ "$MODE" == "reap" ]]; then
         skipped=$(( skipped + 1 )); continue
       fi
       # Same re-check for ownership: work can start in the workspace during the
-      # gap, so the cached cwd scan is discarded and re-taken.
-      LIVE_CWD_HASHES=""; LIVE_CWD_SCAN_OK=false
-      owner="$(owner_status "$pid")"
+      # gap, and each call takes its own cwd snapshot.
+      owner="$(owner_status "$pid" "$sdir")"
       if [[ "${owner%%:*}" != "dead" ]]; then
         echo "SKIP   pid=$pid (owner ${owner%%:*} before kill: ${owner#*:})"
         skipped=$(( skipped + 1 )); continue

--- a/skills/codex-review-wrap/codex-broker-reaper.sh
+++ b/skills/codex-review-wrap/codex-broker-reaper.sh
@@ -11,23 +11,25 @@
 #   surfaces as kernel_task sys time — a non-linear spike, not a linear one.
 #
 # Safety model:
-#   - A broker with ANY child process is KEPT. Its descendants include the live
-#     `codex app-server` backend, and collect_tree() signals the whole tree — so
-#     reaping such a broker kills the owning session, not leaked infra (#919:
-#     13 live-but-idle sessions were killed this way).
-#   - The idle gate (--max-age) is a necessary but NOT sufficient condition: it
-#     measures whether the broker is serving right now, not whether its session
-#     is alive. A session idle between turns leaves broker.log untouched.
-#   - Only a childless, idle broker is reaped — the backend has already detached,
-#     so the worst case is a benign respawn on the next codex call.
-#   - When idleness cannot be determined (no logFile), the broker is KEPT.
+#   - The idle gate (--max-age) is necessary but NOT sufficient: it measures
+#     whether the broker is serving right now, not whether its owner is alive.
+#     A session idle between turns leaves broker.log untouched — that is how
+#     #919 killed 13 live sessions.
+#   - So a kill also requires positive evidence that the owner is GONE: the
+#     broker's workspace root (recovered from its state dir) has been deleted,
+#     or no live process is working in it. See the owner-liveness oracle below.
+#   - Every indeterminate signal KEEPS the broker: unknown idleness (no
+#     logFile), no state dir for the pid, no recorded workspaceRoot, or a
+#     failed cwd scan.
+#   - A reap therefore costs at worst a respawn on the next codex call in a
+#     workspace nobody is using.
 #
 # Modes:
 #   --gc                 GC only: remove stale tmp sessionDirs whose broker pid
 #                        is dead. Zero risk. (default)
-#   --reap [--max-age N] Also kill RUNNING brokers that are childless AND idle
-#                        > N minutes (default 30), then GC. Used by the launchd
-#                        job and the opt-in
+#   --reap [--max-age N] Also kill RUNNING brokers idle > N minutes (default 30)
+#                        whose owning workspace is provably gone, then GC. Used
+#                        by the launchd job and the opt-in
 #                        PRAXIS_CODEX_REAP=1 path in codex-review-wrap.
 #   --dry-run            Print actions without executing.
 #
@@ -50,9 +52,9 @@ usage() {
 Usage: codex-broker-reaper.sh [--gc | --reap] [--max-age MINUTES] [--dry-run]
 
   --gc            Remove stale tmp sessionDirs of dead brokers (zero risk). Default.
-  --reap          Also kill running brokers that have no child process AND have
-                  been idle longer than --max-age, then GC. A broker with a
-                  child still owns a live codex backend and is never killed.
+  --reap          Also kill running brokers idle longer than --max-age whose
+                  owning workspace is provably gone (deleted, or no live process
+                  works in it), then GC. Anything undetermined is kept.
   --max-age N     Idle-minutes threshold for --reap (default: 30).
   --dry-run       Show what would happen; make no changes.
   -h, --help      This help.
@@ -114,16 +116,6 @@ collect_tree() {
   printf '%s ' "$pid"
 }
 
-# Direct children of a pid as a space-separated list; empty when it has none.
-# `pgrep` exits 1 on no match, so the pipeline is terminated by `tr` (always 0)
-# to keep `set -e` out of it.
-child_pids_of() {
-  local kids
-  kids="$(pgrep -P "$1" 2>/dev/null | tr '\n' ' ')"
-  [[ -n "${kids// /}" ]] && printf '%s' "${kids% }"
-  return 0
-}
-
 # Resolve the broker's sessionDir from its command-line endpoint:
 #   ... serve --endpoint unix:/<sessionDir>/broker.sock
 session_dir_of() {
@@ -150,6 +142,81 @@ is_safe_session_dir() {
     /var/folders/*|/private/var/folders/*|/tmp/*|/private/tmp/*) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+# --- Owner-liveness oracle (#919) -------------------------------------------
+# "Has no children" is NOT a liveness signal: app-server-broker.mjs connects a
+# CodexAppServerClient at startup (which spawns `codex app-server` as its child)
+# and only closes it from its own shutdown path, so a genuine orphan keeps that
+# child forever. Every live broker observed had one, and so would every orphan.
+#
+# The broker's owning unit is the WORKSPACE ROOT, not the session: the plugin
+# names its state dir `<slug>-<sha256(workspaceRoot) first 16 hex>`. That gives
+# two positive orphan signals — a broker is reaped only when one of them fires:
+#   C  workspaceRoot is known (from the state dir's jobs/*.json) and that
+#      directory no longer exists → the worktree is gone → orphan.
+#   D  workspaceRoot still exists but NO live process has it as its cwd →
+#      nothing is working in that workspace → orphan.
+# Every indeterminate path (no state dir for the pid, no jobs file, lsof or
+# shasum failure) reports "unknown" and the broker is KEPT.
+
+# sha256-16 of every live process cwd, computed once per scan. Empty list =>
+# the scan failed or is not yet run; LIVE_CWD_SCAN_OK distinguishes the two.
+LIVE_CWD_HASHES=""
+LIVE_CWD_SCAN_OK=false
+scan_live_cwds() {
+  if [[ "$LIVE_CWD_SCAN_OK" == "true" ]]; then return 0; fi
+  local paths p h
+  paths="$(lsof -a -d cwd -Fn -w 2>/dev/null | sed -n 's/^n//p' | sort -u)"
+  [[ -n "$paths" ]] || return 0
+  while IFS= read -r p; do
+    [[ -n "$p" ]] || continue
+    h="$(printf '%s' "$p" | shasum -a 256 2>/dev/null | cut -c1-16)"
+    [[ -n "$h" ]] && LIVE_CWD_HASHES="$LIVE_CWD_HASHES $h"
+  done <<< "$paths"
+  [[ -n "$LIVE_CWD_HASHES" ]] && LIVE_CWD_SCAN_OK=true
+  return 0
+}
+
+# The state dir whose broker.json claims this pid, or empty. grep narrows the
+# candidates so the jq confirmation runs on one file, not all ~400.
+state_dir_of_broker() {
+  local pid="$1" bj
+  for bj in $(grep -lE "\"pid\"[[:space:]]*:[[:space:]]*$pid([^0-9]|\$)" "$STATE_DIR"/*/broker.json 2>/dev/null || true); do
+    if [[ "$(jq -r '.pid // empty' "$bj" 2>/dev/null || true)" == "$pid" ]]; then
+      dirname "$bj"; return 0
+    fi
+  done
+  return 0
+}
+
+# "<status>:<reason>" where status is dead | alive | unknown. Only `dead`
+# licenses a kill.
+owner_status() {
+  local pid="$1" sdir suffix wroot
+  sdir="$(state_dir_of_broker "$pid")"
+  if [[ -z "$sdir" ]]; then
+    printf 'unknown:no state dir claims this pid'; return 0
+  fi
+  suffix="$(basename "$sdir")"; suffix="${suffix##*-}"
+  if [[ ! "$suffix" =~ ^[0-9a-f]{16}$ ]]; then
+    printf 'unknown:state dir %s has no workspace hash suffix' "$(basename "$sdir")"; return 0
+  fi
+  wroot="$(jq -r '.workspaceRoot // empty' "$sdir"/jobs/*.json 2>/dev/null | head -1 || true)"
+  if [[ -z "$wroot" ]]; then
+    printf 'unknown:no workspaceRoot recorded in %s/jobs' "$(basename "$sdir")"; return 0
+  fi
+  if [[ ! -d "$wroot" ]]; then
+    printf 'dead:workspace %s no longer exists' "$wroot"; return 0
+  fi
+  scan_live_cwds
+  if [[ "$LIVE_CWD_SCAN_OK" != "true" ]]; then
+    printf 'unknown:live-cwd scan produced nothing'; return 0
+  fi
+  case " $LIVE_CWD_HASHES " in
+    *" $suffix "*) printf 'alive:a live process is working in %s' "$wroot"; return 0 ;;
+  esac
+  printf 'dead:no live process has %s as its cwd' "$wroot"
 }
 
 # Best-effort single instance: the opt-in phase-end reaper and the launchd job
@@ -188,13 +255,11 @@ if [[ "$MODE" == "reap" ]]; then
       skipped=$(( skipped + 1 )); continue
     fi
 
-    # Owner-liveness gate (#919). A broker's children are its `codex app-server`
-    # backend; collect_tree() below would sweep them into the kill. An idle log
-    # only proves the broker is not serving *right now*, so children are the
-    # evidence that a session still owns it.
-    children="$(child_pids_of "$pid")"
-    if [[ -n "$children" ]]; then
-      echo "SKIP   pid=$pid (owner alive: child pids $children — reaping would kill the codex backend)"
+    # Owner-liveness gate (#919). Idleness only says the broker is not serving
+    # right now; the kill needs positive evidence that its workspace is gone.
+    owner="$(owner_status "$pid")"
+    if [[ "${owner%%:*}" != "dead" ]]; then
+      echo "SKIP   pid=$pid (owner ${owner%%:*}: ${owner#*:})"
       skipped=$(( skipped + 1 )); continue
     fi
 
@@ -209,11 +274,12 @@ if [[ "$MODE" == "reap" ]]; then
         echo "SKIP   pid=$pid (became active before kill)"
         skipped=$(( skipped + 1 )); continue
       fi
-      # Same re-check for ownership: a backend can attach in the gap, and
-      # collect_tree() would then sweep it into the kill.
-      children="$(child_pids_of "$pid")"
-      if [[ -n "$children" ]]; then
-        echo "SKIP   pid=$pid (owner attached before kill: child pids $children)"
+      # Same re-check for ownership: work can start in the workspace during the
+      # gap, so the cached cwd scan is discarded and re-taken.
+      LIVE_CWD_HASHES=""; LIVE_CWD_SCAN_OK=false
+      owner="$(owner_status "$pid")"
+      if [[ "${owner%%:*}" != "dead" ]]; then
+        echo "SKIP   pid=$pid (owner ${owner%%:*} before kill: ${owner#*:})"
         skipped=$(( skipped + 1 )); continue
       fi
       tree="$(collect_tree "$pid")"

--- a/skills/codex-review-wrap/codex-broker-reaper.sh
+++ b/skills/codex-review-wrap/codex-broker-reaper.sh
@@ -16,21 +16,21 @@
 #     A session idle between turns leaves broker.log untouched — that is how
 #     #919 killed 13 live sessions.
 #   - So a kill also requires positive evidence that the owner is GONE: the
-#     broker's workspace root (recovered from its state dir) has been deleted,
-#     or no live process is working in it. See the owner-liveness oracle below.
-#   - Every indeterminate signal KEEPS the broker: unknown idleness (no
-#     logFile), no state dir for the pid, no recorded workspaceRoot, or a
-#     failed cwd scan.
+#     broker's workspace root, recovered from its state dir, has been deleted.
+#     See the owner-liveness oracle below.
+#   - Every other signal KEEPS the broker: unknown idleness (no logFile), no
+#     unambiguous state dir for the pid, no recorded workspaceRoot, or a
+#     workspace that still exists. Under-reaping is the intended bias.
 #   - A reap therefore costs at worst a respawn on the next codex call in a
-#     workspace nobody is using.
+#     workspace that has been deleted.
 #
 # Modes:
 #   --gc                 GC only: remove stale tmp sessionDirs whose broker pid
 #                        is dead. Zero risk. (default)
 #   --reap [--max-age N] Also kill RUNNING brokers idle > N minutes (default 30)
-#                        whose owning workspace is provably gone, then GC. Used
-#                        by the launchd job and the opt-in
-#                        PRAXIS_CODEX_REAP=1 path in codex-review-wrap.
+#                        whose workspace root has been deleted, then GC. Used by
+#                        the launchd job and the opt-in PRAXIS_CODEX_REAP=1 path
+#                        in codex-review-wrap.
 #   --dry-run            Print actions without executing.
 #
 # macOS-only: the leak it addresses is inherent to launchd reparenting and the
@@ -53,8 +53,9 @@ Usage: codex-broker-reaper.sh [--gc | --reap] [--max-age MINUTES] [--dry-run]
 
   --gc            Remove stale tmp sessionDirs of dead brokers (zero risk). Default.
   --reap          Also kill running brokers idle longer than --max-age whose
-                  owning workspace is provably gone (deleted, or no live process
-                  works in it), then GC. Anything undetermined is kept.
+                  workspace root has been deleted, then GC. A broker whose
+                  workspace still exists, or whose owner cannot be determined,
+                  is kept.
   --max-age N     Idle-minutes threshold for --reap (default: 30).
   --dry-run       Show what would happen; make no changes.
   -h, --help      This help.
@@ -150,45 +151,21 @@ is_safe_session_dir() {
 # and only closes it from its own shutdown path, so a genuine orphan keeps that
 # child forever. Every live broker observed had one, and so would every orphan.
 #
-# The broker's owning unit is the WORKSPACE ROOT, not the session: the plugin
-# names its state dir `<slug>-<sha256(workspaceRoot) first 16 hex>`. That gives
-# two positive orphan signals — a broker is reaped only when one of them fires:
+# The broker's owning unit is the WORKSPACE ROOT, not the session. Exactly ONE
+# positive orphan signal is trusted here:
 #   C  workspaceRoot is known (from the state dir's jobs/*.json) and that
 #      directory no longer exists → the worktree is gone → orphan.
-#   D  workspaceRoot still exists but no live process OUTSIDE the broker's own
-#      tree has it as its cwd → nothing is working in that workspace → orphan.
-# Every indeterminate path (no unambiguous state dir for the pid, no jobs file,
-# lsof or shasum failure) reports "unknown" and the broker is KEPT.
-
-# "<pid> <sha256-16 of its cwd>" per live process. The pid is retained because
-# the broker itself is started IN its workspace root and never chdirs — so is
-# its app-server child. Counting those as "someone is working here" would make
-# signal D unfirable, so the caller subtracts the tree it is judging.
+# Every other outcome KEEPS the broker: workspace still present, no unambiguous
+# state dir for the pid, no jobs file, no recorded workspaceRoot.
 #
-# owner_status() runs inside a command substitution, so this snapshot lives for
-# exactly one judgement — which is what the pre-kill re-check needs anyway.
-# Empty map => the scan failed; LIVE_CWD_SCAN_OK distinguishes it from unrun.
-LIVE_CWD_MAP=""
-LIVE_CWD_SCAN_OK=false
-scan_live_cwds() {
-  if [[ "$LIVE_CWD_SCAN_OK" == "true" ]]; then return 0; fi
-  local raw line cur="" h
-  raw="$(lsof -a -d cwd -Fpn -w 2>/dev/null)"
-  [[ -n "$raw" ]] || return 0
-  while IFS= read -r line; do
-    case "$line" in
-      p*) cur="${line#p}" ;;
-      n*)
-        [[ -n "$cur" ]] || continue
-        h="$(printf '%s' "${line#n}" | shasum -a 256 2>/dev/null | cut -c1-16)"
-        [[ -n "$h" ]] && LIVE_CWD_MAP="$LIVE_CWD_MAP$cur $h"$'\n'
-        ;;
-    esac
-  done <<< "$raw"
-  [[ -n "$LIVE_CWD_MAP" ]] && LIVE_CWD_SCAN_OK=true
-  return 0
-}
-
+# A second signal — "workspace exists but nobody is working in it", decided by
+# matching live process cwds against the state dir's workspace hash — was built
+# and then dropped from this pass. It could not be made safe here: the plugin
+# records the GIT ROOT as workspaceRoot while a session's cwd may be any
+# subdirectory (lib/workspace.mjs `resolveWorkspaceRoot` -> `ensureGitRepository`),
+# so exact matching reports a live owner as dead. It also depends on `lsof`,
+# which the Ubuntu CI runner cannot be assumed to provide, and costs a full cwd
+# scan per broker. That recovery path is tracked separately.
 # The one state dir that belongs to this broker, or empty when that cannot be
 # decided. pid alone is not a key: broker.json files left behind by crashed
 # brokers are never GC'd, and pids get reused (observed: two state dirs claiming
@@ -211,14 +188,10 @@ state_dir_of_broker() {
 # "<status>:<reason>" where status is dead | alive | unknown. Only `dead`
 # licenses a kill. $2 is the sessionDir read off the broker's command line.
 owner_status() {
-  local pid="$1" want="$2" sdir suffix wroot own lpid lhash
+  local pid="$1" want="$2" sdir wroot
   sdir="$(state_dir_of_broker "$pid" "$want")"
   if [[ -z "$sdir" ]]; then
     printf 'unknown:no single state dir matches this pid and sessionDir'; return 0
-  fi
-  suffix="$(basename "$sdir")"; suffix="${suffix##*-}"
-  if [[ ! "$suffix" =~ ^[0-9a-f]{16}$ ]]; then
-    printf 'unknown:state dir %s has no workspace hash suffix' "$(basename "$sdir")"; return 0
   fi
   wroot="$(jq -r '.workspaceRoot // empty' "$sdir"/jobs/*.json 2>/dev/null | head -1 || true)"
   if [[ -z "$wroot" ]]; then
@@ -227,20 +200,7 @@ owner_status() {
   if [[ ! -d "$wroot" ]]; then
     printf 'dead:workspace %s no longer exists' "$wroot"; return 0
   fi
-  scan_live_cwds
-  if [[ "$LIVE_CWD_SCAN_OK" != "true" ]]; then
-    printf 'unknown:live-cwd scan produced nothing'; return 0
-  fi
-  # The broker and its app-server child sit in the workspace themselves, so they
-  # are subtracted before the match — otherwise every broker would vouch for its
-  # own owner and D could never fire.
-  own=" $(collect_tree "$pid")"
-  while read -r lpid lhash; do
-    [[ "$lhash" == "$suffix" ]] || continue
-    case "$own" in *" $lpid "*) continue ;; esac
-    printf 'alive:pid %s is working in %s' "$lpid" "$wroot"; return 0
-  done <<< "$LIVE_CWD_MAP"
-  printf 'dead:no live process outside the broker tree has %s as its cwd' "$wroot"
+  printf 'alive:workspace %s still exists' "$wroot"
 }
 
 # Best-effort single instance: the opt-in phase-end reaper and the launchd job
@@ -298,8 +258,8 @@ if [[ "$MODE" == "reap" ]]; then
         echo "SKIP   pid=$pid (became active before kill)"
         skipped=$(( skipped + 1 )); continue
       fi
-      # Same re-check for ownership: work can start in the workspace during the
-      # gap, and each call takes its own cwd snapshot.
+      # Same re-check for ownership: the workspace can be restored (a worktree
+      # re-added, a checkout redone) between the gate and the kill.
       owner="$(owner_status "$pid" "$sdir")"
       if [[ "${owner%%:*}" != "dead" ]]; then
         echo "SKIP   pid=$pid (owner ${owner%%:*} before kill: ${owner#*:})"

--- a/skills/codex-review-wrap/codex-broker-reaper.sh
+++ b/skills/codex-review-wrap/codex-broker-reaper.sh
@@ -11,18 +11,23 @@
 #   surfaces as kernel_task sys time — a non-linear spike, not a linear one.
 #
 # Safety model:
-#   - A broker actively serving a review has a freshly-touched broker.log, so
-#     the idle-age gate (--max-age) skips it. We never broad-kill: each running
-#     broker must individually pass the idle gate.
-#   - Worst case for a misjudged reap is a benign respawn on the next codex
-#     call (the broker is stateless infra) — never a correctness break.
+#   - A broker with ANY child process is KEPT. Its descendants include the live
+#     `codex app-server` backend, and collect_tree() signals the whole tree — so
+#     reaping such a broker kills the owning session, not leaked infra (#919:
+#     13 live-but-idle sessions were killed this way).
+#   - The idle gate (--max-age) is a necessary but NOT sufficient condition: it
+#     measures whether the broker is serving right now, not whether its session
+#     is alive. A session idle between turns leaves broker.log untouched.
+#   - Only a childless, idle broker is reaped — the backend has already detached,
+#     so the worst case is a benign respawn on the next codex call.
 #   - When idleness cannot be determined (no logFile), the broker is KEPT.
 #
 # Modes:
 #   --gc                 GC only: remove stale tmp sessionDirs whose broker pid
 #                        is dead. Zero risk. (default)
-#   --reap [--max-age N] Also kill RUNNING brokers idle > N minutes (default 30),
-#                        then GC. Used by the launchd job and the opt-in
+#   --reap [--max-age N] Also kill RUNNING brokers that are childless AND idle
+#                        > N minutes (default 30), then GC. Used by the launchd
+#                        job and the opt-in
 #                        PRAXIS_CODEX_REAP=1 path in codex-review-wrap.
 #   --dry-run            Print actions without executing.
 #
@@ -45,7 +50,9 @@ usage() {
 Usage: codex-broker-reaper.sh [--gc | --reap] [--max-age MINUTES] [--dry-run]
 
   --gc            Remove stale tmp sessionDirs of dead brokers (zero risk). Default.
-  --reap          Also kill running brokers idle longer than --max-age, then GC.
+  --reap          Also kill running brokers that have no child process AND have
+                  been idle longer than --max-age, then GC. A broker with a
+                  child still owns a live codex backend and is never killed.
   --max-age N     Idle-minutes threshold for --reap (default: 30).
   --dry-run       Show what would happen; make no changes.
   -h, --help      This help.
@@ -105,6 +112,16 @@ collect_tree() {
     collect_tree "$child"
   done
   printf '%s ' "$pid"
+}
+
+# Direct children of a pid as a space-separated list; empty when it has none.
+# `pgrep` exits 1 on no match, so the pipeline is terminated by `tr` (always 0)
+# to keep `set -e` out of it.
+child_pids_of() {
+  local kids
+  kids="$(pgrep -P "$1" 2>/dev/null | tr '\n' ' ')"
+  [[ -n "${kids// /}" ]] && printf '%s' "${kids% }"
+  return 0
 }
 
 # Resolve the broker's sessionDir from its command-line endpoint:
@@ -171,6 +188,16 @@ if [[ "$MODE" == "reap" ]]; then
       skipped=$(( skipped + 1 )); continue
     fi
 
+    # Owner-liveness gate (#919). A broker's children are its `codex app-server`
+    # backend; collect_tree() below would sweep them into the kill. An idle log
+    # only proves the broker is not serving *right now*, so children are the
+    # evidence that a session still owns it.
+    children="$(child_pids_of "$pid")"
+    if [[ -n "$children" ]]; then
+      echo "SKIP   pid=$pid (owner alive: child pids $children — reaping would kill the codex backend)"
+      skipped=$(( skipped + 1 )); continue
+    fi
+
     if [[ "$DRY_RUN" == "true" ]]; then
       echo "WOULD REAP pid=$pid idle=${idle}s dir=$sdir"
     else
@@ -180,6 +207,13 @@ if [[ "$MODE" == "reap" ]]; then
       case "$m2" in ''|*[!0-9]*) m2=$now2 ;; esac
       if (( now2 - m2 < max_age_sec )); then
         echo "SKIP   pid=$pid (became active before kill)"
+        skipped=$(( skipped + 1 )); continue
+      fi
+      # Same re-check for ownership: a backend can attach in the gap, and
+      # collect_tree() would then sweep it into the kill.
+      children="$(child_pids_of "$pid")"
+      if [[ -n "$children" ]]; then
+        echo "SKIP   pid=$pid (owner attached before kill: child pids $children)"
         skipped=$(( skipped + 1 )); continue
       fi
       tree="$(collect_tree "$pid")"

--- a/skills/codex-review-wrap/codex-broker-reaper.sh
+++ b/skills/codex-review-wrap/codex-broker-reaper.sh
@@ -176,11 +176,17 @@ is_safe_session_dir() {
 state_dir_of_broker() {
   local pid="$1" want="$2" bj found="" n=0
   [[ -n "$want" ]] || return 0
-  for bj in $(grep -lE "\"pid\"[[:space:]]*:[[:space:]]*$pid([^0-9]|\$)" "$STATE_DIR"/*/broker.json 2>/dev/null || true); do
+  # Read the grep hits line by line instead of splitting a bare command
+  # substitution: CLAUDE_CONFIG_DIR is relocatable (CONTRIBUTING.md), so a path
+  # like "/Volumes/External Drive/.claude" would otherwise be split at the space
+  # and every jq lookup would miss — leaving each broker "unknown" and the reap
+  # pass dead. Process substitution keeps the counters in this shell.
+  while IFS= read -r bj; do
+    [[ -n "$bj" ]] || continue
     [[ "$(jq -r '.pid // empty' "$bj" 2>/dev/null || true)" == "$pid" ]] || continue
     [[ "$(jq -r '.sessionDir // empty' "$bj" 2>/dev/null || true)" == "$want" ]] || continue
     found="$(dirname "$bj")"; n=$(( n + 1 ))
-  done
+  done < <(grep -lE "\"pid\"[[:space:]]*:[[:space:]]*$pid([^0-9]|\$)" "$STATE_DIR"/*/broker.json 2>/dev/null || true)
   (( n == 1 )) && printf '%s' "$found"
   return 0
 }

--- a/tests/test_codex_broker_reaper.sh
+++ b/tests/test_codex_broker_reaper.sh
@@ -94,12 +94,22 @@ fi
 # sandbox tree, so the real ~/.claude state dirs are never read or written, and
 # TMPDIR keeps the lock inside the sandbox too.
 #
-# Four fixture brokers, all equally idle, differing only in owner evidence:
-#   ALIVE   workspace exists + a live process cwd'd there   → must survive
-#   WSGONE  workspaceRoot recorded, directory deleted       → reap (signal C)
-#   NOCWD   workspace exists, nothing working in it         → reap (signal D)
-#   NOJOBS  state dir without jobs/*.json (undeterminable)  → must survive
-#   NOSTATE no state dir claims the pid (undeterminable)    → must survive
+# The fixtures mirror two production invariants that the oracle depends on:
+#   - a broker is started IN its workspace root and never chdirs, and its
+#     app-server child inherits that cwd (so both must be subtracted before
+#     "someone is working here" can mean anything);
+#   - broker.json files of crashed brokers are never GC'd, so a pid can be
+#     claimed by more than one state dir.
+#
+# Seven brokers, all equally idle, differing only in owner evidence:
+#   ALIVE   workspace has a live process outside the broker tree → survive
+#   WSGONE  workspaceRoot recorded, directory deleted            → reap (C)
+#   NOCWD   only the broker tree itself sits in the workspace    → reap (D)
+#   NOJOBS  state dir without jobs/*.json (undeterminable)       → survive
+#   NOSTATE no state dir claims the pid (undeterminable)         → survive
+#   PIDDUP  a stale state dir claims the same pid; the sessionDir-matching one
+#           (workspace alive) must win over it                   → survive
+#   AMBIG   two state dirs match both pid AND sessionDir         → survive
 
 TMPD="$(mktemp -d /private/tmp/px919.XXXXXX)"
 FIXTURE="$TMPD/broker-fixture.sh"
@@ -119,14 +129,18 @@ cleanup_fixtures() {
 }
 trap cleanup_fixtures EXIT INT TERM
 
-# Both fixtures block on a fifo via the `read` builtin — no child process, no
-# busy loop, and they die only when killed.
+# Broker stand-in: parked in its workspace root with one child that inherits the
+# cwd, exactly like `app-server-broker.mjs` -> `codex app-server`. Blocks on a
+# fifo through the `read` builtin, so the process tree is exactly two entries.
 cat > "$FIXTURE" <<'FIX'
 #!/bin/bash
+cd "$PX919_CWD" || exit 1
+sleep 600 &
 exec 3<> "$PX919_FIFO"
 read -r -u 3
 FIX
 
+# What "someone is working in this workspace" looks like to the cwd scan.
 cat > "$HOLDER" <<'HOLD'
 #!/bin/bash
 cd "$PX919_CWD" || exit 1
@@ -150,27 +164,36 @@ proc_gone() {
   done
   return 1
 }
+# Wait until $1 reports $2 as its cwd, so the scan cannot race the fixture.
+wait_for_cwd() {
+  local i
+  for i in $(seq 1 50); do
+    if lsof -a -d cwd -p "$1" -Fn -w 2>/dev/null | grep -qx "n$2"; then return 0; fi
+    sleep 0.1
+  done
+  return 1
+}
 
 # The plugin keys its state dir on the workspace root: <slug>-<sha256[0:16]>.
 ws_hash() { printf '%s' "$1" | shasum -a 256 | cut -c1-16; }
 
-# A fixture broker whose command line carries a resolvable sessionDir, with a
-# backdated broker.log so the idle gate always passes.
+# A fixture broker running in workspace $2, with a backdated broker.log so the
+# idle gate always passes.
 start_broker() {
   local name="$1"
+  local ws="$2"
   local sdir="$TMPD/cxc-$name"
   local fifo="$TMPD/$name.fifo"
   local pid
   mkdir -p "$sdir"
   mkfifo "$fifo"
   touch -t 202001010000 "$sdir/broker.log"
-  PX919_FIFO="$fifo" bash "$FIXTURE" serve --endpoint "unix:$sdir/broker.sock" >/dev/null 2>&1 &
+  PX919_FIFO="$fifo" PX919_CWD="$ws" \
+    bash "$FIXTURE" serve --endpoint "unix:$sdir/broker.sock" >/dev/null 2>&1 &
   pid=$!
   printf '%s' "$pid"   # caller records it in FIXTURE_PIDS (this runs in a subshell)
 }
 
-# A process parked in $1, i.e. what "someone is working in this workspace"
-# looks like to the cwd scan.
 start_cwd_holder() {
   local dir="$1"
   local fifo="$TMPD/holder-$2.fifo"
@@ -181,68 +204,79 @@ start_cwd_holder() {
   printf '%s' "$pid"
 }
 
-# state dir for a broker pid: broker.json carries the pid, jobs/*.json the
-# workspaceRoot — the same two files the oracle reads in production.
+# A state dir as the plugin writes it: broker.json carries pid + sessionDir,
+# jobs/*.json the workspaceRoot. $5 names the sessionDir it claims, which is how
+# a stale duplicate is told apart from the real one.
 write_state() {
-  local name="$1" wroot="$2" pid="$3" with_jobs="$4"
+  local slug="$1" wroot="$2" pid="$3" with_jobs="$4" session="$5"
   local sd
-  sd="$STATE_ROOT/$name-$(ws_hash "$wroot")"
+  sd="$STATE_ROOT/$slug-$(ws_hash "$wroot")"
   mkdir -p "$sd"
-  printf '{"sessionDir":"%s","pid":%s}\n' "$TMPD/cxc-$name" "$pid" > "$sd/broker.json"
+  printf '{"sessionDir":"%s","pid":%s}\n' "$TMPD/cxc-$session" "$pid" > "$sd/broker.json"
   if [ "$with_jobs" = 1 ]; then
     mkdir -p "$sd/jobs"
-    printf '{"id":"job-%s","workspaceRoot":"%s"}\n' "$name" "$wroot" > "$sd/jobs/job.json"
+    printf '{"id":"job-%s","workspaceRoot":"%s"}\n' "$slug" "$wroot" > "$sd/jobs/job.json"
   fi
 }
 
 if ! grep -q "^BROKER_PATTERN='$FIXTURE'$" "$REAPER_COPY"; then
   fail "#919: could not isolate BROKER_PATTERN in the reaper copy (refusing to run against real brokers)"
 else
-  WS_ALIVE="$TMPD/ws-alive"; WS_GONE="$TMPD/ws-gone"
-  WS_NOCWD="$TMPD/ws-nocwd"; WS_NOJOBS="$TMPD/ws-nojobs"; WS_NOSTATE="$TMPD/ws-nostate"
-  mkdir -p "$WS_ALIVE" "$WS_GONE" "$WS_NOCWD" "$WS_NOJOBS" "$WS_NOSTATE"
-
-  PID_ALIVE="$(start_broker ALIVE)"
-  PID_WSGONE="$(start_broker WSGONE)"
-  PID_NOCWD="$(start_broker NOCWD)"
-  PID_NOJOBS="$(start_broker NOJOBS)"
-  PID_NOSTATE="$(start_broker NOSTATE)"
-  HOLDER_PID="$(start_cwd_holder "$WS_ALIVE" alive)"
-  FIXTURE_PIDS+=("$PID_ALIVE" "$PID_WSGONE" "$PID_NOCWD" "$PID_NOJOBS" "$PID_NOSTATE" "$HOLDER_PID")
-
-  write_state ALIVE   "$WS_ALIVE"   "$PID_ALIVE"   1
-  write_state WSGONE  "$WS_GONE"    "$PID_WSGONE"  1
-  write_state NOCWD   "$WS_NOCWD"   "$PID_NOCWD"   1
-  write_state NOJOBS  "$WS_NOJOBS"  "$PID_NOJOBS"  0
-  # NOSTATE deliberately gets no state dir at all.
-  rmdir "$WS_GONE"   # signal C: the workspace is deleted after the job recorded it
-
-  # Wait until the holder has actually chdir'd, or the cwd scan would race.
-  ready=false
-  for _ in $(seq 1 50); do
-    if lsof -a -d cwd -p "$HOLDER_PID" -Fn -w 2>/dev/null | grep -qx "n$WS_ALIVE"; then ready=true; break; fi
-    sleep 0.1
+  for w in alive wsgone nocwd nojobs nostate piddup pidgone ambig ambgone; do
+    mkdir -p "$TMPD/ws-$w"
   done
+  WS_ALIVE="$TMPD/ws-alive"; WS_GONE="$TMPD/ws-wsgone"; WS_NOCWD="$TMPD/ws-nocwd"
+  WS_NOJOBS="$TMPD/ws-nojobs"; WS_NOSTATE="$TMPD/ws-nostate"
+  WS_PIDDUP="$TMPD/ws-piddup"; WS_PIDGONE="$TMPD/ws-pidgone"
+  WS_AMBIG="$TMPD/ws-ambig"; WS_AMBGONE="$TMPD/ws-ambgone"
 
-  if [ "$ready" != true ]; then
-    fail "#919: cwd holder never entered $WS_ALIVE (pid=$HOLDER_PID)"
-  elif ! proc_alive "$PID_WSGONE" || ! proc_alive "$PID_NOCWD"; then
-    fail "#919: fixture brokers did not come up"
+  PID_ALIVE="$(start_broker ALIVE "$WS_ALIVE")"
+  PID_WSGONE="$(start_broker WSGONE "$WS_GONE")"
+  PID_NOCWD="$(start_broker NOCWD "$WS_NOCWD")"
+  PID_NOJOBS="$(start_broker NOJOBS "$WS_NOJOBS")"
+  PID_NOSTATE="$(start_broker NOSTATE "$WS_NOSTATE")"
+  PID_PIDDUP="$(start_broker PIDDUP "$WS_PIDDUP")"
+  PID_AMBIG="$(start_broker AMBIG "$WS_AMBIG")"
+  HOLDER_ALIVE="$(start_cwd_holder "$WS_ALIVE" alive)"
+  HOLDER_PIDDUP="$(start_cwd_holder "$WS_PIDDUP" piddup)"
+  FIXTURE_PIDS+=("$PID_ALIVE" "$PID_WSGONE" "$PID_NOCWD" "$PID_NOJOBS" "$PID_NOSTATE"
+                 "$PID_PIDDUP" "$PID_AMBIG" "$HOLDER_ALIVE" "$HOLDER_PIDDUP")
+
+  write_state alive   "$WS_ALIVE"   "$PID_ALIVE"   1 ALIVE
+  write_state wsgone  "$WS_GONE"    "$PID_WSGONE"  1 WSGONE
+  write_state nocwd   "$WS_NOCWD"   "$PID_NOCWD"   1 NOCWD
+  write_state nojobs  "$WS_NOJOBS"  "$PID_NOJOBS"  0 NOJOBS
+  # NOSTATE deliberately gets no state dir at all.
+
+  # PIDDUP: the "aaa" slug sorts first, so a first-match lookup would take the
+  # stale dir — whose sessionDir does not match and whose workspace is gone.
+  write_state aaastale "$WS_PIDGONE" "$PID_PIDDUP" 1 OTHER
+  write_state piddup   "$WS_PIDDUP"  "$PID_PIDDUP" 1 PIDDUP
+  # AMBIG: both candidates match pid AND sessionDir → undecidable → keep.
+  write_state aaaambig "$WS_AMBGONE" "$PID_AMBIG"  1 AMBIG
+  write_state ambig    "$WS_AMBIG"   "$PID_AMBIG"  1 AMBIG
+
+  rmdir "$WS_GONE" "$WS_PIDGONE" "$WS_AMBGONE"   # signal C for these workspaces
+
+  if ! wait_for_cwd "$HOLDER_ALIVE" "$WS_ALIVE" || ! wait_for_cwd "$HOLDER_PIDDUP" "$WS_PIDDUP"; then
+    fail "#919: cwd holders never entered their workspaces"
+  elif ! wait_for_cwd "$PID_NOCWD" "$WS_NOCWD" || ! wait_for_cwd "$PID_ALIVE" "$WS_ALIVE"; then
+    fail "#919: fixture brokers never entered their workspaces"
   else
-    RUN_ENV_OUT="$(TMPDIR="$TMPD" CLAUDE_CONFIG_DIR="$TMPD/config" bash "$REAPER_COPY" --reap --max-age 5 --dry-run 2>&1)"
+    DRY_OUT="$(TMPDIR="$TMPD" CLAUDE_CONFIG_DIR="$TMPD/config" bash "$REAPER_COPY" --reap --max-age 5 --dry-run 2>&1)"
 
-    case "$RUN_ENV_OUT" in
-      *"SKIP   pid=$PID_ALIVE (owner alive"*) pass "#919 dry-run: broker whose workspace has a live cwd is SKIP (owner alive)" ;;
-      *) fail "#919 dry-run: expected owner-alive SKIP for pid=$PID_ALIVE, got: $RUN_ENV_OUT" ;;
+    case "$DRY_OUT" in
+      *"SKIP   pid=$PID_ALIVE (owner alive"*) pass "#919 dry-run: broker whose workspace has another live cwd is SKIP" ;;
+      *) fail "#919 dry-run: expected owner-alive SKIP for pid=$PID_ALIVE, got: $DRY_OUT" ;;
     esac
-    case "$RUN_ENV_OUT" in
+    case "$DRY_OUT" in
       *"WOULD REAP pid=$PID_WSGONE"*) pass "#919 dry-run: deleted-workspace broker is WOULD REAP" ;;
-      *) fail "#919 dry-run: expected WOULD REAP for pid=$PID_WSGONE, got: $RUN_ENV_OUT" ;;
+      *) fail "#919 dry-run: expected WOULD REAP for pid=$PID_WSGONE, got: $DRY_OUT" ;;
     esac
 
     REAP_OUT="$(TMPDIR="$TMPD" CLAUDE_CONFIG_DIR="$TMPD/config" bash "$REAPER_COPY" --reap --max-age 5 2>&1)"
 
-    # 1. Regression: idle + workspace alive + someone working in it → survive.
+    # 1. Regression: idle + someone else working in the workspace → survive.
     if proc_alive "$PID_ALIVE"; then
       pass "#919 regression: idle broker with a live workspace cwd survived --reap"
     else
@@ -254,9 +288,9 @@ else
       fail "#919 regression: surviving broker's sessionDir was removed"
     fi
     case "$REAP_OUT" in
-      *"SKIP   pid=$PID_ALIVE (owner alive: a live process is working in $WS_ALIVE)"*)
-        pass "#919 regression: skip reason names the live workspace" ;;
-      *) fail "#919 regression: expected owner-alive SKIP naming $WS_ALIVE, got: $REAP_OUT" ;;
+      *"SKIP   pid=$PID_ALIVE (owner alive: pid $HOLDER_ALIVE is working in $WS_ALIVE)"*)
+        pass "#919 regression: skip reason names the live pid and workspace" ;;
+      *) fail "#919 regression: expected owner-alive SKIP naming pid $HOLDER_ALIVE in $WS_ALIVE, got: $REAP_OUT" ;;
     esac
 
     # 2. Signal C — workspaceRoot recorded but the directory is gone → reap.
@@ -275,11 +309,12 @@ else
       fail "#919 C: reaped broker's sessionDir still present"
     fi
 
-    # 3. Signal D — workspace exists but no live process is cwd'd there → reap.
+    # 3. Signal D — the broker's OWN tree sits in the workspace and must not
+    #    count as an owner, or D can never fire (codex round-2 F2).
     if proc_gone "$PID_NOCWD"; then
-      pass "#919 D: broker with no live process in its workspace is reaped"
+      pass "#919 D: broker alone in its workspace is reaped (own tree excluded)"
     else
-      fail "#919 D: unused-workspace broker survived --reap (output: $REAP_OUT)"
+      fail "#919 D: broker alone in its workspace survived --reap (output: $REAP_OUT)"
     fi
     case "$REAP_OUT" in
       *"REAPED pid=$PID_NOCWD"*) pass "#919 D: reap reported for the unused-workspace broker" ;;
@@ -303,13 +338,35 @@ else
       fail "#919 safe-default: broker with no state dir was killed (output: $REAP_OUT)"
     fi
     case "$REAP_OUT" in
-      *"SKIP   pid=$PID_NOSTATE (owner unknown: no state dir claims this pid)"*)
+      *"SKIP   pid=$PID_NOSTATE (owner unknown: no single state dir matches this pid and sessionDir)"*)
         pass "#919 safe-default: missing state dir reported as unknown owner" ;;
       *) fail "#919 safe-default: expected unknown-owner SKIP for pid=$PID_NOSTATE, got: $REAP_OUT" ;;
     esac
+
+    # 5. PID reuse — a stale broker.json claiming the same pid must not decide
+    #    the verdict (codex round-2 F3).
+    if proc_alive "$PID_PIDDUP"; then
+      pass "#919 F3: stale duplicate state dir did not get the live broker killed"
+    else
+      fail "#919 F3: broker killed via a stale state dir claiming its pid (output: $REAP_OUT)"
+    fi
+    case "$REAP_OUT" in
+      *"SKIP   pid=$PID_PIDDUP (owner alive: pid $HOLDER_PIDDUP is working in $WS_PIDDUP)"*)
+        pass "#919 F3: the sessionDir-matching state dir is the one adopted" ;;
+      *) fail "#919 F3: expected the sessionDir-matching state dir to decide pid=$PID_PIDDUP, got: $REAP_OUT" ;;
+    esac
+    if proc_alive "$PID_AMBIG"; then
+      pass "#919 F3: two equally-matching state dirs fall back to KEEP"
+    else
+      fail "#919 F3: ambiguous state dirs got the broker killed (output: $REAP_OUT)"
+    fi
+    case "$REAP_OUT" in
+      *"SKIP   pid=$PID_AMBIG (owner unknown: no single state dir matches this pid and sessionDir)"*)
+        pass "#919 F3: ambiguity reported as unknown owner" ;;
+      *) fail "#919 F3: expected unknown-owner SKIP for pid=$PID_AMBIG, got: $REAP_OUT" ;;
+    esac
   fi
 fi
-
 echo ""
 echo "=== summary ==="
 echo "PASS: $PASS"

--- a/tests/test_codex_broker_reaper.sh
+++ b/tests/test_codex_broker_reaper.sh
@@ -8,6 +8,9 @@
 #   2. is_safe_session_dir() must reject traversal-shaped paths. A path like
 #      /tmp/../Users/me/cxc-x string-matches the /tmp/* allowlist yet resolves
 #      OUTSIDE the temp root, letting rm -rf escape.
+#   3. (#919) The reap decision itself: a broker with children owns a live codex
+#      backend — collect_tree() would kill it, so it must survive even when the
+#      idle gate says "idle". Only a childless idle broker may be reaped.
 #
 # Run:  ./tests/test_codex_broker_reaper.sh
 # Exit: 0 on success, 1 on first failure (after summary).
@@ -77,6 +80,141 @@ else
   assert_reject "relative/cxc-a"               # not absolute
   assert_reject "/tmp/notcxc"                  # basename not cxc-*
   assert_reject "/etc/cxc-a"                   # outside allowlist
+fi
+
+# --- Gate 3: #919 owner-liveness — a broker with children is never reaped ----
+# Real execution against synthetic processes. The shipped pgrep pattern
+# (app-server-broker.mjs) would match this host's PRODUCTION brokers, so the SUT
+# is copied with ONLY BROKER_PATTERN rewritten to this run's unique fixture path
+# — the reap decision under test is the shipped code, and every pid the copy can
+# see is one this test started. TMPDIR/CLAUDE_CONFIG_DIR are redirected so the
+# lock and the GC pass stay inside the sandbox.
+
+TMPD="$(mktemp -d /private/tmp/px919.XXXXXX)"
+FIXTURE="$TMPD/broker-fixture.sh"
+REAPER_COPY="$TMPD/reaper-copy.sh"
+FIXTURE_PIDS=()
+
+cleanup_fixtures() {
+  local p kid
+  for p in "${FIXTURE_PIDS[@]}"; do
+    [ -n "$p" ] || continue
+    for kid in $(pgrep -P "$p" 2>/dev/null); do kill -KILL "$kid" 2>/dev/null; done
+    kill -KILL "$p" 2>/dev/null
+  done
+  rm -rf "$TMPD"
+}
+trap cleanup_fixtures EXIT INT TERM
+
+# Blocks on a fifo via the `read` builtin, so a "childless" fixture really has
+# no child process of its own.
+cat > "$FIXTURE" <<'FIX'
+#!/bin/bash
+if [ "${PX919_SPAWN_CHILD:-0}" = 1 ]; then
+  sleep 600 &
+fi
+exec 3<> "$PX919_FIFO"
+read -r -u 3
+FIX
+
+sed "s|^BROKER_PATTERN=.*|BROKER_PATTERN='$FIXTURE'|" "$REAPER" > "$REAPER_COPY"
+
+proc_alive() {
+  local st; st="$(ps -o state= -p "$1" 2>/dev/null | tr -d ' ')"
+  [ -n "$st" ] || return 1
+  case "$st" in Z*) return 1 ;; esac
+  return 0
+}
+proc_gone() {
+  local i
+  for i in $(seq 1 30); do
+    proc_alive "$1" || return 0
+    sleep 0.1
+  done
+  return 1
+}
+
+# Start a fixture broker whose command line carries a resolvable sessionDir, and
+# backdate its broker.log so the idle gate always considers it idle.
+start_fixture() {
+  # One assignment per line: bash 3.2 does not let a later `local` assignment
+  # see an earlier one from the same statement.
+  local name="$1"
+  local spawn_child="$2"
+  local sdir="$TMPD/cxc-$name"
+  local fifo="$TMPD/$name.fifo"
+  local pid
+  mkdir -p "$sdir"
+  mkfifo "$fifo"
+  touch -t 202001010000 "$sdir/broker.log"
+  PX919_FIFO="$fifo" PX919_SPAWN_CHILD="$spawn_child" \
+    bash "$FIXTURE" serve --endpoint "unix:$sdir/broker.sock" >/dev/null 2>&1 &
+  pid=$!
+  printf '%s' "$pid"   # caller records it in FIXTURE_PIDS (this runs in a subshell)
+}
+
+if ! grep -q "^BROKER_PATTERN='$FIXTURE'$" "$REAPER_COPY"; then
+  fail "#919: could not isolate BROKER_PATTERN in the reaper copy (refusing to run against real brokers)"
+else
+  OWNED_PID="$(start_fixture AAA 1)"   # has a child → stands in for a live backend
+  LONE_PID="$(start_fixture BBB 0)"    # childless → a real orphan
+  FIXTURE_PIDS+=("$OWNED_PID" "$LONE_PID")
+
+  # Wait for the owned fixture's child to exist; otherwise the run would race.
+  ready=false
+  for _ in $(seq 1 50); do
+    if [ -n "$(pgrep -P "$OWNED_PID" 2>/dev/null)" ]; then ready=true; break; fi
+    sleep 0.1
+  done
+
+  if [ "$ready" != true ] || ! proc_alive "$LONE_PID"; then
+    fail "#919: fixture brokers did not come up (owned=$OWNED_PID lone=$LONE_PID)"
+  else
+    DRY_OUT="$(TMPDIR="$TMPD" CLAUDE_CONFIG_DIR="$TMPD/config" bash "$REAPER_COPY" --reap --max-age 5 --dry-run 2>&1)"
+
+    case "$DRY_OUT" in
+      *"SKIP   pid=$OWNED_PID (owner alive"*) pass "#919 dry-run: broker with a child reported as SKIP (owner alive)" ;;
+      *) fail "#919 dry-run: expected owner-alive SKIP for pid=$OWNED_PID, got: $DRY_OUT" ;;
+    esac
+    case "$DRY_OUT" in
+      *"WOULD REAP pid=$LONE_PID"*) pass "#919 dry-run: childless idle broker reported as WOULD REAP" ;;
+      *) fail "#919 dry-run: expected WOULD REAP for pid=$LONE_PID, got: $DRY_OUT" ;;
+    esac
+
+    REAP_OUT="$(TMPDIR="$TMPD" CLAUDE_CONFIG_DIR="$TMPD/config" bash "$REAPER_COPY" --reap --max-age 5 2>&1)"
+
+    # 1. Regression: the idle broker that still owns a backend must survive.
+    if proc_alive "$OWNED_PID"; then
+      pass "#919 regression: idle broker WITH a child survived --reap"
+    else
+      fail "#919 regression: idle broker WITH a child was killed by --reap (output: $REAP_OUT)"
+    fi
+    if [ -d "$TMPD/cxc-AAA" ]; then
+      pass "#919 regression: surviving broker's sessionDir kept"
+    else
+      fail "#919 regression: surviving broker's sessionDir was removed"
+    fi
+    case "$REAP_OUT" in
+      *"SKIP   pid=$OWNED_PID (owner alive"*) pass "#919 regression: skip reason names the live owner" ;;
+      *) fail "#919 regression: expected owner-alive SKIP line for pid=$OWNED_PID, got: $REAP_OUT" ;;
+    esac
+
+    # 2. The childless idle broker is still reaped (the fix is not a blanket no-op).
+    if proc_gone "$LONE_PID"; then
+      pass "#919: childless idle broker was reaped"
+    else
+      fail "#919: childless idle broker survived --reap (output: $REAP_OUT)"
+    fi
+    if [ ! -d "$TMPD/cxc-BBB" ]; then
+      pass "#919: reaped broker's sessionDir removed"
+    else
+      fail "#919: reaped broker's sessionDir still present"
+    fi
+    case "$REAP_OUT" in
+      *"REAPED pid=$LONE_PID"*) pass "#919: reap reported for the childless broker" ;;
+      *) fail "#919: expected REAPED line for pid=$LONE_PID, got: $REAP_OUT" ;;
+    esac
+  fi
 fi
 
 echo ""

--- a/tests/test_codex_broker_reaper.sh
+++ b/tests/test_codex_broker_reaper.sh
@@ -9,14 +9,16 @@
 #      /tmp/../Users/me/cxc-x string-matches the /tmp/* allowlist yet resolves
 #      OUTSIDE the temp root, letting rm -rf escape.
 #   3. (#919) The reap decision itself. Idleness does not imply the owner is
-#      gone, so a kill needs positive orphan evidence about the broker's
-#      WORKSPACE ROOT: it was deleted, or no live process has it as its cwd.
-#      Anything undetermined must keep the broker. (Children are NOT a liveness
-#      signal — the broker spawns `codex app-server` at startup and closes it
+#      gone, so a kill needs positive orphan evidence: the broker's WORKSPACE
+#      ROOT has been deleted. Anything else — including a workspace that still
+#      exists — must keep the broker. (Children are NOT a liveness signal
+#      either: the broker spawns `codex app-server` at startup and closes it
 #      only on its own shutdown, so orphans keep a child too.)
 #
 # Run:  ./tests/test_codex_broker_reaper.sh
 # Exit: 0 on success, 1 on first failure (after summary).
+# Gates whose platform prerequisites are missing print a SKIPPED line and are
+# listed in the summary; they never fail the run.
 
 set +e
 
@@ -31,9 +33,13 @@ fi
 PASS=0
 FAIL=0
 FAILED_NAMES=()
+SKIPPED_NAMES=()
 
 pass() { PASS=$((PASS + 1)); echo "  PASS  $1"; }
 fail() { FAIL=$((FAIL + 1)); FAILED_NAMES+=("$1"); echo "  FAIL  $1" >&2; }
+# A gate whose platform prerequisites are absent. Announced here and listed in
+# the summary — never silently dropped (mirrors run-tests.sh's SKIPPED lines).
+skip() { SKIPPED_NAMES+=("$1"); echo "SKIPPED: $1"; }
 
 # --- Gate 1: --max-age validation -------------------------------------------
 # Expect exit 2 (rejected) for non-positive / non-numeric values.
@@ -85,35 +91,33 @@ else
   assert_reject "/etc/cxc-a"                   # outside allowlist
 fi
 
-# --- Gate 3: #919 owner-liveness oracle (behavior) ---------------------------
+# --- Gate 3: #919 owner-death oracle (behavior) ------------------------------
 # Real execution against synthetic processes. The shipped pgrep pattern
-# (app-server-broker.mjs) would match this host's PRODUCTION brokers, so the SUT
-# is copied with ONLY BROKER_PATTERN rewritten to this run's unique fixture path
-# — the reap decision under test is the shipped code, and every pid the copy can
-# see is one this test started. CLAUDE_CONFIG_DIR points the state root at a
-# sandbox tree, so the real ~/.claude state dirs are never read or written, and
+# (app-server-broker.mjs) would match a developer host's PRODUCTION brokers, so
+# the SUT is copied with ONLY BROKER_PATTERN rewritten to this run's unique
+# fixture path — the reap decision under test is the shipped code, and every pid
+# the copy can see is one this test started. CLAUDE_CONFIG_DIR points the state
+# root at a sandbox tree, so real state dirs are never read or written, and
 # TMPDIR keeps the lock inside the sandbox too.
 #
-# The fixtures mirror two production invariants that the oracle depends on:
-#   - a broker is started IN its workspace root and never chdirs, and its
-#     app-server child inherits that cwd (so both must be subtracted before
-#     "someone is working here" can mean anything);
-#   - broker.json files of crashed brokers are never GC'd, so a pid can be
-#     claimed by more than one state dir.
-#
-# Seven brokers, all equally idle, differing only in owner evidence:
-#   ALIVE   workspace has a live process outside the broker tree → survive
-#   WSGONE  workspaceRoot recorded, directory deleted            → reap (C)
-#   NOCWD   only the broker tree itself sits in the workspace    → reap (D)
-#   NOJOBS  state dir without jobs/*.json (undeterminable)       → survive
-#   NOSTATE no state dir claims the pid (undeterminable)         → survive
+# Six brokers, all equally idle, differing only in owner evidence:
+#   ALIVE   workspaceRoot recorded and still present        → survive
+#   WSGONE  workspaceRoot recorded, directory deleted        → reap
+#   NOJOBS  state dir without jobs/*.json (undeterminable)   → survive
+#   NOSTATE no state dir claims the pid (undeterminable)     → survive
 #   PIDDUP  a stale state dir claims the same pid; the sessionDir-matching one
-#           (workspace alive) must win over it                   → survive
-#   AMBIG   two state dirs match both pid AND sessionDir         → survive
+#           (workspace alive) must win over it               → survive
+#   AMBIG   two state dirs match both pid AND sessionDir     → survive
+#
+# The reaper's idle gate reads mtime through BSD `stat -f %m`, which is Darwin
+# syntax, so this gate is skipped elsewhere (the CI runner is Ubuntu).
+if [ "$(uname -s)" != "Darwin" ]; then
+  skip "gate 3 owner-death behavior (needs Darwin: reaper's idle gate uses BSD 'stat -f %m')"
+else
 
-TMPD="$(mktemp -d /private/tmp/px919.XXXXXX)"
+TMPROOT="${TMPDIR:-/tmp}"; TMPROOT="${TMPROOT%/}"
+TMPD="$(mktemp -d "$TMPROOT/px919.XXXXXX")"
 FIXTURE="$TMPD/broker-fixture.sh"
-HOLDER="$TMPD/cwd-holder.sh"
 REAPER_COPY="$TMPD/reaper-copy.sh"
 STATE_ROOT="$TMPD/config/plugins/data/codex-openai-codex/state"
 FIXTURE_PIDS=()
@@ -140,14 +144,6 @@ exec 3<> "$PX919_FIFO"
 read -r -u 3
 FIX
 
-# What "someone is working in this workspace" looks like to the cwd scan.
-cat > "$HOLDER" <<'HOLD'
-#!/bin/bash
-cd "$PX919_CWD" || exit 1
-exec 3<> "$PX919_FIFO"
-read -r -u 3
-HOLD
-
 sed "s|^BROKER_PATTERN=.*|BROKER_PATTERN='$FIXTURE'|" "$REAPER" > "$REAPER_COPY"
 
 proc_alive() {
@@ -160,15 +156,6 @@ proc_gone() {
   local i
   for i in $(seq 1 30); do
     proc_alive "$1" || return 0
-    sleep 0.1
-  done
-  return 1
-}
-# Wait until $1 reports $2 as its cwd, so the scan cannot race the fixture.
-wait_for_cwd() {
-  local i
-  for i in $(seq 1 50); do
-    if lsof -a -d cwd -p "$1" -Fn -w 2>/dev/null | grep -qx "n$2"; then return 0; fi
     sleep 0.1
   done
   return 1
@@ -194,16 +181,6 @@ start_broker() {
   printf '%s' "$pid"   # caller records it in FIXTURE_PIDS (this runs in a subshell)
 }
 
-start_cwd_holder() {
-  local dir="$1"
-  local fifo="$TMPD/holder-$2.fifo"
-  local pid
-  mkfifo "$fifo"
-  PX919_FIFO="$fifo" PX919_CWD="$dir" bash "$HOLDER" >/dev/null 2>&1 &
-  pid=$!
-  printf '%s' "$pid"
-}
-
 # A state dir as the plugin writes it: broker.json carries pid + sessionDir,
 # jobs/*.json the workspaceRoot. $5 names the sessionDir it claims, which is how
 # a stale duplicate is told apart from the real one.
@@ -222,29 +199,25 @@ write_state() {
 if ! grep -q "^BROKER_PATTERN='$FIXTURE'$" "$REAPER_COPY"; then
   fail "#919: could not isolate BROKER_PATTERN in the reaper copy (refusing to run against real brokers)"
 else
-  for w in alive wsgone nocwd nojobs nostate piddup pidgone ambig ambgone; do
+  for w in alive wsgone nojobs nostate piddup pidgone ambig ambgone; do
     mkdir -p "$TMPD/ws-$w"
   done
-  WS_ALIVE="$TMPD/ws-alive"; WS_GONE="$TMPD/ws-wsgone"; WS_NOCWD="$TMPD/ws-nocwd"
+  WS_ALIVE="$TMPD/ws-alive"; WS_GONE="$TMPD/ws-wsgone"
   WS_NOJOBS="$TMPD/ws-nojobs"; WS_NOSTATE="$TMPD/ws-nostate"
   WS_PIDDUP="$TMPD/ws-piddup"; WS_PIDGONE="$TMPD/ws-pidgone"
   WS_AMBIG="$TMPD/ws-ambig"; WS_AMBGONE="$TMPD/ws-ambgone"
 
   PID_ALIVE="$(start_broker ALIVE "$WS_ALIVE")"
   PID_WSGONE="$(start_broker WSGONE "$WS_GONE")"
-  PID_NOCWD="$(start_broker NOCWD "$WS_NOCWD")"
   PID_NOJOBS="$(start_broker NOJOBS "$WS_NOJOBS")"
   PID_NOSTATE="$(start_broker NOSTATE "$WS_NOSTATE")"
   PID_PIDDUP="$(start_broker PIDDUP "$WS_PIDDUP")"
   PID_AMBIG="$(start_broker AMBIG "$WS_AMBIG")"
-  HOLDER_ALIVE="$(start_cwd_holder "$WS_ALIVE" alive)"
-  HOLDER_PIDDUP="$(start_cwd_holder "$WS_PIDDUP" piddup)"
-  FIXTURE_PIDS+=("$PID_ALIVE" "$PID_WSGONE" "$PID_NOCWD" "$PID_NOJOBS" "$PID_NOSTATE"
-                 "$PID_PIDDUP" "$PID_AMBIG" "$HOLDER_ALIVE" "$HOLDER_PIDDUP")
+  FIXTURE_PIDS+=("$PID_ALIVE" "$PID_WSGONE" "$PID_NOJOBS" "$PID_NOSTATE"
+                 "$PID_PIDDUP" "$PID_AMBIG")
 
   write_state alive   "$WS_ALIVE"   "$PID_ALIVE"   1 ALIVE
   write_state wsgone  "$WS_GONE"    "$PID_WSGONE"  1 WSGONE
-  write_state nocwd   "$WS_NOCWD"   "$PID_NOCWD"   1 NOCWD
   write_state nojobs  "$WS_NOJOBS"  "$PID_NOJOBS"  0 NOJOBS
   # NOSTATE deliberately gets no state dir at all.
 
@@ -256,17 +229,20 @@ else
   write_state aaaambig "$WS_AMBGONE" "$PID_AMBIG"  1 AMBIG
   write_state ambig    "$WS_AMBIG"   "$PID_AMBIG"  1 AMBIG
 
-  rmdir "$WS_GONE" "$WS_PIDGONE" "$WS_AMBGONE"   # signal C for these workspaces
+  rmdir "$WS_GONE" "$WS_PIDGONE" "$WS_AMBGONE"   # the deleted workspaces
 
-  if ! wait_for_cwd "$HOLDER_ALIVE" "$WS_ALIVE" || ! wait_for_cwd "$HOLDER_PIDDUP" "$WS_PIDDUP"; then
-    fail "#919: cwd holders never entered their workspaces"
-  elif ! wait_for_cwd "$PID_NOCWD" "$WS_NOCWD" || ! wait_for_cwd "$PID_ALIVE" "$WS_ALIVE"; then
-    fail "#919: fixture brokers never entered their workspaces"
+  ready=true
+  for p in "$PID_ALIVE" "$PID_WSGONE" "$PID_NOJOBS" "$PID_NOSTATE" "$PID_PIDDUP" "$PID_AMBIG"; do
+    proc_alive "$p" || ready=false
+  done
+
+  if [ "$ready" != true ]; then
+    fail "#919: fixture brokers did not come up"
   else
     DRY_OUT="$(TMPDIR="$TMPD" CLAUDE_CONFIG_DIR="$TMPD/config" bash "$REAPER_COPY" --reap --max-age 5 --dry-run 2>&1)"
 
     case "$DRY_OUT" in
-      *"SKIP   pid=$PID_ALIVE (owner alive"*) pass "#919 dry-run: broker whose workspace has another live cwd is SKIP" ;;
+      *"SKIP   pid=$PID_ALIVE (owner alive"*) pass "#919 dry-run: broker with a live workspace is SKIP (owner alive)" ;;
       *) fail "#919 dry-run: expected owner-alive SKIP for pid=$PID_ALIVE, got: $DRY_OUT" ;;
     esac
     case "$DRY_OUT" in
@@ -276,11 +252,11 @@ else
 
     REAP_OUT="$(TMPDIR="$TMPD" CLAUDE_CONFIG_DIR="$TMPD/config" bash "$REAPER_COPY" --reap --max-age 5 2>&1)"
 
-    # 1. Regression: idle + someone else working in the workspace → survive.
+    # 1. Regression: idle is not death — a live workspace keeps the broker.
     if proc_alive "$PID_ALIVE"; then
-      pass "#919 regression: idle broker with a live workspace cwd survived --reap"
+      pass "#919 regression: idle broker with a live workspace survived --reap"
     else
-      fail "#919 regression: idle broker with a live workspace cwd was killed (output: $REAP_OUT)"
+      fail "#919 regression: idle broker with a live workspace was killed (output: $REAP_OUT)"
     fi
     if [ -d "$TMPD/cxc-ALIVE" ]; then
       pass "#919 regression: surviving broker's sessionDir kept"
@@ -288,12 +264,12 @@ else
       fail "#919 regression: surviving broker's sessionDir was removed"
     fi
     case "$REAP_OUT" in
-      *"SKIP   pid=$PID_ALIVE (owner alive: pid $HOLDER_ALIVE is working in $WS_ALIVE)"*)
-        pass "#919 regression: skip reason names the live pid and workspace" ;;
-      *) fail "#919 regression: expected owner-alive SKIP naming pid $HOLDER_ALIVE in $WS_ALIVE, got: $REAP_OUT" ;;
+      *"SKIP   pid=$PID_ALIVE (owner alive: workspace $WS_ALIVE still exists)"*)
+        pass "#919 regression: skip reason names the live workspace" ;;
+      *) fail "#919 regression: expected owner-alive SKIP naming $WS_ALIVE, got: $REAP_OUT" ;;
     esac
 
-    # 2. Signal C — workspaceRoot recorded but the directory is gone → reap.
+    # 2. The one orphan signal — workspaceRoot recorded, directory gone → reap.
     if proc_gone "$PID_WSGONE"; then
       pass "#919 C: broker whose workspace was deleted is reaped"
     else
@@ -309,19 +285,7 @@ else
       fail "#919 C: reaped broker's sessionDir still present"
     fi
 
-    # 3. Signal D — the broker's OWN tree sits in the workspace and must not
-    #    count as an owner, or D can never fire (codex round-2 F2).
-    if proc_gone "$PID_NOCWD"; then
-      pass "#919 D: broker alone in its workspace is reaped (own tree excluded)"
-    else
-      fail "#919 D: broker alone in its workspace survived --reap (output: $REAP_OUT)"
-    fi
-    case "$REAP_OUT" in
-      *"REAPED pid=$PID_NOCWD"*) pass "#919 D: reap reported for the unused-workspace broker" ;;
-      *) fail "#919 D: expected REAPED line for pid=$PID_NOCWD, got: $REAP_OUT" ;;
-    esac
-
-    # 4. Undeterminable owners must fall to KEEP.
+    # 3. Undeterminable owners must fall to KEEP.
     if proc_alive "$PID_NOJOBS"; then
       pass "#919 safe-default: broker with no jobs file survived --reap"
     else
@@ -343,15 +307,15 @@ else
       *) fail "#919 safe-default: expected unknown-owner SKIP for pid=$PID_NOSTATE, got: $REAP_OUT" ;;
     esac
 
-    # 5. PID reuse — a stale broker.json claiming the same pid must not decide
-    #    the verdict (codex round-2 F3).
+    # 4. PID reuse — a stale broker.json claiming the same pid must not decide
+    #    the verdict, or its deleted workspace kills a live broker.
     if proc_alive "$PID_PIDDUP"; then
       pass "#919 F3: stale duplicate state dir did not get the live broker killed"
     else
       fail "#919 F3: broker killed via a stale state dir claiming its pid (output: $REAP_OUT)"
     fi
     case "$REAP_OUT" in
-      *"SKIP   pid=$PID_PIDDUP (owner alive: pid $HOLDER_PIDDUP is working in $WS_PIDDUP)"*)
+      *"SKIP   pid=$PID_PIDDUP (owner alive: workspace $WS_PIDDUP still exists)"*)
         pass "#919 F3: the sessionDir-matching state dir is the one adopted" ;;
       *) fail "#919 F3: expected the sessionDir-matching state dir to decide pid=$PID_PIDDUP, got: $REAP_OUT" ;;
     esac
@@ -367,10 +331,21 @@ else
     esac
   fi
 fi
+
+fi   # Darwin gate
 echo ""
 echo "=== summary ==="
 echo "PASS: $PASS"
 echo "FAIL: $FAIL"
+echo "SKIP: ${#SKIPPED_NAMES[@]}"
+
+if [ "${#SKIPPED_NAMES[@]}" -gt 0 ]; then
+  echo ""
+  echo "Skipped gates:"
+  for n in "${SKIPPED_NAMES[@]}"; do
+    echo "  - $n"
+  done
+fi
 
 if [ "$FAIL" -gt 0 ]; then
   echo ""

--- a/tests/test_codex_broker_reaper.sh
+++ b/tests/test_codex_broker_reaper.sh
@@ -8,9 +8,12 @@
 #   2. is_safe_session_dir() must reject traversal-shaped paths. A path like
 #      /tmp/../Users/me/cxc-x string-matches the /tmp/* allowlist yet resolves
 #      OUTSIDE the temp root, letting rm -rf escape.
-#   3. (#919) The reap decision itself: a broker with children owns a live codex
-#      backend — collect_tree() would kill it, so it must survive even when the
-#      idle gate says "idle". Only a childless idle broker may be reaped.
+#   3. (#919) The reap decision itself. Idleness does not imply the owner is
+#      gone, so a kill needs positive orphan evidence about the broker's
+#      WORKSPACE ROOT: it was deleted, or no live process has it as its cwd.
+#      Anything undetermined must keep the broker. (Children are NOT a liveness
+#      signal — the broker spawns `codex app-server` at startup and closes it
+#      only on its own shutdown, so orphans keep a child too.)
 #
 # Run:  ./tests/test_codex_broker_reaper.sh
 # Exit: 0 on success, 1 on first failure (after summary).
@@ -82,17 +85,27 @@ else
   assert_reject "/etc/cxc-a"                   # outside allowlist
 fi
 
-# --- Gate 3: #919 owner-liveness — a broker with children is never reaped ----
+# --- Gate 3: #919 owner-liveness oracle (behavior) ---------------------------
 # Real execution against synthetic processes. The shipped pgrep pattern
 # (app-server-broker.mjs) would match this host's PRODUCTION brokers, so the SUT
 # is copied with ONLY BROKER_PATTERN rewritten to this run's unique fixture path
 # — the reap decision under test is the shipped code, and every pid the copy can
-# see is one this test started. TMPDIR/CLAUDE_CONFIG_DIR are redirected so the
-# lock and the GC pass stay inside the sandbox.
+# see is one this test started. CLAUDE_CONFIG_DIR points the state root at a
+# sandbox tree, so the real ~/.claude state dirs are never read or written, and
+# TMPDIR keeps the lock inside the sandbox too.
+#
+# Four fixture brokers, all equally idle, differing only in owner evidence:
+#   ALIVE   workspace exists + a live process cwd'd there   → must survive
+#   WSGONE  workspaceRoot recorded, directory deleted       → reap (signal C)
+#   NOCWD   workspace exists, nothing working in it         → reap (signal D)
+#   NOJOBS  state dir without jobs/*.json (undeterminable)  → must survive
+#   NOSTATE no state dir claims the pid (undeterminable)    → must survive
 
 TMPD="$(mktemp -d /private/tmp/px919.XXXXXX)"
 FIXTURE="$TMPD/broker-fixture.sh"
+HOLDER="$TMPD/cwd-holder.sh"
 REAPER_COPY="$TMPD/reaper-copy.sh"
+STATE_ROOT="$TMPD/config/plugins/data/codex-openai-codex/state"
 FIXTURE_PIDS=()
 
 cleanup_fixtures() {
@@ -106,16 +119,20 @@ cleanup_fixtures() {
 }
 trap cleanup_fixtures EXIT INT TERM
 
-# Blocks on a fifo via the `read` builtin, so a "childless" fixture really has
-# no child process of its own.
+# Both fixtures block on a fifo via the `read` builtin — no child process, no
+# busy loop, and they die only when killed.
 cat > "$FIXTURE" <<'FIX'
 #!/bin/bash
-if [ "${PX919_SPAWN_CHILD:-0}" = 1 ]; then
-  sleep 600 &
-fi
 exec 3<> "$PX919_FIFO"
 read -r -u 3
 FIX
+
+cat > "$HOLDER" <<'HOLD'
+#!/bin/bash
+cd "$PX919_CWD" || exit 1
+exec 3<> "$PX919_FIFO"
+read -r -u 3
+HOLD
 
 sed "s|^BROKER_PATTERN=.*|BROKER_PATTERN='$FIXTURE'|" "$REAPER" > "$REAPER_COPY"
 
@@ -134,85 +151,161 @@ proc_gone() {
   return 1
 }
 
-# Start a fixture broker whose command line carries a resolvable sessionDir, and
-# backdate its broker.log so the idle gate always considers it idle.
-start_fixture() {
-  # One assignment per line: bash 3.2 does not let a later `local` assignment
-  # see an earlier one from the same statement.
+# The plugin keys its state dir on the workspace root: <slug>-<sha256[0:16]>.
+ws_hash() { printf '%s' "$1" | shasum -a 256 | cut -c1-16; }
+
+# A fixture broker whose command line carries a resolvable sessionDir, with a
+# backdated broker.log so the idle gate always passes.
+start_broker() {
   local name="$1"
-  local spawn_child="$2"
   local sdir="$TMPD/cxc-$name"
   local fifo="$TMPD/$name.fifo"
   local pid
   mkdir -p "$sdir"
   mkfifo "$fifo"
   touch -t 202001010000 "$sdir/broker.log"
-  PX919_FIFO="$fifo" PX919_SPAWN_CHILD="$spawn_child" \
-    bash "$FIXTURE" serve --endpoint "unix:$sdir/broker.sock" >/dev/null 2>&1 &
+  PX919_FIFO="$fifo" bash "$FIXTURE" serve --endpoint "unix:$sdir/broker.sock" >/dev/null 2>&1 &
   pid=$!
   printf '%s' "$pid"   # caller records it in FIXTURE_PIDS (this runs in a subshell)
+}
+
+# A process parked in $1, i.e. what "someone is working in this workspace"
+# looks like to the cwd scan.
+start_cwd_holder() {
+  local dir="$1"
+  local fifo="$TMPD/holder-$2.fifo"
+  local pid
+  mkfifo "$fifo"
+  PX919_FIFO="$fifo" PX919_CWD="$dir" bash "$HOLDER" >/dev/null 2>&1 &
+  pid=$!
+  printf '%s' "$pid"
+}
+
+# state dir for a broker pid: broker.json carries the pid, jobs/*.json the
+# workspaceRoot — the same two files the oracle reads in production.
+write_state() {
+  local name="$1" wroot="$2" pid="$3" with_jobs="$4"
+  local sd
+  sd="$STATE_ROOT/$name-$(ws_hash "$wroot")"
+  mkdir -p "$sd"
+  printf '{"sessionDir":"%s","pid":%s}\n' "$TMPD/cxc-$name" "$pid" > "$sd/broker.json"
+  if [ "$with_jobs" = 1 ]; then
+    mkdir -p "$sd/jobs"
+    printf '{"id":"job-%s","workspaceRoot":"%s"}\n' "$name" "$wroot" > "$sd/jobs/job.json"
+  fi
 }
 
 if ! grep -q "^BROKER_PATTERN='$FIXTURE'$" "$REAPER_COPY"; then
   fail "#919: could not isolate BROKER_PATTERN in the reaper copy (refusing to run against real brokers)"
 else
-  OWNED_PID="$(start_fixture AAA 1)"   # has a child → stands in for a live backend
-  LONE_PID="$(start_fixture BBB 0)"    # childless → a real orphan
-  FIXTURE_PIDS+=("$OWNED_PID" "$LONE_PID")
+  WS_ALIVE="$TMPD/ws-alive"; WS_GONE="$TMPD/ws-gone"
+  WS_NOCWD="$TMPD/ws-nocwd"; WS_NOJOBS="$TMPD/ws-nojobs"; WS_NOSTATE="$TMPD/ws-nostate"
+  mkdir -p "$WS_ALIVE" "$WS_GONE" "$WS_NOCWD" "$WS_NOJOBS" "$WS_NOSTATE"
 
-  # Wait for the owned fixture's child to exist; otherwise the run would race.
+  PID_ALIVE="$(start_broker ALIVE)"
+  PID_WSGONE="$(start_broker WSGONE)"
+  PID_NOCWD="$(start_broker NOCWD)"
+  PID_NOJOBS="$(start_broker NOJOBS)"
+  PID_NOSTATE="$(start_broker NOSTATE)"
+  HOLDER_PID="$(start_cwd_holder "$WS_ALIVE" alive)"
+  FIXTURE_PIDS+=("$PID_ALIVE" "$PID_WSGONE" "$PID_NOCWD" "$PID_NOJOBS" "$PID_NOSTATE" "$HOLDER_PID")
+
+  write_state ALIVE   "$WS_ALIVE"   "$PID_ALIVE"   1
+  write_state WSGONE  "$WS_GONE"    "$PID_WSGONE"  1
+  write_state NOCWD   "$WS_NOCWD"   "$PID_NOCWD"   1
+  write_state NOJOBS  "$WS_NOJOBS"  "$PID_NOJOBS"  0
+  # NOSTATE deliberately gets no state dir at all.
+  rmdir "$WS_GONE"   # signal C: the workspace is deleted after the job recorded it
+
+  # Wait until the holder has actually chdir'd, or the cwd scan would race.
   ready=false
   for _ in $(seq 1 50); do
-    if [ -n "$(pgrep -P "$OWNED_PID" 2>/dev/null)" ]; then ready=true; break; fi
+    if lsof -a -d cwd -p "$HOLDER_PID" -Fn -w 2>/dev/null | grep -qx "n$WS_ALIVE"; then ready=true; break; fi
     sleep 0.1
   done
 
-  if [ "$ready" != true ] || ! proc_alive "$LONE_PID"; then
-    fail "#919: fixture brokers did not come up (owned=$OWNED_PID lone=$LONE_PID)"
+  if [ "$ready" != true ]; then
+    fail "#919: cwd holder never entered $WS_ALIVE (pid=$HOLDER_PID)"
+  elif ! proc_alive "$PID_WSGONE" || ! proc_alive "$PID_NOCWD"; then
+    fail "#919: fixture brokers did not come up"
   else
-    DRY_OUT="$(TMPDIR="$TMPD" CLAUDE_CONFIG_DIR="$TMPD/config" bash "$REAPER_COPY" --reap --max-age 5 --dry-run 2>&1)"
+    RUN_ENV_OUT="$(TMPDIR="$TMPD" CLAUDE_CONFIG_DIR="$TMPD/config" bash "$REAPER_COPY" --reap --max-age 5 --dry-run 2>&1)"
 
-    case "$DRY_OUT" in
-      *"SKIP   pid=$OWNED_PID (owner alive"*) pass "#919 dry-run: broker with a child reported as SKIP (owner alive)" ;;
-      *) fail "#919 dry-run: expected owner-alive SKIP for pid=$OWNED_PID, got: $DRY_OUT" ;;
+    case "$RUN_ENV_OUT" in
+      *"SKIP   pid=$PID_ALIVE (owner alive"*) pass "#919 dry-run: broker whose workspace has a live cwd is SKIP (owner alive)" ;;
+      *) fail "#919 dry-run: expected owner-alive SKIP for pid=$PID_ALIVE, got: $RUN_ENV_OUT" ;;
     esac
-    case "$DRY_OUT" in
-      *"WOULD REAP pid=$LONE_PID"*) pass "#919 dry-run: childless idle broker reported as WOULD REAP" ;;
-      *) fail "#919 dry-run: expected WOULD REAP for pid=$LONE_PID, got: $DRY_OUT" ;;
+    case "$RUN_ENV_OUT" in
+      *"WOULD REAP pid=$PID_WSGONE"*) pass "#919 dry-run: deleted-workspace broker is WOULD REAP" ;;
+      *) fail "#919 dry-run: expected WOULD REAP for pid=$PID_WSGONE, got: $RUN_ENV_OUT" ;;
     esac
 
     REAP_OUT="$(TMPDIR="$TMPD" CLAUDE_CONFIG_DIR="$TMPD/config" bash "$REAPER_COPY" --reap --max-age 5 2>&1)"
 
-    # 1. Regression: the idle broker that still owns a backend must survive.
-    if proc_alive "$OWNED_PID"; then
-      pass "#919 regression: idle broker WITH a child survived --reap"
+    # 1. Regression: idle + workspace alive + someone working in it → survive.
+    if proc_alive "$PID_ALIVE"; then
+      pass "#919 regression: idle broker with a live workspace cwd survived --reap"
     else
-      fail "#919 regression: idle broker WITH a child was killed by --reap (output: $REAP_OUT)"
+      fail "#919 regression: idle broker with a live workspace cwd was killed (output: $REAP_OUT)"
     fi
-    if [ -d "$TMPD/cxc-AAA" ]; then
+    if [ -d "$TMPD/cxc-ALIVE" ]; then
       pass "#919 regression: surviving broker's sessionDir kept"
     else
       fail "#919 regression: surviving broker's sessionDir was removed"
     fi
     case "$REAP_OUT" in
-      *"SKIP   pid=$OWNED_PID (owner alive"*) pass "#919 regression: skip reason names the live owner" ;;
-      *) fail "#919 regression: expected owner-alive SKIP line for pid=$OWNED_PID, got: $REAP_OUT" ;;
+      *"SKIP   pid=$PID_ALIVE (owner alive: a live process is working in $WS_ALIVE)"*)
+        pass "#919 regression: skip reason names the live workspace" ;;
+      *) fail "#919 regression: expected owner-alive SKIP naming $WS_ALIVE, got: $REAP_OUT" ;;
     esac
 
-    # 2. The childless idle broker is still reaped (the fix is not a blanket no-op).
-    if proc_gone "$LONE_PID"; then
-      pass "#919: childless idle broker was reaped"
+    # 2. Signal C — workspaceRoot recorded but the directory is gone → reap.
+    if proc_gone "$PID_WSGONE"; then
+      pass "#919 C: broker whose workspace was deleted is reaped"
     else
-      fail "#919: childless idle broker survived --reap (output: $REAP_OUT)"
-    fi
-    if [ ! -d "$TMPD/cxc-BBB" ]; then
-      pass "#919: reaped broker's sessionDir removed"
-    else
-      fail "#919: reaped broker's sessionDir still present"
+      fail "#919 C: deleted-workspace broker survived --reap (output: $REAP_OUT)"
     fi
     case "$REAP_OUT" in
-      *"REAPED pid=$LONE_PID"*) pass "#919: reap reported for the childless broker" ;;
-      *) fail "#919: expected REAPED line for pid=$LONE_PID, got: $REAP_OUT" ;;
+      *"REAPED pid=$PID_WSGONE"*) pass "#919 C: reap reported for the deleted-workspace broker" ;;
+      *) fail "#919 C: expected REAPED line for pid=$PID_WSGONE, got: $REAP_OUT" ;;
+    esac
+    if [ ! -d "$TMPD/cxc-WSGONE" ]; then
+      pass "#919 C: reaped broker's sessionDir removed"
+    else
+      fail "#919 C: reaped broker's sessionDir still present"
+    fi
+
+    # 3. Signal D — workspace exists but no live process is cwd'd there → reap.
+    if proc_gone "$PID_NOCWD"; then
+      pass "#919 D: broker with no live process in its workspace is reaped"
+    else
+      fail "#919 D: unused-workspace broker survived --reap (output: $REAP_OUT)"
+    fi
+    case "$REAP_OUT" in
+      *"REAPED pid=$PID_NOCWD"*) pass "#919 D: reap reported for the unused-workspace broker" ;;
+      *) fail "#919 D: expected REAPED line for pid=$PID_NOCWD, got: $REAP_OUT" ;;
+    esac
+
+    # 4. Undeterminable owners must fall to KEEP.
+    if proc_alive "$PID_NOJOBS"; then
+      pass "#919 safe-default: broker with no jobs file survived --reap"
+    else
+      fail "#919 safe-default: broker with no jobs file was killed (output: $REAP_OUT)"
+    fi
+    case "$REAP_OUT" in
+      *"SKIP   pid=$PID_NOJOBS (owner unknown: no workspaceRoot recorded"*)
+        pass "#919 safe-default: missing jobs file reported as unknown owner" ;;
+      *) fail "#919 safe-default: expected unknown-owner SKIP for pid=$PID_NOJOBS, got: $REAP_OUT" ;;
+    esac
+    if proc_alive "$PID_NOSTATE"; then
+      pass "#919 safe-default: broker with no state dir survived --reap"
+    else
+      fail "#919 safe-default: broker with no state dir was killed (output: $REAP_OUT)"
+    fi
+    case "$REAP_OUT" in
+      *"SKIP   pid=$PID_NOSTATE (owner unknown: no state dir claims this pid)"*)
+        pass "#919 safe-default: missing state dir reported as unknown owner" ;;
+      *) fail "#919 safe-default: expected unknown-owner SKIP for pid=$PID_NOSTATE, got: $REAP_OUT" ;;
     esac
   fi
 fi

--- a/tests/test_codex_broker_reaper.sh
+++ b/tests/test_codex_broker_reaper.sh
@@ -116,7 +116,7 @@ if [ "$(uname -s)" != "Darwin" ]; then
 else
 
 TMPROOT="${TMPDIR:-/tmp}"; TMPROOT="${TMPROOT%/}"
-TMPD="$(mktemp -d "$TMPROOT/px919.XXXXXX")"
+TMPD="$(mktemp -d "$TMPROOT/px919.XXXXXX")" || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
 FIXTURE="$TMPD/broker-fixture.sh"
 REAPER_COPY="$TMPD/reaper-copy.sh"
 # The space is deliberate: CLAUDE_CONFIG_DIR is relocatable (CONTRIBUTING.md),

--- a/tests/test_codex_broker_reaper.sh
+++ b/tests/test_codex_broker_reaper.sh
@@ -119,7 +119,13 @@ TMPROOT="${TMPDIR:-/tmp}"; TMPROOT="${TMPROOT%/}"
 TMPD="$(mktemp -d "$TMPROOT/px919.XXXXXX")"
 FIXTURE="$TMPD/broker-fixture.sh"
 REAPER_COPY="$TMPD/reaper-copy.sh"
-STATE_ROOT="$TMPD/config/plugins/data/codex-openai-codex/state"
+# The space is deliberate: CLAUDE_CONFIG_DIR is relocatable (CONTRIBUTING.md),
+# and a bare `for f in $(grep -l ...)` over the state dir splits such a path at
+# the space — every lookup misses, every broker reads as "unknown", and the reap
+# pass silently dies. Keeping the fixture path spaced makes that a standing
+# regression check for the whole gate rather than one bolted-on case.
+CONFIG_FIXTURE="$TMPD/config dir"
+STATE_ROOT="$CONFIG_FIXTURE/plugins/data/codex-openai-codex/state"
 FIXTURE_PIDS=()
 
 cleanup_fixtures() {
@@ -239,7 +245,7 @@ else
   if [ "$ready" != true ]; then
     fail "#919: fixture brokers did not come up"
   else
-    DRY_OUT="$(TMPDIR="$TMPD" CLAUDE_CONFIG_DIR="$TMPD/config" bash "$REAPER_COPY" --reap --max-age 5 --dry-run 2>&1)"
+    DRY_OUT="$(TMPDIR="$TMPD" CLAUDE_CONFIG_DIR="$CONFIG_FIXTURE" bash "$REAPER_COPY" --reap --max-age 5 --dry-run 2>&1)"
 
     case "$DRY_OUT" in
       *"SKIP   pid=$PID_ALIVE (owner alive"*) pass "#919 dry-run: broker with a live workspace is SKIP (owner alive)" ;;
@@ -250,7 +256,7 @@ else
       *) fail "#919 dry-run: expected WOULD REAP for pid=$PID_WSGONE, got: $DRY_OUT" ;;
     esac
 
-    REAP_OUT="$(TMPDIR="$TMPD" CLAUDE_CONFIG_DIR="$TMPD/config" bash "$REAPER_COPY" --reap --max-age 5 2>&1)"
+    REAP_OUT="$(TMPDIR="$TMPD" CLAUDE_CONFIG_DIR="$CONFIG_FIXTURE" bash "$REAPER_COPY" --reap --max-age 5 2>&1)"
 
     # 1. Regression: idle is not death — a live workspace keeps the broker.
     if proc_alive "$PID_ALIVE"; then


### PR DESCRIPTION
## 무엇을

`codex-broker-reaper.sh --reap` 이 살아있는 codex 세션을 종료시키던 결함을 고칩니다. reap 에 **소유자 부재의 적극적 증거**를 요구하고, 판정 불가는 전부 KEEP 으로 떨어뜨립니다.

Refs #919 — 이슈 본문 대비 **부분 범위**입니다. 아래 "이번 범위에서 제외" 참고.

## 왜

idle gate 는 "broker 가 지금 서빙 중인가"만 재고 "소유 세션이 살아있는가"는 재지 못합니다. 턴 사이 유휴 상태인 멀쩡한 세션이 idle 로 판정돼 13개 세션이 종료됐습니다.

## 어떻게

- **C 신호만 신뢰**: state dir 의 `jobs/*.json` 에서 `workspaceRoot` 를 읽어 **그 디렉터리가 삭제됐을 때만** `dead`. worktree 가 사라졌다는 건 확정 신호입니다.
- **state dir 지정은 pid + sessionDir 동시 일치**: `broker.json` 은 비정상 종료 시 남고 pid 는 재사용됩니다(실측: 374개 중 pid 17869 을 2개가 주장). 후보가 0개거나 2개 이상이면 `unknown` → KEEP.
- **경로 안전 순회**: `CLAUDE_CONFIG_DIR` 는 재배치 가능하므로(CONTRIBUTING.md:163-166) 공백 포함 경로에서 단어 분할되지 않도록 `while IFS= read -r` + 프로세스 치환.
- idle gate, kill 직전 재확인, lock, `is_safe_session_dir`, Pass 2 GC 는 그대로.

## 검증

Pre-commit verified: `bash tests/test_codex_broker_reaper.sh` → 38 PASS / 0 FAIL / 0 SKIP (Darwin). `shellcheck --severity=warning` (CI 게이트와 동일 수위) → exit 0.

Caller chain verified: 호출처는 `SKILL.md` Step 6(`--gc` 기본 / `PRAXIS_CODEX_REAP=1` 일 때 `--reap`)과 `LAUNCHD.md` 의 launchd job 두 곳이며, 인자 표면(`--gc`/`--reap`/`--max-age`/`--dry-run`)은 이 PR 에서 바뀌지 않았습니다.

음성 대조 — 새 테스트가 실제로 결함을 잡는지 확인:

```
수정 전 코드 + 공백 포함 config fixture
  → SKIP pid=... (owner unknown) ×6, reaped=0, F3 케이스 FAIL
수정 후
  → PASS: 38 / FAIL: 0 / SKIP: 0
```

실호스트 dry-run (`--reap --dry-run --max-age 30`), 재설계 중간 단계에서 관측:

```
SKIP   pid=92567 (owner alive ...)
WOULD REAP pid=34134 idle=39304s ...
scanned=3 reaped=2 skipped=1
```

## 이번 범위에서 제외 (후속 이슈로 분리)

"workspace 는 남아있는데 아무도 안 쓰는 broker" 회수(D 신호)는 뺐습니다. cwd 기반 소유권 근사가 라운드마다 새 실패 모드를 냈고, 네 개 제약이 미해결입니다:

1. **subdir cwd** — 플러그인은 git 루트를 `workspaceRoot` 로 기록하지만(`lib/workspace.mjs` `resolveWorkspaceRoot` → `ensureGitRepository`) 세션 cwd 는 하위 경로일 수 있어 exact 매칭이 살아있는 소유자를 dead 로 판정
2. **broker 자기 트리** — broker 와 app-server 가 workspace root 를 cwd 로 유지하므로 자기 자신을 소유자로 세어 신호가 발화하지 않음
3. **CI 이식성** — `lsof` / BSD `stat` 전제, CI runner 는 Ubuntu
4. **성능** — broker 수 × 전체 cwd 스캔, 5분 stale-lock 임계 초과 가능

## 미검증

- 실제 codex/broker 프로세스로 kill 경로를 실행하지는 않았습니다(검증 시점 호스트 조건상 dry-run 까지). fixture 는 부모/자식 구조와 state 레이아웃을 재현합니다.
- 공백 포함 `CLAUDE_CONFIG_DIR` 로 프로덕션 broker 를 회수해보지는 않았습니다(호스트 config 경로에 공백 없음) — fixture 재현까지.
- `LAUNCHD.md` / `SKILL.md` 의 안전성 서술과 `--max-age` 기본값 30분(이슈 §5)은 이 PR 범위 밖입니다.

[skip-codex-review] codex review 5라운드 완료 (R1 P1 1건 → R2 P1 2건 → R3 P1 2건+P2 1건 → R4 P2 1건 → R5 findings 0건). 모든 finding 은 사용자 승인 후 적용했고 R5 에서 클린입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved broker cleanup safety by requiring confirmed evidence that the associated workspace was deleted before removing an idle broker.
  * Brokers with unknown, ambiguous, missing, or still-active workspaces are now preserved.
  * Added protection against incorrect cleanup when process identifiers are reused.
  * Owner status is rechecked immediately before termination to prevent unsafe removal.

* **Documentation**
  * Updated usage guidance and safety documentation to explain the stricter cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->