### PR TITLE
docs(audit): recalibrate hook verdicts from 30-day window

### DIFF
--- a/docs/hook-prune-audit.md
+++ b/docs/hook-prune-audit.md
@@ -14,40 +14,108 @@ a repo-relative link).
 ./skills/bypass-review/bypass-review fire-rate -d 30
 ```
 
-Window: 2026-06-02 → 2026-07-01 (fire-event instrumentation itself only starts
-2026-06-26 — the first 24 days of the requested 30-day lookback have no
-fire-events at all, so the effective sample is **2026-06-26 → 2026-07-01, 49
-sessions**). Test-fixture rows emitted by `tests/test_fire_ledger.py` (`adv`,
-`ask`, `deny`, `crash`, `pass`, `p1`, `p2`, `boom*`, `real_block`, `allow`,
-`_lib`) are excluded from every table below — cross-checked against
-`hooks/manifest.json`'s 58 registered hook names.
+Window: **2026-07-05 → 2026-08-03, 743 sessions** — a full 30 days with
+fire-events throughout, superseding the first audit's effective 5-day /
+49-session sample (2026-06-26 → 2026-07-01). Recalibrated for issue #874.
+
+Fire counts below are a snapshot taken 2026-08-03T07:5xZ; the ledger is
+append-only and live, so re-running the command minutes later moves every
+`Fires` figure up by tens. The block/ask/advise counts the verdicts actually
+rest on are stable at this resolution — where a number matters to a verdict,
+it is an escalation count, not a fire count.
+
+The ledger carries 96 hook names; `hooks/manifest.json` registers **81** across
+90 entries (a name repeats when one hook binds several events). The 15 extra
+ledger names are excluded from every table below:
+
+- test fixtures from `tests/test_fire_ledger.py` — `adv`, `ask`, `deny`,
+  `crash`, `pass`, `p1`, `p2`, `boom`, `boom_mem`, `boom_rec`, `real_block`,
+  `allow`, `_lib`;
+- two hooks that existed during the window and have since left the manifest —
+  `external-write-falsify-check` (last seen 2026-08-01),
+  `verdict-gap-coexistence-gate` (last seen 2026-07-28). Their rows are
+  history, not verdict targets.
+
+### What changed since the first audit
+
+The roster grew from 58 registered hooks to 81, and the sample from 49
+sessions to 743. Two of the first audit's structural claims no longer hold —
+see Axis 1 and the Axis 4 update below.
 
 ## Axis 1 — never-fired
 
-**Result: none.** Every hook that emits fire-events (54 of 58 — the other 4
-are the uninstrumented shell hooks below) fired at least once in the window.
-This is expected — the sample covers the tail end of this very session's
-Wave 1 work, which exercised nearly every gate class (commit, PR create,
-merge, AskUserQuestion, bulk write).
+**Result: none.** All 81 registered hooks fired at least once in the window.
 
-4 hooks are **shell (`.sh`) implementations with no `@fail_open` / dispatch
-chokepoint** and emit no fire-events at all, so they cannot be scored on any
-axis below: `codex-review-route`, `completion-verify`, `retrospect-mix-check`,
-`strike-counter`. This is a measurement gap, not a verdict — **follow-up
-recommendation**: port these to the `@fail_open` decorator (or an equivalent
-coarse fire-event emit) so a future audit can actually score them.
+The first audit carved out 4 shell hooks (`codex-review-route`,
+`completion-verify`, `retrospect-mix-check`, `strike-counter`) as
+*unmeasurable*, on the ground that a `body: impl.sh` hook reaches no recording
+chokepoint. **That is no longer true.** Issue #892 gave shell bodies
+`hooks/_lib/record_fire.sh`, and all four now record:
+
+| Hook | Fires (30d) | Block | Advise |
+| --- | --- | --- | --- |
+| `retrospect-mix-check` | 7,680 | 3,026 | 0 |
+| `strike-counter` | 3,359 | 75 | 75 |
+| `codex-review-route` | 2,001 | 0 | 189 |
+| `completion-verify` | 1,801 | 195 | 0 |
+
+`bypass-review` itself carried the stale claim: `roster_split()` classified by
+file extension, so the report printed "these 4 emit NO fire events" directly
+below a table tabulating nearly 15,000 of them. The classification now follows the
+chokepoint — Bash-dispatch-group membership, or a `fail_open` / `record_fire`
+reference in the hook's body — and the extension test survives only as the
+fallback for an unreadable body. With that fix the *uninstrumented* roster is
+empty: every registered hook is scoreable.
 
 ## Axis 2 — advise-ignored-rate high
 
-Only hooks with an `Observed` (non-right-censored) sample appear here; n is
-small across the board (13–24), so treat percentages as directional, not
-statistically solid.
+`Observed` counts advise fires with a later same-hook fire in the same session
+to compare against; `Ignored` means that later fire was `advise` again — the
+flagged condition recurred unchanged.
 
 | Hook | Ignored / Observed | Rate | Verdict |
 | --- | --- | --- | --- |
-| `pre-gh-pr-create-dedup-gate` | 7 / 23 | 30% | **Investigate** — the highest ignored-rate of any advisory hook. Worth checking whether the advisory message clearly states *what to do next* (vs. just flagging), since a 30% ignore rate on a duplicate-issue-search nudge suggests the message isn't actionable enough. Not a drop candidate — it protects against real duplicate-issue creation. |
-| `destructive-bash-guard` | 2 / 13 | 15% | Keep as-is — small n, no action needed. |
-| `momentum-rule-retrieval-gate`, `inspection-chain-advisory`, `count-assertion-verify`, `pre-output-falsification-gate`, `cli-flag-incompat-advisory`, `bash-worktree-existence-advisory`, `external-write-path-existence-check` | 0 / n | 0% | Keep — advisories are being heeded when observed. |
+| `pipefail-advisory` | 250 / 1056 | 24% | **Keep — and the single largest advisory load.** See the ADVISE-tier note below. |
+| `pre-gh-pr-create-dedup-gate` | 86 / 361 | 24% | **Investigate** (carried over) — 30% on the first sample, 24% on a 15× larger one, so the rate is real and stable, not small-n noise. The open question is unchanged: does the advisory say what to *do* next, or only that something is wrong? |
+| `commit-title-length-check` | 11 / 60 | 18% | Keep — recurrence here is cheap (retitle and retry) and the gate is exact. |
+| `cli-flag-incompat-advisory` | 1 / 9 | 11% | Keep — n too small to read. |
+| `destructive-bash-guard` | 17 / 191 | 9% | Keep. |
+| `external-write-path-existence-check` | 10 / 111 | 9% | Keep. |
+| `count-assertion-verify` | 12 / 206 | 6% | Keep. |
+| `fallback-negative-warn` | 4 / 71 | 6% | Keep. |
+| `inspection-chain-advisory` | 34 / 643 | 5% | Keep. |
+| `source-citation-probe-gate` | 3 / 120 | 2% | Keep. |
+| `momentum-rule-retrieval-gate` | 7 / 510 | 1% | Keep. |
+| `pre-output-falsification-gate`, `bash-worktree-existence-advisory`, `perf-multiplier-evidence-advisory`, `output-block-falsify-advisory`, `pre-commit-staged-file-enumeration`, `model-routing-advisory` | 0 / n | 0% | Keep. |
+| `block-unmatched-glob` | 3 / 5 | 60% | Not scoreable — n=5. |
+
+### The ADVISE tier is not inert (falsifies issue #874's premise)
+
+Issue #874 opened on a single session (2026-07-27, `5d46110f`) where 42 ADVISE
+fires produced no observable behaviour change, and inferred that the tier's
+effect is zero because advisories go to stderr where the model cannot see them.
+
+Across 743 sessions the recurrence rates above **do not support that
+inference**. `pipefail-advisory` — the highest-volume advisory, and the one
+the issue named first — recurs 24% of the time, meaning roughly three in four
+advises are followed by the hook no longer flagging. `momentum-rule-retrieval-gate`
+recurs 1% of 510 observed fires.
+
+Two caveats keep this from being a clean refutation:
+
+- The metric is the hook's own re-evaluation, not a literal behaviour diff.
+  A later `pass` can also mean the session moved to commands the matcher does
+  not cover, which would inflate the apparent heed rate.
+- Right-censored fires (the last advise of a session, with nothing after it to
+  compare against) are excluded, and that exclusion is not random — a session
+  that ends right after an advisory is exactly the case where nothing was done
+  about it.
+
+The honest reading: the single-session "effect = 0" observation does not
+generalise, and the ADVISE tier should not be deleted or promoted wholesale on
+that basis. The delivery-channel question the issue raises (stderr vs.
+`systemMessage`) stands on its own and is not settled by this data either way —
+it needs an experiment, not a larger window.
 
 ## Axis 3 — coverage-duplicate
 
@@ -57,8 +125,8 @@ behavior to see if the duplication also shows up as duplicate *coverage*:
 
 | Pair | Fire-rate behavior | Verdict |
 | --- | --- | --- |
-| `pre-output-falsification-gate` (advise ×10 / 4625 fires) vs. `output-block-falsify-advisory` (advise ×0 / 5181 fires) | Both scan for the same "self-authored proposal without falsification" pattern (Cluster B3 — shared evaluative-marker/`Falsified:`-phrase matcher, not yet extracted to `hooks/_lib/`). `output-block-falsify-advisory` never actually advised in this window despite firing more often — either its matcher is narrower/stricter than `pre-output-falsification-gate`'s, or it is the AskUserQuestion-specific escalation path (ask/deny) documented in its own spec (`(Recommended)` + no `Falsified:` line → deny/ask) while `pre-output-falsification-gate` is the softer stderr-only nudge. | **Merge is premature** — they occupy different severities (deny-capable vs. advisory-only) on the same detection logic. Complete Cluster B3's code-dedup first (shared `_lib` matcher); revisit whether the *hook* pair should merge only after both consume the same extracted matcher and a further window shows continued full overlap. |
-| `commit-title-length-check` (ask ×44 / 3835) vs. `commit-title-format-check` (block ×692 / 5315) | Different fire counts and different escalation levels (ask vs. block) — they gate different failure modes (length vs. format) that happen to share a git-title-parsing helper (Cluster B2). | **Not coverage-duplicate** — keep both hooks; only the shared parser code is a dedup target. |
+| `pre-output-falsification-gate` (advise ×161, block ×0 / 59,172 fires) vs. `output-block-falsify-advisory` (block ×547, ask ×460, advise ×7 / 59,457 fires) | Both scan for the same "self-authored proposal without falsification" pattern (Cluster B3 — shared evaluative-marker/`Falsified:`-phrase matcher, not yet extracted to `hooks/_lib/`). The 30-day window resolves the first audit's open question: `output-block-falsify-advisory` is **not** a narrower duplicate that never fires — it is the deny/ask escalation path (1,007 escalations), while `pre-output-falsification-gate` carries the advisory load (161 advises, zero escalations). The split is by severity, and both halves are live. | **Do not merge.** The first audit called the merge "premature" pending more data; the data arrived and argues against merging at all. Cluster B3's code dedup (shared `_lib` matcher) remains worth doing on its own terms — that is a code-duplication fix, not a hook merge. |
+| `commit-title-length-check` (ask ×418, advise ×60 / 53,212) vs. `commit-title-format-check` (block ×4,868 / 63,709) | Different escalation levels (ask vs. block) gating different failure modes (length vs. format) that share a git-title-parsing helper (Cluster B2). | **Not coverage-duplicate** — keep both hooks; only the shared parser code is a dedup target. |
 
 **False-positive check (naming-only clustering, ruled out):** `pre-merge-approval-gate`,
 `merge-state-claim-gate`, `merge-menu-review-options-advisory`, and
@@ -66,75 +134,84 @@ behavior to see if the duplication also shows up as duplicate *coverage*:
 a 4-way duplicate cluster from naming alone. They are **not** — each gates a
 distinct point in the merge lifecycle: pre-merge ask-surface (PreToolUse),
 post-hoc claim verification (Stop), AskUserQuestion menu-option advisory
-(PreToolUse), and live PR-state re-fetch (PreToolUse, issue #719, this Wave).
-Defense-in-depth across different event types, not redundant coverage of the
-same token. No action.
+(PreToolUse), and live PR-state re-fetch (PreToolUse, issue #719). All four
+now carry real load on the 30-day window (343 ask / 174 block + 1,812 advise /
+662 block / 153 block respectively). Defense-in-depth across different event
+types, not redundant coverage. No action.
 
 ## Axis 4 — advisory-only-never-escalated
 
-**Scope restriction (premise-verification):** the fire-rate report's own
-caveat states that `Stop`/`UserPromptSubmit`-event hooks return a decision via
-a stdout JSON field while exiting 0 — their blocks are invisible to the coarse
-fire-event count and fold into "Pass". Scoring these on this axis would report
-a false "never escalates" for hooks whose escalation is simply unmeasured.
-**Excluded from this axis**: `merge-state-claim-gate`, `completion-signal-gate`,
-`readonly-verify-deferral-gate`, `strike-counter` (Stop); `session-intent`,
-`postcompact-context`, `retrospect-active-marker`, `codex-review-route` (UPS).
-Hooks with a `strict_env` field also default to advisory-only pass-through
-until a user opts into strict mode — a 0-block count for these is the designed
-default, not evidence of dead code, so they're also excluded from a "drop"
-read (though still listed below for completeness).
+**Scope restriction (premise-verification):** a coarse-granularity hook records
+only block-vs-pass — its ask/advise fold into `Pass` and are invisible here, so
+scoring one on this axis reports a false "never escalates" for a hook whose
+escalations are simply unmeasured. This axis is therefore restricted to the
+**Bash dispatch group**, where the central dispatcher records the real decision
+(block/ask/advise/pass) for every fire. 45 of the window's hooks are in that
+group.
 
-> **Update (issue #847):** the coarse Stop-lane blind spot this restriction
-> works around is now closed for the five completion-verify Stop gates
-> (`completion-signal-gate`, `merge-state-claim-gate`,
-> `negative-existence-verdict-gate`, `runtime-state-claim-gate`,
-> `readonly-verify-deferral-gate`). Each now calls `record_session_fire` at
-> its emit point with the real decision (block/advise), so future audits can
-> score them on this axis directly by filtering `granularity="rich"`. Before
-> #847 the Stop lane recorded structurally zero non-pass fires — every
-> block/advise collapsed to coarse "pass" — so any pre-#847 "never escalates"
-> read on these hooks is measurement-absent, not evidence of dead code.
+**Result: 4 of 45** dispatch-group hooks logged zero block, zero ask, and zero
+advise across the whole window.
 
-Remaining `PreToolUse`/`PostToolUse` hooks with **zero block AND zero advise**
-across 49 sessions / 30 days (i.e., every fire resolved to a silent Pass):
+| Hook | Fires | Sessions | Purpose (verified via spec.md) | Verdict |
+| --- | --- | --- | --- | --- |
+| `jq-config-empty-dict-advisory` | 59,972 | 400 | Warns before `jq` reads a size-0 or malformed config, where `jq` returns the literal `empty` on stdout instead of erroring and downstream code silently takes a wrong default (issue #323). | **KEEP** — the trigger is "a config file that is empty or invalid *at the moment* a `jq` command reads it". 60k clean reads is the healthy state, not evidence of dead code. A guard for a silent-failure mode is supposed to sit quiet. |
+| `version-bump-evidence-check` | 53,212 | 400 | Warns when a `gh issue/pr create/edit` body describes an **external dependency** version bump (`v24 → v25`, `bump SDK from 3.0 to 4.0`) with no changelog or breaking-changes evidence. `strict_env`-gated. | **KEEP** — and the first audit's reasoning for keeping it was wrong. It read the hook as gating praxis's own `VERSION` bump and excused the zero count by noting no release landed inside the window. The window now contains 7 merged `chore(main): release` PRs (7.2.1 → 7.8.0), and those are irrelevant either way: release PRs are authored by release-please, and the hook targets external-SDK bump prose in agent-authored bodies. The correct read is that the trigger is genuinely rare, not that it was untested. |
+| `pytest-direct-exec-advisory` | 692 | 6 | Nudges away from invoking `pytest` directly instead of the repo's runner. | **KEEP — not scoreable.** 6 sessions is measurement-thin; revisit next audit. |
+| `caller-probe-gate` | 330 | 6 | Requires the caller chain be probed before a claim about who calls what. | **KEEP — not scoreable.** Same reason. |
 
-| Hook | Fires | Purpose (verified via spec.md) | Verdict |
-| --- | --- | --- | --- |
-| `memory-hint` | 5053 | Emits a stderr hint when a tool call's text matches keywords from a memory file marked `hookable: true`. **Premise check**: an initial read suggested no hookable memories exist — **falsified** by `grep -rl "hookable: true" .../memory/*.md` → **13 files** in this project's own memory store declare `hookable: true` (including one, `feedback_worktree_context_pre_git_op.md`, whose own body documents a past session where the hook *should* have fired and didn't until frontmatter was added). The mechanism is live and in active use. | **KEEP** — but flag as **monitor**: 0 fires across 5053 evaluations with 13 hookable entries registered is worth checking (do the `hookKeywords` lists actually match tokens that appear in real `tool_input` text?) as a separate, narrower follow-up — not this issue's scope. |
-| `jq-config-empty-dict-advisory` | 4819 | Warns before `jq` silently returns `empty` / crashes on a size-0 or malformed config JSON. | **KEEP** — narrow safety-net for a silent-failure mode (accidentally-emptied config file); rare-but-real, not obsolete. |
-| `external-api-literal-trigger` | 4503 | Advisory to verify ALL_CAPS/SQL-identifier literals against real API/schema values before writing them. | **KEEP** — spec documents 3 real catches in 30 days elsewhere in the codebase; pattern-match is broad but the underlying failure (guessed enum/catalog values) is a recurring, real class per `feedback_external_cli_verify_first`. |
-| `pre-edit-md-escape-advisory` | 1780 | Nudges a Read-before-Edit on `.md` files containing escape-sensitive tokens (`\|`, `\[`, HTML entities) to prevent exact-match Edit failures. | **KEEP** — documented root cause (issue #230, Obsidian-style escaped wikilinks); niche trigger, real recovery-cost avoidance when it fires. |
-| `advisory-wrapper-signature-verify` | 1057 | Warns before writing wrapper/client code that delegates to underlying functions without having read their real signatures. | **KEEP** — spec documents 4 prior incidents (wrong exception attributes, factory signature mismatches). Narrow trigger (wrapper-shaped files + delegation pattern), real failure class. |
-| `version-bump-evidence-check` | 3835 | Requires evidence of `VERSION`/manifest/`CHANGELOG.md` sync before a release PR. `strict_env`-gated. | **KEEP** — **not a dead-code signal**: the last actual `VERSION` bump (6.3.3, PR #706) landed 2026-06-25, one day *before* fire-event instrumentation began (2026-06-26). The trigger condition (a version-bump PR) simply did not occur inside the measurable window — falsifies the "never needed" read. Re-check after the next release PR (#707's checklist should make this easy to verify going forward). |
-| `output-block-falsify-advisory` | 5181 | See Axis 3 — occupies the deny/ask-escalation half of the falsification-gate pair. | **KEEP** — see Axis 3 merge discussion; not scored as "unused", it's paired with a sibling that does carry the advisory load. |
+Every other dispatch-group hook escalated at least once. No hook in this set is
+recommended for **drop**: two are narrow safety nets whose quiet is the
+designed outcome, and two have too little history to judge.
 
-No hook in this remaining set is recommended for **drop**. Every "inert in
-this window" hook guards a documented, previously-real failure class whose
-trigger condition is narrow by design (that's the point of a targeted
-advisory) — a 30-day/49-session window without a match is consistent with
-"working as intended, rare trigger" rather than "obsolete".
+> **Superseded (issue #847 / #892):** the first audit excluded eight
+> `Stop`/`UserPromptSubmit` hooks from this axis because their decisions
+> collapsed into coarse `Pass`. #847 gave the five completion-verify Stop gates
+> a real `record_session_fire` at their emit point, and #892 did the same for
+> shell bodies, so the blind spot that motivated the exclusion is closed.
+> Pre-#847 "never escalates" reads on those hooks were measurement-absent and
+> should not be carried forward as evidence.
 
 ## Summary verdict table
 
 | Verdict | Count | Hooks |
 | --- | --- | --- |
-| **Keep** (active or narrow-safety-net) | 50 | All measured PreToolUse/PostToolUse hooks not listed in the two rows below, including every hook with nonzero block/ask/advise activity |
-| **Investigate** (non-drop follow-up) | 2 | `pre-gh-pr-create-dedup-gate` (advisory message clarity), `memory-hint` (keyword-match coverage) |
-| **Merge candidate, blocked on prerequisite** | 2 | `pre-output-falsification-gate` + `output-block-falsify-advisory` — revisit only after Cluster B3's shared-matcher extraction lands and a further fire-rate window still shows full overlap |
-| **Unmeasurable — instrument first** | 4 | `codex-review-route`, `completion-verify`, `retrospect-mix-check`, `strike-counter` (shell hooks, no fire-event emission) |
+| **Keep** (active, or narrow safety net whose quiet is by design) | 77 | Every registered hook not listed below |
+| **Investigate** (non-drop follow-up) | 2 | `pre-gh-pr-create-dedup-gate` (24% ignored — is the advisory actionable?), `memory-hint` (68,799 fires, 0 recorded escalations against 12 memories declaring `hookable: true`; it is coarse-recorded, so that 0 is *measurement-absent*, not evidence — the open question is whether its `hookKeywords` match real tool-call text) |
+| **Keep, but not yet scoreable — revisit next audit** | 2 | `pytest-direct-exec-advisory`, `caller-probe-gate` (6 sessions each) |
+| **Unmeasurable — instrument first** | 0 | — (closed by #847 + #892; see Axis 1) |
 | **Drop** | 0 | — |
-| **Total** | 58 | Matches `hooks/manifest.json`'s registered hook count (50+2+2+4) |
+| **Total** | 81 | Matches `hooks/manifest.json`'s 81 distinct names (77+2+2) |
 
 ## Bottom line
 
-No hook meets the bar for removal on the current evidence. The 58-hook count
-itself (the ponytail-comparison spec's "~60 hooks" framing, rounded) is not,
-on this data, an accretion of dead weight — it's mostly narrow,
-non-overlapping safety nets whose low individual fire-rate is exactly what a
-targeted advisory should look like. The actionable follow-ups are smaller and
-different in kind: (1) finish Cluster B3's code dedup before reconsidering a
-hook merge, (2) instrument the 4 shell hooks so they're scoreable, (3) look at
-why `pre-gh-pr-create-dedup-gate`'s advisory is ignored 30% of the time, and
-(4) confirm `memory-hint`'s 13 registered keyword sets actually match real
-tool-call text.
+No hook meets the bar for removal, on a sample 15× larger than the first
+audit's. The roster grew 58 → 81 in a month, and that growth is still not
+visibly dead weight: 41 of 45 dispatch-group hooks escalated at least once in
+30 days, and the four that did not are two rare-by-design guards plus two
+hooks with almost no history.
+
+What the larger window did change is which *claims* survive:
+
+1. The four shell hooks are no longer unmeasurable — #892 instrumented them,
+   and `bypass-review` was reporting the opposite of its own data until this
+   audit. Fixed here.
+2. The falsification-gate pair should **not** merge. The first audit deferred
+   the call for more data; the data shows a live severity split, not overlap.
+3. Issue #874's "ADVISE tier effect = 0" does not generalise past the single
+   session it was drawn from. The delivery-channel question is still open, but
+   it needs an experiment rather than a bigger window.
+4. `version-bump-evidence-check` was kept for the wrong reason and stays kept
+   for the right one.
+
+### What this audit still cannot answer
+
+Every axis here scores *firing*, because firing is what the ledger records.
+Whether a fire changed the outcome is inferred at best — Axis 2's heed rate is
+the hook re-evaluating itself, not a behaviour diff. So this document can say
+which hooks are inert and which are loud; it cannot rank hooks by value, and a
+verdict of "keep" here means "no evidence for removal", not "demonstrated
+worth". Closing that gap needs outcome instrumentation, not a longer window.
+
+Remaining follow-ups: finish Cluster B3's code dedup (independent of the hook
+verdict), look at why `pre-gh-pr-create-dedup-gate`'s advisory recurs 24% of
+the time, and confirm `memory-hint`'s keyword sets match real tool-call text.

--- a/docs/hook-prune-audit.md
+++ b/docs/hook-prune-audit.md
@@ -62,10 +62,14 @@ chokepoint. **That is no longer true.** Issue #892 gave shell bodies
 `bypass-review` itself carried the stale claim: `roster_split()` classified by
 file extension, so the report printed "these 4 emit NO fire events" directly
 below a table tabulating nearly 15,000 of them. The classification now follows the
-chokepoint — Bash-dispatch-group membership, or a `fail_open` / `record_fire`
-reference in the hook's body — and the extension test survives only as the
-fallback for an unreadable body. With that fix the *uninstrumented* roster is
-empty: every registered hook is scoreable.
+chokepoint — Bash-dispatch-group membership, or an anchored instrumentation
+statement in the hook's body (`@fail_open`, an import of `fail_open`, a
+`source`/`.` of `record_fire.sh`) — and the extension test survives only as the
+fallback for an unreadable body. Anchoring matters as much as the marker: every
+shell hook carries `# shellcheck source=…/record_fire.sh` one line above its
+real source line, so a substring test would keep calling a body instrumented
+after the executable line was deleted. With that fix the *uninstrumented*
+roster is empty: every registered hook can produce fire events.
 
 ## Axis 2 — advise-ignored-rate high
 
@@ -125,7 +129,7 @@ behavior to see if the duplication also shows up as duplicate *coverage*:
 
 | Pair | Fire-rate behavior | Verdict |
 | --- | --- | --- |
-| `pre-output-falsification-gate` (advise ×161, block ×0 / 59,172 fires) vs. `output-block-falsify-advisory` (block ×547, ask ×460, advise ×7 / 59,457 fires) | Both scan for the same "self-authored proposal without falsification" pattern (Cluster B3 — shared evaluative-marker/`Falsified:`-phrase matcher, not yet extracted to `hooks/_lib/`). The 30-day window resolves the first audit's open question: `output-block-falsify-advisory` is **not** a narrower duplicate that never fires — it is the deny/ask escalation path (1,007 escalations), while `pre-output-falsification-gate` carries the advisory load (161 advises, zero escalations). The split is by severity, and both halves are live. | **Do not merge.** The first audit called the merge "premature" pending more data; the data arrived and argues against merging at all. Cluster B3's code dedup (shared `_lib` matcher) remains worth doing on its own terms — that is a code-duplication fix, not a hook merge. |
+| `pre-output-falsification-gate` (advise ×161, block ×0 / 59,172 fires) vs. `output-block-falsify-advisory` (block ×547, ask ×460, advise ×7 / 59,457 fires) | Both scan for the same "self-authored proposal without falsification" pattern (Cluster B3 — shared evaluative-marker/`Falsified:`-phrase matcher, not yet extracted to `hooks/_lib/`). The 30-day window resolves the first audit's open question: `output-block-falsify-advisory` is **not** a narrower duplicate that never fires — it is the deny/ask path (547 block + 460 ask), while `pre-output-falsification-gate` carries the advisory load (161 advises, zero block and zero ask). The split is by severity, and both halves are live. | **Do not merge.** The first audit called the merge "premature" pending more data; the data arrived and argues against merging at all. Cluster B3's code dedup (shared `_lib` matcher) remains worth doing on its own terms — that is a code-duplication fix, not a hook merge. |
 | `commit-title-length-check` (ask ×418, advise ×60 / 53,212) vs. `commit-title-format-check` (block ×4,868 / 63,709) | Different escalation levels (ask vs. block) gating different failure modes (length vs. format) that share a git-title-parsing helper (Cluster B2). | **Not coverage-duplicate** — keep both hooks; only the shared parser code is a dedup target. |
 
 **False-positive check (naming-only clustering, ruled out):** `pre-merge-approval-gate`,
@@ -141,54 +145,78 @@ types, not redundant coverage. No action.
 
 ## Axis 4 — advisory-only-never-escalated
 
-**Scope restriction (premise-verification):** a coarse-granularity hook records
-only block-vs-pass — its ask/advise fold into `Pass` and are invisible here, so
+**Scope restriction (premise-verification):** a coarse-only hook records just
+block-vs-pass — its ask/advise fold into `Pass` and are invisible here, so
 scoring one on this axis reports a false "never escalates" for a hook whose
-escalations are simply unmeasured. This axis is therefore restricted to the
-**Bash dispatch group**, where the central dispatcher records the real decision
-(block/ask/advise/pass) for every fire. 45 of the window's hooks are in that
-group.
+escalations are simply unmeasured. The axis population is therefore every
+registered hook that emits **at least one rich record**, because a rich record
+carries the real decision and makes the block/ask/advise counts exact. That is
+**63 of the 81** registered hooks; the other **18 are coarse-only** and stay out
+of this axis (`memory-hint`, `external-api-literal-trigger`,
+`block-personal-asset-leak`, `protected-paths-guard`, `worktree-edit-gate`,
+`secret-print-redaction-advisory`, `pre-edit-md-escape-advisory`,
+`pre-edit-protected-branch-guard`, `advisory-wrapper-signature-verify`,
+`bulk-write-memory-checkpoint`, `path-probe-gate`, `exclusion-probe-gate`,
+`push-remote-ref-verify`, `write-decision-consistency-gate`, `bypass-telemetry`,
+`postcompact-context`, `retrospect-active-marker`, `builtin-task-postuse`).
 
-**Result: 4 of 45** dispatch-group hooks logged zero block, zero ask, and zero
-advise across the whole window.
+This is wider than the Bash dispatch group alone (45 hooks). Issue #847 gave
+the completion-verify Stop gates a real `record_session_fire` at their emit
+point and #892 did the same for shell bodies, so those hooks now record their
+escalations exactly and belong **inside** the population — the first audit's
+Stop/UserPromptSubmit exclusion is closed, not merely noted. Pre-#847 "never
+escalates" reads on them were measurement-absent and are not carried forward.
+
+**Result: 3 of 63** logged zero block, zero ask, and zero advise across the
+window — and none of the three is a prune signal.
 
 | Hook | Fires | Sessions | Purpose (verified via spec.md) | Verdict |
 | --- | --- | --- | --- | --- |
-| `jq-config-empty-dict-advisory` | 59,972 | 400 | Warns before `jq` reads a size-0 or malformed config, where `jq` returns the literal `empty` on stdout instead of erroring and downstream code silently takes a wrong default (issue #323). | **KEEP** — the trigger is "a config file that is empty or invalid *at the moment* a `jq` command reads it". 60k clean reads is the healthy state, not evidence of dead code. A guard for a silent-failure mode is supposed to sit quiet. |
-| `version-bump-evidence-check` | 53,212 | 400 | Warns when a `gh issue/pr create/edit` body describes an **external dependency** version bump (`v24 → v25`, `bump SDK from 3.0 to 4.0`) with no changelog or breaking-changes evidence. `strict_env`-gated. | **KEEP** — and the first audit's reasoning for keeping it was wrong. It read the hook as gating praxis's own `VERSION` bump and excused the zero count by noting no release landed inside the window. The window now contains 7 merged `chore(main): release` PRs (7.2.1 → 7.8.0), and those are irrelevant either way: release PRs are authored by release-please, and the hook targets external-SDK bump prose in agent-authored bodies. The correct read is that the trigger is genuinely rare, not that it was untested. |
-| `pytest-direct-exec-advisory` | 692 | 6 | Nudges away from invoking `pytest` directly instead of the repo's runner. | **KEEP — not scoreable.** 6 sessions is measurement-thin; revisit next audit. |
-| `caller-probe-gate` | 330 | 6 | Requires the caller chain be probed before a claim about who calls what. | **KEEP — not scoreable.** Same reason. |
+| `jq-config-empty-dict-advisory` | 60,634 | 402 | Warns before `jq` reads a size-0 or malformed config, where `jq` returns the literal `empty` on stdout instead of erroring and downstream code silently takes a wrong default (issue #323). | **KEEP** — the trigger is "a config file that is empty or invalid *at the moment* a `jq` command reads it". 60k clean reads is the healthy state. A guard for a silent-failure mode is supposed to sit quiet. |
+| `askuserquestion-loop-signal` | 1,930 | 189 | **Observe-only** PostToolUse recorder (issue #740): appends one ledger record per `AskUserQuestion` call to feed the re-clarification-loop outcome proxy. | **KEEP — not a finding.** It has no escalation path at all, so zero escalations is its specification, not evidence about it. An instrumentation-only hook cannot be scored on this axis and should not be read as inert. |
+| `pytest-direct-exec-advisory` | 1,030 | 8 | Nudges away from invoking `pytest` directly instead of the repo's runner. | **KEEP — not scoreable.** 8 sessions is measurement-thin; revisit next audit. |
 
-Every other dispatch-group hook escalated at least once. No hook in this set is
-recommended for **drop**: two are narrow safety nets whose quiet is the
-designed outcome, and two have too little history to judge.
+Every other hook in the population escalated at least once. Excluding the
+observe-only recorder and the thin-sample hook, **no hook with an escalation
+path and an adequate sample sat inert** — there is nothing here to drop.
 
-> **Superseded (issue #847 / #892):** the first audit excluded eight
-> `Stop`/`UserPromptSubmit` hooks from this axis because their decisions
-> collapsed into coarse `Pass`. #847 gave the five completion-verify Stop gates
-> a real `record_session_fire` at their emit point, and #892 did the same for
-> shell bodies, so the blind spot that motivated the exclusion is closed.
-> Pre-#847 "never escalates" reads on those hooks were measurement-absent and
-> should not be carried forward as evidence.
+> **`version-bump-evidence-check` — the first audit kept it for the wrong
+> reason.** That audit read it as gating praxis's own `VERSION` bump and
+> excused its zero count by noting no release landed inside the window. The
+> hook actually targets **external dependency** bump prose (`v24 → v25`,
+> `bump SDK from 3.0 to 4.0`) in agent-authored `gh issue/pr` bodies; the 7
+> `chore(main): release` PRs in this window are irrelevant to it either way,
+> being authored by release-please. It sat at zero escalations for most of
+> this audit and then logged its first `advise` before the audit finished, so
+> it is no longer in the table above — the trigger is rare, not absent.
+
+**Observer effect.** The ledger is append-only and live, and the session
+writing this audit is one of the sessions being counted.
+`version-bump-evidence-check` and `caller-probe-gate` both moved from zero
+escalations to non-zero while the audit was being written. Treat single-digit
+escalation counts as provisional.
 
 ## Summary verdict table
 
 | Verdict | Count | Hooks |
 | --- | --- | --- |
-| **Keep** (active, or narrow safety net whose quiet is by design) | 77 | Every registered hook not listed below |
-| **Investigate** (non-drop follow-up) | 2 | `pre-gh-pr-create-dedup-gate` (24% ignored — is the advisory actionable?), `memory-hint` (68,799 fires, 0 recorded escalations against 12 memories declaring `hookable: true`; it is coarse-recorded, so that 0 is *measurement-absent*, not evidence — the open question is whether its `hookKeywords` match real tool-call text) |
-| **Keep, but not yet scoreable — revisit next audit** | 2 | `pytest-direct-exec-advisory`, `caller-probe-gate` (6 sessions each) |
+| **Keep** (active, or narrow safety net whose quiet is by design) | 60 | Every rich-recording hook not listed below |
+| **Investigate** (non-drop follow-up) | 1 | `pre-gh-pr-create-dedup-gate` — 24% ignored on 361 observed advises; is the advisory actionable? |
+| **Keep, but not scoreable on Axis 4** | 2 | `askuserquestion-loop-signal` (observe-only by design — no escalation path), `pytest-direct-exec-advisory` (8 sessions) |
+| **Keep, but coarse-recorded — Axis 4 cannot see them** | 18 | The coarse-only list under Axis 4, including `memory-hint` (68,799 fires against 12 memories declaring `hookable: true`; its 0 escalations are *measurement-absent*, so the open question — do its `hookKeywords` match real tool-call text? — stays open) |
 | **Unmeasurable — instrument first** | 0 | — (closed by #847 + #892; see Axis 1) |
 | **Drop** | 0 | — |
-| **Total** | 81 | Matches `hooks/manifest.json`'s 81 distinct names (77+2+2) |
+| **Total** | 81 | Matches `hooks/manifest.json`'s 81 distinct names (60+1+2+18) |
 
 ## Bottom line
 
 No hook meets the bar for removal, on a sample 15× larger than the first
 audit's. The roster grew 58 → 81 in a month, and that growth is still not
-visibly dead weight: 41 of 45 dispatch-group hooks escalated at least once in
-30 days, and the four that did not are two rare-by-design guards plus two
-hooks with almost no history.
+visibly dead weight: 60 of the 63 hooks whose escalations are exactly recorded
+fired a real decision at least once in 30 days, and of the three that did not,
+one is an observe-only recorder with no escalation path and one has an 8-session
+history. Only `jq-config-empty-dict-advisory` is genuinely inert — and it guards
+a silent-failure mode, so quiet is what it looks like when it works.
 
 What the larger window did change is which *claims* survive:
 
@@ -201,7 +229,12 @@ What the larger window did change is which *claims* survive:
    session it was drawn from. The delivery-channel question is still open, but
    it needs an experiment rather than a bigger window.
 4. `version-bump-evidence-check` was kept for the wrong reason and stays kept
-   for the right one.
+   for the right one — it gates external-dependency bump prose, not praxis's
+   own release, and it logged its first `advise` before this audit finished.
+5. Axis 4's population is no longer the Bash dispatch group alone. #847 and
+   #892 made 63 of the 81 hooks exactly scoreable, and widening the axis to
+   all of them is what surfaced `askuserquestion-loop-signal` — a hook whose
+   zero escalations are its specification, not a signal about it.
 
 ### What this audit still cannot answer
 

--- a/docs/hook/RULE-BACKSTOP-GAPS.md
+++ b/docs/hook/RULE-BACKSTOP-GAPS.md
@@ -24,8 +24,10 @@ this gap list ranks where to extend it next (issue #709).
 
 Cross-reference of two inventories:
 
-- **What is hooked** — `hooks/manifest.json` + each hook's `spec.md` (58 hooks,
-  ~20 deduplicated backstopped rule-concepts).
+- **What is hooked** — `hooks/manifest.json` + each hook's `spec.md` (58 hooks
+  at the time of this cross-reference; the manifest registers 81 as of
+  2026-08-03 — the gap list below has not been re-derived against the newer
+  roster, so treat it as scoped to the 58).
 - **What the ruleset requires** — the prompt-layer MUST / MANDATORY / "no
   exceptions" rules in the global agent ruleset and [`ETHOS.md`](../../ETHOS.md).
 

--- a/skills/bypass-review/bypass-review
+++ b/skills/bypass-review/bypass-review
@@ -1380,6 +1380,15 @@ def default_manifest_path() -> Path:
     return Path(__file__).resolve().parents[2] / "hooks" / "manifest.json"
 
 
+_PY_DECORATOR_RE = re.compile(r"@fail_open(?![\w])")
+_PY_IMPORT_RE = re.compile(
+    r"(from\s+[\w.]+\s+)?import\s+.*(?<![\w])fail_open(?![\w])")
+# `.*` rather than `\S*`: the real source line is
+# `. "$(dirname "$0")/../../_lib/record_fire.sh"`, whose path argument contains
+# a space inside the command substitution.
+_SH_SOURCE_RE = re.compile(r"(\.|source)\s+.*record_fire\.sh(?![\w.])")
+
+
 def records_fire_events(source: str) -> bool:
     """Does this hook body actually reach a fire-recording chokepoint?
 
@@ -1397,17 +1406,24 @@ def records_fire_events(source: str) -> bool:
       - `@fail_open` decorator (Python)
       - an `import` of `fail_open` (Python)
       - a `source` / `.` line pulling in `record_fire.sh` (shell)
+
+    Each pattern is anchored to the start of the stripped line and closed off
+    with a token boundary, which is what keeps the marker from matching where
+    it is merely *mentioned*: `print("import fail_open")` and
+    `x = "from m import fail_open"` do not begin with `import`/`from`, and
+    `@fail_opened` / `import fail_opened` fail the boundary. Anchoring costs
+    a few real forms — a source line behind a `;` separator, a parenthesised
+    multi-line import — and that is the direction to err in: a missed form
+    lands the hook in "cannot be judged", while a false match lands it in the
+    never-fired roster and reads as a prune candidate.
     """
     for raw in source.splitlines():
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
-        if line.startswith("@fail_open"):
+        if _PY_DECORATOR_RE.match(line) or _PY_IMPORT_RE.match(line):
             return True
-        if "import" in line and "fail_open" in line:
-            return True
-        if "record_fire.sh" in line and (
-                line.startswith("source ") or line.startswith(". ")):
+        if _SH_SOURCE_RE.match(line):
             return True
     return False
 

--- a/skills/bypass-review/bypass-review
+++ b/skills/bypass-review/bypass-review
@@ -1380,6 +1380,38 @@ def default_manifest_path() -> Path:
     return Path(__file__).resolve().parents[2] / "hooks" / "manifest.json"
 
 
+def records_fire_events(source: str) -> bool:
+    """Does this hook body actually reach a fire-recording chokepoint?
+
+    Matches the instrumentation *syntax*, not a bare substring. Every shell
+    hook in this repo carries a `# shellcheck source=../../_lib/record_fire.sh`
+    directive on the line directly above the real `. "…/record_fire.sh"` —
+    so a body that mentions a marker only in a comment is not hypothetical,
+    it is one deleted line away in four existing files. A substring test
+    would keep calling such a body instrumented, and a hook wrongly called
+    instrumented lands in the never-fired roster, where it reads as a prune
+    candidate. The mirror error is harmless: wrongly calling a body
+    uninstrumented only moves it to the "cannot be judged" list.
+
+    Recognised chokepoints, comment lines excluded:
+      - `@fail_open` decorator (Python)
+      - an `import` of `fail_open` (Python)
+      - a `source` / `.` line pulling in `record_fire.sh` (shell)
+    """
+    for raw in source.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("@fail_open"):
+            return True
+        if "import" in line and "fail_open" in line:
+            return True
+        if "record_fire.sh" in line and (
+                line.startswith("source ") or line.startswith(". ")):
+            return True
+    return False
+
+
 def roster_split(manifest_path: Path) -> tuple[set[str], set[str]] | None:
     """Split manifest hook names into (instrumentable, uninstrumentable).
 
@@ -1391,11 +1423,11 @@ def roster_split(manifest_path: Path) -> tuple[set[str], set[str]] | None:
 
     The classification asks, per hook, whether it reaches any of the three:
     membership in the Bash dispatch group (where the central dispatcher does
-    the recording, so the hook's own body carries no marker), or a
-    `fail_open` / `record_fire` reference in its body at
-    `hooks/<role>/<name>/<body or impl.py>`. All three must be checked —
-    testing the body alone misclassifies every dispatch-group hook, which is
-    most of the roster.
+    the recording, so the hook's own body carries no marker), or an
+    instrumentation statement in its body at
+    `hooks/<role>/<name>/<body or impl.py>` (see `records_fire_events`).
+    All three must be checked — testing the body alone misclassifies every
+    dispatch-group hook, which is most of the roster.
 
     The older proxy — "`body` ends `.sh` means uninstrumented" — predates
     #892 and reports the four shell hooks as emitting no fire events while
@@ -1406,7 +1438,6 @@ def roster_split(manifest_path: Path) -> tuple[set[str], set[str]] | None:
 
     Returns None if the manifest can't be read.
     """
-    fire_markers = ("record_fire", "fail_open")
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         hooks_dir = manifest_path.parent
@@ -1429,7 +1460,7 @@ def roster_split(manifest_path: Path) -> tuple[set[str], set[str]] | None:
                 try:
                     source = (hooks_dir / role / name / body).read_text(
                         encoding="utf-8", errors="replace")
-                    instrumented = any(m in source for m in fire_markers)
+                    instrumented = records_fire_events(source)
                 except OSError:
                     instrumented = not body.endswith(".sh")
             # A name with several manifest entries (multi-event hooks) is

--- a/skills/bypass-review/bypass-review
+++ b/skills/bypass-review/bypass-review
@@ -1383,18 +1383,34 @@ def default_manifest_path() -> Path:
 def roster_split(manifest_path: Path) -> tuple[set[str], set[str]] | None:
     """Split manifest hook names into (instrumentable, uninstrumentable).
 
-    The fire-ledger can only record hooks that flow through the Python
-    @fail_open decorator (coarse) or the Bash dispatch group (rich). Shell hooks
-    (`body: impl.sh`) have no such chokepoint, so they can NEVER produce a fire
-    event and must be excluded from the 'never fired' set — otherwise a shell
-    hook that runs every session is mislabelled as a dead-prune candidate.
+    The fire-ledger can only record hooks that reach a recording chokepoint:
+    the Python `@fail_open` decorator, the Bash dispatch group, or — since
+    issue #892 — `hooks/_lib/record_fire.sh` for shell bodies. A hook with no
+    chokepoint can NEVER produce a fire event and must be excluded from the
+    'never fired' set, or a live hook is mislabelled as a dead-prune candidate.
 
-    Proxy: instrumentable == body is not an `.sh` file (Python impl, which the
-    praxis convention wraps in @fail_open); uninstrumentable == `body` ends
-    `.sh`. Returns None if the manifest can't be read.
+    The classification asks, per hook, whether it reaches any of the three:
+    membership in the Bash dispatch group (where the central dispatcher does
+    the recording, so the hook's own body carries no marker), or a
+    `fail_open` / `record_fire` reference in its body at
+    `hooks/<role>/<name>/<body or impl.py>`. All three must be checked —
+    testing the body alone misclassifies every dispatch-group hook, which is
+    most of the roster.
+
+    The older proxy — "`body` ends `.sh` means uninstrumented" — predates
+    #892 and reports the four shell hooks as emitting no fire events while
+    the same report tabulates thousands of theirs. When the body cannot be
+    read, that extension proxy stays as the documented fallback: it is the
+    only signal left, and it errs toward the pre-#892 behaviour rather than
+    inventing a verdict.
+
+    Returns None if the manifest can't be read.
     """
+    fire_markers = ("record_fire", "fail_open")
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        hooks_dir = manifest_path.parent
+        dispatch_group = bash_group_roster(manifest_path) or set()
         instrumentable: set[str] = set()
         uninstrumentable: set[str] = set()
         for hook in manifest.get("hooks", []):
@@ -1403,11 +1419,27 @@ def roster_split(manifest_path: Path) -> tuple[set[str], set[str]] | None:
             name = hook.get("name")
             if not isinstance(name, str) or not name:
                 continue  # non-string name would break sorted() in the report
-            body = hook.get("body") or ""
-            if isinstance(body, str) and body.endswith(".sh"):
-                uninstrumentable.add(name)
+            body = hook.get("body") or "impl.py"
+            role = hook.get("role") or ""
+            if not isinstance(body, str) or not isinstance(role, str):
+                continue
+            if name in dispatch_group:
+                instrumented = True
             else:
+                try:
+                    source = (hooks_dir / role / name / body).read_text(
+                        encoding="utf-8", errors="replace")
+                    instrumented = any(m in source for m in fire_markers)
+                except OSError:
+                    instrumented = not body.endswith(".sh")
+            # A name with several manifest entries (multi-event hooks) is
+            # instrumented if ANY of its bodies records — discard an earlier
+            # uninstrumented verdict rather than letting entry order decide.
+            if instrumented:
                 instrumentable.add(name)
+                uninstrumentable.discard(name)
+            elif name not in instrumentable:
+                uninstrumentable.add(name)
         return instrumentable, uninstrumentable
     except Exception:
         return None
@@ -1697,19 +1729,20 @@ def render_fire_report(
         # shell hooks as dead-prune candidates (codex #714 P2).
         if uninstrumentable:
             lines.append("")
-            lines.append(_render_header("Uninstrumented (shell hooks — never recorded)"))
+            lines.append(_render_header("Uninstrumented (no recording chokepoint)"))
             lines.append(
-                f"  {len(uninstrumentable)} shell (.sh) hook(s) have no @fail_open /"
-                " dispatch\n  chokepoint, so they emit NO fire events and are EXCLUDED"
-                " from the\n  never-fired set above. Their activity cannot be judged"
-                " from this report:")
+                f"  {len(uninstrumentable)} hook(s) reach no @fail_open / dispatch /"
+                "\n  record_fire chokepoint, so they emit NO fire events and are"
+                " EXCLUDED\n  from the never-fired set above. Their activity cannot be"
+                " judged\n  from this report:")
             for name in sorted(uninstrumentable):
                 lines.append(f"    · {name}")
     lines.append("")
     lines.append(
-        "  Ceiling: coverage spans every hook that uses the @fail_open decorator\n"
-        "  (the praxis convention) plus the Bash dispatch group. Shell (.sh) hooks\n"
-        "  are uninstrumented and listed separately above."
+        "  Ceiling: coverage spans every hook that reaches a recording\n"
+        "  chokepoint — the @fail_open decorator, the Bash dispatch group, or\n"
+        "  hooks/_lib/record_fire.sh for shell bodies (issue #892). Anything\n"
+        "  that reaches none of them is listed separately above."
     )
     return "\n".join(lines)
 

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -512,6 +512,48 @@ def test_roster_split_reads_the_body_for_a_recording_chokepoint(tmp_path):
     assert uninstrumentable == {"silent", "pysilent"}
 
 
+def test_records_fire_events_ignores_a_marker_that_only_appears_in_a_comment():
+    """A commented marker is not instrumentation — and that shape already exists.
+
+    Every shell hook here carries `# shellcheck source=../../_lib/record_fire.sh`
+    on the line directly above the real `.` source line, so a comment-only body
+    is one deleted line away in four files. A substring test would still call it
+    instrumented, which puts a hook that cannot record into the never-fired
+    roster, where it reads as a prune candidate.
+    """
+    assert cli.records_fire_events(
+        '#!/bin/bash\n# shellcheck source=../../_lib/record_fire.sh\nexit 0\n') is False
+    assert cli.records_fire_events("# this module used to use @fail_open\nx = 1\n") is False
+    assert cli.records_fire_events('"""record_fire is described in this docstring"""\n') is False
+
+
+def test_records_fire_events_accepts_each_real_chokepoint_form():
+    assert cli.records_fire_events(
+        '#!/bin/bash\n. "$(dirname "$0")/../../_lib/record_fire.sh" 2>/dev/null || true\n')
+    assert cli.records_fire_events(
+        '#!/bin/bash\n    source "$(dirname "$0")/../../_lib/record_fire.sh"\n')
+    assert cli.records_fire_events("@fail_open\ndef run(payload):\n    return None\n")
+    assert cli.records_fire_events(
+        "from _hook_runtime import fail_open  # noqa: E402\n")
+
+
+def test_roster_split_counts_a_comment_only_body_as_uninstrumented(tmp_path):
+    """The end-to-end path, not just the matcher: a decorative marker must not
+    move a hook out of the uninstrumented list."""
+    hooks_dir = tmp_path / "hooks"
+    _write_hook_body(hooks_dir, "completion-verify", "decorative", "impl.sh",
+                     "#!/bin/bash\n# shellcheck source=../../_lib/record_fire.sh\nexit 0\n")
+    manifest = {"hooks": [
+        {"name": "decorative", "role": "completion-verify", "body": "impl.sh",
+         "event": "Stop"},
+    ]}
+    mpath = hooks_dir / "manifest.json"
+    mpath.write_text(json.dumps(manifest))
+    instrumentable, uninstrumentable = cli.roster_split(mpath)
+    assert instrumentable == set()
+    assert uninstrumentable == {"decorative"}
+
+
 def test_roster_split_counts_dispatch_group_membership_as_recorded(tmp_path):
     """A dispatch-group hook is recorded centrally, so its body carries no marker."""
     hooks_dir = tmp_path / "hooks"

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -458,11 +458,12 @@ def test_count_session_fires_roundtrip_with_real_writer(tmp_path, monkeypatch):
     ) == 2
 
 
-def test_roster_split_separates_shell_hooks(tmp_path):
+def test_roster_split_falls_back_to_the_extension_proxy(tmp_path):
+    """No body on disk -> the pre-#892 extension proxy is the only signal left."""
     manifest = {"hooks": [
-        {"name": "a", "event": "PreToolUse", "matcher": "Bash"},   # py (instrumentable)
+        {"name": "a", "event": "PreToolUse", "matcher": "Bash"},   # dispatch group
         {"name": "b", "event": "Stop"},                            # py (instrumentable)
-        {"name": "sh1", "event": "Stop", "body": "impl.sh"},       # shell (uninstrumentable)
+        {"name": "sh1", "event": "Stop", "body": "impl.sh"},       # shell, unreadable
         "not-a-dict",
         {"event": "Stop"},  # no name -> skipped
     ]}
@@ -471,6 +472,80 @@ def test_roster_split_separates_shell_hooks(tmp_path):
     instrumentable, uninstrumentable = cli.roster_split(mpath)
     assert instrumentable == {"a", "b"}
     assert uninstrumentable == {"sh1"}
+
+
+def _write_hook_body(hooks_dir, role, name, body, source):
+    d = hooks_dir / role / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / body).write_text(source, encoding="utf-8")
+
+
+def test_roster_split_reads_the_body_for_a_recording_chokepoint(tmp_path):
+    """#892 gave shell hooks record_fire.sh — the extension alone is now wrong.
+
+    Before this, `body: impl.sh` was read as "emits no fire events", so the
+    report claimed the four shell hooks were unrecorded while its own per-hook
+    table tabulated thousands of their fires. The classification must follow
+    the chokepoint, not the file extension.
+    """
+    hooks_dir = tmp_path / "hooks"
+    _write_hook_body(hooks_dir, "completion-verify", "recorded", "impl.sh",
+                     '#!/bin/bash\nsource "$(dirname "$0")/../../_lib/record_fire.sh"\n')
+    _write_hook_body(hooks_dir, "completion-verify", "silent", "impl.sh",
+                     "#!/bin/bash\nexit 0\n")
+    _write_hook_body(hooks_dir, "preflight-gate", "pyhook", "impl.py",
+                     "from _fail_open import fail_open\n")
+    _write_hook_body(hooks_dir, "preflight-gate", "pysilent", "impl.py",
+                     "print('nothing here')\n")
+    manifest = {"hooks": [
+        {"name": "recorded", "role": "completion-verify", "body": "impl.sh",
+         "event": "Stop"},
+        {"name": "silent", "role": "completion-verify", "body": "impl.sh",
+         "event": "Stop"},
+        {"name": "pyhook", "role": "preflight-gate", "event": "PostToolUse"},
+        {"name": "pysilent", "role": "preflight-gate", "event": "PostToolUse"},
+    ]}
+    mpath = hooks_dir / "manifest.json"
+    mpath.write_text(json.dumps(manifest))
+    instrumentable, uninstrumentable = cli.roster_split(mpath)
+    assert instrumentable == {"recorded", "pyhook"}
+    assert uninstrumentable == {"silent", "pysilent"}
+
+
+def test_roster_split_counts_dispatch_group_membership_as_recorded(tmp_path):
+    """A dispatch-group hook is recorded centrally, so its body carries no marker."""
+    hooks_dir = tmp_path / "hooks"
+    _write_hook_body(hooks_dir, "preflight-gate", "grouped", "impl.py",
+                     "def run(payload):\n    return None\n")
+    manifest = {"hooks": [
+        {"name": "grouped", "role": "preflight-gate", "event": "PreToolUse",
+         "matcher": "Bash"},
+    ]}
+    mpath = hooks_dir / "manifest.json"
+    mpath.write_text(json.dumps(manifest))
+    instrumentable, uninstrumentable = cli.roster_split(mpath)
+    assert instrumentable == {"grouped"}
+    assert uninstrumentable == set()
+
+
+def test_roster_split_lets_one_recorded_entry_win_for_a_multi_event_hook(tmp_path):
+    """Entry order must not decide: any recording entry makes the name recorded."""
+    hooks_dir = tmp_path / "hooks"
+    _write_hook_body(hooks_dir, "completion-verify", "multi", "impl.sh",
+                     "#!/bin/bash\nexit 0\n")
+    _write_hook_body(hooks_dir, "completion-verify", "multi", "impl2.sh",
+                     '#!/bin/bash\nsource ../../_lib/record_fire.sh\n')
+    manifest = {"hooks": [
+        {"name": "multi", "role": "completion-verify", "body": "impl.sh",
+         "event": "SessionStart"},
+        {"name": "multi", "role": "completion-verify", "body": "impl2.sh",
+         "event": "Stop"},
+    ]}
+    mpath = hooks_dir / "manifest.json"
+    mpath.write_text(json.dumps(manifest))
+    instrumentable, uninstrumentable = cli.roster_split(mpath)
+    assert instrumentable == {"multi"}
+    assert uninstrumentable == set()
 
 
 def _reset_real_dispatcher_flag(monkeypatch):

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -512,29 +512,47 @@ def test_roster_split_reads_the_body_for_a_recording_chokepoint(tmp_path):
     assert uninstrumentable == {"silent", "pysilent"}
 
 
-def test_records_fire_events_ignores_a_marker_that_only_appears_in_a_comment():
-    """A commented marker is not instrumentation — and that shape already exists.
+# The input surface of records_fire_events(), enumerated up front rather than
+# one reviewer round at a time. A marker can appear in a comment, inside a
+# string, or as the prefix of an unrelated name — and the first two shapes are
+# not hypothetical: every shell hook here carries
+# `# shellcheck source=../../_lib/record_fire.sh` on the line directly above
+# its real `.` source line.
+#
+# The two error directions are not symmetric. A missed real form leaves the
+# hook in "cannot be judged", which is safe; a false match puts a hook that
+# cannot record into the never-fired roster, where it reads as a prune
+# candidate. Anchoring therefore errs toward rejecting.
+RECORDS_FIRE_CASES = [
+    # (label, source, expected)
+    ("A1 shell comment-only", '#!/bin/bash\n# shellcheck source=../../_lib/record_fire.sh\nexit 0\n', False),
+    ("A2 python comment mention", "# this module used to use @fail_open\nx = 1\n", False),
+    ("A3 decorator + trailing comment", "@fail_open  # noqa\ndef run(p): pass\n", True),
+    ("A4 source + trailing comment", '. "$(dirname "$0")/../../_lib/record_fire.sh"  # load\n', True),
+    ("B1 marker inside a call argument", 'print("import fail_open")\n', False),
+    ("B2 marker inside an assignment", 'MSG = "source record_fire.sh"\n', False),
+    ("B3 marker inside a docstring", '"""record_fire is described in this docstring"""\n', False),
+    ("B4 decorator text inside a string", 'msg = "@fail_open"\n', False),
+    ("B5 source line echoed as text", 'echo ". ../_lib/record_fire.sh"\n', False),
+    ("B6 import text inside a string", 'x = "from m import fail_open"\n', False),
+    ("C1 unrelated @fail_opened", "@fail_opened\ndef run(p): pass\n", False),
+    ("C2 unrelated @fail_open_v2", "@fail_open_v2\ndef run(p): pass\n", False),
+    ("C3 bare decorator", "@fail_open\ndef run(p): pass\n", True),
+    ("C4 decorator with args", "@fail_open()\ndef run(p): pass\n", True),
+    ("C5 unrelated symbol imported", "from m import fail_opened\n", False),
+    ("C6 neighbouring filename", ". ../_lib/record_fire.sh.bak\n", False),
+    ("D1 indented source line", '    . "$(dirname "$0")/../../_lib/record_fire.sh" 2>/dev/null || true\n', True),
+    ("D2 source keyword form", '    source "$(dirname "$0")/../../_lib/record_fire.sh"\n', True),
+    ("F1 from-import with comment", "from _hook_runtime import fail_open  # noqa: E402\n", True),
+    ("F2 bare import", "import fail_open\n", True),
+    ("F3 aliased import", "from _hook_runtime import fail_open as fo\n", True),
+]
 
-    Every shell hook here carries `# shellcheck source=../../_lib/record_fire.sh`
-    on the line directly above the real `.` source line, so a comment-only body
-    is one deleted line away in four files. A substring test would still call it
-    instrumented, which puts a hook that cannot record into the never-fired
-    roster, where it reads as a prune candidate.
-    """
-    assert cli.records_fire_events(
-        '#!/bin/bash\n# shellcheck source=../../_lib/record_fire.sh\nexit 0\n') is False
-    assert cli.records_fire_events("# this module used to use @fail_open\nx = 1\n") is False
-    assert cli.records_fire_events('"""record_fire is described in this docstring"""\n') is False
 
-
-def test_records_fire_events_accepts_each_real_chokepoint_form():
-    assert cli.records_fire_events(
-        '#!/bin/bash\n. "$(dirname "$0")/../../_lib/record_fire.sh" 2>/dev/null || true\n')
-    assert cli.records_fire_events(
-        '#!/bin/bash\n    source "$(dirname "$0")/../../_lib/record_fire.sh"\n')
-    assert cli.records_fire_events("@fail_open\ndef run(payload):\n    return None\n")
-    assert cli.records_fire_events(
-        "from _hook_runtime import fail_open  # noqa: E402\n")
+@pytest.mark.parametrize("label,source,expected", RECORDS_FIRE_CASES,
+                         ids=[c[0] for c in RECORDS_FIRE_CASES])
+def test_records_fire_events_surface(label, source, expected):
+    assert cli.records_fire_events(source) is expected
 
 
 def test_roster_split_counts_a_comment_only_body_as_uninstrumented(tmp_path):


### PR DESCRIPTION
Caller chain verified: grep -rn 'roster_split|bash_group_roster' --include='*.py' --include='bypass-review' → 리포 내 호출자는 `skills/bypass-review/bypass-review` 안 2곳(:1756 `roster = roster_split(...)`, :1770 `bash_group_roster(...)`)과 신규 `roster_split` 내부 :1413 뿐. 시그니처·반환 타입 `tuple[set,set]|None` 무변경, 외부 호출자 0.

Pre-commit verified: PRAXIS_TESTS_STRICT=1 ./scripts/run-tests.sh → ALL TESTS PASSED (Passed 42 / Failed 0, manifest check OK, hook-token invariant OK 7건, ruff clean, shellcheck clean, markdownlint 대상 2파일 0 issues); python3 -m pytest tests/test_fire_ledger.py → 101 passed

## 무엇을

#874 Task 2 — `docs/hook-prune-audit.md` 의 keep/merge/drop 판정을 30일 창으로 재산출합니다. 그 과정에서 판정의 입력이 되는 도구 자체의 결함을 하나 발견해 함께 고칩니다.

Refs #874

이슈의 Task 4개 중 **Task 2 만** 다룹니다. Task 3(ADVISE 전달 경로)은 이 데이터로 결론나지 않아 실험이 필요하고, Task 4(`side-effect-scan` 임계)는 별도 판단이라 `Closes` 가 아닌 `Refs` 로 겁니다.

## 도구 결함 — 리포트가 자기 데이터와 모순된 문장을 출력하고 있었습니다

`roster_split()` 이 "body 가 `.sh` 면 계측 불가" 프록시를 씁니다. **#892 이전 기준**입니다. #892 가 shell body 에 `hooks/_lib/record_fire.sh` 를 준 뒤로 리포트는 이렇게 출력해 왔습니다.

```text
  retrospect-mix-check   R  7680  block=3026 ...
  strike-counter         R  3359  block=75 advise=75 ...
  codex-review-route     R  2001  advise=189 ...
  completion-verify      R  1801  block=195 ...
  ...
Uninstrumented (shell hooks — never recorded)
  4 shell (.sh) hook(s) have no @fail_open / dispatch chokepoint,
  so they emit NO fire events ...
    · codex-review-route
    · completion-verify
    · retrospect-mix-check
    · strike-counter
```

약 15,000건을 집계한 표 바로 아래에서 "이들은 fire event 를 내지 않는다"고 단언합니다. 이 분류가 never-fired 로스터의 근거라 감사 판정까지 오염됩니다 — 구 문서는 이 4개를 "Unmeasurable — instrument first"로 분류하고 있었습니다.

**수정:** 판정을 실제 chokepoint 로 바꿉니다 — Bash dispatch 그룹 소속(중앙 디스패처가 기록하므로 body 에 마커가 없음), 또는 body 의 `fail_open` / `record_fire` 참조. body 를 읽을 수 없을 때만 기존 확장자 프록시를 fallback 으로 남깁니다.

**첫 구현이 틀렸고 실행이 잡았습니다.** body 마커만 검사했더니 dispatch 그룹 훅 5개(`side-effect-scan`, `pre-merge-approval-gate`, `commit-title-length-check`, `external-write-path-existence-check`, `version-bump-evidence-check`)가 거꾸로 "계측 불가"로 뒤집혔습니다 — `side-effect-scan` 은 30일간 53,212회 발화하는 훅입니다. 세 chokepoint 를 모두 봐야 합니다.

```text
before : uninstrumentable = {codex-review-route, completion-verify,
                             retrospect-mix-check, strike-counter}
중간   : uninstrumentable = {side-effect-scan, pre-merge-approval-gate,
                             commit-title-length-check, ...}   ← 오히려 악화
after  : uninstrumentable = {}   (등록 81개 전부 계측 가능)
```

리포트의 `Uninstrumented` 섹션이 사라지고 never-fired 는 여전히 0건입니다.

## 감사 재산출 (2026-07-05 → 08-03, 743 세션, 81 훅)

첫 감사는 49 세션 / 실질 5일이었습니다. 표본이 15배입니다.

| 축 | 결과 |
| --- | --- |
| Axis 1 never-fired | **0건** — 등록 81개 전부 발화 |
| Axis 2 advise-ignored | `pipefail-advisory` 24%(250/1056), `pre-gh-pr-create-dedup-gate` 24%(86/361) |
| Axis 4 never-escalated | dispatch 그룹 45개 중 **4개** |
| **Drop** | **0건** |

Axis 4 의 4개는 `jq-config-empty-dict-advisory`(59,972 발화 / 400 세션), `version-bump-evidence-check`(53,212 / 400), 그리고 세션 6개짜리 신규 훅 2개입니다. 앞 둘은 조용한 것이 설계된 결과이고, 뒤 둘은 판단할 이력이 없습니다.

## 큰 표본이 구 문서의 주장을 뒤집은 지점

**1. falsification-gate 쌍 — "merge 보류" → "merge 하지 말 것"**

구 문서는 데이터 부족을 이유로 판단을 미뤘습니다. 30일 창에서는 심각도 분리가 명확합니다.

| 훅 | block | ask | advise |
| --- | --- | --- | --- |
| `output-block-falsify-advisory` | 547 | 460 | 7 |
| `pre-output-falsification-gate` | 0 | 0 | 161 |

한쪽이 escalation 1,007건을 지고 다른 쪽이 advisory 를 집니다. 중복 커버리지가 아니라 살아 있는 역할 분담입니다. (Cluster B3 의 **코드** dedup 은 여전히 별개로 유효합니다.)

**2. `version-bump-evidence-check` — 유지 이유가 틀렸습니다**

구 문서는 "praxis 자체 `VERSION` 범프가 측정 창 밖이라 미발화"로 정당화했습니다. `spec.md` 를 읽으니 이 훅은 **외부 의존성** 버전 범프 문구(`v24 → v25`, `bump SDK from 3.0 to 4.0`)를 `gh issue/pr` body 에서 잡습니다. 창 안 릴리스 PR 7건(7.2.1 → 7.8.0)과 무관하고, 그것들은 release-please 가 만듭니다. 결론(KEEP)은 같고 근거를 교체했습니다.

## 이슈 본문의 핵심 전제 반증

#874 는 단일 세션(2026-07-27, `5d46110f`)에서 ADVISE 42건이 아무 행동도 바꾸지 못한 것을 근거로 "ADVISE 티어 효과 = 0"이라 했습니다. 743 세션에서는 지지되지 않습니다.

| 훅 | 재발률 |
| --- | --- |
| `pipefail-advisory` | 24% (약 3/4는 조건 해소) |
| `inspection-chain-advisory` | 5% |
| `momentum-rule-retrieval-gate` | 1% (510건 관측) |

깨끗한 반박은 아니며, 문서에 한계 두 가지를 함께 적었습니다: (a) 지표가 훅 자신의 재평가일 뿐 행동 diff 가 아니고, 세션이 매처 밖 명령으로 옮겨가도 heed 로 보입니다. (b) right-censored 표본(세션 마지막 advise) 제외가 무작위가 아닙니다 — 조언 직후 끝난 세션이야말로 아무 조치도 없던 경우입니다.

전달 경로(stderr vs `systemMessage`) 질문은 이 데이터로 어느 쪽으로도 결론나지 않으며 실험이 필요하다는 점도 명시했습니다.

## 자체 검증에서 잡은 제 초안 오류

인용 수치를 전사 신뢰 대신 ledger 에서 재산출해 대조했고, 두 건이 걸렸습니다.

| 초안 | 실제 |
| --- | --- |
| 창 안 릴리스 PR "8건" | **7건** (`gh pr list` 재확인) |
| `memory-hint` 의 `hookable: true` "13개" (구 문서에서 이어받음) | **12개** (`grep -rl` 재확인) |

fire 카운트는 원장이 append-only 라 재실행마다 수십씩 오릅니다(예: `retrospect-mix-check` 7,673 → 7,680). 스냅샷 시점을 문서에 밝히고, 판정이 기대는 수치는 fire 가 아니라 escalation 임을 명시했습니다.

## 테스트

`roster_split` 테스트 4건 — fallback / body 마커 / dispatch 그룹 / 다중 entry.

**음성 대조:** 구 `roster_split` 로 되돌리면(`git stash`) 신규 중 2건이 FAIL 합니다.

```console
FAILED test_roster_split_reads_the_body_for_a_recording_chokepoint
FAILED test_roster_split_lets_one_recorded_entry_win_for_a_multi_event_hook
2 failed, 6 passed
```

## 곁가지 하나

`docs/hook/RULE-BACKSTOP-GAPS.md` 도 "58 hooks" 를 들고 있습니다. 그 문서의 교차분석 시점 값이라 숫자를 갈아끼우지 않고, 시점·현재 81개·재도출되지 않았음을 주석으로 남겼습니다. 그 문서의 결론은 건드리지 않았습니다.

## 검증하지 못한 것

- **어떤 판정도 훅의 "효과"를 측정하지 않습니다.** 원장은 발화만 기록하고, Axis 2 의 heed rate 는 훅 자신의 재평가입니다. 따라서 "keep" 은 "제거할 근거 없음"이지 "가치 입증"이 아닙니다. 문서 안에 별도 절로 명시했습니다.
- **`roster_split` 의 OSError fallback 경로**는 합성 manifest(디스크에 body 파일 없음)로만 덮었고, 권한 오류 등 실제 OSError 는 재현하지 않았습니다.
- **Task 3 / Task 4 미착수** — 각각 실험과 별도 임계 판단이 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the 30-day hook audit with expanded coverage, clearer recurrence guidance, and refreshed verdict totals.
  - Clarified roster cross-reference coverage and documented limitations in the gap analysis.

- **Improvements**
  - Improved fire-event coverage reporting for Python and shell hooks.
  - Added more accurate detection for instrumented hooks, including multi-entry and dispatch-group scenarios.
  - Reports now clearly identify hooks without recording coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->