### PR TITLE
test: isolate CLAUDE_CONFIG_DIR from the test suite

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -65,6 +65,17 @@ trap 'rm -rf "$PRAXIS_HOME"' EXIT
 # prefix on a specific call still wins over this exported default.
 export PRAXIS_FIRE_TELEMETRY_FILE="$PRAXIS_HOME/fire-events-test.jsonl"
 
+# Third isolation, and the one that breaks the pattern of the two above (#1003).
+# CLAUDE_CONFIG_DIR relocates Claude Code's config root, and resolve_memory_dir()
+# treats it as authoritative over the HOME-derived default (#853). A test that
+# builds a HOME fixture and expects that default therefore reads the developer's
+# real store instead. The fix cannot be a throwaway export the way PRAXIS_HOME
+# was: what wins is the variable being *set*, not its value, so an override
+# fails those tests identically to the ambient value. Unset is the only
+# isolation. Saved first, because step 5 wants the real root back.
+CLAUDE_CONFIG_DIR_AMBIENT="${CLAUDE_CONFIG_DIR-}"
+unset CLAUDE_CONFIG_DIR
+
 FAILED=0
 SKIPPED_TOOLS=()
 
@@ -154,7 +165,15 @@ echo "=== memory frontmatter lint ==="
 # only actual detected drift (exit 1 with violations listed) fails this step.
 # The script's own PRAXIS_TESTS_STRICT support still works for direct
 # standalone invocation (see its tests / docstring).
-if ! env -u PRAXIS_TESTS_STRICT python3 ./scripts/check-memory-frontmatter.py; then
+# Re-inject the ambient CLAUDE_CONFIG_DIR the preamble unset (#1003). This is
+# the one step whose whole point is reading the developer's *real* memory store,
+# so the suite-wide isolation above would silently retarget it — at the default
+# root, which on a relocated host holds a different store or none at all.
+MEMCHECK_ENV=(env -u PRAXIS_TESTS_STRICT)
+if [ -n "$CLAUDE_CONFIG_DIR_AMBIENT" ]; then
+  MEMCHECK_ENV+=("CLAUDE_CONFIG_DIR=$CLAUDE_CONFIG_DIR_AMBIENT")
+fi
+if ! "${MEMCHECK_ENV[@]}" python3 ./scripts/check-memory-frontmatter.py; then
   FAILED=1
 fi
 

--- a/tests/hooks/advisory-nudge/test_memory_hint.sh
+++ b/tests/hooks/advisory-nudge/test_memory_hint.sh
@@ -313,8 +313,16 @@ EOF
 FALLBACK_ERR=$(mktemp)
 (
   cd "$FALLBACK_CWD" || exit 1
+  # CLAUDE_CONFIG_DIR must be unset, not pointed elsewhere: resolve_memory_dir()
+  # treats it as authoritative over the HOME-derived default (#853), and the
+  # default is exactly the branch this case exercises. An ambient value sends
+  # the hook to the developer's real store instead of the fixture. Overriding
+  # it with a throwaway path fails identically — "set" is what wins, not the
+  # value. Mirrors tests/hooks/_lib/test_memory_dir.py, whose HOME fixtures all
+  # delenv it and which covers the relocated root as its own separate case.
   echo '{"tool_name": "Bash", "tool_input": {"command": "echo FallbackSlugToken"}}' \
-    | env -u PRAXIS_MEMORY_DIR HOME="$FALLBACK_HOME" "$HOOK" >/dev/null 2>"$FALLBACK_ERR"
+    | env -u PRAXIS_MEMORY_DIR -u CLAUDE_CONFIG_DIR HOME="$FALLBACK_HOME" "$HOOK" \
+      >/dev/null 2>"$FALLBACK_ERR"
 )
 FALLBACK_RC=$?
 FALLBACK_OUT=$(cat "$FALLBACK_ERR")


### PR DESCRIPTION
Closes #1003

### 무엇을 하는가

앰비언트 `CLAUDE_CONFIG_DIR`가 테스트 스위트로 새어 들어가는 것을 막는다. `HOME`
픽스처를 만든 테스트가 픽스처 대신 개발자의 실제 Claude Code config 루트를 읽고
있었고, 그 조건에서 `test_memory_hint.sh` #35가 실패했다.

리졸버는 정상이다 — `CLAUDE_CONFIG_DIR`를 권위 있는 값으로 쓰는 것은 #853에서
의도적으로 만든 동작이다. 결함은 테스트 위생 쪽이었다.

| 커밋 | 범위 |
| --- | --- |
| `test(hooks)` | `test_memory_hint.sh:317` — `env`에 `-u CLAUDE_CONFIG_DIR` 추가. 실제로 깨지던 1건을 고치는 것은 이 커밋이다 |
| `test(ci)` | `run-tests.sh` — 프리앰블에서 저장 후 해제, memory frontmatter lint 단계에만 재주입 |

### 왜 override 가 아니라 unset 인가

`PRAXIS_HOME`(#903)·`PRAXIS_FIRE_TELEMETRY_FILE`(#849) 선례는 둘 다 "버려도 되는 값으로
export"다. 이 변수만 형태가 다르다 — **설정돼 있기만 하면** `HOME` 기반 기본 경로를
이기는데, #35가 검증하려는 대상이 바로 그 기본 분기다. throwaway 값도 "설정됨"이므로
같은 실패가 재현된다.

```
CLAUDE_CONFIG_DIR=<throwaway>/claude-config bash …/test_memory_hint.sh
FAIL  [35 …]   Passed: 35  Failed: 1
```

### 왜 memory lint 만 되돌려 주는가

`run-tests.sh` 주석이 그 단계에 대해 "CI에는 구조적으로 없고 로컬에서만 enforcement
value 를 갖는다"고 명시한다. 전역 해제는 그 단계가 읽는 대상 자체를 바꿔버리므로,
앰비언트 값을 저장했다가 그 호출에만 돌려준다.

### 두 커밋이 중복이 아닌 이유

범위가 다르다. 프리앰블은 스위트를 통해 돌릴 때만 듣고, 테스트 파일 단독 실행은
per-test 해제만이 고친다. pytest 쪽 형제(`tests/hooks/_lib/test_memory_dir.py`)도
픽스처 3곳 전부 `monkeypatch.delenv`를 부르는 per-test 형태다.

`(a)+(b)`가 오늘 고치는 테스트는 0건이다 — 앞으로 `HOME` 픽스처를 쓰는 테스트가 같은
함정에 빠지는 것을 막는 예방 계층이며, 커밋 trailer에 `Not-tested:`로 남겨두었다.

### 리뷰

`praxis:codex-review-wrap` 1라운드, findings 0건. codex는 read-only sandbox라 임시 파일
생성이 막혀 실제 shell test를 실행하지 못했고 정적 검사(`bash -n` / ShellCheck /
`git diff --check`)만 통과했다. 기능 검증은 검증 코멘트에 붙인 실행 출력이 근거다.

Pre-commit verified: `bash -n` exit=0, `shellcheck` exit=0, `ruff` `All checks passed!`, `check-plugin-manifests.py` → `plugin-manifest check OK`

Caller chain verified: `CLAUDE_CONFIG_DIR` 소비자 전수 — `hooks/_lib/_memory_dir.py:66`(유일 리졸버, memory-hint·momentum-rule-retrieval-gate 가 import) · `scripts/check-memory-frontmatter.py:57`(위 리졸버에 위임) · `skills/codex-review-wrap/codex-broker-reaper.sh:49`(테스트가 호출마다 값을 명시하므로 무영향)
