### PR TITLE
fix(hooks): stop gh api squash path falling through

### DIFF
--- a/hooks/preflight-gate/commit-title-length-check/impl.py
+++ b/hooks/preflight-gate/commit-title-length-check/impl.py
@@ -429,6 +429,10 @@ def main() -> int:
                 )
                 return 0
 
+            # The `gh api` branch is done with this argv — `merge_segment` is
+            # None here, so falling through would unpack None.
+            continue
+
         tail, repo = merge_segment
         has_squash, identifier, tail_repo, subject = _scan_merge_tail(tail)
         if not has_squash:

--- a/tests/hooks/preflight-gate/test_commit_title_length_check.sh
+++ b/tests/hooks/preflight-gate/test_commit_title_length_check.sh
@@ -485,6 +485,9 @@ run_case_gh "gh api pulls/N/merge with explicit commit_title over limit (advisor
 run_case_gh "gh api pulls/N/merge merge_method=merge is silent (not squash)" \
   silent 'gh api repos/o/r/pulls/42/merge -X PUT -f merge_method=merge -f commit_title="this title can stay long because merge_method is merge"' "$ERROR_GH"
 
+run_case_gh "gh api pulls/N/merge with commit_title within limit (silent, no fallthrough)" \
+  silent 'gh api repos/o/r/pulls/42/merge -X PUT -f merge_method=squash -f commit_title="fix: short title"' "$ERROR_GH"
+
 run_case_gh "path-prefixed gh api pulls/N/merge is still checked" \
   advisory '/usr/bin/gh api repos/o/r/pulls/42/merge -X PUT -f merge_method=squash -f commit_title="this subject line is definitely far too long to pass fifty chars"' "$ERROR_GH"
 


### PR DESCRIPTION
### 무엇

`gh api .../pulls/N/merge -f merge_method=squash` 에 50자 **이하** 타이틀이 붙으면
훅이 `TypeError` 로 죽습니다.

```text
Probe: printf '{"tool_name":"Bash","tool_input":{"command":"gh api ... -f merge_method=squash -f commit_title=\"fix: short title\""}}' | python3 impl.py
  → TypeError: cannot unpack non-iterable NoneType object   (rc=1)
```

`gh api` 분기는 `merge_segment is None` 일 때만 진입하는데, 타이틀이 한계 안이면
분기 안에서 빠져나가지 않고 아래 `tail, repo = merge_segment` 로 낙하합니다.
한계를 넘는 경로는 advisory 를 내고 `return 0` 하므로 이 구멍이 가려져 있었습니다.

분기 끝에 `continue` 를 넣습니다. `gh pr merge` 경로와 한계 초과 경로의 동작은
바뀌지 않습니다.

### #843 검증 계획 이행

이슈 본문이 요구한 "51자 title PR 대상 `gh pr merge --squash` dry 시나리오 +
50자 이하 통과 확인" 을 **실재 PR** 로 수행했습니다 (합성 payload 가 아니라
`gh pr view` 가 실제 타이틀을 해석하는 경로).

| 대상 | 타이틀 길이 | 결과 |
| --- | --- | --- |
| PR #834 (실재) | 61자 | advisory 발화, rc=0 |
| PR #950 (실재) | 38자 | 무음, rc=0 |
| `gh api` 합성 payload | 63자 | advisory 발화, rc=0 |
| `gh api` 합성 payload | 15자 | 무음, rc=0 (수정 전 rc=1 크래시) |

이슈의 순서 구속(release-lag 해소 전 `gh api` 완전 봉쇄 금지)은 지킵니다 —
severity 는 advisory 그대로이고 이 PR 은 deny 로 올리지 않습니다.

Caller chain verified: `main()` → `_gh_api_segment(argv)` → `_parse_gh_api_merge(api_tail)`
→ (한계 이하) 분기 종료. 낙하 지점 `tail, repo = merge_segment` 는 `gh pr merge`
경로 전용이며 호출자는 `main()` 하나뿐 (`grep -n 'merge_segment' impl.py` 로 확인,
정의 1곳 · 참조 4곳 전부 `main()` 내부).

### 테스트

- 신규 케이스 1건: `gh api` squash + 한계 이하 타이틀 → `silent`. 수정 전에는
  rc=1 + traceback 이라 반드시 실패합니다.
- 훅 단독 스위트 63/63.

Pre-commit verified: `./scripts/run-tests.sh` → ALL TESTS PASSED
(pytest, shell 42/42, manifest OK, hook-token 7 invariants, ruff, shellcheck).

Closes #843
