### PR TITLE
fix(tests): isolate fire-ledger in run-tests.sh

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -31,6 +31,17 @@ PRAXIS_HOME="$(mktemp -d)" || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
 export PRAXIS_HOME
 trap 'rm -rf "$PRAXIS_HOME"' EXIT
 
+# Same isolation, for the fire-ledger (#849). resolve_path() in
+# hooks/_lib/_fire_ledger.py does NOT fall under PRAXIS_HOME — it defaults to
+# Path.home()/.praxis/telemetry regardless, so PRAXIS_HOME alone leaves it
+# writing into the developer's real ledger. Most tests/hooks/*/test_*.sh files
+# invoke an instrumented impl.sh/impl.py directly and never set
+# PRAXIS_FIRE_TELEMETRY_FILE themselves (only a handful do, e.g.
+# tests/hooks/_lib/test_record_fire.sh) — mirrors the pytest-side fix in
+# tests/conftest.py: an inline `PRAXIS_FIRE_TELEMETRY_FILE=... command`
+# prefix on a specific call still wins over this exported default.
+export PRAXIS_FIRE_TELEMETRY_FILE="$PRAXIS_HOME/fire-events-test.jsonl"
+
 FAILED=0
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 무엇을

`scripts/run-tests.sh` 가 `PRAXIS_FIRE_TELEMETRY_FILE` 을 임시 경로로 export 해, 셸 테스트가 프로덕션 fire-ledger(`~/.praxis/telemetry/`)에 쓰지 못하게 합니다.

Closes #849

## 왜 — 이슈의 잔여분

Python 경로는 PR #883 의 `tests/conftest.py` autouse fixture 로 이미 격리됐고, 이슈 본문의 `_lib` 귀속 항목도 같은 PR 의 conftest 주석이 "attribution quirk, not a second bug" 로 판정을 끝냈습니다. 남아 있던 건 셸 테스트입니다:

- `tests/hooks/*/test_*.sh` 84개 중 자체적으로 `PRAXIS_FIRE_TELEMETRY_FILE` 을 설정하는 건 7개뿐
- #892 로 `impl.sh` 훅들이 `hooks/_lib/record_fire.sh` 를 통해 ledger 에 쓰게 됨
- `record_fire.sh` 는 python `_fire_ledger` 에 위임하고, `resolve_path()` 는 override 가 없으면 `Path.home()/.praxis/telemetry` 로 폴백 — `PRAXIS_HOME` 아래로 떨어지지 않으므로 기존 `PRAXIS_HOME` 격리(#903)만으로는 부족

## 어떻게

기존 `PRAXIS_HOME` mktemp 블록(#903 선례) 바로 다음에 export 를 추가하고, 같은 EXIT trap 이 함께 정리합니다.

레이어 선택 근거: `tests/_assert_lib.sh` 는 5개 파일만 source 하는 정적 문서-assertion 헬퍼라 공통 층이 아니고, `run-tests.sh` 가 `tests/hooks/*/test_*.sh` 와 `tests/test_*.sh` 양쪽을 모두 실행하는 유일한 공통 진입점입니다. 개별 테스트의 인라인 `PRAXIS_FIRE_TELEMETRY_FILE=... command` prefix 는 명령어 prefix 할당이 export 된 기본값보다 우선하므로 깨지지 않습니다(`tests/conftest.py` 의 monkeypatch "마지막 값이 이긴다" 와 같은 원리).

## 검증

Pre-commit verified: 수정 전 재현 — `tests/hooks/advisory-nudge/test_destructive_bash_guard.sh` 단독 실행 시 프로덕션 ledger 가 67153390 → 67255033 bytes (481줄 유입, 그중 135줄이 `hook: destructive-bash-guard`). 수정 후 같은 절차에서 프로덕션 ledger delta 0, 격리된 tmp ledger 에 128줄. 전체 `scripts/run-tests.sh` exit 0 (pytest 510 passed, 셸 서브스위트 전부 0 failed). 프로덕션 ledger 는 읽기만 했고 수정·삭제하지 않았습니다.

Caller chain verified: `PRAXIS_FIRE_TELEMETRY_FILE` 을 읽는 곳은 `hooks/_lib/_fire_ledger.py:204` 의 `resolve_path()` 하나이며, 셸 훅은 `hooks/_lib/record_fire.sh` 를 통해 같은 함수로 들어옵니다. 자체 값을 설정하는 7개 테스트는 인라인 prefix 라 우선순위가 유지됩니다.

## 미검증

`run-tests.sh` 를 거치지 않고 개별 `tests/hooks/*/test_*.sh` 를 직접 실행하는 경로는 여전히 격리되지 않습니다. `PRAXIS_HOME` 을 다루는 #903 도 동일한 한계를 갖고 있어 기존 컨벤션에 맞춘 판단입니다.

[skip-codex-review] codex review 완료 — findings 0건 ("diff 검사, Bash 구문 검사와 shellcheck 에서 문제 없음").
