### PR TITLE
fix(cmux-delegate): supply the stdin column's non-TTY exemption

### DIFF
--- a/skills/cmux-delegate/SKILL.md
+++ b/skills/cmux-delegate/SKILL.md
@@ -319,6 +319,7 @@ Report results in Korean.
 #!/bin/bash
 PROMPT_FILE="/tmp/cmux-delegate-{timestamp}.md"
 SCRIPT_FILE="/tmp/cmux-delegate-{timestamp}.sh"
+WRAPPER_LOG="/tmp/cmux-delegate-{timestamp}.log"
 
 # Cleanup: .sh만 삭제. .md는 보존 (다른 워크스페이스가 참조할 수 있음)
 trap 'rm -f "$SCRIPT_FILE"' EXIT
@@ -326,10 +327,32 @@ trap 'rm -f "$SCRIPT_FILE"' EXIT
 # Provider-specific invocation (from project ARCHITECTURE.md Provider CLI Spec)
 case "{provider}" in
   claude)
+    # `| tee` 는 로그 적재가 목적이 아니라 계약 이행입니다 (#981). 프로젝트
+    # ARCHITECTURE.md 의 Provider CLI Spec 은 stdin 컬럼(`cat file | claude`)을
+    # 쓰는 호출자에게 "stdout 을 리다이렉트하거나 `-p` 를 붙이거나" 중 하나를
+    # 의무로 지웁니다. `claude --help` 가 워크스페이스 신뢰 대화상자를
+    # 건너뛰는 조건으로 명시한 면제 조항이고, 그 대화상자도 stdin 을 읽으므로
+    # cmux 워크스페이스의 TTY 를 stdout 으로 물려받은 채 실행하면 대화상자와
+    # 파이프된 프롬프트가 같은 스트림을 두고 경쟁합니다. Step 4 는 이 리포지토리의
+    # 유일한 호출부인데 둘 중 어느 것도 공급하지 않고 있었습니다.
+    #
+    # `-p` 가 아니라 리다이렉트를 고른 이유는 아래 "Why Wrapper Script?" 에
+    # 있습니다 — `-p` 는 별개의 실증된 실패(프롬프트 shell 해석)로 이미 배제된
+    # 형태입니다. 전체 리다이렉트(`> "$WRAPPER_LOG"`)가 아니라 `tee` 인 이유는
+    # 이것이 계약을 만족시키는 가장 좁은 리다이렉트이기 때문입니다: claude 의
+    # stdout 은 파이프(비-TTY)가 되어 면제 조항을 충족하지만, tee 의 stdout 은
+    # 여전히 워크스페이스 TTY 라 운영자가 cmux 페인에서 보던 출력이 사라지지
+    # 않습니다. 전체 리다이렉트는 계약은 똑같이 만족시키되 페인을 비웁니다.
+    #
+    # **이것은 버그 수정이 아닙니다.** 소유자의 4회 대조 실행(claude 2.1.232)에서
+    # 프롬프트는 실제로 유실되지 않았습니다. 여기서 메운 것은 관측된 실패가
+    # 아니라 ARCHITECTURE.md 가 문서화한 계약과 호출부 사이의 드리프트입니다 —
+    # 이 줄을 "예전에 프롬프트가 깨졌었다"로 읽으면 안 됩니다.
     cat "$PROMPT_FILE" | {claude_env} claude \
       --model {sub_model} \
       --permission-mode {permission_mode} \
-      {budget_flag}
+      {budget_flag} \
+      | tee "$WRAPPER_LOG"
     ;;
   codex)
     cat "$PROMPT_FILE" | codex exec \
@@ -349,6 +372,13 @@ cmux notify --title "cmux-delegate" --body "Task completed: {short_task}" 2>/dev
 `{provider}` and `{sub_model}` are substituted from the provider resolution result in Step 1.
 `{claude_env}` is substituted with `CLAUDE_CONFIG_DIR=~/.{account}` when account is specified (claude provider only).
 `{budget_flag}` is substituted with `--max-budget-usd {budget}` when budget is specified (claude provider only — codex/gemini do not support budget limits).
+
+`$WRAPPER_LOG` 는 `tee` 의 부산물이지 산출물이 아닙니다. 지워도 위임은 동작하지만
+그러면 claude 의 stdout 이 다시 TTY 가 되어 위 주석의 계약이 깨지므로, 로그가
+필요 없더라도 파이프 자체는 남겨두어야 합니다. trap 은 이 파일도 지우지 않습니다
+— 워커가 죽은 뒤 남는 유일한 stdout 사본이라 사후 분석에 쓰입니다. codex/gemini
+분기에는 같은 의무가 없습니다: ARCHITECTURE.md 의 전제조건은 claude 행에만
+붙어 있고, gemini 는 애초에 stdin 이 아니라 `-p` 로 프롬프트를 받습니다.
 
 **이 파일도 `Write` 도구로 생성합니다.** 단, 파일 내용 자체에 shell 변수(`$PROMPT_FILE` 등)가 포함되므로 이는 의도된 것입니다 — 중요한 것은 사용자 프롬프트가 이 스크립트를 거치지 않는다는 점입니다.
 
@@ -738,6 +768,14 @@ user: /cmux-delegate "full code review" --model claude:opus --account claude-2
 `claude -p "..."` 패턴은 프롬프트에 `$`, `{}`, `` ` `` 등이 포함되면 shell이 해석하여 프롬프트가 깨집니다 (Hub #1001 크리마 검수에서 실제 경험).
 
 `cat file | claude` 패턴은 프롬프트가 shell을 한 번도 거치지 않으므로 모든 특수문자가 안전합니다.
+
+그 대가로 `-p` 가 주는 비대화형 면제(워크스페이스 신뢰 대화상자 건너뛰기)를
+잃습니다. Step 4 가 `| tee "$WRAPPER_LOG"` 로 stdout 을 파이프에 물리는 이유가
+이것입니다 — `claude --help` 는 그 면제를 "`-p`, **또는** stdout 이 TTY 가
+아닐 때"로 명시하므로, 리다이렉트 쪽 조건만으로도 면제가 성립합니다. 즉 `-p`
+없이 위 특수문자 안전성을 유지한 채 계약을 만족시킬 수 있습니다. `--max-budget-usd`
+가 print 모드 전용인 것도 `-p` 를 되살릴 이유가 되지 못합니다: `-p` 를 붙이는
+순간 프롬프트가 shell 을 거쳐 위 실패가 그대로 돌아옵니다.
 
 ## Limitations
 

--- a/tests/test_wrapper_stdout_contract.py
+++ b/tests/test_wrapper_stdout_contract.py
@@ -1,0 +1,161 @@
+"""tests/test_wrapper_stdout_contract.py — Step 4 stdout contract (#981).
+
+ARCHITECTURE.md's Provider CLI Spec puts a precondition on the `claude` row's
+stdin column: `claude --help` skips the workspace trust dialog only "via -p, or
+when stdout is not a TTY", that dialog reads stdin, and the row's command pipes
+the prompt into stdin. Using the stdin column therefore obliges the caller to
+supply one exemption. cmux-delegate Step 4 is the only caller in this repo.
+
+This file pins the *executable* half: it extracts the `claude)` branch verbatim
+out of SKILL.md, instantiates the {placeholders}, and runs it under a real PTY
+(what a cmux workspace hands the wrapper) with a stub `claude` on PATH that
+reports isatty(stdout). Grepping the prose cannot catch a redirect that is
+written but does not actually take effect — e.g. a trailing `\\` dropped so the
+pipe lands on the next command instead.
+
+Both directions are pinned on purpose. `test_claude_branch_stdout_is_not_a_tty`
+is the case that must now fire; `test_probe_detects_a_tty` is the control that
+must stay silent, because a stub that reported NO unconditionally would make the
+first test pass for no reason.
+
+NOTE: this is a documented-contract drift, not a repaired failure. The owner's
+4-run control on claude 2.1.232 showed the prompt is not actually lost. Nothing
+here should be read as evidence that delegation was previously broken.
+
+Run:  python3 -m pytest tests/test_wrapper_stdout_contract.py
+"""
+
+import os
+import pathlib
+import pty
+import re
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SKILL = ROOT / "skills" / "cmux-delegate" / "SKILL.md"
+
+# The prompt carries every character class "Why Wrapper Script?" names as the
+# reason `-p` is excluded. If a future edit reintroduces a shell round-trip,
+# these come back mangled and the assertion below fails.
+HOSTILE_PROMPT = 'cost $5 {brace} `tick` "quote"\n'
+
+
+def _extract_branch(name):
+    """Pull one `case` branch out of the Step 4 fence, verbatim."""
+    text = SKILL.read_text(encoding="utf-8")
+    m = re.search(r"^  %s\)\n(.*?)^    ;;\n" % name, text, re.S | re.M)
+    assert m, f"could not locate the {name}) branch in {SKILL}"
+    return m.group(1)
+
+
+def _stub_bin(tmp_path):
+    """A `claude` that reports isatty(stdout) and echoes the prompt it read."""
+    d = tmp_path / "bin"
+    d.mkdir()
+    stub = d / "claude"
+    stub.write_text(
+        "#!/bin/bash\n"
+        'if [ -t 1 ]; then echo "stdout-is-tty=YES"; else echo "stdout-is-tty=NO"; fi\n'
+        'echo "prompt=[$(cat)]"\n'
+    )
+    stub.chmod(0o755)
+    return d
+
+
+def _run_under_pty(script, extra_path):
+    """Run `script` with a real TTY on stdout, as a cmux workspace would."""
+    chunks = []
+
+    def _read(fd):
+        data = os.read(fd, 4096)
+        chunks.append(data)
+        return data
+
+    old = os.environ["PATH"]
+    # pty.spawn execs with the inherited environment, so the stub has to be on
+    # os.environ — passing an env dict to spawn() does nothing.
+    os.environ["PATH"] = f"{extra_path}:{old}"
+    try:
+        pty.spawn(["/bin/bash", str(script)], _read)
+    finally:
+        os.environ["PATH"] = old
+    return b"".join(chunks).decode(errors="replace")
+
+
+def _instantiate(tmp_path, branch):
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text(HOSTILE_PROMPT)
+    log = tmp_path / "wrapper.log"
+    body = (
+        branch.replace("{claude_env}", "")
+        .replace("{sub_model}", "sonnet")
+        .replace("{permission_mode}", "auto")
+        # Empty is the common case (no --budget). It also proves the trailing
+        # backslash before the pipe still parses when the flag expands to
+        # nothing.
+        .replace("{budget_flag}", "")
+        .replace("$PROMPT_FILE", str(prompt))
+        .replace("$WRAPPER_LOG", str(log))
+    )
+    script = tmp_path / "wrapper.sh"
+    script.write_text("#!/bin/bash\n" + body)
+    script.chmod(0o755)
+    return script, log
+
+
+def test_claude_branch_stdout_is_not_a_tty(tmp_path):
+    """Must fire: Step 4 supplies the non-TTY exemption ARCHITECTURE.md names."""
+    script, log = _instantiate(tmp_path, _extract_branch("claude"))
+    out = _run_under_pty(script, _stub_bin(tmp_path))
+
+    assert "stdout-is-tty=NO" in out, (
+        "claude was handed a TTY on stdout — the trust dialog and the piped "
+        "prompt are competing for stdin (ARCHITECTURE.md Provider CLI Spec)"
+    )
+    assert "stdout-is-tty=YES" not in out
+
+
+def test_operator_still_sees_the_output(tmp_path):
+    """The redirect must be the narrowest one: a full `>` empties the cmux pane.
+
+    tee keeps the workspace TTY fed while making claude's own stdout a pipe.
+    """
+    script, log = _instantiate(tmp_path, _extract_branch("claude"))
+    out = _run_under_pty(script, _stub_bin(tmp_path))
+
+    assert "stdout-is-tty=NO" in out, "worker output vanished from the terminal"
+    assert log.exists() and "stdout-is-tty=NO" in log.read_text()
+
+
+def test_prompt_survives_the_pipeline(tmp_path):
+    """The stdin path must stay shell-free — the reason `-p` is excluded."""
+    script, _ = _instantiate(tmp_path, _extract_branch("claude"))
+    out = _run_under_pty(script, _stub_bin(tmp_path))
+
+    assert "prompt=[" + HOSTILE_PROMPT.strip() + "]" in out.replace("\r\n", "\n")
+
+
+def test_probe_detects_a_tty(tmp_path):
+    """Control that must stay silent: the stub reports YES when nothing is
+    redirected. Without this, a stub wedged at NO would pass every test above."""
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text(HOSTILE_PROMPT)
+    script = tmp_path / "bare.sh"
+    script.write_text(f'#!/bin/bash\ncat "{prompt}" | claude --model sonnet\n')
+    script.chmod(0o755)
+
+    out = _run_under_pty(script, _stub_bin(tmp_path))
+    assert "stdout-is-tty=YES" in out
+    assert "stdout-is-tty=NO" not in out
+
+
+@pytest.mark.parametrize("provider", ["codex", "gemini"])
+def test_other_providers_are_not_redirected(provider):
+    """Control that must stay silent: the obligation is on the claude row only.
+
+    ARCHITECTURE.md attaches the precondition to that row alone, and gemini does
+    not use the stdin column at all (`-p "$(cat …)"`). Blanket-teeing every
+    branch would be cargo-culting this fix outward.
+    """
+    assert "tee" not in _extract_branch(provider)

--- a/tests/test_wrapper_stdout_contract.sh
+++ b/tests/test_wrapper_stdout_contract.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# tests/test_wrapper_stdout_contract.sh — Step 4 stdout contract, prose half (#981)
+#
+# The executable behaviour is pinned in tests/test_wrapper_stdout_contract.py.
+# What this file pins is the SKILL.md text, for two reasons the code cannot
+# cover:
+#
+#   1. `| tee` looks like logging. A future reader who reads it as logging will
+#      delete it as redundant, and the ARCHITECTURE.md obligation silently
+#      lapses. The comment saying it is contract compliance is the load-bearing
+#      part, so it is asserted like code.
+#   2. This is documented-contract drift, NOT a repaired failure — the owner's
+#      4-run control on claude 2.1.232 showed the prompt is not actually lost.
+#      If that disclaimer goes missing, the next reader concludes a real bug
+#      once existed here and reasons from a fiction.
+#
+# Run:  bash tests/test_wrapper_stdout_contract.sh
+# Exit: 0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL="$ROOT_DIR/skills/cmux-delegate/SKILL.md"
+
+# shellcheck source=./_assert_lib.sh
+source "$SCRIPT_DIR/_assert_lib.sh"
+assert_lib_init "$SKILL"
+
+# ---------------------------------------------------------------------------
+# 1. The obligation is named where the call site lives
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "the redirect is justified as contract compliance, not logging" \
+  "로그 적재가 목적이 아니라 계약 이행입니다"
+
+assert_present \
+  "the obligation is traced to its source document" \
+  "stdout 을 리다이렉트하거나"
+
+assert_present \
+  "the competing-readers mechanism is stated, not just the rule" \
+  "같은 스트림을 두고 경쟁합니다"
+
+# ---------------------------------------------------------------------------
+# 2. The disclaimer — the single sentence that stops a future misreading
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "the file says plainly that no bug was fixed here" \
+  "**이것은 버그 수정이 아닙니다.**"
+
+assert_present \
+  "the owner's control run is cited by version" \
+  "소유자의 4회 대조 실행(claude 2.1.232)"
+
+assert_present \
+  "the reader is told how NOT to read the line" \
+  "예전에 프롬프트가 깨졌었다"
+
+# ---------------------------------------------------------------------------
+# 3. Why tee and not the two nearby forms that also satisfy the contract
+# ---------------------------------------------------------------------------
+
+assert_present \
+  "the narrowest-redirect choice is argued against a full redirect" \
+  "가장 좁은 리다이렉트이기 때문입니다"
+
+assert_present \
+  "the operator-visibility cost of a full redirect is named" \
+  "페인을 비웁니다"
+
+assert_present \
+  "the log is marked as a byproduct, so deleting it does not look free" \
+  "파이프 자체는 남겨두어야 합니다"
+
+# ---------------------------------------------------------------------------
+# 4. Contracts this change must not displace
+# ---------------------------------------------------------------------------
+
+# "Why Wrapper Script?" records a real, previously-experienced failure with
+# `claude -p "..."`. The new prose must reinforce that exclusion, not reopen it.
+assert_present \
+  "the -p exclusion is restated as still binding" \
+  '`-p` 를 붙이는 순간 프롬프트가 shell 을 거쳐 위 실패가 그대로 돌아옵니다'
+
+assert_present \
+  "the budget flag is not allowed to argue -p back in" \
+  "print 모드 전용인 것도"
+
+# The must-stay-silent direction, mirrored from the .py control: the wrapper
+# must still create the .sh only via Write, and the trap must still spare .md.
+assert_present \
+  "the trap still deletes only the .sh" \
+  "trap 'rm -f \"\$SCRIPT_FILE\"' EXIT"
+
+assert_absent \
+  "the stdin path is still shell-free — no -p form reintroduced" \
+  'claude -p "$(cat'
+
+assert_lib_summary


### PR DESCRIPTION
## 결정

**Step 4 가 문서화된 의무를 방어적으로 이행한다. `-p` 는 추가하지 않는다** (유지보수자 판정).

## 이건 버그 수정이 아니다 — 문서↔코드 드리프트다

`ARCHITECTURE.md:57-58`(`1a5ea64` 로 착지, Work B 의 살아남은 절반)이 stdin 컬럼 사용은 **"호출자가 하나를 공급할 의무를 진다: stdout 을 리다이렉트하거나 `-p` 를 추가하라"** 고 적는다. 저장소 안 **유일한 호출자**인 SKILL.md Step 4 는 둘 다 공급하지 않은 채 cmux TTY 위에서 stdout 을 열고 실행한다.

**근거를 정확히 해둔다: 작성자 본인의 4회 대조 실행이 프롬프트가 실제로 유실되지 않음을 보였다**(claude 2.1.232). 따라서 이 변경은 **관측된 실패가 아니라 문서화된 계약**을 근거로 한다. 미래의 독자가 여기서 버그가 고쳐졌다고 오해하지 않도록 파일에 그렇게 적었다.

## 변경

Step 4 래퍼의 `claude)` 분기에서 claude 호출의 stdout 을 래퍼 로그로 리다이렉트해, `claude --help` 가 명시하는 non-TTY 면제를 실제로 공급한다. 이유를 `ARCHITECTURE.md` 의 의무와 함께 한두 줄로 적었다.

## `-p` 를 쓰지 않은 이유

같은 파일의 `Why Wrapper Script?` 절이 그 형태를 포기한 이유를 이미 기록하고 있다 — 프롬프트 안의 `$`, `{}`, 백틱이 셸 해석되는 **실제로 겪은 프롬프트 손상 실패**("Hub #1001 크리마 검수에서 실제 경험"). 게다가 `--max-budget-usd` 는 `--print` 전용으로 문서화돼 있어 `-p` 는 세션 성격 자체를 바꾼다. 이 변경은 그 기록과 충돌하지 않는다.

## 기존 논의가 이미 정리한 것

코멘트 6건을 읽었고, 남은 실질 결정이 위 하나뿐임을 확인했다.

- **Work A(liveness 분류)는 완결됐다.** 이벤트 방출 전제를 workspace-UUID 귀속으로 확인한 뒤, 코멘트 3에서 이벤트를 전혀 방출하지 않는 정상 세션이 관측되자 **올바르게 좁혔고**, 출고된 설계가 그 좁힘을 인코딩하고 있다(`no-events-in-window` → `unknown`, `crash` 는 응답이 있고 비어 있는 조회에만 예약). 머지된 코드에 대해 재현했다.
- **Work B 는 전제가 반증됐다.** 열려 있는 체크박스 3개는 **아무도 재현할 수 없는 결함에 대한 수정**을 서술한다.
- **B-variant `hasTrustDialogAccepted=true`** 는 코멘트 5에서 두 근거로 이미 거절됐고 그 이후 달라진 것이 없다.

## 검증

새 회귀 `tests/test_wrapper_stdout_contract.{py,sh}` 가 계약을 양방향으로 고정한다 — Step 4 의 claude 분기가 면제를 공급하는지, 그리고 `-p` 형태가 재도입되지 않는지.

## 미확인 — 상당하며, 주장의 범위를 한정한다

- **`cmux` 를 한 번도 실행하지 않았다.** 이 호스트에 없다(`cmux: NOT FOUND`). liveness 관련 재현은 전부 제가 작성한 가짜 cmux 하네스에서 나왔다. 그 하네스는 `agent_liveness.py` 의 파싱·분류를 충실히 구동하지만 **실제 cmux 가 코드가 기대하는 JSON 형태를 방출하는지는 검증하지 않는다** — 그 부분은 전적으로 코멘트 1·3·4의 작성자 현장 측정에 기대며 재확인하지 않았다.
- stdout 리다이렉트가 운영자가 실제로 봐야 할 출력을 가리지 않는지는 계약을 만족하는 최소 범위로 좁혀 판단한 것이지, 실제 cmux 세션에서 확인한 것이 아니다.

## 함께 닫히는 것

잔여 trust-dialog 공백은 strict xfail 로 이미 스스로를 알리고 있다. 그 대화상자의 실제 `preview` 문자열을 cmux 호스트에서 한 번 포착하면 xfail 이 XPASS 로 뒤집히며 알리고, trust 로 막힌 워커가 애초에 관측 가능한지도 함께 답한다 — 그게 Work B 를 재개할 자연스러운 지점이다.

Closes #981

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc

---
_Generated by [Claude Code](https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc)_