### PR TITLE
docs(architecture): state the stdin column's precondition

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,6 +49,14 @@ Skills that dispatch external CLI workers (`cmux-delegate`) can route tasks to m
 
 All providers share the same completion sentinel: `; echo '===WORKER_DONE===' >> $LOG` appended after the CLI exits.
 
+The `claude` row's stdin column carries a precondition the command does not state.
+`claude --help` says the workspace trust dialog is skipped "via `-p`, or when
+stdout is not a TTY", and that dialog reads stdin — so a caller that runs the row's
+command with stdout inherited from a terminal, in a directory the user has never
+trusted, has a dialog and a piped prompt competing for the same stream. Neither
+exemption is supplied by the row itself. Using the stdin column obliges the caller
+to supply one: redirect stdout, or add `-p`.
+
 ### Model Notation
 
 Unified `--model` flag across all skills: `<provider>:<model>` or bare model name.


### PR DESCRIPTION
### 무엇을

`ARCHITECTURE.md` 의 Provider CLI Spec 에서 `claude` 행의 stdin 열이 기대는 전제를 행 옆에 명시합니다.

`claude --help` 는 워크스페이스 신뢰 다이얼로그가 "`-p` 로 실행되거나 stdout 이 TTY 가 아닐 때" 건너뛰어진다고 적고 있고, 그 다이얼로그는 stdin 을 읽습니다. 표의 명령은 둘 중 어느 것도 담고 있지 않으므로, 신뢰되지 않은 디렉터리에서 터미널 stdout 을 물려받아 실행하면 다이얼로그와 파이프된 프롬프트가 같은 스트림을 두고 경합합니다. 그 조건을 만족시키는 것은 **호출자의 의무**라는 점을 적었습니다.

### 왜 이것만

이 조각은 #989 에서 갈라져 나왔습니다. 그 PR 은 위 경합이 실제로 프롬프트를 잃는다는 전제 위에 기동 방식 변경과 신뢰 판별 헬퍼를 얹었는데, **실환경 대조쌍 4회에서 재현되지 않아** 폐기했습니다 (claude 2.1.232, 신뢰된 상위가 없는 신규 경로 — 빈 디렉터리 · 기동 지연 · git 저장소 · argv 대조군, 전부 프롬프트 도달).

남은 이 문장은 그 반증과 무관합니다 — 관찰된 실패가 아니라 벤더 도움말이 명시하는 조건을 옮긴 것이기 때문입니다. 그래서 `fix` 가 아니라 `docs` 이고, 행 계약을 읽는 자리에 전제를 두는 것 이상을 주장하지 않습니다.

Refs #981