### PR TITLE
fix(hooks): verify briefing before marker releases merge

### DIFF
--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -687,9 +687,9 @@ def _has_repetition(command: object) -> bool:
     return any(tok in _LOOP_KEYWORDS for tok in safe_tokenize(command))
 
 
-def _prior_turn_extension_passes(entries: list[dict], idxs: list[int],
-                                 command: object) -> bool:
-    """True when the prior-turn briefing satisfies the gate (issue #826).
+def _correlated_prior_turn_text(entries: list[dict], idxs: list[int],
+                                command: object) -> str | None:
+    """The prior-turn assistant text the gate may score, else None (issue #826).
 
     The mandated flow is briefing → user approval → merge, which places the
     briefing in the turn BEFORE the approving user message — outside the
@@ -697,15 +697,20 @@ def _prior_turn_extension_passes(entries: list[dict], idxs: list[int],
     the immediately preceding assistant turn is scored ALONE (so text authored
     AFTER the approval cannot supplement a briefing the user never saw), and only
     when the merge is correlated to the briefed PR.
+
+    Returning the text rather than a verdict keeps ONE definition of "which
+    window may be scored": the caller decides which threshold applies to it,
+    so the marker's lower floor sees the same window the full-briefing check
+    does instead of scoring an empty current turn (issue #940 review).
     """
     segments = _merge_segments(command)
     # A single approval authorizes ONE merge. A compound `merge A && merge B` (≥2
     # segments) or a shell loop repeating one segment (`for pr in …; do merge`)
     # must not ride a single approval (No Approval Transfer) → no extension.
     if len(segments) != 1 or _has_repetition(command) or len(idxs) < 2:
-        return False
+        return None
     if not _is_approval_reply(entries[idxs[-1]].get("message", {}).get("content")):
-        return False
+        return None
 
     prev_text = _assistant_text(entries, idxs[-2] + 1, idxs[-1])
     pos = segments[0]
@@ -728,13 +733,12 @@ def _prior_turn_extension_passes(entries: list[dict], idxs: list[int],
             # be treated as this branch's target.
             correlated = False
 
-    # The trivial-PR carve-out and the briefing-count pass apply ONLY once the
-    # merge is correlated to the briefed PR — never to an unrelated trivial /
-    # complete briefing about a different PR (P1#1).
+    # An uncorrelated prior turn is not this merge's window at all: returning
+    # None keeps the trivial-PR carve-out, the briefing count, and the marker
+    # floor from ever reading a briefing about a different PR (P1#1).
     if not correlated:
-        return False
-    return _is_trivial_merge(prev_text) \
-        or _briefing_item_count(prev_text) >= MERGE_BRIEFING_MIN_ITEMS
+        return None
+    return prev_text
 
 
 def _merge_escalation_reason(payload: dict) -> str | None:
@@ -781,7 +785,11 @@ def _merge_escalation_reason(payload: dict) -> str | None:
     if items >= MERGE_BRIEFING_MIN_ITEMS:
         return None
 
-    if _prior_turn_extension_passes(entries, idxs, code):
+    prev_text = _correlated_prior_turn_text(entries, idxs, code)
+    if prev_text is not None and (
+        _is_trivial_merge(prev_text)
+        or _briefing_item_count(prev_text) >= MERGE_BRIEFING_MIN_ITEMS
+    ):
         return None
 
     # The marker attests that a briefing was surfaced, so it can stand in for
@@ -789,7 +797,17 @@ def _merge_escalation_reason(payload: dict) -> str | None:
     # phrased outside its vocabulary. It cannot stand in for *existence*: with
     # zero briefing items in the window there is nothing for the attestation to
     # be about, which is exactly the state the marker kept releasing (#940).
-    if marker_ok and items >= MERGE_BRIEFING_MARKER_MIN_ITEMS:
+    #
+    # "The window" is whichever one the gate was allowed to score. In the
+    # mandated briefing → approval → merge flow the briefing sits in the prior
+    # turn and the current turn is empty, so scoring `items` alone would deny a
+    # marked merge whose briefing the user did see — the failure the marker
+    # exists to absorb.
+    marker_items = max(
+        items,
+        _briefing_item_count(prev_text) if prev_text is not None else 0,
+    )
+    if marker_ok and marker_items >= MERGE_BRIEFING_MARKER_MIN_ITEMS:
         return None
 
     if marker_ok:

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -255,7 +255,8 @@ def _emit_for_trigger(trigger: str, directory: str | None) -> str:
 #   • no readable transcript                 → no escalation (fail open)
 #   • CMUX_DELEGATE=1 (background agent)      → no escalation (mirror sibling)
 #   • PRAXIS_MOMENTUM_MERGE_ADVISORY=1        → demote back to advisory only
-#   • `# briefing-surfaced` in the command    → demote back to advisory only
+#   • `# briefing-surfaced` + SOME briefing   → demote back to advisory only
+#     (the marker attests completeness, never existence — see issue #940)
 #   • trivial-PR markers in the briefing text → no escalation (CLAUDE.md carve-out)
 # ---------------------------------------------------------------------------
 
@@ -361,6 +362,14 @@ def _has_briefing_marker(command: object) -> bool:
 # floor of 4 separates that case from a complete (or near-complete) briefing
 # while keeping the false-positive rate low.
 MERGE_BRIEFING_MIN_ITEMS = 4
+
+# Floor for the `# briefing-surfaced` marker to release a merge (issue #940).
+# The marker exists because the counter above reads prose and under-counts a
+# briefing phrased outside its vocabulary — so it substitutes for the missing
+# items, not for the whole briefing. One recognised item is the weakest evidence
+# that a briefing is being attested to at all; zero means the attestation has no
+# referent, which is the state the marker was releasing on 8 of 11 merges.
+MERGE_BRIEFING_MARKER_MIN_ITEMS = 1
 
 # Each tuple is one Pre-Merge Reporting item; a single keyword hit marks the
 # item present. Bilingual (EN/KO) since briefings are authored in Korean.
@@ -503,11 +512,22 @@ def _load_turn_entries(transcript_path: str) -> list[dict] | None:
 
 
 def _human_user_indices(entries: list[dict]) -> list[int]:
-    """Indices of human-authored user messages (skip tool_result-only bridges)."""
+    """Indices of human-authored user messages (skip tool_result-only bridges).
+
+    `isMeta` entries are injected, not typed (issue #940): a skill body loaded
+    mid-turn and the expansion of a slash command both arrive as `role: user`
+    with prose content, and the harness stamps both `isMeta: true` while a
+    genuinely typed message carries no such flag. Counting them starts a new
+    "since the last user message" window, which discards a briefing the user
+    actually saw — a skill invoked between the briefing and the merge was enough
+    to make a compliant flow look unbriefed.
+    """
     idxs: list[int] = []
     for i, ev in enumerate(entries):
         msg = ev.get("message")
         if not isinstance(msg, dict) or msg.get("role") != "user" or ev.get("isSidechain"):
+            continue
+        if ev.get("isMeta"):
             continue
         content = msg.get("content", [])
         if isinstance(content, str):
@@ -737,10 +757,16 @@ def _merge_escalation_reason(payload: dict) -> str | None:
     # hook process — but only for a SINGLE merge with no loop. One
     # self-attestation must not release a compound `merge A && merge B` or a
     # looped merge (round-1 P1: same No-Approval-Transfer guard the prior-turn
-    # extension applies).
-    if _has_briefing_marker(command) \
-            and len(_merge_segments(code)) == 1 and not _has_repetition(code):
-        return None
+    # extension applies). Whether it releases *this* merge is decided below,
+    # after the transcript is read: issue #940 measured the marker riding along
+    # on 8 of 11 merges with no preceding block at all, one of them 627 events
+    # after the last briefing, because it short-circuited before any evidence
+    # was consulted.
+    marker_ok = (
+        _has_briefing_marker(command)
+        and len(_merge_segments(code)) == 1
+        and not _has_repetition(code)
+    )
 
     entries = _load_turn_entries(payload.get("transcript_path", "") or "")
     if entries is None:
@@ -751,11 +777,34 @@ def _merge_escalation_reason(payload: dict) -> str | None:
     current_text = _assistant_text(entries, lo, len(entries))
     if _is_trivial_merge(current_text):
         return None
-    if _briefing_item_count(current_text) >= MERGE_BRIEFING_MIN_ITEMS:
+    items = _briefing_item_count(current_text)
+    if items >= MERGE_BRIEFING_MIN_ITEMS:
         return None
 
     if _prior_turn_extension_passes(entries, idxs, code):
         return None
+
+    # The marker attests that a briefing was surfaced, so it can stand in for
+    # *completeness* — the item counter reads prose and under-counts a briefing
+    # phrased outside its vocabulary. It cannot stand in for *existence*: with
+    # zero briefing items in the window there is nothing for the attestation to
+    # be about, which is exactly the state the marker kept releasing (#940).
+    if marker_ok and items >= MERGE_BRIEFING_MARKER_MIN_ITEMS:
+        return None
+
+    if marker_ok:
+        return format_block(
+            rule_name="Pre-Merge Reporting briefing",
+            why="this gh pr merge carries `# briefing-surfaced` but no briefing "
+                "is present in the window — the marker attests that a briefing "
+                "was complete, not that one exists, and none was found",
+            correct_path="surface the 6-item briefing and an explicit 'Approve "
+                "merge?' question in this turn, then re-run the merge",
+            bypass_env=MERGE_ADVISORY_ENV,
+            bypass_reason_hint="with a one-line reason",
+            reference="CLAUDE.md → Pre-Merge Reporting; "
+                "hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md",
+        )
 
     return format_block(
         rule_name="Pre-Merge Reporting briefing",

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -200,6 +200,35 @@ approve blindly.
   `# briefing-surfaced` inside a heredoc body (`<<EOF … EOF`) is the one residual
   the scanner does not exclude — accepted under the non-adversarial threat model,
   as with the `xargs`/cross-repo gaps above.
+
+  **The marker attests completeness, never existence (issue #940).** It used to
+  short-circuit before the transcript was read, so it released the merge no
+  matter what the window contained. Measured over 2026-08-01~03: it rode along
+  on **11 of 11** merges and **8 of those had no preceding block at all** — two
+  at 322 and 627 events from the last briefing. Once a marker is a command's
+  default suffix, the gate it relaxes can never fire, and a per-merge
+  re-confirmation never happens; global CLAUDE.md permits a bypass token only
+  after the spec is read and the case matched, and one reading does not cover
+  the next N merges.
+
+  The marker is therefore evaluated **after** the transcript is scanned, and
+  releases the merge only when the window already contains at least
+  `MERGE_BRIEFING_MARKER_MIN_ITEMS` (1) recognised briefing item. That keeps its
+  original purpose — the item counter reads prose and under-counts a briefing
+  phrased outside its vocabulary — while removing the one thing it was never
+  meant to do. With zero items the attestation has no referent and the merge is
+  denied with a distinct reason naming the marker. An unreadable transcript
+  still fails open, which is the bridge-session case the marker was invented
+  for: there is nothing to verify against, so nothing is claimed.
+
+- **Injected user entries do not start a new window (issue #940).** A skill body
+  loaded mid-turn and the expansion of a slash command both arrive as
+  `role: user` with prose content; the harness stamps them `isMeta: true` while
+  a genuinely typed message carries no such flag. Counting them would move the
+  "since the last user message" boundary past a briefing the user actually saw,
+  so a skill invoked between the briefing and the merge made a compliant flow
+  look unbriefed. `_human_user_indices` skips them — a structural discriminator,
+  not a content heuristic.
 - Trivial-PR markers (`typo`, `comment-only`, `single-line`, `오타`, `주석만`,
   `trivial pr`, `2-line report`, …) in the briefing text → no escalation,
   matching CLAUDE.md's "Trivial PRs: a 2-line report is fine" carve-out.

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -221,6 +221,14 @@ approve blindly.
   still fails open, which is the bridge-session case the marker was invented
   for: there is nothing to verify against, so nothing is claimed.
 
+  "The window" is whichever one the gate was allowed to score, current turn or
+  correlated prior turn — the same window the full-briefing check reads. The
+  mandated flow is briefing → approval → merge, which leaves the current turn
+  empty, so a marker floor scored against the current turn alone would deny a
+  marked merge whose briefing the user did see. The prior turn is read only
+  when it is correlated to this merge's PR, so an uncorrelated briefing cannot
+  supply the item the floor needs (No Approval Transfer).
+
 - **Injected user entries do not start a new window (issue #940).** A skill body
   loaded mid-turn and the expansion of a slash command both arrive as
   `role: user` with prose content; the harness stamps them `isMeta: true` while

--- a/tests/fixtures/momentum-merge-injected-meta-turn.jsonl
+++ b/tests/fixtures/momentum-merge-injected-meta-turn.jsonl
@@ -1,0 +1,4 @@
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": [{"type": "text", "text": "PR 833 머지해줘"}]}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "PR #833 브리핑. 변경 사항: hook 파일 수정. 테스트 통과 확인(lint clean). 미검증 항목: prod 경로 미확인. 리스크: downstream 없음. 남은 항목: 없음. Approve merge"}]}}
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": [{"type": "text", "text": "Base directory for this skill: /x\n# some-skill\n\n## Overview\n"}]}, "isMeta": true}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "스킬 절차를 따릅니다."}]}}

--- a/tests/fixtures/momentum-merge-marker-no-briefing.jsonl
+++ b/tests/fixtures/momentum-merge-marker-no-briefing.jsonl
@@ -1,0 +1,3 @@
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": [{"type": "text", "text": "PR 833 정리하고 머지해줘"}]}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "워크트리를 정리했습니다."}]}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "브랜치를 삭제했습니다."}]}}

--- a/tests/fixtures/momentum-merge-marker-partial-briefing.jsonl
+++ b/tests/fixtures/momentum-merge-marker-partial-briefing.jsonl
@@ -1,0 +1,2 @@
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": [{"type": "text", "text": "PR 833 머지해줘"}]}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "PR #833 — 변경 사항: hook 파일 한 줄 수정."}]}}

--- a/tests/fixtures/momentum-merge-prior-turn-partial-briefing.jsonl
+++ b/tests/fixtures/momentum-merge-prior-turn-partial-briefing.jsonl
@@ -1,0 +1,6 @@
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": "PR 833 머지 준비됐는지 보고 진행하자"}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "chk", "name": "Bash", "input": {"command": "gh pr checks 833"}}]}}
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "chk", "content": "all checks passing"}]}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "PR #833 — 변경 사항: hook 파일 한 줄 수정."}]}}
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": "ok"}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "머지합니다."}]}}

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -735,6 +735,26 @@ run_merge_escalation_case "merge_escalation_marker_with_partial_briefing_passes"
 run_merge_escalation_case "merge_escalation_partial_briefing_no_marker_denies" \
   "yes" "" "momentum-merge-marker-partial-briefing.jsonl" "gh pr merge 833 --squash"
 
+# The mandated flow puts the briefing in the turn BEFORE the approval, so the
+# current turn is empty. A partial briefing there plus the marker must release
+# the merge: scoring the current turn alone would deny a merge whose briefing
+# the user did see — the exact failure the marker exists to absorb.
+run_merge_escalation_case "merge_escalation_marker_with_prior_turn_partial_passes" \
+  "no" "" "momentum-merge-prior-turn-partial-briefing.jsonl" \
+  "gh pr merge 833 --squash  # briefing-surfaced: counter under-counted"
+
+# Same prior-turn partial briefing WITHOUT the marker → deny (1 item < 4). Pins
+# that the pass above is bought by the marker, not by the extension path.
+run_merge_escalation_case "merge_escalation_prior_turn_partial_no_marker_denies" \
+  "yes" "" "momentum-merge-prior-turn-partial-briefing.jsonl" "gh pr merge 833 --squash"
+
+# Marker + prior turn that briefed a DIFFERENT PR → deny. The lower marker floor
+# reads the prior turn only when the merge correlates to it (No Approval
+# Transfer); an uncorrelated window must not supply the item it needs.
+run_merge_escalation_case "merge_escalation_marker_uncorrelated_prior_turn_denies" \
+  "yes" "" "momentum-merge-prior-turn-partial-briefing.jsonl" \
+  "gh pr merge 999 --squash  # briefing-surfaced: attested"
+
 # An injected (`isMeta`) user entry — a skill body loaded mid-turn — must not
 # start a new window and discard the briefing the user actually saw.
 run_merge_escalation_case "merge_escalation_injected_meta_keeps_window_passes" \

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -704,6 +704,42 @@ run_merge_escalation_case "merge_escalation_loop_repetition_denies" \
 run_merge_escalation_case "merge_escalation_multi_target_denies" \
   "yes" "" "momentum-merge-prior-turn-briefing.jsonl" "gh pr merge 833 --squash && gh pr merge 999 --squash"
 
+# --- `# briefing-surfaced` marker re-verification (issue #940) -----------------
+#
+# The marker used to short-circuit before the transcript was read, so it
+# released a merge no matter how far back the last briefing was — measured at
+# 8 of 11 merges with no preceding block at all, one 627 events out. It now
+# stands in for a briefing's COMPLETENESS (the counter reads prose and
+# under-counts), never for its EXISTENCE.
+
+# Marker present, no briefing anywhere in the window → deny. This is the case
+# that passed before the fix.
+run_merge_escalation_case "merge_escalation_marker_without_briefing_denies" \
+  "yes" "" "momentum-merge-marker-no-briefing.jsonl" \
+  "gh pr merge 833 --squash  # briefing-surfaced: attested"
+
+# Same fixture, same command WITHOUT the marker → also deny. Pins that the deny
+# above comes from the absent briefing, not from the marker itself being read
+# as a violation.
+run_merge_escalation_case "merge_escalation_no_briefing_no_marker_denies" \
+  "yes" "" "momentum-merge-marker-no-briefing.jsonl" "gh pr merge 833 --squash"
+
+# Briefing present but phrased so the counter recognises only 1 of 6 items;
+# marker attests the rest → pass. Without this the marker would have no purpose
+# left and the fix would be an outright removal.
+run_merge_escalation_case "merge_escalation_marker_with_partial_briefing_passes" \
+  "no" "" "momentum-merge-marker-partial-briefing.jsonl" \
+  "gh pr merge 833 --squash  # briefing-surfaced: counter under-counted"
+
+# Same partial briefing without the marker → deny (1 item < 4).
+run_merge_escalation_case "merge_escalation_partial_briefing_no_marker_denies" \
+  "yes" "" "momentum-merge-marker-partial-briefing.jsonl" "gh pr merge 833 --squash"
+
+# An injected (`isMeta`) user entry — a skill body loaded mid-turn — must not
+# start a new window and discard the briefing the user actually saw.
+run_merge_escalation_case "merge_escalation_injected_meta_keeps_window_passes" \
+  "no" "" "momentum-merge-injected-meta-turn.jsonl" "gh pr merge 833 --squash"
+
 # --- verb gate checklist on both channels (issues #873, #932) -----------------
 #
 # The briefing is one of several gates on `gh pr merge`. Before #873 the deny


### PR DESCRIPTION
### 무엇

`# briefing-surfaced` 가 트랜스크립트를 읽기 **전에** 단락해서, 창 안에 브리핑이
전혀 없어도 머지를 통과시켰습니다. 이슈 실측: 2026-08-01~03 머지 11건 전부에
마커가 붙었고 **8건은 직전에 어떤 차단도 없었습니다**(선제 부착). 두 건은 마지막
브리핑에서 322·627 이벤트 떨어져 있었습니다.

마커가 명령의 기본 접미사로 승격되면 그 게이트는 영영 발화하지 못하고, per-merge
재확인도 일어나지 않습니다. 전역 CLAUDE.md 는 bypass 토큰을 "spec 을 읽고 문서화된
skip 조건에 부합함을 확인한 뒤에만" 허용하는데, 1회 확인이 이후 N회를 덮지 않습니다.

### 어떤 수리를 골랐는가

이슈는 두 후보를 두고 "어느 쪽이 옳은 수리인지 spec 에서 먼저 판정" 하라고 합니다.
**둘 다 필요했고, 서로 다른 결함이었습니다.**

**(1) 마커는 완전성을 대신할 수 있어도 존재를 대신할 수 없다.** 판정을 스캔 뒤로
옮기고, 창에 인식된 브리핑 항목이 1개 이상일 때만 해제합니다. 0개면 마커를 명시한
별도 사유로 차단합니다. 마커의 원래 목적 — 항목 카운터가 산문을 읽어 어휘 밖 표현을
덜 세는 것 — 은 그대로 남습니다. 트랜스크립트를 못 읽으면 여전히 fail-open 이고,
그게 마커가 만들어진 bridge-session 사례입니다: 대조할 대상이 없으면 주장할 것도
없습니다.

**(2) 주입된 user 엔트리가 창을 깨고 있었다.** 이슈의 "오진 정정" 절이 지목한
"도구 턴 삽입" 의 구체적 정체입니다. 턴 중간에 로드된 **스킬 본문**과 **슬래시 명령
확장**은 둘 다 `role: user` + 산문으로 도착하는데, 하네스가 `isMeta: true` 를 찍고
실제로 타이핑된 메시지에는 그 필드가 없습니다.

```text
[3056] 사용자가 친 "/loop …"        → isMeta 없음   (genuine)
[3057] /loop 확장 본문               → "isMeta": true
[3544] surface-enumeration SKILL 본문 → "isMeta": true, sourceToolUseID 있음
[4078] 사용자가 친 "진행"            → isMeta 없음, origin.kind = "human"
```

이걸 human user 로 세면 "마지막 사용자 메시지 이후" 경계가 브리핑 뒤로 밀려,
브리핑과 머지 사이에 스킬을 한 번 부른 것만으로 정상 흐름이 미브리핑이 됩니다.
`_human_user_indices` 가 건너뜁니다 — 내용 휴리스틱이 아니라 구조적 판별자입니다.

### 부수 관측 (이 PR 범위 밖)

`AskUserQuestion` 승인은 `tool_result` 로 기록되어 human user 메시지로 세어지지
않습니다. 즉 `_prior_turn_extension_passes` 의 "짧은 승인 답장" 경로는
`AskUserQuestion` 흐름에서 구조적으로 발화할 수 없습니다. 이 PR 은 그 경로를
건드리지 않습니다 — 승인이 안 세어지는 덕분에 창 경계가 브리핑 앞에 머물러
현재-턴 경로가 대신 커버하기 때문이며, 동작상 문제가 관측되지 않았습니다.

항목 카운터의 어휘도 흔한 표현을 놓칩니다(`검증 안 된 것`, `미결 항목` 은 미인식).
둘 다 별건이라 이 PR 에서 고치지 않았습니다.

### 검증

픽스처 3개 · 케이스 5건 추가. **음성 대조**로 수정 전 코드에서 두 결함을 재현했습니다:

| 시나리오 | 수정 전 | 수정 후 | 기대 |
| --- | --- | --- | --- |
| 마커 + 브리핑 없음 | 통과 | **차단** | 차단 |
| 브리핑 + isMeta 스킬 본문 주입 | **차단** | 통과 | 통과 |
| 브리핑 + 도구 턴 3개 삽입 | 통과 | 통과 | 통과 |
| 브리핑 + 마커 없음 | 통과 | 통과 | 통과 |
| 브리핑 + 진짜 신규 사용자 메시지 | 차단 | 차단 | 차단 |
| 부분 브리핑(1항목) + 마커 | 통과 | 통과 | 통과 |
| 부분 브리핑(1항목) + 마커 없음 | 차단 | 차단 | 차단 |

Caller chain verified: `_human_user_indices` 는 이 훅 안에서만 정의·사용됩니다
(`grep -rln '_human_user_indices' hooks/` → 파일 1개). 호출자는
`_merge_escalation_reason` 과 `_prior_turn_extension_passes` 둘 다 같은 파일이라,
`isMeta` 스킵의 파급이 이 게이트를 벗어나지 않습니다.

Pre-commit verified: `./scripts/run-tests.sh` → ALL TESTS PASSED
(pytest, shell 42/42, manifest OK, hook-token 7 invariants, ruff, shellcheck).
훅 단독 스위트 93/93.

Closes #940


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Merge escalation now requires supporting briefing content when the `# briefing-surfaced` marker is used.
  * Missing briefing evidence receives a clear denial outcome, while unreadable transcripts remain fail-open.
  * Metadata messages no longer incorrectly interrupt briefing validation.

* **Tests**
  * Added regression coverage for missing, partial, and valid briefing scenarios, including injected metadata messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->