### PR TITLE
fix(cmux-delegate): key the agent report on the workspace

### DIFF
--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -225,10 +225,15 @@ praxis 가 거기에 파일을 남길 이유가 없습니다.
 
     ARP="${CLAUDE_PLUGIN_ROOT}/skills/cmux-delegate/agent-report-path.sh"
     WORKTREE="$(sh "$ARP" --worktree "$PWD")"   # ← 보고서의 worktree 필드에
-    REPORT="$(sh "$ARP" "$PWD")"
+    REPORT="$(sh "$ARP")"                       # ← 이 워크스페이스의 보고서
 
-`$PWD` 가 worktree 하위 디렉터리여도 됩니다 — 헬퍼가 worktree 루트로
-정규화하므로 위임자와 같은 경로가 나옵니다.
+`REPORT` 에 경로를 넘기지 않습니다 — 보고서는 **워크스페이스** 단위이고, 헬퍼가
+`$CMUX_WORKSPACE_ID` 에서 그 값을 읽습니다. `$WORKTREE` 는 여전히 `$PWD` 를
+받으며, 하위 디렉터리를 줘도 됩니다(헬퍼가 worktree 루트로 정규화).
+
+`REPORT` 가 `rc=2` 로 실패하면 이 셸이 cmux 워크스페이스 밖이라는 뜻입니다.
+그때는 보고서를 쓰지 말고 그 사실을 마지막 메시지에 남기세요 — 읽는 쪽이
+없는 상태이므로, 파일을 만들면 나중의 무관한 위임이 그것을 줍습니다.
 
     {
       "worktree": "/abs/path/to/worktree",
@@ -240,8 +245,9 @@ praxis 가 거기에 파일을 남길 이유가 없습니다.
       "completed_at": "2026-07-28T09:00:00Z"
     }
 
-- `worktree` 는 위 `$WORKTREE` 값을 그대로 넣습니다. 파일명이 해시라서 이
-  필드가 없으면 위임자가 자기 것인지 확인할 수 없습니다.
+- `worktree` 는 위 `$WORKTREE` 값을 그대로 넣습니다. 신원("이게 내 워커의
+  보고서인가")은 파일명인 워크스페이스 UUID 가 답하므로, 이 필드가 답하는 것은
+  **배치** 입니다 — 워커가 엉뚱한 디렉터리에서 돌았는지.
 - `pushed` 는 `git push` 가 **성공한 뒤에만** true. 커밋만 했으면 false.
 - `pr_url` 은 실제로 생성된 PR 이 없으면 `null` — 빈 문자열이나 예상 URL 금지.
 - `tests` 의 숫자는 실행한 명령의 출력에서 그대로 옮깁니다. 추정 금지.
@@ -445,14 +451,10 @@ cmux에서 {session_name} 탭을 확인하세요.
 silence. 어느 쪽도 메시지만 읽어서는 구분되지 않습니다. 파일 부재는
 결정론적으로 "미완료" 이고, 파일 존재는 필드별 재검증의 대상입니다.
 
-```bash
-ARP="${CLAUDE_PLUGIN_ROOT}/skills/cmux-delegate/agent-report-path.sh"
-WORKTREE="$(sh "$ARP" --worktree "{cwd}")"
-REPORT="$(sh "$ARP" "{cwd}")"
-[ -f "$REPORT" ] || { echo "미완료: 완료 보고서 부재 ($REPORT)"; exit 1; }
-[ "$(jq -r '.worktree // ""' "$REPORT")" = "$WORKTREE" ] \
-  || { echo "미완료: 보고서의 worktree 가 $WORKTREE 와 불일치"; exit 1; }
-```
+**보고서는 워커 하나당 하나입니다.** 키가 워크스페이스 UUID 이므로, `--distribute`
+로 띄운 N개가 같은 워크트리에서 돌아도 서로 다른 파일에 씁니다. 그래서 보고서
+검사는 아래 워크스페이스 루프 **안** 에 있습니다 — 루프 밖에서 한 번 하면 N명의
+완료를 1건분으로 판정하게 되고, 그게 이 단계가 오래 갖고 있던 결함이었습니다.
 
 **보고서가 없으면 거기서 멈추지 말고 이유를 묻습니다.** 파일 부재는 네 가지
 서로 다른 상황을 하나로 뭉갠 값이고, 각각 처방이 다릅니다.
@@ -471,6 +473,8 @@ REPORT="$(sh "$ARP" "{cwd}")"
 # 그 제목의 워크스페이스를 아예 만들지 않습니다.
 # distribute 모드는 항목마다 한 파일이므로 전부 돕니다.
 LIVENESS="${CLAUDE_PLUGIN_ROOT}/skills/cmux-delegate/agent-liveness.sh"
+ARP="${CLAUDE_PLUGIN_ROOT}/skills/cmux-delegate/agent-report-path.sh"
+WORKTREE="$(sh "$ARP" --worktree "{cwd}")"
 FOUND=0
 
 # glob 이 아니라 find 인 이유: 매치가 없을 때 zsh 는 `nomatch` 로 블록 전체를
@@ -484,9 +488,23 @@ for WS_FILE in $(find /tmp/ -maxdepth 1 -name 'cmux-delegate-{timestamp}-*.ws' 2
   FOUND=1
   # 반복마다 초기화: eval 이 아무것도 내놓지 않으면 $state 가 직전 워커의 값을
   # 그대로 들고 있어, 그 판정이 이 워커의 것으로 출력됩니다.
+  WS_ID="$(cat "$WS_FILE")"
   state=unknown
-  eval "$(sh "$LIVENESS" "$(cat "$WS_FILE")")"
-  echo "$WS_FILE $state"   # working | idle | waiting-input | crash | unknown
+  eval "$(sh "$LIVENESS" "$WS_ID")"
+
+  # 이 워커의 보고서. 같은 워크트리의 형제 워커와 다른 파일입니다.
+  REPORT="$(sh "$ARP" --workspace "$WS_ID")"
+  if [ ! -f "$REPORT" ]; then
+    report=absent
+  elif [ "$(jq -r '.worktree // ""' "$REPORT")" != "$WORKTREE" ]; then
+    # 신원은 파일명이 이미 답했으므로, 불일치는 "남의 보고서"가 아니라
+    # 이 워커가 엉뚱한 디렉터리에서 돌았다는 뜻입니다.
+    report=misplaced
+  else
+    report=present
+  fi
+
+  echo "$WS_FILE $state $report"   # state: working|idle|waiting-input|crash|unknown
 done
 
 if [ "$FOUND" -eq 0 ]; then
@@ -500,10 +518,16 @@ if [ "$FOUND" -eq 0 ]; then
 fi
 ```
 
-**보고서 층은 아직 이 축을 따라오지 못합니다.** `agent-report-path.sh` 는
-워크트리 경로로 해싱하므로 distribute 모드의 N개 워커가 보고서 파일 하나를
-공유합니다 (#903 선존). 즉 위 루프는 워커별로 살았는지를 답하지만, 아래
-보고서 검증은 여전히 1건분입니다.
+**두 값을 함께 읽습니다.** `state` 는 워커가 살아 있는지를, `report` 는 결과가
+도착했는지를 말합니다. 판정은 조합에서 나옵니다 — `idle` + `absent` 가 가장
+의심스러운 칸이고(턴은 끝났는데 결과가 없다), `idle` + `present` 가 완료입니다.
+`working` + `absent` 는 정상적인 진행 중입니다.
+
+| `report` | 뜻 | 위임자가 할 일 |
+| --- | --- | --- |
+| `present` | 보고서가 있고 워크트리가 일치 | 아래 필드별 재검증으로 |
+| `absent` | 파일 없음 | `state` 와 조합해 판단. 아래 4가지 원인 표 참조 |
+| `misplaced` | 보고서는 있으나 워크트리 불일치 | 이 워커가 엉뚱한 디렉터리에서 돌았음. 미완료로 취급 |
 
 | `state` | 뜻 | 위임자가 할 일 |
 | --- | --- | --- |

--- a/skills/cmux-delegate/agent-report-path.sh
+++ b/skills/cmux-delegate/agent-report-path.sh
@@ -1,32 +1,66 @@
 #!/bin/sh
-# Agent-report path derivation for cmux-delegate (issue #903).
+# Agent-report path derivation for cmux-delegate (issue #997).
 #
 # The delegated agent writes its completion report and the delegator reads it
-# back in Step 7. Both must land on the same file, and the only thing the two
-# share is the worktree path — so the key is derived from that, here, once.
-# Inlining the derivation in both halves of SKILL.md is how one half gets
-# fixed and the completion judgment silently stops finding anything.
+# back in Step 7. Both must land on the same file, and the key is the WORKSPACE
+# the work ran in. Inlining the derivation in both halves of SKILL.md is how one
+# half gets fixed and the completion judgment silently stops finding anything.
 #
-#   report="$(sh path/to/agent-report-path.sh "$PWD")"
+#   report="$(sh path/to/agent-report-path.sh)"                  # writer
+#   report="$(sh path/to/agent-report-path.sh --workspace "$ID")" # delegator
+#
+# The key used to be a hash of the worktree path, on the stated grounds that the
+# worktree was "the only thing the two share". Two consequences, both measured:
+# `--distribute` opens N workers in ONE worktree (the default cwd is the
+# delegator's own), so N workers shared one report file and per-worker
+# completion was unanswerable; and a report from a PREVIOUS delegation in that
+# worktree passed both of Step 7's checks, because the only guard is the
+# `worktree` field and that field matches too.
+#
+# The premise was false. A worker knows its own workspace — cmux exports
+# CMUX_WORKSPACE_ID into the process — and the delegator already stashes the
+# same UUID in a `.ws` file at launch. Both sides know it, and unlike the
+# worktree it differs per worker and per delegation.
 #
 # Reports live under <PRAXIS_HOME>/agent-reports/ rather than the worktree
 # root: the worktree usually belongs to an unrelated repository, and praxis
 # has no business leaving files in it.
-#
-# Hashing goes through python3 rather than shasum/sha1sum — praxis hooks
-# already require python3, and the two checksum binaries are not both present
-# across the platforms praxis targets.
 
 set -eu
 
-_ARP_MODE=path
-if [ "${1:-}" = "--worktree" ]; then
-    _ARP_MODE=worktree
-    shift
-fi
+_ARP_USAGE='usage: agent-report-path.sh --worktree <path-inside-worktree>
+       agent-report-path.sh [--workspace <uuid>]'
 
-if [ $# -ne 1 ] || [ -z "$1" ]; then
-    echo "usage: agent-report-path.sh [--worktree] <path-inside-worktree>" >&2
+_ARP_MODE=path
+_ARP_WS=""
+case "${1:-}" in
+    --worktree)
+        _ARP_MODE=worktree
+        shift
+        ;;
+    --workspace)
+        [ $# -ge 2 ] || { echo "$_ARP_USAGE" >&2; exit 2; }
+        # An empty value is the delegator handing over a corrupt or empty `.ws`
+        # file, and it must NOT fall through to CMUX_WORKSPACE_ID: the delegator
+        # usually runs inside a workspace of its own, so the fall-through would
+        # answer with the delegator's own report path and read one worker's
+        # completion as another's.
+        [ -n "$2" ] || {
+            echo "agent-report-path.sh: --workspace given an empty value" >&2
+            exit 2
+        }
+        _ARP_WS="$2"
+        shift 2
+        ;;
+esac
+
+if [ "$_ARP_MODE" = worktree ]; then
+    [ $# -eq 1 ] && [ -n "$1" ] || { echo "$_ARP_USAGE" >&2; exit 2; }
+elif [ $# -ne 0 ]; then
+    # Path mode takes no positional. An old `... "$PWD"` call site must fail
+    # loudly rather than have its argument ignored: it would otherwise keep
+    # running while silently addressing a different file than the other half.
+    echo "$_ARP_USAGE" >&2
     exit 2
 fi
 
@@ -34,22 +68,44 @@ _ARP_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=../../hooks/_lib/_paths.sh
 . "$_ARP_DIR/../../hooks/_lib/_paths.sh"
 
-# Normalize to the worktree ROOT before hashing. The agent writing the report
-# and the delegator reading it are rarely standing in the same directory — the
-# agent commonly works from a package subdir (`<worktree>/analytics_backend`)
-# while the delegator holds the path it passed to `--cwd`. Hashing the raw
-# argument would give the two different files, and the reader would report a
-# finished task as incomplete. A path outside any repo hashes as given.
-_ARP_TARGET="$(git -C "$1" rev-parse --show-toplevel 2>/dev/null || printf '%s' "${1%/}")"
-
-# `--worktree` exposes that same normalization, so the value the agent records
-# in the report's `worktree` field and the value the delegator compares it
-# against come from one implementation rather than two hand-written commands.
+# `--worktree` normalizes to the worktree ROOT. The agent writing the report and
+# the delegator reading it are rarely standing in the same directory — the agent
+# commonly works from a package subdir (`<worktree>/analytics_backend`) while the
+# delegator holds the path it passed to `--cwd`. Both sides get that value from
+# here rather than from two hand-written commands, so the report's `worktree`
+# field and the value compared against it cannot drift. A path outside any repo
+# is returned as given.
+#
+# This mode returns BEFORE the workspace check below, and the order is load
+# bearing: the value feeds the report's `worktree` field, which must still be
+# obtainable on a host with no cmux. Moving the check above this line breaks it.
 if [ "$_ARP_MODE" = worktree ]; then
-    printf '%s\n' "$_ARP_TARGET"
+    printf '%s\n' "$(git -C "$1" rev-parse --show-toplevel 2>/dev/null || printf '%s' "${1%/}")"
     exit 0
 fi
 
-_ARP_KEY="$(python3 -c 'import hashlib,sys; print(hashlib.sha1(sys.argv[1].rstrip("/").encode()).hexdigest())' "$_ARP_TARGET")"
+# The delegator passes --workspace (read from the `.ws` file it stashed at
+# launch); the agent passes nothing and is identified by its own environment.
+[ -n "$_ARP_WS" ] || _ARP_WS="${CMUX_WORKSPACE_ID:-}"
 
-praxis_resolve_writable agent-reports "$_ARP_KEY.json"
+if [ -z "$_ARP_WS" ]; then
+    # No fallback to a worktree key. The one path where a worker runs outside a
+    # workspace is manual execution after workspace creation failed — and there
+    # no `.ws` file exists, so no delegator is reading anything. A file written
+    # there would be read by nobody now and found by an unrelated delegation
+    # later, which is the exact failure this change removes.
+    echo "agent-report-path.sh: no workspace — pass --workspace <uuid> or run inside cmux" >&2
+    exit 2
+fi
+
+# The UUID becomes a filename, and it arrives from `cat`-ing a file. Anything
+# outside the UUID alphabet is rejected rather than escaped: it is either a
+# traversal attempt or a corrupt `.ws`, and both deserve to stop here.
+case "$_ARP_WS" in
+    *[!0-9A-Fa-f-]* | "" | *--* | -* | *-)
+        echo "agent-report-path.sh: not a workspace UUID: $_ARP_WS" >&2
+        exit 2
+        ;;
+esac
+
+praxis_resolve_writable agent-reports "$_ARP_WS.json"

--- a/tests/test_agent_report_handoff.sh
+++ b/tests/test_agent_report_handoff.sh
@@ -10,9 +10,10 @@
 #   (b) make the orchestrator read that file rather than the message, and
 #   (c) treat file absence as incomplete.
 #
-# Issue #903 moved the report out of the worktree root into
-# <PRAXIS_HOME>/agent-reports/<sha1(worktree)>.json, so §6 additionally
-# exercises the shipped path helper both halves of the protocol call.
+# Issue #997 re-keyed the report on the WORKSPACE rather than the worktree:
+# `--distribute` opens N workers in one worktree, so a worktree key gave N
+# workers one file and per-worker completion was unanswerable. §6 exercises the
+# shipped helper from both halves of the protocol under the new key.
 #
 # Assertions are static document checks against SKILL.md (mirroring
 # tests/test_worktree_merge_cleanup.sh) plus an executable gate in §6.
@@ -94,11 +95,17 @@ assert_present \
 
 assert_present \
   "file absence is deterministic incompletion" \
-  "미완료: 완료 보고서 부재"
+  '결정론적으로 "미완료" 이고'
 
 assert_present \
-  "reader confirms the report belongs to its own worktree (#903)" \
-  "보고서의 worktree 가"
+  "reader confirms the report was written where the work happened" \
+  "불일치 = 다른 작업의 보고서"
+
+# The defect #997 fixed: one report per WORKER, so the check sits inside the
+# per-workspace loop rather than once outside it.
+assert_present \
+  "the report check is per-worker, inside the workspace loop" \
+  "보고서는 워커 하나당 하나입니다"
 
 assert_present \
   "report values are re-verified, not trusted" \
@@ -225,13 +232,21 @@ HELPER="$ROOT_DIR/skills/cmux-delegate/agent-report-path.sh"
 GATE_TMP="$(mktemp -d)" || { echo "FATAL: mktemp -d failed — no writable temp dir" >&2; exit 1; }
 export PRAXIS_HOME="$GATE_TMP/praxis-home"
 
-report_path_for() { sh "$HELPER" "$1"; }
+# The delegator addresses a worker by the UUID it stashed at launch; the worker
+# is addressed by its own environment. Both go through the shipped helper.
+report_for_delegator() { sh "$HELPER" --workspace "$1"; }
+report_for_worker() { CMUX_WORKSPACE_ID="$1" sh "$HELPER"; }
 worktree_for() { sh "$HELPER" --worktree "$1"; }
 
-run_documented_gate() {  # $1 = path the delegator holds (worktree or a subdir)
+WS_NORMAL=AAAAAAAA-1111-2222-3333-444444444444
+WS_FABRICATED=BBBBBBBB-1111-2222-3333-444444444444
+WS_TRUNCATED=CCCCCCCC-1111-2222-3333-444444444444
+WS_MISPLACED=DDDDDDDD-1111-2222-3333-444444444444
+
+run_documented_gate() {  # $1 = workspace UUID, $2 = path the delegator holds
   local report worktree
-  report="$(report_path_for "$1")" || return 1
-  worktree="$(worktree_for "$1")" || return 1
+  report="$(report_for_delegator "$1")" || return 1
+  worktree="$(worktree_for "$2")" || return 1
   [ -f "$report" ] || { echo "미완료: 완료 보고서 부재 ($report)"; return 1; }
   python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$report" 2>/dev/null \
     || { echo "미완료: JSON 파싱 실패"; return 1; }
@@ -241,31 +256,68 @@ run_documented_gate() {  # $1 = path the delegator holds (worktree or a subdir)
 }
 
 WT_NORMAL="$GATE_TMP/normal"
-WT_FABRICATED="$GATE_TMP/fabricated"
 WT_TRUNCATED="$GATE_TMP/truncated"
-WT_FOREIGN="$GATE_TMP/foreign"
+WT_MISPLACED="$GATE_TMP/misplaced"
 
-cat > "$(report_path_for "$WT_NORMAL")" <<JSON
+cat > "$(report_for_delegator "$WS_NORMAL")" <<JSON
 {"worktree": "$WT_NORMAL", "branch": "issue-1-x", "head_sha": "abc", "pushed": true,
  "pr_url": null, "tests": {"command": "true", "passed": 1, "failed": 0},
  "completed_at": "2026-07-28T00:00:00Z"}
 JSON
 # fabricated: the agent said "PR created, all done" and wrote nothing.
-printf '{"worktree": "%s", "head_sha"' "$WT_TRUNCATED" > "$(report_path_for "$WT_TRUNCATED")"
-# foreign: a well-formed report that belongs to some other worktree.
-cat > "$(report_path_for "$WT_FOREIGN")" <<JSON
+printf '{"worktree": "%s", "head_sha"' "$WT_TRUNCATED" > "$(report_for_delegator "$WS_TRUNCATED")"
+# misplaced: a well-formed report whose work happened somewhere else entirely.
+cat > "$(report_for_delegator "$WS_MISPLACED")" <<JSON
 {"worktree": "$GATE_TMP/somewhere-else", "branch": "issue-2-y", "head_sha": "def",
  "pushed": true, "pr_url": null, "tests": {"command": "true", "passed": 1, "failed": 0},
  "completed_at": "2026-07-28T00:00:00Z"}
 JSON
 
-# Writer and reader independently derive the same path — the property the
-# shared helper exists to guarantee.
+# The property the shared helper exists to guarantee: the worker writing from
+# inside its workspace and the delegator holding the stashed UUID land on one
+# file, without either side transcribing the derivation.
 _assert_record "writer and reader derive the same path" \
-  "$([ "$(report_path_for "$WT_NORMAL")" = "$(report_path_for "$WT_NORMAL/")" ] && echo 1 || echo 0)" \
-  "trailing slash changed the derived report path"
+  "$([ "$(report_for_worker "$WS_NORMAL")" = "$(report_for_delegator "$WS_NORMAL")" ] && echo 1 || echo 0)" \
+  "the worker's own-environment path differs from the delegator's --workspace path"
 
-case "$(report_path_for "$WT_NORMAL")" in
+# The defect this file's §6 was rewritten for (#997): N workers in ONE worktree.
+_assert_record "two workers in the same worktree get different reports" \
+  "$([ "$(report_for_delegator "$WS_NORMAL")" != "$(report_for_delegator "$WS_FABRICATED")" ] && echo 1 || echo 0)" \
+  "distinct workspaces collided on one report file"
+
+# No fallback to a worktree key: outside cmux the helper refuses rather than
+# writing a file nobody reads now and an unrelated delegation finds later.
+if env -u CMUX_WORKSPACE_ID sh "$HELPER" >/dev/null 2>&1; then
+  _assert_record "no workspace is a hard failure, not a fallback" 0 "helper answered with no workspace id"
+else
+  _assert_record "no workspace is a hard failure, not a fallback" 1 ""
+fi
+
+# The delegator handing over an empty `.ws` must not be answered from the
+# delegator's OWN environment — that reads one worker's completion as another's.
+if CMUX_WORKSPACE_ID="$WS_NORMAL" sh "$HELPER" --workspace "" >/dev/null 2>&1; then
+  _assert_record "an empty --workspace does not fall through to the environment" 0 \
+    "empty value was answered from CMUX_WORKSPACE_ID"
+else
+  _assert_record "an empty --workspace does not fall through to the environment" 1 ""
+fi
+
+# The UUID becomes a filename and arrives from `cat`-ing a file.
+if sh "$HELPER" --workspace "../../etc/passwd" >/dev/null 2>&1; then
+  _assert_record "a non-UUID workspace is rejected" 0 "traversal-shaped value was accepted"
+else
+  _assert_record "a non-UUID workspace is rejected" 1 ""
+fi
+
+# An old `... "$PWD"` call site must fail loudly rather than have its argument
+# ignored while it addresses a different file than the other half.
+if CMUX_WORKSPACE_ID="$WS_NORMAL" sh "$HELPER" "$WT_NORMAL" >/dev/null 2>&1; then
+  _assert_record "the retired positional call form is rejected" 0 "path argument was silently ignored"
+else
+  _assert_record "the retired positional call form is rejected" 1 ""
+fi
+
+case "$(report_for_delegator "$WS_NORMAL")" in
   "$PRAXIS_HOME"/agent-reports/*) _assert_record "report lands under PRAXIS_HOME" 1 "" ;;
   *) _assert_record "report lands under PRAXIS_HOME" 0 "path escaped PRAXIS_HOME" ;;
 esac
@@ -274,48 +326,56 @@ _assert_record "report does not land in the worktree" \
   "$([ ! -e "$WT_NORMAL" ] && echo 1 || echo 0)" \
   "the worktree dir was created/written to"
 
-run_documented_gate "$WT_NORMAL" >/dev/null
+run_documented_gate "$WS_NORMAL" "$WT_NORMAL" >/dev/null
 _assert_record "gate accepts a normal completion" "$([ $? -eq 0 ] && echo 1 || echo 0)" \
   "documented gate rejected a valid report"
 
-run_documented_gate "$WT_FABRICATED" >/dev/null
+run_documented_gate "$WS_FABRICATED" "$GATE_TMP/fabricated" >/dev/null
 _assert_record "gate rejects a completion claim with no file" \
   "$([ $? -ne 0 ] && echo 1 || echo 0)" "documented gate accepted a missing report"
 
-run_documented_gate "$WT_TRUNCATED" >/dev/null
+run_documented_gate "$WS_TRUNCATED" "$WT_TRUNCATED" >/dev/null
 _assert_record "gate rejects a truncated report" \
   "$([ $? -ne 0 ] && echo 1 || echo 0)" "documented gate accepted malformed JSON"
 
-run_documented_gate "$WT_FOREIGN" >/dev/null
-_assert_record "gate rejects a report from another worktree" \
-  "$([ $? -ne 0 ] && echo 1 || echo 0)" "documented gate accepted a foreign report"
+run_documented_gate "$WS_MISPLACED" "$WT_MISPLACED" >/dev/null
+_assert_record "gate rejects a report whose work happened elsewhere" \
+  "$([ $? -ne 0 ] && echo 1 || echo 0)" "documented gate accepted a misplaced report"
 
-if [ -f "$(report_path_for "$WT_TRUNCATED")" ]; then
+if [ -f "$(report_for_delegator "$WS_TRUNCATED")" ]; then
   _assert_record "gate leaves a malformed report on disk for inspection" 1 ""
 else
   _assert_record "gate leaves a malformed report on disk for inspection" 0 "file removed"
 fi
 
-# The case that motivated the normalization: the agent writes from a package
-# subdirectory while the delegator holds the path it passed to `--cwd`. Hashing
-# the raw argument would send the two to different files, and a finished task
-# would read as incomplete.
+# `--worktree` still normalizes a package subdir to the worktree root: the agent
+# commonly works from `<worktree>/pkg` while the delegator holds `--cwd`, and the
+# report's `worktree` field must match across that gap.
 GIT_WT="$GATE_TMP/real-repo"
 mkdir -p "$GIT_WT/pkg/nested"
 git -C "$GIT_WT" init -q 2>/dev/null
 
-_assert_record "agent in a subdir derives the delegator's report path" \
-  "$([ "$(report_path_for "$GIT_WT/pkg/nested")" = "$(report_path_for "$GIT_WT")" ] && echo 1 || echo 0)" \
-  "subdirectory hashed to a different report than the worktree root"
+_assert_record "a subdir normalizes to the worktree root" \
+  "$([ "$(worktree_for "$GIT_WT/pkg/nested")" = "$(worktree_for "$GIT_WT")" ] && echo 1 || echo 0)" \
+  "subdirectory did not normalize to the worktree root"
 
-cat > "$(report_path_for "$GIT_WT/pkg/nested")" <<JSON
+# And it must keep working with no workspace at all — the field it feeds has to
+# be obtainable on a host with no cmux. Q3 of #997 depends on this ordering.
+if env -u CMUX_WORKSPACE_ID sh "$HELPER" --worktree "$GIT_WT" >/dev/null 2>&1; then
+  _assert_record "--worktree works outside a workspace" 1 ""
+else
+  _assert_record "--worktree works outside a workspace" 0 "the workspace check ran before the --worktree return"
+fi
+
+WS_SUBDIR=EEEEEEEE-1111-2222-3333-444444444444
+cat > "$(report_for_delegator "$WS_SUBDIR")" <<JSON
 {"worktree": "$(worktree_for "$GIT_WT/pkg/nested")", "branch": "issue-3-z",
  "head_sha": "abc", "pushed": true, "pr_url": null,
  "tests": {"command": "true", "passed": 1, "failed": 0},
  "completed_at": "2026-07-28T00:00:00Z"}
 JSON
 
-run_documented_gate "$GIT_WT" >/dev/null
+run_documented_gate "$WS_SUBDIR" "$GIT_WT" >/dev/null
 _assert_record "gate accepts a report written from a subdirectory" \
   "$([ $? -eq 0 ] && echo 1 || echo 0)" \
   "gate rejected a report the agent wrote from a package subdir"


### PR DESCRIPTION
Closes #997

### 무엇이 문제였나

`agent-report-path.sh` 가 보고서 경로를 워크트리 경로로 해싱했습니다. `--distribute` 로 띄운 N개 워커는 같은 워크트리에서 돌므로 **보고서 파일 하나를 공유**했고, Step 7 은 N명의 완료를 1건분으로 판정했습니다. 그리고 Step 7 의 검사는 파일 존재 + `worktree` 필드 일치 두 개뿐이라, **같은 워크트리에서 돈 예전 위임의 보고서도 둘 다 통과**했습니다.

헬퍼 헤더가 근거로 적어 둔 전제 — "둘이 공유하는 유일한 것이 워크트리 경로" — 가 틀렸습니다. 워커는 자기 워크스페이스를 압니다(cmux 가 `CMUX_WORKSPACE_ID` 를 주입). 위임자는 이미 같은 UUID 를 launch 시점에 `.ws` 파일에 박제하고 있습니다. 워크트리와 달리 이 값은 **워커마다, 위임마다** 다릅니다.

### 무엇을 바꿨나

- 보고서 키를 워크스페이스 UUID 로 옮겼습니다. writer 는 자기 환경, 위임자는 `--workspace <uuid>`.
- Step 7 의 보고서 검사를 워크스페이스 루프 **안** 으로 옮기고, 루프 불변 부분(헬퍼 경로, 워크트리 값)은 위로 끌어올렸습니다.
- `worktree` 필드의 역할이 신원 → **배치** 로 좁아집니다. 신원은 이제 파일명이 답합니다.
- `--workspace` 검사는 `--worktree` 조기 반환 **뒤** 에 둡니다. 그 모드가 내는 값은 보고서의 `worktree` 필드에 쓰이므로 cmux 없는 호스트에서도 동작해야 합니다.

### 폴백 없음

워크스페이스를 모르면 워크트리 키로 폴백하지 않고 exit 2 로 실패합니다. 폴백은 "아무도 읽지 않을 파일"을 만들고, 그 파일이 나중의 무관한 위임에게 발견되는 것이 바로 이 PR 이 제거하는 결함입니다. 빈 `--workspace` 값도 같은 이유로 `CMUX_WORKSPACE_ID` 로 흘러가지 않습니다 — 위임자는 대개 자기 워크스페이스 안에서 돌기 때문에, 흘러가면 한 워커의 완료를 다른 워커의 것으로 읽습니다.

### 기존 보고서

키가 바뀌므로 이전 방식으로 쓰인 파일은 조회되지 않습니다. 이것은 비용이 아니라 목적입니다 — 옛 파일이 조회되는 것 자체가 현재의 결함입니다. 마이그레이션도, 자동 삭제도 하지 않습니다.

Pre-commit verified: `bash scripts/run-tests.sh` 전량 실행 (pytest · shell tests · manifest · hook-token invariants · ruff · shellcheck 전부 green; memory frontmatter 단계만 red — 레포 밖 per-user 스토어 3개 파일, 브랜치 무관, 추적 파일 0개).

Caller chain verified: `agent-report-path.sh` 호출처 전수 grep (`.git` 제외 레포 전체). 실행 호출처는 `SKILL.md` 226행(writer)·476행(reader) 둘뿐이며 둘 다 이 PR 에서 새 계약으로 갱신했습니다. 나머지 3건은 문서 언급(`docs/runtime-state-layout.md`, `agent-liveness.sh` 주석, `test_skill_runtime_metadata.py` 주석)으로 호출이 아닙니다.
