### PR TITLE
fix(hooks): exempt live session from cache sweep

### DIFF
--- a/hooks/_lib/_paths.py
+++ b/hooks/_lib/_paths.py
@@ -62,15 +62,19 @@ def _tmp_root() -> str:
     return os.environ.get("TMPDIR") or "/tmp"
 
 
-def resolve_writable(subdir: str, filename: str) -> str:
+def resolve_writable(subdir: str, filename: str, session_id: str | None = None) -> str:
     """Path under ~/.praxis/<subdir>/, creating it; TMPDIR fallback if
-    unwritable. Never raises."""
+    unwritable. Never raises.
+
+    `session_id` names the session whose cache entries the opportunistic sweep
+    must leave alone — see `prune_stale`.
+    """
     try:
         d = os.path.join(praxis_home(), subdir)
         os.makedirs(d, exist_ok=True)
         if os.access(d, os.W_OK):
             if subdir == "cache":
-                _ = prune_stale(d)
+                _ = prune_stale(d, session_id=session_id)
             return os.path.join(d, filename)
     except Exception:
         pass
@@ -82,7 +86,7 @@ def legacy_tmp_path(filename: str) -> str:
     return os.path.join(_tmp_root().rstrip("/") or "/", "praxis-" + filename)
 
 
-def resolve_cache_file(filename: str) -> str:
+def resolve_cache_file(filename: str, session_id: str | None = None) -> str:
     """Cache path for `filename`, adopting the pre-#903 ${TMPDIR} file if present.
 
     Session-scoped state (retrospect marker, session intent, dedup markers) is
@@ -91,8 +95,12 @@ def resolve_cache_file(filename: str) -> str:
     retrospect marker that means the Stop gate silently stops firing, the exact
     failure #666 was opened for. The adoption is a one-time move, mirroring the
     #527 strike-state migration in strike-counter/impl.sh.
+
+    Pass the caller's `session_id` (the same token its filename is keyed on) so
+    the sweep this resolution triggers cannot delete the calling session's own
+    entries — see `prune_stale`.
     """
-    path = resolve_writable("cache", filename)
+    path = resolve_writable("cache", filename, session_id=session_id)
     legacy = legacy_tmp_path(filename)
     if legacy != path and not os.path.exists(path) and os.path.exists(legacy):
         try:
@@ -119,7 +127,21 @@ def cache_ttl_days() -> float:
         return 0.0
 
 
-def prune_stale(directory: str, ttl_days: float | None = None) -> int:
+def _belongs_to_session(name: str, session_id: str) -> bool:
+    """True when cache entry `name` is keyed on `session_id`.
+
+    Consumers all name their entries `<prefix>-<session_id><suffix>`, so the
+    token is matched at a boundary rather than as a bare substring: a PPID
+    fallback key like `123` would otherwise protect `md-read-history-1234.json`
+    belonging to an unrelated session.
+    """
+    head, _sep, tail = name.rpartition("-" + session_id)
+    return bool(head) and _sep != "" and (tail == "" or tail.startswith("."))
+
+
+def prune_stale(
+    directory: str, ttl_days: float | None = None, session_id: str | None = None
+) -> int:
     """Delete entries in `directory` older than the cache TTL; return the count.
 
     TMPDIR had an OS janitor behind it. ~/.praxis/cache does not, and these
@@ -128,6 +150,13 @@ def prune_stale(directory: str, ttl_days: float | None = None) -> int:
     opportunistically from `resolve_writable`, which is already on the write
     path of every cache consumer. Never raises: a failed sweep must not take a
     hook down with it.
+
+    Age is not ownership (#920). A marker is written once at the start of a
+    session and then only read, so its mtime stops advancing while the session
+    is very much alive; past the TTL the sweep would delete it and the gate that
+    reads it goes silently quiet — the #666 failure. `session_id` is therefore
+    excluded from the sweep: entries keyed on the calling session survive
+    regardless of age, while other sessions' entries age out as before.
     """
     ttl = cache_ttl_days() if ttl_days is None else ttl_days
     if ttl <= 0:
@@ -143,6 +172,8 @@ def prune_stale(directory: str, ttl_days: float | None = None) -> int:
     with entries:
         for entry in entries:
             try:
+                if session_id and _belongs_to_session(entry.name, session_id):
+                    continue
                 is_dir = entry.is_dir(follow_symlinks=False)
                 mtime = _newest_mtime(entry.path) if is_dir else entry.stat().st_mtime
                 if mtime >= cutoff:

--- a/hooks/advisory-nudge/jq-config-empty-dict-advisory/impl.py
+++ b/hooks/advisory-nudge/jq-config-empty-dict-advisory/impl.py
@@ -351,7 +351,7 @@ def _extract_session_id(payload: dict) -> Optional[str]:
 
 def _resolve_dedup_path(session_id: Optional[str]) -> str:
     key = session_id or str(os.getppid())
-    return resolve_cache_file(f"jq-config-advisory-{key}.json")
+    return resolve_cache_file(f"jq-config-advisory-{key}.json", session_id=key)
 
 
 def _load_seen(path: str) -> set:

--- a/hooks/advisory-nudge/postcompact-context/impl.py
+++ b/hooks/advisory-nudge/postcompact-context/impl.py
@@ -110,7 +110,9 @@ def resolve_state_path(session_id: str) -> str:
     explicit = os.environ.get(STATE_FILE_ENV, "").strip()
     if explicit:
         return explicit
-    return resolve_cache_file(f"postcompact-context-{session_id}.json")
+    return resolve_cache_file(
+        f"postcompact-context-{session_id}.json", session_id=session_id
+    )
 
 
 def read_state(path: str) -> dict:

--- a/hooks/postuse-correction/pre-edit-md-escape-advisory/impl.py
+++ b/hooks/postuse-correction/pre-edit-md-escape-advisory/impl.py
@@ -170,7 +170,7 @@ def resolve_history_path(session_id: str | None = None) -> str:
         return override
 
     key = session_id or str(os.getppid())
-    return resolve_cache_file(f"md-read-history-{key}.json")
+    return resolve_cache_file(f"md-read-history-{key}.json", session_id=key)
 
 
 def load_history(path: str) -> dict:

--- a/hooks/preflight-gate/retrospect-active-marker/impl.py
+++ b/hooks/preflight-gate/retrospect-active-marker/impl.py
@@ -97,7 +97,7 @@ def resolve_state_path(session_id: str | None = None) -> str:
         return explicit
 
     key = session_id or str(os.getppid())
-    return resolve_cache_file(f"retrospect-active-{key}.json")
+    return resolve_cache_file(f"retrospect-active-{key}.json", session_id=key)
 
 
 def set_marker(path: str, source: str) -> None:
@@ -168,7 +168,7 @@ def resolve_candidates_path(session_id: str | None = None) -> str:
     if explicit:
         return explicit + ".candidates.json"
     token = session_id if session_id else str(os.getppid())
-    return resolve_cache_file(f"retrospect-candidates-{token}.json")
+    return resolve_cache_file(f"retrospect-candidates-{token}.json", session_id=token)
 
 
 def write_candidate_hints(payload: dict, session_id: str | None) -> None:

--- a/hooks/preflight-gate/session-intent/impl.py
+++ b/hooks/preflight-gate/session-intent/impl.py
@@ -268,7 +268,7 @@ def resolve_state_path(session_id: str | None = None) -> str:
         return explicit
 
     key = session_id or str(os.getppid())
-    return resolve_cache_file(f"session-intent-{key}.json")
+    return resolve_cache_file(f"session-intent-{key}.json", session_id=key)
 
 
 def read_state(path: str) -> dict:

--- a/hooks/preflight-gate/worktree-prune-snapshot-gate/impl.py
+++ b/hooks/preflight-gate/worktree-prune-snapshot-gate/impl.py
@@ -152,7 +152,7 @@ def resolve_state_path(session_id: str | None = None) -> str:
     if explicit:
         return explicit
     key = session_id or str(os.getppid())
-    return resolve_cache_file(f"worktree-prune-snapshot-{key}.json")
+    return resolve_cache_file(f"worktree-prune-snapshot-{key}.json", session_id=key)
 
 
 def read_state(path: str) -> dict:

--- a/tests/hooks/_lib/test_paths_prune.py
+++ b/tests/hooks/_lib/test_paths_prune.py
@@ -1,0 +1,155 @@
+"""Tests for hooks/_lib/_paths.py prune_stale session ownership (#920).
+
+`prune_stale` deleted on mtime alone. A session-keyed marker is written once at
+the start of a session and then only read, so its mtime stops advancing while
+the session is alive; past the TTL the sweep removed it and the gate reading it
+went silently quiet — the #666 failure mode. The sweep now excludes entries
+keyed on the calling session.
+
+Coverage:
+  - the calling session's entries survive a sweep that would otherwise delete
+    them (both file and directory entries)
+  - other sessions' stale entries are still swept (the guard is not an off
+    switch)
+  - fresh entries survive regardless of session
+  - token matching is boundary-anchored: a PPID-shaped key like `123` must not
+    protect an unrelated `...-1234.json`
+  - resolve_cache_file threads its session_id through to the sweep
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LIB = REPO_ROOT / "hooks" / "_lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+import _paths  # noqa: E402
+
+SID = "abc123-session"
+OTHER = "zzz999-other"
+DAY = 86400.0
+
+
+def _aged(path: Path, days: float) -> Path:
+    """Backdate `path` (a file, or a directory and its contents) by `days`."""
+    stamp = time.time() - days * DAY
+    targets = [path]
+    if path.is_dir():
+        targets += [Path(r) / f for r, _d, fs in os.walk(path) for f in fs]
+        targets += [Path(r) for r, _d, _f in os.walk(path)]
+    for t in targets:
+        os.utime(t, (stamp, stamp))
+    return path
+
+
+def _file(cache: Path, name: str, days: float) -> Path:
+    p = cache / name
+    _ = p.write_text("{}", encoding="utf-8")
+    return _aged(p, days)
+
+
+def test_current_session_entries_survive_a_sweep(tmp_path: Path) -> None:
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    mine = _file(cache, f"retrospect-active-{SID}.json", days=30)
+    mine_too = _file(cache, f"session-intent-{SID}.json", days=30)
+
+    removed = _paths.prune_stale(str(cache), ttl_days=7.0, session_id=SID)
+
+    assert removed == 0
+    assert mine.exists()
+    assert mine_too.exists()
+
+
+def test_other_sessions_are_still_swept(tmp_path: Path) -> None:
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    mine = _file(cache, f"session-intent-{SID}.json", days=30)
+    theirs = _file(cache, f"session-intent-{OTHER}.json", days=30)
+
+    removed = _paths.prune_stale(str(cache), ttl_days=7.0, session_id=SID)
+
+    assert removed == 1
+    assert mine.exists()
+    assert not theirs.exists()
+
+
+def test_fresh_entries_survive_regardless_of_session(tmp_path: Path) -> None:
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    theirs = _file(cache, f"session-intent-{OTHER}.json", days=1)
+
+    removed = _paths.prune_stale(str(cache), ttl_days=7.0, session_id=SID)
+
+    assert removed == 0
+    assert theirs.exists()
+
+
+def test_session_directory_trees_are_protected(tmp_path: Path) -> None:
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    tree = cache / f"path-probe-gate-{SID}"
+    (tree / "inner").mkdir(parents=True)
+    _ = (tree / "inner" / "k.json").write_text("{}", encoding="utf-8")
+    _ = _aged(tree, days=30)
+
+    removed = _paths.prune_stale(str(cache), ttl_days=7.0, session_id=SID)
+
+    assert removed == 0
+    assert (tree / "inner" / "k.json").exists()
+
+
+def test_token_match_is_boundary_anchored(tmp_path: Path) -> None:
+    """A PPID fallback key is short; substring matching would over-protect."""
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    mine = _file(cache, "md-read-history-123.json", days=30)
+    lookalike = _file(cache, "md-read-history-1234.json", days=30)
+    prefixed = _file(cache, "md-read-history-x123.json", days=30)
+
+    removed = _paths.prune_stale(str(cache), ttl_days=7.0, session_id="123")
+
+    assert mine.exists()
+    assert not lookalike.exists()
+    assert not prefixed.exists()
+    assert removed == 2
+
+
+def test_no_session_id_sweeps_everything_stale(tmp_path: Path) -> None:
+    """Back-compat: callers that pass nothing get the pre-#920 behaviour."""
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    mine = _file(cache, f"session-intent-{SID}.json", days=30)
+
+    removed = _paths.prune_stale(str(cache), ttl_days=7.0)
+
+    assert removed == 1
+    assert not mine.exists()
+
+
+def test_resolve_cache_file_threads_session_id(tmp_path: Path) -> None:
+    """The end-to-end path: resolving one entry must not sweep its siblings."""
+    home = tmp_path / "praxis-home"
+    cache = home / "cache"
+    cache.mkdir(parents=True)
+    os.environ["PRAXIS_HOME"] = str(home)
+    os.environ["PRAXIS_CACHE_TTL_DAYS"] = "7"
+    try:
+        sibling = _file(cache, f"retrospect-active-{SID}.json", days=30)
+        theirs = _file(cache, f"retrospect-active-{OTHER}.json", days=30)
+
+        resolved = _paths.resolve_cache_file(
+            f"session-intent-{SID}.json", session_id=SID
+        )
+
+        assert resolved == str(cache / f"session-intent-{SID}.json")
+        assert sibling.exists()
+        assert not theirs.exists()
+    finally:
+        del os.environ["PRAXIS_HOME"]
+        del os.environ["PRAXIS_CACHE_TTL_DAYS"]


### PR DESCRIPTION
## 무엇을

`hooks/_lib/_paths.py` 의 캐시 스윕에서 **호출 세션 소유 항목을 제외**합니다. 다른 세션의 항목은 종전대로 TTL 로 만료됩니다.

Closes #920

## 왜 — 나이는 소유권이 아니다

`prune_stale()` 은 mtime TTL 하나만 근거로 `shutil.rmtree` / `os.unlink` 를 실행했습니다. #919 에서 실측으로 반증된 reaper 게이트와 같은 추론 구조입니다 — "오래됐다 = 아무도 안 쓴다".

캐시 항목은 세션 키 마커입니다. 세션 시작 시 한 번 쓰이고 그 뒤로는 읽히기만 하므로, 세션이 살아있어도 mtime 이 멈춥니다. 기본 TTL 7일을 넘기면 스윕이 마커를 지우고, 마커를 읽는 게이트는 **조용히 꺼집니다** — `resolve_cache_file` docstring 이 이미 인용하는 #666 실패 모드입니다.

## 접근법 — 왜 세션 ID 배선인가

호출처 열거 결과 `prune_stale` 을 부르는 곳은 `resolve_writable` 의 `subdir == "cache"` 분기 하나뿐이고, 그 함수는 캐시 소비자의 **읽기·쓰기 양쪽** 경로에 있습니다(`resolve_cache_file` → `resolve_writable`). 소비자 7개 호출부가 이미 자신의 키(`session_id or str(os.getppid())`)를 계산하고 있어, 그 값을 그대로 넘기는 것이 추가 상태 없이 "지금 살아있는 세션" 을 아는 유일한 경로였습니다 — `_hook_runtime.py` 에 `CLAUDE_SESSION_ID` 참조는 0건이고, 세션 ID 는 훅 stdin payload 에서만 옵니다.

디렉터리 항목은 이미 `_newest_mtime()` 으로 하위 트리 최신 mtime 을 보므로 별도 처리가 필요 없었고, 노출은 단일 파일 항목에 있었습니다.

토큰 매칭은 경계 앵커입니다. PPID 폴백 키는 짧아서(`123`), 부분 문자열 매칭이면 무관한 세션의 `md-read-history-1234.json` 까지 보호합니다.

## 검증

Pre-commit verified: 신규 `tests/hooks/_lib/test_paths_prune.py` 7건 통과. 음성 대조를 두 단계로 했습니다 — (a) `_paths.py` 전체를 stash 하면 6 FAIL, (b) 시그니처는 유지한 채 가드 2줄만 제거해도 **5 FAIL**, 복원 시 7 PASS. 즉 통과 원인은 새 인자가 아니라 가드 자체입니다. 전체 `scripts/run-tests.sh` exit 0 (ALL TESTS PASSED).

Caller chain verified: `prune_stale` 호출처는 `resolve_writable` 하나. `resolve_cache_file` 을 부르는 7개 지점 전부에 `session_id=` 를 전달했고, 인자를 생략한 호출은 종전 동작(전량 스윕)을 유지합니다 — 회귀 테스트로 고정했습니다.

## 미검증

실제로 7일을 넘긴 라이브 세션에서의 동작은 검증하지 않았습니다(테스트는 `os.utime` 백데이트로 재현). `hooks/_lib/_paths.sh` 는 스윕을 구현하지 않으므로 미러 갱신 대상이 아닙니다.
