### PR TITLE
fix(hooks): emit verb checklist on both channels

### DIFF
--- a/docs/hook/INDEX.md
+++ b/docs/hook/INDEX.md
@@ -36,8 +36,8 @@ stderr, because neither channel alone reaches the model in every case
   the model only when the dispatcher exits 2 — the deny path (`:201`), never
   the ask path (`:207 return 0`).
 
-#873 shipped stderr-only and the `AskUserQuestion` checklist, which travels the
-exit-0 ask path, went nowhere.
+Issue #873 shipped stderr-only, and the `AskUserQuestion` checklist — which
+travels the exit-0 ask path — went nowhere.
 
 A checklist that under-enumerates reproduces the defect it exists to fix, and
 reads as authoritative while doing it — the first draft of the

--- a/docs/hook/INDEX.md
+++ b/docs/hook/INDEX.md
@@ -24,12 +24,20 @@ single source, reached via `verb_gate_checklist(verb)`:
 | `gh pr merge` | momentum-rule-retrieval-gate, pre-merge-approval-gate, side-effect-scan, + conditional (gh-merge-worktree-precondition on `--delete-branch`, commit-title-length-check on `--squash`, pipefail-advisory when piped, session-intent on an undeclared mutation pivot, skill-gate-commands when opted in) | momentum-rule-retrieval-gate |
 | `AskUserQuestion` | output-block-falsify-advisory, block-ask-end-option, + conditional (block-manufactured-action-menu, pr-state-refetch-gate, merge-menu-review-options-advisory) and advisory-only (pre-output-falsification-gate, memory-hint) | output-block-falsify-advisory |
 
-The emitting hook writes the checklist to **stderr**, not into its decision
-JSON. `hooks/_lib/_dispatch.py` forwards every hook's stderr but surfaces only
-the **first** deny's stdout decision — and these gates run in parallel on the
-same command, so a checklist carried in the reason string is dropped exactly
-when a sibling gate denies first, which is the multi-gate case the checklist
-exists for.
+The emitting hook writes the checklist to **both** its decision reason and
+stderr, because neither channel alone reaches the model in every case
+(issue #932):
+
+- `hooks/_lib/_dispatch.py:195-201` surfaces only the **first** deny's stdout
+  decision, and these gates run in parallel on the same command — so a
+  checklist carried only in the reason string is dropped exactly when a sibling
+  gate denies first, the multi-gate case the checklist exists for;
+- stderr is forwarded for every hook, but a PreToolUse hook's stderr is fed to
+  the model only when the dispatcher exits 2 — the deny path (`:201`), never
+  the ask path (`:207 return 0`).
+
+#873 shipped stderr-only and the `AskUserQuestion` checklist, which travels the
+exit-0 ask path, went nowhere.
 
 A checklist that under-enumerates reproduces the defect it exists to fix, and
 reads as authoritative while doing it — the first draft of the

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -975,16 +975,20 @@ def main() -> int:
     if TRIGGER_MERGE in triggers:
         reason = _merge_escalation_reason(payload)
         if reason is not None:
-            # The verb checklist rides stderr, not the decision JSON. Only the
-            # FIRST deny's stdout JSON survives the dispatcher's aggregation
-            # (hooks/_lib/_dispatch.py), so a sibling that denies first — e.g.
-            # gh-merge-worktree-precondition on `--delete-branch` — would
-            # discard this hook's checklist entirely and leave the reader to
-            # discover the remaining gates one block at a time, which is the
-            # cascade #873 exists to remove. Every hook's stderr is forwarded
-            # unconditionally, so the checklist arrives whoever wins the race.
-            sys.stderr.write(verb_gate_checklist("gh pr merge"))
-            emit_decision("deny", reason)
+            # The verb checklist goes out on BOTH channels, because neither one
+            # alone reaches the model in every case (issue #932):
+            #   - decision JSON: only the FIRST deny's stdout survives the
+            #     dispatcher's aggregation (hooks/_lib/_dispatch.py:195-201), so
+            #     a sibling denying first — gh-merge-worktree-precondition on
+            #     `--delete-branch`, say — discards this reason string;
+            #   - stderr: forwarded unconditionally, but a PreToolUse hook's
+            #     stderr reaches the model only when the dispatcher exits 2,
+            #     which is the deny path and not the ask path.
+            # Deny is always exit 2, so stderr suffices here — but splitting the
+            # two hooks' handling is what produced #932, so keep them identical.
+            checklist = verb_gate_checklist("gh pr merge")
+            sys.stderr.write(checklist)
+            emit_decision("deny", f"{reason}\n{checklist}")
             return 0
 
     # Strict mode: block unless PRAXIS_MOMENTUM_ACK=1 is also present.

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -228,17 +228,26 @@ the gap; retrieval at call time was. This hook therefore emits
 is the single source for that mapping (see
 [docs/hook/INDEX.md](../../../docs/hook/INDEX.md)).
 
-**The checklist rides stderr, not the decision JSON.** `hooks/_lib/_dispatch.py`
-forwards **every** hook's stderr, but surfaces only the **first** deny's stdout
-decision JSON. These gates run in parallel on the same command, so whenever a
-sibling gate denies first, a checklist embedded in this hook's
-`permissionDecisionReason` is discarded — precisely in the multi-gate case the
-checklist exists for. Writing it to stderr immediately before
-`emit_decision("deny", ...)` makes it survive regardless of which gate wins the
-decision. `format_block`'s five-field output is therefore unchanged, and the
-checklist is not part of the reason string.
-`tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh::merge_checklist_rides_stderr_not_decision_json`
-pins both halves: the gate names appear in stderr and are absent from the JSON.
+**The checklist goes out on both channels (issue #932).** Neither one alone
+reaches the model in every case:
+
+- **decision JSON** — `hooks/_lib/_dispatch.py:195-201` surfaces only the
+  **first** deny's stdout. These gates run in parallel on the same command, so
+  whenever a sibling denies first, a checklist embedded in this hook's
+  `permissionDecisionReason` is discarded — precisely the multi-gate case the
+  checklist exists for.
+- **stderr** — forwarded for **every** hook, but a PreToolUse hook's stderr is
+  fed to the model only when the dispatcher exits 2. That is the deny path
+  (`:201 return 2`), never the ask path (`:207 return 0`).
+
+A deny is always exit 2, so stderr alone would in fact suffice *here*. #873
+shipped stderr-only for both this hook and `output-block-falsify-advisory`,
+where the ask path exits 0 and the checklist silently went nowhere; splitting
+the two hooks' handling is what let that through, so they now emit identically.
+`format_block`'s five-field output is unchanged — the checklist is appended
+after it.
+`tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh::merge_checklist_on_both_channels`
+pins both channels per gate name.
 
 ### Environment variables
 

--- a/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/impl.py
@@ -609,27 +609,47 @@ def _has_confidence_anchoring(texts: list[str]) -> bool:
 def _emit_verb_checklist() -> None:
     """Write the AskUserQuestion gate checklist to stderr (issue #873).
 
-    Not to the decision JSON: only the FIRST ask/deny's stdout survives the
-    dispatcher's aggregation (hooks/_lib/_dispatch.py), so a sibling that
-    blocks first — block-ask-end-option on an end-option label, say — would
-    discard the checklist and leave the remaining gates to be discovered one
-    block at a time. Every hook's stderr is forwarded unconditionally, so the
-    checklist arrives whoever wins the race.
+    This is the *second* of two channels, not the only one — see
+    `_with_verb_checklist` for why both are needed. Only the FIRST ask/deny's
+    stdout survives the dispatcher's aggregation
+    (`hooks/_lib/_dispatch.py:195-201`), so when a sibling blocks first —
+    block-ask-end-option on an end-option label, say — the reason string this
+    hook built is discarded. Every hook's stderr is forwarded unconditionally,
+    and that sibling's deny makes the dispatcher exit 2, which is exactly when
+    stderr reaches the model. So stderr covers the case the reason string
+    cannot.
     """
     sys.stderr.write(_VERB_CHECKLIST)
+
+
+def _with_verb_checklist(message: str) -> str:
+    """Append the checklist to the decision reason (issue #932).
+
+    Issue #873 first routed the checklist to stderr *instead of* the reason
+    string. That was correct for a deny (the dispatcher returns 2, and a
+    PreToolUse hook's stderr is fed to the model only on exit 2) but wrong
+    here: an ask makes the dispatcher return 0
+    (`hooks/_lib/_dispatch.py:203-207`), and on exit 0 stderr is never
+    surfaced to the model. So in the common case — this hook asking with no
+    sibling denying — the checklist was emitted and then dropped.
+
+    Both channels together cover both exit codes: the reason string reaches
+    the model on the exit-0 ask, stderr reaches it on the exit-2 sibling deny.
+    """
+    return f"{message}\n{_VERB_CHECKLIST}"
 
 
 def _emit_ask(message: str) -> None:
     """T2 path: soft gate. (decision must be "ask"/"deny" — "allow" is never
     emitted; silent-pass is signaled by no JSON output.)"""
     _emit_verb_checklist()
-    emit_decision("ask", message)
+    emit_decision("ask", _with_verb_checklist(message))
 
 
 def _emit_t1_ask(message: str) -> None:
     """T1 path: soft gate (issue #899 — restores the pre-#393 tier)."""
     _emit_verb_checklist()
-    emit_decision("ask", message)
+    emit_decision("ask", _with_verb_checklist(message))
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
@@ -472,11 +472,11 @@ reaches the model in every case:
   discards this hook's reason. That same deny makes the dispatcher exit 2 —
   exactly when stderr does reach the model.
 
-#873 shipped stderr-only, reasoning from the deny path where stderr always
-arrives. The ask path was the majority case and the checklist went nowhere. Issue #874
-records the same exit-0 invisibility for the ADVISE tier generally — 42 fires
-in one session, zero observed effect. The ask-message text is otherwise
-unchanged.
+Issue #873 shipped stderr-only, reasoning from the deny path where stderr
+always arrives. The ask path was the majority case and the checklist went
+nowhere. Issue #874 records the same exit-0 invisibility for the ADVISE tier
+generally — 42 fires in one session, zero observed effect. The ask-message text
+is otherwise unchanged.
 
 The checklist names the `Falsified:` token but **indents** it. That is not
 cosmetic: the token is only recognised at column 0, so an unindented line here

--- a/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
+++ b/hooks/advisory-nudge/output-block-falsify-advisory/spec.md
@@ -457,14 +457,26 @@ ask paths (T1 and the anchoring path) emit
 the single source for the verb → gate mapping (see
 [docs/hook/INDEX.md](../../../docs/hook/INDEX.md)).
 
-**The checklist rides stderr, not the decision JSON.** `hooks/_lib/_dispatch.py`
-forwards every hook's stderr but surfaces only the **first** deny's stdout
-decision JSON. All seven gates run in parallel on the same `AskUserQuestion`
-call, so a checklist embedded in this hook's `permissionDecisionReason` is
-dropped whenever a sibling denies first — the exact multi-gate case the
-checklist exists for. `_emit_verb_checklist()` writes it to stderr from both
-`_emit_ask` and `_emit_t1_ask`, immediately before the decision, so it survives
-regardless of which gate wins. The ask-message text itself is unchanged.
+**The checklist goes out on both channels (issue #932).** Neither one alone
+reaches the model in every case:
+
+- **decision JSON** (`_with_verb_checklist`, appended to the ask reason) — this
+  is the channel that works for the common case, because this hook's decision
+  is an `ask` and the dispatcher returns 0 for an ask
+  (`hooks/_lib/_dispatch.py:203-207`). On exit 0 a PreToolUse hook's stderr is
+  never fed to the model.
+- **stderr** (`_emit_verb_checklist`, called from `_emit_ask` and
+  `_emit_t1_ask`) — covers what the reason string cannot. All seven gates run
+  in parallel on the same `AskUserQuestion` call, and `_dispatch.py:195-201`
+  surfaces only the **first** deny's stdout, so a sibling denying first
+  discards this hook's reason. That same deny makes the dispatcher exit 2 —
+  exactly when stderr does reach the model.
+
+#873 shipped stderr-only, reasoning from the deny path where stderr always
+arrives. The ask path was the majority case and the checklist went nowhere. Issue #874
+records the same exit-0 invisibility for the ADVISE tier generally — 42 fires
+in one session, zero observed effect. The ask-message text is otherwise
+unchanged.
 
 The checklist names the `Falsified:` token but **indents** it. That is not
 cosmetic: the token is only recognised at column 0, so an unindented line here

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -704,18 +704,22 @@ run_merge_escalation_case "merge_escalation_loop_repetition_denies" \
 run_merge_escalation_case "merge_escalation_multi_target_denies" \
   "yes" "" "momentum-merge-prior-turn-briefing.jsonl" "gh pr merge 833 --squash && gh pr merge 999 --squash"
 
-# --- verb gate checklist on stderr (issue #873) -------------------------------
+# --- verb gate checklist on both channels (issues #873, #932) -----------------
 #
 # The briefing is one of several gates on `gh pr merge`. Before #873 the deny
 # named only its own requirement, so the rest were each discovered by a separate
 # block, costing a retry turn apiece.
 #
-# The checklist must ride STDERR, not the decision JSON: `_dispatch.py` surfaces
-# only the FIRST deny's stdout, so a sibling that denies first (e.g.
-# gh-merge-worktree-precondition on `--delete-branch`) would discard it, while
-# every hook's stderr is forwarded unconditionally.
+# The checklist must go out on BOTH channels, because neither alone reaches the
+# model in every case:
+#   - decision JSON — `_dispatch.py:195-201` surfaces only the FIRST deny's
+#     stdout, so a sibling denying first (gh-merge-worktree-precondition on
+#     `--delete-branch`) discards this hook's reason string;
+#   - stderr — forwarded unconditionally, but a PreToolUse hook's stderr reaches
+#     the model only when the dispatcher exits 2 (the deny path), never on the
+#     exit-0 ask path. #873 shipped stderr-only and #932 caught the gap.
 run_merge_checklist_case() {
-  local name="merge_checklist_rides_stderr_not_decision_json"
+  local name="merge_checklist_on_both_channels"
   local payload out err ok=1
   local out_file err_file
   payload=$(python3 -c '
@@ -743,11 +747,8 @@ print(json.dumps({
     "briefing-surfaced:"
   do
     echo "$err" | grep -qF "$token" || { ok=0; echo "        missing from stderr: $token"; }
+    echo "$out" | grep -qF "$token" || { ok=0; echo "        missing from decision JSON: $token"; }
   done
-  # Survives a sibling winning the JSON race only if it is NOT in the JSON.
-  echo "$out" | grep -qF "pre-merge-approval-gate" && {
-    ok=0; echo "        checklist is in the decision JSON — a sibling deny would drop it"
-  }
 
   if [ "$ok" -eq 1 ]; then
     echo "PASS  [$name]"; PASS=$((PASS + 1))

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -736,18 +736,41 @@ print(json.dumps({
   rm -f "$out_file" "$err_file"
 
   echo "$out" | grep -qF '"permissionDecision": "deny"' || ok=0
+
+  # Assert against the decision REASON, not raw stdout — a token matching
+  # anywhere else in the JSON envelope would be a false pass.
+  local reason
+  reason=$(printf '%s' "$out" | python3 -c '
+import json, sys
+print(json.load(sys.stdin)["hookSpecificOutput"]["permissionDecisionReason"])
+') || ok=0
+
+  # Derive every gate name from the registry itself rather than restating a
+  # list here. A hardcoded subset is the same under-enumeration defect this
+  # checklist exists to remove: #932 review found this test naming 5 of the 8
+  # registered gates, so a new registry entry could ship untested.
+  local tokens
+  tokens=$(python3 -c '
+import re, sys
+sys.path.insert(0, sys.argv[1])
+from block_message import verb_gate_checklist
+print("\n".join(sorted(set(re.findall(r"←\s*(\S+)", verb_gate_checklist("gh pr merge"))))))
+' "$ROOT_DIR/hooks/_lib")
+
+  [ -n "$tokens" ] || { ok=0; echo "        derived zero gate names from the registry"; }
+
   local token
-  for token in \
-    "pre-merge-approval-gate" \
-    "side-effect-scan" \
-    "gh-merge-worktree-precondition" \
-    "commit-title-length-check" \
-    "session-intent" \
-    "PRAXIS_MOMENTUM_MERGE_ADVISORY=1" \
-    "briefing-surfaced:"
-  do
-    echo "$err" | grep -qF "$token" || { ok=0; echo "        missing from stderr: $token"; }
-    echo "$out" | grep -qF "$token" || { ok=0; echo "        missing from decision JSON: $token"; }
+  while IFS= read -r token; do
+    [ -n "$token" ] || continue
+    printf '%s' "$err" | grep -qF "$token" || { ok=0; echo "        missing from stderr: $token"; }
+    printf '%s' "$reason" | grep -qF "$token" || { ok=0; echo "        missing from decision reason: $token"; }
+  done <<< "$tokens"
+
+  # Relief affordances are prose, not `←`-tagged gate names, so they are not
+  # derivable above and stay explicit.
+  for token in "PRAXIS_MOMENTUM_MERGE_ADVISORY=1" "briefing-surfaced:"; do
+    printf '%s' "$err" | grep -qF "$token" || { ok=0; echo "        missing from stderr: $token"; }
+    printf '%s' "$reason" | grep -qF "$token" || { ok=0; echo "        missing from decision reason: $token"; }
   done
 
   if [ "$ok" -eq 1 ]; then

--- a/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
@@ -301,28 +301,53 @@ run_case "AskUserQuestion: (recommended) lowercase — T2 escalates to ask (issu
 # #873 shipped stderr-only; the exit-0 ask was the majority case and the
 # checklist silently went nowhere. Assert BOTH channels per case so neither can
 # regress alone.
-run_case "AskUserQuestion: checklist in decision reason, T1 path (issue #932)" \
-  "ask:block-ask-end-option" \
+# Gate names are derived from the registry, not restated here. A hardcoded
+# subset would be the same under-enumeration defect the checklist exists to
+# remove — #932 review caught the sibling merge test naming 5 of its 8
+# registered gates, so a new registry entry could ship untested.
+run_checklist_both_channels_case() {
+  local label="$1" payload="$2"
+  local name="AskUserQuestion: every registered gate on both channels — $label"
+  local out err reason tokens token ok=1
+  local out_file err_file
+  out_file=$(mktemp); err_file=$(mktemp)
+  printf '%s' "$payload" | python3 "$HOOK" >"$out_file" 2>"$err_file"
+  out=$(cat "$out_file"); err=$(cat "$err_file")
+  rm -f "$out_file" "$err_file"
+
+  # Assert against the decision REASON, not raw stdout — a token matching
+  # elsewhere in the JSON envelope would be a false pass.
+  reason=$(printf '%s' "$out" | python3 -c '
+import json, sys
+print(json.load(sys.stdin)["hookSpecificOutput"]["permissionDecisionReason"])
+') || { ok=0; echo "        stdout is not a decision JSON"; }
+
+  tokens=$(python3 -c '
+import re, sys
+sys.path.insert(0, sys.argv[1])
+from block_message import verb_gate_checklist
+print("\n".join(sorted(set(re.findall(r"←\s*(\S+)", verb_gate_checklist("AskUserQuestion"))))))
+' "$ROOT_DIR/hooks/_lib")
+
+  [ -n "$tokens" ] || { ok=0; echo "        derived zero gate names from the registry"; }
+
+  while IFS= read -r token; do
+    [ -n "$token" ] || continue
+    printf '%s' "$err" | grep -qF "$token" || { ok=0; echo "        missing from stderr: $token"; }
+    printf '%s' "$reason" | grep -qF "$token" || { ok=0; echo "        missing from decision reason: $token"; }
+  done <<< "$tokens"
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  [$name]"; PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name]"; FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
+  fi
+}
+
+run_checklist_both_channels_case "T1 path" \
   "$(make_ask_payload '["Option A (Recommended)", "Option B"]')"
 
-run_case "AskUserQuestion: checklist also on stderr, T1 path (issue #873)" \
-  "advisory:block-ask-end-option" \
-  "$(make_ask_payload '["Option A (Recommended)", "Option B"]')"
-
-run_case "AskUserQuestion: checklist names the action-menu gate (issue #873)" \
-  "advisory:block-manufactured-action-menu" \
-  "$(make_ask_payload '["Option A (Recommended)", "Option B"]')"
-
-run_case "AskUserQuestion: action-menu gate reaches the reason too (issue #932)" \
-  "ask:block-manufactured-action-menu" \
-  "$(make_ask_payload '["Option A (Recommended)", "Option B"]')"
-
-run_case "AskUserQuestion: checklist in decision reason, anchoring path (issue #932)" \
-  "ask:block-ask-end-option" \
-  "$(make_ask_payload '["use existing approach (recommended)"]')"
-
-run_case "AskUserQuestion: checklist also on stderr, anchoring path (issue #873)" \
-  "advisory:block-ask-end-option" \
+run_checklist_both_channels_case "anchoring path" \
   "$(make_ask_payload '["use existing approach (recommended)"]')"
 
 # ---------------------------------------------------------------------------

--- a/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_output_block_falsify_advisory.sh
@@ -290,11 +290,22 @@ run_case "AskUserQuestion: (recommended) lowercase — T2 escalates to ask (issu
   "ask:Falsified:" \
   "$(make_ask_payload '["use existing approach (recommended)"]')"
 
-# Issue #873: `Falsified:` is one of several gates on this verb, and the
-# checklist must ride STDERR — `_dispatch.py` surfaces only the FIRST ask/deny's
-# stdout, so a sibling that blocks first (block-ask-end-option on an end-option
-# label) would discard it. Every hook's stderr is forwarded unconditionally.
-run_case "AskUserQuestion: checklist rides stderr, T1 path (issue #873)" \
+# Issues #873 / #932: `Falsified:` is one of several gates on this verb, and the
+# checklist must go out on BOTH channels. The decision JSON is what reaches the
+# model here — an ask makes the dispatcher exit 0, and a PreToolUse hook's
+# stderr is fed to the model only on exit 2. stderr still matters for the case
+# the reason string cannot cover: a sibling denying first (block-ask-end-option
+# on an end-option label) discards this hook's stdout while exiting 2, which is
+# exactly when its stderr does reach the model.
+#
+# #873 shipped stderr-only; the exit-0 ask was the majority case and the
+# checklist silently went nowhere. Assert BOTH channels per case so neither can
+# regress alone.
+run_case "AskUserQuestion: checklist in decision reason, T1 path (issue #932)" \
+  "ask:block-ask-end-option" \
+  "$(make_ask_payload '["Option A (Recommended)", "Option B"]')"
+
+run_case "AskUserQuestion: checklist also on stderr, T1 path (issue #873)" \
   "advisory:block-ask-end-option" \
   "$(make_ask_payload '["Option A (Recommended)", "Option B"]')"
 
@@ -302,7 +313,15 @@ run_case "AskUserQuestion: checklist names the action-menu gate (issue #873)" \
   "advisory:block-manufactured-action-menu" \
   "$(make_ask_payload '["Option A (Recommended)", "Option B"]')"
 
-run_case "AskUserQuestion: checklist rides stderr, anchoring path (issue #873)" \
+run_case "AskUserQuestion: action-menu gate reaches the reason too (issue #932)" \
+  "ask:block-manufactured-action-menu" \
+  "$(make_ask_payload '["Option A (Recommended)", "Option B"]')"
+
+run_case "AskUserQuestion: checklist in decision reason, anchoring path (issue #932)" \
+  "ask:block-ask-end-option" \
+  "$(make_ask_payload '["use existing approach (recommended)"]')"
+
+run_case "AskUserQuestion: checklist also on stderr, anchoring path (issue #873)" \
   "advisory:block-ask-end-option" \
   "$(make_ask_payload '["use existing approach (recommended)"]')"
 


### PR DESCRIPTION
## 문제

PR #931 (`23b0b4a`) 이 verb 게이트 체크리스트를 decision JSON → stderr 로
옮겼습니다. deny 경로는 의도대로 동작하지만 **ask 경로에서는 체크리스트가
모델에 도달하지 않습니다** — #931 이전에는 `permissionDecisionReason` 안에
있어 표면화됐으므로 회귀입니다.

`hooks/_lib/_dispatch.py` 의 종료 코드 분기:

| 라인 | 조건 | 반환 |
| --- | --- | --- |
| `:201` | deny 발견 | `return 2` |
| `:207` | ask 발견 | `return 0` |

PreToolUse 훅의 stderr 는 **exit 2 일 때만** 모델에 전달됩니다. 형제 게이트가
아무도 deny 하지 않는 일반적인 경우(`output-block-falsify-advisory` 단독 ask)
체크리스트는 exit-0 stderr 로 나가고 소실됩니다.

수정 전 probe:

```
$ printf '%s' "$payload" | python3 hooks/_lib/_dispatch.py PreToolUse AskUserQuestion claude
dispatcher exit=0
stderr 1660 bytes, "Every gate on `AskUserQuestion`" 포함
stdout permissionDecisionReason → 체크리스트 MISSING
```

## 수정

양쪽 채널 동시 emit.

- `output-block-falsify-advisory`: `_with_verb_checklist()` 신설 →
  `_emit_ask` / `_emit_t1_ask` 가 reason 에 append. `_emit_verb_checklist()`
  의 stderr write 는 유지.
- `momentum-rule-retrieval-gate`: 동일하게 stderr + reason. deny 는 항상
  exit 2 라 stderr 만으로 충분하지만, 두 훅 처리를 갈라둔 것이 이 결함의
  원인이므로 동일하게 맞췄습니다.

각 채널이 커버하는 케이스:

| 경로 | dispatcher exit | 도달 채널 |
| --- | --- | --- |
| falsify 단독 ask (일반) | 0 | reason 문자열 |
| 형제 게이트 deny 선행 | 2 | stderr (이 훅의 stdout 은 버려짐) |

## 검증

Pre-commit verified: `PRAXIS_TESTS_STRICT=1 ./scripts/run-tests.sh` →
`ALL TESTS PASSED` (manifest OK, hook-token 7 invariants OK, ruff clean,
shellcheck clean)

Caller chain verified: `_dispatch.py:195-207` 의 종료 코드 분기를 dispatcher
직접 실행으로 실측 — ask 경로 `exit=0`, deny 분기 `return 2`. 호출 지점은
`_emit_ask` / `_emit_t1_ask` (falsify), `_merge_escalation_reason` 직후
(momentum) 2곳뿐임을 grep 으로 확인.

fix-up 증상 소멸 확인 (동일 probe, 수정 후):

```
dispatcher exit=0
reason 안 체크리스트 → FOUND, block-ask-end-option 포함
stderr 체크리스트 → 유지 (grep -c = 1)
```

음성대조:

| 대조 | 결과 |
| --- | --- |
| NC3 — falsify reason 채널 제거 | #932 케이스 3건 FAIL (104 passed / 3 failed), 복원 후 107/0 |
| NC4 — momentum reason 채널 제거 | 토큰 5개 `missing from decision JSON`, FAIL (87/1), 복원 후 88/0 |

## 문서

`momentum .../spec.md`, `output-block-falsify-advisory/spec.md`,
`docs/hook/INDEX.md` 의 "stderr 로만 보낸다" 서술을 exit code 별 도달 채널
설명으로 정정했습니다.

## 미검증

exit 2 경로에서 stderr 가 실제로 모델에 전달되는지는 코드 근거까지만입니다
(7.8.0 미배포). exit-0 경로의 비가시성은 #874 본문 실측(ADVISE 42건 발화 /
효과 0건)이 뒷받침합니다.

Closes #932


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Checklists now appear in both decision messages and stderr for merge-denial and AskUserQuestion flows.
  * AskUserQuestion checklists remain visible when the dispatcher returns successfully or another gate blocks first.
  * Parallel deny scenarios retain checklist visibility without changing existing message formatting.

* **Documentation**
  * Updated checklist delivery guidance and behavior descriptions.

* **Tests**
  * Expanded regression coverage for checklist content across decision and stderr output channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->