### PR TITLE
fix(hooks): bind each body flag to its own gh invocation in perf advisory

### DIFF
--- a/hooks/advisory-nudge/perf-multiplier-evidence-advisory/impl.py
+++ b/hooks/advisory-nudge/perf-multiplier-evidence-advisory/impl.py
@@ -57,6 +57,18 @@ artifact actually measures the SAME lever the multiplier claims (that
 adequacy judgment is out of scope, mirroring the sibling gates' presence-
 only enforcement).
 
+Each body is bound to its OWN invocation (issue #973). One command can chain
+several `gh` calls, and a timing artifact posted by one of them measures
+nothing about a multiplier posted by another — so the scan runs per
+invocation, not over the command as a whole. The pre-fix shape read only the
+first `--body` in the flat argv and matched `gh (issue|pr) (create|comment)`
+as a regex over the raw command text, which produced three wrong answers:
+a claim in a second chained call was never seen; a non-`gh` command's
+`--body` was attributed to the `gh` scan; and the words `gh issue create`
+inside a quoted `echo` argument fired the advisory with no deliverable at
+all. The sibling `n1-quantitative-claim-advisory` was corrected the same way
+(PR #969).
+
 Scope (deliberately narrow, per issue): PreToolUse(Bash) only, `gh issue|pr
 create|comment` invocations only. A prose "synthesis block" surfaced with
 no tool call at all is a Stop-lane concern (see `proposal-premise-gate`,
@@ -84,12 +96,22 @@ from pathlib import Path
 _HOOK_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(_HOOK_DIR.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
+from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    iter_command_starts,
+    strip_prefix,
+)
 
 # ---------------------------------------------------------------------------
 # Trigger: gh issue|pr create|comment
+#
+# Structural tokenization, not regex (DESIGN.md "Design mechanisms shared by
+# all hooks"). A regex over raw command text cannot tell a real invocation
+# from the same words inside a quoted string, and it cannot tell which body
+# flag belongs to which invocation when several are chained (issue #973).
 # ---------------------------------------------------------------------------
 
-_GH_DELIVERABLE_RE = re.compile(r"\bgh\s+(?:issue|pr)\s+(?:create|comment)\b")
+_GH_OBJECTS = ("issue", "pr")
+_GH_VERBS = ("create", "comment")
 
 _BODY_TEXT_FLAGS = ("--body", "-b")
 _BODY_FILE_FLAGS = ("--body-file", "-F")
@@ -174,19 +196,34 @@ def _has_timing_artifact(text: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _extract_body_text(command: str) -> str | None:
-    """Return the body text this `gh` invocation would post, or None.
+def _is_gh_deliverable(argv: list[str]) -> bool:
+    """True iff this argv slice is a `gh (issue|pr) (create|comment)` call.
+
+    The object and verb are located by scanning past `gh`'s own global flags
+    (`--repo owner/name`, `-R …`), so a flag sitting between them does not
+    hide the invocation.
+    """
+    if not argv:
+        return False
+    head = argv[0].lstrip("(${")
+    if not (head == "gh" or head.endswith("/gh")):
+        return False
+
+    words = [tok for tok in argv[1:] if not tok.startswith("-")]
+    for i, word in enumerate(words):
+        if word in _GH_OBJECTS:
+            return any(w in _GH_VERBS for w in words[i + 1:i + 3])
+    return False
+
+
+def _body_of(argv: list[str]) -> str | None:
+    """Return the body text THIS invocation would post, or None.
 
     Inline `--body`/`-b` values are read directly from the parsed argv.
     `--body-file`/`-F` values are read from disk (best-effort — an
     unreadable path silently yields None for THIS invocation, not a hook
     failure).
     """
-    try:
-        argv = shlex.split(command, posix=True)
-    except ValueError:
-        return None
-
     for i, tok in enumerate(argv):
         flag, sep, inline_value = tok.partition("=")
         if tok in _BODY_TEXT_FLAGS and i + 1 < len(argv):
@@ -198,6 +235,90 @@ def _extract_body_text(command: str) -> str | None:
         if sep and flag in _BODY_FILE_FLAGS:
             return _read_body_file(inline_value)
     return None
+
+
+def _newlines_to_separators(command: str) -> str:
+    """Rewrite command-separating newlines as `;` so segment splitting sees them.
+
+    A newline separates commands in Bash, but `shlex.split` consumes it as
+    generic whitespace — `git status\\ngh pr comment --body "3x"` flattens into
+    ONE segment whose argv[0] is `git`, and the `gh` body is never scanned.
+    `safe_tokenize` already solves this by inserting a synthetic `;` per line,
+    but it splits on every raw newline, which severs `--body` from a multi-line
+    GitHub body — this hook's primary input. So the newline is rewritten only
+    when it sits OUTSIDE quotes: a body's internal newlines are quoted and stay
+    untouched, while a real command break becomes a separator token.
+
+    Backslash-escaped characters are copied through verbatim, so a `\\`-newline
+    line continuation is not turned into a break.
+    """
+    out: list[str] = []
+    quote: str | None = None
+    i = 0
+    n = len(command)
+    while i < n:
+        ch = command[i]
+        if quote == "'":
+            # Single quotes are literal in Bash — no escapes inside them.
+            if ch == "'":
+                quote = None
+            out.append(ch)
+            i += 1
+        elif ch == "\\" and i + 1 < n:
+            out.append(ch)
+            out.append(command[i + 1])
+            i += 2
+        elif quote == '"':
+            if ch == '"':
+                quote = None
+            out.append(ch)
+            i += 1
+        elif ch in ("'", '"'):
+            quote = ch
+            out.append(ch)
+            i += 1
+        elif ch == "\n":
+            out.append(" ; ")
+            i += 1
+        else:
+            out.append(ch)
+            i += 1
+    return "".join(out)
+
+
+def _extract_bodies(command: str) -> list[str]:
+    """Every body a `gh` deliverable in this command would post.
+
+    One command can chain several invocations; each carries its own body, and
+    a timing artifact cited in one measures nothing about a multiplier claimed
+    by another (issue #973).
+    """
+    # `shlex.split` rather than the shared `safe_tokenize`: this hook's inputs
+    # are multi-line GitHub bodies. `safe_tokenize` pre-splits on every raw
+    # newline (its own docstring flags this as a caller note), so a quoted body
+    # is cut mid-string, every resulting line fails to parse on the unmatched
+    # quote, and the skip-on-ValueError arm drops them all — measured:
+    # `gh pr comment 1 --body "### Verification\n3x speedup expected"`
+    # tokenizes to `[';']`, losing the invocation entirely. `_newlines_to_
+    # separators` above recovers the command breaks that `shlex.split` would
+    # otherwise swallow, without cutting a quoted body. Command-boundary
+    # splitting still uses the shared primitives below.
+    try:
+        tokens = shlex.split(_newlines_to_separators(command), posix=True)
+    except ValueError:
+        return []
+    if not tokens:
+        return []
+
+    bodies = []
+    for segment in iter_command_starts(tokens):
+        argv = strip_prefix(segment)
+        if not _is_gh_deliverable(argv):
+            continue
+        body = _body_of(argv)
+        if body:
+            bodies.append(body)
+    return bodies
 
 
 def _read_body_file(path_text: str) -> str | None:
@@ -217,7 +338,7 @@ def _read_body_file(path_text: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def _advisory_text(body: str) -> str:
+def _advisory_text() -> str:
     return (
         "[perf-multiplier-evidence-advisory] perf multiplier / lever verdict "
         "in this deliverable has no adjacent controlled-timing artifact "
@@ -252,20 +373,19 @@ def main() -> int:
     if not isinstance(command, str) or not command.strip():
         return 0
 
-    if not _GH_DELIVERABLE_RE.search(command):
+    # Each chained invocation is scanned against its OWN body: a timing
+    # artifact cited in one body does not silence a multiplier claimed in
+    # another (issue #973). The first unsatisfied body is reported.
+    for body in _extract_bodies(command):
+        if not (_has_multiplier(body) or _has_lever_verdict(body)):
+            continue
+
+        if _has_timing_artifact(body):
+            continue
+
+        sys.stderr.write(_advisory_text() + "\n")
         return 0
 
-    body = _extract_body_text(command)
-    if not body:
-        return 0
-
-    if not (_has_multiplier(body) or _has_lever_verdict(body)):
-        return 0
-
-    if _has_timing_artifact(body):
-        return 0
-
-    sys.stderr.write(_advisory_text(body) + "\n")
     return 0
 
 

--- a/hooks/advisory-nudge/perf-multiplier-evidence-advisory/spec.md
+++ b/hooks/advisory-nudge/perf-multiplier-evidence-advisory/spec.md
@@ -54,7 +54,9 @@ Reference: issue [#850](https://github.com/devseunggwan/praxis/issues/850).
 
 ## What is detected
 
-Both conditions must hold, scanned over the SAME body text:
+Both conditions must hold, scanned over the SAME body text — and "the same
+body text" means the body of ONE invocation (see
+[Body-text extraction](#body-text-extraction)):
 
 ### (1) Perf multiplier notation OR lever verdict
 
@@ -81,13 +83,59 @@ same design: presence, not adequacy).
 
 ## Body-text extraction
 
+### Each body is bound to its own invocation (issue #973)
+
+One Bash command can chain several `gh` calls. The command is tokenized, split
+into per-command segments at the shell separators (`;`, `&&`, `||`, `|`, `&`,
+and a newline outside quotes), and each segment is tested independently: is
+argv[0] the `gh` binary, does it carry an `issue`/`pr` object followed by a
+`create`/`comment` verb, and what body does THAT segment post. The scan then
+runs per body, and fires on the first body that claims a multiplier or a lever
+verdict without its own timing artifact.
+
+This is structural tokenization, not a regex over the raw command text
+(DESIGN.md, "Design mechanisms shared by all hooks"). The earlier regex shape
+matched `gh (issue|pr) (create|comment)` anywhere in the command string and
+then returned the FIRST `--body` in the flat argv, which gave three wrong
+answers — all three are now pinned as regression cases R1–R4 in the test file:
+
+| Command shape | Pre-fix | Correct |
+| --- | --- | --- |
+| `gh issue comment 1 --body "elapsed 12.0s" && gh pr comment 2 --body "5x faster"` | silent — body 1's artifact was the only body read | advisory: body 2 claims a multiplier with no artifact of its own |
+| `curl -X POST --body "harmless" … && gh issue create --body "5x faster"` | silent — `curl`'s body was donated to the `gh` scan | advisory: only the `gh` segment's body counts |
+| `echo "run gh issue create later" > note.txt && printf %s --body "5x faster"` | advisory — the trigger words matched inside a quoted argument | silent: no deliverable write exists |
+
+**Evidence does not cross invocations.** A timing artifact cited by one `gh`
+call measures nothing about a multiplier posted by another, so it silences only
+its own body.
+
+### Newlines vs multi-line bodies
+
+An unquoted newline is a command separator and is rewritten to `;` before
+tokenizing; a newline INSIDE a quoted body is left alone. The shared
+`safe_tokenize` cannot be used here for exactly this reason — it pre-splits on
+every raw newline, so a quoted multi-line body is cut mid-string, each fragment
+then fails to parse on the unmatched quote, and the skip-on-`ValueError` arm
+drops them all. Measured: `gh pr comment 1 --body "### Verification\n3x speedup
+expected"` tokenizes to `[';']` under `safe_tokenize`, losing the invocation
+entirely. Multi-line bodies are this hook's primary input, so the token pass
+uses `shlex.split` and the command breaks it would otherwise swallow are
+restored by the unquoted-newline rewrite. Command-boundary splitting still uses
+the shared `iter_command_starts` / `strip_prefix` primitives.
+
+### Flag forms
+
 - `--body "..."` / `-b "..."` / `--body=...` — inline value, read directly
-  from the parsed argv (`shlex.split`).
+  from the parsed argv.
 - `--body-file <path>` / `-F <path>` / `--body-file=<path>` — the file is
   read from disk (relative paths resolve against the hook process's cwd).
   An unreadable/missing target silently yields no body text for THIS
   invocation (under-firing accepted over hard-failing the hook on a disk
   read error).
+
+The invocation itself is recognized through a path-prefixed binary
+(`/usr/bin/gh`) and through `gh`'s own global flags sitting between the binary
+and its subcommand (`gh --repo owner/name pr comment …`).
 
 ## Scope — deliberately narrow
 
@@ -107,6 +155,9 @@ the `Stop`-lane concern already covered by `proposal-premise-gate`
 | body with a bare `73%` and no direction word nearby | no direction word — likely an unrelated percentage |
 | body with `lever` discussed but no multiplier and no verdict token | condition (1) not met |
 | `--body-file` target does not exist on disk | no body text extractable |
+| a chain where EVERY `gh` body carries its own timing artifact | each body satisfies the pass condition independently |
+| `gh issue create` appearing only inside a quoted string (`echo "… gh issue create …"`) | no `gh` invocation is actually run |
+| a non-`gh` command's `--body` (e.g. `curl --body …`) with no `gh` deliverable in the command | the body belongs to no deliverable write |
 | non-Bash tool call | out of scope |
 | malformed JSON stdin | fail-open |
 
@@ -116,7 +167,8 @@ the `Stop`-lane concern already covered by `proposal-premise-gate`
 | --- | --- |
 | Malformed / missing stdin JSON | exit 0, silent |
 | `tool_name != "Bash"` | exit 0, silent |
-| No `gh issue\|pr create\|comment` invocation | exit 0, silent |
+| No `gh issue\|pr create\|comment` invocation in any command segment | exit 0, silent |
+| Unbalanced quotes (tokenization raises) | exit 0, silent — no bodies extracted |
 | `--body-file` unreadable | exit 0, silent (for that invocation) |
 | Any uncaught exception | exit 0 (`@fail_open`) |
 

--- a/tests/hooks/advisory-nudge/test_perf_multiplier_evidence_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_perf_multiplier_evidence_advisory.sh
@@ -195,6 +195,80 @@ run_case "--body-file missing target is silent (no body text extractable)" \
 rm -rf "$BODY_FILE_DIR"
 
 # ---------------------------------------------------------------------------
+# === CHAINED INVOCATIONS (issue #973) — each body is bound to its OWN gh call.
+# The pre-fix shape read only the first --body in the flat argv and matched the
+# trigger as a regex over the whole command string; neither R1..R4 nor R7 can be
+# answered that way. See the PR anchor for the pre-fix measurement.
+# ---------------------------------------------------------------------------
+
+# R1 is the issue's exact scenario: evidence in body 1 must NOT silence the
+# bare claim in body 2 — a timing artifact posted by one invocation measures
+# nothing about a multiplier posted by another.
+run_case "R1: evidence in body 1 does not silence a claim in body 2 (&&)" \
+  "advisory:[perf-multiplier-evidence-advisory]" \
+  'gh issue comment 1 --body "wall-clock: elapsed 12.0s baseline" && gh pr comment 2 --body "so the new path is 5x faster"'
+
+run_case "R2: same chain with a ';' separator" \
+  "advisory:[perf-multiplier-evidence-advisory]" \
+  'gh issue comment 1 --body "elapsed 12.0s" ; gh pr create --title t --body "5x faster"'
+
+# R3: a non-gh command's --body used to be donated to the gh scan, hiding the
+# real claim behind curl's harmless body.
+run_case "R3: a non-gh --body ahead of the gh claim is not the gh body" \
+  "advisory:[perf-multiplier-evidence-advisory]" \
+  'curl -X POST --body "harmless" https://x && gh issue create --title t --body "5x faster"'
+
+# R4: the false POSITIVE in the same root cause — there is no deliverable here
+# at all, only the words inside a quoted echo argument.
+run_case "R4: 'gh issue create' inside quoted text posts nothing" \
+  silent \
+  'echo "run gh issue create later" > /tmp/note.txt && printf %s --body "5x faster"'
+
+# R5/R6 pin the control direction: a chain must stay silent when EVERY body
+# carries its own timing artifact, so the per-body loop cannot be "fixed" by
+# firing on any chain that contains a multiplier anywhere.
+run_case "R5: both chained bodies carry their own timing artifact is silent" \
+  silent \
+  'gh issue comment 1 --body "3x faster; elapsed 12.0s" && gh pr comment 2 --body "49m -> 12m; wall-clock: measured"'
+
+run_case "R6: unrelated command chained before a silenced claim stays silent" \
+  silent \
+  'git status && gh pr comment 1 --body "3x faster; real 0m12.400s"'
+
+# R7 pins the newline path. Bash separates commands on a newline, but
+# shlex.split consumes it as whitespace — without the unquoted-newline rewrite
+# this flattens to one segment whose argv[0] is `git`, and the gh body is never
+# scanned.
+run_case "R7: newline-separated chain is split at the command boundary" \
+  "advisory:[perf-multiplier-evidence-advisory]" \
+  'git status
+gh pr comment 1 --body "5x faster"'
+
+# R8 is R7's control: the newline rewrite must NOT cut a multi-line body, which
+# is this hook's primary input (`### Verification` anchors are multi-line).
+run_case "R8: multi-line quoted body keeps its timing artifact attached" \
+  silent \
+  'gh pr comment 1 --body "### Verification
+3x speedup
+$ hyperfine ./bench -> wall-clock: 12.4s"'
+
+run_case "R9: multi-line quoted body with no artifact still fires" \
+  "advisory:[perf-multiplier-evidence-advisory]" \
+  'gh pr comment 1 --body "### Verification
+3x speedup expected"'
+
+# R10/R11 mirror the sibling's invocation-shape cases: structural tokenization
+# must find the deliverable through a path-invoked binary and through gh's own
+# global flags sitting between `gh` and its subcommand.
+run_case "R10: path-invoked gh binary" \
+  "advisory:[perf-multiplier-evidence-advisory]" \
+  '/usr/bin/gh pr comment 1 --body "5x faster"'
+
+run_case "R11: global flag between gh and its subcommand" \
+  "advisory:[perf-multiplier-evidence-advisory]" \
+  'gh --repo owner/name pr comment 1 --body "5x faster"'
+
+# ---------------------------------------------------------------------------
 # === SILENT: non-Bash tool / malformed payload ===
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 요약

`perf-multiplier-evidence-advisory` 는 `gh (issue|pr) (create|comment)` 를 **커맨드 문자열 전체**에 대한 정규식으로 찾고, 그 뒤 평평한 shlex argv 에서 **첫 번째** `--body` 를 반환했다. 두 축 모두 본문이 어느 invocation 소속인지를 잃는다.

## 실측된 세 가지 오답

1. **체인된 두 번째 호출의 주장이 보이지 않는다** — 이슈의 정확한 시나리오(invocation 1 이 근거를 싣고, invocation 2 가 근거 없는 `5x faster` 를 싣는 형태)가 `&&` 와 `;` 양쪽에서 완전히 침묵했다.
2. **비-gh 명령의 `--body` 가 gh 스캔에 기부된다** — `curl -X POST --body "harmless"` 가 뒤따르는 진짜 주장을 가린다.
3. **같은 뿌리의 오탐** — 인용된 `echo` 인자 안에만 등장하는 `gh issue create` 가 딜리버러블 쓰기가 전혀 없는데도 advisory 를 발화시켰다.

## 이슈 작업 1 (범위 판정)

`_extract_body_text` 형 헬퍼와 전체-커맨드 스캔을 조합한 훅을 전수 열거한 결과 **이 훅 하나뿐**이다. 형제 훅 `n1-quantitative-claim-advisory` 는 PR #969(`5dbfa8a`)에서 이미 닫혔다. 이슈가 정한 기준("1개뿐이면 단일 훅 수정, 3개 이상일 때만 공유 헬퍼")에 따라 **단일 훅 수정**으로 처리했다. `hooks/_lib/` 는 건드리지 않았다.

## 수정

한 번 토크나이즈한 뒤 공유 `iter_command_starts` / `strip_prefix` 로 invocation 단위 세그먼트로 쪼개고, 각 세그먼트가 gh 딜리버러블 쓰기인지 판정한 다음 **그 세그먼트의 본문만** 검사한다. 형제 훅의 구조를 따르되 개행 경계 처리를 추가했다 — 형제 구조를 그대로 옮기면 R7(개행으로 분리된 `git status` 다음의 gh 주장)이 회귀한다.

## 회귀 픽스처 11종 — 양·음 양방향

| # | 케이스 | 기대 |
|---|---|---|
| R1 | `&&` 체인, 본문 1 에 타이밍 근거 / 본문 2 에 맨 `5x faster` | advisory (이슈 시나리오) |
| R2 | 같은 체인, `;` 구분자 | advisory |
| R3 | `curl --body "harmless" && gh issue create --body "5x faster"` | advisory (비-gh 본문이 기부되지 않음) |
| R4 | 인용된 `echo` 안의 트리거 단어 | **침묵** (오탐 제거) |
| R5 | 체인된 두 본문 모두 각자 타이밍 근거 보유 | **침묵** (대조군) |
| R6 | `git status && gh pr comment --body "3x faster; real 0m12.400s"` | **침묵** (판정 불변 대조군) |
| R7 | 개행으로 분리된 `git status` 다음 gh 주장 | advisory (개행 경계) |
| R8 | 여러 줄 인용 본문, 타이밍 근거가 뒷줄에 | **침묵** (본문을 자르지 않음) |
| R9 | `### Verification` 으로 시작하고 근거 없는 여러 줄 본문 | advisory (`#` 가 주석으로 먹히지 않음) |
| R10 | 경로 호출 `/usr/bin/gh` | advisory |
| R11 | `gh --repo owner/name pr comment` (전역 플래그 삽입) | advisory |

`tests/hooks/advisory-nudge/test_perf_multiplier_evidence_advisory.sh`: **36 passed, 0 failed** (브랜치 격리 상태에서 실행).

## 미확인

- 이슈 스스로 적었듯 **실제 피해 관측은 0건**이다. 이 결함으로 근거 없는 배수 주장이 실제 딜리버러블에 실려 나간 사례는 확인되지 않았다. 체인된 `gh` 호출 자체가 흔한 형태가 아니다. 이 PR 은 잠재 표면을 닫는 것이지 사고를 수습하는 것이 아니다.
- 형제 훅 `n1-quantitative-claim-advisory` 의 `_extract_bodies` 독스트링에 사실 오류가 있다 — `safe_tokenize` 를 피하는 이유로 "인용 상태 확정 전 `#` 를 줄 끝까지 제거한다" 를 든다. `safe_tokenize` 는 `lex.commenters = ""` 를 설정하므로 사실이 아니다(#1014 에서 실측). 이 PR 범위 밖이라 수정하지 않았다.

Closes #973

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc

---
_Generated by [Claude Code](https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc)_