### PR TITLE
fix(codex-review-wrap): always background the review call

### DIFF
--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -238,7 +238,7 @@ indistinguishable from a clean review. There is no flag that avoids this —
 `task --background`.
 
 ```bash
-cd {selected_path}
+cd -- "{selected_path}"
 node "{resolved_companion_path}" review "{{ARGUMENTS}}"
 ```
 

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -222,8 +222,11 @@ not need to be set.
 #### 4b. Run the review
 
 Change working directory to the selected worktree, then invoke the
-companion. `{{ARGUMENTS}}` passes any flags (e.g. `--model opus`,
-`--wait`) through unchanged.
+companion. `{{ARGUMENTS}}` passes any flags through unchanged. The review
+path reads `--model`, `--base`, `--scope`, and `--json`. It also *accepts*
+`--wait` and `--background` — both sit in its `booleanOptions` and are then
+never read, so neither changes anything; `options.wait` is consumed only by
+`status`, `options.background` only by `task`.
 
 **Always run this via `Bash(..., run_in_background: true)`.** A review
 routinely runs past a foreground tool timeout, and a timed-out call kills
@@ -232,9 +235,7 @@ indistinguishable from a clean review. There is no flag that avoids this —
 `review` has no background path of its own. `handleReview` →
 `handleReviewCommand` → `runForegroundCommand` is unconditional, and the
 `detached: true` worker (`spawnDetachedTaskWorker`) is reachable only from
-`task --background`. The review parser lists `background` in its
-`booleanOptions` and then never reads it, so passing that flag changes
-nothing at all.
+`task --background`.
 
 ```bash
 cd {selected_path}

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -272,6 +272,14 @@ back at the session cwd rather than the worktree Step 2 selected — so
 without it this command reads a different state directory and reports no
 running job at all.
 
+Empty output from that pipeline is **not** the same as "no job is running".
+A failed `status` — wrong directory, unreadable state file, a companion
+version that does not know `--json` — also prints nothing, and `jq` exits 0
+on the empty input, so the pipeline's status says nothing either. Read the
+companion's own exit code before drawing any conclusion from silence, and
+treat a non-zero one as *unknown*, never as *stale*. This matters because
+the next paragraph turns "no matching process" into a cancel.
+
 `.logFile` is an absolute path under the companion's own state directory
 (`$CLAUDE_PLUGIN_DATA/state/<workspace-slug>-<hash>/jobs/`, falling back to
 `$TMPDIR/codex-companion/…`) — it is not relative to the worktree, so use

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -242,7 +242,10 @@ cd {selected_path}
 node "{resolved_companion_path}" review "{{ARGUMENTS}}"
 ```
 
-Return the script's stdout **verbatim** — do not paraphrase, summarize, or
+A backgrounded call hands back a task id, not the review, so there is
+nothing to return yet — say so in one line: "Codex review started in the
+background. Check `/codex:status` for progress." Once the run completes,
+return the script's stdout **verbatim** — do not paraphrase, summarize, or
 add commentary. This matches `/codex:review`'s contract.
 
 ##### Liveness — `ps` and log mtime, never `status` or `elapsed`

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -262,9 +262,15 @@ line only appears for some job states. Take both from `--json`, which
 carries the whole job record:
 
 ```bash
-node "{resolved_companion_path}" status --json \
+node "{resolved_companion_path}" status --cwd "{selected_path}" --json \
   | jq -r '.running[] | "\(.id) \(.pid) \(.logFile)"'
 ```
+
+`--cwd` is not optional here. The companion keys its state directory on the
+workspace root it derives from `process.cwd()`, and each Bash call starts
+back at the session cwd rather than the worktree Step 2 selected — so
+without it this command reads a different state directory and reports no
+running job at all.
 
 `.logFile` is an absolute path under the companion's own state directory
 (`$CLAUDE_PLUGIN_DATA/state/<workspace-slug>-<hash>/jobs/`, falling back to
@@ -281,8 +287,10 @@ GNU (`stat -f` on macOS, `stat -c` on Linux); the reaper script next door
 carries that split and its test skips off Darwin because of it.
 
 `status: "running"` with no matching process is a **stale** job, not a
-progressing one. Cancel it (`node "{resolved_companion_path}" cancel
-{job-id}`) and re-launch; polling it longer never resolves.
+progressing one. Cancel it (`node "{resolved_companion_path}" cancel --cwd
+"{selected_path}" {job-id}`) and re-launch; polling it longer never
+resolves. `cancel` resolves its state directory the same way `status` does,
+so it needs the same `--cwd`.
 
 ##### When the review completes
 

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -263,8 +263,8 @@ progressing one. Cancel it (`node "{resolved_companion_path}" cancel
 
 ##### When the review completes
 
-Step 5 runs once the findings are in hand. Which path they take depends on
-where the session is at that moment:
+Backgrounding defers Step 5, it does not skip it. Which path the findings
+take depends on where the session is when the run completes:
 
 - **User is back in an interactive foreground turn** — collect the findings
   and enter Step 5 from the top (interactivity check → 5f → …); the

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -1244,11 +1244,10 @@ re-ask the same question rather than guessing (same as 5i). Record
 
 1. Return to **Step 4**; skip Steps 1–3 — the review target is already
    fixed.
-2. **Normalize** the original `{{ARGUMENTS}}` before reuse — strip
-   `--background` (a re-backgrounded round breaks the gate's synchronous
-   loop) **and** any existing `--scope` / `--base <ref>`. Then append at
-   most **one** target-selecting flag, the one condition (b) settled
-   above. Stripping first is what keeps the two rules from colliding:
+2. **Normalize** the original `{{ARGUMENTS}}` before reuse — strip any
+   existing `--scope` / `--base <ref>`. Then append at most **one**
+   target-selecting flag, the one condition (b) settled above. Stripping
+   first is what keeps the two rules from colliding:
    without it, "switch the scope for the re-entered round" stacks a second
    `--scope` on top of the caller's, and which one wins is the CLI's
    business, not this skill's. After appending, re-run the condition (b)
@@ -1445,8 +1444,7 @@ user selects: 1
   User: 추가 라운드 실행
   → ledger: round-continued: target=/Users/dev/project-wt/my-repo-feature-1#issue-1-feature | from=1 | applied=1 | decision=continue | to=2
   → re-enter Step 4 (Steps 1–3 skipped, 5d-i and 4a not re-asked — the sibling-id:
-    and review-path: rows for this target exist, --background dropped if it was
-    present, PR-state re-checked)
+    and review-path: rows for this target exist, PR-state re-checked)
 
 [Step 5 — Round 2] Codex now re-suggests changing WHERE col_a = 1 → col_b = 1
   Scan ledger: rejected entry on query.sql:L42 with same A → B transition exists

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -223,9 +223,18 @@ not need to be set.
 
 Change working directory to the selected worktree, then invoke the
 companion. `{{ARGUMENTS}}` passes any flags (e.g. `--model opus`,
-`--wait`, `--background`) through unchanged. One exception: a round
-re-entered from 5j drops `--background`, because a re-backgrounded round
-breaks that gate's synchronous loop.
+`--wait`) through unchanged.
+
+**Always run this via `Bash(..., run_in_background: true)`.** A review
+routinely runs past a foreground tool timeout, and a timed-out call kills
+it mid-run: the round then ends with no findings, which is
+indistinguishable from a clean review. There is no flag that avoids this —
+`review` has no background path of its own. `handleReview` →
+`handleReviewCommand` → `runForegroundCommand` is unconditional, and the
+`detached: true` worker (`spawnDetachedTaskWorker`) is reachable only from
+`task --background`. The review parser lists `background` in its
+`booleanOptions` and then never reads it, so passing that flag changes
+nothing at all.
 
 ```bash
 cd {selected_path}
@@ -235,10 +244,27 @@ node "{resolved_companion_path}" review "{{ARGUMENTS}}"
 Return the script's stdout **verbatim** — do not paraphrase, summarize, or
 add commentary. This matches `/codex:review`'s contract.
 
-If `{{ARGUMENTS}}` includes `--background`, run via `Bash(..., run_in_background: true)`
-and tell the user: "Codex review started in the background. Check `/codex:status` for progress."
-Backgrounding defers Step 5, it does not skip it. Which path the findings
-take depends on where the session is when the run completes:
+##### Liveness — `ps` and log mtime, never `status` or `elapsed`
+
+A killed review leaves its job file reading `status: "running"` with a dead
+pid: the terminal write in `runTrackedJob` never executes, and `elapsed` is
+computed from `startedAt` against the wall clock, so it keeps climbing
+after the process is gone. Both fields report a dead job as a healthy one.
+Judge liveness on two independent signals instead:
+
+```bash
+ps -p {pid} -o pid=,etime=,stat=          # empty output → process is gone
+stat -f '%Sm' -t '%H:%M:%S' {job-id}.log  # log older than a few minutes → stalled
+```
+
+`status: "running"` with no matching process is a **stale** job, not a
+progressing one. Cancel it (`node "{resolved_companion_path}" cancel
+{job-id}`) and re-launch; polling it longer never resolves.
+
+##### When the review completes
+
+Step 5 runs once the findings are in hand. Which path they take depends on
+where the session is at that moment:
 
 - **User is back in an interactive foreground turn** — collect the findings
   and enter Step 5 from the top (interactivity check → 5f → …); the
@@ -247,8 +273,8 @@ take depends on where the session is when the run completes:
   ended) — the interactivity check fails and the findings take the
   non-interactive path: verified, applied to nothing, deferred.
 
-Either way, never apply a background review's findings from the completion
-notification alone.
+Either way, never apply a review's findings from the completion notification
+alone.
 
 ### Step 5: Apply Findings — Premise Verification Gate
 

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -279,7 +279,7 @@ the value the command prints rather than constructing one. Then:
 
 ```bash
 ps -p {pid} -o pid=,etime=,stat=     # empty output → process is gone
-find {logFile} -mmin +5              # prints the path → no write in 5 min
+find "{logFile}" -mmin +5            # prints the path → no write in 5 min
 ```
 
 **Only the first is decisive.** A dead pid settles it: the job is stale,
@@ -291,7 +291,9 @@ while*, never as grounds to cancel. Cancel on the pid.
 
 `find -mmin` is used rather than `stat`, whose mtime syntax splits BSD from
 GNU (`stat -f` on macOS, `stat -c` on Linux); the reaper script next door
-carries that split and its test skips off Darwin because of it.
+carries that split and its test skips off Darwin because of it. Quote the
+path — the state directory is relocatable and may sit under a name
+containing spaces.
 
 `status: "running"` with no matching process is a **stale** job, not a
 progressing one. Cancel it (`node "{resolved_companion_path}" cancel --cwd

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -1292,7 +1292,10 @@ re-ask the same question rather than guessing (same as 5i). Record
 ##### Re-entry
 
 1. Return to **Step 4**; skip Steps 1–3 — the review target is already
-   fixed.
+   fixed. The re-entered round is backgrounded like any other, because
+   Step 4b is unconditional. That is not a loop this gate has to hold
+   open: *When the review completes* already routes a finished background
+   round back into Step 5 from the top.
 2. **Normalize** the original `{{ARGUMENTS}}` before reuse — strip any
    existing `--scope` / `--base <ref>`. Then append at most **one**
    target-selecting flag, the one condition (b) settled above. Stripping

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -254,12 +254,31 @@ A killed review leaves its job file reading `status: "running"` with a dead
 pid: the terminal write in `runTrackedJob` never executes, and `elapsed` is
 computed from `startedAt` against the wall clock, so it keeps climbing
 after the process is gone. Both fields report a dead job as a healthy one.
-Judge liveness on two independent signals instead:
+Judge liveness on two independent signals instead.
+
+The two signals need a pid and a log path, and **neither is in the
+human-readable status output** — `pid` is never rendered there, and the log
+line only appears for some job states. Take both from `--json`, which
+carries the whole job record:
 
 ```bash
-ps -p {pid} -o pid=,etime=,stat=          # empty output → process is gone
-stat -f '%Sm' -t '%H:%M:%S' {job-id}.log  # log older than a few minutes → stalled
+node "{resolved_companion_path}" status --json \
+  | jq -r '.running[] | "\(.id) \(.pid) \(.logFile)"'
 ```
+
+`.logFile` is an absolute path under the companion's own state directory
+(`$CLAUDE_PLUGIN_DATA/state/<workspace-slug>-<hash>/jobs/`, falling back to
+`$TMPDIR/codex-companion/…`) — it is not relative to the worktree, so use
+the value the command prints rather than constructing one. Then:
+
+```bash
+ps -p {pid} -o pid=,etime=,stat=   # empty output → process is gone
+find {logFile} -mmin +5            # prints the path → no write in 5 min, stalled
+```
+
+`find -mmin` is used rather than `stat`, whose mtime syntax splits BSD from
+GNU (`stat -f` on macOS, `stat -c` on Linux); the reaper script next door
+carries that split and its test skips off Darwin because of it.
 
 `status: "running"` with no matching process is a **stale** job, not a
 progressing one. Cancel it (`node "{resolved_companion_path}" cancel

--- a/skills/codex-review-wrap/SKILL.md
+++ b/skills/codex-review-wrap/SKILL.md
@@ -278,9 +278,16 @@ running job at all.
 the value the command prints rather than constructing one. Then:
 
 ```bash
-ps -p {pid} -o pid=,etime=,stat=   # empty output → process is gone
-find {logFile} -mmin +5            # prints the path → no write in 5 min, stalled
+ps -p {pid} -o pid=,etime=,stat=     # empty output → process is gone
+find {logFile} -mmin +5              # prints the path → no write in 5 min
 ```
+
+**Only the first is decisive.** A dead pid settles it: the job is stale,
+whatever the log says. A quiet log does not — the companion appends a line
+per item lifecycle event and runs no periodic heartbeat, so one long
+reasoning or command item produces no write at all while the review is
+perfectly healthy. Read a quiet log as *tell the user this is taking a
+while*, never as grounds to cancel. Cancel on the pid.
 
 `find -mmin` is used rather than `stat`, whose mtime syntax splits BSD from
 GNU (`stat -f` on macOS, `stat -c` on Linux); the reaper script next door


### PR DESCRIPTION
Closes #979

Caller chain verified: `grep -rn "options.background" codex-companion.mjs` → 단 한 곳, `788:  if (options.background) {`. 788 은 `handleTask` 본문이고 `handleReviewCommand` 는 712–751 이므로, review 경로에서 이 플래그를 읽는 호출부는 존재하지 않습니다. (머지 후 정정: `handleReviewCommand` 를 타는 서브커맨드는 `review` 와 `adversarial-review` 둘입니다 — `grep -n "handleReviewCommand"` → 712 정의, 756 `handleReview`, 1039 `adversarial-review`. 둘이 같은 무조건 포그라운드 경로를 공유하므로 결론은 동일하고, 정정 대상은 열거 범위입니다. 앵커 코멘트 rev 2 및 #990 참조.)
Pre-commit: n/a (레포에 `.pre-commit-config.yaml` 도 `.git/hooks/pre-commit` 도 없음 — 이 레포의 게이트는 CI 의 `scripts/run-tests.sh` 이며 아래 검증 절 참조)

## 무엇을 고쳤나

Step 4b 가 `--background` 를 의미 있는 플래그로 취급하고 있었습니다. 실제로는
`review` 파서가 `booleanOptions` 에 `background` 를 올려놓고 본문에서 한 번도 읽지
않으며, `detached: true` 워커는 `task --background` 에서만 도달합니다. 그 위에
"백그라운드로 시작했습니다"라는 안내(구 `:239`)와 재진입 시 플래그를 뗀다는 지시
(구 `:1248`, `:1448`)가 얹혀 있었고, 셋 다 아무것도 하지 않는 동작을 설명하고
있었습니다.

더 큰 문제는 기본 경로였습니다. `review` 는 항상 포그라운드라 평범한 `Bash` 호출로
띄우면 도구 타임아웃에 잘려 죽고, job 파일은 `status: "running"` 에 죽은 pid 를 담은
채 굳습니다. 스킬에는 그 상태를 걸러낼 생존 판정 기준이 없었습니다.

## 변경 내용

- **Step 4b: `run_in_background: true` 를 무조건으로.** 조건부 분기를 없애고, 왜
  다른 선택지가 없는지(`handleReview → handleReviewCommand → runForegroundCommand`
  가 무조건)를 그 자리에 남겼습니다.
- **`Liveness` 절 신설.** `status` 와 `elapsed` 가 죽은 job 을 건강한 것으로 보고하는
  이유(종료 기록 미실행 / `startedAt` 기준 벽시계 계산)를 적고, pid 와 로그 경로를
  `status --json` 에서 뽑도록 했습니다 — 둘 다 사람이 읽는 출력에는 없습니다.
  판정은 `ps -p` 로 고정했고, 로그 mtime 은 보조 신호입니다(아래 2라운드 참조).
- **no-op 플래그 전제 제거.** 5j 재진입의 `--background` strip 지시와 워크스루 예시의
  같은 문구를 삭제했습니다. `--scope` / `--base` strip 은 그대로 유효하므로 유지.
- **죽은 `--wait` 예시 제거** (`af5d0a9`) — 아래 "확인해서 반영한 것" 참조.

## 리뷰 라운드

머지 대기 중 두 번의 리뷰가 돌았고, 지적이 전부 이 PR 의 `Liveness` 블록에
집중됐습니다. 라운드별 결과:

### 1라운드 — codex review (P1 2건, P2 1건, 전부 적용)

| 커밋 | 지적 | 근거 |
|---|---|---|
| `45681e3` | `status` / `cancel` 에 `--cwd` 누락 | companion 이 `process.cwd()` 로 state dir 를 키잉하므로, 세션 cwd ≠ 선택한 worktree 면 다른 디렉터리를 읽습니다 |
| `efb70a1` | 로그 mtime 단독으로 stalled 판정 | 주기적 heartbeat 가 없어(`setInterval` 0건) 긴 item 하나면 정상인데도 조용해집니다. pid 만 결정적 신호로 남기고 mtime 은 강등 |
| `ea8e49f` | `find {logFile}` 무인용 | state dir 은 재배치 가능 |

### 2라운드 — CodeRabbit (3건 중 2건 적용, 1건 반박)

| 커밋 | 지적 | 결과 |
|---|---|---|
| `21dafcc` | `cd {selected_path}` 무인용 | 적용 — `cd -- "{selected_path}"` |
| `5ffdc70` | `status --json` 실패와 빈 `running` 이 구별 불가 | 적용 — 침묵을 "job 없음"으로 읽지 말라는 문단 추가 |
| — | `review "{{ARGUMENTS}}"` 인용이 인자 벡터를 뭉갠다 | **오탐** — 리뷰어가 철회 |

오탐 반박 근거는 [해당 스레드](https://github.com/devseunggwan/praxis/pull/983#discussion_r3775433402)에 실측과 함께 남겼습니다. 요지는 `normalizeArgv` 가 단일 argv 요소를 quote-aware `splitRawArgumentString` 으로 재분해하므로 인용된 형태가 오히려 companion 이 지원하는 계약이라는 것입니다.

## 확인해서 반영한 것 — `--wait`

이슈 #979 §5 는 `--wait` 도 같은 계열의 no-op 인지 확인하지 않았다고 적었고,
이 PR 도 처음에는 범위 밖으로 두었습니다. 이후 확인했고 반영했습니다:

```
$ grep -n "options.wait" codex-companion.mjs
892:    const snapshot = options.wait
902:  if (options.wait) {
```

두 곳 모두 `handleStatus`(883–908) 안입니다. `review` 경로에는 없으므로
`--background` 와 정확히 같은 no-op 이고, `af5d0a9` 이 죽은 `--wait` 예시를
제거했습니다.

## 검증

- **스위트 통과 (`5ffdc70`)** — CI 진입점을 그대로 실행.

```
$ bash scripts/run-tests.sh > /tmp/suite.txt 2>&1; echo "EXIT=$?"
EXIT=0
$ grep -c "ALL TESTS PASSED" /tmp/suite.txt
1
$ grep "^FAIL" /tmp/suite.txt | sort | uniq -c
  10 FAIL: 0
```

- **`status --json` 이 pid 와 logFile 을 싣는다** — 실제 review 를 띄워 확인했습니다.
  합성 job 이 아닙니다.

```
$ node codex-companion.mjs status --json | jq -r '.running[] | "\(.id) \(.pid) \(.logFile)"'
review-msrgk7j5-l81hiq 12633 /…/jobs/review-msrgk7j5-l81hiq.log
$ ps -p 12633 -o command=
node /…/scripts/codex-companion.mjs review --base main
```

  pid 가 레코드에만 있는 숫자가 아니라 실제 review 프로세스에 붙어 있습니다.
  같은 job 을 사람이 읽는 `status` 로 보면 pid 열이 없고 `Log:` 줄만 나옵니다 —
  `Liveness` 절이 `--json` 을 쓰라고 지시하는 이유가 여기서 재현됩니다.

- **markdownlint 신규 위반 0건** — 규칙 코드 히스토그램이 변경 전후 동일.
  이 레포에서 markdownlint 는 advisory 이지만 문서 변경이므로 확인했습니다.

```
$ markdownlint-cli2 skills/codex-review-wrap/SKILL.md 2>&1 | grep -c "MD0"
32
$ git show origin/main:skills/codex-review-wrap/SKILL.md > /tmp/skill-base.md
$ markdownlint-cli2 /tmp/skill-base.md 2>&1 | grep -c "MD0"
32
```

`2>&1` 이 필요합니다 — markdownlint 는 stderr 로 씁니다. 이걸 빠뜨리면 양쪽 다
빈 출력이 나와 "차이 없음"처럼 보이지만, 그건 통과가 아니라 아무것도 측정하지
않은 것입니다.

### 중간에 CI 를 깨뜨린 건 (`1033082` → `bfbe0b4`)

첫 두 커밋 상태에서 CI `test` 잡이 실패했습니다. 원인은 이 PR 의 변경입니다 —
`--background` 조건 분기를 걷어내면서 `Backgrounding defers Step 5, it does not
skip it` 문장까지 같이 지웠고, `tests/test_finding_approval_gate.sh:105-107` 이
그 문자열을 verbatim 으로 검사합니다.

```
CI 로그 (커밋 1033082):
  === shell tests ===
  FAIL: tests/test_finding_approval_gate.sh
  Passed: 47  Failed: 1
  Failed tests:
    - background runs re-enter Step 5 rather than skipping it
```

`bfbe0b4` 에서 **테스트 패턴을 고치지 않고 문장을 되살렸습니다.** 이 변경으로
모든 실행이 백그라운드가 되므로 그 불변식은 약해진 게 아니라 분기에서 정상
경로로 승격됐고, 삭제는 의도한 변경이 아니라 부수 피해였습니다.

markdownlint 는 이 실패와 무관합니다 — 이 레포에서 advisory 이며
`run-tests.sh` 가 `WARNING: ... advisory (CI does not fail on them)` 로 명시하고
`FAILED` 를 세우지 않습니다.

## 다루지 않은 것

- 상류 `openai-codex` 플러그인이 `review --background` 를 실제로 지원하게 만드는
  방향은 판단하지 않았습니다. 이 PR 은 스킬이 현재 동작에 맞게 기술되도록 하는
  범위만 다룹니다.
- 공백을 포함하는 worktree 경로에서 실제로 돌려보지 않았습니다. `cd -- "…"` 와
  `find "…"` 는 셸 인용 원칙에 따른 수정이고, 그 경로를 만든 재현은 없습니다.
- mtime 오탐 자체는 관측하지 못했습니다. heartbeat 부재는 코드로 확정했지만,
  실측한 338초 review 의 최대 무기록 간격은 90초로 5분 임계 아래였습니다.
- `cancel --cwd` 는 `handleCancel` 이 `valueOptions: ["cwd"]` 를 선언한다는 코드
  근거이고, multi-worktree 에서 실행해보지는 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex reviews now run in the background consistently.
  * Added liveness checks using process and log status.
  * Added guidance for relaunching stale review jobs.
  * Completion handling now distinguishes task-start messages from completed review results.

* **Documentation**
  * Clarified that `--wait` and `--background` do not affect review execution.
  * Documented the requirement to provide `--cwd` for status and cancellation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

