### PR TITLE
docs(spec): tracked feature-spec convention under .praxis/specs

### DIFF
--- a/.praxis/specs/001-spec-artifact-convention.md
+++ b/.praxis/specs/001-spec-artifact-convention.md
@@ -1,0 +1,126 @@
+# Feature Specification: Tracked feature-spec convention
+
+**Issue**: #1001
+
+**Feature Branch**: `issue-1001-docs-spec-convention`
+
+**Created**: 2026-08-14
+
+**Input**: User description: "spec-kit 이랑 현재 하네스랑 접목을 하고 싶은데 검토 부탁합니다"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Read a hook's intent from the checkout alone (Priority: P1)
+
+Someone with only a clone of praxis — no GitHub access, no session history —
+wants to know what a given hook or skill was built to satisfy, and which of
+those requirements are load-bearing versus incidental.
+
+**Why this priority**: this is the whole gap. Today the answer lives in a
+remote issue body or in `.omc/plans/`, which `.gitignore` excludes. Every
+other story here is downstream of design intent being present in the tree.
+
+**Independent Test**: clone the repo with no network access, open
+`.praxis/specs/`, and answer "what must this feature do?" for any feature that
+has a spec. Delivers value even if nothing else in this issue ships.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh clone and no network, **When** a reader opens
+   `.praxis/specs/NNN-slug.md`, **Then** they can read that feature's
+   requirements and its back-reference to the originating issue.
+2. **Given** a spec file on a branch, **When** the branch is deleted after
+   merge, **Then** the spec survives on the base branch with its `**Issue**`
+   line intact.
+
+---
+
+### User Story 2 - Review the design and the code in one pass (Priority: P2)
+
+A reviewer on a PR wants to check the diff against stated requirements
+without leaving the diff.
+
+**Why this priority**: valuable, but it only pays off once specs exist, and a
+reviewer can still fall back to the issue body in the meantime.
+
+**Independent Test**: open a PR that changes both a spec and its
+implementation; confirm both appear in the same `gh pr diff` output.
+
+**Acceptance Scenarios**:
+
+1. **Given** a PR implementing a spec'd feature, **When** the reviewer reads
+   the diff, **Then** requirement changes and code changes appear together.
+
+---
+
+### Edge Cases
+
+- **Two branches claim the same `NNN`.** Numbers are assigned from the tree at
+  authoring time, so parallel worktrees can collide. Resolution is a rename on
+  rebase — the number carries no meaning beyond ordering, and nothing links to
+  it by number.
+- **A spec outlives the feature it described.** A removed feature's spec is
+  deleted in the same PR as the removal; a spec with no corresponding code is
+  the failure this convention is meant to make visible, not a state to keep.
+- **A change ships with no spec.** Expected and allowed — see the skip
+  conditions in `README.md`. Absence of a spec is not evidence of a skipped
+  process.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Specs MUST live at `.praxis/specs/NNN-slug.md` and MUST be
+  tracked by git — verified by `git ls-files --error-unmatch <path>` exiting 0.
+  `git check-ignore` is **not** the oracle here: it exits 1 for a file that is
+  merely un-ignored, which every untracked file also is, so it cannot tell
+  "will be tracked once added" from "is tracked".
+- **FR-002**: Every spec MUST carry an `**Issue**: #N` line under its title.
+- **FR-003**: The template MUST be spec-kit's `spec-template.md` verbatim,
+  carrying attribution for its MIT license and the version it was taken from.
+- **FR-004**: `README.md` MUST state when a spec is required and when it is
+  skipped, so that a missing spec is a readable decision rather than an
+  oversight.
+- **FR-005**: The convention MUST NOT introduce a runtime dependency on the
+  `specify` CLI or on any `.specify/` directory.
+- **FR-006**: Adopting this convention MUST NOT change any existing enforcement
+  tier, hook, or skill surface — verified by `./scripts/check-plugin-manifests.py`
+  reporting no surface change.
+
+### Key Entities
+
+*Not applicable — this feature adds documentation conventions and no data.*
+
+## Out of Scope
+
+**Automated drift detection** — reporting which of a spec's requirements the
+current tree does not yet satisfy. It is a separate feature with its own
+oracle, and it gets its own spec and issue rather than a requirement here.
+
+The distinction is what a requirement means: everything under `Requirements`
+above is a contract this change must satisfy, so a `MUST` that ships unmet
+would make the spec self-contradictory and set the precedent that a `MUST` is
+optional. A convention that is worth reading and a report that checks it are
+two features, not one feature delivered in halves.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A reader with a fresh offline clone can state the requirements of
+  any spec'd feature without consulting GitHub.
+- **SC-002**: `git ls-files .praxis` lists every spec file — zero specs are
+  silently untracked.
+- **SC-003**: The full CI entrypoint (`scripts/run-tests.sh`, invoked by
+  `.github/workflows/ci.yml:109`) passes unchanged after adoption.
+
+## Assumptions
+
+- praxis stays a single-trunk repository on `main`; spec numbering assumes no
+  long-lived parallel release lines.
+- Specs are written by whoever opens the issue, in the same session — the
+  convention adds a document, not a handoff.
+- spec-kit's `spec-template.md` stays MIT-licensed; the attribution block
+  records v0.16.3 so a future re-sync is a diff rather than a guess.
+- Reviewers read the spec because it sits in the diff; no gate forces it. If
+  that assumption fails, the remedy is a hook, not a longer README.

--- a/.praxis/specs/README.md
+++ b/.praxis/specs/README.md
@@ -1,0 +1,115 @@
+# Feature specs
+
+Tracked design documents for praxis features. One file per feature:
+`.praxis/specs/NNN-slug.md`.
+
+These are **feature specs** — what a change must satisfy. They are not the
+same thing as the *skill spec drift* gate in
+[`CONTRIBUTING.md`](../../CONTRIBUTING.md), which is about a `SKILL.md`
+matching live runtime behavior.
+
+## Why this exists
+
+Before this convention, praxis design intent lived in two places that the
+repository itself cannot see:
+
+- `.omc/plans/` — excluded by `.gitignore` (`.omc/`)
+- GitHub issue bodies — remote only
+
+So someone reading a checkout could not answer "what was this hook built to
+satisfy?" A spec file closes that gap by putting the requirements next to the
+code, under review, in version control.
+
+## When to write one
+
+Write the spec **after the worktree is created, before implementation starts**.
+
+A spec is a tracked file, so it is written inside the worktree like any other
+change — the mandatory issue-driven workflow has the worktree in place before
+tracked files are touched, and writing the spec earlier would mean editing the
+base checkout.
+
+What matters is that it lands *before* the implementation: writing it after
+work has started turns it into post-hoc justification — the same reason the
+`Judgement` axes of an issue review are only valid before work begins.
+
+Write a spec when the change:
+
+- adds or removes a skill, hook, or CLI surface
+- changes a rule's enforcement tier or its decision predicate
+- spans more than one PR, or more than a handful of files
+
+**Skip** it for a single-file bug fix, a documentation typo, a mechanical
+rename, or anything whose revert is self-evident. A spec that restates a
+one-line diff costs a review round and teaches nothing.
+
+The skip list applies **only when no trigger above fires**. The two overlap on
+purpose — a one-file change to a rule's decision predicate is both a
+single-file fix and a predicate change — and when they do, the trigger wins.
+Size is never the reason to skip: what earns a spec is the change being hard to
+reconstruct later, not the diff being large.
+
+## Naming
+
+| Part | Rule |
+| --- | --- |
+| `NNN` | Highest existing number + 1, zero-padded to three digits |
+| `slug` | Lowercase kebab-case, derived from the issue title |
+
+The slug does not have to match the branch name. Branch `issue-1001-docs-spec-convention`
+and spec `001-spec-artifact-convention.md` are the same work under two names,
+and that is fine — each is named for what its own reader is looking for. The
+link between them is the `**Issue**: #N` line, not a shared string; a slug rule
+strict enough to be greppable is one the very first spec here already broke.
+
+The numbers are independent too: `NNN` is a spec counter, not an issue number.
+
+## Required header
+
+Every spec starts with a back-reference line directly under the title:
+
+```markdown
+# Feature Specification: <name>
+
+**Issue**: #1001
+```
+
+Without it a spec orphans as soon as its branch is deleted.
+
+**`TEMPLATE.md` does not carry this field** — it is upstream's file, and the
+upstream template has no notion of an issue. Add the line by hand when you copy,
+directly above `**Feature Branch**`. Keeping the omission rather than patching
+the template is deliberate: it leaves the copy byte-identical to upstream, so
+re-syncing a newer spec-kit version stays a diff instead of a merge.
+
+## Template
+
+Copy [`TEMPLATE.md`](TEMPLATE.md) and fill it in. It is
+[github/spec-kit](https://github.com/github/spec-kit)'s `spec-template.md`
+v0.16.3 verbatim (MIT), plus an attribution block.
+
+Two conventions on top of the template:
+
+- Delete the sections that do not apply. `Key Entities` is marked
+  *include if feature involves data* and rarely applies to a hook or skill —
+  an empty section reads as an unanswered question.
+- Leave `[NEEDS CLARIFICATION: ...]` markers in place until they are actually
+  resolved. An unresolved marker is the point of the format; replacing it
+  with a guess defeats it.
+- Delete the `**Status**: Draft` line. praxis does not track spec status in the
+  document: a spec on `main` is accepted and one on a branch is not, which git
+  already answers without anyone remembering to edit a field. The line stays in
+  `TEMPLATE.md` only because that file is upstream's, kept byte-identical.
+
+## What praxis did not adopt
+
+praxis takes this one template and nothing else from spec-kit. Not adopted:
+
+| spec-kit component | Reason |
+| --- | --- |
+| `.specify/memory/constitution.md` | Duplicate rule source of truth; `CLAUDE.md` and [`ETHOS.md`](../../ETHOS.md) already hold that role |
+| `.specify/extensions.yml` hooks | They instruct the model to invoke its own gates — the prompt-only form [`ETHOS.md`](../../ETHOS.md) replaced with real hooks |
+| `.specify/workflows/*.yml` gates | Only fire when driven through `specify workflow run`; an agent working directly bypasses them |
+| `speckit-*` agent skills | Namespace pressure on an already-large skill surface |
+| `specify` CLI at runtime | One template needs no external CLI dependency |
+| `plan.md` / `tasks.md` / `checklist.md` | Plan mode and issue checklists already own these |

--- a/.praxis/specs/TEMPLATE.md
+++ b/.praxis/specs/TEMPLATE.md
@@ -1,0 +1,141 @@
+<!--
+  Copied verbatim from github/spec-kit v0.16.3
+  `.specify/templates/spec-template.md` (MIT License, Copyright GitHub, Inc.).
+  Full upstream copyright and permission notice: ../../THIRD-PARTY-NOTICES.md
+  Only this attribution block is added. See .praxis/specs/README.md for how
+  praxis uses it — praxis adopts this one template, not the rest of spec-kit.
+  Delete this block when copying the file into a new spec; the notice lives in
+  THIRD-PARTY-NOTICES.md and does not need to travel into every spec.
+-->
+
+# Feature Specification: [FEATURE NAME]
+
+**Feature Branch**: `[###-feature-name]`
+
+**Created**: [DATE]
+
+**Status**: Draft
+
+**Input**: User description: "$ARGUMENTS"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - [Brief Title] (Priority: P1)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently - e.g., "Can be fully tested by [specific action] and delivers [specific value]"]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+2. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 2 - [Brief Title] (Priority: P2)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 3 - [Brief Title] (Priority: P3)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- What happens when [boundary condition]?
+- How does system handle [error scenario]?
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
+- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]
+- **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
+- **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
+- **FR-005**: System MUST [behavior, e.g., "log all security events"]
+
+*Example of marking unclear requirements:*
+
+- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
+- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
+
+### Key Entities *(include if feature involves data)*
+
+- **[Entity 1]**: [What it represents, key attributes without implementation]
+- **[Entity 2]**: [What it represents, relationships to other entities]
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: [Measurable metric, e.g., "Users can complete account creation in under 2 minutes"]
+- **SC-002**: [Measurable metric, e.g., "System handles 1000 concurrent users without degradation"]
+- **SC-003**: [User satisfaction metric, e.g., "90% of users successfully complete primary task on first attempt"]
+- **SC-004**: [Business metric, e.g., "Reduce support tickets related to [X] by 50%"]
+
+## Assumptions
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right assumptions based on reasonable defaults
+  chosen when the feature description did not specify certain details.
+-->
+
+- [Assumption about target users, e.g., "Users have stable internet connectivity"]
+- [Assumption about scope boundaries, e.g., "Mobile support is out of scope for v1"]
+- [Assumption about data/environment, e.g., "Existing authentication system will be reused"]
+- [Dependency on existing system/service, e.g., "Requires access to the existing user profile API"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Each skill is an orchestrator with pluggable steps. External integrations (issue
 | [`ARCHITECTURE.md`](ARCHITECTURE.md)                               | Skill ↔ hook ↔ manifest dependency graph — provider routing, hook index, multi-platform packaging                                                                      |
 | [`RUNTIME_CONSTRAINTS.md`](RUNTIME_CONSTRAINTS.md)                 | Fixed Claude Code runtime limits every skill must respect                                                                                                              |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md)                               | Skill and hook contribution conventions, live-runtime verification gate                                                                                                |
+| [`.praxis/specs/README.md`](.praxis/specs/README.md)               | Feature-spec convention — tracked design docs at `.praxis/specs/NNN-slug.md`, when one is required and when it is skipped                                              |
 | [`docs/hook-prune-audit.md`](docs/hook-prune-audit.md)             | Evidence-based keep/merge/drop verdict per hook, scored from the fire-rate ledger (issue #713)                                                                         |
 | [`docs/retrospect-prune-audit.md`](docs/retrospect-prune-audit.md) | Same lens on the retrospect skill's gates/fences/stages, scored from retrospective transcript mining (issue #776)                                                      |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,21 @@ Praxis is a personal toolbox — contributions are primarily self-directed, but
 the conventions below keep the repo coherent across sessions and prevent the
 class of drift bugs that have cost the most debugging time.
 
+## Writing a spec
+
+A *feature spec* states what a change must satisfy, before the change exists.
+It is a different artifact from the *skill spec* discussed under
+[Skill spec drift prevention](#skill-spec-drift-prevention) below — that one is
+a `SKILL.md` describing an existing runtime contract.
+
+Feature specs live at `.praxis/specs/NNN-slug.md`, one file per feature, and
+are tracked by git. Write one inside the worktree, before implementation
+starts; writing it afterwards turns it into post-hoc justification.
+
+Not every change needs one — [`.praxis/specs/README.md`](.praxis/specs/README.md)
+is the source of truth for the naming rules, the required `**Issue**: #N`
+header, and the conditions under which a spec is skipped.
+
 ## Adding or modifying a skill
 
 ### Template

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,36 @@
+# Third-party notices
+
+Praxis redistributes the following third-party material. Each entry reproduces
+the upstream copyright and permission notice as its license requires.
+
+## github/spec-kit
+
+**Used in**: [`.praxis/specs/TEMPLATE.md`](.praxis/specs/TEMPLATE.md) — a verbatim
+copy of `.specify/templates/spec-template.md` from spec-kit v0.16.3, carrying an
+added attribution block and no other change.
+
+**Source**: <https://github.com/github/spec-kit>
+
+```text
+MIT License
+
+Copyright GitHub, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```


### PR DESCRIPTION
Closes #1001

### 무엇을 하는가

`.praxis/specs/NNN-slug.md`에 추적되는 feature spec 규약을 도입한다. 지금까지 설계
의도는 `.omc/plans/`(`.gitignore`로 제외)나 원격 이슈 본문에만 있어서, 체크아웃만 받은
사람은 "이 hook/skill이 무엇을 만족하려고 만들어졌는가"를 읽을 곳이 없었다.

| 파일 | 역할 |
| --- | --- |
| `.praxis/specs/TEMPLATE.md` | github/spec-kit v0.16.3 `spec-template.md` — 귀속 블록 1개 외 바이트 동일 |
| `.praxis/specs/README.md` | 번호·슬러그 규칙, 작성 시점, required/skip 우선순위, 미도입 항목 |
| `.praxis/specs/001-spec-artifact-convention.md` | 규약 자신의 spec (dogfood) |
| `THIRD-PARTY-NOTICES.md` | upstream MIT 저작권·permission notice (재배포 조건) |
| `CONTRIBUTING.md` / `AGENTS.md` | `## Writing a spec` 절, 문서 맵 행 |

### spec-kit에서 가져오지 않은 것

집행 계층은 의도적으로 배제했다. spec-kit은 `.claude/settings.json`을 쓰지 않고 hook을
설치하지 않으며, 그 "hook" 체계는 모델에게 *"`.specify/extensions.yml`을 읽고 네가 직접
호출하라"*고 지시하는 프롬프트 텍스트다. `ETHOS.md`가 실패로 판정하고 hook으로 대체한
형태이므로, 파일 규약만 취하고 집행은 기존 hook 계층에 맡긴다.

미도입: `constitution.md`(룰 SoT 이중화) · `extensions.yml` 훅 체계 · `workflow.yml`
게이트 · `speckit-*` 스킬 10종 · `specify` CLI 런타임 의존 · `plan.md`/`tasks.md`/`checklist.md`.

`specify` CLI에 대한 런타임 의존은 없다. 템플릿 1개만 쓴다.

### 리뷰 이력

`praxis:codex-review-wrap` 4라운드, 9건 적용. 라운드별 등급은 P2 2건 → **P1** 1건 + P2 2건
→ P2 1건 → P2 1건 + P3 1건. P1은 MIT permission notice 누락(재배포 조건 위반)이었고
`THIRD-PARTY-NOTICES.md` 신설로 해소했다.

한 건은 이 PR 밖으로도 번졌다 — FR-001이 `git check-ignore`로 "tracked"를 증명한다고
적혀 있었는데, `check-ignore` exit 1은 *미무시*만 뜻하고 아직 `git add`하지 않은 파일도
동일하게 exit 1이다. 올바른 오라클은 `git ls-files --error-unmatch`다. 같은 오류가 이슈
본문에도 있어 #1001 본문에 정정 주석과 함께 반영했다.

Pre-commit verified: ruff `All checks passed!`, `check-plugin-manifests.py` → `plugin-manifest check OK`, markdownlint 신규 파일 `0 issues in 0 files`

Caller chain verified: docs-only 변경으로 도입하거나 참조하는 심볼이 없음
