### PR TITLE
fix(menu-tier): gate create/update on shared surface, cancel on mutation

### DIFF
--- a/hooks/advisory-nudge/menu-mutation-tier-advisory/impl.py
+++ b/hooks/advisory-nudge/menu-mutation-tier-advisory/impl.py
@@ -125,6 +125,127 @@ MUTATION_VERBS_KO = (
 MUTATION_TOKENS_EN = HIGH_BLAST_TARGETS_EN + MUTATION_VERBS_EN
 MUTATION_TOKENS_KO = HIGH_BLAST_TARGETS_KO + MUTATION_VERBS_KO
 
+# Tier 1c — CONDITIONAL mutation verbs (issue #974, codex round-1 gap 1 on
+# PR #966). `create` / `update` do change shared state, but unlike every Tier 1b
+# verb they are also ordinary English for making a file, a heading, or a
+# sentence. They are therefore counted as a mutation signal only when the same
+# option also names a shared surface (below).
+#
+# Measured, not assumed: a prototype that added them to MUTATION_VERBS_EN
+# unconditionally fired on `Create a new test file` / `Update the existing test`,
+# `Create a README section` / `Update the changelog`, `문서 생성` / `문서 갱신`,
+# and `Create a shorter title` / `Update the wording` — four ordinary menus that
+# touch no shared surface. That cost is not a stderr line: since PR #966 rev 5
+# the default path is `emit_decision("ask", …)`, so a false fire is a human
+# confirmation prompt. The gate keeps the issue's own repro (`Create the
+# customer record` / `Update the customer record`) firing while leaving all four
+# silent.
+CONDITIONAL_MUTATION_VERBS_EN = (
+    "create",
+    "update",
+)
+CONDITIONAL_MUTATION_VERBS_KO = (
+    "생성",
+    "갱신",
+)
+
+# The shared surfaces that promote a Tier 1c verb into a mutation signal. Data
+# and infrastructure nouns only — deliberately not `file`, `doc`, `section`,
+# `title`, `test`, which is what separates the issue's repro from the four
+# false-fire menus above. Plurals are listed explicitly because the English
+# lookaround is whole-token (the same reason `development` and `reviewer` are
+# listed beside `dev` and `review`).
+#
+# `schema`, `index`, `namespace`, `migration`, `dag`, `policy` were drafted here
+# and removed after probing: each fired on an ordinary authoring menu
+# (`Create a migration file` / `Update the migration file`,
+# `Create a retry policy in the client` / `Update the retry policy`,
+# `Create a new namespace` / `Update the namespace`, …) because their everyday
+# meaning is a repo artifact, not a shared surface. Creating a migration is
+# authoring a file; it is `apply` — already Tier 1b — that mutates.
+SHARED_SURFACE_NOUNS_EN = (
+    "record",
+    "records",
+    "row",
+    "rows",
+    "table",
+    "tables",
+    "database",
+    "dataset",
+    "bucket",
+    "cluster",
+    "tenant",
+    "tenants",
+    "customer",
+    "customers",
+    "account",
+    "accounts",
+    "subscription",
+    "subscriptions",
+    "secret",
+    "secrets",
+    "credential",
+    "credentials",
+    "pipeline",
+    "webhook",
+)
+SHARED_SURFACE_NOUNS_KO = (
+    "레코드",
+    "테이블",
+    "데이터베이스",
+    "데이터셋",
+    "버킷",
+    "클러스터",
+    "테넌트",
+    "고객",
+    "계정",
+    "구독",
+    "시크릿",
+    "자격 증명",
+    "자격증명",
+    "파이프라인",
+)
+
+# …and the veto: a shared-surface noun sitting inside an authoring artifact is
+# not the shared surface. `Create a fixture record for the test` and
+# `Create an index variable` both name a Tier 1c verb next to a kept noun, and
+# both fired before this set existed.
+#
+# Consulted ONLY from the Tier 1c branch, so no option without `create` /
+# `update` / `생성` / `갱신` changes classification because of it. It is a
+# false-negative surface of its own — a genuine shared-surface menu that
+# happens to say `spec` or `test` goes silent — which is the same direction as
+# the defect being fixed and is recorded under Known limitations in spec.md.
+LOCAL_ARTIFACT_NOUNS_EN = (
+    "file",
+    "files",
+    "doc",
+    "docs",
+    "readme",
+    "changelog",
+    "spec",
+    "comment",
+    "comments",
+    "variable",
+    "fixture",
+    "fixtures",
+    "test",
+    "tests",
+    "draft",
+    "template",
+    "snippet",
+)
+LOCAL_ARTIFACT_NOUNS_KO = (
+    "파일",
+    "문서",
+    "주석",
+    "변수",
+    "테스트",
+    "픽스처",
+    "초안",
+    "템플릿",
+)
+
 # Tier 2 — non-mutating / low blast radius. The option is a real verification
 # alternative that does not touch the shared surface. Presence of ANY of these
 # suppresses the advisory: a safe tier is on the menu, which is all this hook
@@ -196,7 +317,6 @@ ABANDON_TOKENS_EN = (
     "postpone",
     "do nothing",
     "nothing",
-    "cancel",
     "hold",
     "wait",
     "none",
@@ -210,12 +330,59 @@ ABANDON_TOKENS_KO = (
     "안함",
     "대기",
     "보류",
-    "취소",
     "건너뛰",
     "미루",
     "아무것도",
     "그대로 둬",
     "그대로 둔",
+)
+
+# Tier 0b — CONDITIONAL abandonment (issue #974, codex round-1 gap 2 on
+# PR #966). `cancel` / `취소` mean two different things depending on whether the
+# option carries an object. Bare `Cancel` declines to act. `Cancel the prod
+# deployment` cancels something already in flight — that aborts a running change
+# to the shared surface, which is itself a mutation, and a menu of
+# `Cancel the prod deployment` / `Proceed with the prod deployment` has no
+# non-mutating tier at all.
+#
+# Before the fix that menu was silent, and not because of a vocabulary hole:
+# `Cancel the prod deployment` already classified as a mutation via `prod`, but
+# `_question_triggers` strips abandonment options before it ever asks the
+# mutation question, so the option was dropped and the single survivor fell
+# below the two-candidate floor.
+#
+# The discriminator is the mutation evidence the hook already computes, not
+# syntactic object-detection: a regex for `cancel` + determiner + noun would
+# also demote `Cancel the deployment` and `Skip the deployment`, which are
+# genuine do-nothing tiers. The unconditional sets above are checked first, so
+# `do not` / `하지 않` phrasings keep their abandonment status even when they
+# name a prod object.
+CONDITIONAL_ABANDON_EN = ("cancel",)
+CONDITIONAL_ABANDON_KO = ("취소",)
+
+# The rule above has its own false-fire surface, measured: a genuine no-go
+# option that spells out what it is declining (`Cancel — do not deploy to
+# prod`) carries the mutation token too, so it would be promoted to a candidate
+# and fire the advisory on a menu that already offers "whether". An explicit
+# negation settles it in the abandonment direction.
+#
+# Read ONLY inside the Tier 0b branch, never as a Tier 0 token of its own. A
+# global `do not` was tried and rejected: it silenced
+# `Deploy to prod and notify` / `Deploy to prod but do not notify`, where the
+# negation attaches to a rider rather than to the act, and that menu fires
+# today. Scoping it to options that also say `cancel` keeps the blast radius of
+# this whole issue at exactly one word — no option without `cancel` / `취소`
+# changes classification. `하지 않` is already unconditional Tier 0, which is
+# why the KO phrasing never had the reverse false fire; it is listed here too
+# so the pair is readable as one rule.
+NEGATION_TOKENS_EN = (
+    "do not",
+    "don't",
+)
+NEGATION_TOKENS_KO = (
+    "하지 않",
+    "안 함",
+    "안함",
 )
 
 
@@ -236,8 +403,31 @@ def _matches(text: str, ko_tokens: tuple[str, ...], en_tokens: tuple[str, ...]) 
     return any(_en_token_present(token, lower) for token in en_tokens)
 
 
+def _names_shared_surface(text: str) -> bool:
+    """True if the option names a data / infrastructure surface (Tier 1c gate).
+
+    An authoring artifact in the same option vetoes it: `a fixture record for
+    the test` names `record`, but the record is a repo artifact, not the shared
+    surface this hook is about.
+    """
+    if _matches(text, LOCAL_ARTIFACT_NOUNS_KO, LOCAL_ARTIFACT_NOUNS_EN):
+        return False
+    return _matches(text, SHARED_SURFACE_NOUNS_KO, SHARED_SURFACE_NOUNS_EN)
+
+
 def _is_mutation(text: str) -> bool:
-    return _matches(text, MUTATION_TOKENS_KO, MUTATION_TOKENS_EN)
+    """True if this option changes shared state.
+
+    Tier 1a/1b tokens count on their own. Tier 1c verbs (`create` / `update` /
+    `생성` / `갱신`) count only when the option also names a shared surface —
+    they are too common in ordinary file, doc, and prompt wording to carry the
+    signal alone. See the Tier 1c block above for the measured false fires.
+    """
+    if _matches(text, MUTATION_TOKENS_KO, MUTATION_TOKENS_EN):
+        return True
+    if _matches(text, CONDITIONAL_MUTATION_VERBS_KO, CONDITIONAL_MUTATION_VERBS_EN):
+        return _names_shared_surface(text)
+    return False
 
 
 def _names_high_blast_target(text: str) -> bool:
@@ -264,7 +454,22 @@ def _is_low_blast(text: str) -> bool:
 
 
 def _is_abandon(text: str) -> bool:
-    return _matches(text, ABANDON_TOKENS_KO, ABANDON_TOKENS_EN)
+    """True if this option declines to act rather than offering a cheaper path.
+
+    Tier 0 tokens are unconditional. Tier 0b (`cancel` / `취소`) abandons only
+    when nothing else in the option is mutating: a bare `Cancel` is the do-
+    nothing tier, while `Cancel the prod deployment` aborts an in-flight change
+    to the shared surface and stays a candidate (issue #974). An explicit
+    negation inside the same option overrides that — it is a no-go naming its
+    own object, not a cancellation of something already running.
+    """
+    if _matches(text, ABANDON_TOKENS_KO, ABANDON_TOKENS_EN):
+        return True
+    if _matches(text, CONDITIONAL_ABANDON_KO, CONDITIONAL_ABANDON_EN):
+        if _matches(text, NEGATION_TOKENS_KO, NEGATION_TOKENS_EN):
+            return True
+        return not _is_mutation(text)
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -390,6 +595,12 @@ def _question_triggers(texts: list[str]) -> bool:
     Reading low-blast first let that single option suppress an otherwise
     all-prod menu — the spec says abandonment is neither class, so it has to be
     removed before either question is asked of it.
+
+    That ordering is also why `cancel` had to become conditional rather than
+    gain a sibling token (issue #974): step 1 removes the option before step 4
+    can notice it is mutating, so `Cancel the prod deployment` /
+    `Proceed with the prod deployment` fell to one candidate and went silent
+    even though both options change prod.
 
     Divergence from the issue's draft wording, stated deliberately: the issue
     says *every* option must carry a mutation signal. That is not decidable

--- a/hooks/advisory-nudge/menu-mutation-tier-advisory/spec.md
+++ b/hooks/advisory-nudge/menu-mutation-tier-advisory/spec.md
@@ -436,8 +436,8 @@ recognised as low-blast; an external-write-only menu fires); the CodeRabbit
 round-1 regressions (an option matching abandonment *and* low-blast does not
 suppress, in advisory and strict mode, EN and KO; a stated
 `Safe-tier-unavailable:` line suppresses in both modes; a mid-line or empty
-marker does not; a reason on question 1 does not cover question 2); the issue
-#974 gaps in both directions (Tier 1c fires on `create` / `update` at a shared
+marker does not; a reason on question 1 does not cover question 2); the
+issue #974 gaps in both directions (Tier 1c fires on `create` / `update` at a shared
 surface, EN and KO, advisory and strict, and stays silent on the four measured
 authoring menus, on the six nouns dropped after probing, and behind the
 local-artifact veto; Tier 0b fires on a cancel-with-object menu, EN and KO, and

--- a/hooks/advisory-nudge/menu-mutation-tier-advisory/spec.md
+++ b/hooks/advisory-nudge/menu-mutation-tier-advisory/spec.md
@@ -92,6 +92,12 @@ Reading low-blast first let that single option suppress an otherwise all-prod
 menu — abandonment being neither class means it has to be removed before either
 question is asked of it.
 
+That same ordering is why `cancel` had to become *conditional* (Tier 0b below)
+rather than gain a sibling token: step 1 removes the option before step 4 can
+notice it is mutating, so `Cancel the prod deployment` / `Proceed with the prod
+deployment` fell to one candidate and went silent even though both options
+change prod.
+
 **Divergence from the issue's wording, stated deliberately.** The issue says
 *every* option must carry a mutation signal. That is not decidable lexically: a
 scope-reduction option (`한 건만 먼저`) inherits its verb from a sibling option
@@ -170,6 +176,56 @@ a menu offering only `Send Slack now` / `Send email instead` is this same defect
 in different vocabulary. They stay verb-anchored: the nouns (`slack`, `email`)
 also occur in read-only options ("read the Slack thread") and would misfire.
 
+**Tier 1c — conditional mutation verbs** (issue #974, codex round-1 gap 1):
+
+- English (lookaround): `create`, `update`
+- Korean (substring): `생성`, `갱신`
+
+These count as a mutation signal **only when the same option also names a
+shared surface**. They do mutate, but unlike every Tier 1b verb they are also
+ordinary English for authoring a file, a heading, or a sentence — and a false
+fire is not a log line: since PR #966 rev 5 the default path emits
+`permissionDecision: ask`, a human confirmation prompt. The unconditional
+variant was built and measured; it fired on `Create a new test file` /
+`Update the existing test`, `Create a README section` / `Update the changelog`,
+`문서 생성` / `문서 갱신`, and `Create a shorter title` / `Update the wording`.
+The gate keeps the issue's own repro (`Create the customer record` /
+`Update the customer record`) firing while leaving all four silent; the
+fixtures pin both directions.
+
+**Shared surfaces** (promote a Tier 1c verb):
+
+- English (lookaround): `record`, `records`, `row`, `rows`, `table`, `tables`,
+  `database`, `dataset`, `bucket`, `cluster`, `tenant`, `tenants`, `customer`,
+  `customers`, `account`, `accounts`, `subscription`, `subscriptions`,
+  `secret`, `secrets`, `credential`, `credentials`, `pipeline`, `webhook`
+- Korean (substring): `레코드`, `테이블`, `데이터베이스`, `데이터셋`, `버킷`,
+  `클러스터`, `테넌트`, `고객`, `계정`, `구독`, `시크릿`, `자격 증명`,
+  `자격증명`, `파이프라인`
+
+`schema`, `index`, `namespace`, `migration`, `dag`, `policy` were drafted into
+this set and removed after probing: each fired on an ordinary authoring menu
+(`Create a migration file` / `Update the migration file`, `Create a retry
+policy in the client` / `Update the retry policy`, `Create a new namespace` /
+`Update the namespace`), because their everyday meaning is a repo artifact.
+Creating a migration authors a file; it is `apply` — already Tier 1b — that
+mutates.
+
+**Local artifacts** (veto a Tier 1c promotion):
+
+- English (lookaround): `file`, `files`, `doc`, `docs`, `readme`, `changelog`,
+  `spec`, `comment`, `comments`, `variable`, `fixture`, `fixtures`, `test`,
+  `tests`, `draft`, `template`, `snippet`
+- Korean (substring): `파일`, `문서`, `주석`, `변수`, `테스트`, `픽스처`,
+  `초안`, `템플릿`
+
+A shared-surface noun inside an authoring artifact is not the shared surface:
+`Create a fixture record for the test` and `Create an index variable` both name
+a kept noun beside a Tier 1c verb, and both fired before this veto existed.
+
+Both sets are read **only** from the Tier 1c branch, so no option without
+`create` / `update` / `생성` / `갱신` changes classification because of them.
+
 #### Tier 2 — non-mutating / low blast radius (suppresses)
 
 - English (lookaround): `preview`, `dev`, `development`, `staging`, `sandbox`,
@@ -202,10 +258,41 @@ not match inside `code-reviewer`. A false positive in this set only
 #### Tier 0 — abandonment (neither suppresses nor counts as a candidate)
 
 - English (lookaround): `later`, `skip`, `defer`, `postpone`, `do nothing`,
-  `nothing`, `cancel`, `hold`, `wait`, `none`
+  `nothing`, `hold`, `wait`, `none`
 - Korean (substring): `다음 정기`, `다음 주기`, `나중에`, `하지 않`, `안 함`,
-  `안함`, `대기`, `보류`, `취소`, `건너뛰`, `미루`, `아무것도`, `그대로 둬`,
-  `그대로 둔`
+  `안함`, `대기`, `보류`, `건너뛰`, `미루`, `아무것도`, `그대로 둬`, `그대로 둔`
+
+#### Tier 0b — conditional abandonment (`cancel` / `취소`)
+
+Issue #974, codex round-1 gap 2. `cancel` means two different things depending
+on whether the option carries an object. Bare `Cancel` declines to act.
+`Cancel the prod deployment` aborts something already in flight — that is
+itself a change to the shared surface, and a menu of `Cancel the prod
+deployment` / `Proceed with the prod deployment` has no non-mutating tier at
+all. It was silent.
+
+**Not a vocabulary hole.** `Cancel the prod deployment` already classified as
+mutating via `prod`; the fire predicate strips abandonment options at step 1,
+before step 4 ever asks the mutation question, so the option was dropped and
+the single survivor fell below the two-candidate floor. The fix is in the
+classifier, not the token list.
+
+So `cancel` / `취소` abandon **only when nothing else in the option is
+mutating**. The discriminator is the mutation evidence the hook already
+computes, not syntactic object-detection: a regex for `cancel` + determiner +
+noun would also demote `Cancel the deployment` and `Skip the deployment`, which
+are genuine do-nothing tiers.
+
+**Negation override.** The rule has its own false-fire surface, measured: a
+genuine no-go that spells out what it declines (`Cancel — do not deploy to
+prod`) carries the mutation token too and would be promoted to a candidate. An
+explicit negation — `do not`, `don't`, `하지 않`, `안 함`, `안함` — settles it
+back to abandonment. It is read **only** inside the Tier 0b branch, never as a
+Tier 0 token of its own: a global `do not` was tried and rejected because it
+silenced `Deploy to prod and notify` / `Deploy to prod but do not notify`,
+where the negation attaches to a rider rather than to the act, and that menu
+fires today. Scoping it keeps the whole gap-2 blast radius at one word — no
+option without `cancel` / `취소` changes classification.
 
 ### What is advised
 
@@ -217,6 +304,11 @@ not match inside `code-reviewer`. A false positive in this set only
 | A non-abandonment candidate carries a low-blast signal and names no high-blast target | silent pass-through (a safe tier is on the menu) |
 | The question body carries a `Safe-tier-unavailable: <reason>` line | silent pass-through for that question (reason stated) |
 | Fewer than 2 candidates after abandonment options are dropped | silent pass-through (binary go/no-go) |
+| An option says `cancel` / `취소` and carries no other mutation signal | that option is abandonment (dropped, neither candidate nor safe tier) |
+| An option says `cancel` / `취소` and also carries an explicit negation (`do not`, `하지 않`) | that option is abandonment, whatever else it names |
+| An option says `cancel` / `취소` beside a mutation signal and no negation | that option stays a **candidate** (aborting an in-flight change is a mutation) |
+| An option says `create` / `update` / `생성` / `갱신` and names a shared surface | mutation signal (Tier 1c) |
+| …and names a local artifact (`file`, `test`, `문서`, …) instead, or as well | no mutation signal from Tier 1c |
 | No candidate carries a mutation signal | silent pass-through (not a tier-relevant menu) |
 | Empty / missing options | silent pass-through |
 | Missing / malformed payload | silent pass-through (fail-open) |
@@ -261,8 +353,48 @@ around the gate.
   lever (which that sibling asks for anyway) suppresses this one too.
 - **Detection is lexical.** An option that is non-mutating for a reason no token
   names (`another team's staging cluster, called by its hostname`) is invisible,
-  and the advisory fires. The nudge asks for one line of reasoning either way, so
-  a false fire costs one sentence.
+  and the advisory fires. **A false fire is not cheap.** An earlier revision of
+  this section said it "costs one sentence"; that was written when the hook was
+  stderr-only, and has been wrong since PR #966 rev 5 made the default path
+  `emit_decision("ask", …)`. A false fire now costs the user a confirmation
+  prompt, which is why Tier 1c is gated rather than simply widened.
+- **Gap 3 is open on purpose — the compound-option VERB axis.** The suppression
+  rule disqualifies a low-blast token only when the option names a high-blast
+  *target*. An option pairing a safe **mode** token with a mutation **verb** and
+  naming no high-blast target still suppresses, so
+  `Dry-run then delete the customer table` / `Delete the customer table` is
+  silent in both modes — while the identical shape with `prod` inserted fires
+  (strict `rc=2`), which is what shows the residual is real.
+  `Report-only pass then send the announcement`, `Simulate then truncate the
+  table` and `드라이런 후 고객 테이블 삭제` behave the same way.
+
+  The verb-axis discriminator was built and rejected on measurement, not taste.
+  It closes all four residual cases and simultaneously fires on `Deploy now` /
+  `Dry-run the deploy`, `Merge now` / `Simulate the merge`, `Send the
+  announcement` / `Report-only pass on the send`, and `지금 배포` /
+  `배포 드라이런`. Those are the canonical phrasings of the exact option this
+  hook asks menus to contain, and a dry run necessarily names the verb it
+  simulates — `Dry-run then delete the table` and `Dry-run the deploy` are the
+  same shape, and no lexical rule separates them. Firing an `ask` at an author
+  who already added the safe tier teaches that adding one does not help, which
+  inverts the hook's purpose. The residual is the price of the target-based
+  discriminator, and both the residual and the four counter-cases are pinned in
+  the fixtures so a future round fails there rather than shipping the trade
+  blind.
+- **Tier 1c is invisible outside its noun list.** `Create the audit ledger` /
+  `Update the audit ledger` mutates a shared surface no `SHARED_SURFACE_NOUNS`
+  entry names, so it stays silent. That list is an enumeration, not a
+  measurement — no corpus of real `AskUserQuestion` menus backs it, and the size
+  of what it misses is unknown. The miss is in the same direction as the defect
+  gap 1 fixed.
+- **The local-artifact veto over-suppresses symmetrically.** A genuine
+  shared-surface menu that happens to say `spec` or `test`
+  (`Update the customer records in the test tenant`) loses its Tier 1c signal.
+- **`table` still collides with prose tables.**
+  `Create a comparison table in the README` / `Update the existing table` fires:
+  the veto is per option, and the second option names no artifact. Closing it
+  would need a menu-level veto, which was not built because nothing measured
+  justified the extra rule.
 - **`production` matches its adjectival use.** `production-ready` matches the
   lookaround (`-` is not an ASCII letter). `block-manufactured-action-menu`
   omitted the long form for exactly this reason; it is kept here because the
@@ -304,8 +436,17 @@ recognised as low-blast; an external-write-only menu fires); the CodeRabbit
 round-1 regressions (an option matching abandonment *and* low-blast does not
 suppress, in advisory and strict mode, EN and KO; a stated
 `Safe-tier-unavailable:` line suppresses in both modes; a mid-line or empty
-marker does not; a reason on question 1 does not cover question 2); strict-env value
-contract (`1` blocks,
+marker does not; a reason on question 1 does not cover question 2); the issue
+#974 gaps in both directions (Tier 1c fires on `create` / `update` at a shared
+surface, EN and KO, advisory and strict, and stays silent on the four measured
+authoring menus, on the six nouns dropped after probing, and behind the
+local-artifact veto; Tier 0b fires on a cancel-with-object menu, EN and KO, and
+stays silent on a bare `Cancel`, `Cancel this`, KO `취소`, a cancel beside a
+safe tier, and a no-go carrying an explicit negation, while the rider menu
+`do not notify` still fires so the negation token stays scoped; the gap-3
+residual pinned as open, its `prod` control still firing in both modes, and the
+four counter-cases that the rejected verb-axis fix would have broken);
+strict-env value contract (`1` blocks,
 `0` / `false` / `no` / `true` stay advisory); per-question isolation (a safe
 second question does not cover an all-prod first one); malformed-payload
 fail-open across seven shapes; and a self-application regression that feeds the

--- a/tests/hooks/advisory-nudge/test_menu_mutation_tier.sh
+++ b/tests/hooks/advisory-nudge/test_menu_mutation_tier.sh
@@ -279,6 +279,110 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# (d7) Tier 1c — `create` / `update` count only on a shared surface
+# ---------------------------------------------------------------------------
+# Issue #974 gap 1 (codex round-1 on PR #966): a menu whose every option mutates
+# was silent because `create` / `update` were in no vocabulary set at all.
+#
+# They are gated rather than added to MUTATION_VERBS because they are also
+# ordinary English for authoring. The unconditional variant was built and
+# measured: it fired on all four negative cases below. Since PR #966 rev 5 the
+# default path is `emit_decision("ask", …)`, so each of those is a human
+# confirmation prompt, not a log line.
+run_case "Tier 1c: create/update a record fires"   advisory default "$(build_payload '["Create the customer record", "Update the customer record"]')"
+run_case "strict: Tier 1c record blocks"           block    strict  "$(build_payload '["Create the customer record", "Update the customer record"]')"
+run_case "Tier 1c KO: 고객 레코드 생성/갱신"          advisory default "$(build_payload '["고객 레코드 생성", "고객 레코드 갱신"]')"
+run_case "Tier 1c: tenants/accounts fire"          advisory default "$(build_payload '["Create the tenant accounts", "Update the tenant accounts"]')"
+
+# The paired control: a safe tier still suppresses a Tier 1c menu, exactly as it
+# does a Tier 1b one. Tier 1c changes what counts as mutating, nothing else.
+run_case "Tier 1c + safe tier suppresses"          pass default "$(build_payload '["Create the customer record", "Preview the change first"]')"
+
+# Negatives — the measured false fires of the unconditional variant. Each of
+# these must stay silent, and this is the block that fails if a future round
+# moves `create` / `update` into MUTATION_VERBS_EN.
+run_case "Tier 1c neg: local file menu"        pass default "$(build_payload '["Create a new test file", "Update the existing test"]')"
+run_case "Tier 1c neg: doc menu"               pass default "$(build_payload '["Create a README section", "Update the changelog"]')"
+run_case "Tier 1c neg: KO 문서 생성/갱신"        pass default "$(build_payload '["문서 생성", "문서 갱신"]')"
+run_case "Tier 1c neg: prompt wording menu"    pass default "$(build_payload '["Create a shorter title", "Update the wording"]')"
+
+# Negatives for the nouns that were drafted into SHARED_SURFACE_NOUNS and
+# removed after probing: their everyday meaning is a repo artifact. Creating a
+# migration authors a file; it is `apply` (Tier 1b) that mutates.
+run_case "Tier 1c neg: migration file"    pass default "$(build_payload '["Create a migration file", "Update the migration file"]')"
+run_case "Tier 1c neg: JSON schema"       pass default "$(build_payload '["Create a JSON schema file", "Update the JSON schema"]')"
+run_case "Tier 1c neg: retry policy"      pass default "$(build_payload '["Create a retry policy in the client", "Update the retry policy"]')"
+run_case "Tier 1c neg: code namespace"    pass default "$(build_payload '["Create a new namespace", "Update the namespace"]')"
+
+# Negatives for the LOCAL_ARTIFACT veto: a kept shared-surface noun sitting
+# inside an authoring artifact is not the shared surface.
+run_case "Tier 1c veto: fixture record"   pass default "$(build_payload '["Create a fixture record for the test", "Update the fixture record"]')"
+run_case "Tier 1c veto: index variable"   pass default "$(build_payload '["Create an index variable", "Update the index variable"]')"
+run_case "Tier 1c veto: test account"     pass default "$(build_payload '["Create a test account", "Update the test account"]')"
+
+# ---------------------------------------------------------------------------
+# (d8) Tier 0b — `cancel` abandons only when nothing else is mutating
+# ---------------------------------------------------------------------------
+# Issue #974 gap 2 (codex round-1 on PR #966). `Cancel the prod deployment`
+# aborts an in-flight change to prod, which is itself a mutation, so a menu of
+# cancel-vs-proceed has no non-mutating tier. It was silent, and NOT because of
+# a vocabulary hole: the option already classified as mutating via `prod`, but
+# `_question_triggers` strips abandonment options before it asks the mutation
+# question, so the single survivor fell below the two-candidate floor.
+run_case "Tier 0b: cancel-with-object fires"   advisory default "$(build_payload '["Cancel the prod deployment", "Proceed with the prod deployment"]')"
+run_case "strict: cancel-with-object blocks"   block    strict  "$(build_payload '["Cancel the prod deployment", "Proceed with the prod deployment"]')"
+run_case "Tier 0b KO: prod 배포 취소/진행"      advisory default "$(build_payload '["prod 배포 취소", "prod 배포 진행"]')"
+
+# The rule is a new false-fire surface in its own right, so both directions are
+# pinned. A bare cancel is still the do-nothing tier — the binary go/no-go that
+# (d) protects must not start firing.
+run_case "Tier 0b neg: bare Cancel"          pass default "$(build_payload '["deploy to prod", "Cancel"]')"
+run_case "Tier 0b neg: 'Cancel this'"        pass default "$(build_payload '["deploy to prod", "Cancel this"]')"
+run_case "Tier 0b neg: KO bare 취소"          pass default "$(build_payload '["prod 배포", "취소"]')"
+run_case "Tier 0b neg: cancel + safe tier"   pass default "$(build_payload '["Cancel the prod deployment", "Preview the rollout first"]')"
+
+# A no-go that spells out what it declines carries the mutation token too, and
+# would have been promoted to a candidate. An explicit negation settles it —
+# read only inside the Tier 0b branch, never as a Tier 0 token of its own.
+run_case "Tier 0b neg: 'Cancel — do not deploy to prod'"  pass default "$(build_payload '["Deploy to prod", "Cancel — do not deploy to prod"]')"
+run_case "Tier 0b neg: KO 취소 — 배포하지 않음"             pass default "$(build_payload '["prod 배포", "취소 — 배포하지 않음"]')"
+
+# The control that keeps the negation token scoped: a global `do not` was tried
+# and rejected because it silenced this menu, where the negation attaches to a
+# rider rather than to the act. Both options still deploy to prod, so it fires.
+run_case "negation token is scoped to cancel"  advisory default "$(build_payload '["Deploy to prod and notify", "Deploy to prod but do not notify"]')"
+
+# ---------------------------------------------------------------------------
+# (d9) Gap 3 — the compound-option VERB axis, documented and deliberately open
+# ---------------------------------------------------------------------------
+# Issue #974 gap 3 asked whether anything remains after (d2)'s row 4 closed the
+# compound-option TARGET axis. Something does: an option pairing a safe MODE
+# token with a mutation verb and naming no high-blast target still suppresses.
+# It is left open on purpose, and these cases pin the reason rather than the
+# wish — a future round that "fixes" it fails here instead of shipping.
+#
+# The residual. `pass` records what the hook DOES, not what is wanted.
+run_case "gap3 residual (open): dry-run→delete, no prod"  pass default "$(build_payload '["Dry-run then delete the customer table", "Delete the customer table"]')"
+run_case "gap3 residual (open): KO 드라이런 후 삭제"        pass default "$(build_payload '["드라이런 후 고객 테이블 삭제", "고객 테이블 삭제"]')"
+
+# The row-4 control proving the residual is real and not a broken probe: the
+# identical shape with a high-blast target fires, in both modes.
+run_case "gap3 control: same shape WITH prod"        advisory default "$(build_payload '["Dry-run then delete the prod table", "Delete the prod table"]')"
+run_case "strict: gap3 control WITH prod blocks"     block    strict  "$(build_payload '["Dry-run then delete the prod table", "Delete the prod table"]')"
+
+# Why it stays open. A verb-axis discriminator (safe MODE + mutation verb and no
+# safe target ⇒ not low-blast) was built and it closes the residual — while also
+# firing on all four menus below. Those are the canonical phrasings of the exact
+# option this hook asks menus to contain, and a dry run necessarily names the
+# verb it simulates: `Dry-run then delete the table` and `Dry-run the deploy` are
+# the same shape. Firing an `ask` at an author who already added the safe tier
+# teaches that adding one does not help, which inverts the hook's purpose.
+run_case "gap3 counter: Dry-run the deploy"        pass default "$(build_payload '["Deploy now", "Dry-run the deploy"]')"
+run_case "gap3 counter: Simulate the merge"        pass default "$(build_payload '["Merge now", "Simulate the merge"]')"
+run_case "gap3 counter: Report-only on the send"   pass default "$(build_payload '["Send the announcement", "Report-only pass on the send"]')"
+run_case "gap3 counter: KO 배포 드라이런"            pass default "$(build_payload '["지금 배포", "배포 드라이런"]')"
+
+# ---------------------------------------------------------------------------
 # (e) BLOCK — strict mode
 # ---------------------------------------------------------------------------
 run_case "strict: incident menu"       block strict "$(build_payload "$INCIDENT")"


### PR DESCRIPTION
## 요약

PR #966 codex 라운드-1 이 지적한 커버리지 결함 3건 중 **재현된 2건을 닫고, 3번째는 열린 채로 명시 기록**한다.

## Gap 1 — `create` / `update` 가 어떤 어휘 집합에도 없었다

모든 옵션이 mutation 인 메뉴("Create the customer record" / "Update the customer record")가 고-blast 대상 토큰 없이는 침묵했다. `create` / `update` / `생성` / `갱신` 을 **조건부 Tier 1c** 로 넣었다 — 옵션이 공유 표면(`SHARED_SURFACE_NOUNS`)을 함께 지칭하고 로컬 저작 산출물(`LOCAL_ARTIFACT_NOUNS`)이 아닐 때만 mutation 신호가 된다.

**이슈가 스케치한 무조건 확장은 만들어서 측정한 뒤 기각했다.** 다음에서 전부 오발화했다:

- "Create a new test file" / "Update the existing test"
- "Create a README section" / "Update the changelog"
- "문서 생성" / "문서 갱신"
- "Create a shorter title" / "Update the wording"

PR #966 rev 5 이후 기본 경로가 `emit_decision("ask", …)` 이므로 이것들은 로그 한 줄이 아니라 **사람에게 묻는 확인 프롬프트**다. 이 사실은 spec.md 의 "오발화 비용은 한 문장" 이라는 이제 낡은 근거도 함께 바로잡는다. 프로빙 후 명사 6종(`schema`, `index`, `namespace`, `migration`, `dag`, `pipeline` 등)은 오히려 오발화를 늘려 제외했다.

## Gap 2 — 목적어가 명시된 `Cancel` 이 포기로 분류됐다

`cancel` 이 `ABANDON_TOKENS_EN` 에 있어 "Cancel the prod deployment" 가 아무것도 하지 않는 티어로 취급됐다. 진행 중인 배포 취소는 공유 상태를 바꾸는 행위다. "Cancel the prod deployment" / "Proceed with the prod deployment" 메뉴는 둘 다 prod 를 바꾸는데 전체가 침묵했다.

이건 어휘 확장으로 풀리지 않는다 — `cancel` 의 의미가 목적어에 달려 있다. **Tier 0b** 판정 규칙을 넣되, 규칙 자체가 새 오발화 표면이므로 양방향으로 고정했다:

- 발화해야: 목적어가 명시된 `cancel` (EN/KO, advisory·strict 양 모드)
- 침묵해야: 맨 `Cancel`, `Cancel this`, KO 맨 `취소`, 안전 티어 옆의 cancel, 부정어를 실은 no-go 옵션 2종
- 추가로 `do not notify` 라이더 메뉴는 계속 발화해야 한다 — 이것이 부정 토큰의 적용 범위를 `cancel` 로 묶어두는 잠금이다

## Gap 3 — 재현되지 않아 고치지 않았다

이슈 스스로 "이 이슈를 쓰면서 독립 재현하지 않았다" 고 적었고, PR #966 의 앵커 행 4 가 인접 케이스를 이미 닫았다. 그 차집합을 재현으로 갈랐고 **남은 잔여는 있으나 이 PR 이 고르지 않은 축**이다. d9 픽스처가 이 상태를 기록한다 — 잔여 2 케이스를 *현재 동작* 그대로(원하는 동작이 아니라) `pass` 로 고정하고, 잔여가 실재함을 보이는 `prod` 대조군과, 기각한 동사-축 수정이 깨뜨렸을 반례 4종을 함께 남겼다. 재현되지 않은 결함에 추측 픽스를 넣지 않는 것이 이 저장소 ETHOS 의 요구다.

## 검증

`tests/hooks/advisory-nudge/test_menu_mutation_tier.sh`: **PASS=110 FAIL=0** (브랜치 격리 상태). 기존 픽스처의 침묵 케이스를 전수 재확인했고 뒤집힌 것은 없다.

## 미확인

- **실제 피해 관측 0건.** 이 훅은 #966 머지와 함께 처음 배포되므로 관측 이력 자체가 없다.
- 어휘·규칙 확장 후의 오발화 증가량은 제가 저작한 픽스처 범위 안에서만 측정했다. 실제 세션 트래픽 캡처가 아니다.
- Gap 3 의 잔여 범위를 좁히는 작업은 남아 있다.

**부분 범위이므로 `Closes` 가 아니라 `Refs` 를 쓴다** — 이슈 본문의 (3) 이 열린 채이고, `Closes` 로 머지하면 그 추적 스레드가 함께 닫힌다.

Refs #974

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc

---
_Generated by [Claude Code](https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc)_