### PR TITLE
fix(hook): demote 세션 종료 to separator form

### DIFF
--- a/hooks/preflight-gate/block-ask-end-option/impl.py
+++ b/hooks/preflight-gate/block-ask-end-option/impl.py
@@ -70,7 +70,6 @@ from _transcript import read_last_user_message  # type: ignore[import-not-found]
 # collide with inflected nouns.
 END_OPTION_MARKERS_KO = (
     "여기서 종료",
-    "세션 종료",
     "여기서 끝",
     "여기까지",
     # Heading-separator patterns for bare KO end-tokens (issue #236).
@@ -79,6 +78,13 @@ END_OPTION_MARKERS_KO = (
     "종료 —", "종료 -", "종료:",
     "그만 —", "그만 -", "그만:",
     "마무리 —", "마무리 -", "마무리:",
+    # "세션 종료" demoted to the same heading-separator condition (issue
+    # #922). "세션" is an everyday noun for process/workspace/agent
+    # sessions in this tool environment, so bare "세션 종료" clusters in
+    # legitimate work labels ("중복 MCP만, 부모 세션 종료 후",
+    # "21873 세션 종료 여부를 먼저 확인") — same false-positive risk the
+    # bare-token exception above already guards against.
+    "세션 종료 —", "세션 종료 -", "세션 종료:",
     # Indirect Korean: pause / break / defer / other-work framing.
     # Bare "보류" intentionally omitted: substring match would false-block
     # legitimate work labels like "보류 중인 이슈 확인" / "보류 상태 검토".

--- a/hooks/preflight-gate/block-ask-end-option/spec.md
+++ b/hooks/preflight-gate/block-ask-end-option/spec.md
@@ -112,7 +112,6 @@ present, opt out for that call with `PRAXIS_ASK_END_ADVISORY=1`.
 Phrased forms:
 
 - `여기서 종료`
-- `세션 종료`
 - `여기서 끝`
 - `여기까지`
 
@@ -123,14 +122,21 @@ nouns like `종료된`, `마무리 방식`:
 - `종료 —`, `종료 -`, `종료:`
 - `그만 —`, `그만 -`, `그만:`
 - `마무리 —`, `마무리 -`, `마무리:`
+- `세션 종료 —`, `세션 종료 -`, `세션 종료:` (demoted from a bare phrased
+  form by issue #922 — `세션` is an everyday noun for
+  process/workspace/agent sessions in this tool environment, so bare
+  `세션 종료` clustered in legitimate work labels like
+  `중복 MCP만, 부모 세션 종료 후` and `21873 세션 종료 여부를 먼저 확인`;
+  same false-positive risk the bare-token exception below already guards
+  against)
 
-Bare `종료` / `그만` / `마무리` are intentionally **not** markers on the
-option-label side: Korean productively inflects, and labels like
-`종료된 이슈 목록` / `회의 마무리 방식 검토` / `종료 시각 기준` are
-legitimate triage options. The asymmetry with `STOP_SIGNALS_KO` (which
-does match these bare tokens in user prose) is intentional — option
-labels are exactly where these noun forms cluster, while user messages
-typically use phrasal stop signals.
+Bare `종료` / `그만` / `마무리` / `세션 종료` are intentionally **not**
+markers on the option-label side: Korean productively inflects, and labels
+like `종료된 이슈 목록` / `회의 마무리 방식 검토` / `종료 시각 기준` /
+`21873 세션 종료 여부를 먼저 확인` are legitimate triage options. The
+asymmetry with `STOP_SIGNALS_KO` (which does match these bare tokens in user
+prose) is intentional — option labels are exactly where these noun forms
+cluster, while user messages typically use phrasal stop signals.
 
 #### Indirect end-option markers (Korean)
 
@@ -213,8 +219,11 @@ bash hooks/test-block-ask-end-option.sh
 
 Covers: direct Korean/English end markers (block + advisory modes),
 heading-separator KO end-tokens in option labels (issue #236 — `종료 —`,
-`그만 —`, `마무리:`, etc.) including inflected-noun false-positive regression
-(`종료된 이슈 목록`, `회의 마무리 방식 검토`, `종료 시각 기준`), indirect
+`그만 —`, `마무리:`, etc., plus `세션 종료 —` per issue #922) including
+inflected-noun false-positive regression (`종료된 이슈 목록`,
+`회의 마무리 방식 검토`, `종료 시각 기준`) and the issue-#922 real-world
+false positives (`중복 MCP만, 부모 세션 종료 후`,
+`21873 세션 종료 여부를 먼저 확인`), indirect
 English phrasing (take a break, prioritize other work, pause for now, resume in
 a later session, other work first), indirect Korean phrasing (잠시 멈춰, 잠시
 보류, 휴식, 다른 작업 우선, 다음 세션), 4-option padding pattern (4th

--- a/tests/hooks/preflight-gate/test_block_ask_end_option.sh
+++ b/tests/hooks/preflight-gate/test_block_ask_end_option.sh
@@ -133,8 +133,8 @@ P2=$(build_payload "$T2" '["Implement", "Review", "End here"]')
 run_case "english end marker, neutral user message" block default "$P2"
 
 T3=$(build_transcript "다음 단계 진행해주세요")
-P3=$(build_payload "$T3" '["Step 1", "Step 2", "세션 종료"]')
-run_case "korean continuation, korean end marker" block default "$P3"
+P3=$(build_payload "$T3" '["Step 1", "Step 2", "세션 종료 — 여기서 끊자"]')
+run_case "korean continuation, korean end marker (heading-separator)" block default "$P3"
 
 # ---------------------------------------------------------------------------
 # (b) BLOCK cases — explicit strict env var (deprecated, still honoured)
@@ -480,6 +480,28 @@ run_case "[#236-fp] '회의 마무리 방식 검토' (compound) → pass" pass d
 T_fp_inf3=$(build_transcript "이슈 정렬 기준 알려주세요")
 P_fp_inf3=$(build_payload "$T_fp_inf3" '["종료 시각 기준", "생성 시각 기준", "우선순위 기준"]')
 run_case "[#236-fp] '종료 시각 기준' (inflected noun) → pass" pass default "$P_fp_inf3"
+
+# ---------------------------------------------------------------------------
+# (n-pre2) Issue #922 — bare "세션 종료" false positives on work labels
+# ---------------------------------------------------------------------------
+#
+# "세션 종료" was a bare phrased marker matching any label containing the
+# substring, regardless of separator. "세션" is an everyday noun for
+# process/workspace/agent sessions in this tool environment, so it clustered
+# in legitimate work labels. Demoted to the same heading-separator condition
+# as bare 종료/그만/마무리 (see END_OPTION_MARKERS_KO comment in impl.py).
+
+T_922_1=$(build_transcript "프로세스 정리 부탁해")
+P_922_1=$(build_payload "$T_922_1" '["전부 정리", "중복 MCP만, 부모 세션 종료 후", "그대로 둠"]')
+run_case "[#922-fp] '중복 MCP만, 부모 세션 종료 후' (real-world label) → pass" pass default "$P_922_1"
+
+T_922_2=$(build_transcript "남은 중복 MCP 어떻게 할까요")
+P_922_2=$(build_payload "$T_922_2" '["지금 정리", "21873 세션 종료 여부를 먼저 확인", "보류"]')
+run_case "[#922-fp] '21873 세션 종료 여부를 먼저 확인' (real-world label) → pass" pass default "$P_922_2"
+
+T_922_pos=$(build_transcript "다음 단계 진행해주세요")
+P_922_pos=$(build_payload "$T_922_pos" '["Plan A", "Plan B", "세션 종료 — 컨텍스트"]')
+run_case "[#922-pos] '세션 종료 —' separator label still blocks" block default "$P_922_pos"
 
 # ---------------------------------------------------------------------------
 # (n) False positive avoidance — legitimate work options must NOT be blocked


### PR DESCRIPTION
## 무엇을

`block-ask-end-option` 훅의 phrased marker `세션 종료` 를, 같은 파일이 bare 토큰(`종료`/`그만`/`마무리`)에 이미 쓰고 있는 heading-separator 조건으로 강등합니다 — `세션 종료 —` / `세션 종료 -` / `세션 종료:` 만 매칭.

Closes #922

## 왜

`세션` 은 이 도구 환경에서 프로세스·워크스페이스·에이전트 세션을 가리키는 일상 명사라, 정상 작업 라벨에 `세션 종료` 조합이 흔히 등장합니다. 2026-07-31 세션에서 2회 연속 오탐 차단이 실측됐습니다:

- `중복 MCP만, 부모 세션 종료 후` — 프로세스 종료 순서 제안
- `21873 세션 종료 여부를 먼저 확인` — 조사 작업 제안

둘 다 대화·세션을 끝내자는 제안이 아닙니다. spec 은 bare 토큰에 대해 **정확히 이 위험을 이유로** 이미 separator 예외를 두고 있는데(`종료된 이슈 목록` / `회의 마무리 방식 검토`), phrased form 에는 같은 보호가 없었습니다.

문맥 판별(pid / 프로세스명 감지) 휴리스틱은 도입하지 않았습니다 — 기존 sibling 토큰과 대칭 조건으로 맞추는 것이 최소 변경입니다.

## 검증

Pre-commit verified: `bash tests/hooks/preflight-gate/test_block_ask_end_option.sh` → 71 PASS / 0 FAIL. 이슈에 실측된 라벨 2개를 negative fixture(통과해야 함), `세션 종료 — 컨텍스트` 를 positive fixture(여전히 차단)로 추가했습니다. 회귀 확인으로 `test_critic_pre_lock_probe.sh` (26 pass), `test_block_message.py` + `test_transcript.py` (38 pass) 동반 실행.

Caller chain verified: 변경은 `END_OPTION_MARKERS_KO` 튜플 한 곳이며, 이 상수를 읽는 경로는 같은 `impl.py` 내부 매칭 로직뿐입니다. `hooks/manifest.json` · `docs/hook/INDEX.md` · `ARCHITECTURE.md` · `plugins/*/hooks.json` 은 건드리지 않았습니다(훅 추가·제거가 아니라 기존 훅의 마커 조건 변경).

## 미검증

실제 Claude Code 런타임의 PreToolUse 파이프라인 end-to-end 재현은 아니고, `impl.py` 에 synthetic payload 를 stdin 으로 넣는 기존 테스트 컨벤션 방식으로 검증했습니다.

## 참고

추가된 `"세션 종료 —"` 계열 패턴은 기존 `"종료 —"` 가 이미 부분 문자열로 잡으므로 기능적으로는 잉여이지만, 의도를 문면에 남기기 위해 유지했습니다.

[skip-codex-review] codex review 완료 — findings 0건 ("marker 동작은 명세와 일치, payload probe·Ruff·ShellCheck·manifest·hook invariant 검사 통과").
