### PR TITLE
feat(orchestrate): add a run/task ledger for delegated work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 | **Full**           | + all cmux-* skills                                      | + cmux                                                      |
 | **Multi-provider** | + codex/gemini routing in cmux-*                         | + codex-cli, gemini-cli                                     |
 
-## Skills (17)
+## Skills (18)
 
 > **Invocation**: praxis entries are *skills*, not subagents. Always call them
 > via `Skill(skill="praxis:<name>")` — `Agent(subagent_type="praxis:<name>")`
@@ -68,6 +68,7 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 | `recover-sessions`      | Bulk recover sessions after power loss (tmux backend)                 |
 | `cmux-session-manager`  | Daily session lifecycle — status dashboard, cleanup, reorganize       |
 | `cmux-delegate`         | Delegate a task to an independent session with auto-collected context |
+| `cmux-orchestrate`      | Group delegated workspaces into a run and answer how far the work got |
 
 ## Hooks
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Development workflow skills for Claude Code — disciplined, fast, resilient.
 | `cmux-resume-sessions` | `resume sessions`, `restore from snapshot`, `rehydrate sessions`, `세션 복원`, `스냅샷 복원` | To restore workspaces from a saved snapshot (for crash recovery, use `cmux-recover-sessions`) | `/praxis:cmux-resume-sessions` |
 | `cmux-session-manager` | `cmux session`, `session management`, `session cleanup`, `cmux status`, `cmux tidy` | To run routine session cleanup or view a status dashboard | `/praxis:cmux-session-manager` |
 | `cmux-delegate` | `delegate`, `cmux delegate`, `new session` | To delegate to an independent session while preserving the current task's context (split review / debugging / implementation) | `/praxis:cmux-delegate` |
+| `cmux-orchestrate` | `run ledger`, `orchestrate`, `위임 진행 상황` | To ask how far a distributed delegation got, in one answer rather than N sidebar tabs | `/praxis:cmux-orchestrate` |
 
 > **CLI tools (not skills):** praxis also ships `bypass-review`, a shell wrapper
 > with no `SKILL.md` — it is **not** invocable as `/praxis:*` and is absent from

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -53,6 +53,7 @@ NON_HOOK_DOCS: frozenset[str] = frozenset({
 # with an explicit declaration here.
 EXPECTED_SKILLS: frozenset[str] = frozenset({
     "cmux-delegate",
+    "cmux-orchestrate",
     "cmux-recover-sessions",
     "cmux-resume-sessions",
     "cmux-save-sessions",

--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -45,6 +45,7 @@ runtime-verified-note: "cmux 0.64.22 — agent.hook.PostToolUse is not relayed a
 | `--account` | (기본 계정) | Claude 계정 프로필 (예: `claude-2` → `CLAUDE_CONFIG_DIR=~/.claude-2`) |
 | `--session` | (신규 생성) | 기존 워크스페이스에 전달 (이름 또는 workspace ref) |
 | `--distribute` | false | 독립 항목별 병렬 분산 실행 |
+| `--run` | (distribute 시 자동 생성) | 이 위임을 묶을 Run 식별자 (`cmux-orchestrate`) |
 | `--permission-mode` | `auto` | Claude 권한 모드 (acceptEdits/auto/bypassPermissions/default/dontAsk/plan) |
 
 ## Process
@@ -61,6 +62,7 @@ budget = args["max-budget-usd"] || ""
 account = args.account || ""
 session = args.session || ""
 distribute = args.distribute || false
+run = args.run || ""
 permission_mode = args["permission-mode"] || "auto"
 task = args.task (remaining text after flags)
 short_task = task[:30], sanitized to [a-zA-Z0-9가-힣 -] only (for cmux workspace name)
@@ -274,6 +276,28 @@ Report results in Korean.
    - Design/security/review → `claude:opus`
    - Data lookup/status check → `claude:haiku`
 
+### Step 3.6: Resolve the Run
+
+이 위임이 어느 Run 에 속하는지 정하고, 그 식별자를 디스크에 남깁니다.
+
+```bash
+RL="${CLAUDE_PLUGIN_ROOT}/skills/cmux-orchestrate/run-ledger.sh"
+RUN="{run}"                      # --run 인자. 없으면 빈 문자열
+
+# distribute 는 N개를 흩는 것이 정의이므로, 묶을 것이 있는 유일한 자동 생성 조건입니다.
+if [ -z "$RUN" ] && [ "{distribute}" = "true" ]; then
+  eval "$(sh "$RL" create "{short_task}")"
+  RUN="$run"
+fi
+
+[ -n "$RUN" ] && printf '%s' "$RUN" > "/tmp/cmux-delegate-{timestamp}.run"
+```
+
+변수가 아니라 파일인 이유는 `.ws` 와 같습니다 — 셸 상태는 Bash 호출 사이에
+유지되지 않으므로(`RUNTIME_CONSTRAINTS.md` §4), Step 5 와 Step 7 이 이 값을
+읽을 수 있는 곳은 디스크뿐입니다. Run 이 없으면 파일도 없고, 이후 단계의
+원장 호출은 전부 조용히 건너뜁니다 — 원장은 위임의 전제 조건이 아닙니다.
+
 ### Step 4: Generate Wrapper Script
 
 `/tmp/cmux-delegate-{timestamp}.sh`를 생성합니다:
@@ -347,6 +371,10 @@ WS_ID=$(CMUX_QUIET=1 cmux workspace list --json \
 # 빈 파일이 남고, 그 빈 파일은 Step 7 에서 "워커가 있다"로 읽힙니다.
 if [ -n "$WS_ID" ]; then
   echo "$WS_ID" > "/tmp/cmux-delegate-{timestamp}-${WS_REF#workspace:}.ws"
+  # Run 이 있으면 여기서 묶습니다. UUID 를 아는 지점이 여기뿐입니다.
+  RUN=$(cat "/tmp/cmux-delegate-{timestamp}.run" 2>/dev/null || true)
+  [ -n "$RUN" ] && sh "${CLAUDE_PLUGIN_ROOT}/skills/cmux-orchestrate/run-ledger.sh" \
+    bind "$RUN" "$WS_ID" "{short_task}" >/dev/null
 else
   echo "경고: $WS_REF 의 UUID 조회 실패 — Step 7 은 제목/경로 폴백으로 판정합니다"
 fi
@@ -388,6 +416,9 @@ WS_ID=$(CMUX_QUIET=1 cmux workspace list --json \
 
 if [ -n "$WS_ID" ]; then
   echo "$WS_ID" > "/tmp/cmux-delegate-{timestamp}-${TARGET#workspace:}.ws"
+  RUN=$(cat "/tmp/cmux-delegate-{timestamp}.run" 2>/dev/null || true)
+  [ -n "$RUN" ] && sh "${CLAUDE_PLUGIN_ROOT}/skills/cmux-orchestrate/run-ledger.sh" \
+    bind "$RUN" "$WS_ID" "{short_task}" >/dev/null
 else
   echo "경고: $TARGET 의 UUID 조회 실패 — Step 7 은 제목/경로 폴백으로 판정합니다"
 fi
@@ -419,8 +450,11 @@ Distributed to {N} workspaces:
   | {ws_ref}  | {item_title} | {provider} | {sub_model} | {account} |
   ...
 
+  Run: {RUN}
+
 각 cmux 탭에서 진행 상황을 확인하세요.
 완료 시 cmux notify로 개별 알림이 전송됩니다.
+탭을 하나씩 보는 대신 횡단 조회: sh run-ledger.sh summary {RUN}
 ```
 
 **기존 세션 모드:**
@@ -471,6 +505,8 @@ REPORT="$(sh "$ARP" "{cwd}")"
 # 그 제목의 워크스페이스를 아예 만들지 않습니다.
 # distribute 모드는 항목마다 한 파일이므로 전부 돕니다.
 LIVENESS="${CLAUDE_PLUGIN_ROOT}/skills/cmux-delegate/agent-liveness.sh"
+RL="${CLAUDE_PLUGIN_ROOT}/skills/cmux-orchestrate/run-ledger.sh"
+RUN=$(cat "/tmp/cmux-delegate-{timestamp}.run" 2>/dev/null || true)
 FOUND=0
 
 # glob 이 아니라 find 인 이유: 매치가 없을 때 zsh 는 `nomatch` 로 블록 전체를
@@ -487,6 +523,20 @@ for WS_FILE in $(find /tmp/ -maxdepth 1 -name 'cmux-delegate-{timestamp}-*.ws' 2
   state=unknown
   eval "$(sh "$LIVENESS" "$(cat "$WS_FILE")")"
   echo "$WS_FILE $state"   # working | idle | waiting-input | crash | unknown
+
+  # 원장에 접습니다. `crash` 와 `waiting-input` 은 처방이 다르지만(재위임 / 사람이
+  # 키를 누른다) 원장이 답하는 질문은 "누가 사람을 기다리는가" 하나라 둘 다
+  # blocked 입니다. `idle` 은 아직 아무 말도 하지 않습니다 — 보고서 검증이
+  # 판정하고, `unknown` 은 부재이지 상태가 아닙니다.
+  if [ -n "$RUN" ]; then
+    case "$state" in
+      working)             LEDGER_EVENT=start ;;
+      waiting-input|crash) LEDGER_EVENT=block ;;
+      *)                   LEDGER_EVENT="" ;;
+    esac
+    [ -n "$LEDGER_EVENT" ] && sh "$RL" "$LEDGER_EVENT" "$RUN" "$(cat "$WS_FILE")" \
+      "$state" >/dev/null
+  fi
 done
 
 if [ "$FOUND" -eq 0 ]; then
@@ -504,6 +554,20 @@ fi
 워크트리 경로로 해싱하므로 distribute 모드의 N개 워커가 보고서 파일 하나를
 공유합니다 (#903 선존). 즉 위 루프는 워커별로 살았는지를 답하지만, 아래
 보고서 검증은 여전히 1건분입니다.
+
+**그래서 원장의 `done` 은 워커가 하나일 때만 기록합니다.** 보고서 하나를 N명이
+공유하는 동안 그것을 N명의 완료로 접으면, 한 명이 쓴 보고서로 나머지가 끝난
+것이 됩니다 — 원장이 답하기로 한 질문("누가 아직 안 끝났는가")에 정확히 반대로
+답하는 값입니다. distribute 모드의 완료는 #903 이 풀리기 전까지 원장 밖에
+있고, 그 워커들은 `running` 으로 남습니다.
+
+```bash
+if [ -n "$RUN" ] && [ "$(find /tmp/ -maxdepth 1 \
+     -name 'cmux-delegate-{timestamp}-*.ws' 2>/dev/null | wc -l)" -eq 1 ]; then
+  sh "$RL" done "$RUN" "$(cat /tmp/cmux-delegate-{timestamp}-*.ws)" \
+    "보고서 검증 통과" >/dev/null
+fi
+```
 
 | `state` | 뜻 | 위임자가 할 일 |
 | --- | --- | --- |

--- a/skills/cmux-orchestrate/SKILL.md
+++ b/skills/cmux-orchestrate/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: cmux-orchestrate
+description: >
+  Group delegated cmux workspaces into a Run and answer, after the fact, how far
+  that work got. Triggers on "run ledger", "orchestrate", "위임 진행 상황",
+  "그 작업 어디까지", "횡단 조회".
+verified-against-runtime: true
+runtime-verified-at: 2026-08-14
+runtime-verified-note: "cmux 0.64.22 — workspace-group create/add and set-status/set-progress carry no agent prohibition, unlike `cmux todo`, whose --help reserves the checklist for the user."
+---
+
+# cmux-orchestrate
+
+## Overview
+
+`cmux-delegate` hands one task to one workspace and forgets it. Once
+`--distribute` scatters N of them, nothing holds the N together: asking "how far
+did that get" means reading N sidebar tabs by eye, and the only completion
+signal is a report file that exists or does not.
+
+This skill adds the layer above: a Run groups the delegations, and each bound
+workspace carries a task state that distinguishes not-started from in-flight
+from blocked from done.
+
+**Core principle:** the ledger is the record and cmux is a view. Every cmux call
+here can fail without costing an answer.
+
+## When to Use
+
+- A `--distribute` delegation is in flight and you want one answer instead of N tabs
+- A delegation was handed off across a session boundary and its state has to be recovered
+- Something is stuck and the question is *which* worker is waiting on a human
+
+## Process
+
+### Step 1: Create a Run
+
+```bash
+RL="${CLAUDE_PLUGIN_ROOT}/skills/cmux-orchestrate/run-ledger.sh"
+eval "$(sh "$RL" create "P1~P5 에러 조사")"
+echo "$run"      # 1786600000-41234
+```
+
+`cmux-delegate --distribute` does this on its own (its Step 3.6) and reports the
+id. Call it directly only when grouping delegations you are launching by hand.
+
+### Step 2: Bind Workspaces
+
+```bash
+sh "$RL" bind "$RUN" "$WS_UUID" "P1 조사"
+```
+
+The selector is the workspace **UUID**, not `workspace:N` — the ref numbering's
+stability across close/open has never been confirmed, and the UUID does not
+raise the question. `cmux-delegate` stashes it in a `.ws` file at launch, which
+is the one moment it is known.
+
+### Step 3: Record Transitions
+
+```bash
+sh "$RL" start "$RUN" "$WS_UUID" "조사 착수"
+sh "$RL" done  "$RUN" "$WS_UUID" "보고서 검증 통과"
+sh "$RL" block "$RUN" "$WS_UUID" "모달 프롬프트 대기"
+```
+
+Blocked is a current condition, not a scar: a task that was blocked and later
+finished reads as done. A run with any blocked task reads as blocked, because
+the run state exists to surface what needs a human and two workers progressing
+must not paint over the third.
+
+### Step 4: Query
+
+```bash
+eval "$(sh "$RL" summary "$RUN")"
+echo "$state $done/$total"     # blocked 2/3
+```
+
+| `state` | 뜻 | 위임자가 할 일 |
+| --- | --- | --- |
+| `pending` | 묶였으나 아무도 착수 안 함 | 워커가 실제로 떴는지 본다 |
+| `running` | 진행 중 | 기다린다 |
+| `blocked` | 하나 이상이 사람을 기다림 | 그 워크스페이스를 연다 |
+| `complete` | 전부 done | 결과를 수거한다 |
+| `closed` | 명시적으로 닫힘 | 없음 — 이력으로만 읽는다 |
+| `empty` | Run 은 있으나 바인딩 0건 | `done == total` 이 0 == 0 으로 참이 되는 경우. `complete` 와 구분된다 |
+
+`sh "$RL" list` enumerates run ids newest first.
+
+### Step 5: Close
+
+```bash
+sh "$RL" close "$RUN"
+```
+
+`closed` outranks the task counts — a run closed with work outstanding reports
+`closed`, not `blocked`. Closing is the statement that no one is watching any more.
+
+## What This Deliberately Does Not Touch
+
+`cmux todo` is not used, and no code here should start using it. Its own
+`--help` reserves the checklist for the user:
+
+> Note for coding agents: this checklist belongs to the user. Do not add, edit,
+> complete, remove, or replace items on your own initiative — only manage it
+> when the user explicitly asks you to.
+
+The sidebar is painted with `set-status praxis_run <state>` and
+`set-progress <done/total>`, neither of which carries that prohibition. Issue
+#982's body asked for the `todo` route; that checkbox is unadopted for this
+reason rather than unfinished.
+
+## Error Handling
+
+| Error | Recovery |
+|-------|----------|
+| cmux absent or a cmux call fails | Swallowed. The ledger is written and the answer is unaffected |
+| State dir unwritable | Swallowed, exit 0. A ledger that fails a delegation is worse than no ledger |
+| Unknown run id | `total=0 state='empty'`, exit 0 — not an error, an answer |
+| A torn or corrupt event line | That line is skipped; the rest of the history still answers |
+| Malformed argv | usage on stderr, **exit 2**. The one failure not swallowed: the caller has a bug |
+
+## Limitations
+
+- The group is anchor-based and dies with the cmux process; only the ledger
+  survives a restart. This is why the ledger is the record.
+- `done` in a `--distribute` delegation is not recorded per worker — one report
+  file is shared by N workers (#903), so folding it into N completions would
+  answer backwards. Those tasks stay `running` until #903 is resolved.
+- Task labels are free text and never deduplicated. Two workers given the same
+  label are two tasks, distinguished only by workspace UUID.

--- a/skills/cmux-orchestrate/SKILL.md
+++ b/skills/cmux-orchestrate/SKILL.md
@@ -105,14 +105,14 @@ sh "$RL" close "$RUN"
 > when the user explicitly asks you to.
 
 The sidebar is painted with `set-status praxis_run <state>` and
-`set-progress <done/total>`, neither of which carries that prohibition. Issue
-#982's body asked for the `todo` route; that checkbox is unadopted for this
-reason rather than unfinished.
+`set-progress <done/total>`, neither of which carries that prohibition.
+Issue #982's body asked for the `todo` route; that checkbox is unadopted for
+this reason rather than unfinished.
 
 ## Error Handling
 
 | Error | Recovery |
-|-------|----------|
+| ----- | -------- |
 | cmux absent or a cmux call fails | Swallowed. The ledger is written and the answer is unaffected |
 | State dir unwritable | Swallowed, exit 0. A ledger that fails a delegation is worse than no ledger |
 | Unknown run id | `total=0 state='empty'`, exit 0 — not an error, an answer |

--- a/skills/cmux-orchestrate/run-ledger.sh
+++ b/skills/cmux-orchestrate/run-ledger.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Run/Task ledger entry point for cmux-orchestrate (issue #982).
+#
+# Thin wrapper over run_ledger.py, mirroring agent-liveness.sh: the shell side
+# resolves the interpreter and its own directory, the Python side holds the
+# logic. Output is `key='value'` pairs on one line, so a caller reads it with
+#
+#   eval "$(sh run-ledger.sh summary "$RUN")"
+#   [ "$state" = blocked ] && echo "누군가 손을 봐야 합니다"
+#
+# Exit codes: 2 for a malformed invocation (the caller has a bug and silence
+# would hide it), 0 for everything else — a ledger that fails a delegation is
+# worse than no ledger, so a missing run, an unwritable state dir, and an absent
+# cmux all answer rather than fail.
+
+set -eu
+
+_RL_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+exec python3 "$_RL_DIR/run_ledger.py" "$@"

--- a/skills/cmux-orchestrate/run-ledger.sh
+++ b/skills/cmux-orchestrate/run-ledger.sh
@@ -15,6 +15,6 @@
 
 set -eu
 
-_RL_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+_RL_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 exec python3 "$_RL_DIR/run_ledger.py" "$@"

--- a/skills/cmux-orchestrate/run_ledger.py
+++ b/skills/cmux-orchestrate/run_ledger.py
@@ -1,0 +1,411 @@
+"""Run/Task ledger for delegated work (issue #982).
+
+A delegation is a single workspace, and `cmux-delegate --distribute` opens N of
+them at once. Nothing binds those N together, so "how far did that work get?"
+has only ever been answerable by reading the sidebar tabs with your eyes. This
+module gives that set an identity, a history, and a state that is more than
+"report file exists / does not exist".
+
+APPEND-ONLY, FOLDED ON READ. State lives in `<state>/runs/<run-id>/events.jsonl`
+as one JSON object per line, and the current picture is derived by folding the
+events in file order. There is deliberately no mutable state document: N
+delegations write to one run concurrently, and while a read-modify-write of a
+single JSON file races, an append does not. `_fire_ledger._atomic_append` makes
+the same trade for the same reason, and its per-line `os.write` under `O_APPEND`
+is reused here rather than reimplemented.
+
+FAIL-OPEN, ALWAYS. A ledger that breaks a delegation is worse than no ledger.
+Every write swallows its own failure, every cmux call is best-effort, and the
+process exits 0 for any well-formed argument list. The one thing that earns a
+non-zero exit is a malformed invocation (usage, exit 2) — a caller that passed
+the wrong arguments has a bug the silence would hide.
+
+THE LEDGER IS THE RECORD; CMUX IS A VIEW. `cmux workspace-group` already binds
+workspaces natively, but a group dies with the cmux process and carries no
+history, so it cannot be the record. The group, the status pill, and the
+progress bar are all painted from the ledger and none of them is read back —
+on a host with no cmux, every query still answers.
+
+WHAT THIS DELIBERATELY DOES NOT TOUCH: `cmux todo`. Issue #982 asked for the
+task lifecycle to drive it, but `cmux todo --help` reserves that checklist for
+the user in as many words — "Do not add, edit, complete, remove, or replace
+items on your own initiative". `set-status` and `set-progress` carry no such
+reservation, so the sidebar is reflected through those instead.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from typing import Any
+
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "hooks", "_lib"),
+)
+
+try:  # praxis path conventions; absent only in a stripped checkout
+    from _paths import praxis_state_dir  # type: ignore
+except Exception:  # pragma: no cover - exercised by the fallback test
+    def praxis_state_dir() -> str:
+        override = os.environ.get("PRAXIS_STATE_DIR")
+        if override:
+            return os.path.expanduser(override)
+        home = os.path.expanduser(os.environ.get("PRAXIS_HOME") or "~/.praxis")
+        return os.path.join(home, "state")
+
+
+_CMUX_TIMEOUT_S = 5
+_STATUS_KEY = "praxis_run"
+
+# One event per line. `task.*` events all carry `workspace`, which is the task's
+# identity — a run's task list is the set of workspaces bound to it, so a task
+# needs no separate id to be addressed later.
+_RUN_CREATED = "run.created"
+_TASK_ADDED = "task.added"
+_TASK_STARTED = "task.started"
+_TASK_DONE = "task.done"
+_TASK_BLOCKED = "task.blocked"
+_RUN_CLOSED = "run.closed"
+
+
+def _runs_root() -> str:
+    return os.path.join(praxis_state_dir(), "runs")
+
+
+def _events_path(run_id: str) -> str:
+    return os.path.join(_runs_root(), run_id, "events.jsonl")
+
+
+def _new_run_id() -> str:
+    """epoch seconds + PID — the collision-avoidance convention cmux-delegate
+    already uses for its prompt files, and runs are minted in that same flow."""
+    return f"{int(time.time())}-{os.getpid()}"
+
+
+def _append(run_id: str, event: dict[str, Any]) -> bool:
+    """One JSONL line, best-effort. Returns whether it landed."""
+    path = _events_path(run_id)
+    line = json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n"
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        # O_APPEND with a single write per line: a record this small lands
+        # whole, so concurrent delegations interleave lines but never tear one.
+        fd = os.open(path, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+        try:
+            os.write(fd, line.encode("utf-8"))
+        finally:
+            os.close(fd)
+        return True
+    except Exception:
+        return False
+
+
+def _read_events(run_id: str) -> list[dict[str, Any]]:
+    """Events in file order. A corrupt line is skipped, not fatal — a partially
+    readable history answers more questions than a raised exception."""
+    try:
+        with open(_events_path(run_id), encoding="utf-8") as handle:
+            raw = handle.readlines()
+    except OSError:
+        return []
+    events = []
+    for line in raw:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(parsed, dict) and parsed.get("event"):
+            events.append(parsed)
+    return events
+
+
+def fold(events: list[dict[str, Any]]) -> dict[str, Any]:
+    """Current picture from the whole history, in file order.
+
+    Later events win, which is what makes `start → done` and a re-bind of the
+    same workspace both behave. `blocked` is not special-cased as sticky: a task
+    that was blocked and then finished is done, and a run that re-opens work
+    should read as re-opened.
+    """
+    label = ""
+    closed = False
+    tasks: dict[str, dict[str, str]] = {}
+    for event in events:
+        kind = event.get("event")
+        workspace = str(event.get("workspace") or "")
+        if kind == _RUN_CREATED:
+            label = str(event.get("label") or label)
+        elif kind == _RUN_CLOSED:
+            closed = True
+        elif kind == _TASK_ADDED and workspace:
+            tasks[workspace] = {
+                "state": "pending",
+                "label": str(event.get("label") or ""),
+            }
+        elif kind in (_TASK_STARTED, _TASK_DONE, _TASK_BLOCKED) and workspace:
+            task = tasks.setdefault(workspace, {"state": "pending", "label": ""})
+            task["state"] = {
+                _TASK_STARTED: "running",
+                _TASK_DONE: "done",
+                _TASK_BLOCKED: "blocked",
+            }[kind]
+            if event.get("label"):
+                task["label"] = str(event["label"])
+    counts = {"pending": 0, "running": 0, "done": 0, "blocked": 0}
+    for task in tasks.values():
+        counts[task["state"]] = counts.get(task["state"], 0) + 1
+    total = len(tasks)
+    return {
+        "label": label,
+        "closed": closed,
+        "tasks": tasks,
+        "counts": counts,
+        "total": total,
+        "state": _run_state(closed, total, counts),
+    }
+
+
+def _run_state(closed: bool, total: int, counts: dict[str, int]) -> str:
+    """A run is `blocked` while anything is blocked — the whole point of the
+    state is to surface the thing that needs a human, and a run reading `running`
+    because two of three tasks are fine hides exactly that."""
+    if closed:
+        return "closed"
+    if total == 0:
+        return "empty"
+    if counts.get("blocked"):
+        return "blocked"
+    if counts.get("done") == total:
+        return "complete"
+    if counts.get("running"):
+        return "running"
+    return "pending"
+
+
+def _cmux(argv: list[str]) -> str | None:
+    """stdout of a cmux call, or None on any failure. Never raises.
+
+    Mirrors `agent_liveness._run`. Every caller here treats None as "no view was
+    painted" and carries on — praxis is host-neutral (ARCHITECTURE.md) and the
+    ledger is complete without cmux.
+    """
+    try:
+        proc = subprocess.run(
+            ["cmux", *argv],
+            capture_output=True,
+            text=True,
+            timeout=_CMUX_TIMEOUT_S,
+            check=False,
+            env={**os.environ, "CMUX_QUIET": "1"},
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return proc.stdout if proc.returncode == 0 else None
+
+
+def _group_ref(run_id: str) -> str | None:
+    """The group whose name is this run, if cmux is here and holds one."""
+    out = _cmux(["workspace-group", "list", "--json"])
+    if not out:
+        return None
+    try:
+        groups = json.loads(out).get("groups") or []
+    except ValueError:
+        return None
+    for group in groups:
+        if isinstance(group, dict) and group.get("name") == _group_name(run_id):
+            for key in ("ref", "id"):
+                if group.get(key):
+                    return str(group[key])
+    return None
+
+
+def _group_name(run_id: str) -> str:
+    return f"run:{run_id}"
+
+
+def _paint(run_id: str, workspace: str | None = None) -> None:
+    """Push the folded state onto the sidebar. Best-effort throughout.
+
+    The pill key is fixed so this tool owns one entry and never fights another
+    tool's; the progress bar is the run's, so it is painted on every bound
+    workspace rather than only the one that just moved.
+    """
+    view = fold(_read_events(run_id))
+    done = view["counts"].get("done", 0)
+    total = view["total"] or 1
+    targets = [workspace] if workspace else list(view["tasks"])
+    for target in targets:
+        if not target:
+            continue
+        _cmux(["set-status", _STATUS_KEY, view["state"], "--workspace", target])
+        _cmux([
+            "set-progress",
+            f"{done / total:.2f}",
+            "--label",
+            f"{done}/{view['total']}",
+            "--workspace",
+            target,
+        ])
+
+
+def create(label: str) -> dict[str, Any]:
+    run_id = _new_run_id()
+    _append(run_id, {
+        "event": _RUN_CREATED,
+        "at": int(time.time()),
+        "label": label,
+    })
+    # Anchor-only group: members join as delegations bind, so creating it with
+    # --from would capture whatever happens to be live right now instead.
+    _cmux(["workspace-group", "create", "--name", _group_name(run_id)])
+    return {"run": run_id, "state": "empty"}
+
+
+def bind(run_id: str, workspace: str, label: str) -> dict[str, Any]:
+    _append(run_id, {
+        "event": _TASK_ADDED,
+        "at": int(time.time()),
+        "workspace": workspace,
+        "label": label,
+    })
+    group = _group_ref(run_id)
+    if group:
+        _cmux(["workspace-group", "add", "--group", group, "--workspace", workspace])
+    _paint(run_id, workspace)
+    return {"run": run_id, "workspace": workspace, "state": "pending"}
+
+
+def mark(run_id: str, workspace: str, kind: str, note: str = "") -> dict[str, Any]:
+    event = {
+        _TASK_STARTED: _TASK_STARTED,
+        _TASK_DONE: _TASK_DONE,
+        _TASK_BLOCKED: _TASK_BLOCKED,
+    }[kind]
+    payload: dict[str, Any] = {
+        "event": event,
+        "at": int(time.time()),
+        "workspace": workspace,
+    }
+    if note:
+        payload["note"] = note
+    _append(run_id, payload)
+    _paint(run_id, workspace)
+    # The task's state as `fold` names it, not as the event names it: an event is
+    # `task.started` and the state it produces is `running`, and a caller that
+    # reads `state=` from here and from `summary` must not get two vocabularies
+    # for one thing.
+    return {
+        "run": run_id,
+        "workspace": workspace,
+        "state": fold(_read_events(run_id))["tasks"].get(workspace, {}).get("state", ""),
+    }
+
+
+def close(run_id: str) -> dict[str, Any]:
+    _append(run_id, {"event": _RUN_CLOSED, "at": int(time.time())})
+    _paint(run_id)
+    return {"run": run_id, "state": "closed"}
+
+
+def summary(run_id: str) -> dict[str, Any]:
+    view = fold(_read_events(run_id))
+    counts = view["counts"]
+    return {
+        "run": run_id,
+        "label": view["label"],
+        "state": view["state"],
+        "total": view["total"],
+        "done": counts.get("done", 0),
+        "running": counts.get("running", 0),
+        "blocked": counts.get("blocked", 0),
+        "pending": counts.get("pending", 0),
+    }
+
+
+def runs() -> list[str]:
+    """Run ids, newest first. Sorted on the id itself: it opens with epoch
+    seconds, so lexical order over a fixed-width era is chronological."""
+    try:
+        entries = os.listdir(_runs_root())
+    except OSError:
+        return []
+    return sorted((e for e in entries if os.path.isdir(os.path.join(_runs_root(), e))), reverse=True)
+
+
+def _shell_quote(value: str) -> str:
+    """POSIX single-quoting: close, escape, reopen for an embedded quote."""
+    return "'" + str(value).replace("'", "'\\''") + "'"
+
+
+def _format(result: dict[str, Any]) -> str:
+    """`key='value'` pairs — readable by a shell caller under `eval` without a
+    JSON parser. Quoted unconditionally: labels carry user text, and deciding
+    per-value which characters are dangerous is how one gets through."""
+    parts = []
+    for key in ("run", "label", "state", "workspace", "total", "done", "running", "blocked", "pending"):
+        if key not in result:
+            continue
+        value = str(result[key]).replace("\n", " ").strip()
+        parts.append(f"{key}={_shell_quote(value)}")
+    return " ".join(parts)
+
+
+_USAGE = (
+    "usage: run_ledger.py <command> [args]\n"
+    "  create <label>\n"
+    "  bind <run-id> <workspace> <label>\n"
+    "  start|done|block <run-id> <workspace> [note]\n"
+    "  close <run-id>\n"
+    "  summary <run-id>\n"
+    "  list\n"
+)
+
+_ARITY = {
+    "create": (1, 1),
+    "bind": (3, 3),
+    "start": (2, 3),
+    "done": (2, 3),
+    "block": (2, 3),
+    "close": (1, 1),
+    "summary": (1, 1),
+    "list": (0, 0),
+}
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2 or argv[1] not in _ARITY:
+        print(_USAGE, file=sys.stderr, end="")
+        return 2
+    command, args = argv[1], argv[2:]
+    low, high = _ARITY[command]
+    if not low <= len(args) <= high:
+        print(_USAGE, file=sys.stderr, end="")
+        return 2
+
+    if command == "create":
+        print(_format(create(args[0])))
+    elif command == "bind":
+        print(_format(bind(args[0], args[1], args[2])))
+    elif command in ("start", "done", "block"):
+        kind = {"start": _TASK_STARTED, "done": _TASK_DONE, "block": _TASK_BLOCKED}[command]
+        print(_format(mark(args[0], args[1], kind, args[2] if len(args) > 2 else "")))
+    elif command == "close":
+        print(_format(close(args[0])))
+    elif command == "summary":
+        print(_format(summary(args[0])))
+    elif command == "list":
+        for run_id in runs():
+            print(_format(summary(run_id)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/skills/cmux-orchestrate/run_ledger.py
+++ b/skills/cmux-orchestrate/run_ledger.py
@@ -263,8 +263,12 @@ def create(label: str) -> dict[str, Any]:
         "at": int(time.time()),
         "label": label,
     })
-    # Anchor-only group: members join as delegations bind, so creating it with
-    # --from would capture whatever happens to be live right now instead.
+    # Anchor-only, no --from. A cmux group header IS its anchor's sidebar row,
+    # so the group always costs one workspace; --from does not save it, it only
+    # decides whether that row is named after the run or after whichever task
+    # happened to be first. Measured on 0.64.22: member_count 4 for 3 tasks
+    # either way. Reading that count as three tasks plus a stray tab is the
+    # mistake this comment exists to stop.
     _cmux(["workspace-group", "create", "--name", _group_name(run_id)])
     return {"run": run_id, "state": "empty"}
 

--- a/tests/_assert_lib.sh
+++ b/tests/_assert_lib.sh
@@ -31,7 +31,22 @@
 #   assert_present_re "name" "regex"
 #   assert_order "name" "first fixed string" "second fixed string"
 #   assert_order_re "name" "first regex" "second regex"
+#   assert_lib_retarget "path"  # next document, same tally
 #   assert_lib_summary   # prints Passed/Failed, exits 1 if any FAIL
+
+# Swap the document under test without touching the tally. A second
+# assert_lib_init would zero PASS/FAIL, so a suite spanning two documents would
+# exit 0 on a failure in the first one — the failures print and then stop
+# counting, which is worse than not running them.
+assert_lib_retarget() {
+  _ASSERT_TARGET="$1"
+  if [ ! -f "$_ASSERT_TARGET" ]; then
+    echo "FAIL: target not found at $_ASSERT_TARGET" >&2
+    exit 1
+  fi
+  _ASSERT_NORMALIZED="$(sed -e ':a' -e 'N' -e '$!ba' \
+    -e 's/\n[[:blank:]]*/ /g' "$_ASSERT_TARGET")"
+}
 
 assert_lib_init() {
   _ASSERT_TARGET="$1"

--- a/tests/test_cmux_orchestrate.sh
+++ b/tests/test_cmux_orchestrate.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# tests/test_cmux_orchestrate.sh — Run/Task ledger document pins (issue #982)
+#
+# Two documents are pinned here: the cmux-orchestrate skill that owns the
+# ledger, and the cmux-delegate steps that feed it.
+#
+# The load-bearing assertion is an ABSENCE. Issue #982's body asked for the
+# Task lifecycle to be reflected through `cmux todo add / start / check`, and
+# `cmux todo --help` forbids exactly that:
+#
+#   Note for coding agents: this checklist belongs to the user. Do not add,
+#   edit, complete, remove, or replace items on your own initiative.
+#
+# So the route was not taken. A later editor reading only the issue would see
+# an unticked checkbox and an obvious command to tick it with, which is how a
+# vendor prohibition gets walked back by someone acting in good faith. §4 is
+# what stops that, and it is worth more than any of the presence checks.
+#
+# Run:  bash tests/test_cmux_orchestrate.sh
+# Exit: 0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL="$ROOT_DIR/skills/cmux-orchestrate/SKILL.md"
+DELEGATE="$ROOT_DIR/skills/cmux-delegate/SKILL.md"
+
+# shellcheck source=./_assert_lib.sh
+source "$SCRIPT_DIR/_assert_lib.sh"
+assert_lib_init "$SKILL"
+
+# ---------------------------------------------------------------------------
+# 1. The record survives what the view does not
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "the ledger is named as the record and cmux as the view" \
+  "the ledger is the record and cmux is a view"
+
+assert_present \
+  "an absent cmux costs no answer" \
+  "The ledger is written and the answer is unaffected"
+
+assert_present \
+  "a malformed invocation is the one failure not swallowed" \
+  "exit 2"
+
+# ---------------------------------------------------------------------------
+# 2. The state vocabulary the caller reads
+# ---------------------------------------------------------------------------
+
+for state in pending running blocked complete closed empty; do
+  assert_present_re \
+    "state '$state' is documented" \
+    "^\| \`$state\` \|"
+done
+
+assert_present \
+  "empty is distinguished from complete, and why" \
+  "0 == 0"
+
+assert_present \
+  "blocked is not sticky" \
+  "Blocked is a current condition, not a scar"
+
+# ---------------------------------------------------------------------------
+# 3. The selector is the UUID
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "binding takes the workspace UUID, not the ref number" \
+  "workspace **UUID**, not \`workspace:N\`"
+
+# ---------------------------------------------------------------------------
+# 4. The vendor prohibition — an absence, and the reason it is written down
+# ---------------------------------------------------------------------------
+
+assert_absent \
+  "the skill never invokes cmux todo" \
+  "cmux todo add"
+
+assert_absent \
+  "no todo start either" \
+  "cmux todo start"
+
+assert_absent \
+  "no todo check either" \
+  "cmux todo check"
+
+assert_present \
+  "the prohibition is quoted rather than paraphrased" \
+  "this checklist belongs to the user"
+
+assert_present \
+  "the unadopted checkbox is recorded as a decision, not an omission" \
+  "unadopted for this reason rather than unfinished"
+
+# ---------------------------------------------------------------------------
+# 5. cmux-delegate feeds the ledger
+# ---------------------------------------------------------------------------
+
+assert_lib_retarget "$DELEGATE"
+
+assert_absent \
+  "the delegate skill does not reach for todo either" \
+  "cmux todo"
+
+assert_present \
+  "--run is an argument" \
+  "\`--run\`"
+
+assert_present \
+  "the run id is stashed on disk, not carried in a shell variable" \
+  "/tmp/cmux-delegate-{timestamp}.run"
+
+assert_present \
+  "binding happens where the UUID is known" \
+  "UUID 를 아는 지점이 여기뿐입니다"
+
+assert_order \
+  "the run is resolved before the workspaces that bind to it" \
+  "### Step 3.6: Resolve the Run" \
+  "### Step 5a: Launch cmux Workspace"
+
+assert_present \
+  "crash and waiting-input both fold to blocked" \
+  "waiting-input|crash) LEDGER_EVENT=block"
+
+assert_present \
+  "done is withheld where one report is shared by N workers" \
+  "워커가 하나일 때만 기록합니다"
+
+assert_lib_summary

--- a/tests/test_run_ledger.py
+++ b/tests/test_run_ledger.py
@@ -115,6 +115,48 @@ def test_mark_and_summary_use_one_vocabulary(ledger):
 
 
 # ---------------------------------------------------------------------------
+# 1b. The group header is a workspace, and --from does not change that
+# ---------------------------------------------------------------------------
+
+
+def _group_mutations(calls: list[list[str]]) -> list[list[str]]:
+    """Group calls that change something. `_group_ref` reads the group list on
+    every bind, and counting that read as an action makes every assertion here
+    about call ordering rather than about what was done."""
+    return [c for c in calls if c[:1] == ["workspace-group"] and c[1] != "list"]
+
+
+@pytest.fixture()
+def spy(monkeypatch, tmp_path):
+    """The module with every cmux argv captured instead of executed."""
+    module = _load(monkeypatch, tmp_path / "state")
+    calls: list[list[str]] = []
+    monkeypatch.setattr(module, "_cmux", lambda argv: calls.append(argv))
+    return module, calls
+
+
+def test_the_group_is_anchor_only(spy):
+    """Measured on cmux 0.64.22: `create --from <ws>` still opens a fresh anchor
+    workspace and files <ws> under it — member_count 4 for three tasks, exactly
+    as without --from. The extra member is the group header, not a stray tab,
+    so --from buys nothing and costs the header its run name."""
+    ledger, calls = spy
+    ledger.create("run")
+    made = _group_mutations(calls)
+    assert [c[1] for c in made] == ["create"]
+    assert "--from" not in made[0]
+
+
+def test_bind_adds_to_the_existing_group(spy, monkeypatch):
+    ledger, calls = spy
+    monkeypatch.setattr(ledger, "_group_ref", lambda run_id: "workspace_group:1")
+    run = ledger.create("run")["run"]
+    calls.clear()
+    ledger.bind(run, "WS-B", "task b")
+    assert [c[1] for c in _group_mutations(calls)] == ["add"]
+
+
+# ---------------------------------------------------------------------------
 # 2. Concurrency — N delegations write to one run
 # ---------------------------------------------------------------------------
 

--- a/tests/test_run_ledger.py
+++ b/tests/test_run_ledger.py
@@ -1,0 +1,250 @@
+"""tests/test_run_ledger.py — Run/Task ledger for delegated work (#982).
+
+The ledger's whole value is that it answers after the fact, so the properties
+under test are the ones that decide whether an answer is trustworthy: does the
+fold respect event order, does a concurrent write from a sibling delegation
+survive intact, and does a host with no cmux still get a complete record.
+
+Every case runs against a temp PRAXIS_STATE_DIR — the developer's real ledger is
+never read or written.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import itertools
+import json
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+_HELPER = Path(__file__).resolve().parent.parent / "skills" / "cmux-orchestrate" / "run_ledger.py"
+
+
+def _load(monkeypatch, state_dir: Path):
+    """Import the module fresh with PRAXIS_STATE_DIR pointed at a temp root.
+
+    Re-imported per test rather than cached: the path helpers read the
+    environment at call time, but a stale module object would still hold any
+    state a previous test left behind.
+    """
+    monkeypatch.setenv("PRAXIS_STATE_DIR", str(state_dir))
+    spec = importlib.util.spec_from_file_location("run_ledger_under_test", _HELPER)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def ledger(monkeypatch, tmp_path):
+    """The module with cmux stubbed out — every test here is about the record,
+    and a real cmux call would make results depend on the developer's sidebar."""
+    module = _load(monkeypatch, tmp_path / "state")
+    monkeypatch.setattr(module, "_cmux", lambda argv: None)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# 1. The fold — later events win, in file order
+# ---------------------------------------------------------------------------
+
+
+def test_a_bound_task_starts_pending(ledger):
+    run = ledger.create("run")["run"]
+    ledger.bind(run, "WS-A", "task a")
+    assert ledger.summary(run)["pending"] == 1
+
+
+def test_the_last_event_for_a_workspace_decides_its_state(ledger):
+    run = ledger.create("run")["run"]
+    ledger.bind(run, "WS-A", "task a")
+    ledger.mark(run, "WS-A", "task.started")
+    ledger.mark(run, "WS-A", "task.done")
+    assert ledger.summary(run)["done"] == 1
+    assert ledger.summary(run)["running"] == 0
+
+
+def test_a_blocked_task_that_later_finishes_is_done(ledger):
+    """Blocked is a current condition, not a scar. A run whose blocker was
+    cleared must read as cleared, or the state stops tracking reality."""
+    run = ledger.create("run")["run"]
+    ledger.bind(run, "WS-A", "task a")
+    ledger.mark(run, "WS-A", "task.blocked")
+    ledger.mark(run, "WS-A", "task.done")
+    assert ledger.summary(run)["state"] == "complete"
+
+
+def test_one_blocked_task_makes_the_whole_run_blocked(ledger):
+    """The run state exists to surface what needs a human. Two of three tasks
+    progressing must not paint over the third."""
+    run = ledger.create("run")["run"]
+    for ws in ("WS-A", "WS-B", "WS-C"):
+        ledger.bind(run, ws, ws)
+    ledger.mark(run, "WS-A", "task.done")
+    ledger.mark(run, "WS-B", "task.started")
+    ledger.mark(run, "WS-C", "task.blocked")
+    assert ledger.summary(run)["state"] == "blocked"
+
+
+def test_an_empty_run_says_so_rather_than_reading_complete(ledger):
+    """`done == total` is true at 0 == 0. A run that has bound nothing yet must
+    not report the same state as a run that finished everything."""
+    run = ledger.create("run")["run"]
+    assert ledger.summary(run)["state"] == "empty"
+
+
+def test_a_closed_run_reports_closed_over_its_task_counts(ledger):
+    run = ledger.create("run")["run"]
+    ledger.bind(run, "WS-A", "task a")
+    ledger.close(run)
+    assert ledger.summary(run)["state"] == "closed"
+
+
+def test_mark_and_summary_use_one_vocabulary(ledger):
+    """`task.started` produces the state `running`. A caller reading `state=`
+    from a transition and from a summary must not get two names for it."""
+    run = ledger.create("run")["run"]
+    ledger.bind(run, "WS-A", "task a")
+    assert ledger.mark(run, "WS-A", "task.started")["state"] == "running"
+    assert ledger.summary(run)["running"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. Concurrency — N delegations write to one run
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_binds_all_survive_intact(ledger):
+    """The reason there is no mutable state document. Sixteen writers append at
+    once; every line must be whole and every task must be present."""
+    run = ledger.create("run")["run"]
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        list(pool.map(lambda i: ledger.bind(run, f"WS-{i:02d}", f"task {i}"), range(16)))
+
+    path = Path(ledger._events_path(run))
+    lines = [ln for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    for line in lines:
+        json.loads(line)  # raises if a write tore
+    assert ledger.summary(run)["total"] == 16
+
+
+def test_a_corrupt_line_does_not_take_the_history_with_it(ledger):
+    """A partially readable history answers more than a raised exception."""
+    run = ledger.create("run")["run"]
+    ledger.bind(run, "WS-A", "task a")
+    with open(ledger._events_path(run), "a", encoding="utf-8") as handle:
+        handle.write("{not json\n")
+    ledger.bind(run, "WS-B", "task b")
+    assert ledger.summary(run)["total"] == 2
+
+
+# ---------------------------------------------------------------------------
+# 3. Fail-open — the record survives what the view does not
+# ---------------------------------------------------------------------------
+
+
+def test_the_record_is_complete_when_cmux_is_absent(monkeypatch, tmp_path):
+    """praxis is host-neutral (ARCHITECTURE.md). Simulated by an exec failure,
+    which is what an absent binary actually produces."""
+    module = _load(monkeypatch, tmp_path / "state")
+
+    def _no_cmux(*args, **kwargs):
+        raise FileNotFoundError("cmux")
+
+    monkeypatch.setattr(subprocess, "run", _no_cmux)
+    run = module.create("run")["run"]
+    module.bind(run, "WS-A", "task a")
+    module.mark(run, "WS-A", "task.done")
+    assert module.summary(run)["done"] == 1
+
+
+def test_an_unwritable_state_dir_does_not_raise(ledger, monkeypatch):
+    """A ledger that fails a delegation is worse than no ledger."""
+    monkeypatch.setattr(os, "open", lambda *a, **k: (_ for _ in ()).throw(PermissionError()))
+    run_id = "1786600000-1"
+    assert ledger._append(run_id, {"event": "task.added", "workspace": "WS-A"}) is False
+
+
+def test_summary_of_an_unknown_run_answers_rather_than_failing(ledger):
+    result = ledger.summary("no-such-run")
+    assert result["total"] == 0
+    assert result["state"] == "empty"
+
+
+# ---------------------------------------------------------------------------
+# 4. Path convention and the CLI contract
+# ---------------------------------------------------------------------------
+
+
+def test_events_live_under_the_praxis_state_dir(ledger, tmp_path):
+    run = ledger.create("run")["run"]
+    ledger.bind(run, "WS-A", "task a")
+    expected = tmp_path / "state" / "runs" / run / "events.jsonl"
+    assert expected.is_file()
+
+
+def test_run_ids_sort_newest_first(ledger, monkeypatch):
+    """`list` orders on the id itself, which opens with epoch seconds.
+
+    The clock advances by 100 per call rather than per run: `create` reads it
+    twice (the id, then the event's `at`), and a fixture that assumed one read
+    ran dry mid-test.
+    """
+    clock = itertools.count(1786600000, 100)
+    monkeypatch.setattr(ledger.time, "time", lambda: next(clock))
+    ids = [ledger.create("r")["run"] for _ in range(3)]
+    assert len(set(ids)) == 3
+    assert ledger.runs() == sorted(ids, reverse=True)
+
+
+def test_a_label_carrying_a_quote_survives_the_documented_eval(ledger):
+    """The output is consumed with `eval "$(...)"`, and labels carry user text."""
+    run = ledger.create("it's a run")["run"]
+    rendered = ledger._format(ledger.summary(run))
+    extracted = subprocess.run(
+        ["sh", "-c", f'eval "{rendered}"; printf "%s" "$label"'],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert extracted.stdout == "it's a run"
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        [],
+        ["bogus"],
+        ["create"],
+        ["bind", "run-1"],
+        ["bind", "run-1", "WS-A", "label", "extra"],
+    ],
+)
+def test_a_malformed_invocation_exits_2(argv):
+    """The one failure the wrapper does not swallow: a caller with a bug."""
+    proc = subprocess.run(
+        [sys.executable, str(_HELPER), *argv],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 2
+    assert "usage:" in proc.stderr
+
+
+def test_a_well_formed_invocation_exits_0(tmp_path):
+    env = {**os.environ, "PRAXIS_STATE_DIR": str(tmp_path / "state")}
+    proc = subprocess.run(
+        [sys.executable, str(_HELPER), "summary", "no-such-run"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert proc.returncode == 0
+    assert "state='empty'" in proc.stdout

--- a/tests/test_skill_runtime_metadata.py
+++ b/tests/test_skill_runtime_metadata.py
@@ -575,6 +575,7 @@ def test_current_repo_runtime_sensitive_skill_set_is_stable():
         # helper-executable since #903: agent-report-path.sh derives the
         # completion-report path for both halves of the handoff protocol.
         "cmux-delegate": ("external-cli-wrapper", "helper-executable"),
+        "cmux-orchestrate": ("external-cli-wrapper", "helper-executable"),
         "cmux-recover-sessions": (
             "AskUserQuestion",
             "external-cli-wrapper",


### PR DESCRIPTION
Closes #982

### 무엇을

위임 작업에 Run/Task 원장을 붙입니다. `cmux-delegate --distribute` 가 N개
워크스페이스를 흩고 나면 그 N개를 묶는 것이 없어서, "그 작업 어디까지 갔나"는
사이드바 탭을 눈으로 훑어야만 답할 수 있었습니다. 완료 판정도 보고서 파일의
존재/부재라는 2진값이라 착수·진행·블록됨을 표현하지 못했습니다.

- `skills/cmux-orchestrate/run_ledger.py` + `run-ledger.sh` — append-only JSONL
  이벤트 로그를 읽을 때 접어(fold) 현재 상태를 도출합니다. 가변 상태 문서를 두지
  않는 이유는 N개 위임이 한 Run 에 동시에 쓰기 때문입니다 — 단일 JSON 의
  read-modify-write 는 경합하지만 append 는 하지 않습니다.
- `skills/cmux-orchestrate/SKILL.md` — 사용자 진입점.
- `skills/cmux-delegate/SKILL.md` — `--run` 인자, Step 3.6 Run 결정, Step 5a/5b
  바인딩, Step 7 의 liveness→원장 접기.

### 설계 결정 두 가지 (이슈 본문과 다른 부분)

**1. `cmux todo` 를 쓰지 않습니다.** 이슈 본문은 `todo add / start / check` 로
Task 라이프사이클을 반영하라고 적고 있으나, `cmux todo --help` 가 에이전트 사용을
명시적으로 금지합니다 — "this checklist belongs to the user. Do not add, edit,
complete, remove, or replace items on your own initiative". 같은 금지가 없는
`set-status` / `set-progress` 로 대체했고, 해당 체크박스는 **미완이 아니라
벤더 금지로 미채택**입니다. `tests/test_cmux_orchestrate.sh` §4 가 두 스킬
어디에도 그 명령이 등장하지 않음을 단언합니다 — 이슈만 읽은 다음 편집자가
선의로 체크박스를 채우는 경로를 막는 것이 이 테스트의 존재 이유입니다.

**2. 원장이 정본, `workspace-group` 은 표시용.** 그룹은 cmux 프로세스 수명에
묶이고 이력이 없으므로 정본이 될 수 없습니다. 그룹·status pill·progress bar 는
전부 원장에서 그려지고 되읽지 않습니다 — cmux 없는 호스트에서도 모든 조회가
답합니다.

### 커밋

| 커밋 | 관심사 |
| --- | --- |
| `31831f3` | 원장 코어 + 테스트 |
| `e4994a3` | `cmux-delegate` 연결 |
| `ad12a14` | `assert_lib_init` 이 두 번째 호출에서 집계를 리셋하는 함정 |
| `c38a49d` | 스킬 문서 + 문서 고정 테스트 |
| `a2ee7e7` | 매니페스트·문서 등록 |
| `92b5af9` | 그룹이 anchor-only 인 이유 고정 |
| `11f1e84` | shellcheck SC1007 |

`31831f3` 은 계획의 ①·②(원장 코어 / cmux 반영)를 합친 것입니다. 두 관심사가 한
파일에 얽혀 있어 나누면 첫 커밋의 트리가 실행되지 않습니다(`create` 가 `_cmux`
를 호출).

`ad12a14` 는 **잠복 함정**이지 지금 오답을 내던 테스트의 수정이 아닙니다 — 기존
테스트 중 `assert_lib_init` 을 두 번 부르는 파일은 없었고, 이번 PR 이 그런 파일을
처음 만듭니다. 고치지 않았다면 이 PR 의 문서 고정 테스트에서 §1–§4(벤더 금지
부재 단언 포함)가 실패해도 종료 코드가 0 이었을 것입니다.

### 검증 증거

Caller chain verified: `grep -c assert_lib_init tests/*.sh tests/hooks/*/*.sh | awk -F: '$2>1'` → `tests/_assert_lib.sh:3` 한 줄뿐(정의 + 문서 주석). 호출 측 6개 파일은 전부 1회 호출이라 기존 스위트에 오집계 이력 없음. 수정 후 주입 통제 — 첫 문서의 단언 1건을 뒤집으면 `exit 1` (23 passed, 1 failed), 수정 전 동일 주입은 `exit 0`.

Pre-commit verified: `ls "$(git rev-parse --path-format=absolute --git-common-dir)/hooks/pre-commit"` → `No such file or directory`. 이 레포에 pre-commit 훅이 없어 검증은 `bash scripts/run-tests.sh` 와 CI 가 맡습니다. 브랜치 실행 결과 — 테스트 단계 실패 0건, `find . -name '*.sh' -not -path './.git/*' -print0 | xargs -0 shellcheck --severity=warning` (CI 와 동일 호출) 0건, `ruff check .` → All checks passed. 로컬 `memory frontmatter lint` 단계만 3개 파일로 red 인데, 이는 레포 밖 per-user 스토어(`CLAUDE_CONFIG_DIR` 기준 경로)를 읽는 단계라 브랜치와 무관하고 CI 에서는 그 디렉터리가 없어 실행되지 않습니다.

### 남은 구멍

- **status pill / progress bar 의 렌더링은 검증되지 않았습니다.** 명령은
  rc=0 으로 성공하지만 `cmux workspace list --json` 에도
  `rpc mobile.workspace.list` 에도 읽기 경로가 없어, 사이드바에 실제로 그려지는지는
  프로그램으로 확인할 수 없습니다. 검증 앵커에서 `BLOCKED` 입니다.
- distribute 모드의 `done` 은 워커별로 기록되지 않습니다 — `agent-report-path.sh`
  가 워크트리로 해싱해 N개 워커가 보고서 하나를 공유하므로(#903 선존), 그것을 N개
  완료로 접으면 원장이 답하기로 한 질문에 정확히 반대로 답합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `cmux-orchestrate` skill for grouping workspaces into runs and tracking task progress.
  * Added run creation, workspace binding, status updates, summaries, closure, and progress displays.
  * Enhanced delegated work with run identifiers, lifecycle tracking, and summary commands.
  * Expanded the skills catalog from 17 to 18 entries.

* **Tests**
  * Added comprehensive coverage for orchestration, ledger behavior, delegation, error handling, and runtime metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->