### PR TITLE
fix(hooks): serialize jq-config dedup state and stage per process

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -90,8 +90,20 @@ follows is the criterion that settles it per hook, so a new consumer of
 `resolve_cache_file` is classified rather than reflexively locked.
 
 **A lost update needs a lock when the state carries information no later
-event reproduces.** Three questions, in order — the first `yes` decides it:
+event reproduces.** Four questions, in order — the first `yes` decides it.
+The first asks what the concurrent write *is*; only if it is a lost update do
+the remaining three ask what losing it costs:
 
+0. **Does the write stage through a name a sibling sharing this `session_id`
+   also uses?** Then the failure is not loss but corruption, and the three
+   questions below cannot see it — they all price one missing entry. Two
+   processes writing one `<path>.tmp` interleave, and the shorter write
+   published over the longer one's tail leaves bytes that every reader's
+   `except ValueError` answers with *empty state*: the whole accumulated set
+   is gone, not one entry, so a hook whose lost update was merely a repeated
+   advisory now restarts its session's dedup from scratch. **Lock — and give
+   the staging file a per-process name**, because the lock is fail-open and
+   an unacquired one puts the shared name straight back (issue #970).
 1. **Does a threshold read the state?** A hook firing on an exact boundary
    (`count == 2`) misfires in both directions when an increment is lost: two
    processes crossing the boundary together both fire, and the count that
@@ -104,17 +116,27 @@ event reproduces.** Three questions, in order — the first `yes` decides it:
    contention is real, its consequence is not; a lock here buys latency on
    every tool call and nothing else.
 
-The seven consumers as of #951:
+The seven consumers as of #951, with the `jq-config` row re-graded under Q0
+in #970:
 
 | Hook | State | Loss consequence | Locked |
 | --- | --- | --- | --- |
 | `postuse-correction/second-failure-advisory` | per-`(tool, signature)` counter | fires on `prior_count == 1` exactly — Q1 | yes |
 | `postuse-correction/pre-edit-md-escape-advisory` | accumulating set of Read paths | the Edit gate warns, or denies under `PRAXIS_MD_ESCAPE_MODE=block`, for a file that was Read — Q2 | yes |
-| `advisory-nudge/jq-config-empty-dict-advisory` | dedup set of advised paths | one advisory repeats | no |
+| `advisory-nudge/jq-config-empty-dict-advisory` | dedup set of advised paths | one advisory repeats — but the pair shared one `.tmp` staging name, so the surviving file could also be unparseable, which `_load_seen` reads as empty and the session's whole dedup set restarts — Q0 | yes |
 | `advisory-nudge/postcompact-context` | last-injected compact uuid | context re-injected once | no |
 | `preflight-gate/worktree-prune-snapshot-gate` | single `snapshot_taken` flag, only ever set true | concurrent writers write the identical value | no |
 | `preflight-gate/session-intent` | set-once intent flags | written only from `UserPromptSubmit`, which is serialized per session; the `PreToolUse` gate path is read-only | no |
 | `preflight-gate/retrospect-active-marker` | marker existence | whole-file write and `unlink`, no read-modify-write to lose | no |
+
+Q0 was applied to the other six only far enough to see that it moves no other
+row: `second-failure-advisory` and `pre-edit-md-escape-advisory` share a
+staging name too but are already locked, and the lock covers the staging
+window; `worktree-prune-snapshot-gate`, `retrospect-active-marker` and
+`session-intent` stage through `tempfile.mkstemp`, whose name no sibling can
+collide with; `postcompact-context` holds a single uuid, so a corrupted read
+costs exactly what a lost one does. Re-grading every `resolve_cache_file`
+consumer against Q0 in its own right is follow-up work, not part of #970.
 
 `hooks/_lib/_state_lock.py` is the primitive: `with state_lock(path):` around
 the read *and* the write, `fcntl.flock` on a `<path>.lock` sibling. Readers
@@ -127,10 +149,12 @@ behaviour, never to a blocked tool call. The wait has a deadline
 (`PRAXIS_STATE_LOCK_TIMEOUT`, 2s) for the same reason — a lock left by a
 killed sibling must not stall the tool call the hook was only observing.
 
-`tests/test_hook_state_concurrency.py` runs both locked hooks in two real
+`tests/test_hook_state_concurrency.py` runs all three locked hooks in two real
 processes against one state file. It carries an unlocked arm alongside the
 shipped one, so the defect stays pinned and a regression that drops the lock
-fails there instead of quietly passing.
+fails there instead of quietly passing. The `jq-config` arm adds the Q0 half:
+a companion case asserts the staging name varies per process, because a race
+arm alone cannot say which of the two defects a given scheduling hit.
 
 ## Hook ordering and precedence
 

--- a/hooks/advisory-nudge/jq-config-empty-dict-advisory/impl.py
+++ b/hooks/advisory-nudge/jq-config-empty-dict-advisory/impl.py
@@ -39,6 +39,11 @@ Deduplicated per session_id + path so the nudge fires at most once per
 advisory-emitting invocation per session. Session-state file:
   <PRAXIS_HOME>/cache/jq-config-advisory-<session_id>.json
 
+The dedup read-modify-write is serialized by `state_lock` and stages through
+a per-process filename (issue #970). A lock that cannot be taken degrades to
+at most a repeated advisory — never to a dedup set read back as empty, which
+is what a shared staging name published when two processes interleaved there.
+
 Fail-open contract:
   • malformed JSON / non-Bash payload → exit 0
   • empty command → exit 0
@@ -64,6 +69,7 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     _coalesce_subst_runs,
 )
 from _paths import resolve_cache_file  # type: ignore[import-not-found]  # noqa: E402
+from _state_lock import state_lock  # type: ignore[import-not-found]  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -366,13 +372,37 @@ def _load_seen(path: str) -> set:
 
 
 def _save_seen(path: str, seen: set) -> None:
+    """Publish the dedup set atomically, staging through a per-process name.
+
+    The staging name carries the pid because a shared `<path>.tmp` is not a
+    lost update but a corrupted file (issue #970): two processes writing that
+    one name interleave, and whichever `os.replace` lands second publishes a
+    short write over a longer one's tail — bytes that `_load_seen`'s
+    `except ValueError` turns into an EMPTY set, so the session's whole dedup
+    set restarts rather than one entry going missing. Reproduced in 3-7 of
+    every 100 uninstrumented concurrent pairs.
+
+    `main()` holds `state_lock` over this, which closes the same window — but
+    that lock is fail-open by contract (`_state_lock`), and with it present
+    and never acquired the shared name still published unparseable state. The
+    per-process name is the floor under that degraded path: over 100 such
+    pairs it left only lost updates (8), the outcome DESIGN.md already grades
+    as acceptable here, and no wiped set. The rates are scheduling-dependent;
+    that the shared name corrupts and the per-process one cannot is not.
+    """
+    tmp_path = f"{path}.{os.getpid()}.tmp"
     try:
-        tmp_path = path + ".tmp"
         with open(tmp_path, "w", encoding="utf-8") as fh:
             json.dump(sorted(seen), fh)
         os.replace(tmp_path, path)
     except OSError:
-        pass
+        # One staging file per pid, so a failed publish leaks an unbounded
+        # number of them rather than reusing one name — unlink it here
+        # (session-intent/impl.py:300 does the same for the same reason).
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -504,24 +534,37 @@ def main() -> int:
 
     session_id = _extract_session_id(payload)
     dedup_path = _resolve_dedup_path(session_id)
-    seen = _load_seen(dedup_path)
 
-    new_seen = set(seen)
+    # Read, mutate and replace as one critical section (issue #970). `os.replace`
+    # serializes the write alone: two hook processes sharing a session_id — the
+    # ordinary source is parallel sub-agent tool calls — each read the same set
+    # and each published only its own entry. Taken here rather than around the
+    # whole body so a Bash call that names no config path pays nothing.
+    #
+    # `_check_file` shells out to jq inside the section (5s cap) rather than
+    # ahead of it: hoisting it out would decide `key in seen` against a set a
+    # sibling is still writing, which is the duplicate advisory this closes.
+    # A validation that outruns the 2s lock deadline only makes the sibling
+    # proceed unlocked — the fail-open degradation below.
+    with state_lock(dedup_path):
+        seen = _load_seen(dedup_path)
 
-    for path in config_paths:
-        # Canonicalize for dedup: expand user + normalize
-        key = os.path.normpath(os.path.expanduser(path))
-        if key in seen:
-            continue
-        msg = _check_file(path)
-        if msg:
-            sys.stderr.write(msg + "\n")
-            # M3 fix: only record in dedup state when advisory was emitted,
-            # so a file that later becomes empty is re-checked.
-            new_seen.add(key)
+        new_seen = set(seen)
 
-    if new_seen != seen:
-        _save_seen(dedup_path, new_seen)
+        for path in config_paths:
+            # Canonicalize for dedup: expand user + normalize
+            key = os.path.normpath(os.path.expanduser(path))
+            if key in seen:
+                continue
+            msg = _check_file(path)
+            if msg:
+                sys.stderr.write(msg + "\n")
+                # M3 fix: only record in dedup state when advisory was emitted,
+                # so a file that later becomes empty is re-checked.
+                new_seen.add(key)
+
+        if new_seen != seen:
+            _save_seen(dedup_path, new_seen)
 
     return 0
 

--- a/hooks/advisory-nudge/jq-config-empty-dict-advisory/spec.md
+++ b/hooks/advisory-nudge/jq-config-empty-dict-advisory/spec.md
@@ -100,11 +100,21 @@ and later becomes empty will re-trigger the advisory on the next call. State
 file:
 
 ```
-${TMPDIR:-/tmp}/praxis-jq-config-advisory-<session_id>.json
+<PRAXIS_HOME>/cache/jq-config-advisory-<session_id>.json
 ```
 
 PPID is used as a fallback key when `session_id` is absent (direct CLI /
 test invocations).
+
+The read-modify-write on that file is serialized with
+`_state_lock.state_lock` and staged through a per-process
+`<state>.<pid>.tmp` filename (issue #970). Two hook processes sharing a
+`session_id` previously each published a set holding only their own entry —
+and, staging through one shared `.tmp`, could publish an unparseable file
+that every reader turns into an empty set, restarting the session's whole
+dedup. The lock closes both; the per-process name keeps the corruption from
+returning on the lock's fail-open path, where a lock that cannot be taken
+degrades to at most a repeated advisory.
 
 ### Parsing guarantees (fail-open)
 

--- a/tests/test_hook_state_concurrency.py
+++ b/tests/test_hook_state_concurrency.py
@@ -13,6 +13,13 @@ Each case runs twice against the same code:
     silently returning the suite to green.
   * `lock` — the shipped path.
 
+Not every arm pins a lost update. `jq-config-empty-dict-advisory` (#970) also
+staged its write through a filename its sibling used, so an interleaving there
+published bytes no reader can parse — and every reader answers unparseable
+state with an empty one, which loses the whole set rather than one entry. That
+arm therefore asserts what the surviving file cannot hold, and a companion
+case pins the per-process staging name without needing to win a race.
+
 Both arms open with a start barrier, because interpreter startup skew alone
 exceeded the read window often enough that the unlocked arm read as "no race".
 What holds the window open after that differs by arm, and has to:
@@ -33,6 +40,7 @@ Neither arm changes hook logic; both wrap the read at the same point.
 """
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import subprocess
@@ -342,3 +350,147 @@ def test_md_read_history_race(driver, tmp_path, monkeypatch, lock_mode, both_rec
         assert sorted(recorded) == sorted([first, second])
     else:
         assert recorded is None or sorted(recorded) != sorted([first, second])
+
+
+# ---------------------------------------------------------------------------
+# jq-config-empty-dict-advisory — a lost entry repeats one advisory, a
+# corrupted state file drops the session's whole dedup set (issue #970)
+# ---------------------------------------------------------------------------
+
+_JQ_CONFIG_IMPL = (
+    HOOKS / "advisory-nudge" / "jq-config-empty-dict-advisory" / "impl.py"
+)
+
+
+def _jq_payload(session_id: str, config_path: str) -> dict:
+    return {
+        "session_id": session_id,
+        "tool_name": "Bash",
+        "tool_input": {"command": f"jq '.' {config_path}"},
+    }
+
+
+def _dedup_state_file(praxis_home: Path, session_id: str) -> Path:
+    """Where the hook keeps its dedup set. It has no env override — the path
+    is `resolve_cache_file`'s, so `PRAXIS_HOME` is the only way to redirect it."""
+    return praxis_home / "cache" / f"jq-config-advisory-{session_id}.json"
+
+
+def _advised_paths(path: Path) -> list[str] | None:
+    """Paths in the dedup set, or None when the file is gone or no longer parses."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, list) else None
+
+
+@pytest.mark.parametrize(
+    "lock_mode,both_recorded",
+    [
+        # Two outcomes, not one, which is why the unlocked assertion is
+        # "cannot hold both" rather than "holds exactly one". Both children
+        # read the absent state and publish a set containing only their own
+        # path — the lost update #951 graded as a repeated advisory. But the
+        # two also staged through one shared `<path>.tmp` name, and a pair
+        # interleaved there publishes bytes that no longer parse, which
+        # `_load_seen`'s `except ValueError` turns into an empty set: the
+        # session's entire dedup set, not one entry. On the pre-fix code both
+        # showed up unforced — 4 and 5 of 100 uninstrumented pairs (#970).
+        ("nolock", False),
+        ("lock", True),
+    ],
+)
+def test_jq_config_dedup_race(driver, tmp_path, monkeypatch, lock_mode, both_recorded):
+    praxis_home = tmp_path / "praxis-home"
+    monkeypatch.setenv("PRAXIS_HOME", str(praxis_home))
+    session_id = "race-session"
+
+    config_dir = tmp_path / ".claude"
+    config_dir.mkdir()
+    first = config_dir / "alpha.json"
+    second = config_dir / "beta.json"
+    # Size 0 — the [config-empty] branch, which is the one that records a
+    # dedup entry without shelling out to `jq` to validate the contents.
+    first.write_bytes(b"")
+    second.write_bytes(b"")
+
+    outputs = _run_pair(
+        driver,
+        _JQ_CONFIG_IMPL,
+        lock_mode,
+        [
+            _jq_payload(session_id, str(first)),
+            _jq_payload(session_id, str(second)),
+        ],
+        read_fn="_load_seen",
+    )
+
+    for rc, _stdout, stderr in outputs:
+        assert rc == 0, stderr
+        assert "[config-empty]" in stderr, "child emitted no advisory to dedup"
+
+    recorded = _advised_paths(_dedup_state_file(praxis_home, session_id))
+    if both_recorded:
+        assert recorded is not None, "dedup state did not survive the pair"
+        assert sorted(recorded) == sorted([str(first), str(second)])
+    else:
+        assert recorded is None or sorted(recorded) != sorted([str(first), str(second)])
+
+
+def _load_impl(path: Path):
+    spec = importlib.util.spec_from_file_location(f"impl_{path.parent.name}", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_jq_config_staging_name_is_per_process(tmp_path, monkeypatch):
+    """The staging name has to vary per process, pinned without a race.
+
+    The race arm above proves the pair misbehaves but not *which* of the two
+    defects it hit on that scheduling, so a regression to the shared `.tmp`
+    name could pass it on a lucky run. This is the deterministic half: the
+    staging file is what one process can overwrite under another's feet, and
+    it is also the floor under `state_lock`'s documented fail-open path —
+    with the lock present and never acquired, the shared name still published
+    unparseable state and the per-process one only ever lost an entry (#970).
+    """
+    impl = _load_impl(_JQ_CONFIG_IMPL)
+    staged: list[str] = []
+    real_replace = os.replace
+
+    def _recording_replace(src, dst):
+        staged.append(str(src))
+        real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", _recording_replace)
+    state = tmp_path / "jq-config-advisory-race-session.json"
+
+    monkeypatch.setattr(os, "getpid", lambda: 4242)
+    impl._save_seen(str(state), {"/tmp/.claude/alpha.json"})
+    monkeypatch.setattr(os, "getpid", lambda: 5353)
+    impl._save_seen(str(state), {"/tmp/.claude/beta.json"})
+
+    assert len(staged) == 2
+    assert staged[0] != staged[1], "both processes staged through one filename"
+    assert _advised_paths(state) == ["/tmp/.claude/beta.json"]
+
+
+def test_jq_config_staging_file_is_unlinked_on_failure(tmp_path, monkeypatch):
+    """A failed publish must not leave its staging file behind.
+
+    Per-process names trade one leaked `<state>.tmp` for one per pid, so the
+    cleanup that the shared name could skip is now load-bearing.
+    """
+    impl = _load_impl(_JQ_CONFIG_IMPL)
+
+    def _failing_replace(src, dst):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(os, "replace", _failing_replace)
+    state = tmp_path / "jq-config-advisory-race-session.json"
+    impl._save_seen(str(state), {"/tmp/.claude/alpha.json"})
+
+    assert not state.exists()
+    assert list(tmp_path.iterdir()) == [], "staging file survived a failed replace"


### PR DESCRIPTION
## 요약

같은 `session_id` 를 공유하는 두 훅 프로세스가 jq-config dedup 상태를 **서로 다른 두 방식**으로 경쟁했고, #951 은 그중 첫 번째만 등급화했다.

## 이슈 작업 1 — 재현 게이트 (통과)

이슈는 "이 훅을 상대로는 재현하지 않았다 … 재현되지 않으면 여기서 닫는다" 를 게이트로 걸었다. **둘 다 출고된 코드에서 강제 없이 재현됐다** — 계측을 넣지 않은 동시 실행 100쌍에서:

- **lost update 4건** (결함 1)
- **파싱 불가 상태 파일 5건** (결함 2), 그중 하나는 `'["…/a.json"]-much-longer-name.json"]'`

## 두 결함은 다른 등급이다

**(1) 잠기지 않은 read-modify-write** — `main()` 이 로드·변형·저장 사이를 잠그지 않아 각 프로세스가 자기 항목만 담은 집합을 publish 한다. #951 이 "advisory 중복 1회" 로 값을 매긴 손실이다.

**(2) 고정 `.tmp` staging 이름** — `_save_seen` 이 공유 `<path>.tmp` 를 거치므로, 여기서 얽힌 한 쌍은 짧은 쓰기가 긴 쓰기의 꼬리를 덮는다. `_load_seen` 의 `except ValueError` 는 그 바이트를 **빈 집합**으로 답한다. 즉 그 세션의 dedup 집합 전체가 처음부터 다시 시작한다.

**(2)는 손실이 아니라 손상이고, 결과도 "중복 1회" 가 아니라 "세션 dedup 전면 리셋" 이다.** 같은 등급으로 묶일 사안이 아니었다는 것이 이 이슈의 요지이며, 재현이 그것을 뒷받침한다.

## 수정

- `main()` 이 읽기·변형·replace 전체에 `state_lock` 을 잡는다. `if not config_paths` 조기 반환 **뒤에** 잡으므로, config 경로를 하나도 지칭하지 않는 Bash 호출은 비용을 내지 않는다.
- `_save_seen` 이 `<path>.<pid>.tmp` 로 staging 하고, publish 실패 시 unlink 한다 (session-intent 와 같은 형태). unlink 가 없으면 per-pid 이름이 파일을 무한히 남긴다.

`hooks/_lib/` 변경은 필요하지 않았다. `state_lock` / `lock_path_for` 를 `pre-edit-md-escape-advisory` 와 동일하게 쓰며, `_paths.prune_stale` 이 `lock_is_held` 로 `.lock` 을 이미 특별 취급하고 `_belongs_to_session` 이 `<name>-<sid>.<anything>` 를 이미 매칭하는 것을 새 staging 이름 형태로 직접 확인했다.

## DESIGN.md — 손상 축 추가

이슈 작업 2 의 판단이다. `Session state concurrency` 의 판정 기준이 **손실 영향만** 등급화하고 있어 (2)번 형태는 심사 축 자체가 없었다. 손상(corruption) 축을 추가했다. 같은 기준으로 "잠금 불필요" 판정을 받은 다른 훅들의 재심사는 **후속 작업이며 이 PR 범위가 아니다** — 이슈 본문도 "다른 훅의 실제 수정" 을 범위 밖으로 명시하고 있다.

## 회귀 테스트 (`tests/test_hook_state_concurrency.py`, 8 passed)

| 테스트 | 고정하는 것 |
|---|---|
| `test_jq_config_dedup_race[lock-True]` | 두 프로세스가 양쪽 항목의 합집합을 publish (수정 전 실패) |
| `test_jq_config_dedup_race[nolock-False]` | `state_lock` 을 no-op 로 스텁하면 살아남은 파일이 두 항목을 담을 수 없음 — 잠금을 제거하면 여기서 실패하므로 조용히 통과하지 못한다 |
| `test_jq_config_staging_name_is_per_process` | 결함 (2) 의 결정론적 고정 — staging 파일명이 `os.getpid` 에 따라 달라진다 (경쟁을 이길 필요 없이 수정 전 실패) |
| `test_jq_config_staging_file_is_unlinked_on_failure` | `os.replace` 실패 시 staging 파일이 남지 않음 (per-pid 이름이 만들 유출을 막는다) |

## 미확인

- 재현은 이 훅과 형제 훅에 대한 것이다. `DESIGN.md` 의 새 축으로 나머지 훅을 재심사하지 않았다 — 대상 목록조차 만들지 않았다.
- 잠금 도입으로 인한 지연 비용은 조기 반환 뒤에 잡는다는 사실로만 논증했고, 실제 세션에서의 처리량 측정은 하지 않았다.

Closes #970
Refs #951

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc

---
_Generated by [Claude Code](https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc)_