### PR TITLE
fix(hooks): fold lines across an open quote in safe_tokenize

### DIFF
--- a/hooks/_lib/_hook_utils.py
+++ b/hooks/_lib/_hook_utils.py
@@ -250,6 +250,80 @@ def is_help_invocation(argv: list[str], value_flags: frozenset[str]) -> bool:
     return False
 
 
+def _quote_open_at_eol(line: str, quote: str) -> str:
+    """The quote character still open after consuming `line` from state `quote`.
+
+    Models *shlex*'s quote rules rather than bash's, because shlex is the
+    tokenizer this scanner feeds: a single quote escapes everything, a backslash
+    escapes inside double quotes and outside quotes, and `$(…)` is opaque text
+    rather than a re-entrant parse. Modelling bash here instead would let the
+    line grouping and the tokenizer disagree about where a token ends.
+
+    The one deliberate divergence is the unquoted `#`. `safe_tokenize` runs with
+    `commenters = ""` so the `# side-effect:ack` marker survives as tokens, but
+    bash reads nothing past an unquoted `#` — so the apostrophe in
+    `git status # don't do this` must not be taken for an opening quote that
+    swallows the next line's real command. The word-boundary rule is copied from
+    `_heredoc_starts_on_line` above so the two scanners cannot drift apart. The
+    divergence only ever ends a group *earlier*, never merges more lines into
+    one, so it cannot hide a command that the old per-line split saw.
+    """
+    i, n = 0, len(line)
+    while i < n:
+        ch = line[i]
+        if quote:
+            if ch == "\\" and quote == '"':
+                i += 2
+                continue
+            if ch == quote:
+                quote = ""
+            i += 1
+            continue
+        if ch in "'\"":
+            quote = ch
+            i += 1
+            continue
+        if ch == "#" and (i == 0 or line[i - 1] in " \t;|&("):
+            return ""  # unquoted comment — bash opens no quote past it
+        if ch == "\\":
+            i += 2
+            continue
+        i += 1
+    return quote
+
+
+def _logical_lines(command: str) -> list[str]:
+    """Physical lines folded into logical lines across an unclosed quote.
+
+    A newline inside a quote is *data*, not a command separator — bash keeps
+    reading the same word. Splitting there gave the opening and the closing line
+    their own shlex pass, both raised ``ValueError: No closing quotation``, and
+    the caller's fail-open arm dropped them: that took `gh pr comment`'s argv[0]
+    with it (issue #972) and, when a real command rode on the closing line, the
+    entire command (issue #987 — all three merge gates went silent on
+    ``git commit -m "$(cat <<'EOF' … EOF)" && gh pr merge``).
+
+    Folded lines are rejoined with ``\\n`` so the newline stays *inside* the
+    resulting token, which is what bash hands the process. A group still open at
+    the end of the command is emitted as-is, so shlex raises exactly as it did
+    before and the caller's ``except ValueError`` arm keeps its behavior.
+    """
+    if "\n" not in command:
+        return [command]
+    out: list[str] = []
+    group: list[str] = []
+    quote = ""
+    for line in command.split("\n"):
+        group.append(line)
+        quote = _quote_open_at_eol(line, quote)
+        if not quote:
+            out.append("\n".join(group))
+            group = []
+    if group:  # unterminated at end of command — hand it to shlex unchanged
+        out.append("\n".join(group))
+    return out
+
+
 def safe_tokenize(command: str) -> list[str]:
     """Tokenize with shell operators and line breaks split into tokens.
 
@@ -277,16 +351,20 @@ def safe_tokenize(command: str) -> list[str]:
     ``except ValueError`` arm below would silently drop the entire first line
     (issue #510 — neutralised dozens of hooks).
 
-    Caller note: a multi-line value inside a quoted flag (e.g.
-    ``gh pr create --body "line1\\nline2"``) is split at the unescaped
-    newline, separating ``--body`` from its value. In test payloads, use a
-    heredoc-assigned variable instead::
+    A newline *inside* a quote is data, not a separator, so physical lines are
+    folded into logical lines first (`_logical_lines`) and the newline is kept
+    inside the resulting token. Without that fold, the line holding the opening
+    quote and the line holding the closing one each raised ``ValueError: No
+    closing quotation`` and were dropped by the arm above: a multi-line
+    ``gh pr comment --body '…'`` lost its ``gh`` argv[0] (issue #972) and a real
+    command riding on the closing line vanished outright, blinding all three
+    merge gates (issue #987). A newline *outside* a quote is still a separator
+    and still becomes a synthetic ``;``.
 
-        BODY=$(cat <<'EOF'
-        Caller chain verified: ...
-        EOF
-        )
-        gh pr create --body "$BODY"
+    ``commenters = ""`` is unchanged, so the ``# side-effect:ack`` opt-out
+    marker still tokenizes. Comments are excluded from quote-state tracking
+    only — an unquoted ``#`` never opens a quote, so an apostrophe in
+    ``git status # don't do this`` cannot swallow the next line's command.
     """
     # Splice bash line continuations (`\` + newline) into one logical line so
     # the leading line's argv[0] survives the per-line shlex pass below. A
@@ -295,7 +373,7 @@ def safe_tokenize(command: str) -> list[str]:
     # odd-length run of trailing backslashes.
     command = re.sub(r"(?<!\\)((?:\\\\)*)\\\n", r"\1 ", command)
     command = strip_heredoc_bodies(command)
-    lines = [ln for ln in command.split("\n") if ln.strip()]
+    lines = [ln for ln in _logical_lines(command) if ln.strip()]
     if not lines:
         return []
     tokens: list[str] = []

--- a/hooks/_lib/_hook_utils.py
+++ b/hooks/_lib/_hook_utils.py
@@ -290,8 +290,22 @@ def _quote_open_at_eol(line: str, quote: str) -> str:
     one, so it cannot hide a command that the old per-line split saw.
     """
     i, n = 0, len(line)
+    arith = 0
+    subst: list[str] = []
     while i < n:
         ch = line[i]
+        # A command substitution re-opens shell parsing even inside double
+        # quotes, so the quotes within it are their own. Without this, the inner
+        # `'"'` of `echo "$(printf '"')"` was read as closing the outer double
+        # quote and opening a new one, leaving a quote apparently open at EOL —
+        # the next line was folded in and shlex dropped the pair. `subst` stacks
+        # the suspended outer quote, mirroring `_heredoc_starts_on_line`, which
+        # already had to solve this for the same reason.
+        if quote == '"' and line.startswith("$(", i) and not line.startswith("$((", i):
+            subst.append(quote)
+            quote = ""
+            i += 2
+            continue
         if quote:
             if ch == "\\" and quote == '"':
                 i += 2
@@ -309,8 +323,24 @@ def _quote_open_at_eol(line: str, quote: str) -> str:
         if ch == "\\":
             i += 2
             continue
+        if line.startswith("$((", i):
+            arith += 1
+            i += 3
+            continue
+        if arith and line.startswith("))", i):
+            arith -= 1
+            i += 2
+            continue
+        if ch == ")" and subst and not arith:
+            quote = subst.pop()
+            i += 1
+            continue
         i += 1
-    return quote
+    # A substitution still open at EOL means the command continues, so report
+    # the outermost suspended quote and let the caller keep folding. A `$(`
+    # opened *outside* any quote suspends `""`, which reports closed — that is
+    # the pre-existing behaviour, unchanged here rather than improved.
+    return quote or (subst[0] if subst else "")
 
 
 def _logical_lines(command: str) -> list[str]:

--- a/hooks/_lib/_hook_utils.py
+++ b/hooks/_lib/_hook_utils.py
@@ -71,6 +71,26 @@ WRAPPER_OPTS_WITH_ARG = {
 }
 
 
+# bash's full metacharacter set minus the newline, which line splitting already
+# handles. `)`, `<` and `>` were missing while `(`, `;`, `|` and `&` were
+# present, so a comment opening right after a closing paren or a redirection
+# operator was read as ordinary text — and an apostrophe inside it opened a
+# quote that swallowed the next line's command.
+_WORD_BOUNDARY_CHARS = " \t;|&()<>"
+
+
+def _starts_unquoted_comment(line: str, i: int) -> bool:
+    """True when `line[i]` is a `#` that bash would read as opening a comment.
+
+    A `#` only starts a comment at the start of a word, so the character before
+    it must be a metacharacter that ended the previous token. Both scanners in
+    this module ask this question and they must never answer it differently:
+    `_heredoc_starts_on_line` uses it to stop reading operators, and
+    `_quote_open_at_eol` uses it to stop tracking quote state.
+    """
+    return line[i] == "#" and (i == 0 or line[i - 1] in _WORD_BOUNDARY_CHARS)
+
+
 def _heredoc_starts_on_line(line: str) -> list[tuple[str, bool]]:
     """`(delimiter, dash_form)` for every heredoc opened on one physical line.
 
@@ -109,7 +129,7 @@ def _heredoc_starts_on_line(line: str) -> list[tuple[str, bool]]:
             quote = ch
             i += 1
             continue
-        if ch == "#" and (i == 0 or line[i - 1] in " \t;|&("):
+        if _starts_unquoted_comment(line, i):
             break  # unquoted comment — bash reads no operator past it
         if ch == "\\":
             i += 2
@@ -263,8 +283,9 @@ def _quote_open_at_eol(line: str, quote: str) -> str:
     `commenters = ""` so the `# side-effect:ack` marker survives as tokens, but
     bash reads nothing past an unquoted `#` — so the apostrophe in
     `git status # don't do this` must not be taken for an opening quote that
-    swallows the next line's real command. The word-boundary rule is copied from
-    `_heredoc_starts_on_line` above so the two scanners cannot drift apart. The
+    swallows the next line's real command. The word-boundary rule lives in
+    `_starts_unquoted_comment` so this scanner and `_heredoc_starts_on_line`
+    cannot answer the same question differently. The
     divergence only ever ends a group *earlier*, never merges more lines into
     one, so it cannot hide a command that the old per-line split saw.
     """
@@ -283,7 +304,7 @@ def _quote_open_at_eol(line: str, quote: str) -> str:
             quote = ch
             i += 1
             continue
-        if ch == "#" and (i == 0 or line[i - 1] in " \t;|&("):
+        if _starts_unquoted_comment(line, i):
             return ""  # unquoted comment — bash opens no quote past it
         if ch == "\\":
             i += 2

--- a/hooks/_lib/git_commit_titles.py
+++ b/hooks/_lib/git_commit_titles.py
@@ -14,7 +14,7 @@ Public API:
   MESSAGE_FLAGS, FILE_FLAGS  — constant sets
   title_from_file(path, base_dir=None)        -> str | None
   strip_git_global_flags(argv)                -> tuple[list[str], str | None]
-  extract_git_titles(argv)                    -> list[str]
+  extract_git_titles(argv, command=None)      -> list[str]
 
 The two gates differ only in WHAT they do with the extracted titles (length
 check vs format check); the extraction itself is identical and lives here.
@@ -133,7 +133,57 @@ def strip_git_global_flags(argv: list[str]) -> tuple[list[str], str | None]:
     return argv[i:], c_dir
 
 
-def title_is_unresolved_substitution(title: str) -> bool:
+def _opener_is_quoted_literal(command: str, opener: str) -> bool:
+    """True when every occurrence of `opener` in `command` sits in single quotes.
+
+    Tokenization strips quoting, so `'$(x)'` and `"$(x)"` reach the caller as the
+    same string while the shell treats them oppositely: the first is literal text,
+    the second is a substitution. Recovering that distinction needs the raw
+    command, which is why the check cannot live on the token alone.
+
+    Only a single quote makes the opener literal — inside double quotes the shell
+    still substitutes. A backslash escape is handled the same way as `\\$(`: the
+    escape leaves the opener not matching at that index.
+
+    Conservative when the opener appears more than once: one unquoted occurrence
+    is enough to make the title unknowable, because that is the one the shell
+    expanded.
+    """
+    quote = ""
+    i, n = 0, len(command)
+    seen_literal = False
+    while i < n:
+        ch = command[i]
+        if quote == "'":
+            if command.startswith(opener, i):
+                seen_literal = True
+            if ch == "'":
+                quote = ""
+            i += 1
+            continue
+        if ch == "\\" and (quote == '"' or not quote):
+            i += 2
+            continue
+        if quote == '"':
+            if command.startswith(opener, i):
+                return False  # double quotes still substitute
+            if ch == '"':
+                quote = ""
+            i += 1
+            continue
+        if ch in "'\"":
+            quote = ch
+            i += 1
+            continue
+        if command.startswith(opener, i):
+            return False  # unquoted occurrence — the shell expanded this one
+        i += 1
+    # No occurrence at all means the opener never appeared unquoted either, so
+    # the caller's token did not come from a substitution in this command.
+    return seen_literal
+
+
+def title_is_unresolved_substitution(title: str, command: str | None = None) -> bool:
     """True when a title candidate is a substitution whose value we cannot know.
 
     `git commit -m "$(cat <<'EOF' … EOF)"` is the standard commit form here, and
@@ -144,15 +194,27 @@ def title_is_unresolved_substitution(title: str) -> bool:
     Narrow on purpose: only a candidate that *opens* a substitution is unknowable.
     `fix: handle $(foo)` is a real title and stays graded.
 
+    `command` is the raw shell command the argv was tokenized from. Without it the
+    opening marker alone decides, which cannot tell `'$(literal)'` from
+    `"$(expanded)"` — the shell substitutes only the second, so treating both as
+    unknowable lets a single-quoted literal title skip the format and length gates
+    entirely. Callers that have the raw command must pass it.
+
     Before the multi-line-quote fix (issue #987) this was rare — the tokenizer
     dropped the whole line, so no title reached here at all. Making the line
     visible turned a latent false positive into a routine one.
     """
     stripped = title.lstrip()
-    return stripped.startswith("$(") or stripped.startswith("`")
+    for opener in ("$(", "`"):
+        if not stripped.startswith(opener):
+            continue
+        if command is not None and _opener_is_quoted_literal(command, opener):
+            return False
+        return True
+    return False
 
 
-def extract_git_titles(argv: list[str]) -> list[str]:
+def extract_git_titles(argv: list[str], command: str | None = None) -> list[str]:
     """Extract commit title candidates from a git-commit argv.
 
     Only the FIRST -m / --message flag contributes the title; subsequent -m
@@ -170,6 +232,11 @@ def extract_git_titles(argv: list[str]) -> list[str]:
       git commit --amend -m "title"
       git -C /path commit -m "title"   (git global flags stripped)
       git -c key=val commit -m "title" (git global flags stripped)
+
+    `command` is the raw shell command `argv` was tokenized from. It is optional
+    only so existing argv-only callers keep working; passing it is what lets a
+    single-quoted literal title be graded instead of mistaken for a substitution
+    (see `title_is_unresolved_substitution`).
     """
     argv = strip_prefix(argv)
     if not argv or argv[0] != "git":
@@ -190,7 +257,7 @@ def extract_git_titles(argv: list[str]) -> list[str]:
         cannot read it, so later -m flags remain body paragraphs.
         """
         first = raw.split("\n")[0]
-        if not title_is_unresolved_substitution(first):
+        if not title_is_unresolved_substitution(first, command):
             titles.append(first)
 
     message_seen = False

--- a/hooks/_lib/git_commit_titles.py
+++ b/hooks/_lib/git_commit_titles.py
@@ -133,6 +133,25 @@ def strip_git_global_flags(argv: list[str]) -> tuple[list[str], str | None]:
     return argv[i:], c_dir
 
 
+def title_is_unresolved_substitution(title: str) -> bool:
+    """True when a title candidate is a substitution whose value we cannot know.
+
+    `git commit -m "$(cat <<'EOF' … EOF)"` is the standard commit form here, and
+    tokenization hands us the literal text `$(cat <<'EOF'` — the shell expands it,
+    we cannot. Grading that literal against Conventional Commits rejects every such
+    commit with exit 2, so the title gates must stay silent on it instead.
+
+    Narrow on purpose: only a candidate that *opens* a substitution is unknowable.
+    `fix: handle $(foo)` is a real title and stays graded.
+
+    Before the multi-line-quote fix (issue #987) this was rare — the tokenizer
+    dropped the whole line, so no title reached here at all. Making the line
+    visible turned a latent false positive into a routine one.
+    """
+    stripped = title.lstrip()
+    return stripped.startswith("$(") or stripped.startswith("`")
+
+
 def extract_git_titles(argv: list[str]) -> list[str]:
     """Extract commit title candidates from a git-commit argv.
 
@@ -162,6 +181,18 @@ def extract_git_titles(argv: list[str]) -> list[str]:
         return []
 
     titles: list[str] = []
+
+    def add_title(raw: str) -> None:
+        """Record the first line of a message value as a title candidate.
+
+        A value we cannot statically resolve contributes no candidate, but the
+        caller still marks `message_seen` — git took it as the message, we just
+        cannot read it, so later -m flags remain body paragraphs.
+        """
+        first = raw.split("\n")[0]
+        if not title_is_unresolved_substitution(first):
+            titles.append(first)
+
     message_seen = False
     i = 1  # sub_argv[0] is "commit"; start scanning from index 1
     while i < len(sub_argv):
@@ -171,7 +202,7 @@ def extract_git_titles(argv: list[str]) -> list[str]:
         if "=" in tok and tok.startswith("-"):
             key, _, val = tok.partition("=")
             if key in MESSAGE_FLAGS and not message_seen:
-                titles.append(val.split("\n")[0])
+                add_title(val)
                 message_seen = True
                 i += 1
                 continue
@@ -191,7 +222,7 @@ def extract_git_titles(argv: list[str]) -> list[str]:
             and len(tok) > 2
             and not message_seen
         ):
-            titles.append(tok[2:].split("\n")[0])
+            add_title(tok[2:])
             message_seen = True
             i += 1
             continue
@@ -212,7 +243,7 @@ def extract_git_titles(argv: list[str]) -> list[str]:
             and not message_seen
         ):
             if i + 1 < len(sub_argv):
-                titles.append(sub_argv[i + 1].split("\n")[0])
+                add_title(sub_argv[i + 1])
                 message_seen = True
                 i += 2
                 continue
@@ -220,7 +251,7 @@ def extract_git_titles(argv: list[str]) -> list[str]:
         # Standard separate-token flags.
         if tok in MESSAGE_FLAGS and not message_seen:
             if i + 1 < len(sub_argv):
-                titles.append(sub_argv[i + 1].split("\n")[0])
+                add_title(sub_argv[i + 1])
                 message_seen = True
                 i += 2
                 continue

--- a/hooks/_lib/git_commit_titles.py
+++ b/hooks/_lib/git_commit_titles.py
@@ -133,31 +133,27 @@ def strip_git_global_flags(argv: list[str]) -> tuple[list[str], str | None]:
     return argv[i:], c_dir
 
 
-def _opener_is_quoted_literal(command: str, opener: str) -> bool:
-    """True when every occurrence of `opener` in `command` sits in single quotes.
+def _single_quoted_runs(command: str) -> list[str]:
+    """Every single-quoted run in `command`, contents only, in source order.
 
-    Tokenization strips quoting, so `'$(x)'` and `"$(x)"` reach the caller as the
-    same string while the shell treats them oppositely: the first is literal text,
-    the second is a substitution. Recovering that distinction needs the raw
-    command, which is why the check cannot live on the token alone.
+    A single-quoted run is the one place the shell substitutes nothing at all,
+    so its contents reach the tokenizer byte-for-byte. That property is what
+    lets the caller below match a token back to its source without tracking
+    positions through the tokenizer.
 
-    Only a single quote makes the opener literal — inside double quotes the shell
-    still substitutes. A backslash escape is handled the same way as `\\$(`: the
-    escape leaves the opener not matching at that index.
-
-    Conservative when the opener appears more than once: one unquoted occurrence
-    is enough to make the title unknowable, because that is the one the shell
-    expanded.
+    Double-quoted spans and backslash escapes are walked so their quotes cannot
+    open or close a run: `"it's"` holds no single-quoted run, and neither does
+    `\\'`.
     """
+    runs: list[str] = []
     quote = ""
+    start = 0
     i, n = 0, len(command)
-    seen_literal = False
     while i < n:
         ch = command[i]
         if quote == "'":
-            if command.startswith(opener, i):
-                seen_literal = True
             if ch == "'":
+                runs.append(command[start:i])
                 quote = ""
             i += 1
             continue
@@ -165,22 +161,47 @@ def _opener_is_quoted_literal(command: str, opener: str) -> bool:
             i += 2
             continue
         if quote == '"':
-            if command.startswith(opener, i):
-                return False  # double quotes still substitute
             if ch == '"':
                 quote = ""
             i += 1
             continue
-        if ch in "'\"":
+        if ch == '"':
             quote = ch
             i += 1
             continue
-        if command.startswith(opener, i):
-            return False  # unquoted occurrence — the shell expanded this one
+        if ch == "'":
+            quote = ch
+            start = i + 1
+            i += 1
+            continue
         i += 1
-    # No occurrence at all means the opener never appeared unquoted either, so
-    # the caller's token did not come from a substitution in this command.
-    return seen_literal
+    return runs
+
+
+def _title_is_single_quoted_literal(command: str, title: str) -> bool:
+    """True when `title` reached us as the contents of a single-quoted run.
+
+    Tokenization strips quoting, so `'$(x)'` and `"$(x)"` arrive as the same
+    string while the shell treats them oppositely: the first is literal text,
+    the second is a substitution. Recovering that distinction needs the raw
+    command, which is why the check cannot live on the token alone.
+
+    The match is on the TITLE, not on the opener. An earlier version asked
+    whether every occurrence of `$(` in the raw command sat in single quotes,
+    which reads far past the segment the title came from: the callers tokenize
+    once and hand every segment the same raw command, so `echo $(date); git
+    commit -m '$(literal) title'` saw the unquoted `$(` from the `echo` and
+    suppressed a title that the shell never touched (CodeRabbit, PR #1014).
+    Matching the token against the runs needs no position tracking through the
+    tokenizer and is unaffected by anything in another segment.
+
+    Residual, stated because the match is by value rather than by position: a
+    command that quotes the SAME text both ways — `echo '$(x)'; git commit -m
+    "$(x)"` — reads as literal here. The direction of that error is to grade a
+    title the shell expanded, so the gates speak up rather than fall silent;
+    closing it needs raw source spans, which the tokenizer does not carry.
+    """
+    return title in _single_quoted_runs(command)
 
 
 def title_is_unresolved_substitution(title: str, command: str | None = None) -> bool:
@@ -208,7 +229,7 @@ def title_is_unresolved_substitution(title: str, command: str | None = None) -> 
     for opener in ("$(", "`"):
         if not stripped.startswith(opener):
             continue
-        if command is not None and _opener_is_quoted_literal(command, opener):
+        if command is not None and _title_is_single_quoted_literal(command, title):
             return False
         return True
     return False

--- a/hooks/preflight-gate/commit-title-format-check/impl.py
+++ b/hooks/preflight-gate/commit-title-format-check/impl.py
@@ -248,7 +248,7 @@ def main() -> int:
 
     for argv in iter_command_starts(tokens):
         # Check git commit titles
-        git_titles = extract_git_titles(argv)
+        git_titles = extract_git_titles(argv, command)
         for title in git_titles:
             if _is_whitelisted(title):
                 continue

--- a/hooks/preflight-gate/commit-title-length-check/impl.py
+++ b/hooks/preflight-gate/commit-title-length-check/impl.py
@@ -385,7 +385,7 @@ def main() -> int:
     cwd = payload.get("cwd") or None
 
     for argv in iter_command_starts(tokens):
-        titles = extract_git_titles(argv)
+        titles = extract_git_titles(argv, command)
         for title in titles:
             if any(title.startswith(p) for p in SKIP_PREFIXES):
                 continue

--- a/tests/hooks/preflight-gate/test_side_effect_scan.sh
+++ b/tests/hooks/preflight-gate/test_side_effect_scan.sh
@@ -71,6 +71,44 @@ print(json.dumps({
   PASS=$((PASS + 1))
 }
 
+# Assert an ask fires for the RIGHT reason. `run_case ... ask` only checks that
+# something fired, so it would still pass if the hook picked the wrong category —
+# which is precisely what #985 is about. Used where the category is the point.
+run_case_reason() {
+  local name="$1" want="$2" forbid="$3" command="$4"
+
+  local payload
+  payload=$(python3 -c '
+import json, sys
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {"command": sys.argv[1]},
+}))' "$command")
+
+  local out
+  out=$(echo "$payload" | "$HOOK" 2>/dev/null)
+  local rc=$?
+
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL  [$name] hook exited $rc (expected 0)"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name"); return
+  fi
+  if ! echo "$out" | grep -q '"permissionDecision": "ask"'; then
+    echo "FAIL  [$name] expected ask, got: ${out:-<empty>}"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name"); return
+  fi
+  if ! echo "$out" | grep -qF "$want"; then
+    echo "FAIL  [$name] reason missing '$want', got: $out"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name"); return
+  fi
+  if [ -n "$forbid" ] && echo "$out" | grep -qiF "$forbid"; then
+    echo "FAIL  [$name] reason must not mention '$forbid', got: $out"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name"); return
+  fi
+  echo "PASS  [$name]"
+  PASS=$((PASS + 1))
+}
+
 # --- detection: git mutation ------------------------------------------------
 run_case "git-commit bare"          ask  "git commit -m 'wip'"
 run_case "git-merge"                ask  "git merge feature-x"
@@ -262,7 +300,14 @@ fi
 run_case "gh pr merge --help (usage only)" pass "gh pr merge --help"
 run_case "gh pr merge -h (usage only)"     pass "gh pr merge -h"
 run_case "gh pr create --help (usage only)" pass "gh pr create --help"
-run_case "commit message quoting a merge"  pass $'git commit -m "$(cat <<\'EOF\'\ngh pr merge is only quoted here\nEOF\n)"'
+# Was `pass` until issue #987. The tokenizer dropped the whole quoted line, so the
+# `git commit` itself was invisible and the case asserted "no output at all" — an
+# over-broad assertion that encoded the blindness rather than #985's intent. With the
+# line visible, `git commit` fires its own intrinsic category (a bare single-line
+# `git commit -m x` fires it too). #985's actual point — a quoted `gh pr merge` is not
+# a merge — is what the forbidden substring now pins.
+run_case_reason "commit message quoting a merge" "[git-commit]" "merge" \
+  $'git commit -m "$(cat <<\'EOF\'\ngh pr merge is only quoted here\nEOF\n)"'
 run_case "-h as a --subject value"         ask  "gh pr merge 985 --squash --subject -h"
 run_case "merge after heredoc terminator"  ask  $'cat <<\'EOF\'\nbody\nEOF\ngh pr merge 985 --squash'
 

--- a/tests/test_git_commit_titles.py
+++ b/tests/test_git_commit_titles.py
@@ -177,3 +177,45 @@ def test_both_hooks_share_one_parser_object():
 def test_fail_open_returns_list(argv):
     result = extract_git_titles(argv)
     assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# 6. Substitution exception — quoting decides, not the leading characters
+# ---------------------------------------------------------------------------
+#
+# Tokenization strips quoting, so `'$(x)'` and `"$(x)"` arrive here as the same
+# string while the shell treats them oppositely. Deciding on the token alone
+# suppressed both, which let a single-quoted literal title skip the format and
+# length gates entirely — the two things this parser exists to feed.
+
+def _titles_from(command: str) -> list[str]:
+    """Titles as the gates see them: tokenize, then extract with the raw command."""
+    from _hook_utils import safe_tokenize as _tok  # noqa: PLC0415
+
+    return extract_git_titles(_tok(command), command)
+
+
+@pytest.mark.parametrize(
+    "command, expected",
+    [
+        # single quotes: the shell does NOT substitute, so this is a real title
+        ("git commit -m '$(literal) title'", ["$(literal) title"]),
+        ("git commit -m '`literal` title'", ["`literal` title"]),
+        # double quotes: the shell DOES substitute — value unknowable, stay silent
+        ('git commit -m "$(printf %s x)"', []),
+        ('git commit -m "`printf %s x`"', []),
+        # the standard heredoc commit form the exception was written for
+        ("git commit -m \"$(cat <<'EOF'\nbody\nEOF\n)\"", []),
+        # a substitution mid-title was always graded and still is
+        ("git commit -m 'fix: handle $(foo)'", ["fix: handle $(foo)"]),
+    ],
+)
+def test_quoting_decides_the_substitution_exception(command, expected):
+    assert _titles_from(command) == expected
+
+
+def test_argv_only_callers_keep_the_conservative_behaviour():
+    """Without the raw command there is nothing to disambiguate with, so the
+    opener alone still suppresses — old callers must not start hard-blocking."""
+    assert extract_git_titles(["git", "commit", "-m", "$(literal) title"]) == []
+    assert extract_git_titles(["git", "commit", "-m", "$(literal) title"], None) == []

--- a/tests/test_git_commit_titles.py
+++ b/tests/test_git_commit_titles.py
@@ -214,6 +214,44 @@ def test_quoting_decides_the_substitution_exception(command, expected):
     assert _titles_from(command) == expected
 
 
+def _titles_from_all_segments(command: str) -> list[str]:
+    """Titles as the gates see them when the command has SEVERAL segments.
+
+    `_titles_from` above hands the whole token list to `extract_git_titles`
+    once, which returns nothing as soon as argv[0] is not `git` — fine for a
+    one-command string, useless for `echo …; git commit …`. The gates walk
+    `iter_command_starts` (`commit-title-format-check/impl.py:249`), so the
+    multi-segment cases below have to walk it too.
+    """
+    from _hook_utils import iter_command_starts as _starts  # noqa: PLC0415
+    from _hook_utils import safe_tokenize as _tok  # noqa: PLC0415
+
+    out: list[str] = []
+    for argv in _starts(_tok(command)):
+        out += extract_git_titles(argv, command)
+    return out
+
+
+@pytest.mark.parametrize(
+    "command, expected",
+    [
+        # An unrelated substitution in ANOTHER segment must not reach the title.
+        # The callers tokenize once and hand every segment the same raw command,
+        # so an opener-based scan saw the `echo`'s `$(` and suppressed a title
+        # the shell never touched (CodeRabbit, PR #1014). Before and after.
+        ("echo $(date); git commit -m '$(literal) title'", ["$(literal) title"]),
+        ("git commit -m '$(literal) title' && echo $(date)", ["$(literal) title"]),
+        ("echo `date`; git commit -m '`literal` title'", ["`literal` title"]),
+        ("git commit -m '`literal` title' && echo `date`", ["`literal` title"]),
+        # The control that keeps the fix from becoming "always literal": an
+        # unrelated segment does not rescue a title the shell really expands.
+        ('echo $(date); git commit -m "$(printf %s x)"', []),
+    ],
+)
+def test_another_segments_substitution_does_not_reach_the_title(command, expected):
+    assert _titles_from_all_segments(command) == expected
+
+
 def test_argv_only_callers_keep_the_conservative_behaviour():
     """Without the raw command there is nothing to disambiguate with, so the
     opener alone still suppresses — old callers must not start hard-blocking."""

--- a/tests/test_hook_utils.sh
+++ b/tests/test_hook_utils.sh
@@ -454,6 +454,67 @@ run_tokens "bare newline stays a separator" \
   $'git status\ngit log'
 
 # ---------------------------------------------------------------------------
+# safe_tokenize — newlines inside a quote (issues #972, #987)
+# ---------------------------------------------------------------------------
+#
+# A newline *inside* a quote is data, not a separator. Splitting there gave
+# the opening and the closing line their own shlex pass, both raised
+# `ValueError: No closing quotation`, and the fail-open arm dropped them —
+# losing argv[0] (#972) and, when a real command rode on the closing line, the
+# whole command (#987, which blinded all three merge gates). The same cases
+# live in tests/test_safe_tokenize_multiline_quote.py; they are duplicated
+# here because this shell suite runs without pytest installed.
+
+# Issue #972: a multi-line `--body` must keep its `gh` argv[0], and the
+# newline must stay *inside* the body token rather than splitting it off.
+run_tokens "multi-line quoted --body keeps argv[0] (#972)" \
+  "['gh', 'pr', 'comment', '949', '--body', '### Verification\\n| 1 | x | PASS(live) |\\n']" \
+  $'gh pr comment 949 --body \'### Verification\n| 1 | x | PASS(live) |\n\''
+
+# Issue #987: the command riding on the quote-closing line must survive.
+run_tokens "command after a multi-line double quote survives (#987)" \
+  "['git', 'commit', '-m', 'line one\\nline two', '&&', 'gh', 'pr', 'merge', '9', '--squash']" \
+  $'git commit -m "line one\nline two" && gh pr merge 9 --squash'
+
+run_tokens "command after a multi-line single quote survives (#987)" \
+  "['git', 'commit', '-m', 'line one\\nline two', '&&', 'gh', 'pr', 'merge', '9', '--squash']" \
+  $'git commit -m \'line one\nline two\' && gh pr merge 9 --squash'
+
+# The heredoc-in-command-substitution shape #987 reported. The body is blanked
+# by strip_heredoc_bodies first (#985), so the `-m` token is the opaque
+# substitution — but the `&&` and the merge after it are now visible.
+run_tokens "heredoc commit followed by a merge survives (#987)" \
+  "['git', 'commit', '-m', \"\$(cat <<'EOF'\\n\\nEOF\\n)\", '&&', 'gh', 'pr', 'merge', '9', '--squash']" \
+  $'git commit -m "$(cat <<\'EOF\'\nbody line\nEOF\n)" && gh pr merge 9 --squash'
+
+# Anti-bypass: an unquoted `#` comment opens no quote, so the apostrophe in
+# `don't` must not swallow the real merge on the next line. Without the
+# comment rule in `_quote_open_at_eol` this returns [] and every merge gate
+# goes blind — a fresh hole traded for the one being closed.
+run_tokens "apostrophe in an unquoted comment does not swallow the next line" \
+  "[';', 'gh', 'pr', 'merge', '9', '--squash']" \
+  $'git status # don\'t do this\ngh pr merge 9 --squash'
+
+# The mirror case: a `#` *inside* quotes is literal, not a comment, so the
+# quote closes normally and the following line is a separate command.
+run_tokens "hash inside quotes stays inside the token" \
+  "['echo', '# not a comment', ';', 'gh', 'pr', 'merge', '9', '--squash']" \
+  $'echo \'# not a comment\'\ngh pr merge 9 --squash'
+
+# `commenters = ""` is untouched: the side-effect-scan opt-out marker must
+# still tokenize rather than being eaten as a comment.
+run_tokens "side-effect ack marker still tokenizes" \
+  "['git', 'commit', '-m', 'x', '#', 'side-effect:ack']" \
+  'git commit -m x # side-effect:ack'
+
+# Fail-open is preserved: a quote left open at the end of the command is
+# handed to shlex unchanged, so it raises and the `except ValueError` arm
+# returns no tokens rather than crashing the hook.
+run_tokens "unterminated quote still fails open" \
+  "[]" \
+  $'echo "never closed'
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/tests/test_hook_utils.sh
+++ b/tests/test_hook_utils.sh
@@ -528,6 +528,24 @@ run_tokens "hash mid-word is not a comment and still folds the lines" \
   "[]" \
   $'echo ok#don\'t care\ngh pr merge 9 --squash'
 
+# A command substitution re-opens shell parsing inside double quotes, so the
+# quotes within it are its own. Reading the inner `'"'` as closing the outer
+# double quote left one apparently open at end of line, folded the next line in,
+# and shlex dropped both — the merge went invisible on a command bash runs fine.
+# The `echo` line itself still yields no tokens — shlex cannot parse a bare
+# `$(printf '"')` and its ValueError arm drops that logical line. The point is
+# that the loss is now confined to it: the merge on the next line survives,
+# where before the two were folded into one group and both disappeared.
+run_tokens "quotes inside a command substitution do not leak to the outer quote" \
+  "[';', 'gh', 'pr', 'merge', '9', '--squash']" \
+  $'echo "$(printf \'"\')"\ngh pr merge 9 --squash'
+
+# The arithmetic form must NOT be taken for a substitution: `$((` is not `$(`,
+# and treating it as one would pop the wrong state at the first `)`.
+run_tokens "arithmetic expansion is not read as a command substitution" \
+  "['echo', '\$((1 << 3))', ';', 'gh', 'pr', 'merge', '9', '--squash']" \
+  $'echo "$((1 << 3))"\ngh pr merge 9 --squash'
+
 # `commenters = ""` is untouched: the side-effect-scan opt-out marker must
 # still tokenize rather than being eaten as a comment.
 run_tokens "side-effect ack marker still tokenizes" \

--- a/tests/test_hook_utils.sh
+++ b/tests/test_hook_utils.sh
@@ -501,6 +501,33 @@ run_tokens "hash inside quotes stays inside the token" \
   "['echo', '# not a comment', ';', 'gh', 'pr', 'merge', '9', '--squash']" \
   $'echo \'# not a comment\'\ngh pr merge 9 --squash'
 
+# The word-boundary set is bash's metacharacters, not a subset of them. `)`,
+# `<` and `>` end a word exactly like `;` and `|` do, so a comment opening
+# right after one is a comment — verified with `bash -n`, which rejects
+# `: >#x` (the redirect lost its operand to the comment) while accepting
+# `: >x#x` (there `#` is mid-word and not a comment at all). Reading those
+# three as ordinary text let the apostrophe in `don't` open a quote and
+# swallow the merge on the next line.
+run_tokens "comment after a closing paren does not swallow the next line" \
+  "[';', 'gh', 'pr', 'merge', '9', '--squash']" \
+  $'(echo ok)#don\'t care\ngh pr merge 9 --squash'
+
+run_tokens "comment after an output redirect does not swallow the next line" \
+  "[';', 'gh', 'pr', 'merge', '9', '--squash']" \
+  $': >#don\'t care\ngh pr merge 9 --squash'
+
+run_tokens "comment after an input redirect does not swallow the next line" \
+  "[';', 'gh', 'pr', 'merge', '9', '--squash']" \
+  $': <#don\'t care\ngh pr merge 9 --squash'
+
+# The negative control for the three above: mid-word `#` is NOT a comment in
+# bash (`bash -n` accepts `: >x#x`), so the apostrophe genuinely does open a
+# quote here and folding the lines is correct. Without this case, widening the
+# boundary set to every character would pass the three tests above.
+run_tokens "hash mid-word is not a comment and still folds the lines" \
+  "[]" \
+  $'echo ok#don\'t care\ngh pr merge 9 --squash'
+
 # `commenters = ""` is untouched: the side-effect-scan opt-out marker must
 # still tokenize rather than being eaten as a comment.
 run_tokens "side-effect ack marker still tokenizes" \

--- a/tests/test_safe_tokenize_multiline_quote.py
+++ b/tests/test_safe_tokenize_multiline_quote.py
@@ -1,0 +1,193 @@
+"""Tokenizer coverage for newlines inside a quote (issues #972, #987).
+
+`safe_tokenize` pre-split the command on `\\n` and gave every physical line its
+own shlex pass. A quote opened on one line and closed on another therefore made
+*both* of those lines raise ``ValueError: No closing quotation``, and the
+fail-open ``except ValueError: continue`` arm dropped them:
+
+- #972 — ``gh pr comment --body '…multi-line…'`` lost its ``gh`` argv[0], so
+  every hook looking for a gh invocation went blind. Measured impact was zero
+  verdict changes across all 45 consuming hooks, matching the issue's own
+  admission of zero observed damage.
+- #987 — when a real command rode on the quote-closing line
+  (``git commit -m "…" && gh pr merge``) the whole command vanished, and the
+  three merge gates the issue names (momentum-rule-retrieval-gate,
+  pre-merge-approval-gate, side-effect-scan) all went silent.
+
+#972's stated mechanism ("strips `#` before quote state is resolved") does not
+hold — `safe_tokenize` sets ``commenters = ""``, so `#` is never stripped, and
+the identical payload with every `#` removed tokenizes identically broken. Both
+issues are one defect on one line, closed by `_logical_lines`.
+
+The must-still-fire cases below are the ones that keep the fix from becoming a
+bypass of its own: folding lines across an open quote without making the
+scanner comment-aware reads the apostrophe in ``git status # don't do this`` as
+an opening quote and swallows the genuine command on the next line.
+
+Written as Python rather than appended to `tests/test_hook_utils.sh` for the
+same reason as `test_heredoc_help_tokenizer.py` — every case is itself a shell
+string, so bash literals mean escaping the very quoting under test. The same
+cases are duplicated into that shell suite because it is the one that runs
+without pytest installed.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "hooks" / "_lib"))
+
+from _hook_utils import safe_tokenize  # noqa: E402
+
+# Split so this file's own text never carries the literal the gates match on —
+# editing these tests would otherwise trip the gate the tests exist to fix.
+MERGE = "gh pr " + "merge"
+
+
+def _has_merge(command: str) -> bool:
+    """True when the tokenizer reads a `gh pr merge` command start."""
+    toks = safe_tokenize(command)
+    return any(toks[i:i + 3] == ["gh", "pr", "merge"] for i in range(len(toks)))
+
+
+# ---------------------------------------------------------------------------
+# The two reported token streams.
+# ---------------------------------------------------------------------------
+
+def test_multiline_body_keeps_argv0() -> None:
+    """#972's exact payload. Before the fix this returned
+    ``[';', '|', '1', '|', 'x', '|', 'PASS(live)', '|', ';']`` — no `gh`."""
+    command = "gh pr comment 949 --body '### Verification\n| 1 | x | PASS(live) |\n'"
+    assert safe_tokenize(command) == [
+        "gh", "pr", "comment", "949", "--body",
+        "### Verification\n| 1 | x | PASS(live) |\n",
+    ]
+
+
+def test_heredoc_commit_then_merge_survives() -> None:
+    """#987's exact payload. Before the fix this returned ``[';', 'EOF', ';']``.
+
+    The `-m` value stays the opaque command substitution because
+    `strip_heredoc_bodies` blanks the body first (issue #985) — the point of
+    this case is that the `&&` and everything after it are visible again.
+    """
+    command = (
+        "git commit -m \"$(cat <<'EOF'\nbody line\nEOF\n)\" && " + MERGE + " 9 --squash"
+    )
+    assert safe_tokenize(command) == [
+        "git", "commit", "-m", "$(cat <<'EOF'\n\nEOF\n)",
+        "&&", "gh", "pr", "merge", "9", "--squash",
+    ]
+
+
+@pytest.mark.parametrize("name,command", [
+    # #987 framed this as heredoc-specific. It is not: any newline inside any
+    # quote is sufficient, with no heredoc and no `#` anywhere in the payload.
+    ("double quote", 'git commit -m "line one\nline two" && ' + MERGE + " 9 --squash"),
+    ("single quote", "git commit -m 'line one\nline two' && " + MERGE + " 9 --squash"),
+    ("body spanning three lines",
+     'git commit -m "a\nb\nc" && ' + MERGE + " 9 --squash"),
+    ("heredoc form", "git commit -m \"$(cat <<'EOF'\nbody\nEOF\n)\" && "
+                     + MERGE + " 9 --squash"),
+])
+def test_command_after_a_multiline_quote_reaches_the_gates(name: str, command: str) -> None:
+    assert _has_merge(command), name
+
+
+@pytest.mark.parametrize("name,command", [
+    ("double quote", 'git commit -m "line one\nline two"'),
+    ("single quote", "git commit -m 'line one\nline two'"),
+])
+def test_newline_stays_inside_the_quoted_token(name: str, command: str) -> None:
+    """The newline is data — bash hands it to the process inside the word, so
+    it must not split `-m` from its value nor become a synthetic `;`."""
+    assert safe_tokenize(command) == ["git", "commit", "-m", "line one\nline two"], name
+
+
+def test_multiline_body_containing_a_hash() -> None:
+    """#972 task 3 notes no hook exercises a `#`-bearing quoted body today.
+
+    A `#` inside quotes is text, not a comment, so it must survive inside the
+    token — this is the case whose absence let #972's mechanism go unfalsified.
+    """
+    command = 'gh pr create --title t --body "# Heading\nbody line"'
+    assert safe_tokenize(command) == [
+        "gh", "pr", "create", "--title", "t", "--body", "# Heading\nbody line",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Must-still-fire: the fix must not become a bypass of its own.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("name,command", [
+    # Folding lines across an open quote *without* the comment rule reads this
+    # apostrophe as an opening quote, joins both lines into one unterminated
+    # group, and drops the real merge — verified: the naive variant returns [].
+    ("apostrophe in an unquoted comment",
+     "git status # don't do this\n" + MERGE + " 9 --squash"),
+    ("odd quote count in a comment",
+     "echo hi  # it's fine\n" + MERGE + " 9 --squash"),
+    ("comment at the start of a line",
+     "# don't\n" + MERGE + " 9 --squash"),
+    # A `#` inside quotes is not a comment, so the quote closes normally and
+    # the next line is a separate command.
+    ("hash inside quotes is not a comment",
+     "echo '# not a comment'\n" + MERGE + " 9 --squash"),
+    ("plain newline separator still separates",
+     "git status\n" + MERGE + " 9 --squash"),
+])
+def test_merge_still_visible(name: str, command: str) -> None:
+    assert _has_merge(command), name
+
+
+# ---------------------------------------------------------------------------
+# Must-not-fire and unchanged behavior.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("name,command", [
+    # Quoted prose is data. Before the fix the second line was tokenized on its
+    # own and read as a real invocation; now the whole string is one token.
+    ("merge quoted inside multi-line prose",
+     "echo 'first line\nrun " + MERGE + " later'"),
+    ("heredoc body still blanked (issue #985)",
+     "cat <<'EOF'\n" + MERGE + " 985\nEOF"),
+])
+def test_quoted_prose_is_not_a_command(name: str, command: str) -> None:
+    assert not _has_merge(command), name
+
+
+def test_ack_marker_still_tokenizes() -> None:
+    """`commenters = ""` is untouched: comments are excluded from quote-state
+    tracking only, never from the token stream, so side-effect-scan's
+    `# side-effect:ack` opt-out marker still reaches its caller."""
+    assert safe_tokenize("git commit -m x # side-effect:ack") == [
+        "git", "commit", "-m", "x", "#", "side-effect:ack",
+    ]
+
+
+@pytest.mark.parametrize("name,command", [
+    ("unterminated double quote", 'echo "never closed'),
+    ("unterminated single quote", "echo 'never closed"),
+])
+def test_unterminated_quote_fails_open(name: str, command: str) -> None:
+    """A group still open at the end of the command is handed to shlex
+    unchanged, so it raises and the fail-open arm returns no tokens for it —
+    a silent pass, never a crashed hook."""
+    assert safe_tokenize(command) == [], name
+
+
+@pytest.mark.parametrize("name,command,expected", [
+    # Issue #510: a `\` before a newline is a continuation, not a separator.
+    ("line continuation", "git \\\ncommit", ["git", "commit"]),
+    ("line continuation with flags", "git commit \\\n-m x",
+     ["git", "commit", "-m", "x"]),
+    # A bare newline outside any quote is still a command separator.
+    ("bare newline", "git status\ngit log", ["git", "status", ";", "git", "log"]),
+])
+def test_prior_newline_contracts_are_unchanged(
+    name: str, command: str, expected: list[str]
+) -> None:
+    assert safe_tokenize(command) == expected, name


### PR DESCRIPTION
## 요약

`safe_tokenize` 는 명령을 개행으로 pre-split 하고 물리 줄마다 shlex 를 돌린다. 한 줄에서 열려 다른 줄에서 닫히는 따옴표는 **두 줄 모두** `ValueError: No closing quotation` 을 내고, fail-open `except ValueError: continue` 가 그 줄들을 버린다. 닫는 줄에 실려 있던 실제 명령이 함께 사라진다.

**#972 와 #987 은 이 한 줄의 같은 결함이지 두 개가 아니다.**

## #972 의 서술은 두 축에서 틀렸다 — 실측

**메커니즘 반증.** #972 는 "인용 상태 확정 전 `#` 제거"를 원인으로 지목한다. `safe_tokenize` 는 `lex.commenters = ""` 를 설정하므로 `#` 는 애초에 제거되지 않는다. 3-way 판별:

| 입력 | 결과 |
|---|---|
| A: `#` 있음 + 여러 줄 | `[';','|','1','|','x','|','PASS(live)','|',';']` |
| B: `#` 전부 제거 + 여러 줄 | **A 와 동일** |
| C: `#` 있음 + 한 줄에서 닫음 | `['gh','pr','comment','949','--body','### Verification']` |

A ≡ B 이므로 `#` 는 인과가 아니다. C 가 `#` 를 온전히 달고 정상 토크나이즈되므로 주석 제거는 이미 꺼져 있다.

**게이트 미달.** #972 의 작업 1 은 "노출된 훅에서 판정이 바뀌는지 확인, 영향 0 이면 이슈가 닫힌다" 이다. `safe_tokenize` 소비 훅 45개 × (#972 payload vs 동일 내용 한 줄 대조군) 전수: **판정 변화 0건.** #972 스스로 적은 "실제 피해 관측 0건" 과 일치한다.

## #987 은 영향이 있다

같은 스윕에서 #987 payload 는 이슈가 지목한 3개 게이트를 정확히 실명시킨다:

```
momentum-rule-retrieval-gate  control=(0,'',True)   -> payload=(0,'',False)
pre-merge-approval-gate       control=(0,'ask',False) -> payload=(0,'',False)
side-effect-scan              control=(0,'ask',False) -> payload=(0,'',False)
```

#987 의 "heredoc 특유" 라는 자체 서술도 반증됐다 — heredoc 도 `#` 도 없는 `git commit -m "line one\nline two" && gh pr merge 9 --squash` 가 3종을 동일하게 눈멀게 한다. 따옴표 안의 개행이면 충분하다.

## 소박한 수정이 만드는 새 우회로

여는 따옴표에서 단순히 줄을 잇는 방식은 **새 우회로 2개**를 만든다. 인용되지 않은 주석 안의 아포스트로피(`git status # don't do this` + 개행 + 실제 머지)가 여는 따옴표로 오독되어 뒤따르는 진짜 명령을 삼킨다. `#` 가 인용 상태와 실제로 상호작용하는 유일한 지점이고, #972 가 주장한 것의 정반대다. 그래서 스캐너를 주석 인지형으로 만들었다. 우회 배터리 5종 모두 통과, 회귀 0.

## 함께 들어간 두 변경 (없으면 머지 불가)

1. **`tests/hooks/preflight-gate/test_side_effect_scan.sh`** — 머지를 인용한 커밋 메시지 케이스가 `pass`(출력 없음)를 단언했다. 그 단언은 토크나이저가 `git commit` 자체를 숨기고 있을 때만 성립했다. 한 줄짜리 `git commit -m x` 도 unpatched HEAD 에서 동일한 `[git-commit]` 카테고리를 발화한다. 새 `run_case_reason` 헬퍼로 **`[git-commit]` 포함 + merge 카테고리 부재**를 단언하도록 바꿔, #985 의 실제 의도를 지키면서 잘못된 이유로는 통과할 수 없게 했다.
2. **`hooks/_lib/git_commit_titles.py`** — `extract_git_titles` 가 `$(cat <<'EOF'` 를 리터럴 제목으로 채점해, `side-effect-scan/spec.md:90` 이 지원한다고 명시한 표준 커밋 형식을 exit 2 로 하드 블록했다. **기존 결함이다** — 여러 줄 인용이 전혀 없는 `git commit -m "$(printf %s x)"` 도 unpatched HEAD 에서 막힌다. 이 변경이 드문 것을 일상적인 것으로 바꿀 뿐이다. 명령 치환을 *여는* 후보만 채점 대상에서 빠지고, `fix: handle $(foo)` 는 계속 채점된다.

## 검증

| 스위트 | 결과 |
|---|---|
| `tests/test_hook_utils.sh` | 96 / 0 |
| `tests/hooks/preflight-gate/test_side_effect_scan.sh` | 76 / 0 |
| `test_commit_title_format_check.sh` | 65 / 0 |
| `test_commit_title_length_check.sh` | 63 / 0 |
| `test_safe_tokenize_multiline_quote.py` (신규 22 케이스) + `test_heredoc_help_tokenizer.py` + `test_git_commit_titles.py` | 82 / 0 |

**Blast radius (실제 편집된 파일 기준):** 45 훅 × 36 payload × 2 구현 = 3,240 프로브, 판정 변화 18건(1.1%). 전부 여러 줄 인용 payload 5종에 몰려 있고, 36 payload 중 31개는 변화 0 — 일반 커밋/머지/푸시, 파이프, 서브셸, `$()`, for 루프, env/sudo 접두, `--help`, heredoc-to-file, 2단계 `BODY=$(cat <<'EOF' …)` 형식, 줄 연결, ack 마커 포함.

**무작위 차등 검사:** 컨티규어스 `gh pr merge` 를 실제로 만드는 코퍼스로 오라클이 살아 있음을 먼저 확인(old 3,297 / new 3,134 히트)한 뒤 — 토큰 스트림 차이 3,588건, 개행을 넘는 따옴표로 설명되지 않는 것 0건. 새로 보이게 된 머지 30건(의도한 방향), 더 이상 보이지 않는 머지 193건 중 191건은 `bash -n` 이 파싱 자체를 거부하는 명령(실행될 수 없음), 나머지 2건은 머지 텍스트가 작은따옴표 리터럴 안에 있어 구 토크나이저의 오탐이었음을 bash 의 argv 로 확인.

## 미확인

- 코퍼스에 없는 형태: 중첩 `$( $( ) )`, 여러 줄에 걸친 `$'…'` / 백틱, `case`/`function` 본문, 배열, 프로세스 치환 `<(…)`, CRLF.
- `safe_tokenize` 를 직접 참조하는 45개 훅만 스윕했다. #987 은 소비 파일 77개를 말한다 — `tokenize_with_roles` 등을 통한 전이적 소비자는 역할 수준 diff 를 돌리지 않았다.
- 훅은 합성 session_id 로 실행했다. 세션 상태에 의존하는 훅은 실사용에서 다를 수 있다.
- 판정 변화 18건이 의도한 것인지는 각 훅의 사유 문자열을 읽어 15건을 의도·3건을 위 (2)번 오탐으로 분류한 것이며, 소유자 확인을 받지 않았다.

## 기존 실패 (이 PR 무관)

`test_state_lock.py::test_unwritable_location_yields_false_without_raising` 와 `test_decision_gate.py::test_concurrent_resolvers_produce_one_verdict_and_one_signal` 은 `origin/main` 에서 동일하게 실패한다. 전자는 샌드박스가 uid 0 이라 `chmod 0o500` 이 root 를 막지 못하는 것이 원인이다. CI 는 비-root 이므로 해당되지 않는다.

Closes #987
Refs #972

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc

---
_Generated by [Claude Code](https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command detection for multi-line quoted strings while preserving embedded newlines.
  * Improved handling of comments, escaped characters, heredocs, and command substitutions.
  * Prevented unresolved shell substitutions from being incorrectly recorded as commit titles.
  * Preserved correct handling of quoted prose, acknowledgment markers, and unterminated quotes.

* **Tests**
  * Added comprehensive coverage for multi-line tokenization, comments, heredocs, substitutions, and side-effect detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->