### PR TITLE
feat(hooks): enumerate verb gates on first block

### DIFF
--- a/docs/hook/INDEX.md
+++ b/docs/hook/INDEX.md
@@ -21,8 +21,14 @@ single source, reached via `verb_gate_checklist(verb)`:
 | Verb | Gates enumerated on the first block | Emitted by |
 | ------ | ------------------------------------- | ------------ |
 | `gh pr create` | block-pr-without-caller-evidence, block-pr-without-precommit-evidence | both pr-body gates |
-| `gh pr merge` | momentum-rule-retrieval-gate, pre-merge-approval-gate, gh-merge-worktree-precondition, commit-title-length-check | momentum-rule-retrieval-gate |
-| `AskUserQuestion` | output-block-falsify-advisory, block-ask-end-option, block-manufactured-action-menu | output-block-falsify-advisory |
+| `gh pr merge` | momentum-rule-retrieval-gate, pre-merge-approval-gate, side-effect-scan, gh-merge-worktree-precondition, commit-title-length-check, + conditional (pipefail-advisory, skill-gate-commands) | momentum-rule-retrieval-gate |
+| `AskUserQuestion` | output-block-falsify-advisory, block-ask-end-option, block-manufactured-action-menu, + conditional (pr-state-refetch-gate, merge-menu-review-options-advisory) and advisory-only (pre-output-falsification-gate, memory-hint) | output-block-falsify-advisory |
+
+A checklist that under-enumerates reproduces the defect it exists to fix, and
+reads as authoritative while doing it — the first draft of the
+`AskUserQuestion` entry named 3 of the 7 registered hooks.
+`tests/test_block_message.py::test_ask_and_merge_checklists_match_the_hook_registry`
+pins the entry against `hooks/manifest.json` so it cannot silently fall behind.
 
 `git commit` and `gh issue create` also carry several gates each and are not
 covered yet — adding a verb means adding its registry entry *and* wiring one

--- a/docs/hook/INDEX.md
+++ b/docs/hook/INDEX.md
@@ -21,7 +21,7 @@ single source, reached via `verb_gate_checklist(verb)`:
 | Verb | Gates enumerated on the first block | Emitted by |
 | ------ | ------------------------------------- | ------------ |
 | `gh pr create` | block-pr-without-caller-evidence, block-pr-without-precommit-evidence | both pr-body gates |
-| `gh pr merge` | momentum-rule-retrieval-gate, pre-merge-approval-gate, side-effect-scan, gh-merge-worktree-precondition, commit-title-length-check, + conditional (pipefail-advisory, skill-gate-commands) | momentum-rule-retrieval-gate |
+| `gh pr merge` | momentum-rule-retrieval-gate, pre-merge-approval-gate, side-effect-scan, + conditional (gh-merge-worktree-precondition on `--delete-branch`, commit-title-length-check on `--squash`, pipefail-advisory when piped, skill-gate-commands when opted in) | momentum-rule-retrieval-gate |
 | `AskUserQuestion` | output-block-falsify-advisory, block-ask-end-option, block-manufactured-action-menu, + conditional (pr-state-refetch-gate, merge-menu-review-options-advisory) and advisory-only (pre-output-falsification-gate, memory-hint) | output-block-falsify-advisory |
 
 A checklist that under-enumerates reproduces the defect it exists to fix, and

--- a/docs/hook/INDEX.md
+++ b/docs/hook/INDEX.md
@@ -11,6 +11,23 @@ user-facing surface but are **not** (yet) hooked, ranked by user-facing cost, se
 Cross-cutting: every preflight-gate block message shares one five-field format —
 see [block-message-format](block-message-format.md).
 
+Several gates fire on the **same** action verb. Where they do, the first block
+on that verb enumerates every gate the verb owes, so the requirements are
+satisfiable in one authoring pass instead of one retry turn per gate
+(issue #873). The verb → gate mapping is code, not prose — `_VERB_CHECKLISTS`
+in [`hooks/_lib/block_message.py`](../../hooks/_lib/block_message.py) is the
+single source, reached via `verb_gate_checklist(verb)`:
+
+| Verb | Gates enumerated on the first block | Emitted by |
+| ------ | ------------------------------------- | ------------ |
+| `gh pr create` | block-pr-without-caller-evidence, block-pr-without-precommit-evidence | both pr-body gates |
+| `gh pr merge` | momentum-rule-retrieval-gate, pre-merge-approval-gate, gh-merge-worktree-precondition, commit-title-length-check | momentum-rule-retrieval-gate |
+| `AskUserQuestion` | output-block-falsify-advisory, block-ask-end-option, block-manufactured-action-menu | output-block-falsify-advisory |
+
+`git commit` and `gh issue create` also carry several gates each and are not
+covered yet — adding a verb means adding its registry entry *and* wiring one
+hook to emit it, so an unwired entry is never added on its own.
+
 ---
 
 ## preflight-gate

--- a/docs/hook/INDEX.md
+++ b/docs/hook/INDEX.md
@@ -21,8 +21,15 @@ single source, reached via `verb_gate_checklist(verb)`:
 | Verb | Gates enumerated on the first block | Emitted by |
 | ------ | ------------------------------------- | ------------ |
 | `gh pr create` | block-pr-without-caller-evidence, block-pr-without-precommit-evidence | both pr-body gates |
-| `gh pr merge` | momentum-rule-retrieval-gate, pre-merge-approval-gate, side-effect-scan, + conditional (gh-merge-worktree-precondition on `--delete-branch`, commit-title-length-check on `--squash`, pipefail-advisory when piped, skill-gate-commands when opted in) | momentum-rule-retrieval-gate |
-| `AskUserQuestion` | output-block-falsify-advisory, block-ask-end-option, block-manufactured-action-menu, + conditional (pr-state-refetch-gate, merge-menu-review-options-advisory) and advisory-only (pre-output-falsification-gate, memory-hint) | output-block-falsify-advisory |
+| `gh pr merge` | momentum-rule-retrieval-gate, pre-merge-approval-gate, side-effect-scan, + conditional (gh-merge-worktree-precondition on `--delete-branch`, commit-title-length-check on `--squash`, pipefail-advisory when piped, session-intent on an undeclared mutation pivot, skill-gate-commands when opted in) | momentum-rule-retrieval-gate |
+| `AskUserQuestion` | output-block-falsify-advisory, block-ask-end-option, + conditional (block-manufactured-action-menu, pr-state-refetch-gate, merge-menu-review-options-advisory) and advisory-only (pre-output-falsification-gate, memory-hint) | output-block-falsify-advisory |
+
+The emitting hook writes the checklist to **stderr**, not into its decision
+JSON. `hooks/_lib/_dispatch.py` forwards every hook's stderr but surfaces only
+the **first** deny's stdout decision — and these gates run in parallel on the
+same command, so a checklist carried in the reason string is dropped exactly
+when a sibling gate denies first, which is the multi-gate case the checklist
+exists for.
 
 A checklist that under-enumerates reproduces the defect it exists to fix, and
 reads as authoritative while doing it — the first draft of the

--- a/hooks/_lib/block_message.py
+++ b/hooks/_lib/block_message.py
@@ -124,10 +124,18 @@ a `Falsified:` line.
     `# briefing-surfaced: <reason>` on the merge command itself.
   Explicit per-PR user approval             ← pre-merge-approval-gate
     Always asks. No agent-attachable bypass exists, by design.
+  Intentional-side-effect acknowledgement   ← side-effect-scan
+    Asks on every `gh pr merge`. Opt out in-band: `# side-effect:ack`.
   Head-branch worktree removed first        ← gh-merge-worktree-precondition
     Only when `--delete-branch` / `-d` is present.
   PR title ≤ 50 chars                       ← commit-title-length-check
     Advisory. With `--squash` the PR title becomes the squash commit title.
+
+Conditional — fire only in the stated situation:
+  Merge piped into another command          ← pipefail-advisory
+    `gh pr merge ... | tail -3` reports success even when the merge failed.
+  Required skill not invoked this session   ← skill-gate-commands
+    NO-OP unless PRAXIS_SKILL_GATED_COMMANDS lists `gh pr merge`.
 
 Approving one PR approves only that PR — a companion or follow-up merge needs
 its own briefing and its own answer.
@@ -143,9 +151,23 @@ its own briefing and its own answer.
     in the triggering option's own `description`.
   No end-of-session option                  ← block-ask-end-option
     Direct ("세션 종료") and indirect ("잠시 보류", "take a break") forms both
-    block without a user stop signal. Opt out per call: PRAXIS_ASK_END_ADVISORY=1.
+    block without a user stop signal. Opt out by setting
+    PRAXIS_ASK_END_ADVISORY=1 in the SESSION environment — the hook reads its
+    own process env, so an inline `VAR=1 <cmd>` prefix never reaches it and
+    there is no per-call marker.
   No manufactured action menu               ← block-manufactured-action-menu
     Do not re-ask a question the user's own prior message already answered.
+
+Conditional — fire only in the stated situation:
+  Live PR state re-fetched                  ← pr-state-refetch-gate
+    A merge-intent question naming a PR number: warns when that PR is already
+    MERGED/CLOSED, blocks under PRAXIS_PR_STATE_REFETCH_STRICT=1.
+  Merge menu offers a review option         ← merge-menu-review-options-advisory
+    A merge-decision menu with no review/inspect option; blocks under
+    PRAXIS_MERGE_MENU_REVIEW_STRICT=1.
+
+Advisory only — never block, no action needed to proceed:
+  pre-output-falsification-gate, memory-hint (stderr reminders).
 """,
 }
 

--- a/hooks/_lib/block_message.py
+++ b/hooks/_lib/block_message.py
@@ -136,6 +136,9 @@ Conditional — fire only in the stated situation:
     title). Advisory.
   Merge piped into another command          ← pipefail-advisory
     `gh pr merge ... | tail -3` reports success even when the merge failed.
+  Mutation verb declared for this session   ← session-intent
+    A session that opened read-only and never stated a mutation intent: asks,
+    and denies under PRAXIS_INTENT_PIVOT_MODE=block.
   Required skill not invoked this session   ← skill-gate-commands
     NO-OP unless PRAXIS_SKILL_GATED_COMMANDS lists `gh pr merge`.
 
@@ -157,10 +160,11 @@ its own briefing and its own answer.
     PRAXIS_ASK_END_ADVISORY=1 in the SESSION environment — the hook reads its
     own process env, so an inline `VAR=1 <cmd>` prefix never reaches it and
     there is no per-call marker.
-  No manufactured action menu               ← block-manufactured-action-menu
-    Do not re-ask a question the user's own prior message already answered.
 
 Conditional — fire only in the stated situation:
+  No manufactured action menu               ← block-manufactured-action-menu
+    Do not re-ask a question the user's own prior message already answered.
+    Advisory by default; blocks under PRAXIS_BLOCK_MANUFACTURED_MENU_STRICT=1.
   Live PR state re-fetched                  ← pr-state-refetch-gate
     A merge-intent question naming a PR number: warns when that PR is already
     MERGED/CLOSED, blocks under PRAXIS_PR_STATE_REFETCH_STRICT=1.

--- a/hooks/_lib/block_message.py
+++ b/hooks/_lib/block_message.py
@@ -118,6 +118,7 @@ a `Falsified:` line.
 
 📋 Every gate on `gh pr merge` (satisfy ALL before re-running):
 
+Unconditional — fire on every `gh pr merge`, whatever the flags:
   6-item briefing in this turn              ← momentum-rule-retrieval-gate
     What changed / verified / NOT verified / Risk / Open items / approve-ask.
     Relief: PRAXIS_MOMENTUM_MERGE_ADVISORY=1, or an unquoted shell comment
@@ -125,13 +126,14 @@ a `Falsified:` line.
   Explicit per-PR user approval             ← pre-merge-approval-gate
     Always asks. No agent-attachable bypass exists, by design.
   Intentional-side-effect acknowledgement   ← side-effect-scan
-    Asks on every `gh pr merge`. Opt out in-band: `# side-effect:ack`.
-  Head-branch worktree removed first        ← gh-merge-worktree-precondition
-    Only when `--delete-branch` / `-d` is present.
-  PR title ≤ 50 chars                       ← commit-title-length-check
-    Advisory. With `--squash` the PR title becomes the squash commit title.
+    Opt out in-band: `# side-effect:ack`.
 
 Conditional — fire only in the stated situation:
+  Head-branch worktree removed first        ← gh-merge-worktree-precondition
+    Only with `--delete-branch` / `-d`.
+  PR title ≤ 50 chars                       ← commit-title-length-check
+    Only with `--squash` / `-s` (the PR title becomes the squash commit
+    title). Advisory.
   Merge piped into another command          ← pipefail-advisory
     `gh pr merge ... | tail -3` reports success even when the merge failed.
   Required skill not invoked this session   ← skill-gate-commands

--- a/hooks/_lib/block_message.py
+++ b/hooks/_lib/block_message.py
@@ -81,20 +81,26 @@ def format_block(
     return "\n".join(lines)
 
 
-def pr_body_evidence_checklist() -> str:
-    """Full PR-body evidence-token enumeration for pr-body gate deny messages.
+# ---------------------------------------------------------------------------
+# Verb-keyed gate checklists (issue #873)
+#
+# Several gates fire on the SAME action verb, each denying on its own missing
+# token. An author therefore discovers the requirements one deny at a time,
+# spending a retry turn per gate — praxis #873 measured six such blocks in a
+# single session, at least four of which had their satisfaction form already
+# documented. Documentation was never the gap; retrieval at call time was.
+#
+# The fix is to make the FIRST deny on a verb teach every token that verb
+# owes, so the author can satisfy them in one authoring pass. Issue #824
+# introduced this for `gh pr create`; this registry generalises it.
+#
+# Each entry is verified against the owning hook's own source, not recalled —
+# a checklist that names a token the gate does not actually accept is worse
+# than no checklist, because it is read as authoritative.
+# ---------------------------------------------------------------------------
 
-    The two pr-body gates (block-pr-without-caller-evidence,
-    block-pr-without-precommit-evidence) each deny on their own missing
-    token, so an author discovers the required tokens one deny at a time
-    (praxis #824). Appending this checklist to BOTH deny messages teaches
-    the full enumeration on the first deny.
-
-    Returns the checklist WITH a trailing newline — callers concatenate it
-    after their own newline-terminated block message and before any
-    cascade hint.
-    """
-    return """\
+_VERB_CHECKLISTS: dict[str, str] = {
+    "gh pr create": """\
 
 📋 Full PR-body evidence checklist (satisfy ALL in one authoring pass):
 
@@ -107,7 +113,62 @@ the colon on the same line, and the line must sit OUTSIDE fenced code blocks.
 Related gates nearby: `git commit` needs a codex review pass or a
 `[skip-codex-review]` marker; an AskUserQuestion `(Recommended)` label needs
 a `Falsified:` line.
-"""
+""",
+    "gh pr merge": """\
+
+📋 Every gate on `gh pr merge` (satisfy ALL before re-running):
+
+  6-item briefing in this turn              ← momentum-rule-retrieval-gate
+    What changed / verified / NOT verified / Risk / Open items / approve-ask.
+    Relief: PRAXIS_MOMENTUM_MERGE_ADVISORY=1, or an unquoted shell comment
+    `# briefing-surfaced: <reason>` on the merge command itself.
+  Explicit per-PR user approval             ← pre-merge-approval-gate
+    Always asks. No agent-attachable bypass exists, by design.
+  Head-branch worktree removed first        ← gh-merge-worktree-precondition
+    Only when `--delete-branch` / `-d` is present.
+  PR title ≤ 50 chars                       ← commit-title-length-check
+    Advisory. With `--squash` the PR title becomes the squash commit title.
+
+Approving one PR approves only that PR — a companion or follow-up merge needs
+its own briefing and its own answer.
+""",
+    "AskUserQuestion": """\
+
+📋 Every gate on `AskUserQuestion` (satisfy ALL before re-running):
+
+  Falsified: <result>                       ← output-block-falsify-advisory
+    Required for a `(Recommended)` label and for confidence-anchoring framing
+    (safer / obvious / default / 당연히 / 추천 …). Must begin at column 0 of
+    its own line — prose, bullets, and code fences are not detected. Put it
+    in the triggering option's own `description`.
+  No end-of-session option                  ← block-ask-end-option
+    Direct ("세션 종료") and indirect ("잠시 보류", "take a break") forms both
+    block without a user stop signal. Opt out per call: PRAXIS_ASK_END_ADVISORY=1.
+  No manufactured action menu               ← block-manufactured-action-menu
+    Do not re-ask a question the user's own prior message already answered.
+""",
+}
+
+
+def verb_gate_checklist(verb: str) -> str:
+    """Full gate-token enumeration for every gate that fires on `verb`.
+
+    Args:
+      verb: the action verb key — one of the `_VERB_CHECKLISTS` keys, e.g.
+        "gh pr create", "gh pr merge", "AskUserQuestion".
+
+    Returns:
+      The checklist WITH a leading blank line and a trailing newline — callers
+      concatenate it after their own newline-terminated block message and
+      before any cascade hint. An unregistered verb returns "" so a caller
+      cannot inject a stray blank block into its deny message.
+    """
+    return _VERB_CHECKLISTS.get(verb, "")
+
+
+def pr_body_evidence_checklist() -> str:
+    """Back-compat alias for `verb_gate_checklist("gh pr create")` (#824)."""
+    return verb_gate_checklist("gh pr create")
 
 
 def emit_block(

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -52,7 +52,10 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
 )
 from _memory_dir import resolve_memory_dir  # type: ignore[import-not-found]  # noqa: E402
 from _transcript import TRANSCRIPT_SCAN_LINES  # type: ignore[import-not-found]  # noqa: E402
-from block_message import format_block  # type: ignore[import-not-found]  # noqa: E402
+from block_message import (  # type: ignore[import-not-found]  # noqa: E402
+    format_block,
+    verb_gate_checklist,
+)
 
 # ---------------------------------------------------------------------------
 # Prefix used on every stderr line.
@@ -754,6 +757,9 @@ def _merge_escalation_reason(payload: dict) -> str | None:
     if _prior_turn_extension_passes(entries, idxs, code):
         return None
 
+    # Issue #873: teach every gate this verb owes on the FIRST deny. The
+    # briefing is only one of four; discovering the rest one block at a time
+    # costs a retry turn each.
     return format_block(
         rule_name="Pre-Merge Reporting briefing",
         why="this gh pr merge is not preceded by the Pre-Merge Reporting "
@@ -768,7 +774,7 @@ def _merge_escalation_reason(payload: dict) -> str | None:
             "`# briefing-surfaced: <reason>` to the merge command",
         reference="CLAUDE.md → Pre-Merge Reporting; "
             "hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md",
-    )
+    ) + verb_gate_checklist("gh pr merge")
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -757,9 +757,6 @@ def _merge_escalation_reason(payload: dict) -> str | None:
     if _prior_turn_extension_passes(entries, idxs, code):
         return None
 
-    # Issue #873: teach every gate this verb owes on the FIRST deny. The
-    # briefing is only one of four; discovering the rest one block at a time
-    # costs a retry turn each.
     return format_block(
         rule_name="Pre-Merge Reporting briefing",
         why="this gh pr merge is not preceded by the Pre-Merge Reporting "
@@ -774,7 +771,7 @@ def _merge_escalation_reason(payload: dict) -> str | None:
             "`# briefing-surfaced: <reason>` to the merge command",
         reference="CLAUDE.md → Pre-Merge Reporting; "
             "hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md",
-    ) + verb_gate_checklist("gh pr merge")
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -978,6 +975,15 @@ def main() -> int:
     if TRIGGER_MERGE in triggers:
         reason = _merge_escalation_reason(payload)
         if reason is not None:
+            # The verb checklist rides stderr, not the decision JSON. Only the
+            # FIRST deny's stdout JSON survives the dispatcher's aggregation
+            # (hooks/_lib/_dispatch.py), so a sibling that denies first — e.g.
+            # gh-merge-worktree-precondition on `--delete-branch` — would
+            # discard this hook's checklist entirely and leave the reader to
+            # discover the remaining gates one block at a time, which is the
+            # cascade #873 exists to remove. Every hook's stderr is forwarded
+            # unconditionally, so the checklist arrives whoever wins the race.
+            sys.stderr.write(verb_gate_checklist("gh pr merge"))
             emit_decision("deny", reason)
             return 0
 

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -211,11 +211,14 @@ The `dispatch` and `force-push` triggers never emit a decision — escalation is
 merge-only, per the issue scope (only the merge failure was reproduced).
 
 **Deny reason carries the whole verb's checklist (issue #873).** The briefing
-is one of five unconditional gates on `gh pr merge` — the others are
-`pre-merge-approval-gate`, `side-effect-scan`, `gh-merge-worktree-precondition`,
-and `commit-title-length-check` (squash path) — plus two conditional ones
-(`pipefail-advisory` when the merge is piped, `skill-gate-commands` when
-`PRAXIS_SKILL_GATED_COMMANDS` lists the verb).
+is one of three gates that fire on every `gh pr merge` whatever the flags — the
+other two are `pre-merge-approval-gate` and `side-effect-scan`. Four more are
+conditional: `gh-merge-worktree-precondition` (only with `--delete-branch`),
+`commit-title-length-check` (only with `--squash`), `pipefail-advisory` (only
+when the merge is piped), and `skill-gate-commands` (only when
+`PRAXIS_SKILL_GATED_COMMANDS` lists the verb). The checklist keeps that split
+explicit — a conditional gate listed as unconditional sends the reader looking
+for a requirement that does not apply to their command.
 Before #873 each was discovered by its own separate block, costing a retry turn
 apiece — praxis #873 measured six such blocks in one session, at least four of
 which already had their satisfaction form documented. Documentation was never

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -211,8 +211,11 @@ The `dispatch` and `force-push` triggers never emit a decision — escalation is
 merge-only, per the issue scope (only the merge failure was reproduced).
 
 **Deny reason carries the whole verb's checklist (issue #873).** The briefing
-is one of four gates on `gh pr merge`; the other three are `pre-merge-approval-gate`,
-`gh-merge-worktree-precondition`, and `commit-title-length-check` (squash path).
+is one of five unconditional gates on `gh pr merge` — the others are
+`pre-merge-approval-gate`, `side-effect-scan`, `gh-merge-worktree-precondition`,
+and `commit-title-length-check` (squash path) — plus two conditional ones
+(`pipefail-advisory` when the merge is piped, `skill-gate-commands` when
+`PRAXIS_SKILL_GATED_COMMANDS` lists the verb).
 Before #873 each was discovered by its own separate block, costing a retry turn
 apiece — praxis #873 measured six such blocks in one session, at least four of
 which already had their satisfaction form documented. Documentation was never

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -212,21 +212,33 @@ merge-only, per the issue scope (only the merge failure was reproduced).
 
 **Deny reason carries the whole verb's checklist (issue #873).** The briefing
 is one of three gates that fire on every `gh pr merge` whatever the flags — the
-other two are `pre-merge-approval-gate` and `side-effect-scan`. Four more are
+other two are `pre-merge-approval-gate` and `side-effect-scan`. Five more are
 conditional: `gh-merge-worktree-precondition` (only with `--delete-branch`),
 `commit-title-length-check` (only with `--squash`), `pipefail-advisory` (only
-when the merge is piped), and `skill-gate-commands` (only when
+when the merge is piped), `session-intent` (only when the session never declared
+a mutation intent), and `skill-gate-commands` (only when
 `PRAXIS_SKILL_GATED_COMMANDS` lists the verb). The checklist keeps that split
 explicit — a conditional gate listed as unconditional sends the reader looking
 for a requirement that does not apply to their command.
 Before #873 each was discovered by its own separate block, costing a retry turn
 apiece — praxis #873 measured six such blocks in one session, at least four of
 which already had their satisfaction form documented. Documentation was never
-the gap; retrieval at call time was. The deny message therefore appends
+the gap; retrieval at call time was. This hook therefore emits
 `verb_gate_checklist("gh pr merge")` from `hooks/_lib/block_message.py`, which
 is the single source for that mapping (see
-[docs/hook/INDEX.md](../../../docs/hook/INDEX.md)). The checklist is appended to
-the `format_block` output, so the five-field format is unchanged.
+[docs/hook/INDEX.md](../../../docs/hook/INDEX.md)).
+
+**The checklist rides stderr, not the decision JSON.** `hooks/_lib/_dispatch.py`
+forwards **every** hook's stderr, but surfaces only the **first** deny's stdout
+decision JSON. These gates run in parallel on the same command, so whenever a
+sibling gate denies first, a checklist embedded in this hook's
+`permissionDecisionReason` is discarded — precisely in the multi-gate case the
+checklist exists for. Writing it to stderr immediately before
+`emit_decision("deny", ...)` makes it survive regardless of which gate wins the
+decision. `format_block`'s five-field output is therefore unchanged, and the
+checklist is not part of the reason string.
+`tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh::merge_checklist_rides_stderr_not_decision_json`
+pins both halves: the gate names appear in stderr and are absent from the JSON.
 
 ### Environment variables
 

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -210,6 +210,18 @@ approve blindly.
 The `dispatch` and `force-push` triggers never emit a decision — escalation is
 merge-only, per the issue scope (only the merge failure was reproduced).
 
+**Deny reason carries the whole verb's checklist (issue #873).** The briefing
+is one of four gates on `gh pr merge`; the other three are `pre-merge-approval-gate`,
+`gh-merge-worktree-precondition`, and `commit-title-length-check` (squash path).
+Before #873 each was discovered by its own separate block, costing a retry turn
+apiece — praxis #873 measured six such blocks in one session, at least four of
+which already had their satisfaction form documented. Documentation was never
+the gap; retrieval at call time was. The deny message therefore appends
+`verb_gate_checklist("gh pr merge")` from `hooks/_lib/block_message.py`, which
+is the single source for that mapping (see
+[docs/hook/INDEX.md](../../../docs/hook/INDEX.md)). The checklist is appended to
+the `format_block` output, so the five-field format is unchanged.
+
 ### Environment variables
 
 | Variable | Effect |

--- a/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
@@ -61,6 +61,7 @@ from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from ask_option_text import collect_option_texts  # type: ignore[import-not-found]  # noqa: E402
 import _fire_ledger  # type: ignore[import-not-found]  # noqa: E402
+from block_message import verb_gate_checklist  # type: ignore[import-not-found]  # noqa: E402
 
 _TELEMETRY_HOOK_NAME = "output-block-falsify-advisory"
 _TELEMETRY_HOOK_ROLE = "advisory-nudge"
@@ -528,18 +529,24 @@ def _falsified_scaffold(labels: list[str]) -> str:
     return "\n".join(lines)
 
 
+# Issue #873: `Falsified:` is one of three gates on this verb. An author who
+# only learns about it here spends a further retry turn on the next one, so
+# every block teaches the whole verb's enumeration.
+_VERB_CHECKLIST = verb_gate_checklist("AskUserQuestion")
+
+
 def _build_ask_msg(labels: list[str]) -> str:
     scaffold = _falsified_scaffold(labels)
     if not scaffold:
-        return ASK_MSG
-    return f"{ASK_MSG} [scaffold]\n{scaffold}"
+        return ASK_MSG + _VERB_CHECKLIST
+    return f"{ASK_MSG} [scaffold]\n{scaffold}\n{_VERB_CHECKLIST}"
 
 
 def _build_anchoring_ask_msg(labels: list[str]) -> str:
     scaffold = _falsified_scaffold(labels)
     if not scaffold:
-        return ANCHORING_ASK_MSG
-    return f"{ANCHORING_ASK_MSG} [scaffold]\n{scaffold}"
+        return ANCHORING_ASK_MSG + _VERB_CHECKLIST
+    return f"{ANCHORING_ASK_MSG} [scaffold]\n{scaffold}\n{_VERB_CHECKLIST}"
 
 
 def _record_block_telemetry(session_id: object, decision: str) -> None:

--- a/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
@@ -529,24 +529,25 @@ def _falsified_scaffold(labels: list[str]) -> str:
     return "\n".join(lines)
 
 
-# Issue #873: `Falsified:` is one of three gates on this verb. An author who
+# Issue #873: `Falsified:` is one of several gates on this verb. An author who
 # only learns about it here spends a further retry turn on the next one, so
-# every block teaches the whole verb's enumeration.
+# every block teaches the whole verb's enumeration — see `_emit_verb_checklist`
+# for why it rides stderr rather than the decision JSON.
 _VERB_CHECKLIST = verb_gate_checklist("AskUserQuestion")
 
 
 def _build_ask_msg(labels: list[str]) -> str:
     scaffold = _falsified_scaffold(labels)
     if not scaffold:
-        return ASK_MSG + _VERB_CHECKLIST
-    return f"{ASK_MSG} [scaffold]\n{scaffold}\n{_VERB_CHECKLIST}"
+        return ASK_MSG
+    return f"{ASK_MSG} [scaffold]\n{scaffold}"
 
 
 def _build_anchoring_ask_msg(labels: list[str]) -> str:
     scaffold = _falsified_scaffold(labels)
     if not scaffold:
-        return ANCHORING_ASK_MSG + _VERB_CHECKLIST
-    return f"{ANCHORING_ASK_MSG} [scaffold]\n{scaffold}\n{_VERB_CHECKLIST}"
+        return ANCHORING_ASK_MSG
+    return f"{ANCHORING_ASK_MSG} [scaffold]\n{scaffold}"
 
 
 def _record_block_telemetry(session_id: object, decision: str) -> None:
@@ -605,14 +606,29 @@ def _has_confidence_anchoring(texts: list[str]) -> bool:
     return False
 
 
+def _emit_verb_checklist() -> None:
+    """Write the AskUserQuestion gate checklist to stderr (issue #873).
+
+    Not to the decision JSON: only the FIRST ask/deny's stdout survives the
+    dispatcher's aggregation (hooks/_lib/_dispatch.py), so a sibling that
+    blocks first — block-ask-end-option on an end-option label, say — would
+    discard the checklist and leave the remaining gates to be discovered one
+    block at a time. Every hook's stderr is forwarded unconditionally, so the
+    checklist arrives whoever wins the race.
+    """
+    sys.stderr.write(_VERB_CHECKLIST)
+
+
 def _emit_ask(message: str) -> None:
     """T2 path: soft gate. (decision must be "ask"/"deny" — "allow" is never
     emitted; silent-pass is signaled by no JSON output.)"""
+    _emit_verb_checklist()
     emit_decision("ask", message)
 
 
 def _emit_t1_ask(message: str) -> None:
     """T1 path: soft gate (issue #899 — restores the pre-#393 tier)."""
+    _emit_verb_checklist()
     emit_decision("ask", message)
 
 

--- a/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
@@ -446,8 +446,11 @@ block on retry for the un-addressed question.
 
 #### Verb gate checklist (issue #873)
 
-`Falsified:` is one of three gates on `AskUserQuestion` — the other two are
-`block-ask-end-option` and `block-manufactured-action-menu`. An author who
+`Falsified:` is one of seven PreToolUse hooks registered on `AskUserQuestion`:
+`block-ask-end-option` and `block-manufactured-action-menu` block
+unconditionally, `pr-state-refetch-gate` and `merge-menu-review-options-advisory`
+block only under their strict env vars, and `pre-output-falsification-gate` and
+`memory-hint` never block. An author who
 learns only about this one spends a further retry turn on the next, so both
 ask messages (T1 and the anchoring path) append
 `verb_gate_checklist("AskUserQuestion")` from `hooks/_lib/block_message.py`,

--- a/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
@@ -444,6 +444,22 @@ aggregated into the same scaffold (not just the first one encountered) —
 otherwise fixing only the first question's line would still hit a second
 block on retry for the un-addressed question.
 
+#### Verb gate checklist (issue #873)
+
+`Falsified:` is one of three gates on `AskUserQuestion` — the other two are
+`block-ask-end-option` and `block-manufactured-action-menu`. An author who
+learns only about this one spends a further retry turn on the next, so both
+ask messages (T1 and the anchoring path) append
+`verb_gate_checklist("AskUserQuestion")` from `hooks/_lib/block_message.py`,
+the single source for the verb → gate mapping (see
+[docs/hook/INDEX.md](../../../docs/hook/INDEX.md)).
+
+The checklist names the `Falsified:` token but **indents** it. That is not
+cosmetic: the token is only recognised at column 0, so an unindented line here
+would let this hook's own output satisfy the predicate it is asking the author
+to satisfy. `tests/test_block_message.py::test_verb_checklists_do_not_start_a_column_0_falsified_line`
+pins that for every registered verb.
+
 **Anti-bypass guard**: because the scaffold line itself starts with
 `Falsified:`, a verbatim copy-paste that never fills in the placeholders
 would otherwise satisfy the exact-prefix check with zero probe evidence —

--- a/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
@@ -447,15 +447,24 @@ block on retry for the un-addressed question.
 #### Verb gate checklist (issue #873)
 
 `Falsified:` is one of seven PreToolUse hooks registered on `AskUserQuestion`:
-`block-ask-end-option` and `block-manufactured-action-menu` block
-unconditionally, `pr-state-refetch-gate` and `merge-menu-review-options-advisory`
-block only under their strict env vars, and `pre-output-falsification-gate` and
+`block-ask-end-option` blocks unconditionally, `block-manufactured-action-menu`,
+`pr-state-refetch-gate` and `merge-menu-review-options-advisory` block only
+under their strict env vars, and `pre-output-falsification-gate` and
 `memory-hint` never block. An author who
 learns only about this one spends a further retry turn on the next, so both
-ask messages (T1 and the anchoring path) append
+ask paths (T1 and the anchoring path) emit
 `verb_gate_checklist("AskUserQuestion")` from `hooks/_lib/block_message.py`,
 the single source for the verb → gate mapping (see
 [docs/hook/INDEX.md](../../../docs/hook/INDEX.md)).
+
+**The checklist rides stderr, not the decision JSON.** `hooks/_lib/_dispatch.py`
+forwards every hook's stderr but surfaces only the **first** deny's stdout
+decision JSON. All seven gates run in parallel on the same `AskUserQuestion`
+call, so a checklist embedded in this hook's `permissionDecisionReason` is
+dropped whenever a sibling denies first — the exact multi-gate case the
+checklist exists for. `_emit_verb_checklist()` writes it to stderr from both
+`_emit_ask` and `_emit_t1_ask`, immediately before the decision, so it survives
+regardless of which gate wins. The ask-message text itself is unchanged.
 
 The checklist names the `Falsified:` token but **indents** it. That is not
 cosmetic: the token is only recognised at column 0, so an unindented line here

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -704,6 +704,45 @@ run_merge_escalation_case "merge_escalation_loop_repetition_denies" \
 run_merge_escalation_case "merge_escalation_multi_target_denies" \
   "yes" "" "momentum-merge-prior-turn-briefing.jsonl" "gh pr merge 833 --squash && gh pr merge 999 --squash"
 
+# --- verb gate checklist in the deny reason (issue #873) ----------------------
+#
+# The briefing is one of four gates on `gh pr merge`. Before #873 the deny named
+# only its own requirement, so the remaining three were each discovered by a
+# separate block, costing a retry turn apiece. The deny must now enumerate the
+# whole verb.
+run_merge_checklist_case() {
+  local name="merge_deny_reason_enumerates_verb_gates"
+  local payload out ok=1
+  payload=$(python3 -c '
+import json, sys
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {"command": "gh pr merge --squash --delete-branch"},
+    "transcript_path": sys.argv[1],
+    "session_id": "test-momentum-checklist",
+}))' "$FIXTURES_DIR/momentum-merge-fidelity-unreliable.jsonl")
+  out=$(echo "$payload" | python3 "$HOOK" 2>/dev/null)
+
+  echo "$out" | grep -qF '"permissionDecision": "deny"' || ok=0
+  local token
+  for token in \
+    "pre-merge-approval-gate" \
+    "gh-merge-worktree-precondition" \
+    "commit-title-length-check" \
+    "PRAXIS_MOMENTUM_MERGE_ADVISORY=1" \
+    "briefing-surfaced:"
+  do
+    echo "$out" | grep -qF "$token" || { ok=0; echo "        missing: $token"; }
+  done
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  [$name]"; PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name]"; FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+run_merge_checklist_case
+
 # Fused global flag (`gh --repo=o/r pr merge 833`) → tokenizer still extracts
 # target 833, correlation passes → no deny.
 run_merge_escalation_case "merge_escalation_fused_repo_flag_passes" \

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -704,15 +704,20 @@ run_merge_escalation_case "merge_escalation_loop_repetition_denies" \
 run_merge_escalation_case "merge_escalation_multi_target_denies" \
   "yes" "" "momentum-merge-prior-turn-briefing.jsonl" "gh pr merge 833 --squash && gh pr merge 999 --squash"
 
-# --- verb gate checklist in the deny reason (issue #873) ----------------------
+# --- verb gate checklist on stderr (issue #873) -------------------------------
 #
-# The briefing is one of four gates on `gh pr merge`. Before #873 the deny named
-# only its own requirement, so the remaining three were each discovered by a
-# separate block, costing a retry turn apiece. The deny must now enumerate the
-# whole verb.
+# The briefing is one of several gates on `gh pr merge`. Before #873 the deny
+# named only its own requirement, so the rest were each discovered by a separate
+# block, costing a retry turn apiece.
+#
+# The checklist must ride STDERR, not the decision JSON: `_dispatch.py` surfaces
+# only the FIRST deny's stdout, so a sibling that denies first (e.g.
+# gh-merge-worktree-precondition on `--delete-branch`) would discard it, while
+# every hook's stderr is forwarded unconditionally.
 run_merge_checklist_case() {
-  local name="merge_deny_reason_enumerates_verb_gates"
-  local payload out ok=1
+  local name="merge_checklist_rides_stderr_not_decision_json"
+  local payload out err ok=1
+  local out_file err_file
   payload=$(python3 -c '
 import json, sys
 print(json.dumps({
@@ -721,19 +726,28 @@ print(json.dumps({
     "transcript_path": sys.argv[1],
     "session_id": "test-momentum-checklist",
 }))' "$FIXTURES_DIR/momentum-merge-fidelity-unreliable.jsonl")
-  out=$(echo "$payload" | python3 "$HOOK" 2>/dev/null)
+  out_file=$(mktemp); err_file=$(mktemp)
+  echo "$payload" | python3 "$HOOK" >"$out_file" 2>"$err_file"
+  out=$(cat "$out_file"); err=$(cat "$err_file")
+  rm -f "$out_file" "$err_file"
 
   echo "$out" | grep -qF '"permissionDecision": "deny"' || ok=0
   local token
   for token in \
     "pre-merge-approval-gate" \
+    "side-effect-scan" \
     "gh-merge-worktree-precondition" \
     "commit-title-length-check" \
+    "session-intent" \
     "PRAXIS_MOMENTUM_MERGE_ADVISORY=1" \
     "briefing-surfaced:"
   do
-    echo "$out" | grep -qF "$token" || { ok=0; echo "        missing: $token"; }
+    echo "$err" | grep -qF "$token" || { ok=0; echo "        missing from stderr: $token"; }
   done
+  # Survives a sibling winning the JSON race only if it is NOT in the JSON.
+  echo "$out" | grep -qF "pre-merge-approval-gate" && {
+    ok=0; echo "        checklist is in the decision JSON — a sibling deny would drop it"
+  }
 
   if [ "$ok" -eq 1 ]; then
     echo "PASS  [$name]"; PASS=$((PASS + 1))

--- a/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
@@ -290,19 +290,20 @@ run_case "AskUserQuestion: (recommended) lowercase — T2 escalates to ask (issu
   "ask:Falsified:" \
   "$(make_ask_payload '["use existing approach (recommended)"]')"
 
-# Issue #873: `Falsified:` is one of three gates on this verb. The ask message
-# must enumerate all three so the other two are not discovered one block at a
-# time — the sibling gates are named here, not just the format rule.
-run_case "AskUserQuestion: ask reason enumerates sibling verb gates (issue #873)" \
-  "ask:block-ask-end-option" \
+# Issue #873: `Falsified:` is one of several gates on this verb, and the
+# checklist must ride STDERR — `_dispatch.py` surfaces only the FIRST ask/deny's
+# stdout, so a sibling that blocks first (block-ask-end-option on an end-option
+# label) would discard it. Every hook's stderr is forwarded unconditionally.
+run_case "AskUserQuestion: checklist rides stderr, T1 path (issue #873)" \
+  "advisory:block-ask-end-option" \
   "$(make_ask_payload '["Option A (Recommended)", "Option B"]')"
 
-run_case "AskUserQuestion: ask reason names the action-menu gate (issue #873)" \
-  "ask:block-manufactured-action-menu" \
+run_case "AskUserQuestion: checklist names the action-menu gate (issue #873)" \
+  "advisory:block-manufactured-action-menu" \
   "$(make_ask_payload '["Option A (Recommended)", "Option B"]')"
 
-run_case "AskUserQuestion: anchoring path also carries the checklist (issue #873)" \
-  "ask:block-ask-end-option" \
+run_case "AskUserQuestion: checklist rides stderr, anchoring path (issue #873)" \
+  "advisory:block-ask-end-option" \
   "$(make_ask_payload '["use existing approach (recommended)"]')"
 
 # ---------------------------------------------------------------------------

--- a/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
@@ -290,6 +290,21 @@ run_case "AskUserQuestion: (recommended) lowercase — T2 escalates to ask (issu
   "ask:Falsified:" \
   "$(make_ask_payload '["use existing approach (recommended)"]')"
 
+# Issue #873: `Falsified:` is one of three gates on this verb. The ask message
+# must enumerate all three so the other two are not discovered one block at a
+# time — the sibling gates are named here, not just the format rule.
+run_case "AskUserQuestion: ask reason enumerates sibling verb gates (issue #873)" \
+  "ask:block-ask-end-option" \
+  "$(make_ask_payload '["Option A (Recommended)", "Option B"]')"
+
+run_case "AskUserQuestion: ask reason names the action-menu gate (issue #873)" \
+  "ask:block-manufactured-action-menu" \
+  "$(make_ask_payload '["Option A (Recommended)", "Option B"]')"
+
+run_case "AskUserQuestion: anchoring path also carries the checklist (issue #873)" \
+  "ask:block-ask-end-option" \
+  "$(make_ask_payload '["use existing approach (recommended)"]')"
+
 # ---------------------------------------------------------------------------
 # AskUserQuestion negative cases
 # ---------------------------------------------------------------------------

--- a/tests/test_block_message.py
+++ b/tests/test_block_message.py
@@ -150,6 +150,7 @@ def test_merge_verb_checklist_names_every_merge_gate() -> None:
         "gh-merge-worktree-precondition",
         "commit-title-length-check",
         "pipefail-advisory",
+        "session-intent",
         "skill-gate-commands",
     ):
         assert gate in out, f"merge checklist must name {gate}"
@@ -177,9 +178,28 @@ def test_merge_checklist_splits_unconditional_from_conditional() -> None:
         "gh-merge-worktree-precondition",   # requires -d / --delete-branch
         "commit-title-length-check",        # requires -s / --squash
         "pipefail-advisory",                # requires a pipe
+        "session-intent",                   # requires a read-only-intent session
         "skill-gate-commands",              # requires PRAXIS_SKILL_GATED_COMMANDS
     ):
         assert flag_gated in tail, f"{flag_gated} is flag-gated — belongs below the split"
+
+
+def test_ask_checklist_splits_unconditional_from_conditional() -> None:
+    """Same split on the ask side. `block-manufactured-action-menu` is advisory
+    by default and blocks only under PRAXIS_BLOCK_MANUFACTURED_MENU_STRICT, so
+    listing it among the always-satisfy gates makes readers rewrite menus that
+    were never blocked (Codex round 2, PR #931)."""
+    out = bm.verb_gate_checklist("AskUserQuestion")
+    head, _, tail = out.partition("Conditional — fire only in the stated situation:")
+    assert tail, "AskUserQuestion checklist must carry a Conditional section"
+    for always in ("output-block-falsify-advisory", "block-ask-end-option"):
+        assert always in head, f"{always} blocks by default — belongs above the split"
+    for gated in (
+        "block-manufactured-action-menu",     # strict-mode only
+        "pr-state-refetch-gate",              # merge-intent question + strict
+        "merge-menu-review-options-advisory",  # merge menu + strict
+    ):
+        assert gated in tail, f"{gated} is conditional — belongs below the split"
 
 
 def test_ask_verb_checklist_names_every_ask_gate() -> None:

--- a/tests/test_block_message.py
+++ b/tests/test_block_message.py
@@ -146,13 +146,17 @@ def test_merge_verb_checklist_names_every_merge_gate() -> None:
     for gate in (
         "momentum-rule-retrieval-gate",
         "pre-merge-approval-gate",
+        "side-effect-scan",
         "gh-merge-worktree-precondition",
         "commit-title-length-check",
+        "pipefail-advisory",
+        "skill-gate-commands",
     ):
         assert gate in out, f"merge checklist must name {gate}"
     # Satisfaction forms, verified against each hook's own source.
     assert "PRAXIS_MOMENTUM_MERGE_ADVISORY=1" in out
     assert "# briefing-surfaced:" in out
+    assert "# side-effect:ack" in out
     assert "--delete-branch" in out
     assert out.endswith("\n")
 
@@ -163,11 +167,48 @@ def test_ask_verb_checklist_names_every_ask_gate() -> None:
         "output-block-falsify-advisory",
         "block-ask-end-option",
         "block-manufactured-action-menu",
+        "pr-state-refetch-gate",
+        "merge-menu-review-options-advisory",
+        "pre-output-falsification-gate",
+        "memory-hint",
     ):
         assert gate in out, f"AskUserQuestion checklist must name {gate}"
     assert "PRAXIS_ASK_END_ADVISORY=1" in out
     assert "column 0" in out
     assert out.endswith("\n")
+
+
+def test_ask_end_optout_is_not_described_as_per_call() -> None:
+    """`block-ask-end-option` reads PRAXIS_ASK_END_ADVISORY from its own process
+    env (impl.py: `os.environ.get`), so an inline `VAR=1 <cmd>` prefix never
+    reaches it. Calling the opt-out per-call sends the reader into a retry loop
+    — the exact cost this checklist exists to remove."""
+    out = bm.verb_gate_checklist("AskUserQuestion")
+    assert "Opt out per call" not in out
+    assert "SESSION environment" in out
+
+
+def test_ask_and_merge_checklists_match_the_hook_registry() -> None:
+    """The checklists must not drift below what `hooks/manifest.json` registers.
+
+    Codex review of PR #931 caught this exact gap: the first draft named 3 of
+    the 7 PreToolUse hooks on AskUserQuestion. A checklist that under-enumerates
+    reproduces the very defect #873 fixes, and reads as authoritative while
+    doing it.
+    """
+    import json
+
+    manifest = json.loads(
+        (REPO_ROOT / "hooks" / "manifest.json").read_text(encoding="utf-8")
+    )
+    registered = {
+        h["name"]
+        for h in manifest["hooks"]
+        if h.get("event") == "PreToolUse" and "AskUserQuestion" in (h.get("matcher") or "")
+    }
+    out = bm.verb_gate_checklist("AskUserQuestion")
+    missing = sorted(name for name in registered if name not in out)
+    assert not missing, f"AskUserQuestion checklist omits registered hooks: {missing}"
 
 
 def test_verb_checklists_do_not_start_a_column_0_falsified_line() -> None:

--- a/tests/test_block_message.py
+++ b/tests/test_block_message.py
@@ -161,6 +161,27 @@ def test_merge_verb_checklist_names_every_merge_gate() -> None:
     assert out.endswith("\n")
 
 
+def test_merge_checklist_splits_unconditional_from_conditional() -> None:
+    """A conditional gate listed as unconditional sends the reader looking for a
+    requirement that does not apply to their command — the mirror of the
+    under-enumeration this checklist exists to prevent (CodeRabbit, PR #931).
+
+    Only three gates fire on every `gh pr merge`; the rest are flag-gated.
+    """
+    out = bm.verb_gate_checklist("gh pr merge")
+    head, _, tail = out.partition("Conditional — fire only in the stated situation:")
+    assert tail, "merge checklist must carry a Conditional section"
+    for always in ("momentum-rule-retrieval-gate", "pre-merge-approval-gate", "side-effect-scan"):
+        assert always in head, f"{always} fires on every merge — belongs above the split"
+    for flag_gated in (
+        "gh-merge-worktree-precondition",   # requires -d / --delete-branch
+        "commit-title-length-check",        # requires -s / --squash
+        "pipefail-advisory",                # requires a pipe
+        "skill-gate-commands",              # requires PRAXIS_SKILL_GATED_COMMANDS
+    ):
+        assert flag_gated in tail, f"{flag_gated} is flag-gated — belongs below the split"
+
+
 def test_ask_verb_checklist_names_every_ask_gate() -> None:
     out = bm.verb_gate_checklist("AskUserQuestion")
     for gate in (

--- a/tests/test_block_message.py
+++ b/tests/test_block_message.py
@@ -121,6 +121,84 @@ def test_pr_body_gates_append_checklist() -> None:
 
 
 # ---------------------------------------------------------------------------
+# 1b. Verb-keyed gate checklists (issue #873)
+# ---------------------------------------------------------------------------
+
+ADVISORY_DIR = REPO_ROOT / "hooks" / "advisory-nudge"
+
+
+def test_verb_gate_checklist_unknown_verb_is_empty() -> None:
+    """An unregistered verb yields "" so a caller cannot append a stray blank
+    block to its deny message."""
+    assert bm.verb_gate_checklist("git bisect") == ""
+    assert bm.verb_gate_checklist("") == ""
+
+
+def test_pr_body_checklist_is_the_create_verb_entry() -> None:
+    """The #824 helper is an alias, not a second copy that can drift."""
+    assert bm.pr_body_evidence_checklist() == bm.verb_gate_checklist("gh pr create")
+
+
+def test_merge_verb_checklist_names_every_merge_gate() -> None:
+    """One deny on `gh pr merge` must teach all four gates on that verb —
+    discovering them one block at a time is the #873 defect."""
+    out = bm.verb_gate_checklist("gh pr merge")
+    for gate in (
+        "momentum-rule-retrieval-gate",
+        "pre-merge-approval-gate",
+        "gh-merge-worktree-precondition",
+        "commit-title-length-check",
+    ):
+        assert gate in out, f"merge checklist must name {gate}"
+    # Satisfaction forms, verified against each hook's own source.
+    assert "PRAXIS_MOMENTUM_MERGE_ADVISORY=1" in out
+    assert "# briefing-surfaced:" in out
+    assert "--delete-branch" in out
+    assert out.endswith("\n")
+
+
+def test_ask_verb_checklist_names_every_ask_gate() -> None:
+    out = bm.verb_gate_checklist("AskUserQuestion")
+    for gate in (
+        "output-block-falsify-advisory",
+        "block-ask-end-option",
+        "block-manufactured-action-menu",
+    ):
+        assert gate in out, f"AskUserQuestion checklist must name {gate}"
+    assert "PRAXIS_ASK_END_ADVISORY=1" in out
+    assert "column 0" in out
+    assert out.endswith("\n")
+
+
+def test_verb_checklists_do_not_start_a_column_0_falsified_line() -> None:
+    """Self-application guard (#873).
+
+    The AskUserQuestion checklist names the `Falsified:` token, and this text
+    is emitted into the transcript on every block. `output-block-falsify-
+    advisory` accepts the token only at column 0, so an unindented occurrence
+    here would let the hook's own message satisfy the very predicate it is
+    asking the author to satisfy.
+    """
+    for verb in ("gh pr create", "gh pr merge", "AskUserQuestion"):
+        for line in bm.verb_gate_checklist(verb).splitlines():
+            assert not line.startswith("Falsified:"), (
+                f"{verb} checklist emits a column-0 'Falsified:' line"
+            )
+
+
+def test_verb_wired_hooks_append_their_checklist() -> None:
+    """Each hook named by #873 must append its verb's checklist."""
+    for name, verb in (
+        ("momentum-rule-retrieval-gate", "gh pr merge"),
+        ("output-block-falsify-advisory", "AskUserQuestion"),
+    ):
+        src = (ADVISORY_DIR / name / "impl.py").read_text(encoding="utf-8")
+        assert f'verb_gate_checklist("{verb}")' in src, (
+            f"{name} must append verb_gate_checklist(\"{verb}\") to its message"
+        )
+
+
+# ---------------------------------------------------------------------------
 # 2. Adoption lint
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 배경

같은 action verb 에 여러 게이트가 걸리는데 각 게이트가 자기 토큰만 보고합니다. 작성자는 요구사항을 한 번에 하나씩 발견하며 게이트마다 리트라이 턴을 소모합니다. #873 은 한 세션에서 그런 차단 6회를 측정했고, 그중 최소 4건은 만족 형태가 이미 문서에 있었습니다 — 문서 부재가 아니라 **호출 시점 retrieval** 이 갭입니다.

이 세션에서도 같은 패턴이 1회 더 발생했습니다. `momentum-rule-retrieval-gate` 가 머지를 차단했고, `# briefing-surfaced:` 마커는 spec 에 이미 있었는데 차단당한 뒤에야 읽었습니다.

## 진단 — 이슈의 방식 B 전제는 절반만 맞았습니다

`hooks/_lib/block_message.py` 의 `pr_body_evidence_checklist()` (#824)가 이미 "한 deny 가 전체를 가르친다" 패턴을 구현하고 있었으나 `gh pr create` 하나에 하드코딩돼 있었습니다. `output-block-falsify-advisory` 는 #787/#682/#828 로 자기 토큰 안내가 이미 충실합니다.

실제 갭은 "deny 가 첫 누락만 보고한다"가 아니라 **같은 verb 의 형제 게이트를 한 번도 알려주지 않는다** 였습니다.

## 변경 사항

`hooks/_lib/block_message.py` — verb 키 레지스트리 `_VERB_CHECKLISTS` + `verb_gate_checklist(verb)`:

| verb | 첫 차단에서 나열되는 게이트 | 방출 훅 |
| --- | --- | --- |
| `gh pr create` | caller-evidence, precommit-evidence | 두 pr-body 게이트 (기존) |
| `gh pr merge` | momentum, pre-merge-approval, worktree-precondition, title-length(squash) | momentum-rule-retrieval-gate |
| `AskUserQuestion` | falsify-advisory, block-ask-end-option, block-manufactured-action-menu | output-block-falsify-advisory |

- 각 토큰은 소유 훅의 소스에서 직접 확인해 적었습니다 (`PRAXIS_MOMENTUM_MERGE_ADVISORY=1`, `# briefing-surfaced:`, `--delete-branch` 조건, `PRAXIS_ASK_END_ADVISORY=1`, pre-merge-approval 의 "bypass 없음"). 게이트가 실제로 받지 않는 토큰은 권위 있게 읽히므로 체크리스트 부재보다 나쁩니다.
- `pr_body_evidence_checklist()` 는 사본이 아니라 alias — 두 벌이 되면 drift 합니다.
- 미등록 verb 는 `""` 를 반환해 호출자가 빈 블록을 붙일 수 없습니다.

## 자기적용 함정

AskUserQuestion 체크리스트는 `Falsified:` 토큰을 언급하고, 이 텍스트는 차단할 때마다 트랜스크립트로 나갑니다. 해당 토큰은 컬럼 0 에서만 인식되므로 들여쓰지 않으면 **훅 자신의 출력이 작성자에게 요구하는 술어를 스스로 만족**시킵니다. 들여쓰기로 막고 모든 등록 verb 에 대해 `test_verb_checklists_do_not_start_a_column_0_falsified_line` 로 고정했습니다.

## 검증

```
python3 -m pytest tests/test_block_message.py -q          → 15 passed
tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh   → 88 passed, 0 failed
tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh  → 104 passed, 0 failed
scripts/run-tests.sh                                     → exit 0
```

음성 대조 — momentum impl 만 되돌리면 신규 케이스가 `missing: pre-merge-approval-gate / gh-merge-worktree-precondition / commit-title-length-check` 로 FAIL, falsify impl 만 되돌리면 신규 3케이스 전부 FAIL.

Pre-commit verified: scripts/run-tests.sh → ALL TESTS PASSED (1 skipped: markdownlint, 로컬 미설치), ruff clean, shellcheck clean, manifest check OK
Caller chain verified: `verb_gate_checklist` 호출부 3곳 전수 — momentum impl.py(merge deny), output-block-falsify-advisory impl.py(`_build_ask_msg`/`_build_anchoring_ask_msg`), block_message.py 내부 `pr_body_evidence_checklist()` alias. 기존 `pr_body_evidence_checklist` 호출부 2곳(block-pr-without-caller-evidence, block-pr-without-precommit-evidence)은 시그니처 변경 없이 그대로 동작

## 미검증 / 범위 밖

- **이슈 작업 3번(fire ledger 로 재차단률 측정)은 배포 후에만 가능합니다.** 활성 캐시 플러그인이 `7.7.0` 이고 릴리스 PR #904(7.8.0)가 열려 있어, 이 변경은 릴리스 전까지 실행되지 않습니다. 측정은 배포 이후 별도로 해야 합니다.
- `git commit` / `gh issue create` verb 는 배선할 훅 없이 레지스트리 항목만 추가하면 죽은 코드가 되므로 넣지 않았습니다. `docs/hook/INDEX.md` 에 미커버로 명시했습니다.

Closes #873


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive gate checklists for pull request creation, pull request merging, and user-question prompts.
  * Denial and escalation messages now include applicable required, conditional, and advisory checks.
  * Checklists clearly identify required approvals, worktree conditions, commit-title validation, and briefing details.

* **Documentation**
  * Documented checklist coverage, delivery behavior, and current limitations.

* **Bug Fixes**
  * Improved checklist formatting to prevent misleading or self-satisfying entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->