### PR TITLE
fix(cmux-delegate): pass the claude prompt over argv, not stdin

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,6 +49,13 @@ Skills that dispatch external CLI workers (`cmux-delegate`) can route tasks to m
 
 All providers share the same completion sentinel: `; echo '===WORKER_DONE===' >> $LOG` appended after the CLI exits.
 
+The `claude` row's stdin column carries a precondition the command does not state:
+`claude --help` says the trust dialog is skipped "via `-p`, or when stdout is not a
+TTY". Neither is guaranteed by the row itself, so **a caller that runs it with
+stdout inherited from a terminal loses the exemption, and the piped prompt is
+consumed exactly as in the interactive case below.** Using the stdin column
+obliges the caller to supply one of the two — redirect stdout, or add `-p`.
+
 **Interactive launches do not use the stdin column (#981).** The table above is the
 *non-interactive* contract, and it is safe precisely because it is non-interactive:
 Claude Code skips its workspace trust dialog when stdout is not a TTY. A launch into

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,6 +49,25 @@ Skills that dispatch external CLI workers (`cmux-delegate`) can route tasks to m
 
 All providers share the same completion sentinel: `; echo '===WORKER_DONE===' >> $LOG` appended after the CLI exits.
 
+**Interactive launches do not use the stdin column (#981).** The table above is the
+*non-interactive* contract, and it is safe precisely because it is non-interactive:
+Claude Code skips its workspace trust dialog when stdout is not a TTY. A launch into
+a real terminal — `cmux new-workspace --command` is the one in this repo — gets no
+such exemption, and that dialog **consumes piped stdin**, silently swallowing the
+prompt and leaving an idle worker. Interactive launches therefore pass the prompt as
+a positional argument read from the same file:
+
+| Provider | Interactive command | Trust dialog eats stdin? |
+| ---------- | --------------------- | -------------------------- |
+| `claude` | `claude --model {m} --permission-mode {p} "$(cat $F)"` | Yes — hence argv |
+| `codex` | unchanged (`cat $F \| codex exec`) | Unverified — not probed |
+| `gemini` | unchanged (`gemini -p "$(cat $F)"`) | N/A — already argv |
+
+The prompt still lives in a file in every row; what changes is how it reaches the
+process. Reading it into argv is not the inline-`-p` that `cmux-delegate` forbids —
+that prohibition is about embedding prompt *text* in the command, and the `gemini`
+row has always been argv-shaped.
+
 ### Model Notation
 
 Unified `--model` flag across all skills: `<provider>:<model>` or bare model name.

--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -286,9 +286,14 @@ Report results in Korean.
 PROMPT_FILE="/tmp/cmux-delegate-{timestamp}.md"
 SCRIPT_FILE="/tmp/cmux-delegate-{timestamp}.sh"
 
-# argv 로 넘길 수 있는 상한. ARG_MAX 는 실측 1048576 이고 환경변수도 그 예산을
-# 나눠 쓰므로 넉넉히 아래로 잡습니다. 실제 위임 프롬프트는 5~16KB 였습니다.
-ARGV_LIMIT=262144
+# argv 로 넘길 수 있는 상한. 구속하는 것은 총 ARG_MAX 가 아니라 **인자 하나**의
+# 상한입니다 — Linux 는 MAX_ARG_STRLEN = 32 페이지로 문자열 하나를 자릅니다
+# (execve(2), 2.6.25+). 4KiB 페이지에서 131072 이므로 고정 리터럴 262144 는
+# 그 호스트에서 조용히 넘어섭니다. praxis 는 host-neutral 이라 값을 박지 않고
+# 페이지 크기에서 도출하고, 한 페이지를 여유로 뺍니다(NUL·포인터 부기 몫).
+# 실제 위임 프롬프트는 5~16KB 라 어느 호스트에서도 여유가 큽니다.
+_PAGE=$(getconf PAGE_SIZE 2>/dev/null || echo 4096)
+ARGV_LIMIT=$(( 32 * _PAGE - _PAGE ))
 
 # Cleanup: .sh만 삭제. .md는 보존 (다른 워크스페이스가 참조할 수 있음)
 trap 'rm -f "$SCRIPT_FILE"' EXIT

--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -292,8 +292,17 @@ SCRIPT_FILE="/tmp/cmux-delegate-{timestamp}.sh"
 # 그 호스트에서 조용히 넘어섭니다. praxis 는 host-neutral 이라 값을 박지 않고
 # 페이지 크기에서 도출하고, 한 페이지를 여유로 뺍니다(NUL·포인터 부기 몫).
 # 실제 위임 프롬프트는 5~16KB 라 어느 호스트에서도 여유가 큽니다.
+#
+# 상한은 둘이고 더 작은 쪽이 구속합니다. 하나는 위의 인자별 상한, 다른 하나는
+# 인자와 환경변수가 함께 쓰는 총 ARG_MAX 예산입니다 — POSIX 최소값이 4096 이라
+# 인자별 상한만 보면 총량이 먼저 터지는 호스트를 놓칩니다. 환경변수는 상속되므로
+# 실측해서 빼고, 나머지 옵션 몫으로 64KiB 를 더 남깁니다.
 _PAGE=$(getconf PAGE_SIZE 2>/dev/null || echo 4096)
-ARGV_LIMIT=$(( 32 * _PAGE - _PAGE ))
+_ARG_MAX=$(getconf ARG_MAX 2>/dev/null || echo 4096)
+_ENV_BYTES=$(env | wc -c)
+_PER_STRING=$(( 32 * _PAGE - _PAGE ))
+_TOTAL_BUDGET=$(( _ARG_MAX - _ENV_BYTES - 65536 ))
+ARGV_LIMIT=$(( _PER_STRING < _TOTAL_BUDGET ? _PER_STRING : _TOTAL_BUDGET ))
 
 # Cleanup: .sh만 삭제. .md는 보존 (다른 워크스페이스가 참조할 수 있음)
 trap 'rm -f "$SCRIPT_FILE"' EXIT

--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -367,7 +367,11 @@ Step 7 의 liveness 판정이 `waiting-input` 으로 잡습니다.
 # 기동 전 신뢰 상태를 읽어, 워커가 키 입력을 기다릴 것이면 미리 말합니다.
 # 프롬프트 자체는 argv 로 가므로 유실되지 않습니다 (Step 4) — 이건 대기를
 # 예고하는 것이지 막는 것이 아닙니다.
-eval "$(sh "${CLAUDE_PLUGIN_ROOT}/skills/cmux-delegate/cwd-trust.sh" "{cwd}")"
+#
+# {claude_env} 를 붙이는 것이 필수입니다. --account 는 워커를 다른
+# CLAUDE_CONFIG_DIR 로 보내므로, 프로브가 그걸 빼면 위임자 자신의 설정을 읽고
+# 남의 신뢰 상태를 자신 있게 보고합니다 — 안 묻는 것보다 나쁩니다.
+eval "$({claude_env} sh "${CLAUDE_PLUGIN_ROOT}/skills/cmux-delegate/cwd-trust.sh" "{cwd}")"
 if [ "$trusted" = no ]; then
   echo "주의: {cwd} 는 신뢰되지 않은 경로입니다 (${reason}) — 워커가 신뢰"
   echo "      다이얼로그에서 멈춥니다. cmux 탭에서 한 번 키를 눌러 주세요."

--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -14,6 +14,9 @@ runtime-verified-note: "cmux 0.64.22 — agent.hook.PostToolUse is not relayed a
 
 **Core principles:**
 - 프롬프트는 반드시 파일 기반 전달. 인라인 `-p` 절대 사용 금지 (shell escaping 문제 회피).
+  금지 대상은 **프롬프트 텍스트를 명령문에 박는 것**입니다. 파일에서 읽어
+  `"$(cat "$PROMPT_FILE")"` 한 겹으로 넘기는 것은 파일 기반 전달에 해당하며,
+  `gemini` 분기가 처음부터 그 형태였습니다.
 - 유저가 세션명/계정을 명시하면 글자 그대로 따른다. 자의적 재해석 금지.
 
 ## When to Use
@@ -283,16 +286,32 @@ Report results in Korean.
 PROMPT_FILE="/tmp/cmux-delegate-{timestamp}.md"
 SCRIPT_FILE="/tmp/cmux-delegate-{timestamp}.sh"
 
+# argv 로 넘길 수 있는 상한. ARG_MAX 는 실측 1048576 이고 환경변수도 그 예산을
+# 나눠 쓰므로 넉넉히 아래로 잡습니다. 실제 위임 프롬프트는 5~16KB 였습니다.
+ARGV_LIMIT=262144
+
 # Cleanup: .sh만 삭제. .md는 보존 (다른 워크스페이스가 참조할 수 있음)
 trap 'rm -f "$SCRIPT_FILE"' EXIT
 
 # Provider-specific invocation (from project ARCHITECTURE.md Provider CLI Spec)
 case "{provider}" in
   claude)
-    cat "$PROMPT_FILE" | {claude_env} claude \
-      --model {sub_model} \
-      --permission-mode {permission_mode} \
-      {budget_flag}
+    # 프롬프트는 argv 로 넘깁니다. 파이프로 넘기면 신뢰 다이얼로그가 그걸
+    # 먹어버리고 워커는 빈 REPL 로 떨어집니다 (#981) — 아래 설명 참조.
+    if [ "$(wc -c < "$PROMPT_FILE")" -lt "$ARGV_LIMIT" ]; then
+      {claude_env} claude \
+        --model {sub_model} \
+        --permission-mode {permission_mode} \
+        {budget_flag} \
+        "$(cat "$PROMPT_FILE")"
+    else
+      echo "경고: 프롬프트가 ${ARGV_LIMIT}바이트를 넘어 stdin 으로 넘깁니다 —" >&2
+      echo "      신뢰되지 않은 경로라면 프롬프트가 유실됩니다 (#981)" >&2
+      cat "$PROMPT_FILE" | {claude_env} claude \
+        --model {sub_model} \
+        --permission-mode {permission_mode} \
+        {budget_flag}
+    fi
     ;;
   codex)
     cat "$PROMPT_FILE" | codex exec \
@@ -313,6 +332,24 @@ cmux notify --title "cmux-delegate" --body "Task completed: {short_task}" 2>/dev
 `{claude_env}` is substituted with `CLAUDE_CONFIG_DIR=~/.{account}` when account is specified (claude provider only).
 `{budget_flag}` is substituted with `--max-budget-usd {budget}` when budget is specified (claude provider only — codex/gemini do not support budget limits).
 
+**왜 claude 분기만 argv 인가 (#981).** Claude Code 는 신뢰되지 않은 디렉터리에서
+시작할 때 워크스페이스 신뢰 다이얼로그를 띄우고, **그 다이얼로그가 파이프된 stdin 을
+소비합니다.** 위임 프롬프트가 stdin 으로 들어오면 통째로 사라지고, 워커는 빈 대화형
+REPL 로 떨어져 아무 일도 하지 않습니다 — 위임자에게는 그저 보고서가 없는 것으로만
+보입니다. 위임의 주 사용처가 **새로 만든 worktree** 라 이 경로가 드물지 않습니다.
+
+argv 로 넘기면 다이얼로그는 여전히 뜨지만 프롬프트를 먹지 못하므로, 사람이 키를
+누르는 순간 그대로 진행됩니다. 조용한 유실이 **보이는 대기**로 바뀌고, 그 대기는
+Step 7 의 liveness 판정이 `waiting-input` 으로 잡습니다.
+
+`claude --help` 는 이 다이얼로그가 `-p` 또는 **stdout 이 TTY 가 아닐 때** 건너뛰어진다고
+명시합니다. `ARCHITECTURE.md` 의 비대화형 행이 안전한 이유가 그것이고, cmux 워크스페이스는
+진짜 터미널이라 그 면제를 받지 못합니다.
+
+`gemini` 분기는 이미 `-p "$(cat …)"` 인자 형태라 해당 없습니다. `codex` 분기는
+`cat … | codex exec` 로 같은 파이프 모양이지만, **codex 에 신뢰 프롬프트가 있는지는
+확인하지 않았습니다** — 미확인이므로 이 이슈에서 건드리지 않습니다.
+
 **이 파일도 `Write` 도구로 생성합니다.** 단, 파일 내용 자체에 shell 변수(`$PROMPT_FILE` 등)가 포함되므로 이는 의도된 것입니다 — 중요한 것은 사용자 프롬프트가 이 스크립트를 거치지 않는다는 점입니다.
 
 **CRITICAL — trap에서 .md 파일을 삭제하지 않습니다.** 워크스페이스가 닫힐 때 trap이 실행되는데, 다른 워크스페이스가 동일 .md 파일을 참조할 수 있기 때문입니다 (distribute 모드, 재시도 등).
@@ -322,6 +359,16 @@ cmux notify --title "cmux-delegate" --body "Task completed: {short_task}" 2>/dev
 `--session`이 지정되지 않은 경우:
 
 ```bash
+# 기동 전 신뢰 상태를 읽어, 워커가 키 입력을 기다릴 것이면 미리 말합니다.
+# 프롬프트 자체는 argv 로 가므로 유실되지 않습니다 (Step 4) — 이건 대기를
+# 예고하는 것이지 막는 것이 아닙니다.
+eval "$(sh "${CLAUDE_PLUGIN_ROOT}/skills/cmux-delegate/cwd-trust.sh" "{cwd}")"
+if [ "$trusted" = no ]; then
+  echo "주의: {cwd} 는 신뢰되지 않은 경로입니다 (${reason}) — 워커가 신뢰"
+  echo "      다이얼로그에서 멈춥니다. cmux 탭에서 한 번 키를 눌러 주세요."
+  [ -n "${ancestor:-}" ] && echo "      상위 ${ancestor} 는 신뢰됨 (상속 여부는 미확인)"
+fi
+
 WS_RAW=$(cmux new-workspace \
   --name "[delegate] {short_task}" \
   --cwd "{cwd}" \

--- a/skills/cmux-delegate/cwd-trust.sh
+++ b/skills/cmux-delegate/cwd-trust.sh
@@ -91,11 +91,15 @@ if accepted(target):
     emit(trusted="yes", reason="entry-accepted", config=config, matched=target)
 
 # Nearest accepted ancestor, reported but never substituted for the verdict.
+# `/` is a candidate like any other — dirname("/") is "/", so the walk has to
+# stop on the second visit rather than on arrival, or a root entry is skipped.
 ancestor = None
 walk = os.path.dirname(target)
-while walk and walk != "/":
+while walk:
     if accepted(walk):
         ancestor = walk
+        break
+    if walk == "/":
         break
     walk = os.path.dirname(walk)
 

--- a/skills/cmux-delegate/cwd-trust.sh
+++ b/skills/cmux-delegate/cwd-trust.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+# Workspace-trust lookup for cmux-delegate (issue #981, Work B).
+#
+# Claude Code shows a workspace trust dialog the first time it starts in a
+# directory, and that dialog CONSUMES PIPED STDIN. A delegation whose prompt
+# arrives on stdin therefore loses it silently: the worker lands in an empty
+# REPL and does nothing, while the delegator sees only an absent report. Step 4
+# now hands the prompt over argv so nothing can be eaten, and this script
+# answers the other half — will the worker sit at that dialog waiting for a
+# keypress? Knowing before launch turns a mystery into an expected wait.
+#
+#   eval "$(sh path/to/cwd-trust.sh "$PWD")"
+#   [ "$trusted" = no ] && echo "이 워커는 신뢰 다이얼로그에서 대기합니다"
+#
+# Output is `key=value` pairs on one line, values single-quoted. Exits 0 for
+# well-formed arguments; an unreadable config yields trusted=unknown, never a
+# failure. praxis is host-neutral (ARCHITECTURE.md) and a probe that cannot run
+# must not manufacture an answer.
+#
+# WHICH CONFIG FILE. `CLAUDE_CONFIG_DIR` set → `$CLAUDE_CONFIG_DIR/.claude.json`,
+# otherwise `$HOME/.claude.json`. Measured rather than assumed: on this host
+# `$HOME/.claude.json` carried 43 projects with a same-day mtime while
+# `$HOME/.claude/.claude.json` held 2 and had not moved in eight days, and a
+# per-account dir (`~/.claude-2/.claude.json`) carried its own live 17. The
+# delegator must read the SAME file the worker will, because `--account` sends
+# the worker to a different one — asking the wrong file is worse than not
+# asking, since it answers confidently about someone else's trust state.
+#
+# UNKNOWN IS NOT NO. `no` means "a human will have to press a key", so treating
+# an unreadable config as `no` would attach that warning to every healthy
+# delegation until nobody reads it.
+#
+# CWD OR ANCESTOR — the exact key is UNVERIFIED. The lookup is keyed on the
+# directory as given, and a trusted ancestor is reported separately in
+# `ancestor` rather than folded into the verdict. Whether Claude Code inherits
+# trust from a parent directory was not established: this host has 43 project
+# entries and none is a subdirectory of a repository, which is equally
+# consistent with "trust is inherited" and with "claude was always started at a
+# repository root". Reporting both facts is what keeps an unresolved question
+# from being silently answered by this script's return value.
+
+set -eu
+
+if [ $# -ne 1 ] || [ -z "$1" ]; then
+    echo "usage: cwd-trust.sh <directory>" >&2
+    exit 2
+fi
+
+if [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
+    _CT_CONFIG="$CLAUDE_CONFIG_DIR/.claude.json"
+else
+    _CT_CONFIG="$HOME/.claude.json"
+fi
+
+python3 - "$1" "$_CT_CONFIG" <<'PY'
+import json
+import os
+import sys
+
+
+def quote(value):
+    """POSIX single-quoting: close, escape, reopen for an embedded quote."""
+    return "'" + str(value).replace("'", "'\\''") + "'"
+
+
+def emit(**fields):
+    print(" ".join(f"{k}={quote(v)}" for k, v in fields.items() if v is not None))
+    raise SystemExit(0)
+
+
+target = os.path.realpath(sys.argv[1]).rstrip("/") or "/"
+config = sys.argv[2]
+
+try:
+    with open(config, encoding="utf-8") as handle:
+        projects = json.load(handle).get("projects", {})
+except (OSError, ValueError):
+    # Absent, unreadable, or malformed — all the same answer, and it is not `no`.
+    emit(trusted="unknown", reason="config-unreadable", config=config)
+
+if not isinstance(projects, dict):
+    emit(trusted="unknown", reason="config-shape-unexpected", config=config)
+
+
+def accepted(path):
+    entry = projects.get(path)
+    return isinstance(entry, dict) and entry.get("hasTrustDialogAccepted") is True
+
+
+if accepted(target):
+    emit(trusted="yes", reason="entry-accepted", config=config, matched=target)
+
+# Nearest accepted ancestor, reported but never substituted for the verdict.
+ancestor = None
+walk = os.path.dirname(target)
+while walk and walk != "/":
+    if accepted(walk):
+        ancestor = walk
+        break
+    walk = os.path.dirname(walk)
+
+reason = "entry-declined" if target in projects else "no-entry"
+emit(trusted="no", reason=reason, config=config, ancestor=ancestor)
+PY

--- a/tests/test_cwd_trust.sh
+++ b/tests/test_cwd_trust.sh
@@ -138,6 +138,18 @@ check "the trusted ancestor is surfaced" \
 check "no ancestor is claimed when there is none" \
   "" "$(field ancestor "$UNSEEN" "CLAUDE_CONFIG_DIR=$CONFIG_DIR")"
 
+# `/` is an ancestor of everything, and dirname("/") is "/" — a walk that stops
+# on arrival at the root never tests it, so a root entry goes unreported for
+# every path on the machine.
+ROOT_CFG="$TMP/rootcfg"
+mkdir -p "$ROOT_CFG"
+printf '{"projects": {"/": {"hasTrustDialogAccepted": true}}}' > "$ROOT_CFG/.claude.json"
+check "an accepted root entry is reported as the ancestor" \
+  "/" "$(field ancestor "$UNSEEN" "CLAUDE_CONFIG_DIR=$ROOT_CFG")"
+
+check "the root entry does not silently become the verdict" \
+  "no" "$(field trusted "$UNSEEN" "CLAUDE_CONFIG_DIR=$ROOT_CFG")"
+
 # ---------------------------------------------------------------------------
 # 5. Calling convention
 # ---------------------------------------------------------------------------

--- a/tests/test_cwd_trust.sh
+++ b/tests/test_cwd_trust.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# tests/test_cwd_trust.sh — workspace-trust lookup for cmux-delegate (#981 Work B)
+#
+# Claude Code's trust dialog consumes piped stdin, so a delegation into an
+# untrusted directory loses its prompt and the worker sits in an empty REPL.
+# Step 4 now passes the prompt over argv so nothing can be eaten; this helper
+# answers whether the worker will nonetheless stop at that dialog, so the
+# delegator can say so up front instead of discovering it as silence.
+#
+# Every case runs against a fixture `.claude.json` under a temp dir — the real
+# config is never read, so the result does not drift with the developer's own
+# trust decisions.
+#
+# Run:  bash tests/test_cwd_trust.sh
+# Exit: 0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HELPER="$ROOT_DIR/skills/cmux-delegate/cwd-trust.sh"
+
+# shellcheck source=./_assert_lib.sh
+source "$SCRIPT_DIR/_assert_lib.sh"
+assert_lib_init "$HELPER"
+
+TMP="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
+trap 'rm -rf "$TMP"' EXIT
+
+TRUSTED="$TMP/trusted"
+DECLINED="$TMP/declined"
+UNSEEN="$TMP/unseen"
+CHILD="$TRUSTED/child"
+mkdir -p "$TRUSTED" "$DECLINED" "$UNSEEN" "$CHILD"
+
+# realpath, because the helper resolves its argument and macOS maps /tmp to
+# /private/tmp — comparing against the unresolved form would fail for a reason
+# that has nothing to do with trust.
+r() { python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$1"; }
+
+CONFIG_DIR="$TMP/cfg"
+mkdir -p "$CONFIG_DIR"
+python3 - "$CONFIG_DIR/.claude.json" "$(r "$TRUSTED")" "$(r "$DECLINED")" <<'PY'
+import json, sys
+out, trusted, declined = sys.argv[1:4]
+json.dump({"projects": {
+    trusted: {"hasTrustDialogAccepted": True},
+    declined: {"hasTrustDialogAccepted": False},
+}}, open(out, "w"))
+PY
+
+# Field extractor: the helper emits eval-able `key='value'` pairs, so read them
+# the way the documented caller does rather than by regex.
+field() {  # $1 = key, $2 = directory, $3... = env assignments
+  local key="$1" dir="$2"; shift 2
+  ( eval "$(env "$@" sh "$HELPER" "$dir")"; eval "printf '%s' \"\${$key:-}\"" )
+}
+
+check() {  # $1 = name, $2 = expected, $3 = actual
+  _assert_record "$1" "$([ "$2" = "$3" ] && echo 1 || echo 0)" "expected '$2', got '$3'"
+}
+
+# ---------------------------------------------------------------------------
+# 1. The three verdicts
+# ---------------------------------------------------------------------------
+
+check "accepted entry reads as trusted" \
+  "yes" "$(field trusted "$TRUSTED" "CLAUDE_CONFIG_DIR=$CONFIG_DIR")"
+
+check "declined entry reads as untrusted" \
+  "no" "$(field trusted "$DECLINED" "CLAUDE_CONFIG_DIR=$CONFIG_DIR")"
+
+check "a directory with no entry reads as untrusted" \
+  "no" "$(field trusted "$UNSEEN" "CLAUDE_CONFIG_DIR=$CONFIG_DIR")"
+
+# Declined and never-seen are both `no` but call for different words to the
+# user — one had a dialog answered, the other has never had one.
+check "declined and unseen are distinguishable by reason" \
+  "entry-declined" "$(field reason "$DECLINED" "CLAUDE_CONFIG_DIR=$CONFIG_DIR")"
+
+check "an unseen directory says so" \
+  "no-entry" "$(field reason "$UNSEEN" "CLAUDE_CONFIG_DIR=$CONFIG_DIR")"
+
+# ---------------------------------------------------------------------------
+# 2. Unreadable config is `unknown`, never `no`
+#
+# `no` means "a human will have to press a key". Attaching that to every
+# delegation whose config could not be read is how a warning stops being read.
+# ---------------------------------------------------------------------------
+
+check "a missing config is unknown" \
+  "unknown" "$(field trusted "$TRUSTED" "CLAUDE_CONFIG_DIR=$TMP/nowhere")"
+
+BROKEN="$TMP/broken"
+mkdir -p "$BROKEN"
+printf '{"projects": {' > "$BROKEN/.claude.json"
+check "a malformed config is unknown" \
+  "unknown" "$(field trusted "$TRUSTED" "CLAUDE_CONFIG_DIR=$BROKEN")"
+
+SHAPE="$TMP/shape"
+mkdir -p "$SHAPE"
+printf '{"projects": ["not", "a", "map"]}' > "$SHAPE/.claude.json"
+check "an unexpected config shape is unknown" \
+  "unknown" "$(field trusted "$SHAPE" "CLAUDE_CONFIG_DIR=$SHAPE")"
+
+# ---------------------------------------------------------------------------
+# 3. The account split
+#
+# `--account claude-2` sends the worker to ~/.claude-2/.claude.json. A
+# delegator that reads its own config would answer confidently about someone
+# else's trust state, which is worse than not answering.
+# ---------------------------------------------------------------------------
+
+OTHER="$TMP/other-account"
+mkdir -p "$OTHER"
+printf '{"projects": {}}' > "$OTHER/.claude.json"
+check "the same directory is untrusted under another account" \
+  "no" "$(field trusted "$TRUSTED" "CLAUDE_CONFIG_DIR=$OTHER")"
+
+check "the config actually read is reported" \
+  "$OTHER/.claude.json" "$(field config "$TRUSTED" "CLAUDE_CONFIG_DIR=$OTHER")"
+
+# ---------------------------------------------------------------------------
+# 4. A trusted ancestor is reported, never substituted for the verdict
+#
+# Whether Claude Code inherits trust from a parent directory is UNVERIFIED (see
+# the helper's header). The helper must therefore not answer that question by
+# way of its verdict — it reports the ancestor and leaves the verdict keyed on
+# the directory it was asked about.
+# ---------------------------------------------------------------------------
+
+check "a child of a trusted directory is not silently trusted" \
+  "no" "$(field trusted "$CHILD" "CLAUDE_CONFIG_DIR=$CONFIG_DIR")"
+
+check "the trusted ancestor is surfaced" \
+  "$(r "$TRUSTED")" "$(field ancestor "$CHILD" "CLAUDE_CONFIG_DIR=$CONFIG_DIR")"
+
+check "no ancestor is claimed when there is none" \
+  "" "$(field ancestor "$UNSEEN" "CLAUDE_CONFIG_DIR=$CONFIG_DIR")"
+
+# ---------------------------------------------------------------------------
+# 5. Calling convention
+# ---------------------------------------------------------------------------
+
+env "CLAUDE_CONFIG_DIR=$CONFIG_DIR" sh "$HELPER" "$TRUSTED" >/dev/null 2>&1
+_assert_record "a well-formed call exits 0" "$([ $? -eq 0 ] && echo 1 || echo 0)" \
+  "helper exited non-zero on a valid lookup"
+
+env "CLAUDE_CONFIG_DIR=$TMP/nowhere" sh "$HELPER" "$TRUSTED" >/dev/null 2>&1
+_assert_record "an unreadable config still exits 0" "$([ $? -eq 0 ] && echo 1 || echo 0)" \
+  "a fail-open probe must not fail the caller"
+
+sh "$HELPER" >/dev/null 2>&1
+_assert_record "a missing argument exits 2" "$([ $? -eq 2 ] && echo 1 || echo 0)" \
+  "usage error did not exit 2"
+
+# A value carrying a single quote must not break out of the eval the documented
+# caller performs — the directory name is attacker-adjacent input in the sense
+# that it comes from whatever path the user delegated into.
+QUOTED="$TMP/it's here"
+mkdir -p "$QUOTED"
+check "a quote in the path survives the eval" \
+  "no" "$(field trusted "$QUOTED" "CLAUDE_CONFIG_DIR=$CONFIG_DIR")"
+
+assert_lib_summary

--- a/tests/test_delegate_launch.sh
+++ b/tests/test_delegate_launch.sh
@@ -102,9 +102,16 @@ assert_present \
 # 4. The pre-launch warning
 # ---------------------------------------------------------------------------
 
+# The env prefix is the whole point: --account sends the worker to a different
+# CLAUDE_CONFIG_DIR, and a probe without it reads the delegator's own config and
+# reports someone else's trust state with full confidence.
 assert_present \
-  "Step 5a consults the trust helper before launching" \
-  'sh "${CLAUDE_PLUGIN_ROOT}/skills/cmux-delegate/cwd-trust.sh" "{cwd}"'
+  "Step 5a consults the trust helper under the worker's own account" \
+  'eval "$({claude_env} sh "${CLAUDE_PLUGIN_ROOT}/skills/cmux-delegate/cwd-trust.sh" "{cwd}")"'
+
+assert_absent \
+  "the probe never runs unprefixed" \
+  'eval "$(sh "${CLAUDE_PLUGIN_ROOT}/skills/cmux-delegate/cwd-trust.sh"'
 
 assert_present \
   "the warning tells the human what to do" \

--- a/tests/test_delegate_launch.sh
+++ b/tests/test_delegate_launch.sh
@@ -172,4 +172,15 @@ assert_in_arch \
   "codex is unverified here too" \
   "Unverified — not probed"
 
+# The non-interactive row is safe only under a condition it does not state. Left
+# implicit, a caller reads the row as self-sufficient and reintroduces #981 on
+# the path the table calls safe.
+assert_in_arch \
+  "the stdin column names its precondition" \
+  "carries a precondition the command does not state"
+
+assert_in_arch \
+  "and says who has to satisfy it" \
+  "obliges the caller to supply one of the two"
+
 assert_lib_summary

--- a/tests/test_delegate_launch.sh
+++ b/tests/test_delegate_launch.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# tests/test_delegate_launch.sh — how cmux-delegate hands the prompt over (#981 Work B)
+#
+# The prompt used to arrive on stdin. Claude Code's workspace trust dialog
+# consumes piped stdin, so a delegation into an untrusted directory — which is
+# what a freshly created worktree always is — lost its prompt with no error
+# anywhere: the worker sat in an empty REPL and the delegator saw only a
+# missing report.
+#
+# These are static document checks against SKILL.md and ARCHITECTURE.md. The
+# load-bearing one is the ABSENCE assertion: a future edit that restores the
+# pipe would reopen the defect while every presence check kept passing.
+#
+# Run:  bash tests/test_delegate_launch.sh
+# Exit: 0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL="$ROOT_DIR/skills/cmux-delegate/SKILL.md"
+
+# shellcheck source=./_assert_lib.sh
+source "$SCRIPT_DIR/_assert_lib.sh"
+assert_lib_init "$SKILL"
+
+# ---------------------------------------------------------------------------
+# 1. The claude branch passes the prompt as an argument
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "claude receives the prompt as a positional argument" \
+  '{budget_flag} \ "$(cat "$PROMPT_FILE")"'
+
+assert_present \
+  "the size guard names the limit it enforces" \
+  'if [ "$(wc -c < "$PROMPT_FILE")" -lt "$ARGV_LIMIT" ]; then'
+
+assert_present \
+  "the limit is defined, not implied" \
+  "ARGV_LIMIT=262144"
+
+# Falling back to the pipe is the defect's own path. It may happen — an
+# oversized prompt has nowhere else to go — but it may not happen quietly.
+assert_present \
+  "the stdin fallback announces itself" \
+  "신뢰되지 않은 경로라면 프롬프트가 유실됩니다"
+
+# ---------------------------------------------------------------------------
+# 2. The reason, so the next editor does not undo it
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "the mechanism is stated: the dialog eats stdin" \
+  "그 다이얼로그가 파이프된 stdin 을 소비합니다"
+
+assert_present \
+  "the exemption the interactive path does not get is stated" \
+  "stdout 이 TTY 가 아닐 때** 건너뛰어진다고"
+
+assert_present \
+  "the loss is tied to the liveness verdict that now surfaces it" \
+  "waiting-input"
+
+assert_present \
+  "codex is declared unprobed rather than assumed safe" \
+  "codex 에 신뢰 프롬프트가 있는지는 확인하지 않았습니다"
+
+# ---------------------------------------------------------------------------
+# 3. The file-based principle is clarified, not contradicted
+#
+# The Core principle forbids inline `-p`. Reading a file into argv is not that,
+# and the gemini branch has always been argv-shaped — but a reader who meets
+# only the prohibition will "fix" the claude branch back to a pipe.
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "the prohibition survives" \
+  "인라인 \`-p\` 절대 사용 금지"
+
+assert_present \
+  "what it actually forbids is spelled out" \
+  "프롬프트 텍스트를 명령문에 박는 것"
+
+# ---------------------------------------------------------------------------
+# 4. The pre-launch warning
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "Step 5a consults the trust helper before launching" \
+  'sh "${CLAUDE_PLUGIN_ROOT}/skills/cmux-delegate/cwd-trust.sh" "{cwd}"'
+
+assert_present \
+  "the warning tells the human what to do" \
+  "cmux 탭에서 한 번 키를 눌러 주세요"
+
+assert_present \
+  "ancestor trust is reported as unverified, not as permission" \
+  "상속 여부는 미확인"
+
+# ---------------------------------------------------------------------------
+# 5. The pipe is gone from the claude branch (regression guard)
+#
+# Checked against the raw file rather than the normalized buffer: this is about
+# one exact line, and `assert_absent` over a whole SKILL.md would also match the
+# codex branch and the documented fallback, both of which legitimately pipe.
+# ---------------------------------------------------------------------------
+
+CLAUDE_PIPE_COUNT="$(grep -c 'cat "\$PROMPT_FILE" | {claude_env} claude' "$SKILL")"
+
+# Exactly one: the announced oversize fallback. Two would mean the primary path
+# still pipes; zero would mean the fallback lost its warning-paired invocation.
+_assert_record "the claude branch pipes only on the announced fallback" \
+  "$([ "$CLAUDE_PIPE_COUNT" -eq 1 ] && echo 1 || echo 0)" \
+  "expected exactly 1 piped claude invocation, found $CLAUDE_PIPE_COUNT"
+
+# ---------------------------------------------------------------------------
+# 6. ARCHITECTURE.md carries the same split
+#
+# Checked with a second buffer rather than a second assert_lib_init: that
+# function resets PASS/FAIL/FAILED_NAMES, so re-calling it discards every
+# result above — a failing assertion in §1-§5 would vanish and the file would
+# summarise as green. Measured: FAIL=1 before a re-init, FAIL=0 after.
+# ---------------------------------------------------------------------------
+
+ARCH="$ROOT_DIR/ARCHITECTURE.md"
+[ -f "$ARCH" ] || { echo "FAIL: target not found at $ARCH" >&2; exit 1; }
+
+# Same wrap-insensitive normalization assert_lib_init performs on its target.
+ARCH_NORMALIZED="$(sed -e ':a' -e 'N' -e '$!ba' -e 's/\n[[:blank:]]*/ /g' "$ARCH")"
+
+assert_in_arch() {  # $1 = name, $2 = fixed-string pattern
+  if grep -Fq -- "$2" <<<"$ARCH_NORMALIZED"; then
+    _assert_record "$1" 1 ""
+  else
+    _assert_record "$1" 0 "pattern not found in ARCHITECTURE.md: $2"
+  fi
+}
+
+assert_in_arch \
+  "the SoT distinguishes interactive from non-interactive" \
+  "Interactive launches do not use the stdin column"
+
+assert_in_arch \
+  "the interactive claude row is argv-shaped" \
+  '`claude --model {m} --permission-mode {p} "$(cat $F)"`'
+
+assert_in_arch \
+  "codex is unverified here too" \
+  "Unverified — not probed"
+
+assert_lib_summary

--- a/tests/test_delegate_launch.sh
+++ b/tests/test_delegate_launch.sh
@@ -45,8 +45,19 @@ assert_present \
   "_PAGE=\$(getconf PAGE_SIZE 2>/dev/null || echo 4096)"
 
 assert_present \
-  "the derivation keeps a page of headroom below the per-string cap" \
-  "ARGV_LIMIT=\$(( 32 * _PAGE - _PAGE ))"
+  "the per-string cap keeps a page of headroom" \
+  "_PER_STRING=\$(( 32 * _PAGE - _PAGE ))"
+
+# Two ceilings bind, and only the smaller one matters. Modelling the per-string
+# cap alone misses a host whose total ARG_MAX blows first — POSIX floors it at
+# 4096, far under any per-string figure.
+assert_present \
+  "the total budget subtracts the inherited environment it must share with" \
+  "_TOTAL_BUDGET=\$(( _ARG_MAX - _ENV_BYTES - 65536 ))"
+
+assert_present \
+  "the smaller ceiling wins" \
+  "ARGV_LIMIT=\$(( _PER_STRING < _TOTAL_BUDGET ? _PER_STRING : _TOTAL_BUDGET ))"
 
 assert_present \
   "the binding constraint is named so the next editor does not re-flatten it" \

--- a/tests/test_delegate_launch.sh
+++ b/tests/test_delegate_launch.sh
@@ -36,8 +36,24 @@ assert_present \
   "the size guard names the limit it enforces" \
   'if [ "$(wc -c < "$PROMPT_FILE")" -lt "$ARGV_LIMIT" ]; then'
 
+# The policy, not the number. A literal would encode this host's page size into a
+# file that runs on every host — which is the defect the derivation replaces:
+# Linux caps a single argument at MAX_ARG_STRLEN = 32 pages, so 262144 was under
+# the cap here (16KiB pages) and over it on any 4KiB-page host.
 assert_present \
-  "the limit is defined, not implied" \
+  "the limit is derived from the platform page size" \
+  "_PAGE=\$(getconf PAGE_SIZE 2>/dev/null || echo 4096)"
+
+assert_present \
+  "the derivation keeps a page of headroom below the per-string cap" \
+  "ARGV_LIMIT=\$(( 32 * _PAGE - _PAGE ))"
+
+assert_present \
+  "the binding constraint is named so the next editor does not re-flatten it" \
+  "MAX_ARG_STRLEN = 32"
+
+assert_absent \
+  "no host-specific literal survives" \
   "ARGV_LIMIT=262144"
 
 # Falling back to the pipe is the defect's own path. It may happen — an


### PR DESCRIPTION
### 무엇이 깨져 있었나

`cmux-delegate` 는 위임 프롬프트를 `cat "$PROMPT_FILE" | claude …` 로 넘겼습니다. Claude Code 는 신뢰되지 않은 디렉터리에서 시작하면 워크스페이스 신뢰 다이얼로그를 띄우고, **그 다이얼로그가 파이프된 stdin 을 소비합니다.** 프롬프트는 사라지고 워커는 빈 REPL 로 떨어지며, 어느 쪽에도 에러가 남지 않습니다.

가장 흔한 위임이 정확히 이 경로였습니다 — 새로 만든 worktree 는 정의상 신뢰되지 않은 경로입니다.

`ARCHITECTURE.md` 의 Provider CLI Spec 은 **비대화형** 기동(`--output-format stream-json`)을 기술하고 있었고, 그 경로는 stdout 이 TTY 가 아니라 다이얼로그가 뜨지 않습니다. Step 4 는 cmux 터미널 안에서 **대화형**으로 돕니다. 스펙과 실제 기동이 어긋난 자리가 결함의 자리였습니다.

### 무엇을 바꿨나

- **프롬프트를 argv 로 전달** — 다이얼로그는 여전히 뜨지만 argv 를 먹을 수 없습니다. 사람이 키를 누르면 프롬프트 그대로 진행되고, 그 대기는 Work A(#988)가 `waiting-input` 으로 잡습니다. 조용한 유실이 보이는 대기로 바뀝니다.
- **`cwd-trust.sh` 신규** — 기동 전에 대상 경로의 신뢰 상태를 읽어, 신뢰되지 않았으면 위임자에게 미리 알립니다. `unknown` 은 `no` 로 접지 않습니다 — `no` 의 처방이 "사람을 부르라"이므로, 못 읽은 것을 `no` 로 만들면 멀쩡한 위임마다 거짓 경고가 붙습니다.
- **`ARCHITECTURE.md` 행 분리** — 대화형/비대화형을 합치는 게 아니라 구분을 명시합니다. codex 는 "미확인"으로 기록했습니다(파이프 모양은 같지만 신뢰 프롬프트 유무를 확인하지 않았습니다).

### 택하지 않은 길

`hasTrustDialogAccepted=true` 를 미리 써넣어 다이얼로그 자체를 없애는 방법은 택하지 않았습니다. 스킬이 사용자 전역 설정을 대신 쓰고 신뢰를 대신 부여하는 결정이고, 그 방법이 실제로 다이얼로그를 억제하는지도 미실측입니다.

### 미검증

- **신뢰 키가 cwd 인가 상위 디렉터리인가 — UNKNOWN.** 격리 프로브(임시 `CLAUDE_CONFIG_DIR`)는 인증을 잃어 실행 불가였고, pty 대조군은 타임아웃했습니다. 그래서 헬퍼는 이 질문을 반환값으로 답하지 않고 `ancestor` 를 별도 필드로 보고합니다.
- **실환경 대조쌍 미실행.** 실제 cmux 워크스페이스에서 수정 전/후를 띄워 유실과 도달을 각각 확인하는 작업이 남아 있습니다.

Closes #981

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified interactive and non-interactive provider launch behavior.
  * Documented Claude prompt delivery, workspace trust dialogs, size limits, and fallback warnings.
  * Added guidance for identifying when user input may be required before launching a new session.

* **Enhancements**
  * Improved workspace trust detection, including trusted, declined, unknown, and inherited trust states.
  * Large prompts now use a documented fallback path with warnings when needed.

* **Tests**
  * Added coverage for workspace trust scenarios, configuration errors, safe output handling, and launch documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->