### PR TITLE
ci(tests): fail loud on skipped linters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,12 +92,23 @@ jobs:
           python-version: "3.x"
           cache: pip
           cache-dependency-path: .github/workflows/ci.yml
-      - run: python3 -m pip install pytest
+      # ruff is pinned to the same version as the `ruff` job so the local-parity
+      # step cannot disagree with the blocking one.
+      - run: python3 -m pip install pytest "ruff==0.15.8"
       # zsh is not preinstalled on ubuntu-latest. block-unmatched-glob delegates
       # its verdict to a real zsh, so without it that hook's suite has nothing to
       # assert against and silently degrades to fail-open coverage.
-      - run: sudo apt-get update -y && sudo apt-get install -y jq zsh
+      # shellcheck and markdownlint-cli2 are here for the same reason ruff is:
+      # under PRAXIS_TESTS_STRICT their absence would abort the run (#917).
+      - run: sudo apt-get update -y && sudo apt-get install -y jq zsh shellcheck
+      - run: npm install -g markdownlint-cli2
+      # Strict: in CI the toolchain is installed, so a SKIPPED line means the
+      # run silently stopped checking something rather than accommodating a
+      # contributor's machine. markdownlint stays advisory — strict gates on a
+      # step being skipped, not on its findings.
       - run: bash scripts/run-tests.sh
+        env:
+          PRAXIS_TESTS_STRICT: "1"
 
   link-check:
     runs-on: ubuntu-latest

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -15,7 +15,16 @@
 # an explicit SKIPPED line when its tool is absent, so a contributor without
 # the toolchain is not blocked — CI remains authoritative either way.
 #
-# Exit code is non-zero if any step fails.
+# A skip is not a pass (#917). The SKIPPED line used to scroll past and the run
+# still ended on a bare "ALL TESTS PASSED", which read as full coverage: PR #912
+# shipped 15 markdownlint violations that way, and PR #864 had shipped 23 for the
+# same reason five days earlier. The summary now names what was skipped, and
+# PRAXIS_TESTS_STRICT=1 turns any skip into a non-zero exit — opt-in locally,
+# always on in CI, where the toolchain is installed and a skip means the job
+# silently stopped checking something.
+#
+# Exit code is non-zero if any step fails, or if anything was skipped under
+# PRAXIS_TESTS_STRICT=1.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -43,6 +52,14 @@ trap 'rm -rf "$PRAXIS_HOME"' EXIT
 export PRAXIS_FIRE_TELEMETRY_FILE="$PRAXIS_HOME/fire-events-test.jsonl"
 
 FAILED=0
+SKIPPED_TOOLS=()
+
+# Records a skipped step and prints its SKIPPED line in one place, so the
+# summary can never drift from what the run actually announced.
+skip_step() {
+  SKIPPED_TOOLS+=("$1")
+  echo "SKIPPED: $1 (not installed — $2)"
+}
 
 # ---------------------------------------------------------------------------
 # 1. pytest
@@ -119,7 +136,7 @@ else
 fi
 
 if [[ ${#RUFF[@]} -eq 0 ]]; then
-  echo "SKIPPED: ruff (not installed — pip install 'ruff==0.15.8')"
+  skip_step ruff "pip install 'ruff==0.15.8'"
 elif ! "${RUFF[@]}" check .; then
   FAILED=1
 fi
@@ -130,7 +147,7 @@ fi
 echo ""
 echo "=== shellcheck ==="
 if ! command -v shellcheck >/dev/null 2>&1; then
-  echo "SKIPPED: shellcheck (not installed — brew install shellcheck)"
+  skip_step shellcheck "brew install shellcheck"
 else
   # Mirrors the CI invocation verbatim so severity and file set cannot drift.
   if ! find . -name '*.sh' -not -path './.git/*' -print0 \
@@ -166,7 +183,7 @@ else
 fi
 
 if [[ ${#MDL[@]} -eq 0 ]]; then
-  echo "SKIPPED: markdownlint (not installed — npm i -g markdownlint-cli2)"
+  skip_step markdownlint "npm i -g markdownlint-cli2"
 else
   # Diff base: the merge-base with origin/main when it is known, else the whole
   # tracked set. `git merge-base` failing (no origin/main in a fresh clone) must
@@ -203,4 +220,21 @@ if [[ $FAILED -ne 0 ]]; then
   echo "TEST SUITE FAILED" >&2
   exit 1
 fi
-echo "ALL TESTS PASSED"
+
+# Scope note: this counts the three tool steps this script owns (5-7). Gates
+# that a sub-suite skips internally — e.g. the Darwin-only gate in
+# tests/test_codex_broker_reaper.sh — announce themselves in their own summary
+# and are not aggregated here; conflating them would make a portable-by-design
+# skip look like a missing toolchain.
+if [[ ${#SKIPPED_TOOLS[@]} -eq 0 ]]; then
+  echo "ALL TESTS PASSED"
+  exit 0
+fi
+
+skipped_list="$(IFS=', '; echo "${SKIPPED_TOOLS[*]}")"
+if [[ "${PRAXIS_TESTS_STRICT:-0}" == "1" ]]; then
+  echo "TEST SUITE INCOMPLETE (${#SKIPPED_TOOLS[@]} skipped: $skipped_list)" >&2
+  echo "PRAXIS_TESTS_STRICT=1 treats a skipped step as a failure — install the tool(s) above or unset the variable." >&2
+  exit 1
+fi
+echo "ALL TESTS PASSED (${#SKIPPED_TOOLS[@]} skipped: $skipped_list)"


### PR DESCRIPTION
## 무엇을

`scripts/run-tests.sh` 가 SKIP 을 PASS 와 구분하고, `PRAXIS_TESTS_STRICT=1` 이 skip 을 종료 코드로 승격합니다. CI `test` job 은 세 linter 를 설치하고 strict 로 돕니다.

Refs #917 (PR 1/2 — PR 2 는 retrospect `remedy_reach:` 계약, 별건)

## 왜

로컬 실행이 `SKIPPED: markdownlint (not installed)` 를 찍은 뒤 그대로 `ALL TESTS PASSED` 로 끝났습니다. 요약만 읽으면 전체 커버리지로 보이므로 PR #912 에 markdownlint 위반 15건이 실려 나갔고, 닷새 전 PR #864 에도 같은 이유로 23건이 나갔습니다. 그때 처방으로 지정된 이슈는 승인 대기 상태로 제출되지 않았습니다.

## 실측으로 확인한 CI 전제 정정

이슈 본문의 "CI 는 strict 로 실행" 은 현재 워크플로우에서 그대로는 성립하지 않습니다. `test` job 은 `pytest` 와 `jq zsh` 만 설치하므로 **지금 CI 의 `run-tests.sh` 는 세 linter 를 전부 SKIP** 하고 있었습니다. strict 만 켜면 즉시 3건 skip 으로 빨간불입니다. 그래서 세 도구를 job 에 설치한 뒤 strict 를 켭니다.

- `ruff` 는 전용 `ruff` job 과 같은 `0.15.8` 로 핀 — local-parity 단계가 blocking 단계와 어긋날 수 없게
- `shellcheck` 는 apt
- `markdownlint-cli2` 는 npm 전역
- **markdownlint 는 여전히 advisory** 입니다. strict 는 *단계가 건너뛰어졌는지* 를 판정하지 그 단계의 findings 를 판정하지 않으며, `run-tests.sh` 의 markdownlint 분기는 종전대로 `FAILED` 를 세우지 않습니다 — CI 의 reviewdog 정책(`filter_mode: added`, `fail_level: none`)이 유지됩니다

## 집계 범위

이 스크립트가 소유한 세 도구 단계만 셉니다. 하위 스위트가 내부적으로 건너뛰는 게이트(예: `tests/test_codex_broker_reaper.sh` 의 Darwin 전용 게이트)는 자기 요약에서 스스로 알리며 여기서 합산하지 않습니다 — 이식성 설계에 의한 skip 을 툴체인 부재처럼 보이게 만들기 때문입니다.

## 검증

Pre-commit verified: 이 호스트에 markdownlint 가 실제로 없는 상태에서 두 번 실행했습니다.

```
### RUN 1: default
exit=0
SKIPPED: markdownlint (not installed — npm i -g markdownlint-cli2)
ALL TESTS PASSED (1 skipped: markdownlint)

### RUN 2: PRAXIS_TESTS_STRICT=1
exit=1
SKIPPED: markdownlint (not installed — npm i -g markdownlint-cli2)
TEST SUITE INCOMPLETE (1 skipped: markdownlint)
PRAXIS_TESTS_STRICT=1 treats a skipped step as a failure — install the tool(s) above or unset the variable.
```

Caller chain verified: `SKIPPED:` 를 출력하던 세 지점(`:122` ruff / `:133` shellcheck / `:169` markdownlint)을 모두 단일 `skip_step()` 로 통과시켜, 요약이 실제 출력과 어긋날 수 없게 했습니다. 빈 배열 접근은 macOS 기본 bash 3.2(`set -euo pipefail`)에서 확인했습니다 — `${#A[@]}` 는 unbound 오류를 내지 않습니다.

## 미검증

CI 러너에서의 `npm install -g markdownlint-cli2` 와 strict 통과는 실행하지 않았습니다 — 이 PR 의 CI 가 첫 실행입니다. ruff/shellcheck 부재 시의 집계는 markdownlint 경로로만 확인했습니다(세 지점이 같은 함수를 공유).
