### PR TITLE
fix(telemetry): divert dev-checkout fires off the ledger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ __pycache__/
 # plugin installs do not run the build script, so the wrappers must
 # be present in the checkout for ${CLAUDE_PLUGIN_ROOT}/hooks/<name>.sh
 # to resolve. See ADR-0001 §2.3 + Codex round-1 P1 finding.
+
+# Dev-checkout fire ledger (issue #934): hooks run out of a git checkout
+# write telemetry here instead of ~/.praxis/telemetry, so running a single
+# test file cannot pollute the real ledger.
+.praxis-dev-telemetry/

--- a/hooks/_lib/_fire_ledger.py
+++ b/hooks/_lib/_fire_ledger.py
@@ -78,9 +78,11 @@ Record fields (JSONL, one line per hook fire):
   decision     "block" | "ask" | "advise" | "pass"
   granularity  "rich" | "coarse"
 
-Storage:
-  Default:  ~/.praxis/telemetry/fire-events-YYYY-MM-DD.jsonl  (daily rotation)
+Storage (precedence order — see `resolve_path`):
   Override: PRAXIS_FIRE_TELEMETRY_FILE (full path, used by tests)
+  Dev:      <checkout>/.praxis-dev-telemetry/fire-events-YYYY-MM-DD.jsonl when
+            this module lives inside a git checkout (issue #934)
+  Default:  ~/.praxis/telemetry/fire-events-YYYY-MM-DD.jsonl  (daily rotation)
   Opt-out:  PRAXIS_FIRE_TELEMETRY_DISABLE=1 → no-op
 
 Fail-open: any error → silently no-op. Never raises into the dispatcher.
@@ -199,13 +201,51 @@ def _atomic_append(path: Path, lines: list[str]) -> None:
         os.close(fd)
 
 
+DEV_LEDGER_DIRNAME = ".praxis-dev-telemetry"
+
+
+def _checkout_root() -> Path | None:
+    """Return the git checkout this module lives in, or None when installed.
+
+    Issue #934: isolation used to live only at the full-suite entrypoints
+    (`scripts/run-tests.sh` exports the override, `tests/conftest.py` sets it
+    per-test), so running a single shell test — `bash tests/hooks/.../test_x.sh`,
+    an everyday thing while developing — wrote straight into the real ledger.
+    105 of the 112 shell tests never set the override themselves, and CI always
+    goes through `run-tests.sh`, so CI can never catch the leak.
+
+    Anchoring on the module's own location fixes every entrypoint at once,
+    including manual `python3 hooks/_lib/_dispatch.py` probes. An installed
+    plugin is not a checkout — `installed_plugins.json` resolves praxis to
+    `~/.claude/plugins/cache/praxis/praxis/<version>/`, which ships no `.git` —
+    so real usage keeps writing to the real ledger, while running a hook out of
+    a development checkout is by definition development and does not belong in
+    production telemetry.
+    """
+    try:
+        here = Path(__file__).resolve()
+    except Exception:
+        return None
+    for parent in here.parents:
+        if (parent / ".git").exists():
+            return parent
+    return None
+
+
 def resolve_path() -> Path:
-    """Resolve today's fire-events JSONL path (PRAXIS_FIRE_TELEMETRY_FILE wins)."""
+    """Resolve today's fire-events JSONL path.
+
+    Precedence: `PRAXIS_FIRE_TELEMETRY_FILE` → dev checkout → real ledger.
+    """
     override = os.environ.get("PRAXIS_FIRE_TELEMETRY_FILE", "").strip()
     if override:
         return Path(override)
     today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
-    return Path.home() / ".praxis" / "telemetry" / f"fire-events-{today}.jsonl"
+    filename = f"fire-events-{today}.jsonl"
+    checkout = _checkout_root()
+    if checkout is not None:
+        return checkout / DEV_LEDGER_DIRNAME / filename
+    return Path.home() / ".praxis" / "telemetry" / filename
 
 
 def _extract_payload(payload_raw: str) -> tuple[str, str]:

--- a/hooks/_lib/_fire_ledger.py
+++ b/hooks/_lib/_fire_ledger.py
@@ -221,15 +221,42 @@ def _checkout_root() -> Path | None:
     so real usage keeps writing to the real ledger, while running a hook out of
     a development checkout is by definition development and does not belong in
     production telemetry.
+
+    Only the **package root** is inspected, never an arbitrary ancestor. This
+    module sits at `<root>/hooks/_lib/_fire_ledger.py` in both layouts, so the
+    root is exactly `parents[2]`. Walking further up would call an installed
+    plugin a checkout whenever any ancestor happens to be a git repository —
+    and `CONTRIBUTING.md` states the config dir is relocatable, so
+    `~/.claude` is a default rather than a guarantee. A user whose config dir
+    (or `$HOME`) lives inside a dotfiles repo would silently lose all live
+    telemetry to a dev ledger.
     """
     try:
         here = Path(__file__).resolve()
     except Exception:
         return None
-    for parent in here.parents:
-        if (parent / ".git").exists():
-            return parent
-    return None
+    parents = here.parents
+    if len(parents) < 3:
+        return None
+    root = parents[2]
+    # `.git` is a directory in a normal clone and a file in a linked worktree.
+    return root if (root / ".git").exists() else None
+
+
+def resolve_telemetry_dir() -> Path:
+    """Directory every praxis telemetry writer appends to.
+
+    Shared by the fire ledger and `hooks/postuse-correction/bypass-telemetry`
+    so the two families never split across directories. `bypass-review
+    fire-rate` joins fire-events and bypass-events out of a *single*
+    `telemetry_dir`, so a split would corrupt both sides of that report at
+    once: the default view would mix production fires with development
+    bypasses, and `--dir <dev>` would show fires with no bypasses at all.
+    """
+    checkout = _checkout_root()
+    if checkout is not None:
+        return checkout / DEV_LEDGER_DIRNAME
+    return Path.home() / ".praxis" / "telemetry"
 
 
 def resolve_path() -> Path:
@@ -241,11 +268,7 @@ def resolve_path() -> Path:
     if override:
         return Path(override)
     today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
-    filename = f"fire-events-{today}.jsonl"
-    checkout = _checkout_root()
-    if checkout is not None:
-        return checkout / DEV_LEDGER_DIRNAME / filename
-    return Path.home() / ".praxis" / "telemetry" / filename
+    return resolve_telemetry_dir() / f"fire-events-{today}.jsonl"
 
 
 def _extract_payload(payload_raw: str) -> tuple[str, str]:

--- a/hooks/postuse-correction/bypass-telemetry/impl.py
+++ b/hooks/postuse-correction/bypass-telemetry/impl.py
@@ -52,6 +52,7 @@ import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
+from _fire_ledger import resolve_telemetry_dir  # type: ignore[import-not-found]  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -211,13 +212,22 @@ def derive_status(tool_response: object) -> str:
 
 
 def resolve_telemetry_path() -> Path:
-    """Resolve the target JSONL path for today's bypass events."""
+    """Resolve the target JSONL path for today's bypass events.
+
+    Shares `_fire_ledger.resolve_telemetry_dir()` so bypass-events and
+    fire-events always land in the same directory (issue #934). `bypass-review
+    fire-rate` joins both families out of a single `telemetry_dir`, so letting
+    only one of them divert to a dev checkout would corrupt both sides of that
+    report: the default view would mix production fires with development
+    bypasses, and `--dir <dev>` would show fires with no bypasses at all.
+
+    """
     override = os.environ.get("PRAXIS_BYPASS_TELEMETRY_FILE", "").strip()
     if override:
         return Path(override)
 
     today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
-    return Path.home() / ".praxis" / "telemetry" / f"bypass-events-{today}.jsonl"
+    return resolve_telemetry_dir() / f"bypass-events-{today}.jsonl"
 
 
 def append_record(record: dict) -> None:

--- a/skills/bypass-review/bypass-review
+++ b/skills/bypass-review/bypass-review
@@ -1726,6 +1726,10 @@ def run_fire_rate(args: argparse.Namespace, telemetry_dir: Path) -> int:
     # SAME telemetry_dir's bypass-events-*.jsonl files (both are written to
     # ~/.praxis/telemetry by default — see hooks/_lib/_fire_ledger.py and
     # hooks/postuse-correction/bypass-telemetry/impl.py resolve_*_path()).
+    # This default stays the REAL ledger on purpose: since issue #934 a hook run
+    # from a git checkout writes to <checkout>/.praxis-dev-telemetry instead, so
+    # the production numbers this report exists to judge are no longer mixed with
+    # local test runs. Pass --dir to inspect a checkout's dev ledger.
     bypass_events = load_events(telemetry_dir, args.days)
     # Scope advise-ignored to full-rich hooks: single-event-rich Stop hooks
     # (issue #847) record only escalations, so their silent passes are invisible

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -22,6 +22,7 @@ import os
 import stat
 import subprocess
 import sys
+import uuid
 from contextlib import redirect_stdout
 from datetime import datetime, timezone
 from importlib.machinery import SourceFileLoader
@@ -1381,30 +1382,88 @@ def test_installed_plugin_still_uses_the_real_ledger(monkeypatch):
 def test_direct_shell_test_run_does_not_touch_the_real_ledger(tmp_path):
     """Reproduce the exact failure mode: one hook invoked with NO override.
 
-    Reads the real ledger only to compare line counts — never writes to it.
+    Reads the real ledger only — never writes to it.
+
+    Scoped to THIS invocation on both sides, because neither file is quiet:
+    concurrent live sessions append to the real ledger while the test runs (358
+    records were observed during one shell-test run), so a whole-file size
+    comparison fails spuriously; and a fixed session id would let a leftover
+    record from an earlier run on the same UTC date satisfy the dev-ledger
+    assertion even if this dispatcher wrote nothing at all.
     """
-    real_dir = Path.home() / ".praxis" / "telemetry"
     today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
-    real_file = real_dir / f"fire-events-{today}.jsonl"
-    before = real_file.stat().st_size if real_file.exists() else 0
+    real_file = Path.home() / ".praxis" / "telemetry" / f"fire-events-{today}.jsonl"
+    dev_file = _REPO / fl.DEV_LEDGER_DIRNAME / f"fire-events-{today}.jsonl"
+    session_id = f"test-934-isolation-{uuid.uuid4()}"
+
+    # Byte offsets, so only what this invocation appends is ever inspected.
+    real_offset = real_file.stat().st_size if real_file.exists() else 0
+    dev_offset = dev_file.stat().st_size if dev_file.exists() else 0
 
     env = {k: v for k, v in os.environ.items() if k != "PRAXIS_FIRE_TELEMETRY_FILE"}
     env.pop("PRAXIS_FIRE_TELEMETRY_DISABLE", None)
     payload = json.dumps({
-        "session_id": "test-934-isolation",
+        "session_id": session_id,
         "hook_event_name": "PreToolUse",
         "tool_name": "Bash",
         "tool_input": {"command": "echo hi"},
     })
-    subprocess.run(
+    proc = subprocess.run(
         [sys.executable, str(_REPO / "hooks" / "_lib" / "_dispatch.py"),
          "PreToolUse", "Bash", "claude"],
         input=payload, text=True, capture_output=True, env=env, check=False,
     )
+    # A crashed dispatcher writes nothing anywhere, which would otherwise read
+    # as "isolation works". 0 = allow, 2 = a member blocked; both are real runs.
+    assert proc.returncode in (0, 2), (
+        f"dispatcher failed (rc={proc.returncode}): {proc.stderr[:400]}"
+    )
 
-    after = real_file.stat().st_size if real_file.exists() else 0
-    assert after == before, "a hook run from the checkout appended to the real ledger"
+    def _tail(path: Path, offset: int) -> str:
+        if not path.exists():
+            return ""
+        with path.open(encoding="utf-8", errors="replace") as fh:
+            fh.seek(offset)
+            return fh.read()
 
-    dev_file = _REPO / fl.DEV_LEDGER_DIRNAME / f"fire-events-{today}.jsonl"
-    assert dev_file.exists(), "the dev ledger received nothing — telemetry silently off?"
-    assert "test-934-isolation" in dev_file.read_text(encoding="utf-8")
+    assert session_id not in _tail(real_file, real_offset), (
+        "a hook run from the checkout appended this invocation to the real ledger"
+    )
+    assert session_id in _tail(dev_file, dev_offset), (
+        "the dev ledger did not receive this invocation — telemetry silently off?"
+    )
+
+
+def test_install_layout_under_a_git_ancestor_is_not_a_checkout(tmp_path, monkeypatch):
+    """An installed plugin nested inside someone's git repo stays production.
+
+    `CONTRIBUTING.md` documents the config dir as relocatable, so the plugin
+    cache can sit under a dotfiles repository. An unbounded ancestor walk finds
+    that `.git` and diverts every live fire into a dev ledger — the whole
+    telemetry stream disappears silently. Only the package root is inspected.
+    """
+    root = tmp_path / "dotfiles"
+    (root / ".git").mkdir(parents=True)
+    pkg = root / "cache" / "praxis" / "7.7.0"
+    lib = pkg / "hooks" / "_lib"
+    lib.mkdir(parents=True)
+    installed = lib / "_fire_ledger.py"
+    installed.write_text(
+        (_REPO / "hooks" / "_lib" / "_fire_ledger.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    mod = _load("_fire_ledger_installed", installed)
+    assert mod._checkout_root() is None, "install layout misread as a checkout"
+
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_FILE", raising=False)
+    assert mod.resolve_telemetry_dir() == Path.home() / ".praxis" / "telemetry"
+
+
+def test_bypass_and_fire_writers_share_one_directory():
+    """Split directories would corrupt both halves of the fire-rate report."""
+    bypass = _load(
+        "bypass_telemetry_impl",
+        _REPO / "hooks" / "postuse-correction" / "bypass-telemetry" / "impl.py",
+    )
+    assert bypass.resolve_telemetry_path().parent == fl.resolve_telemetry_dir()

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -1339,3 +1339,72 @@ def test_fire_rate_report_includes_remaining_scope_sections(tmp_path, monkeypatc
     assert "Bypass Attribution" in report
     assert "Outcome Proxy" in report
     assert "s1" in report and "1" in report  # strike_count surfaced
+
+
+# ---------------------------------------------------------------------------
+# Dev-checkout isolation (issue #934)
+#
+# Isolation used to live only at the full-suite entrypoints, so running one
+# shell test directly wrote into the real ~/.praxis/telemetry ledger — 105 of
+# 112 shell tests never set the override themselves, and CI always goes through
+# run-tests.sh, so CI could not catch it. Seven days of ledger were 26% synthetic
+# in the advise tier.
+# ---------------------------------------------------------------------------
+
+
+def test_override_still_wins_over_dev_checkout(tmp_path, monkeypatch):
+    """PRAXIS_FIRE_TELEMETRY_FILE keeps absolute precedence."""
+    target = tmp_path / "explicit.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(target))
+    assert fl.resolve_path() == target
+
+
+def test_dev_checkout_diverts_off_the_real_ledger(monkeypatch):
+    """Running from a checkout must never resolve into ~/.praxis/telemetry."""
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_FILE", raising=False)
+    resolved = fl.resolve_path()
+    real = Path.home() / ".praxis" / "telemetry"
+    assert real not in resolved.parents, f"{resolved} is inside the real ledger dir"
+    assert resolved.parent.name == fl.DEV_LEDGER_DIRNAME
+    # The tests run from a checkout, so this is the checkout branch by construction.
+    assert (resolved.parent.parent / ".git").exists()
+
+
+def test_installed_plugin_still_uses_the_real_ledger(monkeypatch):
+    """No checkout above the module → unchanged production behaviour."""
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_FILE", raising=False)
+    monkeypatch.setattr(fl, "_checkout_root", lambda: None)
+    resolved = fl.resolve_path()
+    assert resolved.parent == Path.home() / ".praxis" / "telemetry"
+
+
+def test_direct_shell_test_run_does_not_touch_the_real_ledger(tmp_path):
+    """Reproduce the exact failure mode: one hook invoked with NO override.
+
+    Reads the real ledger only to compare line counts — never writes to it.
+    """
+    real_dir = Path.home() / ".praxis" / "telemetry"
+    today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+    real_file = real_dir / f"fire-events-{today}.jsonl"
+    before = real_file.stat().st_size if real_file.exists() else 0
+
+    env = {k: v for k, v in os.environ.items() if k != "PRAXIS_FIRE_TELEMETRY_FILE"}
+    env.pop("PRAXIS_FIRE_TELEMETRY_DISABLE", None)
+    payload = json.dumps({
+        "session_id": "test-934-isolation",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "echo hi"},
+    })
+    subprocess.run(
+        [sys.executable, str(_REPO / "hooks" / "_lib" / "_dispatch.py"),
+         "PreToolUse", "Bash", "claude"],
+        input=payload, text=True, capture_output=True, env=env, check=False,
+    )
+
+    after = real_file.stat().st_size if real_file.exists() else 0
+    assert after == before, "a hook run from the checkout appended to the real ledger"
+
+    dev_file = _REPO / fl.DEV_LEDGER_DIRNAME / f"fire-events-{today}.jsonl"
+    assert dev_file.exists(), "the dev ledger received nothing — telemetry silently off?"
+    assert "test-934-isolation" in dev_file.read_text(encoding="utf-8")

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -1379,10 +1379,14 @@ def test_installed_plugin_still_uses_the_real_ledger(monkeypatch):
     assert resolved.parent == Path.home() / ".praxis" / "telemetry"
 
 
-def test_direct_shell_test_run_does_not_touch_the_real_ledger(tmp_path):
+def test_direct_shell_test_run_does_not_touch_the_real_ledger(tmp_path, monkeypatch):
     """Reproduce the exact failure mode: one hook invoked with NO override.
 
-    Reads the real ledger only — never writes to it.
+    `HOME` is redirected into `tmp_path` first, so the production fallback
+    resolves inside the sandbox and the developer's own ledger is neither read
+    nor written. The oracle survives the redirect: if checkout detection
+    regressed, the record would land in the sandbox ledger and the first
+    assertion below would still fire.
 
     Scoped to THIS invocation on both sides, because neither file is quiet:
     concurrent live sessions append to the real ledger while the test runs (358
@@ -1391,6 +1395,7 @@ def test_direct_shell_test_run_does_not_touch_the_real_ledger(tmp_path):
     record from an earlier run on the same UTC date satisfy the dev-ledger
     assertion even if this dispatcher wrote nothing at all.
     """
+    monkeypatch.setenv("HOME", str(tmp_path))
     today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
     real_file = Path.home() / ".praxis" / "telemetry" / f"fire-events-{today}.jsonl"
     dev_file = _REPO / fl.DEV_LEDGER_DIRNAME / f"fire-events-{today}.jsonl"


### PR DESCRIPTION
## 문제

테스트 픽스처가 프로덕션 fire ledger(`~/.praxis/telemetry/`)에 계속 섞여
들어갑니다. 최근 7일(1,075,016 레코드) 집계:

| tier | 전체 | `test-*` session | 합성 비율 |
| --- | --- | --- | --- |
| block | 20,208 | 3,344 | 16.5% |
| advise | 5,602 | 1,465 | **26.2%** |
| ask | 1,886 | 214 | 11.3% |

일자별 오염률이 0%(07-29, 07-30)에서 4.23%(08-02)까지 널뛰기 때문에,
fire-rate 로 훅을 판정하는 `docs/hook-prune-audit.md` 의 순위가 **언제
집계했느냐에 따라 달라집니다.**

## 원인

#849 가 격리를 넣은 층이 **전체 스위트 진입점**뿐입니다:

- `scripts/run-tests.sh:52` — `export PRAXIS_FIRE_TELEMETRY_FILE=...`
- `tests/conftest.py:39` — pytest autouse fixture

셸 테스트 **112개 중 자체 설정은 7개**입니다. 따라서 개별 파일을 직접
실행하면 105개가 프로덕션 ledger 로 샙니다. 개발 중 한 파일만 돌려보는 것은
일상적인 동작이고, **CI 는 항상 `run-tests.sh` 를 거치므로 이 누수를
구조적으로 잡을 수 없습니다.**

실측 귀속: 08-02 의 합성 레코드 2,119건은 **전부 `retrospect-mix-check`**
이고, 시간대(02:23–08:41 UTC)가 PR #930 의 Gate-11 작업 중 해당 테스트
파일을 반복 실행한 구간과 일치합니다.

## 수정

격리를 **경로 해석 한 곳**(`_fire_ledger.resolve_path`)으로 옮깁니다.
개별 테스트가 무엇을 잊든, 수동 `python3 hooks/_lib/_dispatch.py` probe 든
전부 덮입니다.

| 조건 | 결과 |
| --- | --- |
| `PRAXIS_FIRE_TELEMETRY_FILE` 있음 | 그대로 (기존 동작) |
| 모듈이 git 체크아웃 안 | `<repo>/.praxis-dev-telemetry/` (신규, gitignored) |
| 그 외 | `~/.praxis/telemetry/` (기존 동작) |

설치된 플러그인은 체크아웃이 아닙니다 — `installed_plugins.json` 의
`installPath` 가 `~/.claude/plugins/cache/praxis/praxis/<ver>/` 이고 그 안에
`.git` 이 없음을 확인했습니다. 반대로 체크아웃에서 훅을 실행하는 것은
정의상 개발 행위입니다.

**버린 대안**: `tests/_assert_lib.sh` 에 export 추가 — 112개 중 6개만 이
파일을 source 하므로 106개를 편집해야 하고, 새 테스트가 빠뜨리면 같은
결함이 재발합니다.

`bypass-review` CLI 의 기본 디렉터리는 실제 ledger 로 **의도적으로
유지**했습니다. 이 리포트가 판정해야 할 대상이 프로덕션 수치이기 때문이며,
이유를 주석에 남겼습니다.

## 검증

Pre-commit verified: `PRAXIS_TESTS_STRICT=1 ./scripts/run-tests.sh` →
`ALL TESTS PASSED`

Caller chain verified: `resolve_path()` 호출자는 `_fire_ledger.py` 내부
쓰기 경로뿐임을 grep 으로 확인했고, 진입점 3종(전체 스위트 / 개별 셸 테스트 /
수동 dispatcher probe)을 각각 실행해 도달 경로를 실측했습니다.

**NC934 — 수정 되돌림** (프로덕션 무오염을 위해 `HOME` 을 임시 디렉터리로):

| 조건 | home ledger | dev ledger |
| --- | --- | --- |
| 수정 되돌림 | **45건 기록됨** | — |
| 수정 적용 | **0건** | 90건 |

**실제 실패 모드 재현** — 08-02 오염의 출처인
`tests/hooks/completion-verify/test_retrospect_mix_check.sh` 직접 실행:

| | 프로덕션 ledger | dev ledger |
| --- | --- | --- |
| `retrospect-mix-check` 레코드 | 87 → 88 (**+1**) | **+157** |

그 +1 은 합성이 아니라 다른 라이브 세션(`8dd54523-…`, `granularity: rich`)의
정상 기록입니다.

신규 테스트 4종 (`tests/test_fire_ledger.py`, 96 passed):
override 우선순위 유지 / 체크아웃에서 실제 ledger 경로로 해석되지 않을 것 /
설치 환경에서는 기존 동작 유지 / **실패 모드 그대로** — override 없이
dispatcher 를 직접 실행했을 때 실제 ledger 파일 크기가 변하지 않을 것
(실제 ledger 는 크기만 읽고 절대 쓰지 않습니다).

## 남긴 것

기존 오염 레코드는 **삭제하지 않았습니다.** 판정 근거로 남겨두고, 집계 시
필터할지 별도 격리할지는 #874 에서 결정합니다.

## 미검증

플러그인을 로컬 체크아웃으로 심볼릭 설치하는 사용자는 dev ledger 로 가게
됩니다. `CONTRIBUTING.md` / `CLAUDE.md` 에 그런 설치 모드가 문서화돼 있지
않아 실측 대상이 없었습니다.

Closes #934


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Development checkouts now store telemetry separately from production telemetry by default.
  * Explicit telemetry file and directory overrides continue to take priority.
* **Documentation**
  * Fire-rate mode now clarifies how production and development telemetry are selected.
* **Bug Fixes**
  * Prevented development activity from being written to the production telemetry ledger.
  * Bypass and fire telemetry now consistently use the same resolved storage location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->