### PR TITLE
feat(cmux-delegate): classify delegated worker liveness

### DIFF
--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -335,7 +335,28 @@ if [[ "$WS_RAW" != OK* ]]; then
 fi
 
 WS_REF=$(echo "$WS_RAW" | sed 's/^OK //')
+
+# Step 7 이 읽을 셀렉터를 지금 박제합니다. 지금이 유일하게 안전한 시점입니다 —
+# 방금 생성된 ref 는 정확히 이 워크스페이스를 가리키고, 나중에 제목으로 되찾으면
+# `short_task` 30자 절단이 만든 동명 워크스페이스와 구별되지 않습니다.
+WS_ID=$(CMUX_QUIET=1 cmux workspace list --json \
+  | jq -r --arg r "$WS_REF" '.workspaces[] | select(.ref == $r) | .id' \
+  | head -1)
+
+# 리다이렉트를 조회에 직접 걸지 않는 이유: 조회가 실패해도 `head` 는 성공하므로
+# 빈 파일이 남고, 그 빈 파일은 Step 7 에서 "워커가 있다"로 읽힙니다.
+if [ -n "$WS_ID" ]; then
+  echo "$WS_ID" > "/tmp/cmux-delegate-{timestamp}-${WS_REF#workspace:}.ws"
+else
+  echo "경고: $WS_REF 의 UUID 조회 실패 — Step 7 은 제목/경로 폴백으로 판정합니다"
+fi
 ```
+
+파일명에 ref 번호가 들어가는 이유는 distribute 모드 때문입니다 — 이 블록이
+항목 수만큼 반복되는데 `{timestamp}` 는 호출 1건당 하나라, 고정 이름이면
+마지막 워크스페이스가 앞의 것들을 전부 덮어씁니다. 파일 안에 ref 가 아니라
+UUID 를 담는 이유는 별개입니다: 워크스페이스가 닫히고 열리는 사이
+`workspace:N` 번호의 안정성이 확인되지 않았고, UUID 는 그 질문 자체가 없습니다.
 
 **distribute 모드에서는 분할된 항목 수만큼 반복 실행합니다.**
 
@@ -357,6 +378,19 @@ fi
 cmux send --workspace "$TARGET" \
   "{prompt_file_path} 파일을 읽고 조사해주세요."
 cmux send-key --workspace "$TARGET" Enter
+
+# 3. Step 7 이 읽을 셀렉터 박제 (Step 5a 와 같은 이유·같은 파일).
+#    이 모드는 "[delegate] …" 워크스페이스를 만들지 않으므로 제목 조회로는
+#    아예 되찾을 수 없습니다 — 여기서 안 쓰면 Step 7 은 경로로 떨어집니다.
+WS_ID=$(CMUX_QUIET=1 cmux workspace list --json \
+  | jq -r --arg r "$TARGET" '.workspaces[] | select(.ref == $r) | .id' \
+  | head -1)
+
+if [ -n "$WS_ID" ]; then
+  echo "$WS_ID" > "/tmp/cmux-delegate-{timestamp}-${TARGET#workspace:}.ws"
+else
+  echo "경고: $TARGET 의 UUID 조회 실패 — Step 7 은 제목/경로 폴백으로 판정합니다"
+fi
 ```
 
 ### Step 6: Report
@@ -423,32 +457,61 @@ REPORT="$(sh "$ARP" "{cwd}")"
 **보고서가 없으면 거기서 멈추지 말고 이유를 묻습니다.** 파일 부재는 네 가지
 서로 다른 상황을 하나로 뭉갠 값이고, 각각 처방이 다릅니다.
 
-```bash
-# Step 5b(기존 세션)로 보냈다면 그 워크스페이스의 디렉터리를 조회합니다.
-# {cwd} 는 위임자가 서 있는 곳이고, --session 으로 잡은 워크스페이스는
-# 대개 다른 곳에 있습니다 — 그 경우 일치하는 워크스페이스가 없어
-# 살아있는 세션이 `crash` 로, 즉 재위임 대상으로 보고됩니다.
-# TARGET 은 `workspace:N` 형태의 ref 입니다. RPC 응답의 `.id` 는 UUID 라
-# 그쪽으로 매칭하면 영원히 빈손입니다 — ref 와 디렉터리를 함께 들고 있는
-# `workspace list --json` 에서 한 번에 읽습니다.
-PROBE_DIR="{cwd}"
-if [ -n "${TARGET:-}" ]; then
-  PROBE_DIR=$(CMUX_QUIET=1 cmux workspace list --json \
-    | jq -r --arg ref "$TARGET" '.workspaces[] | select(.ref == $ref) | .current_directory')
-  [ -n "$PROBE_DIR" ] || { echo "Error: '$TARGET' 의 디렉터리를 찾지 못했습니다"; exit 1; }
-fi
+**조회 대상은 경로가 아니라 워크스페이스입니다.** Step 5 의 `{cwd}` 기본값은
+`args.cwd || $(pwd)` 라 위임된 워크스페이스가 **위임자와 같은 디렉터리에**
+열립니다. 실측: 한 디렉터리에 워크스페이스 18개. 경로로 조회하면 그중 아무거나
+하나가 잡히고, 이벤트도 그 경로 전체에서 걸리므로 **이 프로브를 실행하는
+위임자 자신의 이벤트가 최신**이 되어 끝난 워커도 `working` 으로 보고됩니다.
+그래서 Step 5 가 박제한 워크스페이스 UUID 를 씁니다.
 
-eval "$(sh "${CLAUDE_PLUGIN_ROOT}/skills/cmux-delegate/agent-liveness.sh" "$PROBE_DIR")"
-echo "$state"   # working | idle | waiting-input | crash | unknown
+```bash
+# 셸 상태는 Bash 호출 간에 유지되지 않으므로(RUNTIME_CONSTRAINTS.md §4)
+# Step 5a/5b 가 파일에 남긴 UUID 를 읽습니다. 제목으로 되찾는 길은 폴백입니다 —
+# `short_task` 30자 절단이 동명 워크스페이스를 만들 수 있고, `--session` 모드는
+# 그 제목의 워크스페이스를 아예 만들지 않습니다.
+# distribute 모드는 항목마다 한 파일이므로 전부 돕니다.
+LIVENESS="${CLAUDE_PLUGIN_ROOT}/skills/cmux-delegate/agent-liveness.sh"
+FOUND=0
+
+# glob 이 아니라 find 인 이유: 매치가 없을 때 zsh 는 `nomatch` 로 블록 전체를
+# 죽입니다(bash 는 리터럴을 넘겨 폴백으로 갑니다). 위임자 셸을 고를 수 없습니다.
+# `/tmp/` 의 후행 슬래시는 필수입니다 — macOS 에서 /tmp 는 private/tmp 심볼릭
+# 링크이고, find 는 기본적으로 링크를 따라가지 않아 무조건 0건이 나옵니다.
+for WS_FILE in $(find /tmp/ -maxdepth 1 -name 'cmux-delegate-{timestamp}-*.ws' 2>/dev/null); do
+  # 빈 파일은 워커가 아니라 조회 실패의 흔적이므로 FOUND 를 올리지 않습니다 —
+  # 올리면 폴백이 막히고, probe 는 빈 인자에 usage/rc=2 로 끝납니다.
+  [ -s "$WS_FILE" ] || { echo "$WS_FILE 비어 있음 — 건너뜀"; continue; }
+  FOUND=1
+  # 반복마다 초기화: eval 이 아무것도 내놓지 않으면 $state 가 직전 워커의 값을
+  # 그대로 들고 있어, 그 판정이 이 워커의 것으로 출력됩니다.
+  state=unknown
+  eval "$(sh "$LIVENESS" "$(cat "$WS_FILE")")"
+  echo "$WS_FILE $state"   # working | idle | waiting-input | crash | unknown
+done
+
+if [ "$FOUND" -eq 0 ]; then
+  WS_SEL=$(CMUX_QUIET=1 cmux workspace list --json \
+    | jq -r --arg t "[delegate] {short_task}" '.workspaces[] | select(.title == $t) | .ref' \
+    | head -1)
+  # 제목으로도 못 찾으면 경로로 떨어지되, 그 답은 ambiguous 를 달고 옵니다.
+  eval "$(sh "$LIVENESS" "${WS_SEL:-{cwd}}")"
+  echo "$state"
+  [ "${ambiguous:-1}" -gt 1 ] && echo "경고: 경로가 워크스페이스 $ambiguous 개와 일치 — 판정은 그중 하나에 대한 것"
+fi
 ```
+
+**보고서 층은 아직 이 축을 따라오지 못합니다.** `agent-report-path.sh` 는
+워크트리 경로로 해싱하므로 distribute 모드의 N개 워커가 보고서 파일 하나를
+공유합니다 (#903 선존). 즉 위 루프는 워커별로 살았는지를 답하지만, 아래
+보고서 검증은 여전히 1건분입니다.
 
 | `state` | 뜻 | 위임자가 할 일 |
 | --- | --- | --- |
 | `working` | 턴 진행 중 (툴 실행 또는 사고) | 기다린다. 재지시는 진행 중인 작업을 버린다 |
 | `idle` | 턴이 끝났는데 보고서가 없다 | 재지시하거나 인수한다. 가장 의심스러운 값 |
 | `waiting-input` | 모달 프롬프트에서 멈춤 | 사람이 그 워크스페이스에서 키를 누른다 |
-| `crash` | cmux 가 응답했고 해당 경로에 워크스페이스가 없음 | 재위임 |
-| `unknown` | 판정 불가 (`reason` 이 어느 쪽인지 말한다: `cmux-unavailable` · `workspace-lookup-failed` · `no-events-in-window`) | 부재를 사망으로 읽지 않는다. 화면을 직접 본다 |
+| `crash` | cmux 가 목록을 정상으로 답했고 그 셀렉터에 해당하는 워크스페이스가 없음 | 재위임 |
+| `unknown` | 판정 불가 (`reason` 이 어느 쪽인지 말한다: `cmux-unavailable` · `workspace-lookup-failed` · `workspace-ref-not-found` · `workspace-has-no-id` · `no-events-in-window`) | 부재를 사망으로 읽지 않는다. 화면을 직접 본다 |
 
 `crash` 와 `unknown/workspace-lookup-failed` 의 경계가 이 표에서 가장 비싼
 지점입니다. `crash` 의 처방은 재위임이므로, 조회가 실패했을 뿐인 경우를 여기로
@@ -483,8 +546,12 @@ echo "$state"   # working | idle | waiting-input | crash | unknown
 **커버리지 한계 (명기).** 위 판정은 워크스페이스 목록과 이벤트 스트림이
 보이는 것까지만 답합니다. 남는 구멍 셋:
 
-- 같은 디렉터리에 워크스페이스가 둘 이상이면 첫 번째 것을 기술합니다.
-  `ambiguous=N` 이 붙으므로 그때는 답을 그대로 믿지 않습니다.
+- `WS_SEL` 이 비어 경로로 떨어진 경우에만 열리는 구멍: 같은 디렉터리에
+  워크스페이스가 둘 이상이면 그중 첫 번째 것을 기술합니다. 위임 기본값이
+  위임자와 같은 디렉터리이므로 이 갈래는 드물지 않고, 실측 최대는 한 경로에
+  18개였습니다. `ambiguous=N` (N>1) 이 붙은 답은 "N개 중 하나에 대한 판정"
+  이므로, 재위임 같은 비가역 처방의 근거로 쓰지 말고 제목으로 ref 를 다시
+  찾거나 화면을 직접 봅니다. ref 로 조회하면 `ambiguous` 자체가 없습니다.
 - 이벤트 보존 창(4096건)을 벗어난 워커는 `unknown` 입니다. 바쁜 호스트에서는
   몇 분이면 벗어납니다.
 - 폴더 신뢰 다이얼로그의 `preview` 문구는 아직 채집되지 않아,

--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -2,8 +2,8 @@
 name: cmux-delegate
 description: Delegate a task to an independent Claude Code session in a new cmux workspace with auto-collected context. Triggers on "cmux delegate", "delegate task", "delegate to new session", "별도 세션", "세션에 위임".
 verified-against-runtime: true
-runtime-verified-at: 2026-06-17
-runtime-verified-note: "cmux/gh/claude/codex/gemini --help probe — cmux new-workspace exists, gh exposes pr/issue commands, claude supports --model/--permission-mode, codex exposes exec, and gemini supports -p/--prompt."
+runtime-verified-at: 2026-08-13
+runtime-verified-note: "cmux 0.64.22 — agent.hook.PostToolUse is not relayed and PreToolUse received/completed pair in ~2 seq while the tool runs, so liveness reads the turn boundary (agent.hook.Stop); Notification arrives after Stop; cmux events keeps streaming past --limit so it must be read line-wise; rpc mobile.workspace.list exposes current_directory/last_activity_at/preview."
 ---
 
 # cmux-delegate
@@ -420,6 +420,51 @@ REPORT="$(sh "$ARP" "{cwd}")"
   || { echo "미완료: 보고서의 worktree 가 $WORKTREE 와 불일치"; exit 1; }
 ```
 
+**보고서가 없으면 거기서 멈추지 말고 이유를 묻습니다.** 파일 부재는 네 가지
+서로 다른 상황을 하나로 뭉갠 값이고, 각각 처방이 다릅니다.
+
+```bash
+# Step 5b(기존 세션)로 보냈다면 그 워크스페이스의 디렉터리를 조회합니다.
+# {cwd} 는 위임자가 서 있는 곳이고, --session 으로 잡은 워크스페이스는
+# 대개 다른 곳에 있습니다 — 그 경우 일치하는 워크스페이스가 없어
+# 살아있는 세션이 `crash` 로, 즉 재위임 대상으로 보고됩니다.
+# TARGET 은 `workspace:N` 형태의 ref 입니다. RPC 응답의 `.id` 는 UUID 라
+# 그쪽으로 매칭하면 영원히 빈손입니다 — ref 와 디렉터리를 함께 들고 있는
+# `workspace list --json` 에서 한 번에 읽습니다.
+PROBE_DIR="{cwd}"
+if [ -n "${TARGET:-}" ]; then
+  PROBE_DIR=$(CMUX_QUIET=1 cmux workspace list --json \
+    | jq -r --arg ref "$TARGET" '.workspaces[] | select(.ref == $ref) | .current_directory')
+  [ -n "$PROBE_DIR" ] || { echo "Error: '$TARGET' 의 디렉터리를 찾지 못했습니다"; exit 1; }
+fi
+
+eval "$(sh "${CLAUDE_PLUGIN_ROOT}/skills/cmux-delegate/agent-liveness.sh" "$PROBE_DIR")"
+echo "$state"   # working | idle | waiting-input | crash | unknown
+```
+
+| `state` | 뜻 | 위임자가 할 일 |
+| --- | --- | --- |
+| `working` | 턴 진행 중 (툴 실행 또는 사고) | 기다린다. 재지시는 진행 중인 작업을 버린다 |
+| `idle` | 턴이 끝났는데 보고서가 없다 | 재지시하거나 인수한다. 가장 의심스러운 값 |
+| `waiting-input` | 모달 프롬프트에서 멈춤 | 사람이 그 워크스페이스에서 키를 누른다 |
+| `crash` | cmux 가 응답했고 해당 경로에 워크스페이스가 없음 | 재위임 |
+| `unknown` | 판정 불가 (`reason` 이 어느 쪽인지 말한다: `cmux-unavailable` · `workspace-lookup-failed` · `no-events-in-window`) | 부재를 사망으로 읽지 않는다. 화면을 직접 본다 |
+
+`crash` 와 `unknown/workspace-lookup-failed` 의 경계가 이 표에서 가장 비싼
+지점입니다. `crash` 의 처방은 재위임이므로, 조회가 실패했을 뿐인 경우를 여기로
+넣으면 **살아서 일하고 있는 워커 밑에서 같은 작업이 두 번째로 시작됩니다.**
+그래서 RPC 타임아웃·비정상 종료·깨진 JSON 은 전부 `unknown` 입니다 —
+"워크스페이스가 없다"는 cmux 가 목록을 정상으로 답했을 때만 할 수 있는 말입니다.
+
+출력의 모든 값은 작은따옴표로 감싸집니다. `preview` 가 위임된 에이전트의 답변
+텍스트를 그대로 싣기 때문에, 전개되는 인용으로 내보내면 위임받은 쪽이 위임자
+셸에서 실행될 내용을 고르게 됩니다. `eval` 로 읽는 위 관용구는 그대로 두되,
+`grep`/`sed` 로 직접 파싱한다면 이 따옴표를 벗겨야 합니다.
+
+`working` 과 `idle` 은 턴 경계(`agent.hook.Stop`)로 갈립니다. **툴 실행 중인지
+사고 중인지는 구분되지 않습니다** — `agent.hook.PostToolUse` 가 중계되지 않아
+바깥에서 볼 방법이 없고, 위임자의 처방은 어느 쪽이든 "기다린다"로 같습니다.
+
 읽은 값은 **그대로 믿지 않고** 필드마다 fresh 하게 재확인합니다. 보고서는
 에이전트가 쓴 것이므로 그 자체로는 증거가 아닙니다 — 아래 명령의 출력이
 증거입니다.
@@ -435,9 +480,21 @@ REPORT="$(sh "$ARP" "{cwd}")"
 있으나 push 는 남았다는 뜻이므로, 위임자가 push 를 이어받거나 에이전트에
 재지시합니다.
 
-**커버리지 한계 (명기).** 이 단계는 silence 를 *탐지* 할 뿐 원인을 진단하지
-않습니다 — 세션 crash 인지 장시간 도구 호출 대기인지는 파일 부재만으로
-구분되지 않으며, 그 판별은 이 스킬의 범위 밖입니다.
+**커버리지 한계 (명기).** 위 판정은 워크스페이스 목록과 이벤트 스트림이
+보이는 것까지만 답합니다. 남는 구멍 셋:
+
+- 같은 디렉터리에 워크스페이스가 둘 이상이면 첫 번째 것을 기술합니다.
+  `ambiguous=N` 이 붙으므로 그때는 답을 그대로 믿지 않습니다.
+- 이벤트 보존 창(4096건)을 벗어난 워커는 `unknown` 입니다. 바쁜 호스트에서는
+  몇 분이면 벗어납니다.
+- 폴더 신뢰 다이얼로그의 `preview` 문구는 아직 채집되지 않아,
+  `waiting-input` 이 그 케이스를 잡는지 확인되지 않았습니다.
+- Stop 훅이 `decision: block` 을 내면 턴이 끝나지 않았는데도 `Stop` 이벤트는
+  발생합니다. 중계되는 페이로드는 어느 쪽인지 말하지 않으므로(보존 창의
+  Stop 204건 전수가 `result=acknowledged`·`is_error=null`) 이벤트만으로는
+  구별할 수 없고, 대신 워크스페이스가 30초 이상 조용해야 `idle` 로 갑니다.
+  그 전까지는 `working reason=stop-not-yet-quiet` 입니다 — 끝난 워커를 잠시
+  기다리는 비용이, 일하는 워커에 작업을 두 번 걸치는 비용보다 쌉니다.
 
 ## Error Handling
 
@@ -450,7 +507,7 @@ REPORT="$(sh "$ARP" "{cwd}")"
 | `--session` 매칭 실패 | 사용 가능한 워크스페이스 목록을 보여주고 중단 |
 | `--account` 디렉토리 미존재 | 에러 메시지 출력 후 중단 |
 | distribute 분할 실패 | 분할 불가 시 단일 세션으로 fallback, 유저에게 알림 |
-| 완료 보고서 부재 | **미완료로 취급** — 완료 주장 메시지가 있어도 마찬가지. 에이전트에 재지시하거나 위임자가 인수 |
+| 완료 보고서 부재 | **미완료로 취급** — 완료 주장 메시지가 있어도 마찬가지. 그 다음 `agent-liveness.sh` 로 이유를 판정하고 위 표대로 처방 |
 | 완료 보고서 JSON 파싱 실패 | 미완료로 취급. 파일 내용을 그대로 보여주고 중단 (부분 기록일 수 있으므로 삭제 금지) |
 | 보고서 필드 ↔ 재검증 불일치 | 재검증 출력을 채택하고 보고서 값은 폐기. 어긋난 필드를 사용자에게 명시 |
 
@@ -531,7 +588,7 @@ user: /cmux-delegate "full code review" --model claude:opus --account claude-2
 ## Limitations
 
 - 완료 판정은 완료 보고서 파일로 결정론적이지만, **작업 산출물 자체의 자동 수집은 미지원** → 사용자가 cmux에서 직접 확인
-- silence 는 *탐지* 만 가능하고 원인(세션 crash vs 장시간 도구 대기)은 판별 불가 — 파일 부재만으로는 구분되지 않음
+- silence 의 원인은 `agent-liveness.sh` 로 4분류되지만, **툴 실행 중과 사고 중은 구분 불가** — `agent.hook.PostToolUse` 가 중계되지 않음. 보존 창 밖이면 `unknown`
 - 작업 유형별 템플릿 미지원 → 사용자가 프롬프트에 직접 명시
 - distribute 모드의 자동 분할은 섹션 헤더 기반 — 비정형 프롬프트는 수동 분할 필요
 - **Handoff 합성 품질은 오케스트레이터 대화에 의존** (Step 2.5) — 대화 맥락이 빈약하면 raw git 맥락만 전달되고, fresh-eyes 위임에서는 편향 방지를 위해 의도적으로 최소화됨

--- a/skills/cmux-delegate/agent-liveness.sh
+++ b/skills/cmux-delegate/agent-liveness.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Liveness probe entry point for cmux-delegate (issue #981).
+#
+# Step 7 reads the completion report; this answers the other half — when the
+# report is absent, is the worker dead, blocked on a keypress, or still working?
+# Classification lives in agent_liveness.py. This script exists for one reason:
+# to normalize the argument to the worktree ROOT exactly as agent-report-path.sh
+# does, so the liveness answer and the report lookup are keyed on one identity.
+# Inlining that derivation in both is how one half gets fixed and the two stop
+# agreeing about which worker they are talking about.
+#
+# No state is kept. An earlier draft cached an event cursor here; that was a
+# bug rather than an optimization — see the module docstring's WINDOW DIRECTION
+# note — and removing it took the only writable path with it.
+#
+#   eval "$(sh path/to/agent-liveness.sh "$PWD")"
+#   echo "$state"        # working | idle | waiting-input | crash | unknown
+#
+# Output is `key=value` pairs on one line. Always exits 0 when the arguments
+# are well-formed: an unreachable cmux yields state=unknown, never a failure.
+# A probe that exits non-zero on a host without cmux would turn praxis's
+# host-neutral posture (ARCHITECTURE.md) into a hard cmux dependency.
+
+set -eu
+
+if [ $# -ne 1 ] || [ -z "$1" ]; then
+    echo "usage: agent-liveness.sh <workspace-ref|workspace-uuid|path>" >&2
+    exit 2
+fi
+
+_AL_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# A `workspace:N` ref or a UUID names ONE workspace and is passed through
+# untouched. Only a path needs the worktree-root normalization that
+# agent-report-path.sh also does — and a path is the weak selector, because
+# delegation defaults to the delegator's own directory and so routinely names
+# several workspaces at once. Prefer the ref that Step 5 captured.
+case "$1" in
+    workspace:*)
+        _AL_TARGET="$1"
+        ;;
+    *)
+        _AL_TARGET="$(git -C "$1" rev-parse --show-toplevel 2>/dev/null || printf '%s' "${1%/}")"
+        ;;
+esac
+
+exec python3 "$_AL_DIR/agent_liveness.py" "$_AL_TARGET"

--- a/skills/cmux-delegate/agent_liveness.py
+++ b/skills/cmux-delegate/agent_liveness.py
@@ -1,0 +1,681 @@
+"""Liveness classification for a delegated cmux worker (issue #981).
+
+Step 7 of cmux-delegate judges completion from the report file, which is a
+two-valued oracle: the file is there or it is not. "Not there" covers a worker
+that crashed, one that is thirty seconds into a long tool call, and one sitting
+at a prompt waiting for a keypress — three states that call for three different
+responses. This module supplies the missing axis.
+
+Four states, and the reason each needs its own name:
+
+  working        mid-turn — a tool is running or the model is thinking. Both
+                 look identical from outside and are treated the same by the
+                 delegator (wait), so they are not split.
+  idle           the turn ended and nothing new arrived. For a delegated worker
+                 this is the suspicious one: it was given a task and stopped
+                 without leaving a report.
+  waiting-input  alive but blocked on a keypress (permission prompt, folder
+                 trust dialog)
+  crash          the selector resolved and cmux answered with no workspace
+
+`unknown` is the fail-open value: cmux absent, RPC unreachable, malformed
+output. praxis targets hosts without cmux (ARCHITECTURE.md, host-neutral), and
+a liveness probe that cannot run must never be read as "the worker is dead".
+A lookup that fails is `unknown`, never `crash`: only an answered query that
+came back empty is evidence of death.
+
+IDENTITY IS THE WORKSPACE, NOT THE DIRECTORY. The first design keyed on the
+worktree root, on the premise that a delegated worker has a directory of its
+own. It does not — SKILL.md's dispatch defaults `cwd` to the delegator's own
+`$(pwd)`, so delegator and delegate normally share one path. Measured on this
+host: 18 workspaces at a single repo root, where a path-keyed probe answered
+`{ambiguous: 18, idle_seconds: 10264, state: "working"}` — two fields drawn
+from two different workspaces and a state taken from the prober's own events.
+So a `workspace:N` ref (translated to its id via `cmux workspace list --json`,
+the only surface carrying `ref`) or a raw id is the selector; a path is the
+weak fallback that answers about one of N and says so in `ambiguous`.
+
+Evidence comes from two cmux surfaces:
+
+  cmux rpc mobile.workspace.list   id, current_directory, last_activity_at,
+                                   preview, terminals[].is_ready
+  cmux workspace list --json       ref → id translation (this surface alone
+                                   carries `ref`; the RPC alone carries the rest)
+  cmux events --category agent     turn boundaries
+
+TURN BOUNDARY, NOT TOOL BOUNDARY. The first design read a PreToolUse
+`received` with no matching `completed` as "inside a tool call". That is wrong
+twice over, and both were caught only by watching a real worker:
+
+  1. `agent.hook.PostToolUse` is NOT among the relayed events. Measured over a
+     1500-event sample the relayed set is PreToolUse, Stop, UserPromptSubmit,
+     SessionStart, Notification, PermissionRequest, SubagentStop. With no
+     PostToolUse there is no "tool finished" signal to pair against.
+  2. `received`/`completed` are the start and end of the HOOK DISPATCH, not of
+     the tool. They arrive milliseconds apart — observed as seq 75152/75154
+     while the tool itself (`sleep 50`) had 40 seconds left to run.
+
+What the stream does give is the turn: `Stop` fires when the agent finishes
+its turn. So the newest event decides — `Stop` means idle, anything later than
+the last `Stop` means still working. A worker mid-tool and a worker mid-thought
+are indistinguishable here, and the name says so.
+
+`preview` is the sidebar's notification text, and a blocked Claude Code puts
+its prompt there verbatim ("Claude needs your permission"). That is the only
+signal that separates waiting-input from crash without scraping the screen, so
+the pattern list below is load-bearing; `read-screen` stays available as a
+confirmation path but is not on the hot path.
+
+WINDOW DIRECTION. `--after N --limit M` returns the M events that come *after*
+N, oldest-first — so a cold cursor of 0 returns the oldest slice of the
+retained log, which on a busy host is entirely historical. The first design
+read that empty-of-recent slice as "nothing outstanding" and reported a working
+agent as idle. The window is therefore anchored to the ack frame's `latest_seq`
+and walked backwards, never forwards from 0.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import threading
+import time
+
+# Substrings that mark a worker blocked on a MODAL PROMPT — a dialog that will
+# not clear until someone presses a key. Matched case-insensitively against the
+# workspace `preview` text.
+#
+# "waiting for your input" is deliberately absent. cmux emits it when the agent
+# simply finishes its turn, so matching it collapses two states the delegator
+# treats differently: a modal prompt means go press a key, while a finished
+# turn with no report means re-dispatch or take the work over. Turn ends are
+# `idle`, and only the turn logic decides them.
+# Kept to strings the HOST generates. `preview` carries the agent's own reply
+# text verbatim — observed previews include whole paragraphs of Korean prose —
+# so a marker that plausibly occurs in an ordinary answer ("(y/n)", "do you
+# want to proceed") reports a working agent as blocked. The surviving markers
+# are Claude Code's and cmux's own wording, which an agent has no reason to
+# emit while answering.
+# Each marker is a phrase the HOST emits as a whole, not a fragment that also
+# reads as ordinary prose. `do you trust` and a bare `enter to confirm` were
+# dropped for failing that test: a delegated review answering "Do you trust
+# this refactor?" would be reported as blocked, and a false `waiting-input`
+# spends a person's attention walking to a workspace that wants nothing.
+# `esc to cancel` is carried along with `enter to confirm` for the same reason
+# — the pair is the host's key hint, while the first half alone is a sentence
+# anyone can write.
+# Each entry is a whole observed preview, matched from the START (see
+# `_blocked_on_prompt`). The guessed `trust this folder` was dropped rather
+# than anchored: it was never observed, and under a prefix match it could
+# never fire, so keeping it would read as coverage of the folder-trust dialog
+# that does not exist. The gap is pinned as an xfail test instead.
+_PROMPT_MARKERS = (
+    "claude needs your permission",
+    "enter to confirm · esc to cancel",
+)
+
+# The only events that move the turn. Everything else cmux relays under the
+# `agent` category — Notification, SessionStart, PermissionRequest — is noise
+# for this decision and actively harmful if counted: Notification fires AFTER
+# Stop when the agent goes quiet (measured: Stop at seq 77009, Notification at
+# 77168 for the same idle worker), so a rule that simply reads the newest agent
+# event flips a finished worker back to "working" seconds after it settles.
+#
+# SubagentStop is excluded on the same principle from the other side: a
+# subagent finishing says nothing about whether the main agent's turn is over.
+_TURN_END = "agent.hook.Stop"
+_TURN_EVENTS = (
+    _TURN_END,
+    "agent.hook.PreToolUse",
+    "agent.hook.UserPromptSubmit",
+)
+
+# Selector shapes. `workspace:N` is what `cmux workspace list` prints and what
+# Step 5 captures at delegation time; the UUID is the RPC's own `id` and the
+# key events carry as `workspace_id`.
+_WS_REF_RE = re.compile(r"^workspace:\d+$")
+_UUID_RE = re.compile(r"^[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}$")
+
+_RPC_TIMEOUT_S = 10
+_EVENTS_TIMEOUT_S = 10
+# Once per candidate workspace, so it is kept short — a hung git here would
+# multiply across the list.
+_GIT_TIMEOUT_S = 5
+
+# How long a workspace must be quiet before a turn-ending `Stop` is allowed to
+# mean `idle`.
+#
+# A Stop hook may answer `{"decision": "block"}`, which re-prompts the model —
+# praxis ships several such hooks (`completion-verify`, `strike-counter`,
+# `negative-existence-verdict-gate`, `merge-state-claim-gate`). The Stop EVENT
+# fires either way, and the relayed payload does not say which happened: across
+# 204 Stop events in the retained window, `result` was `acknowledged` and
+# `is_error` was null without exception. So a bare Stop cannot distinguish a
+# finished worker from one that was just sent back to work.
+#
+# `last_activity_at` can, because a re-prompted worker keeps moving. Below the
+# threshold the answer is `working`, which costs a wait; above it, `idle`, which
+# costs a re-dispatch on top of a live session. The two errors are not
+# symmetric, so the ambiguous side is given to the cheap one.
+_IDLE_QUIET_S = 30
+
+# How far back from the stream head to look for this worker's newest event.
+#
+# Sized to cmux's whole retained log rather than to a time budget, because the
+# obvious cheaper signal does not work: `last_activity_at` keeps climbing while
+# a tool runs (measured at 49s into a 50s call), so a busy worker and an idle
+# one are indistinguishable by idle time. The event window is the only
+# discriminator, and a window narrower than retention silently converts "idle"
+# into "unknown" on a chatty host.
+#
+# Past retention cmux no longer holds the answer, and `unknown` is then correct
+# rather than conservative.
+_EVENT_WINDOW = 4096
+_EVENT_LIMIT = 4096
+
+
+def _run(argv: list[str], timeout: int) -> str | None:
+    """stdout of `argv`, or None on any failure. Never raises."""
+    try:
+        proc = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def _normalize(path: str) -> str:
+    """Compare paths by their resolved form.
+
+    /tmp is a symlink to /private/tmp on macOS, and cmux reports the resolved
+    side while a caller standing in /tmp reports the link. Comparing the raw
+    strings finds no workspace and reports a live worker as crashed.
+    """
+    try:
+        return os.path.realpath(path).rstrip("/") or "/"
+    except OSError:
+        return path.rstrip("/") or "/"
+
+
+_ROOT_CACHE: dict[str, str] = {}
+
+
+def _worktree_root(path: str) -> str:
+    """`path` reduced to its git worktree root, or `_normalize(path)`.
+
+    Both sides of the workspace comparison have to be reduced the same way.
+    `agent-liveness.sh` already does this to its argument, so a worker sitting
+    in a SUBDIRECTORY of the worktree — which cmux reports verbatim — fails an
+    exact comparison against the root and reads as `crash`, whose remedy is
+    re-dispatch. Reducing the candidate too is what makes "the same worktree"
+    the thing being compared, rather than "the same string".
+
+    Memoized because the event loop asks this of every relayed event's cwd —
+    up to `_EVENT_LIMIT` of them, nearly all repeats — and an un-memoized
+    subprocess per line would cost more than the whole probe budget.
+    """
+    cached = _ROOT_CACHE.get(path)
+    if cached is not None:
+        return cached
+    out = _run(["git", "-C", path, "rev-parse", "--show-toplevel"], _GIT_TIMEOUT_S)
+    root = out.strip() if out is not None else ""
+    resolved = _normalize(root) if root else _normalize(path)
+    _ROOT_CACHE[path] = resolved
+    return resolved
+
+
+def _all_workspaces() -> list[dict[str, object]] | None:
+    """Every workspace the RPC reports, or None if the lookup itself failed.
+
+    `None` covers an RPC timeout, a non-zero exit, output that is not JSON, and
+    a well-formed object carrying no workspace list — an error envelope or a
+    renamed field is an ANSWER ABOUT SOMETHING ELSE, and reading it as "zero
+    workspaces" reaches `crash`, whose remedy is re-dispatch.
+    """
+    raw = _run(["cmux", "rpc", "mobile.workspace.list"], _RPC_TIMEOUT_S)
+    if raw is None:
+        return None
+    try:
+        payload: object = json.loads(raw)
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    workspaces: object = payload.get("workspaces")
+    if not isinstance(workspaces, list):
+        return None
+    return [ws for ws in workspaces if isinstance(ws, dict)]
+
+
+def _workspaces_for(cwd: str) -> list[dict[str, object]] | None:
+    """Every workspace whose directory (or one of its terminals') is `cwd`.
+
+    Usually one — a delegated worktree is its own path. But nothing stops two
+    workspaces from sitting in the same directory, and then the classification
+    describes whichever one is listed first, which may not be the delegate.
+    The caller is told how many matched rather than being handed a confident
+    answer about the wrong session.
+
+    `None` when the lookup itself failed (RPC timeout, non-zero exit, output
+    that is not the expected JSON) and `[]` only when cmux answered and no
+    workspace matched. Collapsing the two lets a slow or broken RPC read as
+    `crash`, whose documented remedy is re-dispatch — so a live worker would
+    have its work started a second time underneath it.
+    """
+    workspaces = _all_workspaces()
+    if workspaces is None:
+        return None
+
+    target = _worktree_root(cwd)
+    matched: list[dict[str, object]] = []
+    for ws in workspaces:
+        if not isinstance(ws, dict):
+            continue
+        candidates: list[object] = [ws.get("current_directory")]
+        terminals: object = ws.get("terminals")
+        for term in terminals if isinstance(terminals, list) else []:
+            if isinstance(term, dict):
+                candidates.append(term.get("current_directory"))
+        if any(isinstance(c, str) and c and _worktree_root(c) == target for c in candidates):
+            matched.append(ws)
+    return matched
+
+
+def _id_for_ref(ref: str) -> str | None:
+    """The UUID behind a `workspace:N` ref.
+
+    Two surfaces are needed because neither is complete: the RPC carries
+    `preview` / `last_activity_at` / `terminals` but no `ref`, while
+    `workspace list --json` carries `ref` but none of those. Events key on the
+    UUID, so the ref is translated once here.
+    """
+    raw = _run(["cmux", "workspace", "list", "--json"], _RPC_TIMEOUT_S)
+    if raw is None:
+        return None
+    try:
+        payload: object = json.loads(raw)
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    listed: object = payload.get("workspaces")
+    for ws in listed if isinstance(listed, list) else []:
+        if not isinstance(ws, dict):
+            continue
+        if ws.get("ref") == ref:
+            found = ws.get("id")
+            return found if isinstance(found, str) and found else None
+    return None
+
+
+def _workspace_by_id(workspace_id: str) -> dict[str, object] | None:
+    """The RPC entry for one workspace, or None if the lookup failed."""
+    entries = _all_workspaces()
+    if entries is None:
+        return None
+    for ws in entries:
+        if ws.get("id") == workspace_id:
+            return ws
+    return None
+
+
+def _blocked_on_prompt(preview: str | None) -> bool:
+    """Whether `preview` is a modal prompt rather than text mentioning one.
+
+    Anchored at the start, not searched anywhere in the string. A modal prompt
+    takes the preview over; an agent that merely QUOTES the host — "the
+    workspace says Claude needs your permission, so I waited" — is answering,
+    not blocked, and a false `waiting-input` spends a person's walk to a
+    workspace that wants nothing. Round 2 lengthened the markers against this
+    and it did not help: the flaw was where the match was allowed to land, not
+    how long the needle was.
+    """
+    if not preview:
+        return False
+    low = preview.strip().lower().lstrip("*·•- \t")
+    return any(low.startswith(marker) for marker in _PROMPT_MARKERS)
+
+
+def _latest_seq() -> int | None:
+    """The stream's newest sequence, read from the ack frame.
+
+    This is the GLOBAL head and there is no way to ask for a per-category one:
+    `--category agent` is recorded in the ack's `filters` but leaves
+    `latest_seq` untouched (measured — both forms returned 79166 on the same
+    host, seconds apart). So the number handed to `_stream_until` as a stop
+    target is routinely a sequence the agent-filtered stream will never emit,
+    and that reader cannot rely on reaching it. Its wall-clock bound, not this
+    target, is what has to terminate it.
+    """
+    raw = _run(
+        ["cmux", "events", "--after", "0", "--limit", "1", "--no-heartbeat"],
+        _EVENTS_TIMEOUT_S,
+    )
+    if raw is None:
+        return None
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            frame: object = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(frame, dict) or frame.get("type") != "ack":
+            continue
+        resume: object = frame.get("resume")
+        if isinstance(resume, dict):
+            seq = resume.get("latest_seq")
+            if isinstance(seq, int):
+                return seq
+        return None
+    return None
+
+
+def _kill_group(proc: subprocess.Popen[str]) -> None:
+    """SIGKILL the process's whole group, falling back to the process itself."""
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (OSError, ProcessLookupError):
+        try:
+            proc.kill()
+        except OSError:
+            pass
+
+
+def _stream_until(start: int, target: int) -> list[str]:
+    """Replayed event lines from `start`, stopping once `target` is reached.
+
+    `cmux events` does not exit after replaying: it keeps streaming live, so a
+    `--limit` sized for the replay is never reached and the process runs until
+    it is killed. `subprocess.run(timeout=...)` then raises and the caller sees
+    no events at all — which read as "this worker is not running", the exact
+    wrong answer for a worker that is mid-tool.
+
+    So the stream is consumed line by line and stopped at the sequence the ack
+    frame reported as the head. Whatever was collected before the bound is
+    returned rather than discarded: the replay arrives first and in full, so a
+    cut-short read still holds this worker's newest event, and a partial answer
+    beats an empty one.
+
+    The bound is a WATCHDOG, not the in-loop deadline check. `for line in
+    stream` blocks until the next line arrives, so a deadline tested inside the
+    loop is only reached when a line does — and `target` comes from the global
+    head while this stream is filtered to `agent`, so the line that would end
+    the loop is frequently one the stream will never emit (see `_latest_seq`).
+    A timer that kills the process is the only bound that holds when nothing is
+    arriving; the in-loop check stays as the cheap path that stops a stream
+    still producing output.
+    """
+    argv = [
+        "cmux",
+        "events",
+        "--after",
+        str(start),
+        "--category",
+        "agent",
+        "--limit",
+        str(_EVENT_LIMIT),
+        "--no-ack",
+        "--no-heartbeat",
+    ]
+    lines: list[str] = []
+    deadline = time.time() + _EVENTS_TIMEOUT_S
+    proc = None
+    watchdog = None
+    try:
+        proc = subprocess.Popen(
+            argv,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            # Its own process group, so the watchdog can take the whole tree.
+            start_new_session=True,
+        )
+        # What unblocks the read below is the pipe's write end closing, and
+        # `proc.kill()` alone does not guarantee that: a child of the spawned
+        # process inherits that fd and holds it open after its parent dies, so
+        # the reader waits out the child instead of the deadline. Measured — a
+        # `sh -c 'printf …; sleep 30'` stand-in ran the full 30s under a
+        # kill-the-parent watchdog with the timeout set to 2s. Signalling the
+        # group is what closes every copy. Daemon so a stuck probe cannot hold
+        # up interpreter exit.
+        watchdog = threading.Timer(_EVENTS_TIMEOUT_S, _kill_group, args=(proc,))
+        watchdog.daemon = True
+        watchdog.start()
+        stream = proc.stdout
+        if stream is None:
+            return lines
+        for line in stream:
+            lines.append(line)
+            if time.time() > deadline:
+                break
+            seq = _seq_of(line)
+            if seq is not None and seq >= target:
+                break
+    except (OSError, ValueError):
+        return lines
+    finally:
+        if watchdog is not None:
+            watchdog.cancel()
+        if proc is not None:
+            _kill_group(proc)
+            try:
+                _ = proc.wait(timeout=2)
+            except subprocess.SubprocessError:
+                pass
+    return lines
+
+
+def _seq_of(line: str) -> int | None:
+    try:
+        frame: object = json.loads(line)
+    except ValueError:
+        return None
+    if not isinstance(frame, dict):
+        return None
+    seq = frame.get("seq")
+    return seq if isinstance(seq, int) else None
+
+
+def _turn_state(workspace_id: str) -> str:
+    """`working`, `idle`, or `no-events` for one workspace.
+
+    The newest agent event carrying this `workspace_id` decides:
+    `agent.hook.Stop` is the turn boundary, so it means idle, and anything
+    newer than it means the agent is still mid-turn. `SubagentStop` is
+    deliberately not a boundary — a subagent finishing says nothing about
+    whether the main agent is done.
+
+    Keyed on the workspace, NOT on `cwd`. Delegation defaults to the
+    delegator's own directory (`cwd = args.cwd || $(pwd)`), so a cwd filter
+    admits the delegator's events alongside the delegate's — including the
+    events of the probe making this very call, which then become the newest
+    and report every delegate as `working`. Measured on this host: 18
+    workspaces sharing one directory. The event's top-level `workspace_id` is
+    the same UUID the RPC lists as `id`, so the two surfaces join cleanly.
+    """
+    latest = _latest_seq()
+    if latest is None:
+        return "no-events"
+
+    # Anchored backwards from the head, every call. A remembered cursor was the
+    # first design and it is actively wrong here: this reads the worker's
+    # NEWEST event, so a cursor sitting past that event hides it and the answer
+    # flips to "no events". There is no incremental version of "what is the
+    # latest thing that happened".
+    start = max(0, latest - _EVENT_WINDOW)
+
+    newest_seq = -1
+    newest_name = ""
+    for line in _stream_until(start, latest):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event: object = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        if event.get("workspace_id") != workspace_id:
+            continue
+        name = event.get("name")
+        if not isinstance(name, str) or name not in _TURN_EVENTS:
+            continue
+        seq = event.get("seq")
+        if not isinstance(seq, int) or seq <= newest_seq:
+            continue
+        newest_seq = seq
+        newest_name = name
+
+    if newest_seq < 0:
+        return "no-events"
+    return "idle" if newest_name == _TURN_END else "working"
+
+
+def _select(selector: str) -> tuple[dict[str, object] | None, str, int]:
+    """Resolve a selector to one workspace.
+
+    Returns `(workspace, failure_reason, ambiguous_count)`. Three selector
+    forms, in descending order of how much they can be trusted:
+
+      `workspace:N`   a cmux ref — exact, and what Step 5 hands out
+      a UUID          the RPC's own `id` — exact
+      a path          the fallback, and the WEAK one: delegation defaults to
+                      the delegator's directory, so a path routinely names
+                      several workspaces at once
+
+    The path form still answers, because a delegator that never captured a ref
+    has nothing else, but it reports `ambiguous` so the caller knows the answer
+    describes one of N rather than the one it asked about.
+    """
+    if _WS_REF_RE.match(selector):
+        workspace_id = _id_for_ref(selector)
+        if workspace_id is None:
+            return None, "workspace-ref-not-found", 0
+        found = _workspace_by_id(workspace_id)
+        return (found, "" if found else "workspace-lookup-failed", 0)
+
+    if _UUID_RE.match(selector):
+        entries = _all_workspaces()
+        if entries is None:
+            return None, "workspace-lookup-failed", 0
+        for ws in entries:
+            if ws.get("id") == selector:
+                return ws, "", 0
+        return None, "no-workspace", 0
+
+    matched = _workspaces_for(selector)
+    if matched is None:
+        return None, "workspace-lookup-failed", 0
+    if not matched:
+        return None, "no-workspace", 0
+    return matched[0], "", len(matched)
+
+
+def classify(selector: str) -> dict[str, object]:
+    """Classify one worker, named by `workspace:N` ref, UUID, or path.
+
+    Never raises.
+    """
+    if _run(["cmux", "capabilities"], _RPC_TIMEOUT_S) is None:
+        return {"state": "unknown", "reason": "cmux-unavailable"}
+
+    workspace, failure, ambiguous = _select(selector)
+    if workspace is None:
+        # `no-workspace` is the only one of these that means the worker is
+        # gone. The rest are lookup failures, and `crash` prescribes
+        # re-dispatch — which would start the work a second time underneath a
+        # worker that is very likely still running.
+        if failure == "no-workspace":
+            return {"state": "crash", "reason": "no-workspace"}
+        return {"state": "unknown", "reason": failure or "workspace-lookup-failed"}
+
+    workspace_id = workspace.get("id")
+    if not isinstance(workspace_id, str) or not workspace_id:
+        return {"state": "unknown", "reason": "workspace-has-no-id"}
+
+    result: dict[str, object] = {"workspace": workspace_id}
+    if ambiguous > 1:
+        result["ambiguous"] = ambiguous
+    last_activity = workspace.get("last_activity_at")
+    if isinstance(last_activity, (int, float)):
+        result["idle_seconds"] = int(max(0.0, time.time() - float(last_activity)))
+
+    preview = workspace.get("preview")
+    if _blocked_on_prompt(preview if isinstance(preview, str) else None):
+        result["state"] = "waiting-input"
+        result["preview"] = preview
+        return result
+
+    turn = _turn_state(workspace_id)
+    if turn == "idle":
+        quiet = result.get("idle_seconds")
+        if not isinstance(quiet, int) or quiet < _IDLE_QUIET_S:
+            # Stop fired, but the workspace is still moving — which is what a
+            # blocked Stop looks like from out here. Hold at `working` until it
+            # goes quiet; see `_IDLE_QUIET_S`.
+            result["state"] = "working"
+            result["reason"] = "stop-not-yet-quiet"
+            return result
+    if turn == "no-events":
+        # The workspace exists and is not prompting, but this worker has left
+        # no trace in the retained window. That is not a state — it is the
+        # absence of evidence, and calling it `idle` would licence a re-dispatch
+        # against a worker that may be working.
+        result["state"] = "unknown"
+        result["reason"] = "no-events-in-window"
+        return result
+
+    result["state"] = turn
+    return result
+
+
+def _shell_quote(value: str) -> str:
+    """POSIX single-quoting: close, escape, reopen for an embedded quote."""
+    return "'" + value.replace("'", "'\\''") + "'"
+
+
+def _format(result: dict[str, object]) -> str:
+    """Render as `key=value` pairs — the shape shell callers can read with
+    `case`/`grep` without pulling in a JSON parser.
+
+    Single quotes, always, even where the value looks inert. `preview` carries
+    the delegated agent's own text verbatim, so under the documented
+    `eval "$(...)"` a double-quoted value runs any `$(...)` or backtick in that
+    text inside the DELEGATOR's shell — the delegate would be choosing what the
+    delegator executes. Single quotes suppress every expansion, and quoting
+    unconditionally keeps that from depending on a per-value judgement about
+    which characters are dangerous.
+    """
+    parts = []
+    for key in ("state", "reason", "workspace", "ambiguous", "idle_seconds", "preview"):
+        if key not in result:
+            continue
+        value = str(result[key]).replace("\n", " ").strip()
+        parts.append(f"{key}={_shell_quote(value)}")
+    return " ".join(parts)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: agent_liveness.py <path-inside-worktree>", file=sys.stderr)
+        return 2
+    print(_format(classify(argv[1])))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_agent_liveness.py
+++ b/tests/test_agent_liveness.py
@@ -1,0 +1,591 @@
+"""tests/test_agent_liveness.py — delegated-worker liveness classification (#981).
+
+Every fixture here is TRANSCRIBED from a live cmux 0.64.22 session recorded
+while building the classifier, not composed against the code. That matters more
+than usual: three of the defects these tests pin were invisible to reasoning
+about the payload shape and only appeared when a real worker was watched.
+
+  1. `agent.hook.PostToolUse` is never relayed, and `received`/`completed` are
+     the hook dispatch's own boundaries — they pair milliseconds apart while
+     the tool keeps running. Anything reading them as a tool boundary reports
+     a busy worker as free.
+  2. `agent.hook.Notification` arrives AFTER `Stop` when a worker settles, so
+     "newest agent event" flips a finished worker back to working.
+  3. `preview` carries the agent's own reply text, so prompt detection keyed on
+     conversational phrasing fires on ordinary answers.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import time
+
+import pytest
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_MODULE_PATH = _ROOT / "skills" / "cmux-delegate" / "agent_liveness.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("agent_liveness", _MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["agent_liveness"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+liveness = _load()
+
+
+# --- transcribed fixtures ---------------------------------------------------
+
+# `cmux rpc mobile.workspace.list`, trimmed to the fields the classifier reads.
+WORKSPACE_LIST = json.dumps(
+    {
+        "groups": [],
+        "workspaces": [
+            {
+                "id": "461FB6D2-6A13-455B-8A79-3F3EB890B42D",
+                "current_directory": "/private/tmp/praxis-981-probe3",
+                "last_activity_at": 1786610431.614037,
+                "preview": None,
+                "terminals": [
+                    {
+                        "id": "BD214FD2-48D1-488C-97AC-3E39C9DA4632",
+                        "current_directory": "/private/tmp/praxis-981-probe3",
+                        "is_ready": True,
+                    }
+                ],
+            },
+            {
+                "id": "8C5566DA-4DC6-4C8C-998B-83D1DC98352C",
+                "current_directory": "/private/tmp/praxis-981-blocked",
+                "last_activity_at": 1786610431.614037,
+                "preview": "Claude needs your permission",
+                "terminals": [],
+            },
+            # A sibling sharing probe3's directory and prompting for nothing —
+            # the ordinary case the default delegation produces.
+            {
+                "id": "C7A1E9F0-1111-4222-8333-444455556666",
+                "current_directory": "/private/tmp/praxis-981-probe3",
+                "last_activity_at": 1786610431.614037,
+                "preview": None,
+                "terminals": [],
+            },
+        ],
+    }
+)
+
+# `cmux events --category agent`, probe3's tail. Stop at 77025/77027, then
+# SubagentStop, then Notification — the ordering that broke the first rule.
+_CWD = "/private/tmp/praxis-981-probe3"
+
+
+_WS_ID = "461FB6D2-6A13-455B-8A79-3F3EB890B42D"
+_BLOCKED_WS_ID = "8C5566DA-4DC6-4C8C-998B-83D1DC98352C"
+_SIBLING_WS_ID = "C7A1E9F0-1111-4222-8333-444455556666"
+
+
+def _event(seq: int, name: str, phase: str, workspace_id: str = _WS_ID) -> str:
+    """One relayed agent event.
+
+    `workspace_id` is the top-level field the classifier keys on — measured to
+    be the same UUID the RPC lists as `id`. `payload.cwd` is deliberately left
+    identical across workspaces here, because that is the real situation: the
+    default delegation opens the delegate in the delegator's own directory.
+    """
+    return json.dumps(
+        {
+            "type": "event",
+            "seq": seq,
+            "name": name,
+            "category": "agent",
+            "workspace_id": workspace_id,
+            "payload": {"cwd": _CWD, "phase": phase, "tool_name": None},
+        }
+    )
+
+
+IDLE_TAIL = [
+    _event(77009, "agent.hook.Stop", "received"),
+    _event(77011, "agent.hook.Stop", "completed"),
+    _event(77055, "agent.hook.SubagentStop", "received"),
+    _event(77168, "agent.hook.Notification", "received"),
+    _event(77174, "agent.hook.Notification", "completed"),
+]
+
+WORKING_TAIL = [
+    _event(75099, "agent.hook.UserPromptSubmit", "received"),
+    _event(75152, "agent.hook.PreToolUse", "received"),
+    # The pair that closes milliseconds later while the tool still runs.
+    _event(75154, "agent.hook.PreToolUse", "completed"),
+]
+
+
+@pytest.fixture
+def stub(monkeypatch: pytest.MonkeyPatch):
+    """Wire the two cmux surfaces without touching a real cmux."""
+
+    def _apply(workspace_json: str | None, event_lines: list[str] | None, latest: int = 99999):
+        def fake_run(argv: list[str], timeout: int) -> str | None:
+            if argv[:3] == ["cmux", "rpc", "mobile.workspace.list"]:
+                return workspace_json
+            if argv[:2] == ["cmux", "capabilities"]:
+                return "{}"
+            return None
+
+        monkeypatch.setattr(liveness, "_run", fake_run)
+        monkeypatch.setattr(liveness, "_latest_seq", lambda: latest)
+        monkeypatch.setattr(
+            liveness, "_stream_until", lambda start, target: list(event_lines or [])
+        )
+
+    return _apply
+
+
+# --- prompt markers ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "preview",
+    [
+        # Transcribed from a live workspace's `preview` field.
+        "Claude needs your permission",
+        "Enter to confirm · Esc to cancel",
+    ],
+)
+def test_modal_prompts_are_detected(preview: str) -> None:
+    assert liveness._blocked_on_prompt(preview) is True
+
+
+@pytest.mark.xfail(
+    reason="the folder-trust dialog's preview text has never been captured",
+    strict=True,
+)
+def test_folder_trust_dialog_is_a_known_gap() -> None:
+    """The one modal prompt this detector is not known to catch.
+
+    Its on-screen wording was transcribed — `Quick safety check: Is this a
+    project you created or one you trust?` above `1. Yes, I trust this folder`
+    — but the SCREEN is not the surface this function reads. What cmux puts in
+    `preview` for that dialog was never observed, and it may put nothing at
+    all, in which case no marker list can help and the fallback has to be
+    `read-screen`.
+
+    Guessing a marker from the screen text would make this test pass while
+    proving nothing about the real path, so the gap is pinned as xfail instead:
+    it fails loudly the day someone captures the real preview and adds it.
+    """
+    assert liveness._blocked_on_prompt(
+        "Quick safety check: Is this a project you created or one you trust?"
+    )
+
+
+@pytest.mark.parametrize(
+    "preview",
+    [
+        # Loose connectives an ordinary answer can contain. A false
+        # `waiting-input` sends a person to a workspace that wants nothing, so
+        # a marker has to be a phrase the host emits whole.
+        "Do you trust this refactor? I would not.",
+        "Press Enter to confirm your understanding of the tradeoff",
+        # cmux emits this when a worker merely finishes its turn. Treating it
+        # as a modal prompt collapses `idle` into `waiting-input`, and the two
+        # call for different responses from the delegator.
+        "Claude is waiting for your input",
+        # A real transcribed preview: `preview` is the agent's own reply.
+        "정리됐습니다. 원칙대로 백엔드부터 여는 게 맞고, 바꿔야 할 지점이 코드로 확정됐습니다.",
+        # Prose that an ordinary answer can contain. Markers must not match it.
+        "삭제할까요? (y/n) 형태로 물어보도록 바꾸는 편이 좋겠습니다",
+        "Do you want to proceed with the migration? I would not — here is why.",
+        None,
+        "",
+    ],
+)
+def test_non_modal_text_is_not_a_prompt(preview: str | None) -> None:
+    assert liveness._blocked_on_prompt(preview) is False
+
+
+# --- classification ---------------------------------------------------------
+
+
+def test_missing_workspace_is_crash(stub) -> None:
+    stub(WORKSPACE_LIST, [])
+    assert liveness.classify("/private/tmp/nowhere")["state"] == "crash"
+
+
+def test_modal_prompt_short_circuits_to_waiting_input(stub) -> None:
+    stub(WORKSPACE_LIST, WORKING_TAIL)
+    result = liveness.classify("/private/tmp/praxis-981-blocked")
+    assert result["state"] == "waiting-input"
+    assert result["preview"] == "Claude needs your permission"
+
+
+def test_open_turn_is_working(stub) -> None:
+    stub(WORKSPACE_LIST, WORKING_TAIL)
+    assert liveness.classify(_CWD)["state"] == "working"
+
+
+def test_stop_is_idle_even_when_newer_noise_follows(stub) -> None:
+    """Regression: Notification and SubagentStop arrive after Stop.
+
+    Both are newer than the turn boundary, and both were once read as "still
+    working" — a finished worker flipped back seconds after settling, so the
+    delegator never saw the state that means "it stopped without reporting".
+    """
+    stub(WORKSPACE_LIST, IDLE_TAIL)
+    assert liveness.classify(_CWD)["state"] == "idle"
+
+
+def test_stop_while_still_moving_is_working_not_idle(stub) -> None:
+    """A Stop hook answering `decision: block` re-prompts the model.
+
+    The Stop EVENT fires either way and the relayed payload does not say which
+    — measured, `result` was `acknowledged` and `is_error` null across all 204
+    Stop events in the window. So a Stop on a workspace that is still moving
+    must not be handed the `idle` prescription, which is re-dispatch.
+    """
+    moving = json.loads(WORKSPACE_LIST)
+    moving["workspaces"][0]["last_activity_at"] = time.time() - 1
+    stub(json.dumps(moving), IDLE_TAIL)
+    result = liveness.classify(_CWD)
+    assert result["state"] == "working"
+    assert result["reason"] == "stop-not-yet-quiet"
+
+
+def test_stop_after_the_quiet_window_is_idle(stub) -> None:
+    """The other side: quiet long enough that a re-prompt would have shown."""
+    settled = json.loads(WORKSPACE_LIST)
+    settled["workspaces"][0]["last_activity_at"] = time.time() - (liveness._IDLE_QUIET_S + 5)
+    stub(json.dumps(settled), IDLE_TAIL)
+    assert liveness.classify(_CWD)["state"] == "idle"
+
+
+def test_a_sibling_workspace_in_the_same_directory_does_not_decide_this_one(stub) -> None:
+    """The delegator shares the delegate's directory by default.
+
+    So the sibling's events carry the SAME `payload.cwd` and differ only by
+    `workspace_id` — which is why the cwd filter had to go. Under it, the
+    delegator's own probe activity was the newest event and every finished
+    delegate read as `working`.
+    """
+    sibling = [_event(78000, "agent.hook.PreToolUse", "received", workspace_id=_BLOCKED_WS_ID)]
+    stub(WORKSPACE_LIST, IDLE_TAIL + sibling)
+    assert liveness.classify(_WS_ID)["state"] == "idle"
+
+
+def test_no_events_is_unknown_not_idle(stub) -> None:
+    """Absence of evidence must not licence a re-dispatch.
+
+    The workspace is alive and not prompting, but nothing about this worker is
+    left in the retained window — which is what a busy host looks like once the
+    worker's events age out. Reporting `idle` here would tell the delegator to
+    take over work that may still be running.
+    """
+    stub(WORKSPACE_LIST, [])
+    result = liveness.classify(_CWD)
+    assert result["state"] == "unknown"
+    assert result["reason"] == "no-events-in-window"
+
+
+def test_cmux_absent_is_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    """praxis runs on hosts without cmux; a probe that cannot run is not a death
+    certificate."""
+    monkeypatch.setattr(liveness, "_run", lambda argv, timeout: None)
+    result = liveness.classify(_CWD)
+    assert result["state"] == "unknown"
+    assert result["reason"] == "cmux-unavailable"
+
+
+def test_duplicate_directories_are_reported_not_hidden(stub) -> None:
+    """The count is the whole caveat: the verdict describes one of N.
+
+    The fixture already holds two workspaces at probe3 (the default delegation
+    puts delegator and delegate in one directory), so a third makes 3.
+    """
+    stub(WORKSPACE_LIST, IDLE_TAIL)
+    assert liveness.classify(_CWD)["ambiguous"] == 2
+
+    doubled = json.loads(WORKSPACE_LIST)
+    doubled["workspaces"].append(dict(doubled["workspaces"][0], id="SECOND"))
+    stub(json.dumps(doubled), IDLE_TAIL)
+    assert liveness.classify(_CWD)["ambiguous"] == 3
+
+
+# --- path identity ----------------------------------------------------------
+
+
+# --- selector forms ---------------------------------------------------------
+
+# `cmux workspace list --json` — the only surface carrying `ref`. The RPC has
+# no such field (measured), which is why the ref is translated here first.
+REF_LISTING = json.dumps(
+    {
+        "window_ref": "window:1",
+        "workspaces": [
+            {"ref": "workspace:2", "id": _WS_ID, "title": "[delegate] a"},
+            {"ref": "workspace:3", "id": _SIBLING_WS_ID, "title": "[delegate] b"},
+        ],
+    }
+)
+
+
+@pytest.fixture
+def ref_stub(monkeypatch: pytest.MonkeyPatch):
+    def _apply(event_lines: list[str]):
+        def fake_run(argv: list[str], timeout: int) -> str | None:
+            if argv[:2] == ["cmux", "capabilities"]:
+                return "{}"
+            if argv[:3] == ["cmux", "rpc", "mobile.workspace.list"]:
+                return WORKSPACE_LIST
+            if argv[:4] == ["cmux", "workspace", "list", "--json"]:
+                return REF_LISTING
+            return None
+
+        monkeypatch.setattr(liveness, "_run", fake_run)
+        monkeypatch.setattr(liveness, "_latest_seq", lambda: 99999)
+        monkeypatch.setattr(liveness, "_stream_until", lambda start, target: list(event_lines))
+
+    return _apply
+
+
+def test_a_ref_selects_one_workspace_with_no_ambiguity(ref_stub) -> None:
+    """The whole point of the ref: it names one workspace, not a directory.
+
+    The path form cannot do this — the default delegation puts delegate and
+    delegator in the same directory, so a path answers about one of N.
+    """
+    ref_stub(IDLE_TAIL)
+    result = liveness.classify("workspace:2")
+    assert result["workspace"] == _WS_ID
+    assert "ambiguous" not in result
+    assert result["state"] == "idle"
+
+
+def test_a_ref_reads_only_its_own_workspaces_events(ref_stub) -> None:
+    """Two refs, one event stream, two different answers.
+
+    Both workspaces sit in the same directory, so a path selector would fold
+    them into one verdict; the refs keep them apart.
+    """
+    sibling = [_event(78000, "agent.hook.PreToolUse", "received", workspace_id=_SIBLING_WS_ID)]
+    ref_stub(IDLE_TAIL + sibling)
+    assert liveness.classify("workspace:2")["state"] == "idle"
+    assert liveness.classify("workspace:3")["state"] == "working"
+
+
+def test_an_unknown_ref_is_unknown_not_crash(ref_stub) -> None:
+    """A ref that resolves to nothing is a lookup miss, not a dead worker."""
+    ref_stub(IDLE_TAIL)
+    result = liveness.classify("workspace:999")
+    assert result["state"] == "unknown"
+    assert result["reason"] == "workspace-ref-not-found"
+
+
+def test_a_uuid_selector_skips_the_ref_lookup(stub) -> None:
+    """The RPC id is accepted directly — no `workspace list` call needed."""
+    stub(WORKSPACE_LIST, IDLE_TAIL)
+    result = liveness.classify(_WS_ID)
+    assert result["workspace"] == _WS_ID
+    assert "ambiguous" not in result
+
+
+def test_worker_in_a_subdirectory_is_not_a_crash(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The wrapper reduces its argument to the worktree root; cmux does not.
+
+    A worker standing in `<root>/pkg` is reported there verbatim, so an exact
+    comparison against the root finds nothing and answers `crash` — whose
+    prescription is re-dispatch, against a session that is alive.
+    """
+    root = tmp_path / "repo"
+    (root / "pkg").mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", str(root)], check=True, timeout=30)
+
+    listing = json.dumps(
+        {
+            "workspaces": [
+                {
+                    "id": "W1",
+                    "current_directory": str(root / "pkg"),
+                    "last_activity_at": 0,
+                    "preview": None,
+                    "terminals": [],
+                }
+            ]
+        }
+    )
+
+    real_run = liveness._run
+
+    def fake_run(argv: list[str], timeout: int) -> str | None:
+        if argv[:2] == ["cmux", "capabilities"]:
+            return "{}"
+        if argv[:3] == ["cmux", "rpc", "mobile.workspace.list"]:
+            return listing
+        # `git rev-parse` runs for real — the reduction under test is git's.
+        return real_run(argv, timeout)
+
+    monkeypatch.setattr(liveness, "_run", fake_run)
+    monkeypatch.setattr(liveness, "_ROOT_CACHE", {})
+    monkeypatch.setattr(liveness, "_latest_seq", lambda: None)
+
+    result = liveness.classify(str(root))
+    assert result["state"] != "crash", result
+    assert result.get("workspace") == "W1"
+
+
+def test_symlinked_tmp_matches_resolved_workspace_path(stub) -> None:
+    """cmux reports /private/tmp while a caller standing in /tmp says /tmp.
+
+    Raw string comparison finds no workspace and calls a live worker crashed —
+    on macOS that is every delegation under /tmp.
+    """
+    if not os.path.islink("/tmp"):
+        pytest.skip("/tmp is not a symlink on this host")
+    stub(WORKSPACE_LIST, IDLE_TAIL)
+    assert liveness.classify("/tmp/praxis-981-probe3")["state"] == "idle"
+
+
+# --- output shape -----------------------------------------------------------
+
+
+def test_output_quotes_every_value() -> None:
+    rendered = liveness._format({"state": "waiting-input", "preview": "Claude needs your permission"})
+    assert rendered.startswith("state='waiting-input' ")
+    assert "preview='Claude needs your permission'" in rendered
+
+
+def test_output_keeps_one_line_when_preview_is_multiline() -> None:
+    rendered = liveness._format({"state": "idle", "preview": "line one\nline two"})
+    assert "\n" not in rendered
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        "Claude needs your permission $(id -un)",
+        "Claude needs your permission `id -un`",
+        "it's ${HOME} and \"quoted\"",
+        "close'; id -un; echo '",
+    ],
+)
+def test_eval_of_output_cannot_execute_preview_text(hostile: str) -> None:
+    """The documented caller is `eval "$(agent-liveness.sh …)"`.
+
+    `preview` is the delegated agent's own text, so a shell-expanding encoding
+    lets the DELEGATE choose what runs in the DELEGATOR's shell. The check is
+    end-to-end on purpose: asserting the quoting style would pass on an
+    encoding that quotes and still expands, which is exactly what the
+    double-quoted version did.
+    """
+    rendered = liveness._format({"state": "waiting-input", "preview": hostile})
+    # The rendered text is passed as an ARGUMENT and eval'd from "$1", which is
+    # what `eval "$(script)"` does: command-substitution output reaches eval
+    # unexpanded. Interpolating it into the -c string instead would let the
+    # OUTER quotes expand it before eval ever runs, and the test would then
+    # fail against a correct encoding.
+    round_tripped = subprocess.run(
+        ["sh", "-c", 'eval "$1"; printf %s "$preview"', "sh", rendered],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=True,
+    ).stdout
+    assert round_tripped == hostile
+
+
+# --- failure vs absence -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "rpc_output",
+    [
+        None,
+        "{not json",
+        "[]",
+        # Well-formed JSON objects that carry no workspace list. An error
+        # envelope and a schema rename both land here, and both once read as
+        # "zero workspaces" — one layer past the timeout case above.
+        "{}",
+        '{"error": {"code": 503}}',
+        '{"workspaces": null}',
+        '{"workspaces": "nope"}',
+    ],
+)
+def test_workspace_lookup_failure_is_unknown_not_crash(
+    monkeypatch: pytest.MonkeyPatch, rpc_output: str | None
+) -> None:
+    """`crash` prescribes re-dispatch, so it must not cover a broken lookup.
+
+    A timed-out or malformed `mobile.workspace.list` says nothing about the
+    worker. Reading it as death starts the same task a second time underneath a
+    session that is still running it — the one outcome this probe exists to
+    prevent.
+    """
+
+    def fake_run(argv: list[str], timeout: int) -> str | None:
+        if argv[:2] == ["cmux", "capabilities"]:
+            return "{}"
+        return rpc_output
+
+    monkeypatch.setattr(liveness, "_run", fake_run)
+    result = liveness.classify(_CWD)
+    assert result["state"] == "unknown"
+    assert result["reason"] == "workspace-lookup-failed"
+
+
+def test_genuinely_absent_workspace_is_still_crash(stub) -> None:
+    """The other side of the same split: cmux answered, nothing matched."""
+    stub(WORKSPACE_LIST, [])
+    assert liveness.classify("/private/tmp/nowhere") == {
+        "state": "crash",
+        "reason": "no-workspace",
+    }
+
+
+def test_stream_read_is_bounded_when_the_target_never_arrives(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stop target the stream will never emit must not hang the probe.
+
+    `_latest_seq` reads the GLOBAL head — measured, `--category agent` leaves
+    `latest_seq` unchanged — while this stream is agent-filtered, so the target
+    is routinely a sequence no line here will carry. Without a watchdog the
+    `for line in stream` blocks forever and the in-loop deadline, which only
+    runs after a line arrives, never gets to fire.
+    """
+    monkeypatch.setattr(liveness, "_EVENTS_TIMEOUT_S", 2)
+    started = time.monotonic()
+    original_popen = subprocess.Popen
+
+    # Emits one line, then holds the pipe open saying nothing — a live stream
+    # whose next agent event is not coming.
+
+    # `sh` forks for `sleep` rather than exec'ing it, so the grandchild keeps
+    # the pipe's write end open after its parent dies — the exact shape that
+    # defeats a kill-the-parent watchdog.
+    def fake_popen(argv, **kwargs):
+        _ = argv
+        _ = kwargs
+        return original_popen(
+            ["sh", "-c", 'printf \'{"seq":1}\\n\'; sleep 30'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            start_new_session=True,
+        )
+
+    monkeypatch.setattr(liveness.subprocess, "Popen", fake_popen)
+    lines = liveness._stream_until(0, 999999)
+    elapsed = time.monotonic() - started
+    assert elapsed < 10, f"probe did not terminate promptly: {elapsed:.1f}s"
+    assert lines, "the line delivered before the block should still be returned"

--- a/tests/test_agent_report_handoff.sh
+++ b/tests/test_agent_report_handoff.sh
@@ -147,6 +147,50 @@ assert_present \
   "a failed lookup is not allowed to read as death" \
   "부재를 사망으로 읽지 않는다"
 
+# The selector is stashed at Step 5 rather than re-derived at Step 7, because
+# neither re-derivation path is sound: `short_task` is truncated to 30 chars so
+# titles collide, and `--session` never creates a titled workspace at all.
+# Pinned here because both halves live in one file and a title-lookup rewrite
+# would silently reopen the gap.
+
+assert_present \
+  "Step 7 reads the selectors Step 5 stashed" \
+  "find /tmp/ -maxdepth 1 -name 'cmux-delegate-{timestamp}-*.ws'"
+
+assert_present \
+  "the new-session path stashes one file per workspace" \
+  'echo "$WS_ID" > "/tmp/cmux-delegate-{timestamp}-${WS_REF#workspace:}.ws"'
+
+assert_present \
+  "the existing-session path stashes it the same way" \
+  'echo "$WS_ID" > "/tmp/cmux-delegate-{timestamp}-${TARGET#workspace:}.ws"'
+
+# A failed lookup still lets `head` succeed, so redirecting the pipeline itself
+# leaves a zero-byte file — which the consumer would read as "a worker exists"
+# and then probe with an empty argument, getting usage/rc=2 and no state.
+assert_present \
+  "the stash is gated on a non-empty lookup" \
+  'if [ -n "$WS_ID" ]; then'
+
+assert_present \
+  "the consumer skips an empty stash instead of counting it" \
+  '[ -s "$WS_FILE" ] || { echo "$WS_FILE 비어 있음 — 건너뜀"; continue; }'
+
+assert_present \
+  "state is reset per iteration so one worker cannot inherit another's verdict" \
+  "직전 워커의 값"
+
+# `/tmp` is a symlink to `private/tmp` on macOS, so a bare `find /tmp` returns
+# nothing whether or not the files exist — a dead oracle that reads as "no
+# workers to check". The trailing slash is what makes find follow it.
+assert_present \
+  "the trailing slash that keeps find from silently finding nothing is explained" \
+  "find 는 기본적으로 링크를 따라가지 않아"
+
+assert_present \
+  "the reason the title lookup is only a fallback is stated" \
+  "30자 절단이 동명 워크스페이스를"
+
 # ---------------------------------------------------------------------------
 # 5. Error-handling rows for the three failure shapes
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_report_handoff.sh
+++ b/tests/test_agent_report_handoff.sh
@@ -121,16 +121,31 @@ assert_present \
   "정상적인 부분 완료"
 
 # ---------------------------------------------------------------------------
-# 4. Honest scope — detection only, not diagnosis (issue #842)
+# 4. Honest scope (issue #842, narrowed by #981)
+#
+# #842 could only DETECT silence, so it declared the cause out of scope
+# entirely. #981 classifies that cause, which retires the blanket disclaimer —
+# but not the honesty requirement behind it. What remains uncertain has to stay
+# on the page, so these assertions now pin the narrower limits rather than the
+# retired sentence: the two states the stream cannot separate, and the value
+# that means "no answer" instead of "dead".
 # ---------------------------------------------------------------------------
 
 assert_present \
-  "silence cause is declared out of scope" \
-  "silence 를 *탐지* 할 뿐 원인을 진단하지"
+  "tool-execution and thinking are declared indistinguishable" \
+  "툴 실행 중인지"
+
+assert_present \
+  "the reason PostToolUse cannot close that gap is stated" \
+  "agent.hook.PostToolUse\` 가 중계되지 않아"
 
 assert_present \
   "limitation restated in the Limitations section" \
-  "silence 는 *탐지* 만 가능하고"
+  "툴 실행 중과 사고 중은 구분 불가"
+
+assert_present \
+  "a failed lookup is not allowed to read as death" \
+  "부재를 사망으로 읽지 않는다"
 
 # ---------------------------------------------------------------------------
 # 5. Error-handling rows for the three failure shapes


### PR DESCRIPTION
## 배경

Step 7 의 완료 판정은 보고서 파일 유무라는 2치 오라클입니다. "없음" 이 크래시,
장기 툴 실행, 키 입력 대기(권한 프롬프트·폴더 신뢰 다이얼로그)를 한 값으로
뭉개는데, 세 상황의 처방은 각각 재위임 / 대기 / 사람 호출로 전부 다릅니다.
이 PR 이 그 빠진 축을 채웁니다.

Closes #981

## 무엇이 바뀌나

`agent_liveness.py` 가 워크스페이스 목록과 이벤트 스트림을 읽어
`working | idle | waiting-input | crash` 를 판정하고, cmux 가 없거나 조회가
실패하면 `unknown` 으로 fail-open 합니다. praxis 는 host-neutral 이고
(ARCHITECTURE.md), 못 돈 프로브는 사망 진단서가 아닙니다. `crash` 는 cmux 가
목록을 정상으로 응답했는데 비었을 때만 나옵니다 — 처방이 재위임이라, 조회
실패를 여기 넣으면 살아서 일하는 워커 밑에서 같은 작업이 두 번 시작됩니다.

Step 7 은 Step 5 가 박제해 둔 워크스페이스 UUID 로 그 판정을 부릅니다.

## 설계상 중요한 두 가지

**식별 키는 경로가 아니라 workspace id 입니다.** 위임 기본값이 `args.cwd || $(pwd)`
라 위임된 워크스페이스가 위임자와 같은 디렉터리에 열립니다. 실측으로 한 저장소
루트에 워크스페이스 18개가 있었고, 경로로 조회하면 이 프로브를 실행하는 위임자
자신의 이벤트가 최신이 되어 **끝난 워커도 `working`** 으로 읽혔습니다. 경로는
약한 폴백으로만 남기고 `ambiguous=N` 으로 자백합니다.

**턴 경계이지 툴 경계가 아닙니다.** `agent.hook.PostToolUse` 는 중계되지 않고
(보존 창 실측 기준 중계 집합은 PreToolUse·Stop·UserPromptSubmit·SessionStart·
Notification·PermissionRequest·SubagentStop), `received`/`completed` 는 훅
디스패치의 시작·끝이라 밀리초 간격입니다. 그래서 툴 실행 중과 사고 중은
구분되지 않으며, 위임자의 처방이 어느 쪽이든 "기다린다"로 같아 한 값으로 둡니다.

## 알려진 한계 (문서에 명기)

- 이벤트 보존 창(4096건)을 벗어난 워커는 `unknown` — 바쁜 호스트에서는 몇 분
- 폴더 신뢰 다이얼로그의 `preview` 문구 미채집 (테스트에 `xfail` 로 고정)
- `agent-report-path.sh` 는 여전히 워크트리 경로 해시라 distribute 모드 N개
  워커가 보고서 파일 하나를 공유 (#903 선존, 이 PR 범위 밖)