### PR TITLE
fix(bypass-review): filter fixture sessions

### DIFF
--- a/docs/hook-prune-audit.md
+++ b/docs/hook-prune-audit.md
@@ -14,9 +14,51 @@ a repo-relative link).
 ./skills/bypass-review/bypass-review fire-rate -d 30
 ```
 
-Window: **2026-07-05 → 2026-08-03, 743 sessions** — a full 30 days with
+Window: **2026-07-05 → 2026-08-03, 466 sessions** — a full 30 days with
 fire-events throughout, superseding the first audit's effective 5-day /
 49-session sample (2026-06-26 → 2026-07-01). Recalibrated for issue #874.
+
+**Contamination floor (issue #939).** This audit originally read the window as
+743 sessions. That count included fixture sessions: before issue #934 redirected
+development runs to `<checkout>/.praxis-dev-telemetry`, invoking a shell test
+directly wrote straight into the production ledger. Re-measuring the same window
+gives **751 session ids read, 285 synthetic (37.9%), 466 human** and **53,654
+synthetic records of 2,958,085 (1.81%)**. The 743 → 751 gap on the read side is
+the snapshot boundary — the original figure was taken 2026-08-03T07:5xZ, part-way
+through the window's last day.
+
+`bypass-review fire-rate` now drops synthetic records on read and prints both
+figures under `Record provenance`, so this correction does not have to be
+remembered. The ledger is append-only; nothing was deleted.
+
+Contamination is heavily skewed by hook, so the correction is not uniform
+(re-measured over the whole window, so the denominators run slightly above the
+part-way snapshot the tables below use):
+
+| Hook | Fires | Synthetic | Share |
+| --- | --- | --- | --- |
+| `retrospect-mix-check` | 7,837 | 6,285 | 80.2% |
+| `completion-signal-gate` | 13,106 | 1,245 | 9.5% |
+| `output-block-falsify-advisory` | 61,175 | 1,965 | 3.2% |
+| `jq-config-empty-dict-advisory` | 61,676 | 1,124 | 1.8% |
+| `askuserquestion-loop-signal` | 1,948 | 0 | 0.0% |
+| `pytest-direct-exec-advisory` | 1,734 | 0 | 0.0% |
+
+Per-hook figures below predate the filter and come from the part-way snapshot,
+so re-running the command moves them: fire counts down (synthetic records leave)
+and per-hook session counts either way (synthetic sessions leave, but the rest of
+the last day arrives). `pytest-direct-exec-advisory`, for instance, reads 8
+sessions below and 12 filtered over the whole window.
+
+**The verdicts do not move.** They rest on escalation counts, and re-aggregating
+the three Axis 4 escalation-free candidates with synthetic sessions excluded
+leaves all three still escalation-free:
+
+| Hook | Sessions (filtered) | Decisions | Escalations |
+| --- | --- | --- | --- |
+| `askuserquestion-loop-signal` | 192 | `pass` 1,948 | 0 |
+| `jq-config-empty-dict-advisory` | 403 | `pass` 60,552 | 0 |
+| `pytest-direct-exec-advisory` | 12 | `pass` 1,734 | 0 |
 
 Fire counts below are a snapshot taken 2026-08-03T07:5xZ; the ledger is
 append-only and live, so re-running the command minutes later moves every
@@ -39,7 +81,7 @@ ledger names are excluded from every table below:
 ### What changed since the first audit
 
 The roster grew from 58 registered hooks to 81, and the sample from 49
-sessions to 743. Two of the first audit's structural claims no longer hold —
+sessions to 466. Two of the first audit's structural claims no longer hold —
 see Axis 1 and the Axis 4 update below.
 
 ## Axis 1 — never-fired
@@ -99,7 +141,7 @@ Issue #874 opened on a single session (2026-07-27, `5d46110f`) where 42 ADVISE
 fires produced no observable behaviour change, and inferred that the tier's
 effect is zero because advisories go to stderr where the model cannot see them.
 
-Across 743 sessions the recurrence rates above **do not support that
+Across 466 sessions the recurrence rates above **do not support that
 inference**. `pipefail-advisory` — the highest-volume advisory, and the one
 the issue named first — recurs 24% of the time, meaning roughly three in four
 advises are followed by the hook no longer flagging. `momentum-rule-retrieval-gate`

--- a/skills/bypass-review/bypass-review
+++ b/skills/bypass-review/bypass-review
@@ -812,8 +812,32 @@ def _render_error_events(lines: list[str], error_events: list[dict]) -> None:
 # Fire-rate mode (issue #710) — hook fire ledger from fire-events JSONL
 # ---------------------------------------------------------------------------
 
-def load_fire_events(telemetry_dir: Path, days: int) -> list[dict]:
-    """Load valid JSONL records from the last N days of fire-events files."""
+def is_test_session(session_id: str) -> bool:
+    """True for a synthetic session id written by a test fixture.
+
+    Real ids are UUIDs, whose hex alphabet cannot spell `test`, so the
+    substring is unambiguous. Issue #939 measured every synthetic record in the
+    2026-07-05..08-03 window this way — `test`, `test-session`, `fixture-test`,
+    `replay-test`, `test-<pid>-<n>` — and the count is identical whether or not
+    `fixture` is also matched, because every fixture id carries `test` too.
+    """
+    return "test" in (session_id or "").lower()
+
+
+def load_fire_events(
+    telemetry_dir: Path, days: int, include_test_sessions: bool = False
+) -> list[dict]:
+    """Load valid JSONL records from the last N days of fire-events files.
+
+    Synthetic records are dropped by default (issue #939). Before #934 taught
+    the ledger to redirect development runs, a directly-invoked shell test wrote
+    into the production ledger: 53,654 records over the audit window, spread
+    across 285 of 751 session ids. Those records are still there — the ledger is
+    append-only — so a report that counts them reads fixture volume as usage.
+
+    Pass `include_test_sessions=True` to get the raw set; `run_fire_rate` does
+    that so it can print both figures rather than silently shrinking the window.
+    """
     events: list[dict] = []
     for date_str in date_range(days):
         path = telemetry_dir / f"fire-events-{date_str}.jsonl"
@@ -829,8 +853,13 @@ def load_fire_events(telemetry_dir: Path, days: int) -> list[dict]:
                         record = json.loads(line)
                     except json.JSONDecodeError:
                         continue
-                    if isinstance(record, dict):
-                        events.append(record)
+                    if not isinstance(record, dict):
+                        continue
+                    if not include_test_sessions and is_test_session(
+                        str(record.get(FIELD_SESSION_ID) or "")
+                    ):
+                        continue
+                    events.append(record)
         except OSError:
             continue
     return events
@@ -1794,8 +1823,48 @@ def render_fire_report(
     return "\n".join(lines)
 
 
+def format_fire_provenance(raw: list[dict], kept: list[dict]) -> str:
+    """Report what the test-session filter dropped (issue #939).
+
+    Both figures, always — a reader who sees only the filtered count cannot
+    distinguish a genuinely quiet window from one whose fixture records were
+    quietly removed, and the contamination rate is itself the signal that says
+    how far an older audit of the same window can be trusted.
+    """
+    def _sessions(events: list[dict]) -> set[str]:
+        return {
+            str(ev.get(FIELD_SESSION_ID) or "")
+            for ev in events
+            if ev.get(FIELD_SESSION_ID)
+        }
+
+    dropped = len(raw) - len(kept)
+    raw_sids, kept_sids = _sessions(raw), _sessions(kept)
+    pct = (dropped / len(raw) * 100) if raw else 0.0
+    return (
+        "\nRecord provenance (issue #939)\n"
+        f"  Records:  {len(raw):,} read, {dropped:,} synthetic dropped "
+        f"({pct:.2f}%), {len(kept):,} counted\n"
+        f"  Sessions: {len(raw_sids):,} read, "
+        f"{len(raw_sids) - len(kept_sids):,} synthetic dropped, "
+        f"{len(kept_sids):,} counted\n"
+        "  Synthetic = session id containing `test`, written by a fixture that ran\n"
+        "  before issue #934 redirected checkout runs to .praxis-dev-telemetry.\n"
+        "  The ledger is append-only, so these records stay and are filtered on read."
+    )
+
+
 def run_fire_rate(args: argparse.Namespace, telemetry_dir: Path) -> int:
-    events = load_fire_events(telemetry_dir, args.days)
+    # Load raw, then split, so the report can state what it dropped. Reporting
+    # only the filtered figure would leave a reader unable to tell a quiet
+    # window from a heavily-contaminated one.
+    raw_events = load_fire_events(telemetry_dir, args.days, include_test_sessions=True)
+    events = [
+        ev
+        for ev in raw_events
+        if not is_test_session(str(ev.get(FIELD_SESSION_ID) or ""))
+    ]
+    provenance = format_fire_provenance(raw_events, events)
     by_hook = aggregate_fires(events)
     manifest_path = (
         Path(args.manifest_path) if args.manifest_path else default_manifest_path()
@@ -1834,6 +1903,7 @@ def run_fire_rate(args: argparse.Namespace, telemetry_dir: Path) -> int:
         bypass_join=bypass_join,
         outcome_proxy=outcome_proxy,
     ))
+    print(provenance)
     return 0
 
 

--- a/tests/test_bypass_review.sh
+++ b/tests/test_bypass_review.sh
@@ -798,6 +798,77 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# fire-rate: synthetic (test-session) records are filtered and reported (#939)
+#
+# Record fields copied verbatim from the writer:
+#   hooks/_lib/_fire_ledger.py record_session_fire() lines 387-395.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== bypass-review fire-rate: test-session filter (#939) ==="
+
+DIR18="$TMP_DIR/t18"
+mkdir -p "$DIR18"
+make_fire() {
+  python3 -c "
+import json, sys
+print(json.dumps({
+    'timestamp': sys.argv[1] + 'T00:00:00+00:00',
+    'session_id': sys.argv[2],
+    'tool': 'Bash',
+    'hook': 'pipefail-advisory',
+    'role': 'advisory-nudge',
+    'decision': sys.argv[3],
+    'granularity': 'rich',
+}))" "$TODAY" "$1" "$2"
+}
+{
+  make_fire "11111111-2222-3333-4444-555555555555" "pass"
+  make_fire "11111111-2222-3333-4444-555555555555" "advise"
+  make_fire "test-session" "pass"
+  make_fire "fixture-test" "advise"
+  make_fire "test-72669-24423" "pass"
+} > "$DIR18/fire-events-$TODAY.jsonl"
+
+out18=$(python3 "$CLI" fire-rate --dir "$DIR18" --days 1 2>&1)
+rc18=$?
+
+if [ "$rc18" -ne 0 ]; then
+  assert_fail "fire-rate filter: exit 0" "exited $rc18; output: $out18"
+else
+  assert_pass "fire-rate filter: exit 0"
+fi
+
+# 5 records read, 3 synthetic dropped, 2 counted; 4 session ids read, 1 counted.
+if echo "$out18" | grep -q "5 read, 3 synthetic dropped"; then
+  assert_pass "fire-rate filter: record counts reported both ways"
+else
+  assert_fail "fire-rate filter: record counts reported both ways" "output: $out18"
+fi
+
+if echo "$out18" | grep -q "Sessions: 4 read, 3 synthetic dropped, 1 counted"; then
+  assert_pass "fire-rate filter: session counts reported both ways"
+else
+  assert_fail "fire-rate filter: session counts reported both ways" "output: $out18"
+fi
+
+# Negative control: a ledger with no synthetic records must report zero dropped,
+# so a passing assertion above cannot come from the filter matching everything.
+DIR19="$TMP_DIR/t19"
+mkdir -p "$DIR19"
+{
+  make_fire "11111111-2222-3333-4444-555555555555" "pass"
+  make_fire "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" "advise"
+} > "$DIR19/fire-events-$TODAY.jsonl"
+
+out19=$(python3 "$CLI" fire-rate --dir "$DIR19" --days 1 2>&1)
+
+if echo "$out19" | grep -q "2 read, 0 synthetic dropped"; then
+  assert_pass "fire-rate filter: clean ledger drops nothing"
+else
+  assert_fail "fire-rate filter: clean ledger drops nothing" "output: $out19"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
### 무엇

`fire-rate` 가 원장의 합성 레코드를 그대로 집계해, 픽스처 볼륨이 사용량으로
읽히고 있었습니다. 감사 창(2026-07-05~08-03) 실측:

```text
total records      : 2,958,085
test-origin records:    53,654  (1.81%)
distinct sessions  :       751
  test-like sids   :       285  (37.9%)
  human sessions   :       466
```

- `is_test_session()` — 실 세션 id 는 UUID 라 hex 알파벳으로 `test` 를 만들 수
  없어 부분문자열 판정이 모호하지 않습니다. `fixture` 를 함께 매칭해도 건수가
  동일합니다(53,654 = 53,654) — 모든 픽스처 id 가 `test` 를 포함합니다.
- `load_fire_events()` 가 기본으로 합성 레코드를 제외하고,
  `include_test_sessions=True` 로 원본을 받을 수 있습니다. `run_fire_rate` 는
  그 경로로 읽어 **적용/미적용 수치를 함께** 출력합니다 — 필터 후 수치만 보이면
  조용한 창과 오염된 창을 구별할 수 없습니다.
- `docs/hook-prune-audit.md` 를 743 → **466 사람 세션**으로 정정하고, 오염 하한과
  훅별 편중, Axis 4 재집계를 방법론 절에 명시했습니다.

### 이슈 작업목록 1번은 구현하지 않습니다

"`bash tests/*.sh` 직접 호출 차단" 은 **이미 #934 가 근본에서 해결**했습니다.
`hooks/_lib/_fire_ledger.py:207 _checkout_root()` 가 모듈 자신의 위치로 개발
체크아웃을 판별해, 체크아웃에서 돌린 훅은 프로덕션 원장이 아니라
`<root>/.praxis-dev-telemetry` 에 씁니다.

```text
$ python3 -c "import sys; sys.path.insert(0,'hooks/_lib'); import _fire_ledger as f; \
              print(f._checkout_root()); print(f.resolve_telemetry_dir())"
/private/tmp/praxis-939
/private/tmp/praxis-939/.praxis-dev-telemetry
```

새 PreToolUse 훅을 하나 만들어 27케이스 매트릭스까지 통과시킨 뒤에야 이 사실을
확인했고, 중복이므로 폐기했습니다. 이 PR 에는 포함돼 있지 않습니다.

이슈의 2번(음성 대조)은 위 프로브의 반대 방향으로 충족됩니다 — 리다이렉트가
없으면 `Path.home()/.praxis/telemetry` 로 떨어지는 것이 같은 함수의 else 분기입니다.

### Axis 4 결론은 유지됩니다

합성 세션을 제외하고 재집계해도 escalation-free 후보 3건 전부 escalation 0:

| Hook | Sessions (filtered) | Decisions | Escalations |
| --- | --- | --- | --- |
| `askuserquestion-loop-signal` | 192 | `pass` 1,948 | 0 |
| `jq-config-empty-dict-advisory` | 403 | `pass` 60,552 | 0 |
| `pytest-direct-exec-advisory` | 12 | `pass` 1,734 | 0 |

### 범위 밖 (이슈 명시)

이미 기록된 53,654건의 소급 삭제. 원장은 append-only 이므로 읽는 시점에 거릅니다.

Caller chain verified: `load_fire_events` 호출자는 `run_fire_rate` 하나뿐
(`grep -rn 'load_fire_events' .` → 정의 1 + 호출 1). 기본 인자를 필터 적용으로
바꿔도 다른 호출 경로가 없어 조용한 동작 변화가 생기지 않습니다.

### 테스트

`tests/test_bypass_review.sh` 에 4건 추가 — 필터 발화, 레코드/세션 양쪽 수치,
그리고 **음성 대조**(합성이 없는 원장은 `0 synthetic dropped`)로 위 단언이
"필터가 전부를 지워서" 통과하는 경우를 배제합니다. 61/61.

Pre-commit verified: `./scripts/run-tests.sh` → ALL TESTS PASSED
(pytest, shell 42/42, manifest OK, hook-token 7 invariants, ruff, shellcheck).
markdownlint 0.18.1 로 변경 문서 0 error.

Closes #939
