### PR TITLE
fix(hooks): guard session state read-modify-write

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -74,6 +74,64 @@ Design mechanisms shared by all hooks:
   the second half expecting the first half to have landed. Single-command
   rejections receive no suffix (no cascade to warn about).
 
+## Session-state concurrency
+
+Every hook that keeps session state does the same three things: read the
+JSON at `resolve_cache_file(...)`, modify it, replace it. `os.replace` makes
+the *replace* atomic — a reader never sees half a file — and that is all it
+makes atomic. The read-modify-write around it is not serialized, so two hook
+processes sharing a `session_id` (parallel sub-agent tool calls are the
+ordinary source) read the same value, each modifies its own copy, and the
+later replace discards the earlier modification.
+
+Locking all of them would be the wrong reading of that. The absence of a lock
+was neither documented as intent nor as an oversight before issue #951; what
+follows is the criterion that settles it per hook, so a new consumer of
+`resolve_cache_file` is classified rather than reflexively locked.
+
+**A lost update needs a lock when the state carries information no later
+event reproduces.** Three questions, in order — the first `yes` decides it:
+
+1. **Does a threshold read the state?** A hook firing on an exact boundary
+   (`count == 2`) misfires in both directions when an increment is lost: two
+   processes crossing the boundary together both fire, and the count that
+   never advanced never fires again. **Lock.**
+2. **Does a gate read the state to decide block vs. pass?** A dropped entry
+   becomes a false verdict about the session — a file that was Read scored as
+   unread — and the verdict lands on the user, not in a log. **Lock.**
+3. **Otherwise:** the state is a dedup marker or a monotone flag, and the
+   worst case is one advisory line repeated or missing. **No lock.** The
+   contention is real, its consequence is not; a lock here buys latency on
+   every tool call and nothing else.
+
+The seven consumers as of #951:
+
+| Hook | State | Loss consequence | Locked |
+| --- | --- | --- | --- |
+| `postuse-correction/second-failure-advisory` | per-`(tool, signature)` counter | fires on `prior_count == 1` exactly — Q1 | yes |
+| `postuse-correction/pre-edit-md-escape-advisory` | accumulating set of Read paths | the Edit gate warns, or denies under `PRAXIS_MD_ESCAPE_MODE=block`, for a file that was Read — Q2 | yes |
+| `advisory-nudge/jq-config-empty-dict-advisory` | dedup set of advised paths | one advisory repeats | no |
+| `advisory-nudge/postcompact-context` | last-injected compact uuid | context re-injected once | no |
+| `preflight-gate/worktree-prune-snapshot-gate` | single `snapshot_taken` flag, only ever set true | concurrent writers write the identical value | no |
+| `preflight-gate/session-intent` | set-once intent flags | written only from `UserPromptSubmit`, which is serialized per session; the `PreToolUse` gate path is read-only | no |
+| `preflight-gate/retrospect-active-marker` | marker existence | whole-file write and `unlink`, no read-modify-write to lose | no |
+
+`hooks/_lib/_state_lock.py` is the primitive: `with state_lock(path):` around
+the read *and* the write, `fcntl.flock` on a `<path>.lock` sibling. Readers
+take no lock — `os.replace` already gives them a whole file.
+
+It yields False rather than raising or waiting when the lock cannot be taken,
+and the body runs regardless. That is the fail-open contract above, applied
+one level down: a hook that cannot lock must degrade to the pre-lock
+behaviour, never to a blocked tool call. The wait has a deadline
+(`PRAXIS_STATE_LOCK_TIMEOUT`, 2s) for the same reason — a lock left by a
+killed sibling must not stall the tool call the hook was only observing.
+
+`tests/test_hook_state_concurrency.py` runs both locked hooks in two real
+processes against one state file. It carries an unlocked arm alongside the
+shipped one, so the defect stays pinned and a regression that drops the lock
+fails there instead of quietly passing.
+
 ## Hook ordering and precedence
 
 - PreToolUse hooks run **in parallel**. Decision precedence is

--- a/hooks/_lib/_paths.py
+++ b/hooks/_lib/_paths.py
@@ -26,6 +26,11 @@ import os
 import shutil
 import time
 
+from _state_lock import (  # type: ignore[import-not-found]
+    LOCK_SUFFIX,
+    lock_is_held,
+)
+
 _LEGACY_STATE_DIRNAME = ("~", ".claude", "state", "praxis")
 _DEFAULT_CACHE_TTL_DAYS = 7.0
 
@@ -157,6 +162,12 @@ def prune_stale(
     reads it goes silently quiet — the #666 failure. `session_id` is therefore
     excluded from the sweep: entries keyed on the calling session survive
     regardless of age, while other sessions' entries age out as before.
+
+    A held `.lock` is excluded for the same reason by a different test (#951).
+    Its mtime never advances past creation, so age reports it abandoned while
+    a live session holds it — and unlinking it lets the next caller create a
+    fresh inode at the same name and take a second, concurrent lock. Only the
+    lock itself can answer, so the sweep probes it.
     """
     ttl = cache_ttl_days() if ttl_days is None else ttl_days
     if ttl <= 0:
@@ -173,6 +184,8 @@ def prune_stale(
         for entry in entries:
             try:
                 if session_id and _belongs_to_session(entry.name, session_id):
+                    continue
+                if entry.name.endswith(LOCK_SUFFIX) and lock_is_held(entry.path):
                     continue
                 is_dir = entry.is_dir(follow_symlinks=False)
                 mtime = _newest_mtime(entry.path) if is_dir else entry.stat().st_mtime

--- a/hooks/_lib/_state_lock.py
+++ b/hooks/_lib/_state_lock.py
@@ -1,0 +1,129 @@
+"""Serialize read-modify-write on a session state file (issue #951).
+
+`os.replace` makes the *write* atomic; it does nothing about the window
+between a hook reading the state and replacing it. Two hook processes sharing
+a `session_id` — parallel sub-agent tool calls are the ordinary source — read
+the same value, each increments its own copy, and the later `os.replace`
+discards the earlier increment.
+
+Whether that loss is a defect depends on what the state means, so this helper
+is applied selectively rather than to every consumer of `resolve_cache_file`.
+The criterion and the per-hook verdicts live in
+[`DESIGN.md`](../../DESIGN.md#session-state-concurrency) — read it before
+adding a call site.
+
+    with state_lock(path):
+        state = load(path)
+        state["count"] += 1
+        save(path, state)
+
+`state_lock` never raises and never blocks past its deadline: acquisition
+failure yields False and the caller proceeds exactly as it did before the
+lock existed. That is the `@fail_open` contract (DESIGN.md) — a hook that
+cannot take a lock must degrade to the racy behaviour, never to a blocked
+tool call. Readers need no lock: `os.replace` guarantees they see either the
+whole previous file or the whole next one.
+"""
+from __future__ import annotations
+
+import contextlib
+import os
+import time
+from typing import Iterator
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX host
+    # Imported at module scope by hook impls, so an unguarded ImportError here
+    # would take the hook down *outside* `@fail_open`'s reach (it wraps main(),
+    # not the import). praxis targets POSIX hosts; on anything else the lock
+    # degrades to the same no-op as a failed acquisition.
+    fcntl = None  # type: ignore[assignment]
+
+_TIMEOUT_ENV = "PRAXIS_STATE_LOCK_TIMEOUT"
+_DEFAULT_TIMEOUT_SECONDS = 2.0
+_POLL_INTERVAL_SECONDS = 0.005
+
+
+def lock_path_for(path: str) -> str:
+    """Companion lock file for a state file.
+
+    A sibling rather than the state file itself: the writers this serializes
+    finish with `os.replace`, which swaps the inode out from under any lock
+    held on it, so the next process would lock a file no longer at that name.
+    The `.lock` suffix keeps `_paths._belongs_to_session` matching, so the
+    cache sweep still treats it as the calling session's own entry.
+    """
+    return path + ".lock"
+
+
+def lock_timeout() -> float:
+    """Seconds to wait for the lock. `PRAXIS_STATE_LOCK_TIMEOUT` overrides.
+
+    A malformed or negative value falls back to the default rather than
+    disabling the wait — a typo in the override must not silently reintroduce
+    the race it was set to tune.
+    """
+    raw = os.environ.get(_TIMEOUT_ENV)
+    if raw is None:
+        return _DEFAULT_TIMEOUT_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        return _DEFAULT_TIMEOUT_SECONDS
+    if value < 0:
+        return _DEFAULT_TIMEOUT_SECONDS
+    return value
+
+
+@contextlib.contextmanager
+def state_lock(path: str, timeout: float | None = None) -> Iterator[bool]:
+    """Hold an exclusive advisory lock over `path` for the block's duration.
+
+    Yields True when the lock was taken, False when it was not (unwritable
+    directory, non-POSIX host, or `timeout` seconds of contention). The body
+    runs either way — a caller that wants to know checks the yielded value.
+
+    Non-blocking retries rather than a blocking `flock`: a blocking call has
+    no deadline, and a hook process wedged behind a lock left by a killed
+    sibling would stall the tool call it was meant to observe.
+    """
+    if fcntl is None:
+        yield False
+        return
+
+    deadline = time.monotonic() + (lock_timeout() if timeout is None else timeout)
+    fd = None
+    try:
+        parent = os.path.dirname(path)
+        if parent and not os.path.isdir(parent):
+            os.makedirs(parent, exist_ok=True)
+        fd = os.open(lock_path_for(path), os.O_CREAT | os.O_RDWR, 0o600)
+    except OSError:
+        if fd is not None:
+            os.close(fd)
+        yield False
+        return
+
+    acquired = False
+    try:
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+                break
+            except OSError:
+                if time.monotonic() >= deadline:
+                    break
+                time.sleep(_POLL_INTERVAL_SECONDS)
+        yield acquired
+    finally:
+        try:
+            if acquired:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        try:
+            os.close(fd)
+        except OSError:
+            pass

--- a/hooks/_lib/_state_lock.py
+++ b/hooks/_lib/_state_lock.py
@@ -27,6 +27,7 @@ whole previous file or the whole next one.
 from __future__ import annotations
 
 import contextlib
+import math
 import os
 import time
 from typing import Iterator
@@ -63,6 +64,13 @@ def lock_timeout() -> float:
     A malformed or negative value falls back to the default rather than
     disabling the wait — a typo in the override must not silently reintroduce
     the race it was set to tune.
+
+    `float()` accepts `nan` and `inf`, and neither is caught by the negative
+    check: `nan < 0` and `inf < 0` are both False. Either one reaches the
+    acquisition loop's `time.monotonic() >= deadline` as a comparison that can
+    never be True, so a contended hook spins until the tool call times out.
+    That failure is a hang rather than an exception, so `@fail_open` cannot
+    reach it — the guard has to be here.
     """
     raw = os.environ.get(_TIMEOUT_ENV)
     if raw is None:
@@ -71,7 +79,7 @@ def lock_timeout() -> float:
         value = float(raw)
     except ValueError:
         return _DEFAULT_TIMEOUT_SECONDS
-    if value < 0:
+    if value < 0 or not math.isfinite(value):
         return _DEFAULT_TIMEOUT_SECONDS
     return value
 

--- a/hooks/_lib/_state_lock.py
+++ b/hooks/_lib/_state_lock.py
@@ -46,6 +46,9 @@ _DEFAULT_TIMEOUT_SECONDS = 2.0
 _POLL_INTERVAL_SECONDS = 0.005
 
 
+LOCK_SUFFIX = ".lock"
+
+
 def lock_path_for(path: str) -> str:
     """Companion lock file for a state file.
 
@@ -53,9 +56,52 @@ def lock_path_for(path: str) -> str:
     finish with `os.replace`, which swaps the inode out from under any lock
     held on it, so the next process would lock a file no longer at that name.
     The `.lock` suffix keeps `_paths._belongs_to_session` matching, so the
-    cache sweep still treats it as the calling session's own entry.
+    calling session's own cache sweep treats it as its own entry.
+
+    That match protects the lock from *its owner's* sweep only. Another
+    session's sweep sees a name keyed on someone else and judges the file by
+    age — and a lock file's mtime freezes at creation, because `O_CREAT`
+    leaves an existing file alone and `flock` never touches it. `_paths`
+    therefore probes the lock before unlinking a `.lock` entry; see
+    `_paths._lock_is_held`.
     """
-    return path + ".lock"
+    return path + LOCK_SUFFIX
+
+
+def lock_is_held(lock_path: str) -> bool:
+    """True when some process currently holds the lock on `lock_path`.
+
+    The cache sweep judges every other entry by age, which cannot work here:
+    a lock file's mtime stops advancing the moment it is created, so a lock
+    held for longer than the TTL looks exactly like one abandoned that long
+    ago. Taking the lock is the only way to tell them apart — it succeeds
+    precisely when no one else holds it.
+
+    Answers False when it cannot tell (no `fcntl`, file already gone), which
+    hands the decision back to the caller's age check rather than pinning an
+    entry in the cache forever on an inconclusive probe.
+    """
+    if fcntl is None:
+        return False
+    try:
+        fd = os.open(lock_path, os.O_RDWR)
+    except OSError:
+        return False
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            return True
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        return False
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
 
 
 def lock_timeout() -> float:

--- a/hooks/postuse-correction/pre-edit-md-escape-advisory/impl.py
+++ b/hooks/postuse-correction/pre-edit-md-escape-advisory/impl.py
@@ -111,6 +111,7 @@ _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib")
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _paths import resolve_cache_file  # type: ignore[import-not-found]  # noqa: E402
+from _state_lock import state_lock  # type: ignore[import-not-found]  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -206,19 +207,28 @@ def normalize_path(file_path: str) -> str:
 
 
 def record_read(path: str, file_path: str) -> None:
-    """Record `file_path` as Read in the session history."""
+    """Record `file_path` as Read in the session history.
+
+    The read-modify-write is serialized (issue #951): the history accumulates
+    one entry per Read, and two PostToolUse processes appending concurrently
+    leave only the later one's path on disk. A dropped entry is not a lost log
+    line — `run_pre` reads this set to decide whether the file was Read, so the
+    Edit that follows is warned about, or denied outright under
+    `PRAXIS_MD_ESCAPE_MODE=block`, for a file the agent did read.
+    """
     norm = normalize_path(file_path)
     if not norm:
         return
-    history = load_history(path)
-    read_set = history.setdefault("read", [])
-    if not isinstance(read_set, list):
-        read_set = []
-        history["read"] = read_set
-    if norm not in read_set:
-        read_set.append(norm)
-    history["last_updated"] = int(time.time())
-    save_history(path, history)
+    with state_lock(path):
+        history = load_history(path)
+        read_set = history.setdefault("read", [])
+        if not isinstance(read_set, list):
+            read_set = []
+            history["read"] = read_set
+        if norm not in read_set:
+            read_set.append(norm)
+        history["last_updated"] = int(time.time())
+        save_history(path, history)
 
 
 def get_read_set(path: str) -> set[str]:

--- a/hooks/postuse-correction/pre-edit-md-escape-advisory/spec.md
+++ b/hooks/postuse-correction/pre-edit-md-escape-advisory/spec.md
@@ -91,6 +91,23 @@ earlier session — breaking the "in this session" contract.
 Read failures (missing file, malformed JSON) → empty history,
 fail-open. Write failures → silently skip recording.
 
+#### Concurrency (issue #951)
+
+The PostToolUse read-modify-write is serialized with
+`_lib/_state_lock.state_lock`. The history *accumulates* one entry per
+Read, so two PostToolUse processes appending concurrently leave only one
+of the two paths on disk — and the dropped entry is not a lost log line:
+`run_pre` reads this set to decide whether the file was Read, so the Edit
+that follows is warned about, or denied outright under
+`PRAXIS_MD_ESCAPE_MODE=block`, for a file the agent did read. The
+criterion and the per-hook verdicts across all seven state-file consumers
+live in
+[`DESIGN.md → Session-state concurrency`](../../../DESIGN.md#session-state-concurrency).
+
+Readers take no lock — `os.replace` already hands them a whole file. A
+lock that cannot be acquired degrades to the pre-lock behaviour rather
+than blocking the tool call (`@fail_open` contract).
+
 ### Response (warn — default)
 
 stderr only:
@@ -197,3 +214,12 @@ Covers 31 cases:
   ignores non-`Read` tools. `session_id`-based history-path resolution.
 - **Fail-open:** malformed stdin (pre + post), empty `file_path`, empty
   `old_string`, missing `tool_input`.
+
+Concurrency (issue #951) is covered separately, in two real processes:
+
+```bash
+python3 -m pytest tests/test_hook_state_concurrency.py
+```
+
+- **Unlocked arm:** the two concurrent Reads do not both survive.
+- **Locked arm:** both paths are recorded.

--- a/hooks/postuse-correction/second-failure-advisory/impl.py
+++ b/hooks/postuse-correction/second-failure-advisory/impl.py
@@ -59,6 +59,7 @@ _ROOT = _Path(__file__).resolve().parent
 sys.path.insert(0, str(_ROOT.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _paths import resolve_cache_file  # type: ignore[import-not-found]  # noqa: E402
+from _state_lock import state_lock  # type: ignore[import-not-found]  # noqa: E402
 
 
 _ADVISORY_PREFIX = (
@@ -312,23 +313,32 @@ def main() -> int:
     )
 
     path = _state_path(session_id)
-    state = _load_state(path)
-    failures = state.get("failures")
-    if not isinstance(failures, dict):
-        failures = {}
-        state["failures"] = failures
-
     pair_key = f"{tool_name}\0{signature}"
-    prior_count = 0
-    count = failures.get(pair_key)
-    if isinstance(count, int) and count > 0:
-        prior_count = count
 
-    failures[pair_key] = prior_count + 1
+    # The whole read-modify-write is serialized (issue #951). The advisory
+    # fires on the exact `prior_count == 1` boundary, so two processes that
+    # read the same count both write count+1 and both cross that boundary —
+    # the duplicate fire recorded as unverified on #950. Persisting inside the
+    # lock is what makes each process observe the other's increment.
+    with state_lock(path):
+        state = _load_state(path)
+        failures = state.get("failures")
+        if not isinstance(failures, dict):
+            failures = {}
+            state["failures"] = failures
 
-    # Persist before advising: a lost write would let the same advisory fire
-    # again on the next failure of this pair.
-    if not _save_state(path, state):
+        prior_count = 0
+        count = failures.get(pair_key)
+        if isinstance(count, int) and count > 0:
+            prior_count = count
+
+        failures[pair_key] = prior_count + 1
+
+        # Persist before advising: a lost write would let the same advisory
+        # fire again on the next failure of this pair.
+        saved = _save_state(path, state)
+
+    if not saved:
         return 0
 
     if prior_count == 1:

--- a/hooks/postuse-correction/second-failure-advisory/spec.md
+++ b/hooks/postuse-correction/second-failure-advisory/spec.md
@@ -136,6 +136,18 @@ exit 0인 PostToolUse 훅의 `stderr`는 디버그 로그로만 가고 모델에
 }
 ```
 
+## Concurrency (issue #951)
+
+카운트 갱신(read → modify → `os.replace`)은 `_lib/_state_lock.state_lock`
+으로 직렬화합니다. advisory가 `prior_count == 1` 경계에서만 발화하므로,
+같은 `session_id` 를 공유하는 두 프로세스가 같은 카운트를 읽으면 둘 다 그
+경계를 넘어 중복 발화하고(#950 의 미검증 항목), 반영되지 못한 증분은 이후
+어떤 이벤트로도 복구되지 않습니다. 판정 기준과 7개 훅 분류는
+[`DESIGN.md → Session-state concurrency`](../../../DESIGN.md#session-state-concurrency).
+
+잠금 획득 실패는 잠금 이전 동작으로 강등될 뿐 훅을 차단으로 바꾸지
+않습니다 (`@fail_open` 계약).
+
 ## Privacy
 
 - 원문 오류 텍스트 자체를 기록하지 않고, 정규화된 signature의 hash를 저장해
@@ -147,6 +159,7 @@ Run:
 
 ```bash
 bash tests/hooks/postuse-correction/test_second_failure_advisory.sh
+python3 -m pytest tests/test_hook_state_concurrency.py
 ```
 
 필수 커버:
@@ -161,3 +174,5 @@ bash tests/hooks/postuse-correction/test_second_failure_advisory.sh
 - `stdout`/`output`만 있는 성공 응답은 반복돼도 무음
 - 실패 텍스트의 `Reference:` 경로가 advisory와 재진술 지시에 포함됨
 - 비실패/비정상 입력은 fail-open
+- 두 프로세스 동시 실행: 잠금 없이는 증분 유실, 잠금 하에서는 카운트 1→2→3
+  과 advisory 1회 (`tests/test_hook_state_concurrency.py`)

--- a/tests/hooks/_lib/test_paths_prune.py
+++ b/tests/hooks/_lib/test_paths_prune.py
@@ -15,6 +15,8 @@ Coverage:
   - token matching is boundary-anchored: a PPID-shaped key like `123` must not
     protect an unrelated `...-1234.json`
   - resolve_cache_file threads its session_id through to the sweep
+  - a `.lock` held right now survives another session's sweep, and an
+    abandoned one does not — the one entry age cannot judge (#951)
 """
 from __future__ import annotations
 
@@ -29,6 +31,7 @@ if str(LIB) not in sys.path:
     sys.path.insert(0, str(LIB))
 
 import _paths  # noqa: E402
+import _state_lock  # noqa: E402
 
 SID = "abc123-session"
 OTHER = "zzz999-other"
@@ -118,6 +121,49 @@ def test_token_match_is_boundary_anchored(tmp_path: Path) -> None:
     assert not lookalike.exists()
     assert not prefixed.exists()
     assert removed == 2
+
+
+def test_a_held_lock_survives_another_sessions_sweep(tmp_path: Path) -> None:
+    """Age cannot judge a lock file (#951).
+
+    Its mtime freezes at creation — `O_CREAT` leaves an existing file alone and
+    `flock` never touches it — so a lock held for longer than the TTL is
+    indistinguishable by age from one abandoned that long ago. Unlinking a held
+    one is not merely premature: the next caller creates a fresh inode at the
+    same name and takes a *second* concurrent lock, which is the race this
+    whole PR removes. The sweeping session is a different one on purpose, so
+    the #920 session-ownership guard cannot be what saves the file.
+    """
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    state = cache / f"session-intent-{OTHER}.json"
+    _ = state.write_text("{}", encoding="utf-8")
+    lock = Path(_state_lock.lock_path_for(str(state)))
+
+    with _state_lock.state_lock(str(state)) as acquired:
+        assert acquired is True
+        _ = _aged(state, days=30)
+        _ = _aged(lock, days=30)
+
+        removed = _paths.prune_stale(str(cache), ttl_days=7.0, session_id=SID)
+
+        assert lock.exists(), "a held lock was swept"
+        assert _state_lock.lock_is_held(str(lock)) is True, "the probe took it"
+    # The state file itself is not protected — only the lock is.
+    assert removed == 1
+    assert not state.exists()
+
+
+def test_an_abandoned_lock_is_still_swept(tmp_path: Path) -> None:
+    """The guard is a probe, not a blanket exemption for `.lock` names."""
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    stale = _file(cache, f"session-intent-{OTHER}.json.lock", days=30)
+
+    removed = _paths.prune_stale(str(cache), ttl_days=7.0, session_id=SID)
+
+    assert removed == 1
+    assert not stale.exists()
 
 
 def test_no_session_id_sweeps_everything_stale(tmp_path: Path) -> None:

--- a/tests/hooks/_lib/test_state_lock.py
+++ b/tests/hooks/_lib/test_state_lock.py
@@ -42,6 +42,31 @@ def test_lock_path_is_a_sibling_of_the_state_file(tmp_path):
     assert _state_lock.lock_path_for(str(state)) == str(state) + ".lock"
 
 
+def test_lock_is_held_answers_only_while_someone_holds_it(tmp_path):
+    """The probe the cache sweep uses instead of an age check.
+
+    A lock file's mtime freezes at creation, so age cannot separate a lock held
+    right now from one abandoned a month ago. Taking it can: the attempt fails
+    precisely when someone else has it. Two `open()` calls contend even inside
+    one process, because `flock` is held per open file description rather than
+    per process — so no child is needed to observe the held case.
+    """
+    state = str(tmp_path / "state.json")
+    lock = _state_lock.lock_path_for(state)
+
+    assert _state_lock.lock_is_held(lock) is False, "no file yet"
+
+    with _state_lock.state_lock(state) as acquired:
+        assert acquired is True
+        assert _state_lock.lock_is_held(lock) is True
+
+    # Released — and the probe must not leave the lock taken on its way out,
+    # or the next holder would be locked out by the sweep that asked.
+    assert _state_lock.lock_is_held(lock) is False
+    with _state_lock.state_lock(state, timeout=0.05) as acquired:
+        assert acquired is True
+
+
 def test_timeout_default_and_override(monkeypatch):
     monkeypatch.delenv("PRAXIS_STATE_LOCK_TIMEOUT", raising=False)
     assert _state_lock.lock_timeout() == 2.0

--- a/tests/hooks/_lib/test_state_lock.py
+++ b/tests/hooks/_lib/test_state_lock.py
@@ -49,7 +49,24 @@ def test_timeout_default_and_override(monkeypatch):
     assert _state_lock.lock_timeout() == 0.25
 
 
-@pytest.mark.parametrize("raw", ["", "soon", "-1"])
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "soon",
+        "-1",
+        # `float()` accepts all four of these and none is caught by a `< 0`
+        # check — `nan < 0` and `inf < 0` are both False. Each would reach the
+        # acquisition loop as a `time.monotonic() >= deadline` that can never
+        # be True, so a contended hook spins until its tool call times out.
+        # That is a hang rather than an exception, which is exactly what
+        # `@fail_open` cannot catch.
+        "nan",
+        "NaN",
+        "inf",
+        "Infinity",
+    ],
+)
 def test_malformed_timeout_falls_back_to_the_default(monkeypatch, raw):
     monkeypatch.setenv("PRAXIS_STATE_LOCK_TIMEOUT", raw)
     assert _state_lock.lock_timeout() == 2.0

--- a/tests/hooks/_lib/test_state_lock.py
+++ b/tests/hooks/_lib/test_state_lock.py
@@ -1,0 +1,132 @@
+"""Unit coverage for the shared state lock (issue #951).
+
+The cross-process behaviour that motivates the helper is pinned in
+`tests/test_hook_state_concurrency.py`, which runs the real hooks in two
+processes. What is checked here is the contract those call sites depend on:
+the lock is exclusive across processes, it is released on every exit path, and
+every failure mode yields False instead of raising — a hook that cannot lock
+must degrade to the racy behaviour, never to a blocked tool call.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "hooks" / "_lib"))
+
+import _state_lock  # noqa: E402
+
+
+# Holds the lock for a fixed span so the parent can observe contention.
+_HOLDER = """
+import sys, time
+sys.path.insert(0, sys.argv[1])
+import _state_lock
+
+with _state_lock.state_lock(sys.argv[2]) as acquired:
+    if not acquired:
+        sys.exit("holder failed to acquire")
+    open(sys.argv[3], "w").close()
+    time.sleep(float(sys.argv[4]))
+"""
+
+
+def test_lock_path_is_a_sibling_of_the_state_file(tmp_path):
+    state = tmp_path / "session-state.json"
+    assert _state_lock.lock_path_for(str(state)) == str(state) + ".lock"
+
+
+def test_timeout_default_and_override(monkeypatch):
+    monkeypatch.delenv("PRAXIS_STATE_LOCK_TIMEOUT", raising=False)
+    assert _state_lock.lock_timeout() == 2.0
+    monkeypatch.setenv("PRAXIS_STATE_LOCK_TIMEOUT", "0.25")
+    assert _state_lock.lock_timeout() == 0.25
+
+
+@pytest.mark.parametrize("raw", ["", "soon", "-1"])
+def test_malformed_timeout_falls_back_to_the_default(monkeypatch, raw):
+    monkeypatch.setenv("PRAXIS_STATE_LOCK_TIMEOUT", raw)
+    assert _state_lock.lock_timeout() == 2.0
+
+
+def test_acquires_and_releases(tmp_path):
+    state = str(tmp_path / "state.json")
+    with _state_lock.state_lock(state) as acquired:
+        assert acquired is True
+    # Released: the same path locks again without waiting out any deadline.
+    started = time.monotonic()
+    with _state_lock.state_lock(state, timeout=0.05) as acquired:
+        assert acquired is True
+    assert time.monotonic() - started < 0.05
+
+
+def test_released_even_when_the_body_raises(tmp_path):
+    state = str(tmp_path / "state.json")
+    with pytest.raises(ValueError):
+        with _state_lock.state_lock(state):
+            raise ValueError("body failed")
+    with _state_lock.state_lock(state, timeout=0.05) as acquired:
+        assert acquired is True
+
+
+def test_creates_the_parent_directory(tmp_path):
+    state = str(tmp_path / "nested" / "dir" / "state.json")
+    with _state_lock.state_lock(state) as acquired:
+        assert acquired is True
+    assert os.path.isdir(os.path.dirname(state))
+
+
+def test_unwritable_location_yields_false_without_raising(tmp_path):
+    denied = tmp_path / "denied"
+    denied.mkdir()
+    denied.chmod(0o500)
+    try:
+        with _state_lock.state_lock(str(denied / "state.json"), timeout=0.05) as acquired:
+            assert acquired is False
+    finally:
+        denied.chmod(0o700)
+
+
+def test_excludes_a_second_process_then_admits_it(tmp_path):
+    state = str(tmp_path / "state.json")
+    held_marker = tmp_path / "held"
+    holder_script = tmp_path / "holder.py"
+    holder_script.write_text(_HOLDER, encoding="utf-8")
+
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            str(holder_script),
+            str(REPO_ROOT / "hooks" / "_lib"),
+            state,
+            str(held_marker),
+            "1.0",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + 15
+        while not held_marker.exists():
+            assert holder.poll() is None, "holder exited before taking the lock"
+            assert time.monotonic() < deadline, "holder never took the lock"
+            time.sleep(0.005)
+
+        # Contended: a deadline shorter than the hold yields False rather than
+        # waiting for the holder or raising.
+        with _state_lock.state_lock(state, timeout=0.05) as acquired:
+            assert acquired is False
+    finally:
+        holder.wait(timeout=15)
+
+    # Uncontended again once the holder exits — an exited process releases the
+    # flock even though nothing unlinked the lock file.
+    with _state_lock.state_lock(state, timeout=0.5) as acquired:
+        assert acquired is True

--- a/tests/hooks/_lib/test_state_lock.py
+++ b/tests/hooks/_lib/test_state_lock.py
@@ -120,9 +120,17 @@ def test_excludes_a_second_process_then_admits_it(tmp_path):
             time.sleep(0.005)
 
         # Contended: a deadline shorter than the hold yields False rather than
-        # waiting for the holder or raising.
+        # waiting for the holder or raising — and it yields at the deadline,
+        # not when the holder happens to finish. That elapsed bound is the
+        # property, not the return value: a hook whose sibling was killed while
+        # holding the lock must not sit on the tool call it was only observing,
+        # and a blocking `flock` returning False after the full hold would
+        # satisfy every other assertion here.
+        started = time.monotonic()
         with _state_lock.state_lock(state, timeout=0.05) as acquired:
             assert acquired is False
+        waited = time.monotonic() - started
+        assert waited < 0.5, f"waited {waited:.3f}s on a 0.05s deadline"
     finally:
         holder.wait(timeout=15)
 

--- a/tests/test_hook_state_concurrency.py
+++ b/tests/test_hook_state_concurrency.py
@@ -1,0 +1,304 @@
+"""Two-process race fixture for session state files (issue #951).
+
+`os.replace` serializes the write, not the read-modify-write around it. These
+cases run the REAL hook impls in two concurrent OS processes against one state
+file and assert the state that survives, because a single-process unit test
+cannot observe an interleaving that only exists between processes.
+
+Each case runs twice against the same code:
+
+  * `nolock` — the child replaces `state_lock` with a no-op context manager,
+    reproducing the pre-#951 behaviour. These assertions pin the defect in
+    place, so a regression that removes the lock fails here rather than
+    silently returning the suite to green.
+  * `lock` — the shipped path.
+
+The interleaving is forced by a start barrier plus a fixed delay inserted
+between the state read and the write in both children. Neither alone is
+enough: without the delay the race is a scheduling coin-flip, and without the
+barrier interpreter startup skew alone exceeded the delay often enough that
+the unlocked arm read as "no race". The delay sits at the same point in both
+arms and changes no hook logic; under `lock` the second child simply waits out
+the first child's critical section, which is why the delay must stay well
+under `PRAXIS_STATE_LOCK_TIMEOUT`'s 2s default.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOKS = REPO_ROOT / "hooks"
+
+# Long enough that both children are provably inside the window together,
+# short enough to stay far below the lock's 2s acquisition deadline.
+READ_DELAY_SECONDS = 0.4
+
+_DRIVER = '''
+import contextlib
+import importlib.util
+import os
+import sys
+import time
+
+impl_path, lock_mode, delay, read_fn, argv_mode, ready_file, go_file = sys.argv[1:8]
+
+spec = importlib.util.spec_from_file_location("impl_under_test", impl_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+if lock_mode == "nolock":
+    @contextlib.contextmanager
+    def _no_lock(path, timeout=None):
+        yield False
+    mod.state_lock = _no_lock
+
+_orig_read = getattr(mod, read_fn)
+
+
+def _slow_read(*args, **kwargs):
+    """Real read, then hold the window open so the sibling reaches it too."""
+    result = _orig_read(*args, **kwargs)
+    time.sleep(float(delay))
+    return result
+
+
+setattr(mod, read_fn, _slow_read)
+
+# Start barrier: interpreter startup alone skewed the two children by more
+# than the read delay often enough to make the unlocked arm flake, which would
+# have read as "the race is gone".
+open(ready_file, "w").close()
+_deadline = time.monotonic() + 30
+while not os.path.exists(go_file):
+    if time.monotonic() >= _deadline:
+        sys.exit("driver: start barrier timed out")
+    time.sleep(0.001)
+
+if argv_mode:
+    sys.exit(mod.main(["impl", argv_mode]))
+sys.exit(mod.main())
+'''
+
+
+def _release_barrier(ready_files, go_file: Path) -> None:
+    """Wait for every child to report ready, then let them all through."""
+    deadline = time.monotonic() + 30
+    while not all(f.exists() for f in ready_files):
+        if time.monotonic() >= deadline:
+            raise AssertionError("children never reached the start barrier")
+        time.sleep(0.005)
+    go_file.write_text("go", encoding="utf-8")
+
+
+def _run_pair(driver: Path, impl: Path, lock_mode: str, payloads, read_fn, argv_mode=""):
+    """Launch one child per payload at the same time; return their results.
+
+    Each payload is staged as a file and handed over as the child's stdin.
+    Feeding it through `communicate` instead would serialize the pair: the
+    child blocks on stdin until the parent writes, and the parent's first
+    `communicate` does not return until that child has exited — so the second
+    child would not start until the first was done and no race could occur.
+    """
+    go_file = driver.parent / "go"
+    ready_files = []
+    procs = []
+    stdin_files = []
+    for index, payload in enumerate(payloads):
+        payload_file = driver.parent / f"payload-{index}.json"
+        payload_file.write_text(json.dumps(payload), encoding="utf-8")
+        handle = payload_file.open("r", encoding="utf-8")
+        stdin_files.append(handle)
+        ready_file = driver.parent / f"ready-{index}"
+        ready_files.append(ready_file)
+        procs.append(
+            subprocess.Popen(
+                [
+                    sys.executable,
+                    str(driver),
+                    str(impl),
+                    lock_mode,
+                    str(READ_DELAY_SECONDS),
+                    read_fn,
+                    argv_mode,
+                    str(ready_file),
+                    str(go_file),
+                ],
+                stdin=handle,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=os.environ.copy(),
+            )
+        )
+    _release_barrier(ready_files, go_file)
+    try:
+        outputs = []
+        for proc in procs:
+            stdout, stderr = proc.communicate(timeout=30)
+            outputs.append((proc.returncode, stdout, stderr))
+        return outputs
+    finally:
+        for handle in stdin_files:
+            handle.close()
+
+
+@pytest.fixture
+def driver(tmp_path: Path) -> Path:
+    path = tmp_path / "race_driver.py"
+    path.write_text(_DRIVER, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# second-failure-advisory — a lost increment misfires the gate twice
+# ---------------------------------------------------------------------------
+
+_SECOND_FAILURE_IMPL = HOOKS / "postuse-correction" / "second-failure-advisory" / "impl.py"
+
+
+def _failure_payload(session_id: str) -> dict:
+    return {
+        "session_id": session_id,
+        "tool_name": "Bash",
+        "tool_input": {"file_path": "/tmp/project/run.sh"},
+        "tool_response": {"exit": 1, "error": "connection refused"},
+    }
+
+
+def _seed_first_failure(state_file: Path, session_id: str) -> None:
+    """Drive one ordinary failure so the pair's count sits at 1."""
+    env = os.environ.copy()
+    env["PRAXIS_SECOND_FAILURE_ADVISORY_FILE"] = str(state_file)
+    proc = subprocess.run(
+        [sys.executable, str(_SECOND_FAILURE_IMPL)],
+        input=json.dumps(_failure_payload(session_id)),
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == "", "first failure must not advise"
+
+
+def _advisory_count(outputs) -> int:
+    return sum(1 for _rc, stdout, _err in outputs if "additionalContext" in stdout)
+
+
+def _counts(state_file: Path) -> list[int]:
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    return [v for v in state["failures"].values() if isinstance(v, int)]
+
+
+@pytest.mark.parametrize(
+    "lock_mode,expected_count,allowed_advisories",
+    [
+        # Both children read count=1 and both write 2, so the third failure is
+        # never recorded. What reaches the model then splits two ways, and the
+        # split is a scheduling detail rather than something to pin: usually
+        # both children cross the `prior_count == 1` boundary and the advisory
+        # fires twice (the duplicate recorded as unverified on #950), but the
+        # two also share one `<path>.tmp` staging name, so one child's
+        # `os.replace` can find it already renamed away, fail, and suppress its
+        # own advisory. The lost increment is the invariant violation common to
+        # both, and it is deterministic.
+        ("nolock", 2, (1, 2)),
+        # Serialized: 1 -> 2 (advises) -> 3 (silent).
+        ("lock", 3, (1,)),
+    ],
+)
+def test_second_failure_advisory_race(
+    driver, tmp_path, monkeypatch, lock_mode, expected_count, allowed_advisories
+):
+    state_file = tmp_path / "second-failure-advisory-race.json"
+    session_id = "race-session"
+    monkeypatch.setenv("PRAXIS_SECOND_FAILURE_ADVISORY_FILE", str(state_file))
+
+    _seed_first_failure(state_file, session_id)
+
+    outputs = _run_pair(
+        driver,
+        _SECOND_FAILURE_IMPL,
+        lock_mode,
+        [_failure_payload(session_id), _failure_payload(session_id)],
+        read_fn="_load_state",
+    )
+
+    for rc, _stdout, stderr in outputs:
+        assert rc == 0, stderr
+
+    assert _advisory_count(outputs) in allowed_advisories
+    assert _counts(state_file) == [expected_count]
+
+
+# ---------------------------------------------------------------------------
+# pre-edit-md-escape-advisory — a lost Read entry misjudges the Edit gate
+# ---------------------------------------------------------------------------
+
+_MD_ESCAPE_IMPL = (
+    HOOKS / "postuse-correction" / "pre-edit-md-escape-advisory" / "impl.py"
+)
+
+
+def _read_payload(session_id: str, file_path: str) -> dict:
+    return {
+        "session_id": session_id,
+        "tool_name": "Read",
+        "tool_input": {"file_path": file_path},
+    }
+
+
+def _recorded_reads(path: Path) -> list[str] | None:
+    """Paths in the history file, or None when the file no longer parses."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))["read"]
+    except (json.JSONDecodeError, KeyError):
+        return None
+
+
+@pytest.mark.parametrize(
+    "lock_mode,both_recorded",
+    [
+        # Both children read the empty history and append only their own path,
+        # so the surviving file holds one of the two — or none of them: the two
+        # also stage through one shared `<path>.tmp` name, and interleaved
+        # writes there publish a file that no longer parses, which `read_state`
+        # reads as an empty history. Either way the Edit gate treats a file that
+        # WAS Read as unread and warns — or denies, under
+        # `PRAXIS_MD_ESCAPE_MODE=block`.
+        ("nolock", False),
+        ("lock", True),
+    ],
+)
+def test_md_read_history_race(driver, tmp_path, monkeypatch, lock_mode, both_recorded):
+    history_file = tmp_path / "md-read-history-race.json"
+    monkeypatch.setenv("PRAXIS_MD_READ_HISTORY_FILE", str(history_file))
+    session_id = "race-session"
+    first = str(tmp_path / "alpha.md")
+    second = str(tmp_path / "beta.md")
+
+    outputs = _run_pair(
+        driver,
+        _MD_ESCAPE_IMPL,
+        lock_mode,
+        [_read_payload(session_id, first), _read_payload(session_id, second)],
+        read_fn="load_history",
+        argv_mode="post",
+    )
+
+    for rc, _stdout, stderr in outputs:
+        assert rc == 0, stderr
+
+    recorded = _recorded_reads(history_file)
+    if both_recorded:
+        assert recorded is not None, "history file did not survive the pair"
+        assert sorted(recorded) == sorted([first, second])
+    else:
+        assert recorded is None or sorted(recorded) != sorted([first, second])

--- a/tests/test_hook_state_concurrency.py
+++ b/tests/test_hook_state_concurrency.py
@@ -13,14 +13,23 @@ Each case runs twice against the same code:
     silently returning the suite to green.
   * `lock` — the shipped path.
 
-The interleaving is forced by a start barrier plus a fixed delay inserted
-between the state read and the write in both children. Neither alone is
-enough: without the delay the race is a scheduling coin-flip, and without the
-barrier interpreter startup skew alone exceeded the delay often enough that
-the unlocked arm read as "no race". The delay sits at the same point in both
-arms and changes no hook logic; under `lock` the second child simply waits out
-the first child's critical section, which is why the delay must stay well
-under `PRAXIS_STATE_LOCK_TIMEOUT`'s 2s default.
+Both arms open with a start barrier, because interpreter startup skew alone
+exceeded the read window often enough that the unlocked arm read as "no race".
+What holds the window open after that differs by arm, and has to:
+
+  * `nolock` — a second barrier, released once *both* children have returned
+    from the state read. A fixed sleep only makes the overlap likely; on a
+    loaded box the first child can complete its whole read-modify-write before
+    the second is scheduled, and the serialized result that produces fails the
+    arm whose entire job is to prove the race.
+  * `lock` — the fixed delay. A post-read barrier is impossible here: the read
+    sits inside the critical section, so a child waiting there for a sibling
+    that cannot enter until it leaves would deadlock the pair. This arm needs
+    no overlap anyway — it asserts the second child waits the first out, which
+    is why the delay must stay well under `PRAXIS_STATE_LOCK_TIMEOUT`'s 2s
+    default.
+
+Neither arm changes hook logic; both wrap the read at the same point.
 """
 from __future__ import annotations
 
@@ -47,7 +56,10 @@ import os
 import sys
 import time
 
-impl_path, lock_mode, delay, read_fn, argv_mode, ready_file, go_file = sys.argv[1:8]
+(
+    impl_path, lock_mode, delay, read_fn, argv_mode, ready_file, go_file,
+    read_file, peer_read_file,
+) = sys.argv[1:10]
 
 spec = importlib.util.spec_from_file_location("impl_under_test", impl_path)
 mod = importlib.util.module_from_spec(spec)
@@ -63,9 +75,30 @@ _orig_read = getattr(mod, read_fn)
 
 
 def _slow_read(*args, **kwargs):
-    """Real read, then hold the window open so the sibling reaches it too."""
+    """Real read, then hold the window open so the sibling reaches it too.
+
+    Under `nolock` the hold is a barrier on the sibling's own read rather than
+    a fixed sleep: a sleep only makes the overlap likely, and on a loaded CI
+    box the first child can finish its whole read-modify-write before the
+    second is scheduled at all — which produces a serialized result and fails
+    the arm that exists to prove the race.
+
+    The barrier is `nolock`-only, and cannot be otherwise: under `lock` the
+    read happens inside the critical section, so waiting there for a sibling
+    that cannot enter until this process leaves would deadlock both children.
+    That arm keeps the sleep, which is all it needs — it asserts the second
+    child waits the first out, not that the two overlap.
+    """
     result = _orig_read(*args, **kwargs)
-    time.sleep(float(delay))
+    if lock_mode == "nolock":
+        open(read_file, "w").close()
+        _read_deadline = time.monotonic() + 30
+        while not os.path.exists(peer_read_file):
+            if time.monotonic() >= _read_deadline:
+                sys.exit("driver: post-read barrier timed out")
+            time.sleep(0.001)
+    else:
+        time.sleep(float(delay))
     return result
 
 
@@ -106,7 +139,12 @@ def _run_pair(driver: Path, impl: Path, lock_mode: str, payloads, read_fn, argv_
     `communicate` does not return until that child has exited — so the second
     child would not start until the first was done and no race could occur.
     """
+    # The post-read barrier pairs each child with exactly one peer, so a third
+    # payload would leave every child waiting on a file no one else writes.
+    assert len(payloads) == 2, "the post-read barrier pairs exactly two children"
+
     go_file = driver.parent / "go"
+    read_files = [driver.parent / f"read-{i}" for i in range(len(payloads))]
     ready_files = []
     procs = []
     stdin_files = []
@@ -129,6 +167,8 @@ def _run_pair(driver: Path, impl: Path, lock_mode: str, payloads, read_fn, argv_
                     argv_mode,
                     str(ready_file),
                     str(go_file),
+                    str(read_files[index]),
+                    str(read_files[1 - index]),
                 ],
                 stdin=handle,
                 stdout=subprocess.PIPE,


### PR DESCRIPTION
### 요약

`resolve_cache_file()` 로 세션 상태를 쓰는 훅 7개는 전부 read → modify →
`os.replace` 형태이고, `fcntl` 잠금은 한 곳도 없었다. `os.replace` 는 *쓰기* 만
원자적으로 만들 뿐 그 앞의 읽기까지 직렬화하지 않으므로, 같은 `session_id` 를
공유하는 두 프로세스(병렬 sub-agent 도구 호출이 흔한 출처)가 같은 값을 읽고
각자 갱신하면 나중 `os.replace` 가 앞선 갱신을 버린다.

7개 전부에 잠금을 다는 것은 이 문제의 오독이다. 상태 손실이 **실제 오작동**인
훅과 무해한 훅을 가르는 판정 기준을 세워 `DESIGN.md` 에 명문화하고, 기준상
"필요" 인 2개에만 잠금을 붙였다.

### 판정 기준

**나중 이벤트가 재생산하지 못하는 정보를 상태가 담고 있을 때 잠근다.** 세 질문을
순서대로, 첫 `yes` 에서 결정:

1. **임계값이 상태를 읽는가** — 정확한 경계(`count == 2`)에서 발화하는 훅은 증분
   유실 시 양방향으로 오작동한다. 경계를 함께 넘은 두 프로세스가 둘 다 발화하고,
   전진하지 못한 카운트는 이후로도 발화하지 않는다. → **잠금**
2. **게이트가 차단/통과 판정에 상태를 읽는가** — 유실된 항목은 세션에 대한 거짓
   판정이 되고, 그 판정은 로그가 아니라 사용자에게 도달한다. → **잠금**
3. **그 외** — dedup 마커이거나 단조 플래그이므로 최악이 advisory 한 줄의
   중복/누락이다. → **잠금 없음.** 경합은 실재하지만 그 결과는 무해하고, 여기서의
   잠금은 모든 도구 호출에 지연만 산다.

### 7개 훅 분류

| 훅 | 상태 | 손실의 결과 | 잠금 |
| --- | --- | --- | --- |
| `postuse-correction/second-failure-advisory` | `(tool, signature)` 별 카운터 | `prior_count == 1` 경계에서만 발화 — Q1 | 예 |
| `postuse-correction/pre-edit-md-escape-advisory` | Read 경로 누적 집합 | 실제로 Read 한 파일에 대해 Edit 게이트가 경고, `PRAXIS_MD_ESCAPE_MODE=block` 에서는 거부 — Q2 | 예 |
| `advisory-nudge/jq-config-empty-dict-advisory` | advise 된 경로 dedup 집합 | advisory 1줄 중복 | 아니오 |
| `advisory-nudge/postcompact-context` | 마지막 주입 compact uuid | 컨텍스트 1회 재주입 | 아니오 |
| `preflight-gate/worktree-prune-snapshot-gate` | `snapshot_taken` 단일 플래그, 항상 true 로만 설정 | 동시 writer 가 같은 값을 쓴다 | 아니오 |
| `preflight-gate/session-intent` | set-once intent 플래그 | writer 가 `UserPromptSubmit` 하나뿐이고 세션당 직렬화됨. `PreToolUse` 게이트 경로는 읽기 전용 | 아니오 |
| `preflight-gate/retrospect-active-marker` | 마커 존재 여부 | 통짜 쓰기와 `unlink` — 잃을 read-modify-write 창이 없다 | 아니오 |

### 변경

- `hooks/_lib/_state_lock.py` — `<path>.lock` 형제 파일에 `fcntl.flock` 을 거는
  컨텍스트 매니저. 획득 실패는 예외가 아니라 `False` 를 내고 본문은 그대로
  실행되므로 잠금 이전 동작으로 강등될 뿐 도구 호출을 차단하지 않는다
  (`@fail_open` 계약). 대기에는 마감 시한이 있어(`PRAXIS_STATE_LOCK_TIMEOUT`,
  기본 2초) 죽은 형제가 남긴 잠금이 호출을 붙잡지 못한다. 읽기 전용 경로는 잠그지
  않는다 — `os.replace` 가 이미 온전한 파일을 보장한다.
- 위 2개 훅의 read-modify-write 를 `state_lock` 으로 묶고 각 spec.md 에 근거를
  기록.
- `DESIGN.md → Session-state concurrency` — 기준과 분류표.
- `tests/test_hook_state_concurrency.py` — 실제 훅 impl 을 두 OS 프로세스로 동시에
  띄워 한 상태 파일을 치게 하는 fixture. 각 케이스가 잠금 arm 과 unlocked arm 두
  번 돌아, 잠금을 걷어내는 회귀는 스위트가 조용히 초록으로 남는 대신 여기서 깨진다.
- `tests/hooks/_lib/test_state_lock.py` — 헬퍼 계약(프로세스 간 배타, 모든 종료
  경로에서 해제, 모든 실패 모드에서 `False`) 단위 커버.

### 범위 밖 (후속 후보)

`jq-config-empty-dict-advisory` 는 `_save_seen` 이 `path + ".tmp"` 라는 고정
staging 이름을 쓴다. 두 프로세스가 그 파일에 동시에 쓰면 publish 되는 상태 파일이
파싱 불가가 되어 dedup 집합 전체가 날아간다 — 잠금 판정과 결과 등급은 같으므로
(advisory 중복) 이 PR 에서 건드리지 않았다. 잠긴 2개 훅도 같은 고정 이름을 쓰지만
임계 구역 안이라 더 이상 충돌하지 않는다.

Closes #951

Caller chain verified: `grep -rn state_lock . --exclude-dir=.git` — 신규 심볼
`state_lock` 의 호출자는 이 PR 이 만든 2개(second-failure-advisory/impl.py:323,
pre-edit-md-escape-advisory/impl.py:222)와 테스트 2개뿐. 기존 심볼 시그니처 변경
없음.

Pre-commit verified: `./scripts/run-tests.sh` (CI 진입점) 전체 실행 — 결과는 검증
앵커 코멘트에 기록.
