### PR TITLE
feat(hooks): gate evidence class on the changed surface

### DIFF
--- a/hooks/completion-verify/completion-verify/impl.sh
+++ b/hooks/completion-verify/completion-verify/impl.sh
@@ -60,6 +60,35 @@ command -v praxis_fire_arm >/dev/null 2>&1 && \
 CLAIM_PATTERNS='(모두 완료(했)?|완료했습니다[.!。?…]?\s*$|작업 완료[.!。?…]?\s*$|완료[.!。?…]?\s*$|\bdone\b[.!?]?\s*$|\bfinished\b[.!?]?\s*$|cleanup (is |was )?finished|implementation complete|all done)'
 EVIDENCE_PATTERNS='(tests? passed|\bPASS\b|exit code 0|\b[1-9][0-9]* tests? (ran|passed)|\b[1-9][0-9]* passed\b|0 errors|build successful|lint clean|성공적으로|테스트.*통과|✅)'
 
+# --- Evidence class by changed surface (issue #943, stage 1: frontend) --------
+#
+# The patterns above are surface-agnostic, so a genuine command that verified
+# the WRONG thing still passes: a `curl` status sweep and a bundle `grep` are
+# valid oracles for a backend change and prove nothing about what a page
+# renders. The observed failure was a frontend doc-link swap declared complete
+# on 38 curl status codes plus a source grep; the conclusion changed once the
+# page was actually opened.
+#
+# This is a deterministic mapping (changed path → required evidence class), not
+# a sufficiency judgement — one regex match, so it fits inside a shell hook.
+# The SOT for the mapping is the global CLAUDE.md verification table.
+#
+# Only extensions that are unambiguously view-layer are listed. Bare `.ts`/`.js`
+# are deliberately absent: they are as often backend as frontend, and a false
+# block on a server change costs more than the miss.
+FRONTEND_PATH_PATTERN='\.(tsx|jsx|vue|svelte|astro|html|htm|css|scss|sass|less)$'
+
+# Oracles that observe a rendered page. `cmux browser` subcommands verified
+# against `cmux --help`: snapshot / get / is / eval / screenshot read the live
+# DOM, and `--snapshot-after` attaches one to a navigation or interaction.
+# A bare `browser open`/`goto` only navigates, so it is not on its own an
+# observation and is not listed.
+BROWSER_EVIDENCE_CMD_PATTERN='(cmux([[:space:]]+--[^[:space:]]+([[:space:]]+[^[:space:]]+)?)*[[:space:]]+browser[[:space:]].*(snapshot|screenshot|eval|get[[:space:]]|is[[:space:]]|wait[[:space:]])|--snapshot-after|playwright|puppeteer)'
+# Browser automation reached through an MCP server never appears as a Bash
+# command, only as a tool name — without this a Playwright-MCP verification
+# would be blocked as if nothing had been checked.
+BROWSER_EVIDENCE_TOOL_PATTERN='(browser|playwright|puppeteer|chrome_devtools)'
+
 # Single jq pass: extract last assistant text + Bash tool_result texts in current turn.
 # Current turn boundary = events after the last real user input (string content, or
 # array containing any non-tool_result block). Tool-result-only user messages are
@@ -111,7 +140,28 @@ TURN_JSON=$(tail -n 400 "$TRANSCRIPT_PATH" | jq -sc '
        | select(((($cmd | test("^\\s*(echo|printf)\\b")) and (($cmd | test("[;&|`$\\n]")) | not))) | not)
        | $r.text]
      | join("\n---\n")) as $genuine_outputs
-  | {last_text: $last_text, bash_outputs: $bash_outputs, genuine_outputs: $genuine_outputs}
+  | ([$turn[]
+       | select(.message.role == "assistant" and (.isSidechain // false) == false)
+       | (.message.content // [])[]
+       | select(.type == "tool_use")
+       | select(.name == "Edit" or .name == "Write" or .name == "MultiEdit"
+                or .name == "NotebookEdit")
+       | ((.input.file_path // .input.notebook_path) // "")]
+     | join("\n")) as $edited_paths
+  | ([$turn[]
+       | select(.message.role == "assistant" and (.isSidechain // false) == false)
+       | (.message.content // [])[]
+       | select(.type == "tool_use")
+       | .name]
+     | join("\n")) as $tool_names
+  | (($bash_uses
+       | map(select(((. .cmd | test("^\\s*(echo|printf)\\b"))
+                     and ((. .cmd | test("[;&|`$\\n]")) | not)) | not))
+       | map(.cmd))
+     | join("\n")) as $genuine_cmds
+  | {last_text: $last_text, bash_outputs: $bash_outputs,
+     genuine_outputs: $genuine_outputs, edited_paths: $edited_paths,
+     tool_names: $tool_names, genuine_cmds: $genuine_cmds}
 ' 2>/dev/null)
 
 [ -z "$TURN_JSON" ] && exit 0
@@ -121,6 +171,9 @@ BASH_OUTPUTS=$(printf '%s' "$TURN_JSON" | jq -r '.bash_outputs // ""')
 # genuine_outputs excludes results produced by echo/printf-only commands, so a
 # fabricated `echo "tests passed"` cannot satisfy the evidence gate. [issue #758]
 GENUINE_OUTPUTS=$(printf '%s' "$TURN_JSON" | jq -r '.genuine_outputs // ""')
+EDITED_PATHS=$(printf '%s' "$TURN_JSON" | jq -r '.edited_paths // ""')
+TOOL_NAMES=$(printf '%s' "$TURN_JSON" | jq -r '.tool_names // ""')
+GENUINE_CMDS=$(printf '%s' "$TURN_JSON" | jq -r '.genuine_cmds // ""')
 
 [ -z "$LAST_TEXT" ] && exit 0
 
@@ -157,6 +210,25 @@ else
 
   if [ "$paste_detected" = "false" ]; then
     block_reason="Bash output has a verification signal but the evidence span (e.g. 'X passed', 'lint clean', '✅') was not quoted in your message. Paste the verify token verbatim into your reply."
+  fi
+fi
+
+# Surface check runs even when the generic gate passed: the whole point is that
+# a curl/grep/CI-green sweep satisfies the surface-agnostic patterns while
+# proving nothing about a page's rendered output. Skipped when the generic gate
+# already blocked, so the reply carries one reason rather than two.
+if [ -z "$block_reason" ] && [ -n "$EDITED_PATHS" ]; then
+  if printf '%s\n' "$EDITED_PATHS" | grep -qiE "$FRONTEND_PATH_PATTERN"; then
+    fe_evidence=false
+    if printf '%s' "$GENUINE_CMDS" | grep -qiE "$BROWSER_EVIDENCE_CMD_PATTERN"; then
+      fe_evidence=true
+    elif printf '%s' "$TOOL_NAMES" | grep -qiE "$BROWSER_EVIDENCE_TOOL_PATTERN"; then
+      fe_evidence=true
+    fi
+    if [ "$fe_evidence" = "false" ]; then
+      fe_files=$(printf '%s\n' "$EDITED_PATHS" | grep -iE "$FRONTEND_PATH_PATTERN" | head -3 | tr '\n' ' ')
+      block_reason="A frontend surface was changed this turn (${fe_files}) but nothing observed the rendered page. curl status codes, a source or bundle grep, and CI green are valid oracles for other surfaces and say nothing about what renders. Open the page and read the DOM (e.g. 'cmux browser goto <url> --snapshot-after', 'cmux browser get text <selector>', or a Playwright run) BEFORE declaring completion."
+    fi
   fi
 fi
 

--- a/hooks/completion-verify/completion-verify/impl.sh
+++ b/hooks/completion-verify/completion-verify/impl.sh
@@ -76,18 +76,40 @@ EVIDENCE_PATTERNS='(tests? passed|\bPASS\b|exit code 0|\b[1-9][0-9]* tests? (ran
 # Only extensions that are unambiguously view-layer are listed. Bare `.ts`/`.js`
 # are deliberately absent: they are as often backend as frontend, and a false
 # block on a server change costs more than the miss.
-FRONTEND_PATH_PATTERN='\.(tsx|jsx|vue|svelte|astro|html|htm|css|scss|sass|less)$'
+FRONTEND_EXT='(tsx|jsx|vue|svelte|astro|html|htm|css|scss|sass|less)'
+FRONTEND_PATH_PATTERN="\\.${FRONTEND_EXT}\$"
+# A frontend file edited through Bash — `sed -i`, a redirect, `tee`, `cp`/`mv`
+# — never reaches `EDITED_PATHS`, so keying the surface only on the file tools
+# lets the choice of editor decide whether the gate applies. Only the writing
+# operators are listed, and the path must be the operand: `grep foo App.tsx >
+# /tmp/out` writes to /tmp/out and is not a surface change.
+#
+# Residual: a script whose own body writes the file (`python build.py`) carries
+# no frontend path on the command line and is not detected. Chasing that needs
+# a general shell parser, which this repo has already found to be unbounded.
+BASH_FRONTEND_MUTATION_PATTERN="(sed[[:space:]]+-i([[:space:]]+[^[:space:]]+)*[[:space:]]+[^[:space:];&|]*\\.${FRONTEND_EXT}|(>>?|tee([[:space:]]+-a)?)[[:space:]]*[^[:space:];&|]*\\.${FRONTEND_EXT}|(cp|mv|install)[[:space:]]+[^;&|]*\\.${FRONTEND_EXT}([[:space:]]|\$))"
 
 # Oracles that observe a rendered page. `cmux browser` subcommands verified
 # against `cmux --help`: snapshot / get / is / eval / screenshot read the live
 # DOM, and `--snapshot-after` attaches one to a navigation or interaction.
 # A bare `browser open`/`goto` only navigates, so it is not on its own an
 # observation and is not listed.
-BROWSER_EVIDENCE_CMD_PATTERN='(cmux([[:space:]]+--[^[:space:]]+([[:space:]]+[^[:space:]]+)?)*[[:space:]]+browser[[:space:]].*(snapshot|screenshot|eval|get[[:space:]]|is[[:space:]]|wait[[:space:]])|--snapshot-after|playwright|puppeteer)'
+#
+# The subcommand must sit IMMEDIATELY after `browser`, and a driver name must
+# sit at command position: matching them anywhere in the string let
+# `npm ls puppeteer`, `grep -R playwright package.json`, and
+# `cmux browser goto http://host/snapshot` all count as having observed a page.
+BROWSER_EVIDENCE_CMD_PATTERN='(^|[;&|][[:space:]]*)[[:space:]]*((cmux([[:space:]]+--[^[:space:]]+([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+browser[[:space:]]+(--surface[[:space:]]+[^[:space:]]+[[:space:]]+)?(snapshot|screenshot|eval|get|is|wait)([[:space:]]|$))|((npx|pnpm|yarn|bunx)[[:space:]]+(exec[[:space:]]+)?)?(playwright|puppeteer)([[:space:]]|$))'
+# `--snapshot-after` is a cmux browser flag and nothing else, so it stands on
+# its own — it is what makes a navigation or interaction also an observation.
+BROWSER_SNAPSHOT_FLAG_PATTERN='--snapshot-after([[:space:]]|$)'
 # Browser automation reached through an MCP server never appears as a Bash
 # command, only as a tool name — without this a Playwright-MCP verification
-# would be blocked as if nothing had been checked.
-BROWSER_EVIDENCE_TOOL_PATTERN='(browser|playwright|puppeteer|chrome_devtools)'
+# would be blocked as if nothing had been checked. The name must also carry an
+# observation verb: `browser_close` and `list_pages` drive the browser without
+# reading anything back. Verbs rather than vendor tool names, because the tool
+# inventory is per-server and not verifiable from here.
+BROWSER_EVIDENCE_TOOL_PATTERN='(browser|playwright|puppeteer|chrome_devtools).*(snapshot|screenshot|eval|content|text|dom|inspect|console|network|query|read|get)'
 
 # Single jq pass: extract last assistant text + Bash tool_result texts in current turn.
 # Current turn boundary = events after the last real user input (string content, or
@@ -141,22 +163,35 @@ TURN_JSON=$(tail -n 400 "$TRANSCRIPT_PATH" | jq -sc '
        | $r.text]
      | join("\n---\n")) as $genuine_outputs
   | ([$turn[]
+       | select(.message.role == "user")
+       | (.message.content // [])[]
+       | select(.type == "tool_result" and ((.is_error // false) | not))
+       | .tool_use_id]) as $ok_ids
+  | ([$turn[]
+       | select(.message.role == "user")
+       | (.message.content // [])[]
+       | select(.type == "tool_result" and ((.is_error // false) == true))
+       | .tool_use_id]) as $failed_ids
+  | ([$turn[]
        | select(.message.role == "assistant" and (.isSidechain // false) == false)
        | (.message.content // [])[]
        | select(.type == "tool_use")
        | select(.name == "Edit" or .name == "Write" or .name == "MultiEdit"
                 or .name == "NotebookEdit")
+       | select(.id as $i | ($failed_ids | any(. == $i)) | not)
        | ((.input.file_path // .input.notebook_path) // "")]
      | join("\n")) as $edited_paths
   | ([$turn[]
        | select(.message.role == "assistant" and (.isSidechain // false) == false)
        | (.message.content // [])[]
        | select(.type == "tool_use")
+       | select(.id as $i | $ok_ids | any(. == $i))
        | .name]
      | join("\n")) as $tool_names
   | (($bash_uses
        | map(select(((. .cmd | test("^\\s*(echo|printf)\\b"))
                      and ((. .cmd | test("[;&|`$\\n]")) | not)) | not))
+       | map(select(.id as $i | $ok_ids | any(. == $i)))
        | map(.cmd))
      | join("\n")) as $genuine_cmds
   | {last_text: $last_text, bash_outputs: $bash_outputs,
@@ -217,16 +252,30 @@ fi
 # a curl/grep/CI-green sweep satisfies the surface-agnostic patterns while
 # proving nothing about a page's rendered output. Skipped when the generic gate
 # already blocked, so the reply carries one reason rather than two.
-if [ -z "$block_reason" ] && [ -n "$EDITED_PATHS" ]; then
-  if printf '%s\n' "$EDITED_PATHS" | grep -qiE "$FRONTEND_PATH_PATTERN"; then
+if [ -z "$block_reason" ]; then
+  fe_files=""
+  if [ -n "$EDITED_PATHS" ]; then
+    fe_files=$(printf '%s\n' "$EDITED_PATHS" | grep -iE "$FRONTEND_PATH_PATTERN" | head -3 | tr '\n' ' ')
+  fi
+  if [ -z "$fe_files" ] && [ -n "$GENUINE_CMDS" ] \
+     && printf '%s\n' "$GENUINE_CMDS" | grep -qiE "$BASH_FRONTEND_MUTATION_PATTERN"; then
+    fe_files=$(printf '%s\n' "$GENUINE_CMDS" | grep -oiE "[^[:space:];&|]*$FRONTEND_PATH_PATTERN" \
+      | head -3 | tr '\n' ' ')
+    [ -z "$fe_files" ] && fe_files="(bash-edited) "
+  fi
+
+  if [ -n "$fe_files" ]; then
     fe_evidence=false
-    if printf '%s' "$GENUINE_CMDS" | grep -qiE "$BROWSER_EVIDENCE_CMD_PATTERN"; then
+    # `-e` is load-bearing: BROWSER_SNAPSHOT_FLAG_PATTERN starts with `--`, which
+    # grep otherwise parses as an option and rejects outright.
+    if printf '%s\n' "$GENUINE_CMDS" | grep -qiE -e "$BROWSER_EVIDENCE_CMD_PATTERN"; then
       fe_evidence=true
-    elif printf '%s' "$TOOL_NAMES" | grep -qiE "$BROWSER_EVIDENCE_TOOL_PATTERN"; then
+    elif printf '%s\n' "$GENUINE_CMDS" | grep -qiE -e "$BROWSER_SNAPSHOT_FLAG_PATTERN"; then
+      fe_evidence=true
+    elif printf '%s\n' "$TOOL_NAMES" | grep -qiE -e "$BROWSER_EVIDENCE_TOOL_PATTERN"; then
       fe_evidence=true
     fi
     if [ "$fe_evidence" = "false" ]; then
-      fe_files=$(printf '%s\n' "$EDITED_PATHS" | grep -iE "$FRONTEND_PATH_PATTERN" | head -3 | tr '\n' ' ')
       block_reason="A frontend surface was changed this turn (${fe_files}) but nothing observed the rendered page. curl status codes, a source or bundle grep, and CI green are valid oracles for other surfaces and say nothing about what renders. Open the page and read the DOM (e.g. 'cmux browser goto <url> --snapshot-after', 'cmux browser get text <selector>', or a Playwright run) BEFORE declaring completion."
     fi
   fi

--- a/hooks/completion-verify/completion-verify/spec.md
+++ b/hooks/completion-verify/completion-verify/spec.md
@@ -52,6 +52,41 @@ pattern, not adversarial evasion. The chaining char in a disguise keeps the
 command in the genuine set by design (avoiding false positives on real
 chained verification).
 
+### Evidence class follows the changed surface (issue #943)
+
+The gates above ask *whether* evidence exists, never *whether that evidence
+can see the thing that changed*. A turn that edits a rendered page and then
+runs `curl -w '%{http_code}'` satisfies L1–L4 in full while nothing ever
+looked at what the browser shows — the motivating failure was exactly that:
+a link swapped in a `.tsx` file, verified by an HTTP status code.
+
+So after the generic gate passes, one surface check runs:
+
+| Changed surface | Detected by | Evidence required |
+| --- | --- | --- |
+| Frontend (`.tsx` `.jsx` `.vue` `.svelte` `.astro` `.html` `.htm` `.css` `.scss` `.sass` `.less`) | terminal extension of `Edit`/`Write`/`MultiEdit`/`NotebookEdit` `file_path` (or `notebook_path`), case-insensitive | a genuine Bash command invoking a browser driver (`cmux … browser {snapshot,screenshot,eval,get,is,wait}`, `--snapshot-after`, `playwright`, `puppeteer`) **or** a `tool_use` whose name carries `browser` / `playwright` / `puppeteer` / `chrome_devtools` |
+| Anything else | — | the generic gate's verdict stands |
+
+Two properties are load-bearing:
+
+- The browser command is drawn from the **genuine** command set, so
+  `echo "cmux browser snapshot"` is a fabrication here for the same reason it
+  is one at L4.
+- The tool-name path exists because a browser MCP tool never appears as a Bash
+  command at all — gating on commands alone would block every turn verified
+  through Playwright MCP.
+
+The extension test is terminal (`\.tsx$`), so a `Docs.tsx.bak` backup is not a
+frontend surface. `.ipynb` is deliberately absent: a notebook is edited through
+`NotebookEdit`'s `notebook_path` and its output is not a rendered page.
+
+**Residuals** (documented, not bugs): the check keys on the *file extension*,
+so a frontend surface authored in a non-listed extension (a `.js` React file, a
+templating language, a design-system token file) is not covered; and a browser
+command that ran but observed a different page than the one edited still
+passes — the gate proves *something* observed a page, not that it observed the
+right one.
+
 ### Response
 
 When blocked, the hook emits:
@@ -92,15 +127,20 @@ same pattern the marker would re-enable.
 
 ### Tests
 
-`tests/test_completion_verify.sh` covers 17 cases: 8 acceptance scenarios
-(same-turn pass, no-Bash claim, no-evidence claim, no-paste claim,
-mid-message claim ignored, non-Bash tool ignored, realistic pytest
-output, Korean evidence), 5 anti-gaming scenarios (echo-fabricated blocked,
-printf-fabricated blocked, real command chained with echo passes, Korean
-echo-fabricated blocked, echo of command-substitution passes — issue #758),
-and 4 fail-safes (`stop_hook_active`, missing transcript, empty file,
-malformed JSONL). Run before editing the hook:
+`tests/hooks/completion-verify/test_completion_verify.sh` covers 31 cases:
+8 acceptance scenarios (same-turn pass, no-Bash claim, no-evidence claim,
+no-paste claim, mid-message claim ignored, non-Bash tool ignored, realistic
+pytest output, Korean evidence), 5 anti-gaming scenarios (echo-fabricated
+blocked, printf-fabricated blocked, real command chained with echo passes,
+Korean echo-fabricated blocked, echo of command-substitution passes —
+issue #758), 14 surface-class scenarios (curl-only evidence on a `.tsx` blocked,
+`--snapshot-after` / `browser get` / a global flag before `browser` /
+a browser MCP tool all pass, echoed browser command blocked, backend edit and
+no-edit turns unaffected, `.tsx.bak` not frontend, uppercase `.TSX` is,
+`Write` counts, `.ipynb` does not, no-claim turn never arms, `.scss` counts —
+issue #943), and 4 fail-safes (`stop_hook_active`, missing transcript, empty
+file, malformed JSONL). Run before editing the hook:
 
 ```bash
-./tests/test_completion_verify.sh
+./tests/hooks/completion-verify/test_completion_verify.sh
 ```

--- a/hooks/completion-verify/completion-verify/spec.md
+++ b/hooks/completion-verify/completion-verify/spec.md
@@ -64,10 +64,10 @@ So after the generic gate passes, one surface check runs:
 
 | Changed surface | Detected by | Evidence required |
 | --- | --- | --- |
-| Frontend (`.tsx` `.jsx` `.vue` `.svelte` `.astro` `.html` `.htm` `.css` `.scss` `.sass` `.less`) | terminal extension of `Edit`/`Write`/`MultiEdit`/`NotebookEdit` `file_path` (or `notebook_path`), case-insensitive | a genuine Bash command invoking a browser driver (`cmux … browser {snapshot,screenshot,eval,get,is,wait}`, `--snapshot-after`, `playwright`, `puppeteer`) **or** a `tool_use` whose name carries `browser` / `playwright` / `puppeteer` / `chrome_devtools` |
+| Frontend (`.tsx` `.jsx` `.vue` `.svelte` `.astro` `.html` `.htm` `.css` `.scss` `.sass` `.less`) | terminal extension of a **succeeded** `Edit`/`Write`/`MultiEdit`/`NotebookEdit` `file_path` (or `notebook_path`), case-insensitive — **or** a genuine Bash command that writes such a path (`sed -i`, `>`/`>>`, `tee`, `cp`/`mv`) | a genuine, **succeeded** Bash command invoking a browser driver (`cmux … browser {snapshot,screenshot,eval,get,is,wait}` with the subcommand immediately after `browser`, `--snapshot-after`, or `playwright`/`puppeteer` at command position) **or** a succeeded `tool_use` whose name carries both a driver (`browser`/`playwright`/`puppeteer`/`chrome_devtools`) and an observation verb |
 | Anything else | — | the generic gate's verdict stands |
 
-Two properties are load-bearing:
+Four properties are load-bearing:
 
 - The browser command is drawn from the **genuine** command set, so
   `echo "cmux browser snapshot"` is a fabrication here for the same reason it
@@ -75,6 +75,21 @@ Two properties are load-bearing:
 - The tool-name path exists because a browser MCP tool never appears as a Bash
   command at all — gating on commands alone would block every turn verified
   through Playwright MCP.
+- **Attempting is not observing.** Evidence tool_uses are correlated
+  `id` ↔ `tool_result.tool_use_id` and must have a result that is not
+  `is_error` — a snapshot that failed, or one whose result never arrived,
+  observed nothing. Conversely a **failed** `Edit` changed nothing, so it is
+  dropped from the surface rather than blocking a reply. The same correlation
+  is used by `advisory-nudge/pre-commit-staged-file-enumeration` and
+  `completion-verify/pr-claim-mutation-gate`.
+- **The match must be an operation, not a mention.** `npm ls puppeteer`,
+  `grep -R playwright package.json`, `cmux browser goto http://host/snapshot`,
+  and `browser_close` all name a driver while reading nothing back, so the
+  subcommand is anchored immediately after `browser`, driver names are anchored
+  at command position, and an MCP tool name must also carry an observation verb
+  (`snapshot`/`screenshot`/`eval`/`content`/`text`/`dom`/`inspect`/`console`/
+  `network`/`query`/`read`/`get`). Verbs rather than a vendor tool list,
+  because the inventory is per-server and not verifiable from inside the hook.
 
 The extension test is terminal (`\.tsx$`), so a `Docs.tsx.bak` backup is not a
 frontend surface. `.ipynb` is deliberately absent: a notebook is edited through
@@ -82,10 +97,15 @@ frontend surface. `.ipynb` is deliberately absent: a notebook is edited through
 
 **Residuals** (documented, not bugs): the check keys on the *file extension*,
 so a frontend surface authored in a non-listed extension (a `.js` React file, a
-templating language, a design-system token file) is not covered; and a browser
+templating language, a design-system token file) is not covered; a browser
 command that ran but observed a different page than the one edited still
 passes — the gate proves *something* observed a page, not that it observed the
-right one.
+right one; a frontend file written by a script whose own body holds the path
+(`python build.py`) carries no frontend path on the command line and is not
+detected, since chasing it needs the general shell parser this repo has already
+found to be unbounded; and an MCP tool whose name puts the observation verb
+before the driver (`snapshot_browser`) is missed by the verb-after-driver
+ordering.
 
 ### Response
 
@@ -127,19 +147,23 @@ same pattern the marker would re-enable.
 
 ### Tests
 
-`tests/hooks/completion-verify/test_completion_verify.sh` covers 31 cases:
+`tests/hooks/completion-verify/test_completion_verify.sh` covers 38 cases:
 8 acceptance scenarios (same-turn pass, no-Bash claim, no-evidence claim,
 no-paste claim, mid-message claim ignored, non-Bash tool ignored, realistic
 pytest output, Korean evidence), 5 anti-gaming scenarios (echo-fabricated
 blocked, printf-fabricated blocked, real command chained with echo passes,
 Korean echo-fabricated blocked, echo of command-substitution passes —
-issue #758), 14 surface-class scenarios (curl-only evidence on a `.tsx` blocked,
-`--snapshot-after` / `browser get` / a global flag before `browser` /
-a browser MCP tool all pass, echoed browser command blocked, backend edit and
-no-edit turns unaffected, `.tsx.bak` not frontend, uppercase `.TSX` is,
-`Write` counts, `.ipynb` does not, no-claim turn never arms, `.scss` counts —
-issue #943), and 4 fail-safes (`stop_hook_active`, missing transcript, empty
-file, malformed JSONL). Run before editing the hook:
+issue #758), 21 surface-class scenarios (issue #943) — 14 for the mapping
+itself (curl-only evidence on a `.tsx` blocked, `--snapshot-after` /
+`browser get` / a global flag before `browser` / a browser MCP tool all pass,
+echoed browser command blocked, backend edit and no-edit turns unaffected,
+`.tsx.bak` not frontend, uppercase `.TSX` is, `Write` counts, `.ipynb` does
+not, no-claim turn never arms, `.scss` counts) and 7 from the codex review
+round (failed browser MCP call blocked, failed `Edit` does not block,
+`sed -i` on a `.tsx` blocks, a `.tsx` only read by the command does not,
+`npm ls puppeteer` blocked, `snapshot` inside a `goto` URL blocked,
+`browser_close` blocked) — and 4 fail-safes (`stop_hook_active`, missing
+transcript, empty file, malformed JSONL). Run before editing the hook:
 
 ```bash
 ./tests/hooks/completion-verify/test_completion_verify.sh

--- a/tests/hooks/completion-verify/test_completion_verify.sh
+++ b/tests/hooks/completion-verify/test_completion_verify.sh
@@ -119,13 +119,16 @@ mk_named_use() {
 }
 
 mk_tool_result() {
-  local id="$1" content="$2"
-  jq -nc --arg id "$id" --arg c "$content" '{
+  # $3 = "error" marks the result is_error (a tool call that failed)
+  local id="$1" content="$2" err="${3:-}"
+  local is_err=false
+  [ "$err" = "error" ] && is_err=true
+  jq -nc --arg id "$id" --arg c "$content" --argjson e "$is_err" '{
     type: "user",
     isSidechain: false,
     message: {
       role: "user",
-      content: [{type: "tool_result", tool_use_id: $id, content: $c}]
+      content: [{type: "tool_result", tool_use_id: $id, content: $c, is_error: $e}]
     }
   }'
 }
@@ -351,12 +354,14 @@ $ASST_FE6D"
 USER_FE5=$(mk_user_text "고쳐줘")
 ASST_FE5A=$(mk_assistant "편집 중..." "[$(mk_edit_use "fe5-e" "apps/web/src/Docs.tsx" Edit)]")
 ASST_FE5B=$(mk_assistant "스냅샷..." "[$(mk_named_use "fe5-m" "mcp__playwright__browser_snapshot")]")
+RESULT_FE5M=$(mk_tool_result "fe5-m" "- link \"문서\" [ref=e12]")
 ASST_FE5C=$(mk_assistant "테스트 중..." "[$(mk_bash_use "fe5-b" "pytest -q")]")
 RESULT_FE5=$(mk_tool_result "fe5-b" "$FE_OUT")
 ASST_FE5D=$(mk_assistant "$FE_CITE")
 run_case "FE5 browser MCP tool counts as observation" pass "$USER_FE5
 $ASST_FE5A
 $ASST_FE5B
+$RESULT_FE5M
 $ASST_FE5C
 $RESULT_FE5
 $ASST_FE5D"
@@ -399,6 +404,81 @@ fe_case "FE13 frontend edit without a completion claim" pass \
 # FE14 — stylesheets are a frontend surface too
 fe_case "FE14 scss edit counts as frontend" block \
   "apps/web/src/theme.scss" Edit "pytest -q" "$FE_OUT" "$FE_CITE"
+
+# FE15..FE21 — codex review round 1 (PR #957) -------------------------------
+#
+# The first cut asked only whether a browser call was ATTEMPTED and matched its
+# driver name anywhere in the string, so a failed snapshot, a package listing,
+# and a `sed -i` edit all landed on the wrong side of the gate.
+
+# FE15 — the browser MCP call failed, so nothing observed the page → block.
+USER_FE15=$(mk_user_text "고쳐줘")
+ASST_FE15A=$(mk_assistant "편집 중..." "[$(mk_edit_use "fe15-e" "apps/web/src/Docs.tsx" Edit)]")
+RESULT_FE15E=$(mk_tool_result "fe15-e" "ok")
+ASST_FE15B=$(mk_assistant "스냅샷..." "[$(mk_named_use "fe15-m" "mcp__playwright__browser_snapshot")]")
+RESULT_FE15M=$(mk_tool_result "fe15-m" "Error: browser is not open" error)
+ASST_FE15C=$(mk_assistant "테스트 중..." "[$(mk_bash_use "fe15-b" "pytest -q")]")
+RESULT_FE15=$(mk_tool_result "fe15-b" "$FE_OUT")
+ASST_FE15D=$(mk_assistant "$FE_CITE")
+run_case "FE15 failed browser MCP call is not observation" block "$USER_FE15
+$ASST_FE15A
+$RESULT_FE15E
+$ASST_FE15B
+$RESULT_FE15M
+$ASST_FE15C
+$RESULT_FE15
+$ASST_FE15D"
+
+# FE16 — the .tsx Edit itself failed, so no surface changed → no block.
+USER_FE16=$(mk_user_text "고쳐줘")
+ASST_FE16A=$(mk_assistant "편집 중..." "[$(mk_edit_use "fe16-e" "apps/web/src/Docs.tsx" Edit)]")
+RESULT_FE16E=$(mk_tool_result "fe16-e" "String to replace not found in file" error)
+ASST_FE16B=$(mk_assistant "테스트 중..." "[$(mk_bash_use "fe16-b" "pytest -q")]")
+RESULT_FE16=$(mk_tool_result "fe16-b" "$FE_OUT")
+ASST_FE16C=$(mk_assistant "$FE_CITE")
+run_case "FE16 failed Edit is not a surface change" pass "$USER_FE16
+$ASST_FE16A
+$RESULT_FE16E
+$ASST_FE16B
+$RESULT_FE16
+$ASST_FE16C"
+
+# FE17 — the frontend file was edited through Bash, not a file tool → block.
+fe_case "FE17 sed -i on a .tsx counts as a surface change" block \
+  "src/api/handler.py" Edit \
+  "sed -i '' 's/old/new/' apps/web/src/Docs.tsx" "$FE_OUT" "$FE_CITE"
+
+# FE18 — a frontend path that is only READ by the command is not a change.
+fe_case "FE18 grep of a .tsx redirected elsewhere is not a change" pass \
+  "src/api/handler.py" Edit \
+  "grep -n href apps/web/src/Docs.tsx > /tmp/out.txt" "$FE_OUT" "$FE_CITE"
+
+# FE19 — a package listing mentions the driver but observes nothing → block.
+fe_case "FE19 npm ls puppeteer is not observation" block \
+  "apps/web/src/Docs.tsx" Edit "npm ls puppeteer" "$FE_OUT" "$FE_CITE"
+
+# FE20 — 'snapshot' inside the URL of a navigate-only command → block.
+fe_case "FE20 snapshot in a goto URL is not observation" block \
+  "apps/web/src/Docs.tsx" Edit \
+  "cmux browser goto http://localhost:3000/snapshot" "$FE_OUT" "$FE_CITE"
+
+# FE21 — a browser MCP tool that drives without reading back → block.
+USER_FE21=$(mk_user_text "고쳐줘")
+ASST_FE21A=$(mk_assistant "편집 중..." "[$(mk_edit_use "fe21-e" "apps/web/src/Docs.tsx" Edit)]")
+RESULT_FE21E=$(mk_tool_result "fe21-e" "ok")
+ASST_FE21B=$(mk_assistant "닫는 중..." "[$(mk_named_use "fe21-m" "mcp__playwright__browser_close")]")
+RESULT_FE21M=$(mk_tool_result "fe21-m" "closed")
+ASST_FE21C=$(mk_assistant "테스트 중..." "[$(mk_bash_use "fe21-b" "pytest -q")]")
+RESULT_FE21=$(mk_tool_result "fe21-b" "$FE_OUT")
+ASST_FE21D=$(mk_assistant "$FE_CITE")
+run_case "FE21 browser_close reads nothing back" block "$USER_FE21
+$ASST_FE21A
+$RESULT_FE21E
+$ASST_FE21B
+$RESULT_FE21M
+$ASST_FE21C
+$RESULT_FE21
+$ASST_FE21D"
 
 # Fail-safe 1 — stop_hook_active=true → pass (no block) ---------------------
 fs_payload=$(jq -nc '{transcript_path: "/dev/null", stop_hook_active: true, session_id: "x"}')

--- a/tests/hooks/completion-verify/test_completion_verify.sh
+++ b/tests/hooks/completion-verify/test_completion_verify.sh
@@ -102,6 +102,22 @@ mk_bash_use() {
     '{type: "tool_use", id: $id, name: "Bash", input: {command: $c}}'
 }
 
+mk_edit_use() {
+  # $1 = tool_use id, $2 = path, $3 = tool name (Edit/Write/MultiEdit/NotebookEdit)
+  local id="$1" path="$2" name="${3:-Edit}"
+  local key="file_path"
+  [ "$name" = "NotebookEdit" ] && key="notebook_path"
+  jq -nc --arg id "$id" --arg p "$path" --arg n "$name" --arg k "$key" \
+    '{type: "tool_use", id: $id, name: $n, input: {($k): $p}}'
+}
+
+mk_named_use() {
+  # $1 = tool_use id, $2 = tool name (e.g. an MCP browser tool)
+  local id="$1" name="$2"
+  jq -nc --arg id "$id" --arg n "$name" \
+    '{type: "tool_use", id: $id, name: $n, input: {}}'
+}
+
 mk_tool_result() {
   local id="$1" content="$2"
   jq -nc --arg id "$id" --arg c "$content" '{
@@ -266,6 +282,123 @@ run_case "AG5 echo of command-substitution passes" pass "$USER_AG5
 $ASST_AG5A
 $RESULT_AG5
 $ASST_AG5B"
+
+# FE — evidence class gated by the changed surface [#943] -------------------
+#
+# A frontend surface edited this turn needs evidence that something observed
+# the rendered page. A generic pass (pytest, curl) satisfies the generic gate
+# but says nothing about what the browser shows.
+
+FE_OUT="============= 12 passed in 0.85s ============="
+FE_CITE="12 passed in 0.85s. 작업 완료."
+
+# fe_case <name> <expected> <edited-path> <tool> <verify-cmd> <verify-out> <final-text>
+fe_case() {
+  local name="$1" expected="$2" path="$3" tool="$4" cmd="$5" out="$6" final="$7"
+  local u a1 b a2 r a3
+  u=$(mk_user_text "고쳐줘")
+  a1=$(mk_assistant "편집 중..." "[$(mk_edit_use "fe-e" "$path" "$tool")]")
+  b=$(mk_bash_use "fe-b" "$cmd")
+  a2=$(mk_assistant "확인 중..." "[$b]")
+  r=$(mk_tool_result "fe-b" "$out")
+  a3=$(mk_assistant "$final")
+  run_case "$name" "$expected" "$u
+$a1
+$a2
+$r
+$a3"
+}
+
+# FE1 — the motivating failure: .tsx edited, only curl/grep evidence → block
+fe_case "FE1 frontend edit with curl-only evidence" block \
+  "apps/web/src/Docs.tsx" Edit \
+  "curl -s -o /dev/null -w '%{http_code}' https://example.test" \
+  "200 — 12 passed in 0.85s" "$FE_CITE"
+
+# FE2 — cmux browser navigation with --snapshot-after → pass
+fe_case "FE2 frontend edit with cmux --snapshot-after" pass \
+  "apps/web/src/Docs.tsx" Edit \
+  "cmux browser goto http://localhost:3000/docs --snapshot-after" \
+  "$FE_OUT" "$FE_CITE"
+
+# FE3 — cmux browser observation subcommand (get text) → pass
+fe_case "FE3 frontend edit with cmux browser get text" pass \
+  "apps/web/src/Docs.tsx" Edit \
+  "cmux browser get text '.doc-link'" "$FE_OUT" "$FE_CITE"
+
+# FE4 — global flags between `cmux` and `browser` must not break the match
+fe_case "FE4 cmux global flag before browser subcommand" pass \
+  "apps/web/src/Docs.tsx" Edit \
+  "cmux --password secret browser snapshot --compact" "$FE_OUT" "$FE_CITE"
+
+# FE6 — echoed browser command is fabrication, not observation → block
+USER_FE6=$(mk_user_text "고쳐줘")
+ASST_FE6A=$(mk_assistant "편집 중..." "[$(mk_edit_use "fe6-e" "apps/web/src/Docs.tsx" Edit)]")
+ASST_FE6B=$(mk_assistant "확인 중..." "[$(mk_bash_use "fe6-b0" 'echo "cmux browser snapshot"')]")
+RESULT_FE6A=$(mk_tool_result "fe6-b0" "cmux browser snapshot")
+ASST_FE6C=$(mk_assistant "테스트 중..." "[$(mk_bash_use "fe6-b1" "pytest -q")]")
+RESULT_FE6B=$(mk_tool_result "fe6-b1" "$FE_OUT")
+ASST_FE6D=$(mk_assistant "$FE_CITE")
+run_case "FE6 echoed browser command is not observation" block "$USER_FE6
+$ASST_FE6A
+$ASST_FE6B
+$RESULT_FE6A
+$ASST_FE6C
+$RESULT_FE6B
+$ASST_FE6D"
+
+# FE5 — a browser MCP tool never appears as a Bash command → pass
+USER_FE5=$(mk_user_text "고쳐줘")
+ASST_FE5A=$(mk_assistant "편집 중..." "[$(mk_edit_use "fe5-e" "apps/web/src/Docs.tsx" Edit)]")
+ASST_FE5B=$(mk_assistant "스냅샷..." "[$(mk_named_use "fe5-m" "mcp__playwright__browser_snapshot")]")
+ASST_FE5C=$(mk_assistant "테스트 중..." "[$(mk_bash_use "fe5-b" "pytest -q")]")
+RESULT_FE5=$(mk_tool_result "fe5-b" "$FE_OUT")
+ASST_FE5D=$(mk_assistant "$FE_CITE")
+run_case "FE5 browser MCP tool counts as observation" pass "$USER_FE5
+$ASST_FE5A
+$ASST_FE5B
+$ASST_FE5C
+$RESULT_FE5
+$ASST_FE5D"
+
+# FE7 — backend-only edit keeps the generic gate's verdict (no regression)
+fe_case "FE7 backend edit unaffected" pass \
+  "src/api/handler.py" Edit "pytest -q" "$FE_OUT" "$FE_CITE"
+
+# FE8 — no edit at all (Q&A turn) → no false positive
+USER_FE8=$(mk_user_text "상태 알려줘")
+ASST_FE8A=$(mk_assistant "확인 중..." "[$(mk_bash_use "fe8-b" "pytest -q")]")
+RESULT_FE8=$(mk_tool_result "fe8-b" "$FE_OUT")
+ASST_FE8B=$(mk_assistant "$FE_CITE")
+run_case "FE8 no edit this turn" pass "$USER_FE8
+$ASST_FE8A
+$RESULT_FE8
+$ASST_FE8B"
+
+# FE9 — extension must be terminal: a .tsx.bak backup is not a frontend surface
+fe_case "FE9 .tsx.bak is not a frontend surface" pass \
+  "apps/web/src/Docs.tsx.bak" Edit "pytest -q" "$FE_OUT" "$FE_CITE"
+
+# FE10 — extension matching is case-insensitive
+fe_case "FE10 uppercase .TSX still frontend" block \
+  "apps/web/src/Docs.TSX" Edit "pytest -q" "$FE_OUT" "$FE_CITE"
+
+# FE11 — Write (file creation), not just Edit, counts as a surface change
+fe_case "FE11 Write of a .vue file counts" block \
+  "app/Card.vue" Write "pytest -q" "$FE_OUT" "$FE_CITE"
+
+# FE12 — NotebookEdit carries notebook_path; .ipynb is not a frontend surface
+fe_case "FE12 NotebookEdit .ipynb is not frontend" pass \
+  "nb/analysis.ipynb" NotebookEdit "pytest -q" "$FE_OUT" "$FE_CITE"
+
+# FE13 — no completion claim → the gate never arms, frontend or not
+fe_case "FE13 frontend edit without a completion claim" pass \
+  "apps/web/src/Docs.tsx" Edit "curl -s https://example.test" "200" \
+  "아직 확인 중입니다."
+
+# FE14 — stylesheets are a frontend surface too
+fe_case "FE14 scss edit counts as frontend" block \
+  "apps/web/src/theme.scss" Edit "pytest -q" "$FE_OUT" "$FE_CITE"
 
 # Fail-safe 1 — stop_hook_active=true → pass (no block) ---------------------
 fs_payload=$(jq -nc '{transcript_path: "/dev/null", stop_hook_active: true, session_id: "x"}')


### PR DESCRIPTION
### 무엇

`completion-verify` 는 증거가 **있는지**만 묻고, 그 증거가 **바뀐 것을 볼 수
있는지**는 묻지 않았습니다. 동기가 된 실패가 정확히 그 모양입니다 — `.tsx`
안의 링크를 바꾸고 `curl -w '%{http_code}'` 로 확인. L1~L4 를 전부 통과하지만
렌더된 페이지를 본 것은 아무것도 없습니다.

### 어떻게

일반 게이트가 통과한 **뒤** 표면 검사를 한 번 더 돌립니다.

| 바뀐 표면 | 판별 | 요구되는 증거 |
| --- | --- | --- |
| 프론트엔드 (`.tsx` `.jsx` `.vue` `.svelte` `.astro` `.html` `.htm` `.css` `.scss` `.sass` `.less`) | 이번 턴 `Edit`/`Write`/`MultiEdit`/`NotebookEdit` 의 `file_path`(`notebook_path`) 종단 확장자, 대소문자 무시 | 브라우저 드라이버를 부른 **genuine** Bash 명령(`cmux … browser {snapshot,screenshot,eval,get,is,wait}`, `--snapshot-after`, playwright, puppeteer) **또는** 이름에 browser/playwright/puppeteer/chrome_devtools 를 담은 `tool_use` |
| 그 외 | — | 일반 게이트 판정 그대로 |

두 가지가 설계상 핵심입니다.

- 명령은 L4 의 **genuine** 집합에서 뽑습니다 — `echo "cmux browser snapshot"`
  은 여기서도 같은 이유로 조작입니다.
- tool 이름 경로가 따로 필요한 이유: 브라우저 MCP 도구는 Bash 명령으로 전혀
  나타나지 않아, 명령만 보면 Playwright MCP 로 검증한 턴이 전부 막힙니다.

확장자 검사는 종단(`\.tsx$`)이라 `Docs.tsx.bak` 백업은 프론트 표면이 아닙니다.
`.ipynb` 는 의도적으로 뺐습니다 — `notebook_path` 로 편집되고 그 출력은 렌더된
페이지가 아닙니다.

### 남는 구멍 (스펙에 명시)

- 판별이 **확장자** 기준이라, 목록 밖 확장자로 쓰인 프론트 표면(`.js` React
  파일, 템플릿 언어, 디자인 토큰 파일)은 커버되지 않습니다.
- 브라우저 명령이 돌긴 했지만 **편집한 페이지가 아닌 다른 페이지**를 본
  경우도 통과합니다. 이 게이트가 증명하는 것은 "무언가 페이지를 봤다"이지
  "맞는 페이지를 봤다"가 아닙니다.

### 검증

케이스 14건 추가, 훅 스위트 **31/31**. **음성 대조**로 수정 전 훅에서 결함을
재현했습니다 — FE 차단 5건이 전부 통과로 무너지고 나머지 26건은 그대로 통과
(회귀 없음).

| 시나리오 | 수정 전 | 수정 후 | 기대 |
| --- | --- | --- | --- |
| `.tsx` 편집 + curl 만 | 통과 | **차단** | 차단 |
| `.tsx` 편집 + `--snapshot-after` | 통과 | 통과 | 통과 |
| `.tsx` 편집 + `cmux browser get text` | 통과 | 통과 | 통과 |
| `cmux --password x browser snapshot` | 통과 | 통과 | 통과 |
| `.tsx` 편집 + 브라우저 명령 echo | 통과 | **차단** | 차단 |
| `.tsx` 편집 + Playwright MCP 도구 | 통과 | 통과 | 통과 |
| 백엔드 `.py` 편집 | 통과 | 통과 | 통과 |
| 편집 없는 Q&A 턴 | 통과 | 통과 | 통과 |
| `Docs.tsx.bak` | 통과 | 통과 | 통과 |
| 대문자 `.TSX` | 통과 | **차단** | 차단 |
| `Write` 로 만든 `.vue` | 통과 | **차단** | 차단 |
| `NotebookEdit` `.ipynb` | 통과 | 통과 | 통과 |
| `.tsx` 편집 + 완료 주장 없음 | 통과 | 통과 | 통과 |
| `.scss` 편집 | 통과 | **차단** | 차단 |

Caller chain verified: 새 셸 변수 3개(`EDITED_PATHS` / `TOOL_NAMES` /
`GENUINE_CMDS`)는 이 `impl.sh` 안에서만 정의·사용됩니다
(`grep -rn 'EDITED_PATHS\|GENUINE_CMDS' hooks/` → 파일 1개). 표면 검사는
`block_reason` 이 비어 있을 때만 덧붙으므로, 기존 게이트의 차단 사유를
덮어쓰지 않습니다.

Pre-commit verified: `./scripts/run-tests.sh` → ALL TESTS PASSED
(pytest, shell 42/42, manifest OK, hook-token 7 invariants, ruff, shellcheck).

Closes #943
