### PR TITLE
docs(retrospect): declare memory-lint CI split intended, not a gap

### DIFF
--- a/skills/retrospect/references/stage4-execution.md
+++ b/skills/retrospect/references/stage4-execution.md
@@ -115,8 +115,27 @@ For each approved action:
    prints `N/A` and exits 0 there (verified — F3, issue #942 codex-review
    pass). **CI cannot catch the next drift of this family; only a local
    `run-tests.sh` run, or a contributor running the script directly,
-   catches it.** That re-verification path is therefore still incomplete —
-   it exists, but is opt-in rather than structurally enforced on every push.
+   catches it.**
+
+   **That split is the intended design, not a residual gap (issue #975).**
+   The re-verification path has two halves and only one of them is
+   closable. The script's *logic* is already enforced on every push:
+   `tests/test_check_memory_frontmatter.py` covers 97% of its statements
+   (100 statements, 3 missed — the clean-corpus `OK:` print, its `return
+   0`, and the `sys.exit(main())` entry guard; re-measured under
+   `coverage` for issue #975) and runs inside `run-tests.sh`'s blocking
+   pytest step, which `.github/workflows/ci.yml` executes on every PR. What
+   stays opt-in is only the *scan of the real store*, and that half cannot
+   be closed by writing more tests: its subject is a gitignored per-user
+   memory directory that by construction never enters the repo, so CI is
+   missing an **input**, not a check. Substituting an in-repo fixture
+   corpus would not close it either — it would re-exercise already-covered
+   logic against a second hand-maintained corpus that must stay
+   schema-clean forever, inside a repo whose existing memory fixtures
+   (`tests/fixtures/memory-hint/`) are deliberately drifted on purpose, so
+   pointing this lint at them reports violations by design. Read the `N/A`
+   line as correct output for an absent input, not as a gap awaiting
+   closure.
 
    **⚠️ MANDATORY: Duplicate check before creating any memory file:**
 

--- a/tests/test_retrospect_routing.sh
+++ b/tests/test_retrospect_routing.sh
@@ -168,6 +168,8 @@ run_anchor_check "report template includes critic_diff ledger line" "$SKILL_DIR/
 run_anchor_check "stage4 reference exists with memory-hint contract" "$SKILL_DIR/references/stage4-execution.md" "Frontmatter contract"
 run_anchor_check "stage4 reference reuses repeat scan step 6" "$SKILL_DIR/references/stage4-execution.md" "Stage 2 step 6's repeat scan results"
 run_anchor_check "stage4 reference returns backing_repo misses to step 7" "$SKILL_DIR/references/stage4-execution.md" "re-run Stage 2 step 7"
+run_anchor_check "stage4 reference declares memory-lint CI split intended (issue #975)" "$SKILL_DIR/references/stage4-execution.md" "the intended design, not a residual gap"
+run_forbidden_check "stage4 no longer frames the memory-lint path as an open gap (issue #975)" "still incomplete"
 run_anchor_check "appendices reference exists with Red Flags" "$SKILL_DIR/references/appendices.md" "Red Flags"
 
 echo ""


### PR DESCRIPTION
## 결정

**(c) — 현 상태를 의도된 설계로 확정하고 문서에 기록한다** (유지보수자 판정). 코드 변경 없음.

## 게이트 판정 — (a)를 구현하지 않는 쪽으로

이슈 작업 1의 굵은 선행 확인이 게이트였다: *"(a)는 `tests/test_check_memory_frontmatter.py` 가 이미 상당 부분 해내고 있다 — 그 겹침을 먼저 재측정하라."*

측정했다:

```
statement coverage 97%  (100개 중 3개 미도달)
미도달: 251-252행 (clean corpus 의 `OK:` 출력 + return 0)
        256행    (sys.exit(main()))
```

CI 가 린트하는 저장소 내 픽스처 코퍼스를 추가하면 **정확히 그 2개 statement 만 더 덮는다.** 대신 영원히 스키마 청정으로 유지해야 하는 손수 관리 코퍼스가 하나 더 생긴다 — **기존 memory 픽스처가 의도적으로 드리프트돼 있는 저장소에서**(12건 + 3건 위반, `non_utf8` 에서는 하드 크래시). 기존 픽스처는 재사용할 수도 없다.

즉 (a)의 이득은 2 statement 다. 기각이 근거 있는 판정이다.

## 왜 CI 가 원리적으로 못 하는가

린트의 대상이 **gitignore 된 per-user store** 이고, 저장소에 들어오지도 들어올 수도 없다. 반면 스크립트의 **로직**은 이미 매 푸시마다 pytest 로 강제된다.

## 변경 — 판단 문장 하나

`stage4-execution.md` 의 해당 문단은 사실로는 이미 정확했다("CI 는 이 계열의 다음 드리프트를 잡을 수 없다; 로컬 `run-tests.sh` 실행만이 잡는다") — 그래서 **다시 쓰지 않았다.**

바꾼 것은 **마지막 판단**이다. 문단이 *"그 재검증 경로는 따라서 아직 불완전하다"* 로 끝나 열린 공백처럼 읽혔다. (c) 아래에서는 **경로가 설계대로 닫혀 있다** — 스크립트 로직은 매 푸시 재검증되고, 실제 store 스캔만 영구 opt-in 이며, 이는 저장소에 들어오지 않는 store 에 대해 불가피하다. 그 *왜*를 함께 적었다: 닫히지 않았다가 아니라 **닫을 수 없고 그것이 설계다.**

## 회귀 — 양방향

`tests/test_retrospect_routing.sh` 에 두 줄을 넣었다.

| 방향 | 고정 |
|---|---|
| 있어야 함 | `the intended design, not a residual gap` — 미래 편집이 (c) 판단을 지우거나 뒤집으면 실패 |
| 없어야 함 | `still incomplete` — 옛 열린-공백 프레이밍이 `skills/retrospect/` 어디에든 재도입되면 실패 |

두 줄 모두 이 커밋을 기준으로 판정이 뒤집히는 것을 확인했다. `run_forbidden_check` 를 `FORBIDDEN_PATTERNS` 배열에 넣지 않고 직접 호출한 것은 의도적이다 — 그 배열은 **사용자별 org/handle 하드코딩**을 위한 것이라고 문서화돼 있고 이 패턴은 그 계열이 아니다.

```
$ bash tests/test_retrospect_routing.sh     PASS: 69  FAIL: 0
```

## 남은 것, 그리고 남기지 않은 것

- **(e) `check_file()` 의 처리되지 않은 `UnicodeDecodeError`** — 재현했지만 이 PR 에 넣지 않았다. (c)에서는 도달 불가능하고, (a)·(b)·(d) 중 무엇을 택하든 필수가 된다. **별도 이슈로 내는 것이 맞다.**
- **(d) memory 쓰기 시점 praxis 훅** — 이 저장소가 실제로 특화된 메커니즘이고 모든 플러그인 사용자에게 도달하지만, 오늘 기준 재발 0건으로 ETHOS.md 의 5회 기준 아래다. 재발이 쌓이면 그때 여는 것이 맞다.

## 미확인

- **이슈가 인용한 CI job 로그.** 여기에 `gh` 가 없어 run 31599314837 / job 94122451341 을 가져오지 않았다. 동등 조건은 로컬에서 재현했지만(memory 디렉터리 없음 → `N/A` → strict 제거 시 exit 0), 인용된 두 로그 줄과 그 실행이 접미사 없는 `ALL TESTS PASSED` 로 끝났다는 것은 독립 확인하지 못했다. 그 접미사 로직은 `run-tests.sh:279-297` 을 읽어 판단한 것이지 관측한 것이 아니다.

Closes #975

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc

---
_Generated by [Claude Code](https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc)_