### PR TITLE
feat(hooks): enumerate all required tokens on first block

### DIFF
--- a/hooks/preflight-gate/branch-name-check/impl.py
+++ b/hooks/preflight-gate/branch-name-check/impl.py
@@ -83,6 +83,10 @@ _GIT_GLOBAL_BARE_FLAGS = frozenset({
 # Shell separators that end a single command's argument list.
 _SHELL_SEPARATORS = {";", "&&", "||", "|", "&"}
 
+# Extracts an alternation group like `(feat|fix|docs|...)` from a branch
+# regex pattern, for verbatim display in the block message (issue #941).
+_ALTERNATION_GROUP_RE = re.compile(r"\(([a-z0-9]+(?:\|[a-z0-9]+)+)\)")
+
 # Shell redirect operators. This regex matches a token that *starts* with a
 # redirect operator: optional leading fd digits, then one of `>` `>>` `<` `<<`
 # `<<<` `>&` `<&`, plus the `&>`/`&>>` merge forms. A branch name can never
@@ -111,6 +115,25 @@ def _get_regex() -> re.Pattern:
 
 def _get_strict() -> bool:
     return os.environ.get("PRAXIS_BRANCH_NAME_STRICT", "1").strip() != "0"
+
+
+def _extract_allowed_types(pattern: str) -> str | None:
+    """Best-effort extraction of the `<type>` alternation group from the
+    branch regex, for verbatim display alongside the raw pattern (issue #941
+    — a deny that shows only the regex makes the author re-derive the
+    allowed values by trial and error across retries).
+
+    The default regex has two alternation groups — `(hub|issue)` then
+    `(feat|fix|...)` — so the LAST group is the type segment in every known
+    shape. Returns None when the pattern has fewer than 2 alternation
+    groups (e.g. a `PRAXIS_BRANCH_NAME_REGEX` override with no `<type>`
+    segment); the message then falls back to the raw pattern only, exactly
+    as before this change.
+    """
+    groups = _ALTERNATION_GROUP_RE.findall(pattern)
+    if len(groups) < 2:
+        return None
+    return groups[-1].replace("|", ", ")
 
 
 def _get_whitelist() -> frozenset[str]:
@@ -527,12 +550,14 @@ def _extract_worktree_add_b(args: list[str]) -> str | None:
 # ---------------------------------------------------------------------------
 
 def _emit_block(branch: str, regex_pattern: str, strict: bool) -> None:
+    allowed_types = _extract_allowed_types(regex_pattern)
+    types_clause = f"; allowed <type> values: {allowed_types}" if allowed_types else ""
     reason = format_block(
         rule_name="branch-name-check",
         why=f"branch '{branch}' does not match the required naming convention",
         correct_path=(
             f"rename to hub-<N>-<type>-<desc> or issue-<N>-<type>-<desc> "
-            f"(pattern: {regex_pattern}); "
+            f"(pattern: {regex_pattern}){types_clause}; "
             f"set PRAXIS_BRANCH_NAME_STRICT=0 to switch to advisory-only mode"
         ),
         bypass_env=None,

--- a/hooks/preflight-gate/branch-name-check/spec.md
+++ b/hooks/preflight-gate/branch-name-check/spec.md
@@ -134,6 +134,16 @@ name in the same segment. A genuine job-control `&` (`git status & git checkout
 -b x`, `a && b`) is left untouched — the merge fires only when the tokens
 adjacent to `&` are themselves redirect-shaped.
 
+### Deny message content (issue #941)
+
+The `Correct path` line shows the raw pattern AND, when it parses out, a
+verbatim `allowed <type> values: feat, fix, docs, ...` clause — an author
+who only sees the regex has to re-derive the allowed tokens by trial and
+error across retries. Extraction picks the LAST alternation group in the
+pattern (`(hub|issue)` then `(feat|fix|...)` in the default shape); a
+`PRAXIS_BRANCH_NAME_REGEX` override with fewer than two alternation groups
+falls back to showing the raw pattern only, unchanged from before.
+
 ### Fail-open guarantees
 
 - Malformed JSON stdin → exit 0 (pass)

--- a/hooks/preflight-gate/verify-commit-flag-override/impl.py
+++ b/hooks/preflight-gate/verify-commit-flag-override/impl.py
@@ -222,6 +222,31 @@ def detect_overrides(argv: list[str]) -> list[str]:
 # Output
 # ---------------------------------------------------------------------------
 
+# Sibling gates that also fire on `git commit`, listed once at first block so
+# an author who clears THIS gate does not discover the next one only on the
+# following retry (issue #941). Kept local to this hook rather than in
+# `hooks/_lib/block_message.py` — this hook is the only caller, and each
+# token below is transcribed from the owning hook's own source (verified,
+# not recalled), the same discipline #931's `_VERB_CHECKLISTS` used.
+GIT_COMMIT_GATE_CHECKLIST = """
+📋 Other gates that also fire on `git commit` (satisfy the ones that apply):
+  Codex review pass this session            ← block-commit-without-codex-review
+    Skill(skill="praxis:codex-review-wrap"), OR a `[skip-codex-review]` token
+    in the commit message, OR CLAUDE_HOOK_BYPASS_CODEX_REVIEW_GATE=1 set
+    BEFORE the session started (an inline command prefix never reaches it).
+  Conventional Commits title format         ← commit-title-format-check
+    <type>(<scope>): <lowercase-description>; run with a bad title to see
+    the exact allowed `Types:` list.
+  Title <= 50 characters                    ← commit-title-length-check
+    Or embed `# title-length:ack` on the command to bypass a longer title.
+  No sciomc finding auto-flip               ← block-sciomc-finding-commit
+    Only fires when a [FINDING:...] / [STAGE_COMPLETE:N] / [CONFLICTS:...]
+    marker sits in the recent transcript; re-fetch the user's stated design
+    (PR/issue body) before committing over it.
+  Staged additions never seen via Read/Edit ← pre-commit-staged-file-enumeration
+    Advisory only — never blocks.
+"""
+
 DENY_TEMPLATE = """BLOCKED: Commit-flag override(s) detected.
 
 Detected override(s): {overrides}
@@ -329,7 +354,11 @@ def main() -> int:
     if not all_overrides:
         return 0
 
-    _emit_deny(_build_reason(all_overrides) + compound_cascade_hint(command))
+    _emit_deny(
+        _build_reason(all_overrides)
+        + GIT_COMMIT_GATE_CHECKLIST
+        + compound_cascade_hint(command)
+    )
     return 2
 
 

--- a/hooks/preflight-gate/verify-commit-flag-override/impl.py
+++ b/hooks/preflight-gate/verify-commit-flag-override/impl.py
@@ -264,10 +264,15 @@ These checks help you decide whether the override is appropriate. The
 hook does NOT recognize their completion — re-running the same git
 commit invocation will be blocked again.
 
-To proceed:
-  - Set PRAXIS_SKIP_COMMIT_FLAG_CHECK=1 in the environment (justify the
-    bypass in the commit message body).
-  - Or remove the override flag(s) that triggered the block.
+To proceed, BOTH of the following are required (global CLAUDE.md: lint/hook
+suppression needs a stated reason AND explicit user approval — neither one
+alone is sufficient):
+  1. State the concrete reason a root fix / normal commit is not possible.
+  2. Get the user's explicit approval for this specific override.
+  Then set PRAXIS_SKIP_COMMIT_FLAG_CHECK=1 in the environment, with the
+  reason recorded in the commit message body.
+
+Or remove the override flag(s) that triggered the block.
 """
 
 

--- a/hooks/preflight-gate/verify-commit-flag-override/spec.md
+++ b/hooks/preflight-gate/verify-commit-flag-override/spec.md
@@ -54,6 +54,16 @@ The only allow path the hook actually recognizes is the env-var bypass:
   environment before invoking `git commit`. Use sparingly; the bypass
   must be justified in the commit message body or PR description.
 
+The deny message also enumerates every OTHER gate that fires on `git
+commit` (`block-commit-without-codex-review`, `commit-title-format-check`,
+`commit-title-length-check`, `block-sciomc-finding-commit`,
+`pre-commit-staged-file-enumeration`) in one pass (issue #941) — an author
+clearing this gate should not discover the next commit-time gate only on
+the following retry. The checklist is local to this hook's `impl.py`
+(`GIT_COMMIT_GATE_CHECKLIST`), not in `hooks/_lib/block_message.py`'s
+verb-checklist registry: this hook is its only caller, and each token is
+transcribed from the owning sibling hook's own source.
+
 The deny message also lists "verification commands" (e.g.,
 `git config --get commit.gpgsign`, `gpg --list-secret-keys`). Running
 those does **not** unblock subsequent invocations — the hook does not

--- a/hooks/preflight-gate/verify-commit-flag-override/spec.md
+++ b/hooks/preflight-gate/verify-commit-flag-override/spec.md
@@ -54,6 +54,14 @@ The only allow path the hook actually recognizes is the env-var bypass:
   environment before invoking `git commit`. Use sparingly; the bypass
   must be justified in the commit message body or PR description.
 
+The deny message states BOTH requirements explicitly (global CLAUDE.md:
+suppression needs a stated reason AND explicit user approval, neither one
+alone is sufficient) — the bypass env var is not, on its own, a satisfying
+condition; it must be paired with a recorded reason and the user's
+per-instance approval. Before this change (issue #941) the message read
+as an either/or menu ("set the env var" OR "remove the flag"), which did
+not make the approval half of the rule visible at the block site.
+
 The deny message also enumerates every OTHER gate that fires on `git
 commit` (`block-commit-without-codex-review`, `commit-title-format-check`,
 `commit-title-length-check`, `block-sciomc-finding-commit`,

--- a/tests/hooks/preflight-gate/test_branch_name_check.sh
+++ b/tests/hooks/preflight-gate/test_branch_name_check.sh
@@ -624,6 +624,48 @@ else
   FAILED_NAMES+=("bypass message: no '=1 =0' artifact")
   echo "  FAIL  bypass message: no '=1 =0' artifact"
 fi
+# ---------------------------------------------------------------------------
+# Allowed <type> list verbatim in deny message (issue #941)
+# ---------------------------------------------------------------------------
+
+# Positive: default regex → the deny message enumerates every allowed
+# <type> value verbatim, not just the raw regex.
+raw_out=$(echo '{"tool_name":"Bash","tool_input":{"command":"git checkout -b bad-name"}}' | \
+  env -u PRAXIS_BRANCH_NAME_REGEX -u PRAXIS_BRANCH_NAME_STRICT -u PRAXIS_BRANCH_NAME_WHITELIST \
+  python3 "$HOOK" 2>/dev/null)
+if echo "$raw_out" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+reason = d['hookSpecificOutput']['permissionDecisionReason']
+assert 'allowed <type> values: feat, fix, docs, style, refactor, chore, test, perf, ci, build, hotfix' in reason, f'type list missing: {reason}'
+" 2>/dev/null; then
+  PASS=$((PASS + 1))
+  echo "  PASS  deny message enumerates allowed <type> values verbatim"
+else
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("deny message enumerates allowed <type> values verbatim")
+  echo "  FAIL  deny message enumerates allowed <type> values verbatim"
+fi
+
+# Negative contrast: a custom regex with no <type> alternation group must
+# NOT fabricate a type list — falls back to the raw pattern only.
+raw_out=$(echo '{"tool_name":"Bash","tool_input":{"command":"git checkout -b other-branch"}}' | \
+  env -u PRAXIS_BRANCH_NAME_STRICT -u PRAXIS_BRANCH_NAME_WHITELIST \
+  PRAXIS_BRANCH_NAME_REGEX='^custom-.*$' python3 "$HOOK" 2>/dev/null)
+if echo "$raw_out" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+reason = d['hookSpecificOutput']['permissionDecisionReason']
+assert 'allowed <type> values' not in reason, f'unexpected type list on a pattern with no type group: {reason}'
+" 2>/dev/null; then
+  PASS=$((PASS + 1))
+  echo "  PASS  no fabricated type list for a custom regex without a <type> group"
+else
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("no fabricated type list for a custom regex without a <type> group")
+  echo "  FAIL  no fabricated type list for a custom regex without a <type> group"
+fi
+
 # Fail-open guard opt-in (issue #498): main() must be @fail_open-wrapped;
 # guard behavior is tested centrally in tests/test_hook_runtime.sh.
 _failopen_out=$(python3 - << PYEOF 2>&1

--- a/tests/hooks/preflight-gate/test_verify_commit_flag_override.sh
+++ b/tests/hooks/preflight-gate/test_verify_commit_flag_override.sh
@@ -290,6 +290,22 @@ else
   FAILED_NAMES+=("T01")
 fi
 
+# Positive: the deny message states the reason+approval requirement
+# explicitly — the bypass env var alone is not framed as sufficient.
+if echo "$deny_out" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+reason = d['hookSpecificOutput']['permissionDecisionReason']
+assert 'BOTH of the following are required' in reason, f'missing reason+approval requirement: {reason}'
+" 2>/dev/null; then
+  echo "PASS: T01b: deny message requires BOTH reason and user approval"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: T01b: deny message requires BOTH reason and user approval"
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("T01b")
+fi
+
 # Negative contrast: no override detected → fully silent, no checklist leaks
 # into a passing invocation.
 silent_out=$(echo "$(payload 'git commit -m "regular message"')" | \

--- a/tests/hooks/preflight-gate/test_verify_commit_flag_override.sh
+++ b/tests/hooks/preflight-gate/test_verify_commit_flag_override.sh
@@ -262,6 +262,48 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Sibling git-commit gate checklist on first block (issue #941)
+# ---------------------------------------------------------------------------
+
+# Positive: a deny surfaces the full sibling-gate checklist, not just this
+# gate's own token.
+deny_out=$(echo "$(payload 'git commit -n -m "msg"')" | \
+  env -u PRAXIS_SKIP_COMMIT_FLAG_CHECK python3 "$HOOK" 2>/dev/null)
+if echo "$deny_out" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+reason = d['hookSpecificOutput']['permissionDecisionReason']
+for token in (
+    'block-commit-without-codex-review',
+    'commit-title-format-check',
+    'commit-title-length-check',
+    'block-sciomc-finding-commit',
+    'pre-commit-staged-file-enumeration',
+):
+    assert token in reason, f'missing {token!r} from deny message'
+" 2>/dev/null; then
+  echo "PASS: T01: deny message enumerates every sibling git-commit gate"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: T01: deny message enumerates every sibling git-commit gate"
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("T01")
+fi
+
+# Negative contrast: no override detected → fully silent, no checklist leaks
+# into a passing invocation.
+silent_out=$(echo "$(payload 'git commit -m "regular message"')" | \
+  env -u PRAXIS_SKIP_COMMIT_FLAG_CHECK python3 "$HOOK" 2>/dev/null)
+if [ -z "$silent_out" ]; then
+  echo "PASS: T02: no override → silent, checklist does not fire"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: T02: no override → silent, checklist does not fire (out=$silent_out)"
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("T02")
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # Fail-open guard opt-in (issue #498): main() must be @fail_open-wrapped;
 # guard behavior is tested centrally in tests/test_hook_runtime.sh.

--- a/tests/hooks/preflight-gate/test_verify_commit_flag_override.sh
+++ b/tests/hooks/preflight-gate/test_verify_commit_flag_override.sh
@@ -267,7 +267,7 @@ fi
 
 # Positive: a deny surfaces the full sibling-gate checklist, not just this
 # gate's own token.
-deny_out=$(echo "$(payload 'git commit -n -m "msg"')" | \
+deny_out=$(payload 'git commit -n -m "msg"' | \
   env -u PRAXIS_SKIP_COMMIT_FLAG_CHECK python3 "$HOOK" 2>/dev/null)
 if echo "$deny_out" | python3 -c "
 import json, sys
@@ -308,7 +308,7 @@ fi
 
 # Negative contrast: no override detected → fully silent, no checklist leaks
 # into a passing invocation.
-silent_out=$(echo "$(payload 'git commit -m "regular message"')" | \
+silent_out=$(payload 'git commit -m "regular message"' | \
   env -u PRAXIS_SKIP_COMMIT_FLAG_CHECK python3 "$HOOK" 2>/dev/null)
 if [ -z "$silent_out" ]; then
   echo "PASS: T02: no override → silent, checklist does not fire"


### PR DESCRIPTION
## 배경

게이트가 차단할 때 걸린 토큰 하나만 알려줘 라운드트립이 반복되는 문제 (issue #941). 6/6 차단률로 탐지 자체는 문제가 없으므로, 이 PR 은 **안내 품질**만 다룬다 (새 게이트 추가 없음).

## #873 중복 판정 — 부분 중복 (확장)

`gh issue view 873` 과 PR #931/#933 실제 코드·출력을 확인한 결과:

- **이미 구현됨**: `hooks/_lib/block_message.py` 의 `_VERB_CHECKLISTS` 레지스트리 + `verb_gate_checklist(verb)` (#931/#933). `gh pr create`, `gh pr merge`, `AskUserQuestion` 3개 verb 배선 완료. `block-pr-without-caller-evidence` 와 `output-block-falsify-advisory` 는 **실제 훅 실행으로 확인한 결과 이미 통합 안내를 발화 중**이었다 — 이 두 훅에 대해서는 #941 작업목록 2번이 선행 구현으로 이미 충족돼 있었다.
- **#931 이 명시적으로 범위 밖으로 둔 gap**: `git commit` verb — "배선할 훅이 없어 죽은 코드가 된다"는 이유로 제외됐으나, 그 시점에도 이미 `git commit` 표면에 6개 형제 게이트(block-commit-without-codex-review / commit-title-format-check / commit-title-length-check / block-sciomc-finding-commit / pre-commit-staged-file-enumeration / verify-commit-flag-override 자신)가 존재해 전제가 낡아 있었다.
- `branch-name-check` 의 branch-creation verb 는 형제 게이트가 없어 멀티게이트 열거 자체가 해당하지 않는다 (작업목록 3번으로 별도 처리).

**결론**: 이 PR 은 #873 의 신규 구현이 아니라 **확장**이다. `verify-commit-flag-override`(git commit) 만 실제 gap 이었다.

## 변경 사항

1. **branch-name-check** — 거부 메시지에 정규식뿐 아니라 허용 `<type>` 값을 verbatim 으로 함께 표시. 정규식의 마지막 alternation 그룹을 파싱하며, 커스텀 `PRAXIS_BRANCH_NAME_REGEX` 가 alternation 그룹 2개 미만이면 기존처럼 정규식만 표시 (fallback, 안전).
2. **verify-commit-flag-override** — `git commit` 표면에 걸리는 5개 형제 게이트(block-commit-without-codex-review / commit-title-format-check / commit-title-length-check / block-sciomc-finding-commit / pre-commit-staged-file-enumeration)를 첫 차단 시 한 번에 열거. 각 토큰은 형제 훅의 실제 소스에서 직접 전사했다 (#931 이 쓴 것과 같은 규율).
3. **verify-commit-flag-override** — 우회 안내를 "env var 설정 OR 플래그 제거"라는 either/or 메뉴에서, 전역 CLAUDE.md 가 요구하는 "사유 진술 + 사용자 승인 **둘 다**" 를 명시하는 절차로 변경.
4. `block-pr-without-caller-evidence`, `output-block-falsify-advisory` — **변경 없음.** 실제 훅 실행으로 이미 통합 안내가 발화 중임을 확인했다 (아래 검증 앵커 참조).

## `hooks/_lib/block_message.py` 비접촉 결정

`git commit` 형제 체크리스트를 `verb_gate_checklist("git commit")` 로 공유 레지스트리에 얹지 않고, `verify-commit-flag-override/impl.py` 안에 로컬 상수 `GIT_COMMIT_GATE_CHECKLIST` 로 구현했다. 이유:

1. 이 훅이 유일한 호출자라 공유할 필요가 없다 (YAGNI).
2. `_VERB_CHECKLISTS["AskUserQuestion"]` 의 manifest 기반 드리프트 가드(`test_ask_and_merge_checklists_match_the_hook_registry`)와 달리, git-commit 형제 6개 게이트는 `hooks/manifest.json` 의 `matcher` 로 구분되지 않는다 (46개 훅이 전부 `Bash` matcher 공유) — 레지스트리로 옮겨도 같은 종류의 드리프트 가드를 만들 수 없다.
3. 소스에서 "git commit 에 반응하는 훅 집합"을 도출하는 대안도 검토했으나, git-commit 형제 6개 훅이 서로 다른 5종의 감지 방식을 쓰고 있어 단일 정규식/AST 패턴으로 신뢰성 있게 열거할 수 없다:

   | 훅 | 감지 방식 |
   | --- | --- |
   | `block-commit-without-codex-review` | 토큰 비교 `tokens[j] == "commit"` |
   | `block-sciomc-finding-commit` | 토큰 비교 `tokens[j] == "commit"` (위와 동일 패턴이지만 다른 파일) |
   | `verify-commit-flag-override` | argv 비교 `argv[i] != "commit"` |
   | `commit-title-length-check` | dict-key 매칭 `key == "commit_title"` (커밋 타이틀이 별도 파싱 단계를 거쳐 도달) |
   | `commit-title-format-check` | 헬퍼 함수 내부 분기 — 정적 grep 으로 "git commit 반응 여부"를 판별할 수 있는 표면 패턴이 없음 |
   | `pre-commit-staged-file-enumeration` | `hooks/preflight-gate/` 가 아니라 `hooks/advisory-nudge/` 아래 위치 — 디렉터리 스캔 범위 자체가 다른 5개와 다름 |

   이 열거가 "균일 판별자가 없다"는 결론의 근거다. 균일 판별자가 있다면 그 자체로 이 6개 훅의 구현을 통일하는 별도 리팩터가 필요하다는 뜻이고, 그건 #941 범위 밖이다. 잘못된 휴리스틱은 오탐(무관한 PR 차단)과 미탐(아무것도 안 잡음) 두 실패 모드만 낳으므로, 드리프트 테스트는 넣지 않기로 했다 — 근거는 커밋 a669dce 의 `Not-tested:` 트레일러에도 남겼다.

이번 PR 은 `hooks/_lib/block_message.py` 를 전혀 수정하지 않는다.

## 범위 밖 (이슈 본문에 명시)

- 새 게이트 추가 없음 (6/6 차단률이므로 탐지는 문제가 아님)
- scratchpad vs `/tmp` 규약 (별건)

## 커밋

- `7c25b0c` feat(hooks): show allowed types in branch-name deny
- `a669dce` feat(hooks): list sibling git-commit gates on flag-override deny
- `ea3db2b` fix(hooks): require reason and approval for flag-override
- `e9b5fb5` refactor(tests): drop useless echo in commit-flag fixtures

## 검증

Caller chain verified: `_extract_allowed_types`, `GIT_COMMIT_GATE_CHECKLIST` 모두 신규 심볼이며 호출부는 각 훅 파일 내부 1곳뿐 (grep 으로 확인, 외부 호출자 없음)

Pre-commit verified: 아래 검증 앵커 코멘트 참조 — 훅 직접 실행 출력, 개별 테스트 스위트 106/0·41/0, ruff/shellcheck/manifest/invariants clean, 전체 `./scripts/run-tests.sh` 결과는 검증 앵커에 추가 예정

Closes #941
