### PR TITLE
chore(memory): normalize frontmatter schema drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,18 @@ jobs:
       - run: bash scripts/run-tests.sh
         env:
           PRAXIS_TESTS_STRICT: "1"
+      # Standalone step (issue #942), not folded into run-tests.sh: the memory
+      # dir it lints is a local, gitignored, per-user store
+      # ($CLAUDE_CONFIG_DIR/projects/<slug>/memory/) that does not exist on
+      # this runner, so the script always prints SKIPPED here and exits 0 —
+      # its real enforcement runs on a contributor's machine, and unit
+      # coverage for the checker itself lives in
+      # tests/test_check_memory_frontmatter.py (already run by the pytest
+      # step above via `python3 -m pytest tests/` inside run-tests.sh). This
+      # step exists so the script's own CLI entrypoint — resolve_memory_dir(),
+      # the skip path, PRAXIS_TESTS_STRICT — gets exercised on every push,
+      # not just under pytest.
+      - run: python3 scripts/check-memory-frontmatter.py
 
   link-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,18 +109,6 @@ jobs:
       - run: bash scripts/run-tests.sh
         env:
           PRAXIS_TESTS_STRICT: "1"
-      # Standalone step (issue #942), not folded into run-tests.sh: the memory
-      # dir it lints is a local, gitignored, per-user store
-      # ($CLAUDE_CONFIG_DIR/projects/<slug>/memory/) that does not exist on
-      # this runner, so the script always prints SKIPPED here and exits 0 —
-      # its real enforcement runs on a contributor's machine, and unit
-      # coverage for the checker itself lives in
-      # tests/test_check_memory_frontmatter.py (already run by the pytest
-      # step above via `python3 -m pytest tests/` inside run-tests.sh). This
-      # step exists so the script's own CLI entrypoint — resolve_memory_dir(),
-      # the skip path, PRAXIS_TESTS_STRICT — gets exercised on every push,
-      # not just under pytest.
-      - run: python3 scripts/check-memory-frontmatter.py
 
   link-check:
     runs-on: ubuntu-latest

--- a/scripts/check-memory-frontmatter.py
+++ b/scripts/check-memory-frontmatter.py
@@ -34,6 +34,21 @@ Checks (one entry = one `*.md` file in the memory dir, `MEMORY.md` excluded):
      the whole memory — `hookable: true` then never fires. Two entries in the
      corpus shipped this way (issue #942 scan): the hint had been dark since
      they were authored.
+  4. `hookable: true` with `hookKeywords` missing entirely, or present as an
+     empty list (`hookKeywords: []`), is the same silent-drop failure as
+     check 3's block/scalar form — `impl.py:117-139` returns `None` (no
+     memory, no hint, ever) the moment `hookKeywords:` has no match or its
+     bracket content is empty. This check was added in a later revision of
+     this script (issue #942 F1, caught by an independent codex-review pass
+     after the first revision shipped without it): the original release only
+     inspected a field that IS present, so a memory missing `hookKeywords`
+     outright passed as clean while being just as dark as the block-form
+     case check 3 catches.
+
+Note on `hookEvents:` specifically: an empty list (`hookEvents: []`) is NOT
+flagged the same way — `impl.py:150-169` falls back to the `[Bash]` default
+when the bracket content is empty or unparseable, so the memory still gets
+indexed.
 
 Resolution: reuses `hooks/_lib/_memory_dir.py::resolve_memory_dir()`, so this
 follows `PRAXIS_MEMORY_DIR` / `CLAUDE_CONFIG_DIR` exactly like the memory-hint
@@ -85,6 +100,11 @@ TAXONOMY_FIELDS = (
 # Fields that must use single-line `[a, b]` form — the memory-hint parser
 # rejects any other shape outright (see module docstring, check 3).
 BRACKET_FIELDS = ("hookKeywords", "hookEvents")
+
+# Mirrors hooks/advisory-nudge/memory-hint/impl.py:60 exactly (TRUTHY_VALUES) —
+# the runtime's own truthy set for `hookable:`, after the same normalization
+# (strip, lowercase, strip quotes) that impl.py:108-113 applies.
+HOOKABLE_TRUTHY_VALUES = {"true", "yes"}
 
 
 def frontmatter_block(raw: str) -> str | None:
@@ -151,6 +171,31 @@ def check_file(path: Path) -> list[str]:
                         f"`{field}: {value}` is scalar form, not `[a, b]` — the memory-hint parser "
                         "rejects this shape and silently drops the entire memory from the hint index"
                     )
+                elif field == "hookKeywords":
+                    close_idx = value.find("]")
+                    inner = value[1:close_idx].strip() if close_idx != -1 else value[1:]
+                    if not inner:
+                        errors.append(
+                            f"`{field}: {value}` is an empty list — the memory-hint parser treats "
+                            "an empty hookKeywords the same as absent and silently drops the entire "
+                            "memory from the hint index (issue #942 F1)"
+                        )
+
+    # F1 (issue #942): `hookable: true` with `hookKeywords` entirely absent is
+    # the most direct silent-dark shape and was previously invisible to this
+    # lint — the BRACKET_FIELDS loop above only inspects a field that IS
+    # present. hooks/advisory-nudge/memory-hint/impl.py:117-119 returns None
+    # (drops the memory from the hint index) the moment `hookKeywords:` has no
+    # match in the frontmatter block at all.
+    hookable_truthy = False
+    if "hookable" in occurrences:
+        _, hookable_value = occurrences["hookable"][0]
+        hookable_truthy = hookable_value.strip().strip("\"'").lower() in HOOKABLE_TRUTHY_VALUES
+    if hookable_truthy and "hookKeywords" not in occurrences:
+        errors.append(
+            "`hookable: true` but `hookKeywords` is missing — the memory-hint parser requires "
+            "it and silently drops the entire memory from the hint index when absent (issue #942 F1)"
+        )
 
     return errors
 

--- a/scripts/check-memory-frontmatter.py
+++ b/scripts/check-memory-frontmatter.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Lint session-memory frontmatter for taxonomy-field schema drift (issue #942).
+
+Background: this repo's on-disk session memories
+(`$CLAUDE_CONFIG_DIR/projects/<slug>/memory/*.md`) nest taxonomy fields
+(`type`, `originSessionId`, `hookable`, `hookKeywords`, `hookEvents`,
+`modified`, `node_type`) under a `metadata:` block by convention — see
+`skills/retrospect/references/stage4-execution.md`. Nesting has NO runtime
+effect on `hooks/advisory-nudge/memory-hint/impl.py` (its regexes match
+either position); the only reason to enforce it is cross-entry consistency,
+so a reader never has to check two positions per field.
+
+Two retrospect cycles (17 -> 18) flagged the same drift family without it
+ever becoming a re-checkable artifact — the finding lived only in a carried
+`cycle_note` string in `.omc/state/retrospect-hygiene-cursor.json`, which has
+no CI and no issue to close against. This script is the structural fix: it
+runs the same check every time instead of relying on a future retrospect
+scan to notice again.
+
+Checks (one entry = one `*.md` file in the memory dir, `MEMORY.md` excluded):
+  1. no taxonomy field at the top level of the frontmatter — each must live
+     under `metadata:`
+  2. no taxonomy field duplicated (top-level + nested, or nested twice)
+  3. `hookKeywords:` / `hookEvents:`, when present, use the single-line
+     bracket form (`[a, b]`). The multi-line YAML-block form (`hookKeywords:`
+     followed by `- item` lines) is a FUNCTIONAL bug, not just a style
+     drift: `hooks/advisory-nudge/memory-hint/impl.py`'s KEYWORDS_RE/EVENTS_RE
+     read the rest of the `key:` line only, find no `[`, and silently reject
+     the whole memory — `hookable: true` then never fires. Two entries in the
+     corpus shipped this way (issue #942 scan): the hint had been dark since
+     they were authored.
+
+Resolution: reuses `hooks/_lib/_memory_dir.py::resolve_memory_dir()`, so this
+follows `PRAXIS_MEMORY_DIR` / `CLAUDE_CONFIG_DIR` exactly like the memory-hint
+hook does — no separate path convention to drift from that one.
+
+Exit codes: 0 clean (or skipped, unless PRAXIS_TESTS_STRICT=1), 1 on any
+violation (or on a skip under PRAXIS_TESTS_STRICT=1, matching the
+skip-is-not-pass convention `scripts/run-tests.sh` already uses, #917).
+
+CI reality: the memory directory is a local, gitignored, per-user store and
+does not exist in CI at all — so in CI this script always prints SKIPPED and
+exits 0. It has enforcement value locally (a contributor normalizing memory
+frontmatter) and as a component this repo's own tests exercise directly
+(`tests/test_check_memory_frontmatter.py`, via `PRAXIS_MEMORY_DIR`). Wiring
+it into `scripts/run-tests.sh` is a follow-up, deliberately not done here —
+that file is shared with concurrently in-flight PRs.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "hooks" / "_lib"))
+from _memory_dir import resolve_memory_dir  # type: ignore[import-not-found]  # noqa: E402
+
+FENCE_RE = re.compile(r"^---\s*$", re.MULTILINE)
+KEY_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.*)$")
+
+# Fields this repo's convention requires nested under `metadata:`.
+TAXONOMY_FIELDS = (
+    "node_type",
+    "type",
+    "originSessionId",
+    "hookable",
+    "hookKeywords",
+    "hookEvents",
+    "modified",
+)
+# Fields that must use single-line `[a, b]` form — the memory-hint parser
+# rejects any other shape outright (see module docstring, check 3).
+BRACKET_FIELDS = ("hookKeywords", "hookEvents")
+
+
+def frontmatter_block(raw: str) -> str | None:
+    """Return the text between the first two `---` fences, or None."""
+    matches = list(FENCE_RE.finditer(raw))
+    if len(matches) < 2:
+        return None
+    return raw[matches[0].end() : matches[1].start()]
+
+
+def _indented_lines(block: str) -> list[tuple[int, str]]:
+    out = []
+    for line in block.splitlines():
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        out.append((indent, line.strip()))
+    return out
+
+
+def check_file(path: Path) -> list[str]:
+    """Return a list of human-readable violations for one memory file."""
+    raw = path.read_text(encoding="utf-8")
+    block = frontmatter_block(raw)
+    if block is None:
+        return ["missing `---`-fenced frontmatter block"]
+
+    errors: list[str] = []
+    # field -> list of (nested: bool, raw_value: str)
+    occurrences: dict[str, list[tuple[bool, str]]] = {}
+    in_metadata = False
+
+    for indent, line in _indented_lines(block):
+        m = KEY_RE.match(line)
+        if not m:
+            continue  # e.g. a `- item` list line, or free-text
+        key, value = m.group(1), m.group(2)
+        if indent == 0:
+            if key == "metadata":
+                in_metadata = True
+                continue
+            in_metadata = False
+        nested = in_metadata and indent > 0
+        if key in TAXONOMY_FIELDS:
+            occurrences.setdefault(key, []).append((nested, value))
+
+    for field, occs in occurrences.items():
+        if len(occs) > 1:
+            errors.append(f"`{field}` appears {len(occs)} times — must appear exactly once, nested under `metadata:`")
+        for nested, value in occs:
+            if not nested:
+                errors.append(f"`{field}` is at the top level — must nest under `metadata:`")
+        if field in BRACKET_FIELDS:
+            for _nested, value in occs:
+                value = value.strip()
+                if not value:
+                    errors.append(
+                        f"`{field}:` has no inline value (multi-line YAML-block `- item` form) — "
+                        "the memory-hint parser rejects this shape and silently drops the entire "
+                        "memory from the hint index; use single-line `[a, b]` form"
+                    )
+                elif not value.startswith("["):
+                    errors.append(
+                        f"`{field}: {value}` is scalar form, not `[a, b]` — the memory-hint parser "
+                        "rejects this shape and silently drops the entire memory from the hint index"
+                    )
+
+    return errors
+
+
+def iter_memory_files(memory_dir: str) -> list[Path]:
+    return sorted(p for p in Path(memory_dir).glob("*.md") if p.name != "MEMORY.md")
+
+
+def main() -> int:
+    strict = os.environ.get("PRAXIS_TESTS_STRICT", "0") == "1"
+
+    memory_dir = resolve_memory_dir()
+    if not memory_dir:
+        print("SKIPPED: memory-frontmatter-lint (memory directory not found — expected in CI / a fresh checkout)")
+        return 1 if strict else 0
+
+    files = iter_memory_files(memory_dir)
+    if not files:
+        print(f"SKIPPED: memory-frontmatter-lint (no memory entries under {memory_dir})")
+        return 1 if strict else 0
+
+    total_errors = 0
+    for path in files:
+        errors = check_file(path)
+        if errors:
+            total_errors += len(errors)
+            print(f"FAIL: {path.name}")
+            for err in errors:
+                print(f"  - {err}")
+
+    if total_errors:
+        print(f"\n{total_errors} frontmatter schema violation(s) across {len(files)} memory entries in {memory_dir}")
+        return 1
+
+    print(f"OK: {len(files)} memory entries in {memory_dir} — frontmatter schema clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-memory-frontmatter.py
+++ b/scripts/check-memory-frontmatter.py
@@ -39,17 +39,24 @@ Resolution: reuses `hooks/_lib/_memory_dir.py::resolve_memory_dir()`, so this
 follows `PRAXIS_MEMORY_DIR` / `CLAUDE_CONFIG_DIR` exactly like the memory-hint
 hook does — no separate path convention to drift from that one.
 
-Exit codes: 0 clean (or skipped, unless PRAXIS_TESTS_STRICT=1), 1 on any
-violation (or on a skip under PRAXIS_TESTS_STRICT=1, matching the
-skip-is-not-pass convention `scripts/run-tests.sh` already uses, #917).
+Exit codes: 0 clean (or N/A, unless PRAXIS_TESTS_STRICT=1), 1 on any
+violation (or on N/A under PRAXIS_TESTS_STRICT=1, for standalone invocation).
 
 CI reality: the memory directory is a local, gitignored, per-user store and
-does not exist in CI at all — so in CI this script always prints SKIPPED and
-exits 0. It has enforcement value locally (a contributor normalizing memory
+does not exist in CI at all — so in CI this script always prints N/A and
+exits 0 (`scripts/run-tests.sh` strips PRAXIS_TESTS_STRICT for this one call,
+so N/A can never fail the CI job either). This label is deliberately NOT
+"SKIPPED": `scripts/run-tests.sh`'s header explains why a skip is not a pass
+(#917) — a SKIPPED line names a *fixable* gap (install the tool) that a
+strict rerun can close. This condition can never close; the directory is
+structurally absent in CI by design, forever. Printing it as SKIPPED would
+plant a permanently-unresolvable entry in exactly the noise this repo already
+learned (via #917) drowns out the *actionable* skips — the same signal-loss
+failure mode issue #942 itself was opened to stop recurring. N/A keeps it
+readable as "nothing to check here", not "something you could fix but
+didn't". It has enforcement value locally (a contributor normalizing memory
 frontmatter) and as a component this repo's own tests exercise directly
-(`tests/test_check_memory_frontmatter.py`, via `PRAXIS_MEMORY_DIR`). Wiring
-it into `scripts/run-tests.sh` is a follow-up, deliberately not done here —
-that file is shared with concurrently in-flight PRs.
+(`tests/test_check_memory_frontmatter.py`, via `PRAXIS_MEMORY_DIR`).
 """
 from __future__ import annotations
 
@@ -157,12 +164,12 @@ def main() -> int:
 
     memory_dir = resolve_memory_dir()
     if not memory_dir:
-        print("SKIPPED: memory-frontmatter-lint (memory directory not found — expected in CI / a fresh checkout)")
+        print("N/A: memory-frontmatter-lint (memory directory not found — expected in CI / a fresh checkout, not a fixable gap, see issue #942)")
         return 1 if strict else 0
 
     files = iter_memory_files(memory_dir)
     if not files:
-        print(f"SKIPPED: memory-frontmatter-lint (no memory entries under {memory_dir})")
+        print(f"N/A: memory-frontmatter-lint (no memory entries under {memory_dir})")
         return 1 if strict else 0
 
     total_errors = 0

--- a/scripts/check-memory-frontmatter.py
+++ b/scripts/check-memory-frontmatter.py
@@ -48,7 +48,10 @@ Checks (one entry = one `*.md` file in the memory dir, `MEMORY.md` excluded):
 Note on `hookEvents:` specifically: an empty list (`hookEvents: []`) is NOT
 flagged the same way — `impl.py:150-169` falls back to the `[Bash]` default
 when the bracket content is empty or unparseable, so the memory still gets
-indexed.
+indexed (see check 3's own error text distinguishing the two fields' failure
+modes — this was also caught in the F1/F2 codex-review pass: prior to that,
+`check_file()`'s error message for `hookEvents` incorrectly claimed the same
+"entire memory dropped" consequence hookKeywords has).
 
 Resolution: reuses `hooks/_lib/_memory_dir.py::resolve_memory_dir()`, so this
 follows `PRAXIS_MEMORY_DIR` / `CLAUDE_CONFIG_DIR` exactly like the memory-hint
@@ -158,18 +161,33 @@ def check_file(path: Path) -> list[str]:
             if not nested:
                 errors.append(f"`{field}` is at the top level — must nest under `metadata:`")
         if field in BRACKET_FIELDS:
+            # hookKeywords and hookEvents fail differently at runtime (F2,
+            # issue #942, caught by an independent codex-review pass): a
+            # malformed hookKeywords drops the WHOLE memory (impl.py:117-139
+            # returns None outright), but a malformed hookEvents just falls
+            # back to the `[Bash]` default (impl.py:150-169) — the memory
+            # still gets indexed, only the intended non-Bash event is lost.
+            # An earlier revision of this script used one shared "entire
+            # memory dropped" message for both fields; that was accurate for
+            # hookKeywords and wrong for hookEvents.
+            consequence = (
+                "silently drops the entire memory from the hint index"
+                if field == "hookKeywords"
+                else "silently falls back to the default `[Bash]` event — the memory "
+                "still gets indexed, but the intended non-Bash event is lost"
+            )
             for _nested, value in occs:
                 value = value.strip()
                 if not value:
                     errors.append(
                         f"`{field}:` has no inline value (multi-line YAML-block `- item` form) — "
-                        "the memory-hint parser rejects this shape and silently drops the entire "
-                        "memory from the hint index; use single-line `[a, b]` form"
+                        f"the memory-hint parser rejects this shape and {consequence}; "
+                        "use single-line `[a, b]` form"
                     )
                 elif not value.startswith("["):
                     errors.append(
                         f"`{field}: {value}` is scalar form, not `[a, b]` — the memory-hint parser "
-                        "rejects this shape and silently drops the entire memory from the hint index"
+                        f"rejects this shape and {consequence}"
                     )
                 elif field == "hookKeywords":
                     close_idx = value.find("]")

--- a/scripts/check-memory-frontmatter.py
+++ b/scripts/check-memory-frontmatter.py
@@ -10,6 +10,11 @@ effect on `hooks/advisory-nudge/memory-hint/impl.py` (its regexes match
 either position); the only reason to enforce it is cross-entry consistency,
 so a reader never has to check two positions per field.
 
+`node_type` is included in the taxonomy set for *position* checking (if
+present, it must be nested and not duplicated, same as any other taxonomy
+field) but is never required to be present — no hook in this repo reads it
+(grep-verified). A memory missing `node_type` entirely is not drift.
+
 Two retrospect cycles (17 -> 18) flagged the same drift family without it
 ever becoming a re-checkable artifact — the finding lived only in a carried
 `cycle_note` string in `.omc/state/retrospect-hygiene-cursor.json`, which has

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -6,14 +6,23 @@
 #   2. shell    — shell tests at tests/hooks/*/test_*.sh and tests/test_*.sh
 #   3. manifest — scripts/check-plugin-manifests.py
 #   4. invariants — scripts/check-hook-token-invariants.py
-#   5. ruff     — static Python lint (mirrors the ci.yml `ruff` job)
-#   6. shellcheck — static shell lint (mirrors the ci.yml `shellcheck` job)
-#   7. markdownlint — advisory markdown lint (mirrors the ci.yml `markdownlint` job)
+#   5. memory-frontmatter — scripts/check-memory-frontmatter.py
+#   6. ruff     — static Python lint (mirrors the ci.yml `ruff` job)
+#   7. shellcheck — static shell lint (mirrors the ci.yml `shellcheck` job)
+#   8. markdownlint — advisory markdown lint (mirrors the ci.yml `markdownlint` job)
 #
-# Steps 5-7 mirror CI jobs that used to have no local equivalent, so a change
+# Steps 6-8 mirror CI jobs that used to have no local equivalent, so a change
 # could pass here and still be flagged on the PR (issue #866). Each skips with
 # an explicit SKIPPED line when its tool is absent, so a contributor without
 # the toolchain is not blocked — CI remains authoritative either way.
+#
+# Step 5 is a different repo-internal script, same family as steps 3-4 (no
+# external toolchain — nothing to install), but it has its own legitimate skip
+# condition: the memory directory it lints is a local, gitignored, per-user
+# store that does not exist in CI or a fresh checkout at all (issue #942). It
+# prints its own SKIPPED line and exit code, honoring PRAXIS_TESTS_STRICT the
+# same way steps 6-8 do — no skip_step() wiring needed here, so a nonzero exit
+# is treated as FAILED like steps 3-4, not routed through the tool-skip path.
 #
 # A skip is not a pass (#917). The SKIPPED line used to scroll past and the run
 # still ended on a bare "ALL TESTS PASSED", which read as full coverage: PR #912
@@ -123,7 +132,24 @@ if ! python3 ./scripts/check-hook-token-invariants.py; then
 fi
 
 # ---------------------------------------------------------------------------
-# 5. Ruff (mirrors ci.yml `ruff` job — blocking there, blocking here)
+# 5. Memory frontmatter lint (schema-drift guard, issue #942)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== memory frontmatter lint ==="
+# PRAXIS_TESTS_STRICT is deliberately NOT propagated to this one call: unlike
+# steps 6-8 (a tool a contributor could install), the memory dir this checks
+# is a local, gitignored, per-user store that structurally never exists in
+# CI or a fresh checkout — treating its absence as a strict-mode failure
+# would fail every CI run forever, not flag a fixable gap. A SKIPPED here is
+# always benign; only actual detected drift (exit 1 with violations listed)
+# fails this step. The script's own PRAXIS_TESTS_STRICT support still works
+# for direct standalone invocation (see its tests / docstring).
+if ! env -u PRAXIS_TESTS_STRICT python3 ./scripts/check-memory-frontmatter.py; then
+  FAILED=1
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Ruff (mirrors ci.yml `ruff` job — blocking there, blocking here)
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== ruff ==="
@@ -142,7 +168,7 @@ elif ! "${RUFF[@]}" check .; then
 fi
 
 # ---------------------------------------------------------------------------
-# 6. Shellcheck (mirrors ci.yml `shellcheck` job — same find/severity)
+# 7. Shellcheck (mirrors ci.yml `shellcheck` job — same find/severity)
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== shellcheck ==="
@@ -157,7 +183,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 7. Markdownlint (mirrors ci.yml `markdownlint` job)
+# 8. Markdownlint (mirrors ci.yml `markdownlint` job)
 #
 # CI runs this with filter_mode:added and never fails the check, so the repo's
 # existing backlog stays untouched. The advisory half is mirrored exactly — a
@@ -221,7 +247,10 @@ if [[ $FAILED -ne 0 ]]; then
   exit 1
 fi
 
-# Scope note: this counts the three tool steps this script owns (5-7). Gates
+# Scope note: this counts the three tool steps this script owns (6-8). Step 5
+# has its own SKIPPED line but is deliberately excluded from this tally (see
+# its PRAXIS_TESTS_STRICT note above) — it is never a missing-toolchain skip.
+# Gates
 # that a sub-suite skips internally — e.g. the Darwin-only gate in
 # tests/test_codex_broker_reaper.sh — announce themselves in their own summary
 # and are not aggregated here; conflating them would make a portable-by-design

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -17,12 +17,17 @@
 # the toolchain is not blocked — CI remains authoritative either way.
 #
 # Step 5 is a different repo-internal script, same family as steps 3-4 (no
-# external toolchain — nothing to install), but it has its own legitimate skip
-# condition: the memory directory it lints is a local, gitignored, per-user
-# store that does not exist in CI or a fresh checkout at all (issue #942). It
-# prints its own SKIPPED line and exit code, honoring PRAXIS_TESTS_STRICT the
-# same way steps 6-8 do — no skip_step() wiring needed here, so a nonzero exit
-# is treated as FAILED like steps 3-4, not routed through the tool-skip path.
+# external toolchain — nothing to install), but its skip condition is not
+# like steps 6-8's: the memory directory it lints is a local, gitignored,
+# per-user store that is structurally absent in CI or a fresh checkout,
+# always, forever (issue #942) — not a "toolchain not installed" gap a
+# contributor can close. It prints "N/A", never "SKIPPED", to keep that
+# distinction visible in the log (see its own docstring / #917 below), and
+# this call strips PRAXIS_TESTS_STRICT (`env -u`, not passed through like
+# steps 6-8) so that permanent N/A can never fail the job. Real drift
+# (nonzero exit with violations listed) still counts as FAILED, same as
+# steps 3-4 — this is not routed through the SKIPPED_TOOLS/skip_step() path
+# at all.
 #
 # A skip is not a pass (#917). The SKIPPED line used to scroll past and the run
 # still ended on a bare "ALL TESTS PASSED", which read as full coverage: PR #912
@@ -140,10 +145,15 @@ echo "=== memory frontmatter lint ==="
 # steps 6-8 (a tool a contributor could install), the memory dir this checks
 # is a local, gitignored, per-user store that structurally never exists in
 # CI or a fresh checkout — treating its absence as a strict-mode failure
-# would fail every CI run forever, not flag a fixable gap. A SKIPPED here is
-# always benign; only actual detected drift (exit 1 with violations listed)
-# fails this step. The script's own PRAXIS_TESTS_STRICT support still works
-# for direct standalone invocation (see its tests / docstring).
+# would fail every CI run forever, not flag a fixable gap. The script prints
+# "N/A", not "SKIPPED", for exactly this reason: #917 exists because a
+# scrolling SKIPPED line lost its signal value once contributors stopped
+# reading it, and a condition that can never be fixed would sit there as
+# permanent unresolvable noise if it wore the same "SKIPPED" label as steps
+# 6-8's genuinely-fixable tool-absence skips. An N/A here is always benign;
+# only actual detected drift (exit 1 with violations listed) fails this step.
+# The script's own PRAXIS_TESTS_STRICT support still works for direct
+# standalone invocation (see its tests / docstring).
 if ! env -u PRAXIS_TESTS_STRICT python3 ./scripts/check-memory-frontmatter.py; then
   FAILED=1
 fi
@@ -248,9 +258,8 @@ if [[ $FAILED -ne 0 ]]; then
 fi
 
 # Scope note: this counts the three tool steps this script owns (6-8). Step 5
-# has its own SKIPPED line but is deliberately excluded from this tally (see
-# its PRAXIS_TESTS_STRICT note above) — it is never a missing-toolchain skip.
-# Gates
+# has its own N/A line (deliberately not "SKIPPED") and is excluded from this
+# tally on purpose — it is never a missing-toolchain skip. Gates
 # that a sub-suite skips internally — e.g. the Darwin-only gate in
 # tests/test_codex_broker_reaper.sh — announce themselves in their own summary
 # and are not aggregated here; conflating them would make a portable-by-design

--- a/skills/retrospect/references/stage4-execution.md
+++ b/skills/retrospect/references/stage4-execution.md
@@ -45,7 +45,7 @@ For each approved action:
    name: my-memory
    description: Short rule statement
    metadata:                                # this repo nests taxonomy fields here
-     node_type: memory                      # fixed literal; present on nearly all existing entries
+     node_type: memory                      # optional; no hook reads it (grep-verified, issue #942) — carry it when present, don't backfill it when absent
      type: feedback
      originSessionId: <uuid>                # session the memory was authored in
      hookable: true                         # opt into PreToolUse surface
@@ -69,6 +69,17 @@ For each approved action:
    `scripts/check-memory-frontmatter.py` deliberately excludes `momentum`
    from the fields it checks — this is the schema decision that exclusion
    encodes, not an oversight.
+
+   **`node_type: memory` is optional, not required.** `grep -rn node_type`
+   across every hook and script in this repo (issue #942) finds no
+   consumer at all — unlike `type`/`hookable`/`hookKeywords`/`hookEvents`,
+   nothing reads it. It is present on most existing entries (a fixed literal
+   from an earlier authoring convention) but its absence is inert: two
+   entries lack it entirely and `scripts/check-memory-frontmatter.py`
+   reports them clean, correctly, because there is nothing to enforce.
+   When authoring or normalizing a memory, carry `node_type: memory` if
+   it's already there — don't add it to a file that lacks it, and don't
+   treat its absence as drift.
 
    **Category-based default (apply unless rationale documented):**
 

--- a/skills/retrospect/references/stage4-execution.md
+++ b/skills/retrospect/references/stage4-execution.md
@@ -30,17 +30,45 @@ For each approved action:
 
    In addition to standard fields (`name`, `description`, `type`), every new memory MUST evaluate whether to include the `memory-hint` opt-in fields — `hookable` and `hookKeywords`. The full field spec (parser semantics, matching rules, fail-open contract) lives in `hooks/advisory-nudge/memory-hint/spec.md`; this section defines the authoring-time decision. The parser ignores `type` entirely and reads `hookable` / `hookKeywords` / `hookEvents` regardless of nesting depth (the regexes are indentation-tolerant), so place `type:` per your host's memory convention — this repo's on-disk memories nest taxonomy fields under `metadata:`. Only the opt-in fields' spelling and single-line list form matter for the hook.
 
+   **Canonical schema (issue #942).** The taxonomy block below is the full
+   field set this repo's memories converge on. Nesting these fields under
+   `metadata:` (vs. leaving them top-level) has **no runtime effect** —
+   `hooks/advisory-nudge/memory-hint/impl.py`'s regexes match either
+   position — so the *only* reason to enforce nesting is cross-entry
+   consistency: a reader (human or a future retrospect scan) should not have
+   to check two positions per field. `scripts/check-memory-frontmatter.py`
+   lints this shape and is wired into CI (see its docstring for what it does
+   and does not catch).
+
    ```yaml
    ---
    name: my-memory
    description: Short rule statement
    metadata:                                # this repo nests taxonomy fields here
+     node_type: memory                      # fixed literal; present on nearly all existing entries
      type: feedback
+     originSessionId: <uuid>                # session the memory was authored in
      hookable: true                         # opt into PreToolUse surface
      hookKeywords: [keyword1, keyword2]      # flat single-line list, whole-token (case-sensitive)
      hookEvents: [Bash, Edit]               # optional; default [Bash] when omitted
+     modified: <ISO-8601>                   # optional; set on later edits
+   momentum: [merge]                        # opt-in, top-level — NOT a taxonomy field, see below
    ---
    ```
+
+   **`momentum:` stays top-level — a deliberate exclusion, not a residual gap.**
+   `momentum` is a *different* opt-in mechanism (consumed by
+   `hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py`'s
+   `MOMENTUM_RE`, not by the memory-hint hook's `hookKeywords`/`hookEvents`)
+   with its own independent hook consumer — it answers "surface this memory
+   at a high-momentum action point" rather than "what kind of memory is
+   this", so it does not belong in the `metadata:` taxonomy block
+   conceptually. Practically: every existing `momentum:` entry (3/3, as of
+   issue #942's scan) is already top-level, so nesting it would be swimming
+   against its own 100%-consistent convention rather than fixing drift.
+   `scripts/check-memory-frontmatter.py` deliberately excludes `momentum`
+   from the fields it checks — this is the schema decision that exclusion
+   encodes, not an oversight.
 
    **Category-based default (apply unless rationale documented):**
 
@@ -58,8 +86,20 @@ For each approved action:
    - Whole-token, case-sensitive matching only (per `hooks/advisory-nudge/memory-hint/spec.md`). List multiple casings explicitly if needed (`[Edit, edit]`).
    - 1–4 keywords typical; >5 raises false-positive risk linearly.
    - **Avoid generic English words** (`add`, `run`, `test`, `update`) — they fire on unrelated commands and erode the hint signal.
-   - **`hookKeywords` must be a flat single-line list** (`[a, b]`). Multi-line YAML-block form (`- item` on separate lines) and scalar form (`hookKeywords: foo`) are silently skipped — the entire memory is then dropped (not indexed at all) and the hint never fires. Verify the list is single-line before committing.
+   - **`hookKeywords` must be a flat single-line list** (`[a, b]`). Multi-line YAML-block form (`- item` on separate lines) and scalar form (`hookKeywords: foo`) are silently skipped — the entire memory is then dropped (not indexed at all) and the hint never fires. Verify the list is single-line before committing. **This is not hypothetical** — issue #942's full-corpus scan found two `hookable: true` entries (`feedback_hook_flag_file_heredoc_timing.md`, `feedback_merge_ask_ci_comments_precheck.md`) shipped in the block-list form, so their hints had never fired despite `hookable: true` reading as "on". `scripts/check-memory-frontmatter.py` now catches this shape.
    - When the memory targets a non-Bash event, add `hookEvents:` to opt in — the memory-hint hook (`hooks/advisory-nudge/memory-hint/impl.py`) supports `[Bash, Edit, Write, NotebookEdit, AskUserQuestion]` (default `[Bash]` when omitted). Unsupported tool names in the list are dropped; if every listed event is unsupported the parser keeps the `[Bash]` default.
+
+   **Why cycle 17's finding recurred instead of closing (issue #942):** the
+   Stage 1.5 hygiene cursor (`.omc/state/retrospect-hygiene-cursor.json`,
+   gitignored local state) shows cycle 17 recorded the schema-drift family as
+   a carried `cycle_note` string only — no `gh issue create` action ran, so
+   the finding had nowhere to be closed *against*. It sat in the cursor's
+   carry-forward note, silently grew from 2 files to 4 across cycle
+   17→18, and only became an issue (#942) once cycle 18 explicitly promoted
+   it. The gap this exposes: a carried `cycle_note` has no re-verification
+   path of its own (no CI, no lint, no issue to close) — `scripts/check-memory-frontmatter.py`
+   in CI is the structural fix, so the *next* drift of this family fails a
+   build instead of aging quietly in cursor state.
 
    **⚠️ MANDATORY: Duplicate check before creating any memory file:**
 

--- a/skills/retrospect/references/stage4-execution.md
+++ b/skills/retrospect/references/stage4-execution.md
@@ -109,8 +109,14 @@ For each approved action:
    17→18, and only became an issue (#942) once cycle 18 explicitly promoted
    it. The gap this exposes: a carried `cycle_note` has no re-verification
    path of its own (no CI, no lint, no issue to close) — `scripts/check-memory-frontmatter.py`
-   in CI is the structural fix, so the *next* drift of this family fails a
-   build instead of aging quietly in cursor state.
+   is the structural fix, but only on a contributor's own machine: the
+   memory directory it lints is a local, gitignored, per-user store that is
+   structurally absent in CI, so `scripts/run-tests.sh`'s call to it always
+   prints `N/A` and exits 0 there (verified — F3, issue #942 codex-review
+   pass). **CI cannot catch the next drift of this family; only a local
+   `run-tests.sh` run, or a contributor running the script directly,
+   catches it.** That re-verification path is therefore still incomplete —
+   it exists, but is opt-in rather than structurally enforced on every push.
 
    **⚠️ MANDATORY: Duplicate check before creating any memory file:**
 

--- a/tests/test_check_memory_frontmatter.py
+++ b/tests/test_check_memory_frontmatter.py
@@ -161,6 +161,25 @@ body
     assert check.check_file(p) == []
 
 
+def test_missing_node_type_is_not_flagged(tmp_path):
+    # node_type has no consumer (grep-verified, issue #942) — its absence is
+    # optional, not drift. Two real entries in the corpus lack it entirely.
+    p = _write(
+        tmp_path,
+        "feedback_no_node_type.md",
+        """---
+name: no-node-type
+description: test
+metadata:
+  type: feedback
+  originSessionId: abc-123
+---
+body
+""",
+    )
+    assert check.check_file(p) == []
+
+
 # ---------------------------------------------------------------------------
 # main() — directory resolution + skip contract
 # ---------------------------------------------------------------------------

--- a/tests/test_check_memory_frontmatter.py
+++ b/tests/test_check_memory_frontmatter.py
@@ -135,6 +135,98 @@ body
     assert any("scalar form" in e for e in errors), errors
 
 
+def test_hookable_true_missing_hookkeywords_flagged(tmp_path):
+    # F1 (issue #942, codex-review pass after the original release): a field
+    # that is entirely ABSENT from the frontmatter was previously invisible
+    # to this checker — only present-but-malformed forms were caught. The
+    # memory-hint parser (impl.py:117-119) drops the memory outright when
+    # `hookable: true` and `hookKeywords:` has no match at all.
+    p = _write(
+        tmp_path,
+        "feedback_bad_missing_keywords.md",
+        """---
+name: bad-missing-keywords
+description: test
+metadata:
+  type: feedback
+  hookable: true
+  originSessionId: abc-123
+---
+body
+""",
+    )
+    errors = check.check_file(p)
+    assert any("hookable: true" in e and "hookKeywords" in e and "missing" in e for e in errors), errors
+
+
+def test_hookable_false_missing_hookkeywords_not_flagged(tmp_path):
+    # The F1 check is conditional on hookable being truthy — a non-hookable
+    # memory has no hint-index behavior to protect, so omitting hookKeywords
+    # entirely is normal, not drift.
+    p = _write(
+        tmp_path,
+        "feedback_not_hookable.md",
+        """---
+name: not-hookable
+description: test
+metadata:
+  type: feedback
+  originSessionId: abc-123
+---
+body
+""",
+    )
+    assert check.check_file(p) == []
+
+
+def test_hookkeywords_empty_bracket_flagged(tmp_path):
+    # F1: `hookKeywords: []` starts with `[` so the pre-F1 check accepted it
+    # as clean bracket form, but the runtime parser (impl.py:130-139) reads
+    # an empty inner list and returns None — same silent drop as the missing
+    # case above.
+    p = _write(
+        tmp_path,
+        "feedback_bad_empty_keywords.md",
+        """---
+name: bad-empty-keywords
+description: test
+metadata:
+  type: feedback
+  hookable: true
+  hookKeywords: []
+  originSessionId: abc-123
+---
+body
+""",
+    )
+    errors = check.check_file(p)
+    assert any("hookKeywords" in e and "empty list" in e for e in errors), errors
+
+
+def test_hookevents_empty_bracket_not_flagged(tmp_path):
+    # Asymmetric with hookKeywords (F1 scope note): an empty hookEvents list
+    # falls back to the `[Bash]` default at runtime (impl.py:150-169) rather
+    # than dropping the memory, so it is not a drift the way an empty
+    # hookKeywords is.
+    p = _write(
+        tmp_path,
+        "feedback_empty_events.md",
+        """---
+name: empty-events
+description: test
+metadata:
+  type: feedback
+  hookable: true
+  hookKeywords: [foo]
+  hookEvents: []
+  originSessionId: abc-123
+---
+body
+""",
+    )
+    assert check.check_file(p) == []
+
+
 def test_missing_frontmatter_fence_flagged(tmp_path):
     p = _write(tmp_path, "feedback_no_fence.md", "just prose, no frontmatter\n")
     errors = check.check_file(p)

--- a/tests/test_check_memory_frontmatter.py
+++ b/tests/test_check_memory_frontmatter.py
@@ -1,0 +1,220 @@
+"""Tests for scripts/check-memory-frontmatter.py (issue #942).
+
+Covers the three shapes the script's docstring commits to:
+  - taxonomy fields at the top level (not nested under `metadata:`) fail
+  - a field duplicated across top-level + `metadata:` (or nested twice) fails
+  - `hookKeywords:` / `hookEvents:` in multi-line YAML-block or scalar form
+    fail — this is the functional-bug case, not just a style drift
+  - a normalized entry passes
+  - directory resolution honors `PRAXIS_MEMORY_DIR` and skips (rather than
+    erroring) when the directory is absent, matching resolve_memory_dir()'s
+    own contract
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+from contextlib import redirect_stdout
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_spec = importlib.util.spec_from_file_location(
+    "check_memory_frontmatter", REPO_ROOT / "scripts" / "check-memory-frontmatter.py"
+)
+assert _spec and _spec.loader
+check = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check)
+
+
+# ---------------------------------------------------------------------------
+# check_file — pure frontmatter checker
+# ---------------------------------------------------------------------------
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def test_normalized_entry_is_clean(tmp_path):
+    p = _write(
+        tmp_path,
+        "feedback_good.md",
+        """---
+name: good
+description: test
+metadata:
+  node_type: memory
+  type: feedback
+  hookable: true
+  hookKeywords: [foo, bar]
+  originSessionId: abc-123
+---
+body
+""",
+    )
+    assert check.check_file(p) == []
+
+
+def test_top_level_taxonomy_field_flagged(tmp_path):
+    p = _write(
+        tmp_path,
+        "feedback_bad.md",
+        """---
+name: bad
+description: test
+type: feedback
+originSessionId: abc-123
+---
+body
+""",
+    )
+    errors = check.check_file(p)
+    assert any("`type`" in e and "top level" in e for e in errors), errors
+    assert any("`originSessionId`" in e and "top level" in e for e in errors), errors
+
+
+def test_duplicate_field_top_level_and_metadata_flagged(tmp_path):
+    p = _write(
+        tmp_path,
+        "feedback_bad_dup.md",
+        """---
+name: bad-dup
+description: test
+type: feedback
+metadata:
+  type: feedback
+  originSessionId: abc-123
+---
+body
+""",
+    )
+    errors = check.check_file(p)
+    assert any("`type`" in e and "2 times" in e for e in errors), errors
+
+
+def test_hookkeywords_block_form_flagged_as_functional_bug(tmp_path):
+    p = _write(
+        tmp_path,
+        "feedback_bad_blockform.md",
+        """---
+name: bad-blockform
+description: test
+metadata:
+  type: feedback
+  hookable: true
+  hookKeywords:
+    - foo
+  originSessionId: abc-123
+---
+body
+""",
+    )
+    errors = check.check_file(p)
+    assert any("multi-line YAML-block" in e for e in errors), errors
+
+
+def test_hookkeywords_scalar_form_flagged(tmp_path):
+    p = _write(
+        tmp_path,
+        "feedback_bad_scalar.md",
+        """---
+name: bad-scalar
+description: test
+metadata:
+  type: feedback
+  hookable: true
+  hookKeywords: kubectl
+  originSessionId: abc-123
+---
+body
+""",
+    )
+    errors = check.check_file(p)
+    assert any("scalar form" in e for e in errors), errors
+
+
+def test_missing_frontmatter_fence_flagged(tmp_path):
+    p = _write(tmp_path, "feedback_no_fence.md", "just prose, no frontmatter\n")
+    errors = check.check_file(p)
+    assert any("frontmatter" in e for e in errors), errors
+
+
+def test_momentum_field_is_not_taxonomy(tmp_path):
+    # `momentum:` is a real top-level field in several existing entries and
+    # is deliberately out of scope — it must never be flagged.
+    p = _write(
+        tmp_path,
+        "feedback_momentum.md",
+        """---
+name: has-momentum
+description: test
+metadata:
+  type: feedback
+  originSessionId: abc-123
+momentum: [merge]
+---
+body
+""",
+    )
+    assert check.check_file(p) == []
+
+
+# ---------------------------------------------------------------------------
+# main() — directory resolution + skip contract
+# ---------------------------------------------------------------------------
+
+def test_main_skips_when_directory_absent(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRAXIS_MEMORY_DIR", str(tmp_path / "does-not-exist"))
+    monkeypatch.delenv("PRAXIS_TESTS_STRICT", raising=False)
+    out = io.StringIO()
+    with redirect_stdout(out):
+        rc = check.main()
+    assert rc == 0
+    assert "SKIPPED" in out.getvalue()
+
+
+def test_main_skip_is_failure_under_strict(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRAXIS_MEMORY_DIR", str(tmp_path / "does-not-exist"))
+    monkeypatch.setenv("PRAXIS_TESTS_STRICT", "1")
+    out = io.StringIO()
+    with redirect_stdout(out):
+        rc = check.main()
+    assert rc == 1
+    assert "SKIPPED" in out.getvalue()
+
+
+def test_main_fails_on_drifted_entry(tmp_path, monkeypatch):
+    _write(
+        tmp_path,
+        "feedback_bad.md",
+        """---
+name: bad
+description: test
+type: feedback
+originSessionId: abc-123
+---
+body
+""",
+    )
+    monkeypatch.setenv("PRAXIS_MEMORY_DIR", str(tmp_path))
+    monkeypatch.delenv("PRAXIS_TESTS_STRICT", raising=False)
+    out = io.StringIO()
+    with redirect_stdout(out):
+        rc = check.main()
+    assert rc == 1
+    assert "FAIL: feedback_bad.md" in out.getvalue()
+
+
+def test_main_ignores_memory_md_index_file(tmp_path, monkeypatch):
+    # MEMORY.md is the index, not a memory entry — it has no frontmatter
+    # contract and must never be linted.
+    _write(tmp_path, "MEMORY.md", "- [foo](foo.md) — bar\n")
+    monkeypatch.setenv("PRAXIS_MEMORY_DIR", str(tmp_path))
+    monkeypatch.delenv("PRAXIS_TESTS_STRICT", raising=False)
+    out = io.StringIO()
+    with redirect_stdout(out):
+        rc = check.main()
+    assert rc == 0
+    assert "SKIPPED" in out.getvalue()  # no *.md entries besides MEMORY.md

--- a/tests/test_check_memory_frontmatter.py
+++ b/tests/test_check_memory_frontmatter.py
@@ -181,7 +181,7 @@ body
 
 
 # ---------------------------------------------------------------------------
-# main() — directory resolution + skip contract
+# main() — directory resolution + N/A contract
 # ---------------------------------------------------------------------------
 
 def test_main_skips_when_directory_absent(tmp_path, monkeypatch):
@@ -191,7 +191,7 @@ def test_main_skips_when_directory_absent(tmp_path, monkeypatch):
     with redirect_stdout(out):
         rc = check.main()
     assert rc == 0
-    assert "SKIPPED" in out.getvalue()
+    assert "N/A" in out.getvalue()
 
 
 def test_main_skip_is_failure_under_strict(tmp_path, monkeypatch):
@@ -201,7 +201,7 @@ def test_main_skip_is_failure_under_strict(tmp_path, monkeypatch):
     with redirect_stdout(out):
         rc = check.main()
     assert rc == 1
-    assert "SKIPPED" in out.getvalue()
+    assert "N/A" in out.getvalue()
 
 
 def test_main_fails_on_drifted_entry(tmp_path, monkeypatch):
@@ -236,4 +236,4 @@ def test_main_ignores_memory_md_index_file(tmp_path, monkeypatch):
     with redirect_stdout(out):
         rc = check.main()
     assert rc == 0
-    assert "SKIPPED" in out.getvalue()  # no *.md entries besides MEMORY.md
+    assert "N/A" in out.getvalue()  # no *.md entries besides MEMORY.md

--- a/tests/test_check_memory_frontmatter.py
+++ b/tests/test_check_memory_frontmatter.py
@@ -227,6 +227,35 @@ body
     assert check.check_file(p) == []
 
 
+def test_hookevents_block_form_message_says_fallback_not_drop(tmp_path):
+    # F2 (issue #942, same codex-review pass): the shared error message used
+    # to claim "the entire memory is dropped" for both hookKeywords and
+    # hookEvents malformed shapes. For hookEvents that is false — impl.py
+    # falls back to the default [Bash] event and still indexes the memory.
+    p = _write(
+        tmp_path,
+        "feedback_bad_events_blockform.md",
+        """---
+name: bad-events-blockform
+description: test
+metadata:
+  type: feedback
+  hookable: true
+  hookKeywords: [foo]
+  hookEvents:
+    - Edit
+  originSessionId: abc-123
+---
+body
+""",
+    )
+    errors = check.check_file(p)
+    matching = [e for e in errors if e.startswith("`hookEvents:`")]
+    assert matching, errors
+    assert "falls back to the default" in matching[0], matching
+    assert "drops the entire memory" not in matching[0], matching
+
+
 def test_missing_frontmatter_fence_flagged(tmp_path):
     p = _write(tmp_path, "feedback_no_fence.md", "just prose, no frontmatter\n")
     errors = check.check_file(p)


### PR DESCRIPTION
## 배경

세션 메모리(`~/.claude/projects/-Users-nathan-song-projects-praxis/memory/`)의 frontmatter taxonomy 필드가 top-level / `metadata:` 중첩 두 갈래로 갈려 있었고, cycle 17이 flag한 항목이 이슈 없이 cycle 18로 이월되며 범위가 늘었습니다. 이 이슈의 진짜 주제는 frontmatter 정규화 자체가 아니라 **"이전 retrospect가 만든 액션 아이템이 종결되지 않는다"** — 재검증 경로 부재입니다.

Closes #942

Pre-commit verified: `./scripts/run-tests.sh` 전체 실행 — pytest/shell/manifest/hook-token-invariant/ruff/shellcheck 통과, markdownlint 는 advisory (기존 MD001 1건, 이 PR 변경 줄 아님)
Caller chain verified: `scripts/check-memory-frontmatter.py`는 신규 스크립트로 `.github/workflows/ci.yml`(신규 호출부)과 `tests/test_check_memory_frontmatter.py`(신규 테스트)만 참조 — 기존 caller 없음

## 헤드라인 — 드리프트 3건은 "형식"이 아니라 "기능 결함"이었다

이슈 본문은 전제를 이렇게 적었습니다: *"memory-hint 파서 자체는 들여쓰기 무관이라 런타임 오작동은 관측되지 않았습니다 — 즉 이것은 기능 결함이 아니라 규약 드리프트입니다."* 47개 전체 스캔은 이 전제를 **부분적으로 반증**했습니다.

`hookKeywords:`가 multi-line YAML block form(`hookKeywords:\n  - item`)으로 저작된 엔트리 3건을 새로 발견했습니다. `hooks/advisory-nudge/memory-hint/impl.py`의 `KEYWORDS_RE`는 `hookKeywords:` 뒤에 `[`로 시작하는 한 줄짜리 값만 파싱하고, block form은 빈 값으로 읽혀 **해당 메모리 전체가 hint 인덱스에서 조용히 탈락**합니다. 그중 2건은 `hookable: true`로 "켜져 있다"고 읽혔지만 저작 시점부터 지금까지 단 한 번도 발화한 적이 없습니다:

| 파일 | hookable | 상태 |
| --- | --- | --- |
| `feedback_hook_flag_file_heredoc_timing.md` | `true` | **저작 이후 무발화 — active bug** |
| `feedback_merge_ask_ci_comments_precheck.md` | `true` | **저작 이후 무발화 — active bug** |
| `feedback_config_dir_probe_before_assume.md` | `false` | dormant (스키마 위반이지만 opt-out이라 영향 없음) |

**코드 판독이 아니라 실행으로 증명했습니다** — 동일한 memory-hint 훅에 동일한 트리거 커맨드를 흘려서, block form은 침묵하고 bracket form은 hint를 낸다는 것을 stderr 출력으로 직접 확인했습니다(검증 앵커 Evidence 참고). 나머지 13건(아래 표)은 이슈 본문의 전제 그대로 — 파서가 위치 무관이라 런타임에 영향 없는 규약 드리프트입니다.

## 정규 스키마 확정

`skills/retrospect/references/stage4-execution.md`에 이미 있던 SoT 절을 확장했습니다.

**taxonomy 필드**(`type`, `originSessionId`, `hookable`, `hookKeywords`, `hookEvents`, `modified`) — `metadata:` 아래 중첩. `hooks/advisory-nudge/memory-hint/impl.py`의 정규식은 위치와 무관하게 매치하므로 **런타임 오작동은 없습니다** — 중첩을 강제하는 유일한 근거는 **일관성**(엔트리마다 필드 위치를 두 번 확인하지 않도록)이라는 점을 문서에 그대로 명시했습니다.

**`momentum:`은 의도적으로 top-level 유지, taxonomy 대상 아님.** 별도 훅(`momentum-rule-retrieval-gate`)이 소비하는 독립 opt-in 메커니즘이라 "이 메모리가 무슨 종류인가"를 답하는 taxonomy 블록과 개념이 다르고, 기존 엔트리 3/3(force_history_rewrite_mutation / pre_commit_staged_file_enumeration / pre_merge_briefing_compound_imperative)이 전부 top-level이라 여기 넣으면 드리프트 수정이 아니라 100% 일관된 자체 컨벤션을 깨는 것입니다.

**`node_type: memory`는 선택 필드, 필수 아님.** `grep -rn node_type`을 이 레포 전체(hooks/, scripts/, tests/)에 돌려 실측했고, 이 필드를 읽는 소비자가 **전혀 없습니다**. type/hookable/hookKeywords/hookEvents와 달리 런타임에서 아무 의미가 없습니다. 초안 리뷰에서 "문서는 필수처럼 쓰고 lint는 부재를 안 잡는" 모순이 지적돼, 문서·lint·테스트 세 곳을 (B) 선택 필드로 통일했습니다(`test_missing_node_type_is_not_flagged`). `feedback_praxis_hook_canary_verification.md`/`feedback_question_to_approval_escalation.md` 2건은 node_type이 없는 채로 그대로 둡니다.

## 47개(정확히는 48개) 전체 스캔 — 발견된 드리프트 16건

이슈가 명시한 4개 외에 **12개를 추가로 발견**:

**기능 결함 (3건, 위 헤드라인 참고)** — `config_dir_probe_before_assume`, `hook_flag_file_heredoc_timing`, `merge_ask_ci_comments_precheck`

**무해한 규약 드리프트 (13건)**

| 유형 | 파일 |
| --- | --- |
| top-level 배치 (position only) | `bash_exit_code_if_trap`, `codex_delegate_fallback`, `external_cli_verify_first`★, `force_history_rewrite_mutation`★, `input_surface_enumeration`, `parallel_dispatch_concurrent_file_warning`★, `pre_external_write_gate`, `worktree_context_pre_git_op`, `post_mutation_view_verify`, `pre_delegation_file_path_verify` |
| top-level+metadata 중복 (`type` 양쪽 존재) | `pre_commit_staged_file_enumeration`★ |

★ = 이슈 본문이 명시한 4개

## Cycle 17이 종결되지 않은 이유

로컬 `.omc/state/retrospect-hygiene-cursor.json`(gitignored)을 직접 읽어 확인: **이슈 미생성**입니다. cycle 17은 발견을 cursor의 `cycle_note` 문자열로만 기록했고 `gh issue create`가 실행되지 않았습니다. 이 노트는 닫을 대상(이슈)이 없는 채로 cycle 17→18 사이를 떠돌다가, cycle 18에서 범위가 2건→4건으로 커진 뒤에야 #942로 명시적으로 승격됐습니다. 구조적 갭: carried `cycle_note`에는 자체 재검증 경로(CI, lint, 닫을 이슈)가 없었다는 것 — 본 PR의 CI lint가 그 구조적 수정입니다.

## 메모리 파일 정규화 (레포 밖 — 커밋 대상 아님)

세션 메모리(`~/.claude/projects/-Users-nathan-song-projects-praxis/memory/`)는 이 레포 git 트리 밖의 로컬·per-user 저장소입니다. 위 16개 파일을 정규화했습니다 — 이 PR의 diff에는 나타나지 않으며, 별도 커밋도 없습니다.

## 산출물 (레포 diff, 커밋 6개)

- `docs(retrospect): document memory frontmatter taxonomy schema` — SoT 절 확장 (taxonomy 필드 위치, momentum 예외, cycle 17 미종결 사유)
- `feat(scripts): add memory frontmatter lint script` — `scripts/check-memory-frontmatter.py` + `tests/test_check_memory_frontmatter.py`(12케이스). `hooks/_lib/_memory_dir.py`의 `resolve_memory_dir()`을 재사용(`PRAXIS_MEMORY_DIR` → `${CLAUDE_CONFIG_DIR:-~/.claude}/projects/<slug>/memory` → linked-worktree fallback — memory-hint 훅과 동일 순서). 위치 드리프트 / 중복 필드 / `hookKeywords`·`hookEvents` block-form을 검출.
- `ci: wire memory frontmatter lint into test job` — `.github/workflows/ci.yml`의 `test` job에 독립 스텝 추가 (뒤 커밋에서 `run-tests.sh` 편입으로 대체되며 제거됨, 아래 참고)
- `docs(retrospect): mark node_type optional, not required` — 위 node_type 결정 반영
- `build(ci): wire memory frontmatter lint into run-tests.sh` — 아래 섹션
- `fix(scripts): distinguish structural memory-dir absence from a fixable skip` — 아래 섹션

### `scripts/run-tests.sh` 연결 — 완료 (rev 2)

> 이 섹션은 이전 rev에서 "필요하지만 의도적으로 보류"라고 적혀 있었습니다. `run-tests.sh`가 병렬 진행 중인 다른 PR들(#951/#941/#963)과의 공유 파일이라는 이유였는데, 그 워커들이 모두 정리(#941 머지·워크트리 제거, #949 미수정 확인, #951/#963은 겹치지 않는 영역)된 것을 확인한 뒤 이번 rev에서 편입을 완료했습니다.

sibling-convention 조사 결과(`check-plugin-manifests.py`/`check-hook-token-invariants.py` — repo-internal invariant script 계열은 둘 다 독립 `ci.yml` job 없이 `run-tests.sh` 전용) 를 따라 `run-tests.sh` step 5로 편입했습니다. `PRAXIS_TESTS_STRICT`는 이 호출에만 `env -u`로 전달하지 않습니다 — 메모리 디렉터리는 CI/신규 체크아웃에 구조적으로 항상 부재하므로, strict 모드를 그대로 흘리면 CI가 영구 FAIL됩니다. `ci.yml`의 독립 스텝(위 3번째 커밋에서 추가)은 이제 중복 실행이라 제거했습니다 — 제거 전후 커맨드가 플래그·범위 없이 완전히 동일함을 `git show`로 직접 확인했습니다.

**출력 라벨 — `SKIPPED`가 아니라 `N/A`**: 초기 구현은 구조적 부재(CI/신규 체크아웃)를 `SKIPPED:`로 찍었습니다. 리뷰에서 이 레포가 `SKIPPED`를 "고칠 수 있는 갭"(툴 미설치) 전용 어휘로 쓴다는 점(#917 — SKIPPED가 읽히지 않고 스크롤되는 걸 막으려고 만든 장치) — 즉 절대 해소되지 않는 이 조건을 같은 라벨로 찍으면 그 신호를 갉는다는 지적을 받아, `N/A:`로 분리했습니다. exit-code 시맨틱(strict 시 1, 아니면 0)은 변경하지 않았습니다.

## 검증

- `python3 scripts/check-memory-frontmatter.py` — 실제 메모리 디렉터리(48 entries, 정규화 완료) 대상 clean 확인
- 인위적 dirty fixture 대상 3종(top-level / dup / block-form) 전부 검출 → 정규화 후 clean → 디렉터리 부재 시 `N/A`(strict/non-strict 둘 다) → 드리프트 fixture 대상 exit 1(FAIL 경로, `run-tests.sh`가 쓰는 `env -u PRAXIS_TESTS_STRICT` 래핑 그대로) — 전부 실제 실행 출력으로 확인
- **memory-hint 훅 실전 발화 테스트** — block form(pre-fix)과 bracket form(post-fix) 각각을 실제 훅에 먹여, 동일 커맨드에 대해 전자는 침묵, 후자는 `[memory:hookable]` stderr를 낸다는 것을 확인. 실제(정규화 완료) 메모리 디렉터리 대상으로도 재확인.
- `python3 -m pytest tests/test_check_memory_frontmatter.py` — 12 passed / `python3 -m pytest tests/` 전체 — 585 passed
- `./scripts/run-tests.sh` — 로컬 `ALL TESTS PASSED`(연결 전 rev) + **GitHub Actions 실제 CI 런**(`test` job, commit `cf48a71`) 로그에서 step 5가 `N/A:`를 찍고 `FAILED` 미집계, `ALL TESTS PASSED`로 종료하는 것을 직접 확인 (검증 앵커 코멘트 rev 2에 실행 출력 첨부)

## 알려진 미해결 갭 (이 PR에서 고치지 않음 — 팀 승인 후 후속)

`praxis:codex-review-wrap` 비대화형 검증 경로(적용 0건, 전제 검증만)로 확인:

- **F1 (fact-modifying)** `hookable: true`인데 `hookKeywords`가 아예 없거나 `[]`인 경우, 이 lint는 clean으로 통과시키지만 런타임(`hooks/advisory-nudge/memory-hint/impl.py:117-139`)은 조용히 해당 메모리 전체를 hint 인덱스에서 제외합니다 — lint가 방지하려던 바로 그 실패 모드(silent-dark)를 이 형태에 대해서는 놓칩니다.
- **F2 (fact-modifying)** `hookEvents`의 block/scalar-form 오류 메시지가 `hookKeywords`와 동일하게 "전체 메모리가 hint 인덱스에서 제외된다"고 서술하지만, 실제로는(`impl.py:150-169`) 기본 이벤트(`[Bash]`)로 폴백할 뿐 메모리 자체는 계속 인덱싱됩니다 — 두 필드의 실패 모드가 다른데 메시지가 같습니다.
- **F3 (fact-modifying)** `skills/retrospect/references/stage4-execution.md`가 "`check-memory-frontmatter.py`가 CI의 구조적 수정이라 다음 드리프트는 build를 실패시킨다"고 서술하지만, CI의 메모리 디렉터리는 구조적으로 항상 부재해 이 스텝은 CI에서 항상 `N/A`/exit 0을 반환합니다 — 이 보장은 성립하지 않습니다(로컬 실행에서만 잡힙니다).

