### PR TITLE
fix(retrospect): escalate own-org public repo writes at Gate-4

### DIFF
--- a/hooks/preflight-gate/cross-boundary-preflight/impl.py
+++ b/hooks/preflight-gate/cross-boundary-preflight/impl.py
@@ -6,6 +6,11 @@ Intercepts two patterns:
 1. CROSS_REPO_WRITE — `gh pr create / issue create/comment/edit --repo <X>`
    Emits permissionDecision "ask" with a four-point checklist before the
    command executes. The user must confirm all contracts are satisfied.
+   Fires for every `--repo` target regardless of owner: a public repo owned
+   by the user or their own org is a cross-boundary write too, and needs the
+   same per-action prior approval as a third-party repo (issue #993). The
+   checklist says so explicitly — labelling the gate "external only" was
+   what let own-org writes through without per-action approval.
 
 2. HEREDOC_BODY — `gh pr create / issue create` with a `<<` heredoc operator
    in the same command segment. Hard-blocks (exit 2) and suggests --body-file.
@@ -272,6 +277,9 @@ def _build_checklist(subcommand: tuple[str, str], repo: str) -> str:
         "  ① Per-action authorization gate (CLAUDE.md §External-repo write)",
         "     Explicit approval required for THIS specific action.",
         "     General 'proceed' / 'ok' / 'continue' does NOT count.",
+        "     Ownership does NOT exempt: a public repo owned by you or your",
+        "     own org is a cross-boundary write and needs the same per-action",
+        "     prior approval as a third-party repo (praxis #993).",
         "",
     ]
     if is_pr:

--- a/hooks/preflight-gate/cross-boundary-preflight/spec.md
+++ b/hooks/preflight-gate/cross-boundary-preflight/spec.md
@@ -21,7 +21,7 @@ The two patterns covered:
 | Pattern            | Trigger                                               | Action                                           |
 | ------------------ | ----------------------------------------------------- | ------------------------------------------------ |
 | `HEREDOC_BODY`     | `<<` token in same segment as `gh pr/issue create`    | **Hard block** (exit 2) — suggests `--body-file` |
-| `CROSS_REPO_WRITE` | `--repo/-R` flag in `gh pr/issue create/comment/edit` | **Ask** — surfaces four-point checklist          |
+| `CROSS_REPO_WRITE` | `--repo/-R` flag in `gh pr/issue create/comment/edit` (any owner) | **Ask** — surfaces four-point checklist          |
 
 ### What is blocked / asked
 
@@ -59,17 +59,35 @@ Correct pattern: `Write tool → /tmp/body.md` then `--body-file /tmp/body.md`.
 | `gh pr create --title "t" --body "Caller chain verified: ok"`      | **PASS** — no `--repo`          |
 | `gh issue list --repo owner/repo`                                  | **PASS** — read-only subcommand |
 | `gh pr list --repo owner/repo`                                     | **PASS** — read-only subcommand |
+| `gh issue create --repo <own-org>/repo --title "t"`                | **ASK** — ownership is no exemption |
 | `gh pr create --repo x --title "t" # cross-boundary:ack`           | **PASS** — opt-out              |
 
 The checklist surfaced for `pr create` (four points):
 
-1. **Per-action authorization gate** — explicit approval for THIS specific action
+1. **Per-action authorization gate** — explicit approval for THIS specific
+   action, for **every** `--repo` target including a repo the user or their
+   own org owns
 2. **Caller chain verified** — PR body must contain `Caller chain verified: <source>` (pr create only)
 3. **Body delivery format** — `--body-file`, no heredoc
 4. **Language & content rules** — English only, no internal identifiers
 
 The checklist for `issue create / comment / edit` skips item ② (no caller-chain
 requirement on issues).
+
+#### Ownership is not an exemption (issue #993)
+
+The ASK has always fired on every `--repo` write, but item ① was labelled
+"§External-repo write" only — read as "external repos only", which let own-org
+writes be acked as out of scope. Item ① now states the rule the checklist
+actually enforces: a public repo owned by the user or their own org is a
+cross-boundary write and needs the same per-action prior approval as a
+third-party repo. The verdict and the wording now agree, and they agree with
+retrospect Stage 2.5 Gate-4, where own-org membership likewise stopped being
+an exemption — there the write is unescalated only when the backing repo is
+own-org **and** declared `repo_visibility: private|internal`. This hook cannot
+observe visibility from the command line, so it asks in every case; a repo
+confirmed own-org-and-private is what the `# cross-boundary:ack` marker is
+for.
 
 ### Response format
 
@@ -135,13 +153,15 @@ placement guidance.
 ### Tests
 
 ```bash
-bash tests/test_cross_boundary_preflight.sh
+bash tests/hooks/preflight-gate/test_cross_boundary_preflight.sh
 ```
 
-Covers 35 cases: 7 heredoc block paths (4 original + 3 F2 regression), 12
-cross-repo ask paths (including shorthand flags, chained commands, equals
-forms, F1 regression), 2 ask-detail checks (caller chain item present/absent
-by subcommand), 1 block-msg content check (new ack-placement bullet present
-in stderr), 1 F2 false-positive guard, 9 pass paths (no-repo, read-only,
-non-gh, opt-out, variable-heredoc), 2 infrastructure (non-Bash passthrough,
-malformed JSON fail-open).
+Covers 48 cases: heredoc block paths (originals + F2 regression), cross-repo
+ask paths (shorthand flags, chained commands, equals forms, F1 regression,
+own-org targets per #993), ask-detail checks (caller chain item present/absent
+by subcommand, ownership-is-no-exemption wording per #993), a block-msg
+content check (ack-placement bullet present in stderr), the F2 false-positive
+guard, pass paths (no-repo, read-only including an own-org read-only #993
+control that must stay silent, non-gh, opt-out, variable-heredoc), cascade-hint
+present/absent pair, and infrastructure (non-Bash passthrough, malformed JSON
+fail-open, `@fail_open` wrapping).

--- a/hooks/preflight-gate/cross-boundary-preflight/spec.md
+++ b/hooks/preflight-gate/cross-boundary-preflight/spec.md
@@ -18,9 +18,9 @@ issue #199).
 
 The two patterns covered:
 
-| Pattern            | Trigger                                               | Action                                           |
-| ------------------ | ----------------------------------------------------- | ------------------------------------------------ |
-| `HEREDOC_BODY`     | `<<` token in same segment as `gh pr/issue create`    | **Hard block** (exit 2) — suggests `--body-file` |
+| Pattern            | Trigger                                                           | Action                                           |
+| ------------------ | ----------------------------------------------------------------- | ------------------------------------------------ |
+| `HEREDOC_BODY`     | `<<` token in same segment as `gh pr/issue create`                | **Hard block** (exit 2) — suggests `--body-file` |
 | `CROSS_REPO_WRITE` | `--repo/-R` flag in `gh pr/issue create/comment/edit` (any owner) | **Ask** — surfaces four-point checklist          |
 
 ### What is blocked / asked
@@ -50,17 +50,17 @@ Correct pattern: `Write tool → /tmp/body.md` then `--body-file /tmp/body.md`.
 
 #### CROSS_REPO_WRITE — ask (permissionDecision: "ask")
 
-| Command                                                            | Action                          |
-| ------------------------------------------------------------------ | ------------------------------- |
-| `gh pr create --repo owner/repo --title "t" --body-file /tmp/b.md` | **ASK**                         |
-| `gh issue create --repo owner/repo --title "t"`                    | **ASK**                         |
-| `gh issue comment 42 --repo owner/repo --body "..."`               | **ASK**                         |
-| `gh -R owner/repo pr create --title "t" --body-file /tmp/b.md`     | **ASK**                         |
-| `gh pr create --title "t" --body "Caller chain verified: ok"`      | **PASS** — no `--repo`          |
-| `gh issue list --repo owner/repo`                                  | **PASS** — read-only subcommand |
-| `gh pr list --repo owner/repo`                                     | **PASS** — read-only subcommand |
+| Command                                                            | Action                              |
+| ------------------------------------------------------------------ | ----------------------------------- |
+| `gh pr create --repo owner/repo --title "t" --body-file /tmp/b.md` | **ASK**                             |
+| `gh issue create --repo owner/repo --title "t"`                    | **ASK**                             |
+| `gh issue comment 42 --repo owner/repo --body "..."`               | **ASK**                             |
+| `gh -R owner/repo pr create --title "t" --body-file /tmp/b.md`     | **ASK**                             |
+| `gh pr create --title "t" --body "Caller chain verified: ok"`      | **PASS** — no `--repo`              |
+| `gh issue list --repo owner/repo`                                  | **PASS** — read-only subcommand     |
+| `gh pr list --repo owner/repo`                                     | **PASS** — read-only subcommand     |
 | `gh issue create --repo <own-org>/repo --title "t"`                | **ASK** — ownership is no exemption |
-| `gh pr create --repo x --title "t" # cross-boundary:ack`           | **PASS** — opt-out              |
+| `gh pr create --repo x --title "t" # cross-boundary:ack`           | **PASS** — opt-out                  |
 
 The checklist surfaced for `pr create` (four points):
 

--- a/skills/retrospect/audit-distribution-gates.py
+++ b/skills/retrospect/audit-distribution-gates.py
@@ -371,7 +371,11 @@ def audit(findings: list[Finding], ms_blocks: dict[str, dict[str, str]],
                     f"per-action approval ({why}) but Rationale lacks the "
                     f"literal warning prefix '{EXTERNAL_WARNING}'"
                 )
-        gate4 = "WARN" if any_external else "PASS"
+        # `fallback` holds the verdict off PASS on its own. With the allowlist
+        # unresolved nothing was actually checked, and a row whose backing_repo
+        # never parsed leaves any_external False — the label would then read as
+        # a clean gate over an unread one.
+        gate4 = "WARN" if any_external or fallback else "PASS"
 
     # --- Gate-5: memory-scan completeness ---
     memory_findings = [f for f in findings if "memory" in f.actions]

--- a/skills/retrospect/audit-distribution-gates.py
+++ b/skills/retrospect/audit-distribution-gates.py
@@ -59,9 +59,18 @@ SCHEMA_B_RE = re.compile(r"^\s*not-others: .+")
 BACKING_REPO_RE = re.compile(
     r"^\s*backing_repo: ([A-Za-z0-9_][A-Za-z0-9_.-]*)/[A-Za-z0-9_][A-Za-z0-9_.-]*"
 )
-# Literal Stage 4 warning prefix required on external rows (stage2.5-audit.md
-# Gate-4); Stage 4 scans this exact string — a paraphrase disables the gate.
+# Literal Stage 4 warning prefix required on every cross-boundary row
+# (stage2.5-audit.md Gate-4); Stage 4 scans this exact string — a paraphrase
+# disables the gate.
 EXTERNAL_WARNING = "⚠ EXTERNAL: per-action approval required at Stage 4"
+# Declared visibility of the backing repo (issue #993). Gate-4 keys on
+# visibility, not ownership: a *public* repo is a cross-boundary write even
+# when its owner is the user's own org, so only `private`/`internal` stays
+# unescalated. An absent declaration is treated as public (fail closed).
+REPO_VISIBILITY_RE = re.compile(
+    r"^\s*repo_visibility: (public|private|internal)\s*$"
+)
+UNESCALATED_VISIBILITY = {"private", "internal"}
 
 # Gate-1 behavioral-only safeguard keyword set (stage2.5-audit.md Gate-1).
 SAFEGUARD_KEYWORDS = [
@@ -175,7 +184,12 @@ def parse_memory_scan_blocks(draft_text: str) -> dict[str, dict[str, str]]:
 
 
 def resolve_own_orgs() -> tuple[set[str], bool]:
-    """Allowlist resolution per stage2.5-audit.md Gate-4 priority order.
+    """Own-org handle resolution per stage2.5-audit.md Gate-4 priority order.
+
+    Still called after issue #993, but own-org membership is no longer an
+    exemption on its own — it is only the first half of the (own-org AND
+    private/internal) exemption. A public own-org repo is escalated exactly
+    like a third-party one.
 
     Returns (set of lowercase handles, fallback_used).
     """
@@ -303,13 +317,20 @@ def audit(findings: list[Finding], ms_blocks: dict[str, dict[str, str]],
                 "backing_repo: <owner/repo> — return to Stage 2 step 7"
             )
 
-    # --- Gate-4: external-repo authorization pre-check ---
+    # --- Gate-4: cross-boundary write authorization pre-check (issue #993) ---
+    # Own-org membership no longer exempts on its own: a write to a PUBLIC
+    # repo is a cross-boundary write needing per-action prior approval even
+    # when the owner is the user's own org/handle. The exemption now requires
+    # BOTH halves — own-org owner AND a `repo_visibility: private|internal`
+    # declaration. An undeclared repo counts as public, so a missing line can
+    # never widen the gate, and a third-party repo stays escalated whatever it
+    # declares.
     upstream = [f for f in findings if "upstream_feedback" in f.actions]
     if not upstream:
         gate4 = "NA"
     else:
         own_orgs, fallback = resolve_own_orgs()
-        any_external = fallback
+        any_external = False
         if fallback:
             advisories.append(
                 "gate-4: allowlist unresolved (no PRAXIS_OWN_ORGS, gh "
@@ -317,23 +338,39 @@ def audit(findings: list[Finding], ms_blocks: dict[str, dict[str, str]],
                 "external"
             )
         for f in upstream:
-            owner = None
+            repo = owner = visibility = None
             for ln in f.rationale_lines:
                 m = BACKING_REPO_RE.match(ln)
-                if m:
+                if m and repo is None:
+                    repo = m.group(0).split("backing_repo:", 1)[1].strip()
                     owner = m.group(1).lower()
-                    break
-            if owner is None:
+                v = REPO_VISIBILITY_RE.match(ln)
+                if v and visibility is None:
+                    visibility = v.group(1)
+            if repo is None:
                 continue  # backing_repo violation already recorded above
-            external = fallback or owner not in own_orgs
-            if external:
-                any_external = True
-                if EXTERNAL_WARNING not in f.rationale:
-                    violations.append(
-                        f"finding #{f.num}: external backing_repo owner "
-                        f"'{owner}' but Rationale lacks the literal warning "
-                        f"prefix '{EXTERNAL_WARNING}'"
-                    )
+            own = not fallback and owner in own_orgs
+            if own and visibility is None:
+                advisories.append(
+                    f"gate-4: finding #{f.num} is own-org but declares no "
+                    "'repo_visibility: public|private|internal' line — "
+                    "conservative fallback treats the backing repo as public"
+                )
+            if own and visibility in UNESCALATED_VISIBILITY:
+                continue
+            any_external = True
+            why = (
+                f"own-org owner '{owner}' but {visibility or 'public'} — "
+                "own-org membership no longer exempts a public repo"
+                if own else
+                f"owner '{owner}' is outside the own-org allowlist"
+            )
+            if EXTERNAL_WARNING not in f.rationale:
+                violations.append(
+                    f"finding #{f.num}: backing_repo '{repo}' needs "
+                    f"per-action approval ({why}) but Rationale lacks the "
+                    f"literal warning prefix '{EXTERNAL_WARNING}'"
+                )
         gate4 = "WARN" if any_external else "PASS"
 
     # --- Gate-5: memory-scan completeness ---

--- a/skills/retrospect/references/stage2.5-audit.md
+++ b/skills/retrospect/references/stage2.5-audit.md
@@ -36,15 +36,24 @@ The script mechanizes, mirroring the Stop hook's parsing semantics
   `not <action>: <reason>` lines) or Schema B (1-2 `not-others: <dim-tags>`
   lines, no Schema A lines)
 - **backing_repo** — any row routing `upstream_feedback` or `issue` must
-  declare `backing_repo: <owner>/<repo>` in Rationale
-- **Gate-4** — allowlist resolution (`PRAXIS_OWN_ORGS` →
-  `gh api user --jq .login` → conservative all-external fallback), owner
-  classification, and the literal external warning prefix
-  `⚠ EXTERNAL: per-action approval required at Stage 4` on external rows
-  (Stage 4 scans that exact string; a paraphrase disables the per-action
-  approval gate). Verdict `WARN` means at least one external finding exists,
-  or the conservative fallback was required — Stage 4 must then require
-  per-action approval for external rows
+  declare `backing_repo: <owner>/<repo>` in Rationale. An `upstream_feedback`
+  row may add `repo_visibility: public|private|internal` on its own Rationale
+  line; Gate-4 reads it, and its absence means public (issue #993)
+- **Gate-4** — cross-boundary write classification and the literal external
+  warning prefix `⚠ EXTERNAL: per-action approval required at Stage 4` on
+  every escalated row (Stage 4 scans that exact string; a paraphrase disables
+  the per-action approval gate). Since issue #993 the criterion is
+  **visibility, not ownership**: a write to a *public* backing repo is
+  escalated to per-action prior approval even when the owner is your own
+  handle/org. A row is unescalated only when **both** halves hold — the owner
+  resolves inside the own-org allowlist (`PRAXIS_OWN_ORGS` →
+  `gh api user --jq .login` → conservative all-external fallback) **and** the
+  Rationale declares `repo_visibility: private` or `repo_visibility:
+  internal`. An undeclared repo counts as public (an advisory says so), and a
+  third-party repo stays escalated whatever visibility it declares. Verdict
+  `WARN` means at least one external finding exists, or the conservative
+  fallback was required — Stage 4 must then require per-action approval for
+  those rows
 - **Gate-5** — every memory-action finding needs a complete
   `<!-- memory_scan finding #N: ... -->` block (`scanned: true`,
   `candidates_reviewed`, `repeat`, `repeat_count`)

--- a/tests/hooks/preflight-gate/test_cross_boundary_preflight.sh
+++ b/tests/hooks/preflight-gate/test_cross_boundary_preflight.sh
@@ -139,6 +139,28 @@ run_case_detail "issue create checklist no Caller chain item" \
   "body-file"
 
 # ---------------------------------------------------------------------------
+# #993: own-org membership does not exempt a --repo write. The ASK must fire
+# on an own-org target, and the checklist must say ownership is no exemption
+# (the old wording read as "external repos only", which is what let own-org
+# writes proceed without per-action approval).
+# ---------------------------------------------------------------------------
+
+run_case "own-org repo write is still cross-boundary (#993)" ask \
+  'gh issue create --repo devseunggwan/praxis --title "t"'
+
+run_case "own-org pr create is still cross-boundary (#993)" ask \
+  'gh pr create --repo devseunggwan/praxis --title "t" --body-file /tmp/b.md'
+
+run_case_detail "checklist states ownership is not an exemption (#993)" \
+  'gh issue create --repo devseunggwan/praxis --title "t"' \
+  "Ownership does NOT exempt"
+
+# Opposite direction — the #993 wording must not turn read-only own-org
+# traffic into an ask. This control has to stay silent.
+run_case "own-org read-only stays silent (#993 control)" pass \
+  'gh issue list --repo devseunggwan/praxis --state open'
+
+# ---------------------------------------------------------------------------
 # Message content: new bullet 3 appears in HEREDOC_BLOCK_MSG stderr
 # ---------------------------------------------------------------------------
 

--- a/tests/test_audit_distribution_gates.py
+++ b/tests/test_audit_distribution_gates.py
@@ -132,12 +132,69 @@ def test_routed_action_missing_backing_repo(tmp_path: Path) -> None:
     assert "backing_repo" in r.stdout
 
 
-def test_gate4_internal_owner_passes(tmp_path: Path) -> None:
+def test_gate4_own_org_public_is_escalated(tmp_path: Path) -> None:
+    # #993: own-org membership no longer exempts a public backing repo — this
+    # exact draft returned `gate_4_verdict: PASS` + exit 0 before the change.
+    r = run(tmp_path, draft_of(
+        row(1, "workflow", "—", "upstream_feedback",
+            "backing_repo: devseunggwan/praxis<br>repo_visibility: public")))
+    assert r.returncode == 1
+    assert "own-org membership no longer exempts a public repo" in r.stdout
+    assert "literal warning prefix" in r.stdout
+    assert "- gate_4_verdict: WARN" in r.stdout
+
+
+def test_gate4_own_org_undeclared_visibility_is_escalated(tmp_path: Path) -> None:
+    # #993: a missing `repo_visibility:` line must not widen the gate — the
+    # undeclared repo is treated as public and an advisory says so.
     r = run(tmp_path, draft_of(
         row(1, "workflow", "—", "upstream_feedback",
             "backing_repo: devseunggwan/praxis")))
+    assert r.returncode == 1
+    assert "conservative fallback treats the backing repo as public" in r.stdout
+    assert "- gate_4_verdict: WARN" in r.stdout
+
+
+def test_gate4_own_org_public_with_warning_prefix_passes(tmp_path: Path) -> None:
+    # #993: escalated but compliant — WARN verdict, no violation, exit 0.
+    r = run(tmp_path, draft_of(
+        row(1, "workflow", "—", "upstream_feedback",
+            "backing_repo: devseunggwan/praxis<br>repo_visibility: public<br>"
+            "⚠ EXTERNAL: per-action approval required at Stage 4")))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "- gate_4_verdict: WARN" in r.stdout
+
+
+def test_gate4_own_org_private_is_not_escalated(tmp_path: Path) -> None:
+    # #993 opposite direction: the exemption survives only for a repo that is
+    # own-org AND declared private/internal. This case must stay silent.
+    r = run(tmp_path, draft_of(
+        row(1, "workflow", "—", "upstream_feedback",
+            "backing_repo: devseunggwan/internal-notes<br>"
+            "repo_visibility: private")))
     assert r.returncode == 0, r.stdout + r.stderr
     assert "- gate_4_verdict: PASS" in r.stdout
+    assert "gate-4:" not in r.stdout
+
+
+def test_gate4_own_org_internal_is_not_escalated(tmp_path: Path) -> None:
+    r = run(tmp_path, draft_of(
+        row(1, "workflow", "—", "upstream_feedback",
+            "backing_repo: devseunggwan/internal-notes<br>"
+            "repo_visibility: internal")))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "- gate_4_verdict: PASS" in r.stdout
+
+
+def test_gate4_external_private_stays_escalated(tmp_path: Path) -> None:
+    # #993 guard: the visibility exemption must not de-escalate a third-party
+    # repo — `private` on a non-own-org owner is still a cross-boundary write.
+    r = run(tmp_path, draft_of(
+        row(1, "workflow", "—", "upstream_feedback",
+            "backing_repo: someoneelse/repo<br>repo_visibility: private")))
+    assert r.returncode == 1
+    assert "outside the own-org allowlist" in r.stdout
+    assert "- gate_4_verdict: WARN" in r.stdout
 
 
 def test_gate4_external_owner_needs_warning_prefix(tmp_path: Path) -> None:
@@ -273,7 +330,7 @@ def test_gate4_conservative_fallback_all_external(tmp_path: Path) -> None:
         capture_output=True, text=True, env=env,
     )
     assert r.returncode == 1
-    assert "conservative fallback" in r.stdout
+    assert "allowlist unresolved" in r.stdout
     assert "- gate_4_verdict: WARN" in r.stdout
 
 

--- a/tests/test_audit_distribution_gates.py
+++ b/tests/test_audit_distribution_gates.py
@@ -334,6 +334,46 @@ def test_gate4_conservative_fallback_all_external(tmp_path: Path) -> None:
     assert "- gate_4_verdict: WARN" in r.stdout
 
 
+def test_gate4_fallback_stays_warn_when_no_backing_repo_parses(
+    tmp_path: Path,
+) -> None:
+    """Unresolved allowlist AND an unparseable backing_repo — still WARN.
+
+    The two conditions overlap in exactly one place: the row `continue`s before
+    `any_external` is ever set, so the verdict is decided entirely by the
+    fallback flag. Reading PASS here would label an unread gate as a clean one.
+    The exit code is 1 either way (the missing backing_repo is its own
+    violation), which is why only the label distinguishes the two versions.
+    """
+    draft_file = tmp_path / "draft.md"
+    draft_file.write_text(draft_of(
+        row(1, "workflow", "—", "upstream_feedback",
+            "no backing repo declared here")), encoding="utf-8")
+    env = {k: v for k, v in os.environ.items() if k != "PRAXIS_OWN_ORGS"}
+    env["PATH"] = str(tmp_path)  # empty dir: gh resolution fails
+    r = subprocess.run(
+        [sys.executable, str(SCRIPT), "--draft", str(draft_file)],
+        capture_output=True, text=True, env=env,
+    )
+    assert r.returncode == 1
+    assert "allowlist unresolved" in r.stdout
+    assert "- gate_4_verdict: WARN" in r.stdout
+
+
+def test_gate4_resolved_allowlist_with_no_backing_repo_is_pass(
+    tmp_path: Path,
+) -> None:
+    """The negative control for the case above — without the fallback the same
+    unparseable row leaves the gate at PASS, so the WARN there comes from the
+    unresolved allowlist and not from the missing backing_repo."""
+    r = run(tmp_path, draft_of(
+        row(1, "workflow", "—", "upstream_feedback",
+            "no backing repo declared here")))
+    assert r.returncode == 1  # missing backing_repo is still a violation
+    assert "allowlist unresolved" not in r.stdout
+    assert "- gate_4_verdict: PASS" in r.stdout
+
+
 def test_signals_file_feeds_safeguard(tmp_path: Path) -> None:
     signals = tmp_path / "signals.txt"
     signals.write_text("permission denied while calling kubectl",


### PR DESCRIPTION
## 결정

**(b) — 자기 org 의 public repo 쓰기를 건별 사전 승인으로 격상한다. 규칙과 코드를 함께 움직인다** (유지보수자 판정).

이건 **더 싼 선택지를 알고서 뒤집은 것**입니다. 제 권고는 (a)였고, 근거는 "이미 구현·테스트돼 있다"는 것뿐이었습니다 — 그건 현상 유지가 편하다는 논거이지 그것이 옳다는 논거가 아닙니다.

## 이슈 본문의 가정 하나를 바로잡습니다

본문은 (b)를 **문서 조정**으로 상정했습니다. 아닙니다 — **이 저장소의 출고된 코드가 정반대 독법을 구현하고 테스트로 고정하고 있었습니다.**

```
skills/retrospect/audit-distribution-gates.py  Gate-4  (변경 전)
  backing_repo: devseunggwan/praxis  ->  gate_4_verdict: PASS, exit 0   <- 자기 org 면제
  backing_repo: otherorg/thing       ->  gate_4_verdict: WARN, exit 1
tests/test_audit_distribution_gates.py — 위 동작을 고정
```

그래서 (b)는 문서 한 줄이 아니라 코드+테스트+훅 변경을 동반합니다.

## 변경

1. **`audit-distribution-gates.py`** — Gate-4 에서 자기 org 면제를 제거해 자기 org public backing repo 가 더 이상 PASS 를 반환하지 않는다. `resolve_own_orgs()` 의 호출자가 남아 있는지 확인하고, 죽은 헬퍼를 오해 소지로 남기지 않도록 정리했다.
2. **`tests/test_audit_distribution_gates.py`** — 고정된 기대값을 갱신하고 **양방향을 남겼다**: 자기 org public(이제 격상)과 진짜 internal/private(격상되면 안 됨).
3. **`hooks/preflight-gate/cross-boundary-preflight/`** — (b) 아래에서 자기 org `--repo` 쓰기는 cross-boundary 쓰기이므로, 체크리스트 문구와 판정을 새 규칙과 일치시켰다. **이 훅의 자기 org 라벨링이 이슈가 보고한 혼란의 출처였다.**
4. **`stage2.5-audit.md`** — Gate-4 기준을 서술하는 부분 갱신.

## 검증

```
$ python3 -m pytest tests/test_audit_distribution_gates.py -q      전부 통과
$ bash tests/hooks/preflight-gate/test_cross_boundary_preflight.sh 전부 통과
```

Gate-4 의 before/after 를 직접 실행해 포착했다 — 그것이 이 변경의 실질 전부이기 때문이다.

## ⚠️ 이 PR 만으로는 규칙이 일치하지 않습니다

**저장소 밖 두 출처를 이 세션에서 편집할 수 없습니다.** 별도로 갱신하셔야 저장소와 규칙이 어긋나지 않습니다:

- 전역 `~/.claude/CLAUDE.md` PART VII
- 전역 memory 4항

(b)를 택하셨으므로 **memory 4항 쪽이 이제 정답**이고 CLAUDE.md PART VII 이 개정 대상입니다 — 이슈가 물었던 "어느 쪽이 의도인가" 의 답이 그렇게 정해졌습니다.

## 미확인

- **충돌하는 두 출처를 하나도 읽지 못했다.** `~/.claude/CLAUDE.md` 와 전역 memory 파일이 이 샌드박스에 없다(`ls` + 전체 파일시스템 `find` 로 확인). 조사 보고서의 두 출처 인용은 전부 **이슈 작성자의 것이지 제 것이 아니다.** PART VII 의 정확한 문구도, memory 4항의 정확한 문구도 확인할 수 없었고, 따라서 **"4항이 `unsure 면 external 로 취급` 을 오독했다" 는 본문의 하위 주장은 판정하지 못했다** — 이 PR 은 그 판정에 의존하지 않고, 유지보수자가 고른 규칙을 코드에 반영할 뿐이다.
- 격상 이후 실제 워크플로에서 승인 프롬프트가 얼마나 늘어나는지는 측정하지 않았다.

Closes #993

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc

---
_Generated by [Claude Code](https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc)_