### PR TITLE
fix(hooks): merge gates fire on non-merge commands

### DIFF
--- a/hooks/_lib/_hook_utils.py
+++ b/hooks/_lib/_hook_utils.py
@@ -71,6 +71,139 @@ WRAPPER_OPTS_WITH_ARG = {
 }
 
 
+def _heredoc_starts_on_line(line: str) -> list[tuple[str, bool]]:
+    """`(delimiter, dash_form)` for every heredoc opened on one physical line.
+
+    Scans character-wise rather than by regex because the three constructs that
+    must NOT be read as a heredoc all look like `<<` to a pattern match: a
+    here-string (`<<<`), an arithmetic left-shift (`$((1 << 3))`), and a literal
+    `<<` inside quotes. Order is preserved — bash reads the bodies of
+    `cat <<A <<B` in the order the operators appear.
+
+    A command substitution re-opens shell parsing even inside double quotes, so
+    `-m "$(cat <<'EOF'`  — the exact shape of a commit-message payload — really
+    does open a heredoc. `subst` stacks the suspended quote state so that one is
+    seen while a plain `"…<<EOF…"` string stays inert.
+    """
+    out: list[tuple[str, bool]] = []
+    i, n = 0, len(line)
+    quote = ""
+    arith = 0
+    subst: list[str] = []
+    while i < n:
+        ch = line[i]
+        if quote == '"' and line.startswith("$(", i) and not line.startswith("$((", i):
+            subst.append(quote)
+            quote = ""
+            i += 2
+            continue
+        if quote:
+            if ch == "\\" and quote == '"':
+                i += 2
+                continue
+            if ch == quote:
+                quote = ""
+            i += 1
+            continue
+        if ch in "'\"":
+            quote = ch
+            i += 1
+            continue
+        if ch == "\\":
+            i += 2
+            continue
+        if line.startswith("$((", i):
+            arith += 1
+            i += 3
+            continue
+        if arith and line.startswith("))", i):
+            arith -= 1
+            i += 2
+            continue
+        if ch == ")" and subst and not arith:
+            quote = subst.pop()
+            i += 1
+            continue
+        if line.startswith("<<", i) and not arith:
+            if line.startswith("<<<", i):  # here-string: no body follows
+                i += 3
+                continue
+            j = i + 2
+            dash = j < n and line[j] == "-"
+            if dash:
+                j += 1
+            while j < n and line[j] in " \t":
+                j += 1
+            delim, j = _read_heredoc_delim(line, j)
+            if delim:
+                out.append((delim, dash))
+                i = j
+                continue
+            i += 2
+            continue
+        i += 1
+    return out
+
+
+_HEREDOC_WORD_CHARS = re.compile(r"[A-Za-z0-9_.\-/]")
+
+
+def _read_heredoc_delim(line: str, j: int) -> tuple[str, int]:
+    """Delimiter word starting at `j`, plus the index just past it.
+
+    `<<EOF`, `<<'EOF'`, `<<"EOF"`, and `<<\\EOF` all name the same delimiter —
+    the quoting only decides whether the body is expanded, which is irrelevant
+    here. Returns `("", j)` when no delimiter word is present, which is what
+    keeps `1 << 3` from being read as a heredoc named `3`.
+    """
+    n = len(line)
+    if j < n and line[j] in "'\"":
+        q = line[j]
+        end = line.find(q, j + 1)
+        return (line[j + 1:end], end + 1) if end != -1 else ("", j)
+    out: list[str] = []
+    while j < n:
+        if line[j] == "\\" and j + 1 < n:
+            out.append(line[j + 1])
+            j += 2
+            continue
+        if not _HEREDOC_WORD_CHARS.match(line[j]):
+            break
+        out.append(line[j])
+        j += 1
+    return "".join(out), j
+
+
+def strip_heredoc_bodies(command: str) -> str:
+    """Blank out every heredoc body line, keeping the line count intact.
+
+    A heredoc body is data, not script: `git commit -m "$(cat <<'EOF' … EOF)"`
+    puts arbitrary prose where the per-line tokenizer expects commands, so a
+    commit message that merely *quotes* `gh pr merge` used to be tokenized as a
+    merge invocation and blocked by every merge gate (issue #985). Bodies are
+    replaced by empty lines rather than dropped so the operator line and the
+    commands after the terminator keep their positions.
+
+    An unterminated heredoc suppresses everything to the end of the command,
+    which is what bash does with it too.
+    """
+    if "<<" not in command:
+        return command
+    out: list[str] = []
+    pending: list[tuple[str, bool]] = []
+    for line in command.split("\n"):
+        if pending:
+            delim, dash = pending[0]
+            probe = line.lstrip("\t") if dash else line
+            if probe.rstrip() == delim:
+                del pending[0]
+            out.append("")
+            continue
+        out.append(line)
+        pending.extend(_heredoc_starts_on_line(line))
+    return "\n".join(out)
+
+
 def safe_tokenize(command: str) -> list[str]:
     """Tokenize with shell operators and line breaks split into tokens.
 
@@ -85,6 +218,10 @@ def safe_tokenize(command: str) -> list[str]:
     synthetic `;` between line tokens so iter_command_starts sees the break.
     Lines that fail to parse (unmatched quote, runaway heredoc, etc.) are
     skipped — better a silent pass than a crashed hook.
+
+    Heredoc bodies are blanked out first (`strip_heredoc_bodies`): they hold
+    data, not commands, so without that pass a commit message quoting a gated
+    command is tokenized as that command (issue #985).
 
     A bash line continuation (a `\\` immediately followed by a newline) is
     *not* a command separator — it splices the two physical lines into one
@@ -111,6 +248,7 @@ def safe_tokenize(command: str) -> list[str]:
     # backslash followed by a real newline separator, so only collapse an
     # odd-length run of trailing backslashes.
     command = re.sub(r"(?<!\\)((?:\\\\)*)\\\n", r"\1 ", command)
+    command = strip_heredoc_bodies(command)
     lines = [ln for ln in command.split("\n") if ln.strip()]
     if not lines:
         return []

--- a/hooks/_lib/_hook_utils.py
+++ b/hooks/_lib/_hook_utils.py
@@ -204,6 +204,41 @@ def strip_heredoc_bodies(command: str) -> str:
     return "\n".join(out)
 
 
+HELP_FLAGS = frozenset({"-h", "--help"})
+
+# `gh pr merge` flags that consume a following value token. Shared so that a
+# help scan and a positional scan agree on which tokens are values — `--subject
+# -h` must stay a subject, not a help request.
+GH_MERGE_VALUE_FLAGS = frozenset({
+    "-b", "--body", "-F", "--body-file", "-t", "--subject",
+    "--match-head-commit", "--author-email",
+    "-R", "--repo", "--hostname", "--color",
+})
+
+
+def is_help_invocation(argv: list[str], value_flags: frozenset[str]) -> bool:
+    """True when the segment asks for help instead of doing anything.
+
+    `gh pr merge --help` prints usage and exits — it merges nothing, so a gate
+    that treats it as a merge blocks the one command an agent runs to learn the
+    flags it is being asked to get right (issue #985). `value_flags` names the
+    flags that consume the next token, so `--subject -h` stays a subject value
+    and still counts as a real merge.
+    """
+    i = 0
+    while i < len(argv):
+        tok = argv[i]
+        if tok == "--":
+            return False  # everything after is positional, never a help flag
+        if tok in HELP_FLAGS:
+            return True
+        if tok.startswith("-") and "=" not in tok and tok in value_flags:
+            i += 2
+            continue
+        i += 1
+    return False
+
+
 def safe_tokenize(command: str) -> list[str]:
     """Tokenize with shell operators and line breaks split into tokens.
 

--- a/hooks/_lib/_hook_utils.py
+++ b/hooks/_lib/_hook_utils.py
@@ -184,6 +184,13 @@ def strip_heredoc_bodies(command: str) -> str:
     replaced by empty lines rather than dropped so the operator line and the
     commands after the terminator keep their positions.
 
+    The terminator line is kept. Several hooks run their own heredoc scan on
+    top of this one (`pytest-direct-exec-advisory`, `foreground-poll-loop-guard`,
+    `bash-worktree-existence-advisory`) and each waits for that line to resume
+    scanning — blanking it leaves them inside a body that never closes, so
+    everything after the heredoc goes silent. That is a bigger hole than the
+    false positive being closed here.
+
     An unterminated heredoc suppresses everything to the end of the command,
     which is what bash does with it too.
     """
@@ -197,7 +204,9 @@ def strip_heredoc_bodies(command: str) -> str:
             probe = line.lstrip("\t") if dash else line
             if probe.rstrip() == delim:
                 del pending[0]
-            out.append("")
+                out.append(line)  # terminator survives — see the docstring
+            else:
+                out.append("")
             continue
         out.append(line)
         pending.extend(_heredoc_starts_on_line(line))

--- a/hooks/_lib/_hook_utils.py
+++ b/hooks/_lib/_hook_utils.py
@@ -109,6 +109,8 @@ def _heredoc_starts_on_line(line: str) -> list[tuple[str, bool]]:
             quote = ch
             i += 1
             continue
+        if ch == "#" and (i == 0 or line[i - 1] in " \t;|&("):
+            break  # unquoted comment — bash reads no operator past it
         if ch == "\\":
             i += 2
             continue
@@ -145,7 +147,7 @@ def _heredoc_starts_on_line(line: str) -> list[tuple[str, bool]]:
     return out
 
 
-_HEREDOC_WORD_CHARS = re.compile(r"[A-Za-z0-9_.\-/]")
+_HEREDOC_WORD_CHARS = re.compile(r"[A-Za-z0-9_.~\-/]")
 
 
 def _read_heredoc_delim(line: str, j: int) -> tuple[str, int]:
@@ -202,7 +204,7 @@ def strip_heredoc_bodies(command: str) -> str:
         if pending:
             delim, dash = pending[0]
             probe = line.lstrip("\t") if dash else line
-            if probe.rstrip() == delim:
+            if probe == delim:  # exact — `EOF ` does not close a heredoc
                 del pending[0]
                 out.append(line)  # terminator survives — see the docstring
             else:

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -46,6 +46,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    GH_MERGE_VALUE_FLAGS,
+    is_help_invocation,
     iter_command_starts,
     safe_tokenize,
     strip_prefix,
@@ -460,11 +462,7 @@ _PULL_TOKEN_RE = re.compile(r"^(?:\S*/pull/(\d+)|(\d+))$")
 # gh *global* value flags (`-R`/`--repo`, …) are included because they may trail
 # the subcommand (`gh pr merge -R org/repo 999`); without skipping their value,
 # `org/repo` would be read as the positional and 999 misclassified (P1d).
-_MERGE_VALUE_FLAGS = frozenset({
-    "-b", "--body", "-F", "--body-file", "-t", "--subject",
-    "--match-head-commit", "--author-email",
-    "-R", "--repo", "--hostname", "--color",
-})
+_MERGE_VALUE_FLAGS = GH_MERGE_VALUE_FLAGS
 
 # Read-only `gh pr` verbs whose positional PR argument identifies the PR the
 # session is operating on. A numberless `gh pr merge` runs on the current
@@ -896,7 +894,10 @@ def _is_gh_pr_merge(argv: list[str]) -> bool:
             i += 1
     if i + 1 >= len(argv):
         return False
-    return argv[i] == "pr" and argv[i + 1] == "merge"
+    if argv[i] != "pr" or argv[i + 1] != "merge":
+        return False
+    # `gh pr merge --help` prints usage and merges nothing (issue #985).
+    return not is_help_invocation(argv[i + 2:], _MERGE_VALUE_FLAGS)
 
 
 def _is_cmux_dispatch(argv: list[str]) -> bool:

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -323,6 +323,12 @@ gh global flags (`-R/--repo`, `--hostname`, `--color`) are walked past before
 checking the subcommand so that `gh -R owner/repo pr merge` is detected
 correctly.
 
+A heredoc body matches `gh pr merge` textually and merges nothing, so it is
+not a trigger (issue #985): `safe_tokenize` blanks every body line before the
+per-line split, and a commit message that merely quotes `gh pr merge` is no
+longer read as one. The operator line and everything after the terminator are
+untouched, which is what keeps a real merge on a later line firing.
+
 `git push` force detection scans all tokens after the `push` subcommand for
 `--force`, `-f`, and `--force-with-lease` (including `--force-with-lease=<ref>`
 prefix-matched form).

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -323,11 +323,17 @@ gh global flags (`-R/--repo`, `--hostname`, `--color`) are walked past before
 checking the subcommand so that `gh -R owner/repo pr merge` is detected
 correctly.
 
-A heredoc body matches `gh pr merge` textually and merges nothing, so it is
-not a trigger (issue #985): `safe_tokenize` blanks every body line before the
-per-line split, and a commit message that merely quotes `gh pr merge` is no
-longer read as one. The operator line and everything after the terminator are
-untouched, which is what keeps a real merge on a later line firing.
+Two argv shapes match `gh pr merge` textually and merge nothing, so neither
+counts as a trigger (issue #985):
+
+- **A help invocation** — `--help` / `-h` prints usage and exits. Demanding a
+  merge briefing for it blocks the command an agent runs precisely to get the
+  merge right. `is_help_invocation` skips value-flag values, so `--subject -h`
+  stays a subject and still triggers.
+- **A heredoc body** — `safe_tokenize` blanks every body line before the
+  per-line split, so a commit message that merely quotes `gh pr merge` is no
+  longer read as one. The operator line and everything after the terminator are
+  untouched, which is what keeps a real merge on a later line firing.
 
 `git push` force detection scans all tokens after the `push` subcommand for
 `--force`, `-f`, and `--force-with-lease` (including `--force-with-lease=<ref>`

--- a/hooks/advisory-nudge/pre-commit-staged-file-enumeration/impl.py
+++ b/hooks/advisory-nudge/pre-commit-staged-file-enumeration/impl.py
@@ -50,9 +50,9 @@ Limitations:
     cwd, not `<dir>` (matches the sibling hooks' cwd-scoped git queries).
   - Shared-tokenizer detection boundaries (identical to the blocking sibling
     `block-rename-sweep-survivors`): `result=$(git commit ...)` is missed;
-    partial commits (`--only` / pathspec) over-list all staged additions; a
-    `git commit` literal inside a heredoc body false-surfaces. See spec.md
-    "Detection boundaries" — fixing these belongs in `_hook_utils`, not here.
+    partial commits (`--only` / pathspec) over-list all staged additions. The
+    heredoc-body false-surface listed here was fixed in `_hook_utils` (#985).
+    See spec.md "Detection boundaries" — the rest belong there too, not here.
 """
 from __future__ import annotations
 

--- a/hooks/advisory-nudge/pre-commit-staged-file-enumeration/spec.md
+++ b/hooks/advisory-nudge/pre-commit-staged-file-enumeration/spec.md
@@ -124,7 +124,7 @@ by probing the sibling on identical inputs (all three match this hook exactly):
 | --- | --- | --- |
 | `result=$(git commit -m x)` (commit inside an assignment's command substitution) | **not detected** | a commit whose stdout is captured into a shell variable is missed (false-negative) — even the blocking sibling misses it |
 | `git commit --only <path>` / `git commit -- <pathspec>` / `git commit <path>` (partial commit) | detected, but **all** staged additions are listed | additions the pathspec excludes are over-surfaced (advisory noise) |
-| `cat > f <<'EOF'` … `git commit` … `EOF` (commit literal inside a heredoc body) | detected as a command | a `git commit` that is only heredoc *data* triggers a false-surface |
+| `cat > f <<'EOF'` … `git commit` … `EOF` (commit literal inside a heredoc body) | **not detected** (fixed in #985) | heredoc bodies are blanked in `_hook_utils.safe_tokenize`, so data no longer reads as a command — this row is kept as the record of what changed |
 
 These are accepted boundaries, not per-hook defects: the detection idiom is
 shared across the git-commit hook family, so fixing them belongs in
@@ -167,5 +167,5 @@ transcript).
 The documented boundaries in "Limitations" / "Detection boundaries" are pinned
 by regression tests: single-call create+add+commit is silent; `--only` partial
 commit over-lists the excluded addition; a `git commit` literal in a heredoc
-body false-surfaces; `result=$(git commit)` is not detected. These pin current
+body is silent (#985); `result=$(git commit)` is not detected. These pin current
 behavior so a future tokenizer change surfaces here.

--- a/hooks/advisory-nudge/pytest-direct-exec-advisory/impl.py
+++ b/hooks/advisory-nudge/pytest-direct-exec-advisory/impl.py
@@ -185,6 +185,10 @@ def _without_heredoc_bodies(command: str) -> str:
             candidate = line.lstrip("\t") if strip_tabs else line
             if candidate == marker:
                 active_marker = None
+                # Keep the terminator: this text is handed to safe_tokenize,
+                # whose own heredoc pass (issue #985) would otherwise read the
+                # opener as unterminated and swallow every command after it.
+                live_lines.append(line)
             continue
 
         live_lines.append(line)

--- a/hooks/preflight-gate/foreground-poll-loop-guard/impl.py
+++ b/hooks/preflight-gate/foreground-poll-loop-guard/impl.py
@@ -132,6 +132,10 @@ def _strip_non_executable(command: str) -> str:
             candidate = line.lstrip("\t") if strip_tabs else line
             if candidate == delim:
                 heredoc_delims.pop(0)
+                # Keep the terminator: the result is handed to safe_tokenize,
+                # whose own heredoc pass (issue #985) would otherwise read the
+                # opener as unterminated and drop every command after it.
+                out.append(line)
             continue  # inside a heredoc body — drop
         line = _strip_comment(line)
         for m in _HEREDOC_RE.finditer(line):

--- a/hooks/preflight-gate/pre-merge-approval-gate/impl.py
+++ b/hooks/preflight-gate/pre-merge-approval-gate/impl.py
@@ -40,7 +40,9 @@ from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    GH_MERGE_VALUE_FLAGS,
     _is_gh_binary,
+    is_help_invocation,
     compound_cascade_hint,
     iter_command_starts,
     safe_tokenize,
@@ -99,7 +101,10 @@ def is_gh_pr_merge(argv: list[str]) -> bool:
 
     if i + 1 >= len(argv):
         return False
-    return argv[i] == "pr" and argv[i + 1] == "merge"
+    if argv[i] != "pr" or argv[i + 1] != "merge":
+        return False
+    # `gh pr merge --help` prints usage and merges nothing (issue #985).
+    return not is_help_invocation(argv[i + 2:], GH_MERGE_VALUE_FLAGS)
 
 
 def emit_ask(reason: str) -> None:

--- a/hooks/preflight-gate/pre-merge-approval-gate/spec.md
+++ b/hooks/preflight-gate/pre-merge-approval-gate/spec.md
@@ -43,8 +43,10 @@ is not retrieved.
 3. Any segment whose `argv[0..2] == ("gh", "pr", "merge")` triggers the check
    (`gh` global flags such as `-R/--repo`/`--hostname`/`--color` are skipped
    so `gh -R owner/repo pr merge` is detected correctly).
-4. If `CMUX_DELEGATE=1` in the hook's own process env → pass.
-5. Otherwise → emit `permissionDecision: "ask"`.
+4. Heredoc bodies are blanked by `safe_tokenize` (issue #985): a commit
+   message quoting `gh pr merge` is prose, not a merge.
+5. If `CMUX_DELEGATE=1` in the hook's own process env → pass.
+6. Otherwise → emit `permissionDecision: "ask"`.
 
 ### Inline env limitation (known)
 

--- a/hooks/preflight-gate/pre-merge-approval-gate/spec.md
+++ b/hooks/preflight-gate/pre-merge-approval-gate/spec.md
@@ -43,7 +43,9 @@ is not retrieved.
 3. Any segment whose `argv[0..2] == ("gh", "pr", "merge")` triggers the check
    (`gh` global flags such as `-R/--repo`/`--hostname`/`--color` are skipped
    so `gh -R owner/repo pr merge` is detected correctly).
-4. Heredoc bodies are blanked by `safe_tokenize` (issue #985): a commit
+4. A `--help` / `-h` invocation is not a merge and does not trigger (issue
+   #985) — value-flag values are skipped, so `--subject -h` still triggers.
+   Heredoc bodies are blanked by `safe_tokenize` for the same reason: a commit
    message quoting `gh pr merge` is prose, not a merge.
 5. If `CMUX_DELEGATE=1` in the hook's own process env → pass.
 6. Otherwise → emit `permissionDecision: "ask"`.

--- a/hooks/preflight-gate/side-effect-scan/impl.py
+++ b/hooks/preflight-gate/side-effect-scan/impl.py
@@ -22,7 +22,9 @@ from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    GH_MERGE_VALUE_FLAGS,
     compound_cascade_hint,
+    is_help_invocation,
     iter_command_starts,
     safe_tokenize,
     strip_prefix,
@@ -160,6 +162,8 @@ def _detect_gh(argv: list[str]) -> list[str]:
     group, action = _gh_subcommand_pair(argv)
     if not group or not action:
         return []
+    if is_help_invocation(argv, GH_MERGE_VALUE_FLAGS):
+        return []  # `gh pr merge --help` prints usage, triggers nothing (#985)
     matched: list[str] = []
     for want_group, want_actions, category in _GH_CATEGORY_BY_PAIR:
         if group == want_group and action in want_actions:

--- a/hooks/preflight-gate/side-effect-scan/spec.md
+++ b/hooks/preflight-gate/side-effect-scan/spec.md
@@ -90,6 +90,9 @@ Commands are tokenized with `shlex.shlex(..., posix=True, punctuation_chars=";|&
   so `git commit -m "$(cat <<'EOF' … EOF)"` no longer surfaces the categories
   its *message text* happens to name. The operator line and everything after
   the terminator are still scanned.
+- `--help` / `-h` invocations surface nothing — `gh pr merge --help` prints
+  usage and triggers no remote action (issue #985). A help flag sitting in a
+  value position (`--subject -h`) is a value, not a help request.
 - Newlines in the raw command are treated as command separators so multi-line
   Bash blocks (`echo prep\ngit push origin main` across two lines) get the
   second line scanned as a new segment.

--- a/hooks/preflight-gate/side-effect-scan/spec.md
+++ b/hooks/preflight-gate/side-effect-scan/spec.md
@@ -86,6 +86,10 @@ Commands are tokenized with `shlex.shlex(..., posix=True, punctuation_chars=";|&
   `}`) are peeled from the start of each segment so `if true; then git push`,
   `for x in 1; do kubectl apply`, and `if git push; then ...` all reach the
   real executable.
+- Heredoc bodies are blanked before that split (issue #985): the body is data,
+  so `git commit -m "$(cat <<'EOF' … EOF)"` no longer surfaces the categories
+  its *message text* happens to name. The operator line and everything after
+  the terminator are still scanned.
 - Newlines in the raw command are treated as command separators so multi-line
   Bash blocks (`echo prep\ngit push origin main` across two lines) get the
   second line scanned as a new segment.

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -495,6 +495,44 @@ run_case "compound_merge_and_dispatch_dispatch_surface" \
   "" \
   'gh pr merge --squash && cmux new-workspace --command "claude -p next"'
 
+# --- issue #985: non-merge commands that only look like a merge -------------
+#
+# Both families used to reach the briefing gate, which then demanded a merge
+# briefing for a command that merges nothing. The must-still-fire cases at the
+# end are what keeps the fix from turning into a bypass.
+
+run_case "heredoc_body_quoting_a_merge_is_not_a_merge" \
+  "silent" \
+  "" \
+  "$(printf 'git commit -m "$(cat <<'EOF'\ngh pr merge is only quoted here\nEOF\n)"')"
+
+run_case "heredoc_unquoted_delimiter_body_is_not_a_merge" \
+  "silent" \
+  "" \
+  "$(printf 'cat <<EOF\ngh pr merge 985\nEOF')"
+
+run_case "heredoc_dash_form_body_is_not_a_merge" \
+  "silent" \
+  "" \
+  "$(printf 'cat <<-EOF\n\tgh pr merge 985\n\tEOF')"
+
+run_case "herestring_is_not_a_heredoc_and_stays_silent" \
+  "silent" \
+  "" \
+  "grep x <<< 'gh pr merge 985'"
+
+# Must still fire — the fix must not become a bypass.
+
+run_case "merge_after_heredoc_terminator_still_merges" \
+  "advisory:TRIGGER: gh pr merge" \
+  "" \
+  "$(printf 'cat <<'EOF'\nbody\nEOF\ngh pr merge 985 --squash')"
+
+run_case "arithmetic_shift_does_not_swallow_a_later_merge" \
+  "advisory:TRIGGER: gh pr merge" \
+  "" \
+  'echo $((1 << 3)); gh pr merge 985 --squash'
+
 # Dedicated multi-trigger inspector — asserts BOTH surfaces appear in the SAME
 # stderr capture, not separated by re-invocation.
 run_compound_multi_assert() {

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -501,6 +501,21 @@ run_case "compound_merge_and_dispatch_dispatch_surface" \
 # briefing for a command that merges nothing. The must-still-fire cases at the
 # end are what keeps the fix from turning into a bypass.
 
+run_case "help_long_flag_is_not_a_merge" \
+  "silent" \
+  "" \
+  "gh pr merge --help"
+
+run_case "help_short_flag_is_not_a_merge" \
+  "silent" \
+  "" \
+  "gh pr merge -h"
+
+run_case "help_flag_after_pr_number_is_not_a_merge" \
+  "silent" \
+  "" \
+  "gh pr merge 985 --help"
+
 run_case "heredoc_body_quoting_a_merge_is_not_a_merge" \
   "silent" \
   "" \
@@ -522,6 +537,11 @@ run_case "herestring_is_not_a_heredoc_and_stays_silent" \
   "grep x <<< 'gh pr merge 985'"
 
 # Must still fire — the fix must not become a bypass.
+
+run_case "help_flag_as_a_subject_value_still_merges" \
+  "advisory:TRIGGER: gh pr merge" \
+  "" \
+  "gh pr merge 985 --squash --subject -h"
 
 run_case "merge_after_heredoc_terminator_still_merges" \
   "advisory:TRIGGER: gh pr merge" \

--- a/tests/hooks/advisory-nudge/test_pre_commit_staged_file_enumeration.sh
+++ b/tests/hooks/advisory-nudge/test_pre_commit_staged_file_enumeration.sh
@@ -453,8 +453,10 @@ git -C "$HEREREPO" add seed.txt
 git -C "$HEREREPO" -c commit.gpgsign=false commit -q -m seed
 printf data > "$HEREREPO/staged.txt"
 git -C "$HEREREPO" add staged.txt
-run_dir_case "git commit literal in heredoc body false-surfaces (boundary)" \
-  "surface:staged.txt" "$HEREREPO" \
+# Fixed in #985: the shared tokenizer blanks heredoc bodies, so a `git commit`
+# that is only heredoc data no longer reads as a commit.
+run_dir_case "git commit literal in heredoc body is silent (#985)" \
+  "silent" "$HEREREPO" \
   "$(printf 'cat > guide.md <<%sEOF%s\ngit commit -m in-body\nEOF' "'" "'")" \
   "$TRANSCRIPT_EMPTY"
 rm -rf "$HEREREPO" 2>/dev/null || true

--- a/tests/hooks/preflight-gate/test_pre_merge_approval_gate.sh
+++ b/tests/hooks/preflight-gate/test_pre_merge_approval_gate.sh
@@ -237,9 +237,21 @@ run_case "direct session: /usr/bin/gh pr list (path-prefix read, not merge, sile
 # the flags; a heredoc body is data, so a commit message quoting the command is
 # not the command. The last two cases keep the fix from becoming a bypass.
 
+run_case "direct session: gh pr merge --help (usage only, silent)" \
+  "silent" "no-delegate" \
+  '{"tool_name": "Bash", "tool_input": {"command": "gh pr merge --help"}}'
+
+run_case "direct session: gh pr merge -h (usage only, silent)" \
+  "silent" "no-delegate" \
+  '{"tool_name": "Bash", "tool_input": {"command": "gh pr merge -h"}}'
+
 run_case "direct session: commit message quoting the merge (heredoc body, silent)" \
   "silent" "no-delegate" \
   '{"tool_name": "Bash", "tool_input": {"command": "git commit -m \"$(cat <<'EOF'\ngh pr merge is only quoted here\nEOF\n)\""}}'
+
+run_case "direct session: -h as a --subject value (still a merge, ask)" \
+  "ask" "no-delegate" \
+  '{"tool_name": "Bash", "tool_input": {"command": "gh pr merge 985 --squash --subject -h"}}'
 
 run_case "direct session: merge after a heredoc terminator (still a merge, ask)" \
   "ask" "no-delegate" \

--- a/tests/hooks/preflight-gate/test_pre_merge_approval_gate.sh
+++ b/tests/hooks/preflight-gate/test_pre_merge_approval_gate.sh
@@ -232,6 +232,20 @@ run_case "direct session: /usr/bin/gh pr list (path-prefix read, not merge, sile
   "silent" "no-delegate" \
   '{"tool_name":"Bash","tool_input":{"command":"/usr/bin/gh pr list"}}'
 
+# --- #985: help and heredoc bodies are not merges ---------------------------
+# A gate that asks on `gh pr merge --help` blocks the one command run to learn
+# the flags; a heredoc body is data, so a commit message quoting the command is
+# not the command. The last two cases keep the fix from becoming a bypass.
+
+run_case "direct session: commit message quoting the merge (heredoc body, silent)" \
+  "silent" "no-delegate" \
+  '{"tool_name": "Bash", "tool_input": {"command": "git commit -m \"$(cat <<'EOF'\ngh pr merge is only quoted here\nEOF\n)\""}}'
+
+run_case "direct session: merge after a heredoc terminator (still a merge, ask)" \
+  "ask" "no-delegate" \
+  '{"tool_name": "Bash", "tool_input": {"command": "cat <<'EOF'\nbody\nEOF\ngh pr merge 985 --squash"}}'
+
+
 echo ""
 echo "Result: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/tests/hooks/preflight-gate/test_side_effect_scan.sh
+++ b/tests/hooks/preflight-gate/test_side_effect_scan.sh
@@ -258,6 +258,11 @@ else
   FAIL=$((FAIL + 1)); FAILED_NAMES+=("non-Bash tool passthrough")
 fi
 
+# --- #985: help output and heredoc bodies trigger nothing --------------------
+run_case "commit message quoting a merge"  pass $'git commit -m "$(cat <<\'EOF\'\ngh pr merge is only quoted here\nEOF\n)"'
+run_case "merge after heredoc terminator"  ask  $'cat <<\'EOF\'\nbody\nEOF\ngh pr merge 985 --squash'
+
+
 # --- malformed JSON ---------------------------------------------------------
 bad_out=$(echo 'not json' | "$HOOK" 2>/dev/null)
 bad_rc=$?

--- a/tests/hooks/preflight-gate/test_side_effect_scan.sh
+++ b/tests/hooks/preflight-gate/test_side_effect_scan.sh
@@ -259,7 +259,11 @@ else
 fi
 
 # --- #985: help output and heredoc bodies trigger nothing --------------------
+run_case "gh pr merge --help (usage only)" pass "gh pr merge --help"
+run_case "gh pr merge -h (usage only)"     pass "gh pr merge -h"
+run_case "gh pr create --help (usage only)" pass "gh pr create --help"
 run_case "commit message quoting a merge"  pass $'git commit -m "$(cat <<\'EOF\'\ngh pr merge is only quoted here\nEOF\n)"'
+run_case "-h as a --subject value"         ask  "gh pr merge 985 --squash --subject -h"
 run_case "merge after heredoc terminator"  ask  $'cat <<\'EOF\'\nbody\nEOF\ngh pr merge 985 --squash'
 
 

--- a/tests/test_heredoc_help_tokenizer.py
+++ b/tests/test_heredoc_help_tokenizer.py
@@ -1,0 +1,85 @@
+"""Tokenizer coverage for a merge-gate false positive (issue #985).
+
+A heredoc body reached every `gh pr merge` gate without merging anything: it
+was tokenized line-by-line as if its prose were commands. The cases below are
+the enumerated input surface for `strip_heredoc_bodies`, including the
+must-still-fire variants that keep the fix from becoming a bypass.
+
+Written as Python rather than appended to `tests/test_hook_utils.sh` because
+every case is itself a shell string: expressing them as bash literals means
+escaping the very quoting the parser is being tested on.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "hooks" / "_lib"))
+
+from _hook_utils import safe_tokenize, strip_heredoc_bodies  # noqa: E402
+
+# Split so this file's own text never carries the literal the gates match on —
+# editing these tests would otherwise trip the gate the tests exist to fix.
+MERGE = "gh pr " + "merge"
+
+
+def _has_merge(command: str) -> bool:
+    """True when the tokenizer reads a `gh pr merge` command start."""
+    toks = safe_tokenize(command)
+    return any(toks[i:i + 3] == ["gh", "pr", "merge"] for i in range(len(toks)))
+
+
+# ---------------------------------------------------------------------------
+# Heredoc bodies are data, not commands.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("name,command", [
+    ("unquoted delimiter", f"cat <<EOF\n{MERGE} 985\nEOF"),
+    ("single-quoted delimiter", f"cat <<'EOF'\n{MERGE} 985\nEOF"),
+    ("double-quoted delimiter", f'cat <<"EOF"\n{MERGE} 985\nEOF'),
+    ("backslash-escaped delimiter", f"cat <<\\EOF\n{MERGE} 985\nEOF"),
+    ("dash form, tab-indented terminator", f"cat <<-EOF\n\t{MERGE} 985\n\tEOF"),
+    ("arbitrary delimiter word", f"python3 <<PY\n{MERGE} 985\nPY"),
+    ("two heredocs, both bodies", f"cat <<A <<B\n{MERGE} 1\nA\n{MERGE} 2\nB"),
+    ("unterminated heredoc runs to the end", f"cat <<EOF\n{MERGE} 985"),
+    ("near-miss terminator does not end the body",
+     f"cat <<EOF\nEOFX\n{MERGE} 985\nEOF"),
+    # The shape that actually fired: a commit message assembled through a
+    # command substitution *inside* double quotes, where the substitution
+    # re-opens shell parsing and the heredoc is genuinely a heredoc.
+    ("command substitution inside double quotes",
+     f"git commit -m \"$(cat <<'EOF'\nfix: reword\n\n{MERGE} 시점 설명\nEOF\n)\""),
+])
+def test_heredoc_body_is_not_read_as_a_command(name: str, command: str) -> None:
+    assert not _has_merge(command), name
+
+
+@pytest.mark.parametrize("name,command", [
+    ("merge on a later line", f"cat <<'EOF'\nbody\nEOF\n{MERGE} 985 --squash"),
+    ("merge before the heredoc", f"{MERGE} 985 --squash\ncat <<'EOF'\nbody\nEOF"),
+    ("here-string has no body", f"grep x <<< body\n{MERGE} 985 --squash"),
+    ("arithmetic left-shift is not an operator",
+     f"echo $((1 << 3)); {MERGE} 985 --squash"),
+    ("`<<` inside quotes is literal", f'echo "<<EOF"\n{MERGE} 985 --squash'),
+    ("terminator with trailing whitespace still closes the body",
+     f"cat <<EOF\nbody\nEOF  \n{MERGE} 985 --squash"),
+])
+def test_real_merge_still_reaches_the_gates(name: str, command: str) -> None:
+    assert _has_merge(command), name
+
+
+def test_command_without_heredoc_is_returned_unchanged() -> None:
+    command = f"{MERGE} 985 --squash && echo done"
+    assert strip_heredoc_bodies(command) == command
+
+
+def test_suppressed_body_keeps_the_line_count() -> None:
+    """Blank lines, not deleted ones — line positions stay comparable."""
+    command = f"cat <<EOF\n{MERGE}\nEOF\necho after"
+    assert strip_heredoc_bodies(command).split("\n") == [
+        "cat <<EOF", "", "", "echo after",
+    ]
+
+

--- a/tests/test_heredoc_help_tokenizer.py
+++ b/tests/test_heredoc_help_tokenizer.py
@@ -53,6 +53,11 @@ def _has_merge(command: str) -> bool:
     ("unterminated heredoc runs to the end", f"cat <<EOF\n{MERGE} 985"),
     ("near-miss terminator does not end the body",
      f"cat <<EOF\nEOFX\n{MERGE} 985\nEOF"),
+    # bash closes a heredoc only on an exact delimiter line — `EOF  ` is body,
+    # so everything after it is body too (CodeRabbit, verified against bash).
+    ("terminator with trailing spaces does not close the body",
+     f"cat <<EOF\nbody\nEOF  \n{MERGE} 985 --squash"),
+    ("tilde delimiter", f"cat <<~EOF\n{MERGE} 985\n~EOF"),
     # The shape that actually fired: a commit message assembled through a
     # command substitution *inside* double quotes, where the substitution
     # re-opens shell parsing and the heredoc is genuinely a heredoc.
@@ -69,8 +74,6 @@ def test_heredoc_body_is_not_read_as_a_command(name: str, command: str) -> None:
     ("here-string has no body", f"grep x <<< body\n{MERGE} 985 --squash"),
     ("arithmetic left-shift is not an operator",
      f"echo $((1 << 3)); {MERGE} 985 --squash"),
-    ("terminator with trailing whitespace still closes the body",
-     f"cat <<EOF\nbody\nEOF  \n{MERGE} 985 --squash"),
     ("`<<` inside quotes is literal", f'echo "<<EOF"\n{MERGE} 985 --squash'),
 ])
 def test_real_merge_still_reaches_the_gates(name: str, command: str) -> None:
@@ -80,6 +83,12 @@ def test_real_merge_still_reaches_the_gates(name: str, command: str) -> None:
 def test_command_without_heredoc_is_returned_unchanged() -> None:
     command = f"{MERGE} 985 --squash && echo done"
     assert strip_heredoc_bodies(command) == command
+
+
+def test_heredoc_lookalike_in_a_comment_opens_nothing() -> None:
+    """`# <<EOF` is a comment; bash reads no operator past it, so the next line
+    must stay visible (CodeRabbit, verified against bash)."""
+    assert _has_merge(f'echo hi # <<EOF\n{MERGE} 985 --squash')
 
 
 def test_only_body_lines_are_blanked() -> None:

--- a/tests/test_heredoc_help_tokenizer.py
+++ b/tests/test_heredoc_help_tokenizer.py
@@ -69,9 +69,9 @@ def test_heredoc_body_is_not_read_as_a_command(name: str, command: str) -> None:
     ("here-string has no body", f"grep x <<< body\n{MERGE} 985 --squash"),
     ("arithmetic left-shift is not an operator",
      f"echo $((1 << 3)); {MERGE} 985 --squash"),
-    ("`<<` inside quotes is literal", f'echo "<<EOF"\n{MERGE} 985 --squash'),
     ("terminator with trailing whitespace still closes the body",
      f"cat <<EOF\nbody\nEOF  \n{MERGE} 985 --squash"),
+    ("`<<` inside quotes is literal", f'echo "<<EOF"\n{MERGE} 985 --squash'),
 ])
 def test_real_merge_still_reaches_the_gates(name: str, command: str) -> None:
     assert _has_merge(command), name
@@ -82,11 +82,12 @@ def test_command_without_heredoc_is_returned_unchanged() -> None:
     assert strip_heredoc_bodies(command) == command
 
 
-def test_suppressed_body_keeps_the_line_count() -> None:
-    """Blank lines, not deleted ones — line positions stay comparable."""
+def test_only_body_lines_are_blanked() -> None:
+    """Line positions stay comparable, and the terminator survives — hooks
+    running their own heredoc scan on top of this one wait for that line."""
     command = f"cat <<EOF\n{MERGE}\nEOF\necho after"
     assert strip_heredoc_bodies(command).split("\n") == [
-        "cat <<EOF", "", "", "echo after",
+        "cat <<EOF", "", "EOF", "echo after",
     ]
 
 

--- a/tests/test_heredoc_help_tokenizer.py
+++ b/tests/test_heredoc_help_tokenizer.py
@@ -1,9 +1,11 @@
-"""Tokenizer coverage for a merge-gate false positive (issue #985).
+"""Tokenizer coverage for the two merge-gate false positives (issue #985).
 
-A heredoc body reached every `gh pr merge` gate without merging anything: it
-was tokenized line-by-line as if its prose were commands. The cases below are
-the enumerated input surface for `strip_heredoc_bodies`, including the
-must-still-fire variants that keep the fix from becoming a bypass.
+Both families reached every `gh pr merge` gate without merging anything: a
+heredoc body was tokenized line-by-line as if its prose were commands, and a
+`--help` invocation matched the same argv shape as the real thing. The cases
+below are the enumerated input surface for the two helpers that close them —
+`strip_heredoc_bodies` and `is_help_invocation` — including the must-still-fire
+variants that keep either fix from becoming a bypass.
 
 Written as Python rather than appended to `tests/test_hook_utils.sh` because
 every case is itself a shell string: expressing them as bash literals means
@@ -18,7 +20,12 @@ import pytest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "hooks" / "_lib"))
 
-from _hook_utils import safe_tokenize, strip_heredoc_bodies  # noqa: E402
+from _hook_utils import (  # noqa: E402
+    GH_MERGE_VALUE_FLAGS,
+    is_help_invocation,
+    safe_tokenize,
+    strip_heredoc_bodies,
+)
 
 # Split so this file's own text never carries the literal the gates match on —
 # editing these tests would otherwise trip the gate the tests exist to fix.
@@ -83,3 +90,27 @@ def test_suppressed_body_keeps_the_line_count() -> None:
     ]
 
 
+# ---------------------------------------------------------------------------
+# `--help` prints usage and does nothing.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("argv", [
+    ["--help"],
+    ["-h"],
+    ["985", "--help"],
+    ["--squash", "-h"],
+    ["-h", "985"],
+])
+def test_help_invocation_detected(argv: list[str]) -> None:
+    assert is_help_invocation(argv, GH_MERGE_VALUE_FLAGS)
+
+
+@pytest.mark.parametrize("argv", [
+    ["985", "--squash"],
+    ["985", "--subject", "-h"],          # -h is the subject text
+    ["985", "--body", "--help"],         # --help is the body text
+    ["985", "--subject=-h"],             # inline value, not a flag position
+    ["--", "-h"],                        # everything after `--` is positional
+])
+def test_not_a_help_invocation(argv: list[str]) -> None:
+    assert not is_help_invocation(argv, GH_MERGE_VALUE_FLAGS)


### PR DESCRIPTION
### 무엇을 고쳤나

머지 게이트 3종(`momentum-rule-retrieval-gate` · `pre-merge-approval-gate` · `side-effect-scan`)이 **머지를 하지 않는 명령**에 발화하던 오탐 2종을 닫습니다. 둘 다 원인이 게이트가 아니라 공용 토크나이저(`hooks/_lib/_hook_utils.py`)라, 수정도 거기서 했습니다.

| # | 오탐 | 원인 | 수정 |
|---|---|---|---|
| 1 | heredoc 본문에 게이트 대상 명령이 인용되면 그 명령으로 인식 | `safe_tokenize` 가 본문을 줄 단위로 잘라 명령줄로 넘김 | `strip_heredoc_bodies` 로 본문 줄을 먼저 비움 |
| 2 | `--help` / `-h` 가 실제 실행과 같은 argv 모양으로 매칭 | 게이트들이 argv 형태만 봄 | `is_help_invocation` 으로 usage 호출 제외 |

2번은 특히 손해가 큽니다 — 에이전트가 플래그를 정확히 쓰려고 실행하는 바로 그 명령이 차단됐습니다. 실제로 이 세션에서 두 오탐 모두 실행 중에 걸렸고, 그 재현이 이 PR 의 출발점입니다.

### 우회가 되지 않게 하는 조건

- `--subject -h` 처럼 **값 자리**에 온 help 플래그는 값으로 취급 → 여전히 발화
- heredoc **terminator 이후** 줄의 실제 명령 → 여전히 발화
- here-string(`<<<`), 산술 좌시프트(`$((1 << 3))`), 따옴표 안의 `<<` → heredoc 아님

### 검증

- 열거한 입력 표면 전체를 테스트로 승격: 신규 `tests/test_heredoc_help_tokenizer.py` 30건 + 게이트 3종 스위트에 회귀 케이스 21건
- CI 조건 전체 스위트 `bash scripts/run-tests.sh` → `exit=0`, 실패 스위트 0건 (참고: `pytest tests -q` 만은 `658 passed`, base 628)
- 커밋 4개 — 결함 1건당 1커밋

리뷰 라운드에서 추가된 2·3번째 커밋의 배경은 검증 앵커의 정정 블록에 적었습니다: 자체 heredoc 스캔을 가진 훅 3개와의 충돌(CI 가 잡음), 그리고 bash 실동작과 어긋난 3건(CodeRabbit).

Caller chain verified: `grep -rl safe_tokenize hooks/` → 77 files (공용 토크나이저이므로 heredoc 변경의 폭발 반경이 여기 전부); `grep -rn is_help_invocation hooks/` → 신규 심볼, 호출자 3곳(momentum·approval·side-effect impl)

Pre-commit verified: 이 레포에는 `.pre-commit-config.yaml` 이 없고 `core.hooksPath` 도 미설정 — 대신 CI 가 부르는 `bash scripts/run-tests.sh` 를 커밋 직전 실행 → `exit=0`

Closes #985
