### PR TITLE
fix(hook): accept the english anchor field labels

### DIFF
--- a/hooks/preflight-gate/anchor-comment-gate/impl.py
+++ b/hooks/preflight-gate/anchor-comment-gate/impl.py
@@ -42,11 +42,15 @@ structure case is what keeps that window small.
 ## What blocks (PreToolUse)
 
 All five fields, else block:
-  - `### 검증 — \\`<sha>\\` (rev N)` heading, on the first non-empty line
+  - `### Verification — \\`<sha>\\` (rev N)` heading (or the legacy `### 검증`
+    dialect), on the first non-empty line
   - a claim table with at least one numbered row
-  - a 미검증 toggle
-  - one evidence toggle per numbered table row
-  - a 갱신 이력 toggle
+  - an `Unverified` toggle (`미검증` in the legacy dialect)
+  - one evidence toggle per numbered table row, `Evidence <n> —` (legacy `<n>.`)
+  - a `History` toggle (legacy `갱신 이력`)
+
+The dialect is chosen by the heading and every other field is then read in it,
+so a body cannot pass by taking half its labels from each.
 
 Plus `--edit-last` on an anchor body: that flag edits *the last comment of the
 current user*, which the paired update notice displaces, so from rev 2 it
@@ -101,9 +105,9 @@ _STRICT_ENV = "PRAXIS_ANCHOR_GATE_STRICT"
 # actually open, and that spec points onward.
 _REFERENCE = "hooks/preflight-gate/anchor-comment-gate/spec.md"
 
-# The anchor's first line. Also the prefix the id-recovery jq matches on, so
-# the two must move together — see spec.md.
-_ANCHOR_PREFIX = "### 검증"
+# The anchor's first line, in either dialect. Also the prefix the id-recovery
+# jq matches on, so the two must move together — see spec.md.
+_ANCHOR_PREFIXES = ("### Verification", "### 검증")
 
 _SHORT_FLAGS_WITH_ARG = frozenset({"-b", "-F", "-R", "-f", "-X", "-q", "-H", "-t", "-p"})
 _API_FLAGS_WITH_ARG = frozenset({
@@ -112,11 +116,34 @@ _API_FLAGS_WITH_ARG = frozenset({
     "--preview", "--cache",
 })
 
-_HEADING_RE = re.compile(r"^###\s+검증\s*[—-]\s*`([0-9a-fA-F]{6,40})`\s*\(rev\s*(\d+)\)")
+# Field names come in two dialects. `en` is what the rule prescribes; `ko` is
+# kept because anchors published before it are edited in place, never
+# retrofitted, so rejecting their dialect would lock their own revisions out.
+# A body is read in exactly one dialect, chosen by its heading — mixing the two
+# surfaces as a missing field, which is what it is.
+_DIALECTS = {
+    "en": {
+        "heading": re.compile(
+            r"^###\s+Verification\s*[—-]\s*`([0-9a-fA-F]{6,40})`\s*\(rev\s*(\d+)\)"),
+        "heading_label": "SHA+rev 헤딩 (`### Verification — `<sha>` (rev N)`) — 첫 줄이어야 함",
+        "unverified": "Unverified",
+        "history": "History",
+        "evidence": re.compile(r"^\s*(?:<b>)?\s*Evidence\s+(\d+)\s*[—-]"),
+        "evidence_label": "`<details><summary>Evidence N — …`",
+    },
+    "ko": {
+        "heading": re.compile(
+            r"^###\s+검증\s*[—-]\s*`([0-9a-fA-F]{6,40})`\s*\(rev\s*(\d+)\)"),
+        "heading_label": "SHA+rev 헤딩 (`### 검증 — `<sha>` (rev N)`) — 첫 줄이어야 함",
+        "unverified": "미검증",
+        "history": "갱신 이력",
+        "evidence": re.compile(r"^\s*(?:<b>)?\s*(\d+)\s*\."),
+        "evidence_label": "`<details><summary>N. …`",
+    },
+}
 _TABLE_ROW_RE = re.compile(r"^\|\s*(\d+)\s*\|", re.MULTILINE)
 _DETAILS_RE = re.compile(r"<details\b[^>]*>(.*?)</details>", re.DOTALL)
 _SUMMARY_RE = re.compile(r"<summary\b[^>]*>(.*?)</summary>", re.DOTALL)
-_EVIDENCE_SUMMARY_RE = re.compile(r"^\s*(?:<b>)?\s*(\d+)\s*\.")
 _FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
 # gh accepts the endpoint with or without a leading slash, and with or without
 # the api.github.com host — anchor both forms or the slashless one slips past.
@@ -432,13 +459,26 @@ def _bypassed_with_reason(command: str) -> bool:
 def _is_anchor(body: str) -> bool:
     for line in body.splitlines():
         if line.strip():
-            return line.strip().startswith(_ANCHOR_PREFIX)
+            return line.strip().startswith(_ANCHOR_PREFIXES)
     return False
 
 
 # ---------------------------------------------------------------------------
 # Structure — decidable from the body alone, so both phases share it
 # ---------------------------------------------------------------------------
+
+def _dialect(body: str) -> dict:
+    """The field-name set this body is read in, chosen by its opening keyword.
+
+    Falls back to `en` — the prescribed dialect — when the body opens with
+    neither, so a body that is not an anchor at all reports the field names a
+    new anchor should have had.
+    """
+    for line in body.splitlines():
+        if line.strip():
+            return _DIALECTS["ko" if line.strip().startswith("### 검증") else "en"]
+    return _DIALECTS["en"]
+
 
 def _heading_match(body: str) -> re.Match | None:
     """Match the SHA+rev heading on the body's FIRST non-empty line, or None.
@@ -449,7 +489,7 @@ def _heading_match(body: str) -> re.Match | None:
     """
     for line in body.splitlines():
         if line.strip():
-            return _HEADING_RE.match(line.strip())
+            return _dialect(body)["heading"].match(line.strip())
     return None
 
 
@@ -482,31 +522,32 @@ def _toggle_summaries(body: str) -> list[str]:
 def _structure_findings(body: str) -> list[str]:
     """Return the names of the required fields that are missing or mismatched."""
     missing: list[str] = []
+    d = _dialect(body)
 
     if not _heading_match(body):
-        missing.append("SHA+rev 헤딩 (`### 검증 — `<sha>` (rev N)`) — 첫 줄이어야 함")
+        missing.append(d["heading_label"])
 
     rows = [int(n) for n in _TABLE_ROW_RE.findall(_claim_table_region(body))]
     if not rows:
         missing.append("검증 항목 표 (번호 행이 없음)")
 
     summaries = _toggle_summaries(body)
-    if not any("미검증" in s for s in summaries):
-        missing.append("미검증 토글")
-    if not any("갱신 이력" in s for s in summaries):
-        missing.append("갱신 이력 토글")
+    if not any(d["unverified"] in s for s in summaries):
+        missing.append(f"{d['unverified']} 토글")
+    if not any(d["history"] in s for s in summaries):
+        missing.append(f"{d['history']} 토글")
 
     evidence = {
         int(m.group(1))
         for s in summaries
-        if (m := _EVIDENCE_SUMMARY_RE.match(s))
+        if (m := d["evidence"].match(s))
     }
     uncovered = sorted(set(rows) - evidence)
     if uncovered:
         missing.append(
             "행별 근거 토글 — 표 행 "
             + ", ".join(str(n) for n in uncovered)
-            + " 에 대응하는 `<details><summary>N. …` 이 없음"
+            + f" 에 대응하는 {d['evidence_label']} 이 없음"
         )
     return missing
 

--- a/hooks/preflight-gate/anchor-comment-gate/spec.md
+++ b/hooks/preflight-gate/anchor-comment-gate/spec.md
@@ -92,15 +92,39 @@ Nothing here reaches the network. No repo, no host, no PR number is resolved:
 the checks are exactly those decidable from the body, which is why widening the
 parser is no longer the answer to a miss.
 
-### Structure — five required fields
+### Structure — five required fields, in one of two dialects
 
-| Field | Detected by |
-| --- | --- |
-| SHA+rev heading | `### 검증 — \`<sha>\` (rev N)` **on the first non-empty line** |
-| claim table | at least one `\| <n> \|` row |
-| 미검증 toggle | a `<details>` whose `<summary>` contains `미검증` |
-| per-row evidence toggle | a `<details>` whose `<summary>` starts `<n>.`, for every table row `n` |
-| 갱신 이력 toggle | a `<details>` whose `<summary>` contains `갱신 이력` |
+The field *names* come in two dialects. `en` is what the rule prescribes. `ko`
+is the shape this gate originally required, kept for one reason: anchors
+published under it are edited in place and explicitly not retrofitted, so
+rejecting their dialect would lock their own later revisions out of the
+procedure this gate protects.
+
+| Field | `en` — detected by | `ko` — detected by |
+| --- | --- | --- |
+| SHA+rev heading | `### Verification — \`<sha>\` (rev N)` **on the first non-empty line** | `### 검증 — \`<sha>\` (rev N)`, same position |
+| claim table | at least one `\| <n> \|` row | same |
+| unverified toggle | `<summary>` contains `Unverified` | contains `미검증` |
+| per-row evidence toggle | `<summary>` starts `Evidence <n> —`, for every table row `n` | starts `<n>.` |
+| history toggle | `<summary>` contains `History` | contains `갱신 이력` |
+
+**One body, one dialect.** The dialect is chosen by the heading's own keyword
+and then every other field is read in it, so a body that takes its heading from
+one and its toggles from the other reports the missing fields of the dialect it
+opened in. Letting the two mix would make "the labels are a fixed field name"
+unenforceable in exactly the case where an author is drifting between them.
+
+A body opening with neither keyword is not an anchor at all and is not checked
+(see **Anchor shape decides scope** above) — the dialect question only arises
+once the gate is already in scope. When a body in scope has no usable heading,
+findings are reported in `en`, since that is the dialect a new anchor should
+have been written in.
+
+**Drift is the failure this table exists to prevent, and it has happened once
+in the other direction**: the rule pinned the `Evidence <#> — ` prefix while
+this gate still required `<n>.`, so a correctly-written anchor was blocked and
+the author had the choice of violating the rule or bypassing the gate. When the
+rule's field names change, this table changes with it.
 
 A toggle must be a real `<details>…</details>`: a bare `<summary>` renders as
 plain text, and one quoted inside a code fence is an example — neither is

--- a/hooks/preflight-gate/anchor-comment-gate/spec.md
+++ b/hooks/preflight-gate/anchor-comment-gate/spec.md
@@ -121,7 +121,7 @@ findings are reported in `en`, since that is the dialect a new anchor should
 have been written in.
 
 **Drift is the failure this table exists to prevent, and it has happened once
-in the other direction**: the rule pinned the `Evidence <#> — ` prefix while
+in the other direction**: the rule pinned the `Evidence <#> —` prefix while
 this gate still required `<n>.`, so a correctly-written anchor was blocked and
 the author had the choice of violating the rule or bypassing the gate. When the
 rule's field names change, this table changes with it.

--- a/hooks/preflight-gate/anchor-comment-gate/spec.md
+++ b/hooks/preflight-gate/anchor-comment-gate/spec.md
@@ -58,14 +58,15 @@ without knowing the target at all.
 | Post form | Recognized |
 | --- | --- |
 | `gh pr comment <pr> --body-file anchor.md` | yes |
-| `gh pr comment <pr> --body '### 검증 …'` | yes |
+| `gh pr comment <pr> --body '### Verification …'` | yes |
 | `gh api --method PATCH /repos/{o}/{r}/issues/comments/{id} -F body=@anchor.md` | yes |
 | body from stdin (`-F body=@-`) or `--input payload.json` | no — warns, PostToolUse decides |
 
 **Anchor shape decides scope.** Only a body whose first non-empty line starts
-with `### 검증` is an anchor. The one-line update notice that accompanies every
-anchor edit posts through the same `gh pr comment`; blocking it would break the
-procedure this gate exists to protect. Every other comment passes untouched.
+with `### Verification` or `### 검증` is an anchor. The one-line update notice
+that accompanies every anchor edit posts through the same `gh pr comment`;
+blocking it would break the procedure this gate exists to protect. Every other
+comment passes untouched.
 
 Every segment of a compound command is checked, not just the first: two anchor
 posts joined by `&&` would otherwise let the second through on the strength of
@@ -73,8 +74,8 @@ the first being well-formed.
 
 **Two tokenizations, because neither alone sees every post.** `safe_tokenize`
 splits on newlines — correct for Bash, where a newline separates commands, but
-it shreds a *quoted* multi-line body: an inline `--body '### 검증 …'` spanning
-lines loses its `gh pr comment` segment entirely. `shlex.split` keeps quoted
+it shreds a *quoted* multi-line body: an inline `--body '### Verification …'`
+spanning lines loses its `gh pr comment` segment entirely. `shlex.split` keeps quoted
 newlines but glues shell operators to adjacent words, so it cannot replace the
 primary. Both run when the command contains a newline, de-duplicated by body.
 
@@ -183,7 +184,7 @@ anchor gets corrected in place. `PRAXIS_ANCHOR_GATE_STRICT=1` makes it exit 2
 instead, for sessions that want the correction to interrupt.
 
 An anchor that turns out to be an ordinary issue comment is simply not an
-anchor by the `### 검증` test, and a lookup failure prints why rather than
+anchor by the heading-prefix test, and a lookup failure prints why rather than
 inventing a verdict — after the fact, there is nothing to protect by failing
 closed, and a wrong advisory is worse than a missing one.
 
@@ -213,13 +214,16 @@ the audit trail the waiver exists to leave.
 
 ## Coupled constant
 
-`### 검증` is both the anchor's heading and the prefix the id-recovery lookup
-matches on:
+The heading prefix is both what opens the anchor and what the id-recovery
+lookup matches on, so it has to accept every dialect the gate does:
 
 ```bash
 gh api /repos/{owner}/{repo}/issues/<pr>/comments \
-  --jq '[.[]|select(.body|startswith("### 검증"))][0].id'
+  --jq '[.[]|select(.body|startswith("### Verification") or
+                    (.body|startswith("### 검증")))][0].id'
 ```
 
 Changing one without the other leaves the anchor unfindable after its id is
-lost. `_ANCHOR_PREFIX` in `impl.py` and that jq are the two sites.
+lost. `_ANCHOR_PREFIXES` in `impl.py` and that jq are the two sites — a dialect
+added to one and not the other makes exactly the anchors written in it
+unrecoverable, which is the failure that is invisible until someone needs it.

--- a/tests/hooks/preflight-gate/test_anchor_comment_gate.sh
+++ b/tests/hooks/preflight-gate/test_anchor_comment_gate.sh
@@ -80,8 +80,63 @@ write_anchor() {
   } >"$file"
 }
 
+# write_anchor_en <file> <sha> [omit-field]
+#   The dialect the rule prescribes: English field labels, Korean content, and
+#   the literal `Evidence <#> — ` numbering prefix.
+#   omit-field: history | unverified | evidence | badrev | dialect
+#     dialect — English heading with Korean toggles, i.e. a body in neither
+#     dialect. Must not pass by borrowing half of each.
+write_anchor_en() {
+  local file="$1" sha="$2" omit="${3:-}"
+  local mixed=""; [ "$omit" = "dialect" ] && mixed=1
+  {
+    if [ "$omit" = "badrev" ]; then
+      # Prefix right, rev not parenthesized — inside gate scope, heading invalid.
+      echo "### Verification — \`$sha\` rev 1"
+      echo ""
+    else
+      echo "### Verification — \`$sha\` (rev 1)"
+      echo ""
+    fi
+    echo "| # | Claim | Result |"
+    echo "|---|---|---|"
+    echo "| 1 | impl.py 가 앵커를 검사한다 | PASS(live) |"
+    echo ""
+    if [ "$omit" != "unverified" ]; then
+      if [ -n "$mixed" ]; then echo "<details><summary>미검증 없음</summary>"
+      else echo "<details><summary>Unverified — 없음</summary>"; fi
+      echo "<br>"; echo ""; echo "</details>"; echo ""
+    fi
+    if [ "$omit" != "evidence" ]; then
+      if [ -n "$mixed" ]; then echo "<details><summary>1. impl.py 검사</summary>"
+      else echo "<details><summary>Evidence 1 — impl.py 가 앵커를 검사한다</summary>"; fi
+      echo "<br>"; echo ""
+      echo "훅을 직접 실행하는 것이 이 행의 오라클입니다."
+      echo ""
+      echo '$ echo ok'
+      echo "ok"
+      echo ""
+      echo "</details>"; echo ""
+    fi
+    if [ "$omit" != "history" ]; then
+      if [ -n "$mixed" ]; then echo "<details><summary>갱신 이력</summary>"
+      else echo "<details><summary>History</summary>"; fi
+      echo "<br>"; echo ""
+      echo "- rev 1 — \`$sha\`: 최초 검증."
+      echo ""
+      echo "</details>"
+    fi
+  } >"$file"
+}
+
 write_anchor "$FIX/ok.md" "$SHA"
 write_anchor "$FIX/ok2.md" "$SHA"
+write_anchor_en "$FIX/en-ok.md" "$SHA"
+write_anchor_en "$FIX/en-no-history.md" "$SHA" history
+write_anchor_en "$FIX/en-no-unverified.md" "$SHA" unverified
+write_anchor_en "$FIX/en-no-evidence.md" "$SHA" evidence
+write_anchor_en "$FIX/en-badrev.md" "$SHA" badrev
+write_anchor_en "$FIX/en-mixed.md" "$SHA" dialect
 write_anchor "$FIX/no-history.md" "$SHA" history
 write_anchor "$FIX/no-unverified.md" "$SHA" unverified
 write_anchor "$FIX/no-evidence.md" "$SHA" evidence
@@ -257,6 +312,27 @@ run_case "1d warn: PATCH body 가 stdin (-F body=@-) → 해독 불가 경고" \
 run_case "1e warn: --input JSON 본문 → 해독 불가 경고" \
   "warn:해독하지 못해" PreToolUse "" \
   "gh api --method PATCH /repos/owner/repo/issues/comments/999 --input payload.json"
+
+run_case "1f pass: 규약 방언(en) 앵커" \
+  pass PreToolUse "" "gh pr comment 42 --body-file $FIX/en-ok.md"
+
+run_case "1g block: en 앵커의 History 토글 누락" \
+  block PreToolUse "" "gh pr comment 42 --body-file $FIX/en-no-history.md"
+
+run_case "1h block: en 앵커의 Unverified 토글 누락" \
+  block PreToolUse "" "gh pr comment 42 --body-file $FIX/en-no-unverified.md"
+
+run_case "1i block: en 앵커의 Evidence 토글 누락" \
+  block PreToolUse "" "gh pr comment 42 --body-file $FIX/en-no-evidence.md"
+
+# 헤딩이 아예 없으면 앵커로 인식되지 않아 게이트 범위 밖이다(설계). 범위 안에서
+# 헤딩이 무효인 경우 — 접두사는 맞고 rev 가 괄호에 안 싸인 형태 — 를 대신 본다.
+run_case "1j block: en 앵커의 rev 표기 무효" \
+  block PreToolUse "" "gh pr comment 42 --body-file $FIX/en-badrev.md"
+
+# 두 방언을 반씩 섞어 통과하는 경로가 없어야 한다.
+run_case "1k block: en 헤딩 + ko 토글 혼용" \
+  block PreToolUse "" "gh pr comment 42 --body-file $FIX/en-mixed.md"
 
 run_case "2 block: 갱신 이력 토글 누락" \
   block PreToolUse "" "gh pr comment 42 --body-file $FIX/no-history.md"


### PR DESCRIPTION
## 배경

`anchor-comment-gate` 가 요구하는 앵커 필드 표기가 룰 SoT(`ai-dotfiles` `shared/AGENTS.md`)의 규정과 어긋나 있어서, **규약대로 쓴 앵커가 차단**됐습니다. 작성자에게 남는 선택지는 룰을 어기거나 게이트를 우회하거나 둘뿐이었습니다.

| 필드 | 게이트 (7.9.0) | AGENTS.md |
|---|---|---|
| 헤딩 | `### 검증 — \`<sha>\` (rev N)` | `### Verification — \`<sha>\` (rev N)` |
| 미검증 | summary 에 `미검증` | `Unverified` |
| 이력 | summary 에 `갱신 이력` | `History` |
| 행별 근거 | summary 가 `N.` 으로 시작 | 리터럴 `Evidence <#> — ` 로 시작 |

AGENTS.md 는 게이트가 요구하는 `3. ` 표기를 이름을 지목해 무효로 규정합니다. 방향은 `ai-dotfiles#224`(CLOSED)가 그 표기를 확정했고 게이트가 그 이전 형식을 들고 있는 것 — 게이트가 드리프트한 쪽입니다.

## 변경

방언(dialect) 인식을 도입했습니다. 헤딩의 키워드로 방언을 정하고, 나머지 필드를 **그 방언의 이름으로만** 검사합니다.

- 스코프(`_ANCHOR_PREFIXES`): `### Verification` 또는 `### 검증`
- `en`(규약): `Verification` / `Unverified` / `History` / `Evidence <n> —`
- `ko`(레거시): `검증` / `미검증` / `갱신 이력` / `<n>.`
- 차단 메시지도 판정된 방언의 필드명으로 나옵니다 — `ko` 앵커에 영어 필드명을 요구하면 오히려 혼란입니다

`ko` 를 남긴 이유는 하나입니다: AGENTS.md 가 "published ones are not retrofitted" 로 소급 적용을 배제하므로, 이미 게시된 `ko` 앵커를 rev 2 로 **편집**하는 경로가 막히면 안 됩니다. 그 외의 이유는 없습니다.

혼용(한쪽 헤딩 + 다른 쪽 토글)은 통과하지 않습니다. 반씩 빌려 통과하는 경로가 있으면 "라벨은 고정된 필드 이름" 이라는 규정이, 하필 작성자가 두 표기 사이에서 흔들리는 그 경우에 집행되지 않습니다.

## 검증

```
$ bash tests/hooks/preflight-gate/test_anchor_comment_gate.sh
Passed: 56  Failed: 0

$ ruff check hooks/preflight-gate/anchor-comment-gate/impl.py
All checks passed!
```

- 기존 50건 전건 통과 — `ko` 경로 무회귀가 이 변경의 주 오라클입니다
- 신규 6건: `en` 정상 1 · `History`/`Unverified`/`Evidence` 누락 각 1 · `rev` 표기 무효 1 · 방언 혼용 1

작성 중 케이스 하나가 기대값 오류로 실패했습니다("헤딩 누락 → 차단"). 헤딩이 아예 없으면 설계상 앵커로 인식되지 않아 게이트 범위 밖이며(`_is_anchor`), 범위 안에서 헤딩이 무효인 경우는 접두사는 맞고 `rev` 가 괄호에 안 싸인 형태입니다. 그쪽으로 바꿨습니다.

## 알려진 한계

이 변경만으로는 **신규 앵커가 `ko` 로 작성되는 것을 막지 못합니다.** AGENTS.md 는 표기 하나만 유효하다고 규정하므로, 두 방언을 다 받는 동안 그 규정은 게이트가 집행하지 않는 상태입니다. 신규(`gh pr comment`)와 편집(`gh api PATCH .../comments/{id}`)은 파서가 이미 구분하므로 "신규는 `en` 만" 을 붙이는 것은 가능하지만 별건이라 넣지 않았습니다.

`_dialect` 의 반환 타입은 이 파일의 기존 9개 사례와 같은 bare `dict` 로 뒀습니다(basedpyright `reportMissingTypeArgument`). 이 레포가 집행하는 린터는 ruff 이고 통과합니다.

Closes #960

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Anchor comments now support both the prescribed English format and the retained Korean format.
  - Existing Korean anchors remain compatible while new English anchors can be validated.
- **Bug Fixes**
  - Prevented mixed-language anchor fields from passing validation.
  - Improved detection of required revision, claim, evidence, unverified, and history details.
  - Added clearer handling when a scoped anchor lacks a valid heading.
- **Documentation**
  - Updated the anchor structure specification to document both supported formats and consistency requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->