### PR TITLE
fix(spec-drift): run Verify commands with stdin at /dev/null

### DIFF
--- a/docs/spec-store.md
+++ b/docs/spec-store.md
@@ -169,7 +169,11 @@ Two rules on what may appear there:
   `scripts/run-tests.sh` is the standing example, since it reads a per-user
   store that lives outside the checkout ([#1003](https://github.com/devseunggwan/praxis/issues/1003)).
   A requirement with no eligible command keeps no `Verify:` line.
-- **The command must terminate without input.** It runs unattended.
+- **The command must terminate without input.** It runs unattended, with stdin
+  at `/dev/null` ([#1008](https://github.com/devseunggwan/praxis/issues/1008)),
+  so a command that reads stdin gets immediate EOF. Before that it inherited the
+  report's own stdin, hung until the timeout, and was reported `missing` — a
+  rule stated here but not enforced showed up only as a wrong verdict.
 
 Commands run from the repository root of wherever the report was invoked, so a
 `Verify:` line may use repo-relative paths — and a spec written for repository

--- a/skills/spec-drift/SKILL.md
+++ b/skills/spec-drift/SKILL.md
@@ -11,7 +11,7 @@ description: >
   live-runtime gate) or on deferred-decision trailers (that is `debt`).
 verified-against-runtime: true
 runtime-verified-at: 2026-08-14
-runtime-verified-note: "python3 3.x — ran the report against the real store resolved from praxis_specs_dir() (<PRAXIS_HOME>/docs/specs, no --spec-dir passed): 2 specs, 18 implemented, 0 missing, 6 UNKNOWN. tests/test_spec_drift.sh 33/33 against synthetic fixture spec dirs — case 6 is the parse boundary this design rests on (a fixture requirement whose PROSE quotes `false`; the report neither runs it nor leaves the requirement anything but UNKNOWN), case 14 finds the store via a throwaway PRAXIS_HOME with no --spec-dir, 15 has a caller --spec-dir override it, 16-18 pin where a Verify line binds (later-section rebinding, duplicate ids, a second line in one block), 19 a timed-out command keeping its partial output — positive-controlled on a fixture whose Verify exits 3 (reported `missing` with its command and stderr marker)."
+runtime-verified-note: "python3 3.x — ran the report against the real store resolved from praxis_specs_dir() (<PRAXIS_HOME>/docs/specs, no --spec-dir passed): 2 specs, 18 implemented, 0 missing, 6 UNKNOWN. tests/test_spec_drift.sh 36/36 against synthetic fixture spec dirs — case 6 is the parse boundary this design rests on (a fixture requirement whose PROSE quotes `false`; the report neither runs it nor leaves the requirement anything but UNKNOWN), case 14 finds the store via a throwaway PRAXIS_HOME with no --spec-dir, 15 has a caller --spec-dir override it, 16-18 pin where a Verify line binds (later-section rebinding, duplicate ids, a second line in one block), 19 a timed-out command keeping its partial output, 20 a Verify command that reads stdin reported `implemented` in 0.04s where the pre-fix code reported `missing (exit 124)` after the full timeout (#1008; fed an open stdin through a FIFO, since a runner whose own stdin is already /dev/null would pass the case vacuously) — positive-controlled on a fixture whose Verify exits 3 (reported `missing` with its command and stderr marker)."
 ---
 
 # spec-drift
@@ -114,7 +114,9 @@ The convention and its two rules live in
 [`docs/spec-store.md`](../../docs/spec-store.md) → *Verification lines*. In
 short: a nested `- Verify: \`<command>\`` item under the requirement, whose
 exit code reports **the requirement** and not the environment it ran in, and
-which terminates without input.
+which terminates without input. Commands run with stdin at `/dev/null` (#1008),
+so one that reads stdin gets EOF rather than hanging to the timeout and being
+reported `missing`.
 
 A requirement with no eligible command keeps no `Verify:` line and says why in
 its own prose — that line is what separates "nobody got to it" from "nothing

--- a/skills/spec-drift/spec_drift.py
+++ b/skills/spec-drift/spec_drift.py
@@ -104,7 +104,16 @@ def parse_spec(path: Path) -> list[tuple[str, str | None, list[str]]]:
 
 
 def run_verify(command: str, cwd: Path, timeout: int) -> tuple[int, str]:
-    """Run one Verify command, returning (exit code, combined output)."""
+    """Run one Verify command, returning (exit code, combined output).
+
+    stdin is /dev/null, not the report's own (#1008). Inheriting it meant a
+    command that reads stdin never saw EOF, burned the whole timeout, and was
+    reported `missing (exit 124)` — a working implementation called
+    unimplemented, with the verdict turning on whether the invoking shell
+    happened to have an open stdin at all. docs/spec-store.md already requires
+    a Verify command to terminate without input; this is that rule in code
+    rather than in prose.
+    """
     try:
         proc = subprocess.run(
             ["bash", "-c", command],
@@ -112,6 +121,7 @@ def run_verify(command: str, cwd: Path, timeout: int) -> tuple[int, str]:
             text=True,
             cwd=cwd,
             timeout=timeout,
+            stdin=subprocess.DEVNULL,
         )
     except subprocess.TimeoutExpired as expired:
         # Whatever the command managed to say before it hung is usually the

--- a/tests/test_spec_drift.sh
+++ b/tests/test_spec_drift.sh
@@ -25,6 +25,7 @@
 #  17. A duplicated requirement id keeps its own command, not a shared one
 #  18. A second Verify inside one block is ignored and reported, never silent
 #  19. A timed-out command keeps whatever it printed before it hung
+#  20. A Verify command that reads stdin gets EOF instead of the report's stdin
 #
 # Every case runs against a fixture spec dir. This file is a `Verify:` target
 # for several of 0002's requirements, so running the report over the real spec
@@ -329,6 +330,47 @@ check_has "19 timeout keeps the partial output" "$OUT8" "PARTIAL_BEFORE_HANG"
 check_has "19b timeout still reports exit 124" "$OUT8" "missing      FR-001  (exit 124)"
 check_has "19c timeout names the limit" "$OUT8" "timed out after 1s"
 rm -rf "$FIX7"
+
+# --------------------------------------------------------------------------- #
+# Fixture 8 — a Verify command that reads stdin (#1008). Inheriting the
+# report's stdin meant such a command never saw EOF, burned the whole timeout,
+# and was reported `missing (exit 124)`: a working implementation called
+# unimplemented, with the verdict turning on whether the invoking shell had an
+# open stdin at all.
+#
+# The CLI is fed an OPEN stdin on purpose. scripts/run-tests.sh runs `bash "$f"`
+# with the runner's own stdin, which is usually already /dev/null — this case
+# would then pass on the broken code too, which is the failure mode a regression
+# test exists to rule out. A read-write FIFO is an stdin that never EOFs.
+#
+# FR-002 is the in-test control: a command that genuinely hangs must keep its
+# `exit 124`, so a pass on FR-001 is the stdin fix and not a dead harness.
+# --------------------------------------------------------------------------- #
+FIX8=$(mktemp -d) || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+cat > "$FIX8/0009-stdin.md" <<'EOF'
+# Feature Specification: Stdin
+
+**Issue**: devseunggwan/praxis#1008
+
+### Functional Requirements
+
+- **FR-001**: Reads stdin, and must still terminate.
+  - Verify: `sh -c 'echo READS_STDIN; cat > /dev/null'`
+- **FR-002**: Genuinely hangs, and must stay missing.
+  - Verify: `sh -c 'echo CONTROL_HANG; sleep 30'`
+EOF
+
+mkfifo "$FIX8/stdin.fifo"
+exec 9<> "$FIX8/stdin.fifo"
+OUT9=$("$CLI" --spec-dir "$FIX8" --timeout 2 <&9 2>&1)
+exec 9>&-
+
+check_has "20 stdin-reading Verify -> implemented" "$OUT9" "implemented  FR-001"
+check_lacks "20b stdin-reading Verify does not burn the timeout" "$OUT9" \
+  "missing      FR-001  (exit 124)"
+check_has "20c control: a real hang still reports exit 124" "$OUT9" \
+  "missing      FR-002  (exit 124)"
+rm -rf "$FIX8"
 
 echo ""
 echo "Passed: $PASS  Failed: $FAIL"


### PR DESCRIPTION
## 요약

`run_verify` 가 `subprocess.run` 에 `stdin=` 을 넘기지 않아 모든 `Verify:` 명령이 리포트 자신의 stdin 을 물려받았다. stdin 을 읽는 명령은 EOF 를 못 보고 timeout 전체를 소모한 뒤 `missing (exit 124)` 로 보고된다 — **멀쩡한 구현이 미구현으로 판정된다.** 기본 timeout 이 120초이므로 그런 요구사항 하나당 2분씩 멈춘다.

## 판정이 트리가 아니라 호출한 셸에 달려 있었다

같은 fixture spec, 같은 코드, `--timeout 5`:

```
stdin 열림 (< <(sleep 20))  ->  missing FR-001 (exit 124),  real 0m5.046s
stdin /dev/null             ->  implemented FR-001,          real 0m0.046s
```

수정 후 첫 번째 호출이 `implemented` 를 `0m0.047s` 에 보고한다.

## 수정

`stdin=subprocess.DEVNULL` 을 넘긴다. 명령은 즉시 EOF 를 받고, `docs/spec-store.md` 가 이미 산문으로 적어둔 "명령은 입력 없이 종료해야 한다" 는 규약이 코드로 강제된다. 호출 지점 하나만 바뀐다 — `repo_root()` 의 `git rev-parse` 는 stdin 을 읽지 않으므로 그대로 둔다.

## 회귀 테스트 (`tests/test_spec_drift.sh`, 36 passed / 0 failed)

| 케이스 | 고정하는 것 |
|---|---|
| 20 | stdin 을 읽는 Verify 명령(`sh -c 'echo READS_STDIN; cat > /dev/null'`)이 `implemented` 로 보고된다 |
| 20b | 같은 요구사항이 `missing FR-001 (exit 124)` 로 나타나지 **않는다** (timeout 을 태우지 않음) |
| 20c | 대조군 FR-002 (`sh -c 'echo CONTROL_HANG; sleep 30'`) 는 `missing FR-002 (exit 124)` 를 유지 — 20/20b 의 통과가 stdin 수정 때문이지 하네스가 죽어서가 아님을 보인다 |

**Fixture 8 은 `mkfifo` + `exec 9<> …` + `<&9` 로 CLI 에 실제로 열린 stdin 을 먹인다.** 이게 없으면, 러너 자신의 stdin 이 이미 `/dev/null` 인 환경에서 케이스가 공허하게 통과할 수 있다.

## 미확인

- `skills/spec-drift/SKILL.md` 의 runtime-verified 노트 중 **픽스처 스위트 쪽(33/33 → 36/36)만** 갱신했다. 같은 노트의 다른 주장("실제 store 에 대해 리포트 실행 … 2 specs, 18 implemented, 0 missing, 6 UNKNOWN")은 이 샌드박스에 `/root/.praxis/docs/specs` 가 없어 재실행하지 못했다. 그 문장은 이전 검증에서 이월된 것이며 이 PR 이 확인한 것이 아니다.

## 범위 밖

리포트가 실행하는 명령을 샌드박싱하는 것(#1006 Limitations 의 신뢰 모델)은 별개 사안이다. 이 PR 은 stdin 하나만 닫는다.

Closes #1008
Refs #1005

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc

---
_Generated by [Claude Code](https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc)_