### PR TITLE
docs(spec): a Verify oracle must fail when its inputs are gone

### DIFF
--- a/docs/spec-store.md
+++ b/docs/spec-store.md
@@ -162,7 +162,8 @@ not run. Writing a second `Verify:` in one block is an authoring error — the
 first binds, and the report prints the rest as `warning` lines naming the
 command it did not run.
 
-Two rules on what may appear there:
+Rules on what may appear there — the count is deliberately not stated, so that
+adding one cannot leave a stale number behind:
 
 - **The exit code must report the requirement, not the environment.** A command
   that can exit non-zero for a reason outside the repository is not eligible —
@@ -174,6 +175,17 @@ Two rules on what may appear there:
   so a command that reads stdin gets immediate EOF. Before that it inherited the
   report's own stdin, hung until the timeout, and was reported `missing` — a
   rule stated here but not enforced showed up only as a wrong verdict.
+- **The command must fail when its inputs are gone.** An oracle whose subject
+  has been deleted must exit non-zero, not collapse into a vacuous success. The
+  shape that breaks this is a comparison whose *both* sides are command
+  substitutions: when the subject is absent both substitutions fail, both
+  collapse to the empty string, and `test "" = ""` exits 0 — so the report
+  prints `implemented` for a requirement nothing in the tree satisfies
+  ([#1011](https://github.com/devseunggwan/praxis/issues/1011)). Pin at least
+  one side to a literal, so an absent subject compares against something and
+  the mismatch is visible. This does not conflict with the first rule: that one
+  is about per-user state *outside* the checkout, this one is about the
+  repo-relative inputs the requirement is actually asserting.
 
 Commands run from the repository root of wherever the report was invoked, so a
 `Verify:` line may use repo-relative paths — and a spec written for repository

--- a/skills/spec-drift/SKILL.md
+++ b/skills/spec-drift/SKILL.md
@@ -110,13 +110,19 @@ checkable requirements, which is the feedback loop this design is built on.
 
 ## Writing a Verify line
 
-The convention and its two rules live in
+The convention and its rules live in
 [`docs/spec-store.md`](../../docs/spec-store.md) → *Verification lines*. In
 short: a nested `- Verify: \`<command>\`` item under the requirement, whose
 exit code reports **the requirement** and not the environment it ran in, and
 which terminates without input. Commands run with stdin at `/dev/null` (#1008),
 so one that reads stdin gets EOF rather than hanging to the timeout and being
 reported `missing`.
+
+The oracle must also **fail when its subject is gone** (#1011). A comparison
+whose *both* sides are command substitutions cannot do that: with the subject
+absent both collapse to the empty string and `test "" = ""` exits 0, so the
+report prints `implemented` for a requirement nothing satisfies. Pin one side
+to a literal.
 
 A requirement with no eligible command keeps no `Verify:` line and says why in
 its own prose — that line is what separates "nobody got to it" from "nothing


### PR DESCRIPTION
> **Stacked on #1018.** Base is `claude/issue-1008-spec-drift-stdin`, not `main` — both PRs edit the same two files (`docs/spec-store.md` *Verification lines*, `skills/spec-drift/SKILL.md` *Writing a Verify line*). Rebase onto `main` after #1018 merges, or merge #1018 first and this retargets cleanly.

## 요약

`Verify:` 오라클이 **자기 subject 가 사라졌을 때 실패해야 한다**는 규칙을 컨벤션에 추가한다.

양쪽이 모두 명령 치환인 비교는 그걸 할 수 없다. subject 가 없으면 두 치환이 모두 실패해 빈 문자열로 붕괴하고 `test "" = ""` 는 0으로 종료한다 — 리포트는 **트리의 무엇도 만족시키지 않는 요구사항에 `implemented` 를 찍는다.**

## 재현 — 수정되지 않은 `spec_drift.py` 에 대해 end-to-end

참조하는 파일을 하나도 담지 않은 git 저장소에서 실행:

```
running      FR-001: test "$(cat missing-subject.txt 2>/dev/null)" = "$(cat missing-subject.txt 2>/dev/null)"
implemented  FR-001
running      FR-002: test "$(cat missing-subject.txt 2>/dev/null)" = "expected-content"
missing      FR-002  (exit 1)

1 spec(s): 1 implemented, 1 missing, 0 UNKNOWN
```

**FR-002 가 픽스처 내부 대조군이다** — subject 는 동일하고 한쪽만 리터럴로 고정했는데 올바르게 `missing` 을 보고한다. 따라서 실패의 원인은 파일 부재가 아니라 **양쪽-치환 형태**다. 셸 의미론으로 논증한 것이 아니라 실제 코드 경로에서 실증된다.

## 변경

`docs/spec-store.md` → *Verification lines* 에 세 번째 규칙을 추가하고, `Two rules` 라는 수를 **같은 문서의 Template 절이 이미 쓰고 있는 관례**로 교체했다 — "the count is deliberately not stated, so that adding one cannot leave a stale number behind". 이 불릿 목록이 정확히 그 관례가 쓰인 사례다.

`skills/spec-drift/SKILL.md` → *Writing a Verify line* 도 같은 이유로 "its two rules" 의 수를 뺐고, 새 규칙을 요약했다.

## 첫 번째 규칙과 충돌하지 않는다

기존 규칙 1은 "exit code 는 환경이 아니라 요구사항을 보고해야 한다 — 저장소 밖 이유로 non-zero 가 될 수 있는 명령은 부적격" 이다. 새 규칙 3은 **입력이 없을 때 정확히 non-zero 로 종료할 것**을 요구하므로 표면적으로는 반대로 보인다.

두 규칙의 대상이 다르다:

- **규칙 1** — 체크아웃 **밖**의 per-user 상태(`scripts/run-tests.sh` 가 per-user store 를 읽는 경우, #1003)
- **규칙 3** — 요구사항이 실제로 주장하고 있는 **repo-relative 입력**

겹치지 않는다. 문서에 이 구분을 함께 적었다.

## 코드 변경이 없는 이유

**추적되는 저장소 파일 중 결함 형태를 담은 것이 없다.** 문서의 worked example 은 이미 오른쪽을 리터럴로 고정하고 있다. 이슈를 촉발한 실제 오라클은 체크아웃 밖 per-user store 에 있어 여기서 편집할 수 없다. 그래서 이 PR 의 산출물은 컨벤션 규칙 자체다.

## 미확인

- **실제 0001 spec 을 읽지 못했다.** 이 머신에 `/root/.praxis/docs/specs` 가 없다(`/root/.praxis/cache` 만 존재). FR-001 이 문자 그대로 양쪽-치환 형태이고 FR-007 이 안전한 리터럴 대조라는 것은 이슈 작성자의 진술이며 제가 확인하지 않았다. 제 재현은 **그 형태를 재현하는 픽스처**이지 그 파일이 아니다.
- 이슈 본문의 "나머지 12개가 missing (exit 127) 로 떨어진다" 는 집계도 store 가 없어 확인하지 못했다.

Closes #1011
Refs #1008

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc

---
_Generated by [Claude Code](https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc)_