### PR TITLE
feat(retrospect): add denied-actions lane + Gate-12

### DIFF
--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -1117,10 +1117,19 @@ PY
         ins { buf = buf $0 "\n" }
         END { printf "%s", last }')
       # "Ignored ALL of them" is the block condition: one disposed row clears the
-      # gate. The disposition value is anchored so a prose sentence containing
-      # the word "dismissed" cannot stand in for a row.
-      if ! printf '%s\n' "$DA_BLOCK" | grep -qE 'disposition:[[:space:]]*(promoted|noted|dismissed)([^A-Za-z]|$)'; then
-        GATE12_VIOLATION="denied_actions fence is present but not one of the $DENIED_COUNT transcript rejection(s) carries a disposition — each row needs 'disposition: promoted (finding #N)' / 'noted' / 'dismissed (<reason>)'; an enumerated-but-undisposed rejection is the same silent drop the lane exists to prevent"
+      # gate. The WHOLE row is matched, not just its disposition — a lone
+      # `disposition: noted` line carries no evidence that any rejection was
+      # actually enumerated, and buying the gate off with one such line is the
+      # same silent drop the lane exists to prevent. Anchoring at the list
+      # marker also keeps a prose sentence containing the word "dismissed"
+      # from standing in for a row.
+      da_row_re='^[[:space:]]*-[[:space:]]*denied:[[:space:]]*".*"[[:space:]]*\|'
+      da_row_re="$da_row_re"'[[:space:]]*tool:[[:space:]]*[A-Za-z][A-Za-z0-9_-]*[[:space:]]*\|'
+      da_row_re="$da_row_re"'[[:space:]]*source:[[:space:]]*user_rejection[[:space:]]*\|'
+      da_row_re="$da_row_re"'[[:space:]]*confessed:[[:space:]]*(yes|no)[[:space:]]*\|'
+      da_row_re="$da_row_re"'[[:space:]]*disposition:[[:space:]]*(promoted|noted|dismissed)([^A-Za-z]|$)'
+      if ! printf '%s\n' "$DA_BLOCK" | grep -qE "$da_row_re"; then
+        GATE12_VIOLATION="denied_actions fence is present but carries no schema-valid disposed row for the $DENIED_COUNT transcript rejection(s) — a row must be '- denied: \"<verbatim question>\" | tool: <name> | source: user_rejection | confessed: yes|no | disposition: promoted (finding #N)|noted|dismissed (<reason>)'; a bare 'disposition:' line is not a row, and an enumerated-but-undisposed rejection is the same silent drop the lane exists to prevent"
       fi
     fi
   fi

--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -1054,6 +1054,78 @@ if [ "$GATE10_ELIGIBLE" = "true" ] && [ "$CRITIC_RAN" = "true" ] && [ -n "$CRITI
   done <<< "$CRITIC_ROOTS"
 fi
 
+# Gate-12 (denied-action coverage, issue #1013). Every other lane keys on
+# something that HAPPENED. An action the user refused has no outcome, so it
+# leaves no error, no correction and no confession — and selection by ease of
+# recall never reaches it. In the motivating session the scan was genuinely
+# exhaustive (13,324 records, all 56 is_error bodies read individually) and all
+# five friction slots still went to already-confessed incidents, while the
+# largest-damage item (a rejected approval reopened by an adjacent utterance,
+# ~295M objects) appeared in no lane.
+#
+# The oracle is the LIVE TRANSCRIPT, not the agent's fence — same reason Gate-10
+# reads the critic's subagent return rather than a pasted block: a report cannot
+# self-certify that it enumerated what it was supposed to enumerate. The scan is
+# the shared structural enumerator pre-scan lane 6 uses
+# (hooks/_lib/_transcript.py::scan_user_rejections — toolDenialKind plus
+# is_error plus the runtime's fixed refusal sentence), so lane and gate cannot
+# drift into two definitions of "rejected".
+#
+# SUPPLY GATE, deliberately weak: one disposed row clears it. It forces the
+# unconfessed candidates onto the record; it cannot judge which one deserved a
+# finding slot, and a single `disposition: dismissed` satisfies the letter of it
+# (issue #1013's own stated limit). The real lever stays the externalized critic
+# (Gate-8c/Gate-10); this is the cheap backstop for when the critic does not run.
+#
+# Same Stage-4 carve-out and fence discipline as Gate-8/Gate-11 — a
+# positive-presence gate must not retroactively block a completed cycle.
+#
+# Fail-open at every step: no python3, an unreadable/oversize transcript, or any
+# scanner error yields 0 and the gate stays silent.
+GATE12_VIOLATION=""
+if [ "$STAGE4_AFTER_REPORT" != "1" ] && command -v python3 >/dev/null 2>&1; then
+  DENIED_COUNT=$(python3 - "$_SP_LIB" "$TRANSCRIPT_PATH" 2>/dev/null <<'PY'
+import sys
+sys.path.insert(0, sys.argv[1])
+try:
+    from _transcript import scan_user_rejections
+    print(len(scan_user_rejections(sys.argv[2])))
+except Exception:
+    print(0)
+PY
+)
+  DENIED_COUNT=$(printf '%s' "$DENIED_COUNT" | tr -cd '0-9')
+  [ -z "$DENIED_COUNT" ] && DENIED_COUNT=0
+  if [ "$DENIED_COUNT" -gt 0 ]; then
+    re_db='^[[:space:]]*<!--[[:space:]]*retrospect:denied_actions begin[[:space:]]*-->[[:space:]]*$'
+    re_de='^[[:space:]]*<!--[[:space:]]*retrospect:denied_actions end[[:space:]]*-->[[:space:]]*$'
+    da_begin=$(printf '%s\n' "$MOST_RECENT_BLOCK" | grep -cE "$re_db" || true)
+    da_malformed=$(printf '%s\n' "$MOST_RECENT_BLOCK" | awk -v sb="$re_db" -v se="$re_de" '
+      $0 ~ sb { if (ins) nested=1; ins=1; next }
+      $0 ~ se { ins=0; next }
+      END { print (ins || nested) ? 1 : 0 }')
+    if [ "$da_begin" -lt 1 ]; then
+      GATE12_VIOLATION="the live transcript carries $DENIED_COUNT structurally-rejected tool call(s) but the Stage 3 report has no '<!-- retrospect:denied_actions begin/end -->' fence (issue #1013) — a refused action has no outcome and therefore no confession, which is precisely why the friction scan misses it; emit pre-scan lane 6 with one row per rejection: '- denied: \"<verbatim question>\" | tool: <name> | source: user_rejection | confessed: yes|no | disposition: promoted (finding #N)|noted|dismissed (<reason>)'"
+    elif [ "$da_malformed" -gt 0 ]; then
+      GATE12_VIOLATION="denied_actions fence is malformed (an unterminated or nested 'retrospect:denied_actions begin') — emit exactly one well-formed begin/end fence before Stage 3"
+    elif [ "$da_begin" -gt 1 ]; then
+      GATE12_VIOLATION="Stage 3 report has $da_begin denied_actions fences — emit exactly one; multiple fences let a disposed rejection mask an ignored one"
+    else
+      DA_BLOCK=$(printf '%s\n' "$MOST_RECENT_BLOCK" | awk -v sb="$re_db" -v se="$re_de" '
+        $0 ~ sb { ins=1; buf=""; next }
+        $0 ~ se { if (ins) last=buf; ins=0; next }
+        ins { buf = buf $0 "\n" }
+        END { printf "%s", last }')
+      # "Ignored ALL of them" is the block condition: one disposed row clears the
+      # gate. The disposition value is anchored so a prose sentence containing
+      # the word "dismissed" cannot stand in for a row.
+      if ! printf '%s\n' "$DA_BLOCK" | grep -qE 'disposition:[[:space:]]*(promoted|noted|dismissed)([^A-Za-z]|$)'; then
+        GATE12_VIOLATION="denied_actions fence is present but not one of the $DENIED_COUNT transcript rejection(s) carries a disposition — each row needs 'disposition: promoted (finding #N)' / 'noted' / 'dismissed (<reason>)'; an enumerated-but-undisposed rejection is the same silent drop the lane exists to prevent"
+      fi
+    fi
+  fi
+fi
+
 # Decide block.
 should_block=false
 reason_parts=()
@@ -1138,6 +1210,10 @@ if [ -n "$GATE11_VIOLATION" ]; then
   should_block=true
   reason_parts+=("Gate-11: $GATE11_VIOLATION")
 fi
+if [ -n "$GATE12_VIOLATION" ]; then
+  should_block=true
+  reason_parts+=("Gate-12: $GATE12_VIOLATION")
+fi
 
 if [ "$should_block" = "true" ]; then
   _log="$(praxis_resolve_writable scope-confirm retrospect-mix-blocked.log)"
@@ -1153,7 +1229,7 @@ if [ "$should_block" = "true" ]; then
     fi
   done
 
-  full_reason="Retrospect mix-check gate triggered. ${reason}. Fix guide: Gate-1 → relabel finding category via skills/retrospect/references/stage1-2-analysis.md; Gate-2 → supply either (a) 5-line 'not <action>: <reason>' rationale (Schema A) or (b) 1-2 'not-others: <dim-tags>' lines (Schema B, issue #285) in Stage 2.5; Gate-3 verdict → return to skills/retrospect/references/stage2.5-audit.md and re-evaluate evidence robustness for 2-action findings; Gate-3 backing_repo → return to skills/retrospect/references/stage1-2-analysis.md action assignment (step 7) and add 'backing_repo: <owner/repo>' to Rationale cell; Gate-4 → return to skills/retrospect/references/stage2.5-audit.md Gate-4 and re-run external-repo classification; ensure gate_4_verdict is emitted in the distribution card; Gate-7 → post-compaction session: emit a '<!-- retrospect:transcript_receipt begin/end -->' fence with the real full-transcript scan output (or the 'retrospect:transcript_receipt_skipped: transcript unreachable' line when the jsonl is genuinely unreachable); include both 'is_error_count: N' and 'content_error_count: N' fields; when content_error_count > 0 add a '<!-- retrospect:content_error_enum begin/end -->' block with per-signal promote/note/dismiss disposition rows (issue #670); Gate-8 → emit a '<!-- retrospect:suppression_ledger begin/end -->' fence carrying 'worst_agent_failure:', 'self_adversarial:', and 'critic_diff:' lines (the Stage 2 self-incrimination pass plus conditional externalized critic tier record, mandatory on every path incl. the clean one), and do not claim none-found/clean when live transcript signals exceed tolerance — surface or justify those signals before Stage 3; Gate-11 → emit a '<!-- retrospect:remedy_reach begin/end -->' fence with one row per remedy-layer finding ('- finding #N: reach=full|partial|none | surface: <layer> | unreached: <axis or none> | worse_axis: yes|no|na'), naming the axis the remedy's surface structurally cannot reach instead of describing the shortfall as legitimate. See skills/retrospect/references/stage1-2-analysis.md self-incrimination pass and skills/retrospect/references/stage3-reporting.md."
+  full_reason="Retrospect mix-check gate triggered. ${reason}. Fix guide: Gate-1 → relabel finding category via skills/retrospect/references/stage1-2-analysis.md; Gate-2 → supply either (a) 5-line 'not <action>: <reason>' rationale (Schema A) or (b) 1-2 'not-others: <dim-tags>' lines (Schema B, issue #285) in Stage 2.5; Gate-3 verdict → return to skills/retrospect/references/stage2.5-audit.md and re-evaluate evidence robustness for 2-action findings; Gate-3 backing_repo → return to skills/retrospect/references/stage1-2-analysis.md action assignment (step 7) and add 'backing_repo: <owner/repo>' to Rationale cell; Gate-4 → return to skills/retrospect/references/stage2.5-audit.md Gate-4 and re-run external-repo classification; ensure gate_4_verdict is emitted in the distribution card; Gate-7 → post-compaction session: emit a '<!-- retrospect:transcript_receipt begin/end -->' fence with the real full-transcript scan output (or the 'retrospect:transcript_receipt_skipped: transcript unreachable' line when the jsonl is genuinely unreachable); include both 'is_error_count: N' and 'content_error_count: N' fields; when content_error_count > 0 add a '<!-- retrospect:content_error_enum begin/end -->' block with per-signal promote/note/dismiss disposition rows (issue #670); Gate-8 → emit a '<!-- retrospect:suppression_ledger begin/end -->' fence carrying 'worst_agent_failure:', 'self_adversarial:', and 'critic_diff:' lines (the Stage 2 self-incrimination pass plus conditional externalized critic tier record, mandatory on every path incl. the clean one), and do not claim none-found/clean when live transcript signals exceed tolerance — surface or justify those signals before Stage 3; Gate-11 → emit a '<!-- retrospect:remedy_reach begin/end -->' fence with one row per remedy-layer finding ('- finding #N: reach=full|partial|none | surface: <layer> | unreached: <axis or none> | worse_axis: yes|no|na'), naming the axis the remedy's surface structurally cannot reach instead of describing the shortfall as legitimate; Gate-12 → run pre-scan lane 6 (denied_actions) and emit a '<!-- retrospect:denied_actions begin/end -->' fence with one disposed row per structurally-rejected tool call in the transcript ('- denied: \"<verbatim question>\" | tool: <name> | source: user_rejection | confessed: yes|no | disposition: promoted (finding #N)|noted|dismissed (<reason>)') — a refused action has no outcome, so nothing was written about it and the friction scan cannot reach it. See skills/retrospect/references/stage1-2-analysis.md self-incrimination pass and skills/retrospect/references/stage3-reporting.md."
   PRAXIS_FIRE_DECISION=block
   jq -n --arg r "$full_reason" '{decision: "block", reason: $r}'
   exit 0

--- a/hooks/completion-verify/retrospect-mix-check/spec.md
+++ b/hooks/completion-verify/retrospect-mix-check/spec.md
@@ -52,6 +52,8 @@ of the following hold:
 | Gate-8b (issue #701): `suppression_ledger` claims a clean/no-failure path while a live transcript scan finds more than one deterministic adverse signal                                                                                             | The ledger exists but launders away visible evidence. The hook re-derives `is_error:true`, content-error syntax, and documented `user_correction` markers on user turns before trusting clean ledger language                                                                                                                                     |
 | Gate-8c (issue #715): `critic_diff: not-run` while a live transcript scan finds more than one explicit user-correction marker (tighter `sl_strong_correction_re`, not Gate-8b's broad regex)                                                        | The externalized critic tier — the only anti-concealment mechanism that survives the self-correction literature — was self-skipped in exactly the case its predicate ("a friction_event required user correction") was satisfied. Converts the run-the-critic guidance from unenforced self-feedback into a deterministic format gate             |
 
+| Gate-12 (issue #1013): the live transcript carries at least one structurally-rejected tool call and the report has no `retrospect:denied_actions` fence, has more than one, has a malformed one, or carries no row with a `disposition:` token | Every other lane keys on something that happened; a refused action has no outcome, so it leaves no error, no correction and no confession, and selection by ease of recall never reaches it. Shares Gate-8's Stage-4 carve-out |
+
 ### Gate-11 remedy-reach receipt (issue #917)
 
 A remedy only works on the surface it lives on. The recurring failure this gate
@@ -100,6 +102,80 @@ never named.
 
 Shares Gate-8's Stage-4 carve-out: a positive-presence gate must not
 retroactively block a cycle that already reached `## Actions Executed`.
+
+### Gate-12 denied-action coverage (issue #1013)
+
+The retrospect pipeline enforces a full-corpus scan but does not constrain what
+gets **selected** from it, so selection sorts by ease of recall rather than by
+damage. In the motivating session the scan really was exhaustive — 13,324
+records, all 56 `is_error` bodies read individually, tool census reconciled —
+and all five friction slots still went to incidents the agent had already
+confessed in conversation. The three failures the external critic recovered
+appeared in no lane, and the common factor was that **it never ran**: a machine
+guard or the user stopped it, so no outcome existed and nothing was written
+down. The less recovery signal an item carries, the larger its damage can be.
+
+Pre-scan lane 6 (`denied_actions`) supplies those candidates; Gate-12 makes the
+supply non-optional.
+
+**The oracle is the live transcript, not the fence.** Like Gate-10 (which reads
+the critic's subagent return rather than a pasted block), Gate-12 re-derives the
+denied set itself, via the shared enumerator
+`hooks/_lib/_transcript.py::scan_user_rejections`. A record counts only when
+three independent structural markers agree:
+
+| Marker | Field |
+| --- | --- |
+| Denial kind | top-level `toolDenialKind == "user-rejected"` |
+| Error flag | the `tool_result` block's `is_error: true` |
+| Fixed sentence | the runtime's `"The user doesn't want to proceed with this tool use…"` |
+
+No natural-language judgement is made anywhere: an option label reading "No" is
+never classified as a refusal. The same scanner backs the `#1007`
+`rejected-mutation-reconsent-gate`, so the lane, the gate and the preflight gate
+cannot drift into three definitions of "rejected". The gate is **tool-agnostic**
+— a rejected `Bash` call counts as much as a rejected `AskUserQuestion`; only
+the #1007 preflight gate narrows to approval questions.
+
+When at least one rejection exists, the report must carry exactly one
+well-formed fence with at least one disposed row:
+
+```markdown
+- denied: "<verbatim question>" | tool: <name> | source: user_rejection | confessed: yes|no | disposition: promoted (finding #N)|noted|dismissed (<reason>)
+```
+
+**Supply gate, deliberately weak — stated, not hidden.** One disposed row clears
+it. It forces the unconfessed candidates onto the record; it cannot judge which
+one deserved a finding slot, and a single `disposition: dismissed` satisfies the
+letter of it. That is issue #1013's own known limit (`confessed: yes/no` is a
+proxy, and the unreached axis is the larger-damage one). The real lever remains
+the externalized critic (Gate-8c / Gate-10); Gate-12 is the cheap backstop for
+when the critic does not run. A passing Gate-12 is not evidence of a clean
+session.
+
+**Half-coverage, stated.** Issue #1013 names a second unconfessed source —
+mutations stopped by a hook or command classifier. That half is **not
+mechanizable today**, verified rather than assumed:
+
+- `hooks/_lib/_fire_ledger.py` records `hook`, `role`, `decision`, `session_id`
+  and `tool`, and never the command text — a ledger-driven lane could say "a
+  preflight gate blocked something" but not what;
+- its COARSE standalone path (`record_standalone_fire`) writes
+  `session_id: ""`, so those records cannot even be attributed to the session
+  under analysis;
+- in the transcript a hook/classifier block arrives as an ordinary `is_error`
+  tool_result with **no** `toolDenialKind` field (probe on a real 659-event
+  session: 2 `toolDenialKind` records, both `user-rejected`; 5 `is_error`
+  tool_results, the hook-block one carrying only `Exit code 2` and command
+  output) — indistinguishable from a failed command without parsing
+  block-message prose, i.e. exactly the judgement this lane refuses to make.
+
+Blocked-mutation candidates therefore remain the `is_error` enumeration's job
+and the critic's.
+
+Shares Gate-8's Stage-4 carve-out, and fails open at every step: no `python3`,
+an unreadable or oversize transcript, or any scanner error yields a count of 0
+and a silent gate.
 
 ### Gate-7 value check (issue #671)
 
@@ -328,6 +404,9 @@ The hook exits 0 (passes) when any of:
   the 3 identifier conditions fails)
 - `jq` is not installed
 - The distribution-card fence is malformed (parse error)
+- (Gate-12 only) `python3` is unavailable, or the shared rejection scanner
+  cannot read the transcript / hits its 20 MB bound — the denied count is 0 and
+  the gate stays silent
 
 ### No bypass marker
 
@@ -419,6 +498,17 @@ plus 11 synthetic regression fixtures:
    block; RR9 row without `worse_axis:` → block; RR10 empty `unreached:` value
    → block; RR11 prefixed field labels (`unreach=`, `nonsurface:`) → block;
    RR12 card declares a remedy but no findings row parses as one → block
+- 13 Gate-12 denied-action coverage (issue #1013): DA1 transcript rejection + no
+   fence → block; DA2 rejection + fence with a disposed row → pass; DA3 fence
+   with an undisposed row → block; DA4 empty fence → block; DA5 unterminated
+   fence → block; DA6 duplicate fences → block; DA7 rejected `Bash` call +
+   disposed row → pass (the lane is tool-agnostic); DA8 rejected `Bash` call +
+   no fence → block; DA9 ×3 one structural marker dropped (`is_error`,
+   fixed sentence, `toolDenialKind`) → pass; DA12 ordinary `is_error` tool
+   failure → pass; DA13 Stage-4 Actions Executed → pass (carve-out). Every
+   other case in the suite is an additional silent control: none of them carry
+   a rejection record, so a Gate-12 that fired on the wrong signal would break
+   them rather than pass quietly.
 
 ### Category counts (memory_hygiene, output_quality)
 

--- a/hooks/completion-verify/retrospect-mix-check/spec.md
+++ b/hooks/completion-verify/retrospect-mix-check/spec.md
@@ -52,7 +52,7 @@ of the following hold:
 | Gate-8b (issue #701): `suppression_ledger` claims a clean/no-failure path while a live transcript scan finds more than one deterministic adverse signal                                                                                             | The ledger exists but launders away visible evidence. The hook re-derives `is_error:true`, content-error syntax, and documented `user_correction` markers on user turns before trusting clean ledger language                                                                                                                                     |
 | Gate-8c (issue #715): `critic_diff: not-run` while a live transcript scan finds more than one explicit user-correction marker (tighter `sl_strong_correction_re`, not Gate-8b's broad regex)                                                        | The externalized critic tier — the only anti-concealment mechanism that survives the self-correction literature — was self-skipped in exactly the case its predicate ("a friction_event required user correction") was satisfied. Converts the run-the-critic guidance from unenforced self-feedback into a deterministic format gate             |
 
-| Gate-12 (issue #1013): the live transcript carries at least one structurally-rejected tool call and the report has no `retrospect:denied_actions` fence, has more than one, has a malformed one, or carries no row with a `disposition:` token | Every other lane keys on something that happened; a refused action has no outcome, so it leaves no error, no correction and no confession, and selection by ease of recall never reaches it. Shares Gate-8's Stage-4 carve-out |
+| Gate-12 (issue #1013): the live transcript carries at least one structurally-rejected tool call and the report has no `retrospect:denied_actions` fence, has more than one, has a malformed one, or carries no schema-valid disposed row (the whole row is matched — `denied` / `tool` / `source: user_rejection` / `confessed: yes\|no` / `disposition`, anchored at the list marker — so a lone `disposition:` line cannot buy the gate off) | Every other lane keys on something that happened; a refused action has no outcome, so it leaves no error, no correction and no confession, and selection by ease of recall never reaches it. Shares Gate-8's Stage-4 carve-out |
 
 ### Gate-11 remedy-reach receipt (issue #917)
 
@@ -146,8 +146,11 @@ well-formed fence with at least one disposed row:
 
 **Supply gate, deliberately weak — stated, not hidden.** One disposed row clears
 it. It forces the unconfessed candidates onto the record; it cannot judge which
-one deserved a finding slot, and a single `disposition: dismissed` satisfies the
-letter of it. That is issue #1013's own known limit (`confessed: yes/no` is a
+one deserved a finding slot, and a single schema-valid row carrying
+`disposition: dismissed` satisfies the letter of it. What it no longer accepts
+is a *bare* `disposition:` line — the row must name what was denied, on which
+tool, and whether it was confessed, so the weak gate still costs an enumeration
+rather than one word. That is issue #1013's own known limit (`confessed: yes/no` is a
 proxy, and the unreached axis is the larger-damage one). The real lever remains
 the externalized critic (Gate-8c / Gate-10); Gate-12 is the cheap backstop for
 when the critic does not run. A passing Gate-12 is not evidence of a clean

--- a/skills/retrospect/references/report-template.md
+++ b/skills/retrospect/references/report-template.md
@@ -25,6 +25,13 @@ non-empty, so a single category-assumed row is not a substitute for reading
 each body individually [issue #720]. Omit the nested enum block only when
 `is_error_count == 0` (nothing to enumerate).
 
+The `retrospect:denied_actions` fence (§3d′) is emitted whenever pre-scan lane 6
+produced a row, in any session — it is **not** post-compaction-only. Like the
+receipt it **IS parsed by the Stop hook (Gate-12)**, and against a transcript
+oracle rather than the fence itself: when the live transcript carries a
+structural user rejection and no row disposes of one, Stage 3 blocks [issue
+#1013]. Omit the whole block only when the lane found zero rejections.
+
 ```markdown
 ## Retrospect Report — {session_date}
 
@@ -55,6 +62,10 @@ Hygiene Scan Trail
 <!-- retrospect:self_correction begin -->
 - corrective: "{verbatim corrective-call excerpt}" | prior: "{verbatim prior-call excerpt}" | signature: {oracle-mismatch|wrong-target|basis-change} | reason: {why judged not-a-self-correction} | cite: {turn ref}
 <!-- retrospect:self_correction end -->
+
+<!-- retrospect:denied_actions begin -->
+- denied: "{verbatim rejected question, or one-line tool summary}" | tool: {AskUserQuestion|Bash|…} | source: user_rejection | confessed: {yes|no} | disposition: {promoted (finding #N)|noted|dismissed (<reason>)}
+<!-- retrospect:denied_actions end -->
 
 <!-- retrospect:transcript_receipt begin -->
 $ grep -c '"is_error":true' {transcript_path}

--- a/skills/retrospect/references/report-template.md
+++ b/skills/retrospect/references/report-template.md
@@ -29,8 +29,8 @@ The `retrospect:denied_actions` fence (§3d′) is emitted whenever pre-scan lan
 produced a row, in any session — it is **not** post-compaction-only. Like the
 receipt it **IS parsed by the Stop hook (Gate-12)**, and against a transcript
 oracle rather than the fence itself: when the live transcript carries a
-structural user rejection and no row disposes of one, Stage 3 blocks [issue
-#1013]. Omit the whole block only when the lane found zero rejections.
+structural user rejection and no row disposes of one, Stage 3 blocks
+[issue #1013]. Omit the whole block only when the lane found zero rejections.
 
 ```markdown
 ## Retrospect Report — {session_date}

--- a/skills/retrospect/references/stage1-2-analysis.md
+++ b/skills/retrospect/references/stage1-2-analysis.md
@@ -202,6 +202,8 @@ the last 50 turns. Post-compaction sessions must use the available transcript
 jsonl when readable and emit the Stage 3 transcript receipt trail. The same
 scope window applies to `tool_census`, `user_correction`, and
 `self_correction`, so their counts and early-exit decisions share one oracle.
+`denied_actions` (lane 6) is the deliberate exception — it reads the whole
+readable transcript; see its own entry for why.
 
 **Sidechain (subagent) inclusion — observation layer (MUST, issue #763).**
 The friction/error lanes (`friction_events`, `tool_census`, `self_correction`,
@@ -277,17 +279,70 @@ including sidechain friction here carries no enforcement risk.
      `user_correction` events and before narrative-only events for retained
      `friction_events` slots
    - false-positive drops must be recorded in the ledger
+6. **`denied_actions`**
+   - deterministic enumeration of actions the user REFUSED (issue #1013)
+   - every other lane keys on something that happened. A refused action has no
+     outcome, so it leaves no error, no correction, and no confession — which is
+     exactly why selection by ease of recall never reaches it, and why its
+     damage can be the largest in the session (the canonical instance: a
+     rejected approval reopened by an adjacent utterance, which would have
+     deleted ~295M objects)
+   - row shape:
+     - `denied` — the rejected question, verbatim, or a one-line tool summary
+     - `tool` — the tool whose call was rejected (`AskUserQuestion`, `Bash`, …)
+     - `source` — `user_rejection`
+     - `confessed` — `yes` when this item was already admitted in conversation,
+       `no` otherwise. **If every candidate across all lanes is `confessed: yes`,
+       the selection is biased** — a `no` from this lane must displace a `yes`,
+       not merely be appended
+     - `disposition` — `promoted (finding #N)`, `noted`, or
+       `dismissed (<reason>)`
+   - detection is STRUCTURAL, not linguistic: a record counts only when
+     `toolDenialKind == "user-rejected"`, its `tool_result` carries
+     `is_error: true`, AND the runtime's fixed refusal sentence is present. An
+     option label reading "No" is never classified as a refusal. The shared
+     enumerator is `hooks/_lib/_transcript.py::scan_user_rejections`, which the
+     `retrospect-mix-check` Gate-12 oracle also calls — one scanner, so the lane
+     and the gate cannot drift
+   - scope: unlike lanes 3-5 this lane reads the **whole readable transcript**,
+     not the scope window. A refusal is a standing NO that does not expire after
+     50 turns, and Gate-12 re-derives the same set from the whole transcript — a
+     narrower lane would be blocked against an oracle it never looked at
+   - emit the `retrospect:denied_actions` fence in Stage 3 whenever this lane
+     produced at least one row (see [`stage3-reporting.md`](stage3-reporting.md));
+     with zero rows, omit the fence
+
+   **Limitation — this lane covers the user-rejection half ONLY (MUST read).**
+   Issue #1013 names a second unconfessed source: mutations stopped by a
+   classifier or hook. That half is **not mechanizable today**, and the lane is
+   incomplete without it:
+
+   - `hooks/_lib/_fire_ledger.py` records `hook`, `role`, `decision`,
+     `session_id`, `tool` — and never the command text. A ledger-driven lane
+     could say "a preflight gate blocked something" but not what was blocked,
+     which is the only part a friction candidate needs.
+   - Worse, the COARSE standalone path (`record_standalone_fire`) writes
+     `session_id: ""` for every non-dispatched hook, so those records cannot
+     even be attributed to the session being analyzed.
+   - In the transcript itself a hook/classifier block arrives as an ordinary
+     `is_error` tool_result with **no** `toolDenialKind` field — indistinguishable
+     from a failed command without parsing block-message prose, i.e. the exact
+     natural-language judgement this lane refuses to make.
+
+   Treat blocked-mutation candidates as the `is_error` enumeration's job and as
+   the externalized critic's, and do not read a clean `denied_actions` fence as
+   "no unconfessed failures existed".
 
 ### Self-incrimination pass (anti-suppression, MUST)
 
-The five pre-scan lanes are deterministic and capped, so they structurally miss
+The six pre-scan lanes are deterministic and capped, so they structurally miss
 the friction the analyzing agent is most motivated to bury: its OWN failures
 that left no `user_correction` marker and do not fit the `self_correction`
 three-part signature. The analyzing context is the same context that committed
 those failures, so selection bias suppresses them silently — this is the
 "retrospect hides the painful parts" failure this pass exists to close.
 
-Run this pass AFTER the five lanes and BEFORE root-cause clustering. It is
+Run this pass AFTER the six lanes and BEFORE root-cause clustering. It is
 unconditional whenever the friction path is non-empty. Answer the adversarial
 question in writing before continuing:
 
@@ -389,7 +444,7 @@ project's normal critic subagent when available; otherwise use the closest
 available read-only review/debate agent. The brief must include:
 
 - transcript / scope window identifier
-- the five pre-scan lanes
+- the six pre-scan lanes
 - the self-incrimination pass output, carried **verbatim** — do not paraphrase,
   summarize, or soften the candidate #1-damage wording before it reaches the
   critic. A sanitized brief turns the critic into an echo chamber (issue #715):

--- a/skills/retrospect/references/stage3-reporting.md
+++ b/skills/retrospect/references/stage3-reporting.md
@@ -18,6 +18,7 @@ Stage 3 output MUST emit, in this order:
    - `retrospect:tool_census`
    - `retrospect:user_correction`
    - `retrospect:self_correction`
+   - `retrospect:denied_actions` when pre-scan lane 6 produced at least one row
    - `retrospect:transcript_receipt` in post-compaction sessions
 6. Stage 2.7 audit trail or skip marker
    - `<!-- retrospect:audit_skipped: no artifacts -->`
@@ -245,6 +246,52 @@ reads the critic's transcript return):
 <!-- retrospect:critic_roots end -->
 ```
 
+## Denied-action coverage (Gate-12, issue #1013)
+
+Every other lane keys on something that happened. An action the user **refused**
+has no outcome, so it leaves no error, no correction, and no confession — and
+selection by ease of recall never reaches it. In the session that motivated this
+gate the scan was genuinely exhaustive (13,324 records, all 56 `is_error` bodies
+read individually) and all five friction slots still went to incidents the agent
+had already confessed in conversation; the largest-damage item — a rejected
+approval reopened by an adjacent utterance, which would have deleted ~295M
+objects — appeared in no lane.
+
+When pre-scan lane 6 (see [`stage1-2-analysis.md`](stage1-2-analysis.md))
+produced at least one row, Stage 3 MUST emit them:
+
+```markdown
+<!-- retrospect:denied_actions begin -->
+- denied: "{verbatim rejected question, or one-line tool summary}" | tool: {AskUserQuestion|Bash|…} | source: user_rejection | confessed: {yes|no} | disposition: {promoted (finding #N)|noted|dismissed (<reason>)}
+<!-- retrospect:denied_actions end -->
+```
+
+Emit the fence as **bare markdown in the report body**, not inside a fenced code
+block — the Stop hook strips fenced code before parsing (same discipline as the
+suppression ledger). With zero lane rows, omit the fence entirely.
+
+`retrospect-mix-check` Gate-12 re-derives the denied set from the **live
+transcript** with the same structural scanner the lane uses
+(`hooks/_lib/_transcript.py::scan_user_rejections` — `toolDenialKind ==
+"user-rejected"` plus `is_error: true` plus the runtime's fixed refusal
+sentence), so the agent's fence is not the oracle. It blocks when the transcript
+carries at least one rejection and **not one** of them is disposed of: no fence,
+an empty fence, or rows with no `disposition:` token all read as ignored.
+
+**What this gate is and is not.** It is a *supply* gate: it forces the
+unconfessed candidates onto the record, and one disposed row clears it. It
+cannot judge whether the right one was promoted, and a single
+`disposition: dismissed` row satisfies the letter of it — the issue's own known
+limit, restated here so nobody reads a passing Gate-12 as a clean session. The
+real lever remains the externalized critic (Gate-8c / Gate-10); this is the
+cheap backstop for when the critic does not run.
+
+**Half-coverage, stated.** Gate-12 sees user rejections only. Mutations stopped
+by a hook or command classifier — the issue's second unconfessed source — are
+not mechanizable today; see the limitation block under lane 6 for the evidence
+(`_fire_ledger.py` stores no command text, and its coarse path stores an empty
+`session_id`).
+
 ## Per-finding plan contract
 
 For every non-note-only finding, Stage 3 must explain:
@@ -404,6 +451,9 @@ Stop and return to Stage 2 / Stage 2.5 when any of these are true:
   lines.
 - Silently dropping an agent-caused failure the self-incrimination pass surfaced
   (a `justified-drop` needs an explicit reason in the ledger).
+- Omitting the `retrospect:denied_actions` fence, or emitting it with no
+  `disposition:` on any row, when the transcript carries a user rejection
+  (Gate-12).
 
 ## Quick Reference
 
@@ -430,7 +480,8 @@ Do not run Stage 4 until the user explicitly approves the finding.
 ## Co-update note
 
 Any schema drift here — including the `retrospect:suppression_ledger` fence
-(Gate-8) — must be co-updated with:
+(Gate-8) and the `retrospect:denied_actions` fence (Gate-12) — must be
+co-updated with:
 
 - `hooks/completion-verify/retrospect-mix-check/impl.sh`
 - `tests/hooks/completion-verify/test_retrospect_mix_check.sh`

--- a/tests/hooks/completion-verify/test_retrospect_mix_check.sh
+++ b/tests/hooks/completion-verify/test_retrospect_mix_check.sh
@@ -2564,6 +2564,139 @@ RR12_TEXT="$(mk_stage3_no_remedy_reach "$RR12_CARD" "$RR12_ROW")"
 run_case "RR12_block_card_remedy_without_table_row" "block" \
   "$(mk_assistant "$RR12_TEXT")"
 
+# ---------------------------------------------------------------------------
+# Gate-12 — denied-action coverage (issue #1013)
+#
+# The oracle is the LIVE TRANSCRIPT, not the report: `mk_user_rejection` emits
+# the record shape copied from a real session (toolDenialKind + is_error + the
+# runtime's fixed refusal sentence, joined through sourceToolAssistantUUID).
+# Both directions are pinned — every case above already proves the silent
+# direction (none of them carry a rejection record), and DA1/DA2 below prove it
+# again against the two near-misses that would make the gate fire on everything:
+# a rejection missing one structural marker, and an ordinary is_error result.
+# ---------------------------------------------------------------------------
+
+# mk_user_rejection <tool_name> <question_text> [drop_marker]
+#   drop_marker: "" (complete) | "is_error" | "sentence" | "denial_kind"
+# Emits TWO JSONL lines: the assistant tool_use and the rejection record.
+mk_user_rejection() {
+  local tool="$1" question="$2" drop="${3:-}"
+  python3 - "$tool" "$question" "$drop" <<'PY'
+import json, sys
+tool, question, drop = sys.argv[1], sys.argv[2], sys.argv[3]
+sentence = ("The user doesn't want to proceed with this tool use. The tool use "
+            "was rejected (eg. if it was a file edit, the new_string was NOT "
+            "written to the file). STOP what you are doing and wait for the "
+            "user to tell you how to proceed.")
+if drop == "sentence":
+    sentence = "Tool call failed."
+tool_input = ({"questions": [{"question": question}]}
+              if tool == "AskUserQuestion" else {"command": question})
+assistant = {"type": "assistant", "uuid": "asst-rej-1", "isSidechain": False,
+             "message": {"role": "assistant", "content": [
+                 {"type": "tool_use", "id": "toolu_DENIED1",
+                  "name": tool, "input": tool_input}]}}
+block = {"type": "tool_result", "tool_use_id": "toolu_DENIED1", "content": sentence}
+if drop != "is_error":
+    block["is_error"] = True
+rejection = {"type": "user", "uuid": "rej-1", "timestamp": "2026-08-15T00:00:00Z",
+             "toolUseResult": "User rejected tool use",
+             "sourceToolAssistantUUID": "asst-rej-1",
+             "message": {"role": "user", "content": [block]}}
+if drop != "denial_kind":
+    rejection["toolDenialKind"] = "user-rejected"
+print(json.dumps(assistant))
+print(json.dumps(rejection))
+PY
+}
+
+DA_FENCE='<!-- retrospect:denied_actions begin -->
+- denied: "Delete the remaining ~295M objects under s3://acme-archive/raw/2024/ ?" | tool: AskUserQuestion | source: user_rejection | confessed: no | disposition: promoted (finding #1)
+<!-- retrospect:denied_actions end -->'
+
+DA_QUESTION='Delete the remaining ~295M objects under s3://acme-archive/raw/2024/ ?'
+
+# DA1: block — a structural rejection in the transcript, no denied_actions fence.
+DA1_TRANSCRIPT="$(mk_user_rejection AskUserQuestion "$DA_QUESTION")
+$(mk_assistant "$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")")"
+run_case "DA1_block_rejection_without_denied_actions_fence" "block" "$DA1_TRANSCRIPT"
+
+# DA2: pass — same rejection, fence present with a disposed row. One disposed
+# row clears the gate; this is the supply-gate contract, stated as a test so the
+# weakness is pinned rather than assumed away.
+DA2_TRANSCRIPT="$(mk_user_rejection AskUserQuestion "$DA_QUESTION")
+$(mk_assistant "$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+$DA_FENCE")"
+run_case "DA2_pass_rejection_with_disposed_row" "pass" "$DA2_TRANSCRIPT"
+
+# DA3: block — fence present but every row is undisposed. Enumerating a
+# rejection and then dropping it silently is the failure the lane exists for.
+DA3_FENCE='<!-- retrospect:denied_actions begin -->
+- denied: "Delete the remaining ~295M objects" | tool: AskUserQuestion | source: user_rejection | confessed: no
+<!-- retrospect:denied_actions end -->'
+DA3_TRANSCRIPT="$(mk_user_rejection AskUserQuestion "$DA_QUESTION")
+$(mk_assistant "$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+$DA3_FENCE")"
+run_case "DA3_block_fence_without_disposition" "block" "$DA3_TRANSCRIPT"
+
+# DA4: block — empty fence. Structurally well-formed, zero rows.
+DA4_TRANSCRIPT="$(mk_user_rejection AskUserQuestion "$DA_QUESTION")
+$(mk_assistant "$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+<!-- retrospect:denied_actions begin -->
+<!-- retrospect:denied_actions end -->")"
+run_case "DA4_block_empty_denied_actions_fence" "block" "$DA4_TRANSCRIPT"
+
+# DA5: block — unterminated fence (malformed), mirroring the Gate-8/11 defense.
+DA5_TRANSCRIPT="$(mk_user_rejection AskUserQuestion "$DA_QUESTION")
+$(mk_assistant "$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+<!-- retrospect:denied_actions begin -->
+- denied: \"x\" | tool: AskUserQuestion | source: user_rejection | confessed: no | disposition: noted")"
+run_case "DA5_block_malformed_denied_actions_fence" "block" "$DA5_TRANSCRIPT"
+
+# DA6: block — two fences; a disposed one must not mask an ignored one.
+DA6_TRANSCRIPT="$(mk_user_rejection AskUserQuestion "$DA_QUESTION")
+$(mk_assistant "$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+$DA_FENCE
+$DA_FENCE")"
+run_case "DA6_block_duplicate_denied_actions_fences" "block" "$DA6_TRANSCRIPT"
+
+# DA7: pass — a rejection joined to a Bash tool_use still counts (the LANE is
+# tool-agnostic; only the #1007 preflight gate filters to AskUserQuestion), so
+# this case must still carry a disposed row. It pins that the gate does not
+# silently narrow to AskUserQuestion.
+DA7_TRANSCRIPT="$(mk_user_rejection Bash 'aws s3 rm s3://acme-archive/raw/2024/ --recursive')
+$(mk_assistant "$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+$DA_FENCE")"
+run_case "DA7_pass_bash_rejection_with_disposed_row" "pass" "$DA7_TRANSCRIPT"
+
+DA8_TRANSCRIPT="$(mk_user_rejection Bash 'aws s3 rm s3://acme-archive/raw/2024/ --recursive')
+$(mk_assistant "$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")")"
+run_case "DA8_block_bash_rejection_without_fence" "block" "$DA8_TRANSCRIPT"
+
+# DA9-DA11: silent controls. Each drops exactly one of the three structural
+# markers; a scan that fired on any of them would also fire on ordinary tool
+# failures, which is the false-positive class that would make Gate-12 unusable.
+for _drop in is_error sentence denial_kind; do
+  _t="$(mk_user_rejection AskUserQuestion "$DA_QUESTION" "$_drop")
+$(mk_assistant "$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")")"
+  run_case "DA9_${_drop}_missing_marker_is_not_a_rejection" "pass" "$_t"
+done
+
+# DA12: silent control — an ordinary failed command (is_error tool_result with a
+# real error body) is not a denial.
+DA12_TRANSCRIPT="$(jq -nc '{type:"user", message:{role:"user", content:[{type:"tool_result", tool_use_id:"toolu_FAIL", is_error:true, content:"Exit code 2"}]}}')
+$(mk_assistant "$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")")"
+run_case "DA12_pass_ordinary_tool_error_is_not_a_denial" "pass" "$DA12_TRANSCRIPT"
+
+# DA13: pass — Stage-4 carve-out. A completed cycle (Actions Executed after the
+# report) must not be retroactively blocked, same as Gate-8/Gate-11.
+DA13_TRANSCRIPT="$(mk_user_rejection AskUserQuestion "$DA_QUESTION")
+$(mk_assistant "$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+
+## Actions Executed
+- finding #1: memory entry written")"
+run_case "DA13_pass_stage4_carveout" "pass" "$DA13_TRANSCRIPT"
+
 echo
 echo "================================"
 echo "Cases:    $PASS passed, $FAIL failed"

--- a/tests/hooks/completion-verify/test_retrospect_mix_check.sh
+++ b/tests/hooks/completion-verify/test_retrospect_mix_check.sh
@@ -2664,14 +2664,54 @@ run_case "DA6_block_duplicate_denied_actions_fences" "block" "$DA6_TRANSCRIPT"
 # tool-agnostic; only the #1007 preflight gate filters to AskUserQuestion), so
 # this case must still carry a disposed row. It pins that the gate does not
 # silently narrow to AskUserQuestion.
+#
+# The receipt names Bash, matching the rejection. It previously reused
+# $DA_FENCE, whose row names AskUserQuestion — a receipt for a different tool
+# than the one refused, which made a passing case out of a mismatch and left
+# the reader no way to see that the row is supposed to describe *this*
+# rejection.
+DA7_FENCE='<!-- retrospect:denied_actions begin -->
+- denied: "aws s3 rm s3://acme-archive/raw/2024/ --recursive" | tool: Bash | source: user_rejection | confessed: no | disposition: promoted (finding #1)
+<!-- retrospect:denied_actions end -->'
 DA7_TRANSCRIPT="$(mk_user_rejection Bash 'aws s3 rm s3://acme-archive/raw/2024/ --recursive')
 $(mk_assistant "$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
-$DA_FENCE")"
+$DA7_FENCE")"
 run_case "DA7_pass_bash_rejection_with_disposed_row" "pass" "$DA7_TRANSCRIPT"
 
 DA8_TRANSCRIPT="$(mk_user_rejection Bash 'aws s3 rm s3://acme-archive/raw/2024/ --recursive')
 $(mk_assistant "$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")")"
 run_case "DA8_block_bash_rejection_without_fence" "block" "$DA8_TRANSCRIPT"
+
+# DA7a-DA7f: schema negative controls. The gate matches the whole row, so a
+# fence carrying only part of one buys nothing. The first case is the one that
+# matters most — a lone `disposition:` line is the cheapest possible way to
+# silence the lane, and before this it worked. The rest drop one field each,
+# which is what keeps the anchored regex from being satisfiable by a prefix.
+DA7_MALFORMED_ROWS=(
+  'disposition: noted'
+  '- denied: "aws s3 rm s3://acme-archive/raw/2024/ --recursive" | disposition: noted'
+  '- tool: Bash | source: user_rejection | confessed: no | disposition: noted'
+  '- denied: "x" | tool: Bash | confessed: no | disposition: noted'
+  '- denied: "x" | tool: Bash | source: user_rejection | disposition: noted'
+  '- denied: "x" | tool: Bash | source: user_rejection | confessed: maybe | disposition: noted'
+)
+DA7_MALFORMED_NAMES=(
+  bare_disposition_only
+  no_tool_source_confessed
+  no_denied
+  no_source
+  no_confessed
+  confessed_not_yes_no
+)
+for _i in "${!DA7_MALFORMED_ROWS[@]}"; do
+  _fence="<!-- retrospect:denied_actions begin -->
+${DA7_MALFORMED_ROWS[$_i]}
+<!-- retrospect:denied_actions end -->"
+  _t="$(mk_user_rejection Bash 'aws s3 rm s3://acme-archive/raw/2024/ --recursive')
+$(mk_assistant "$(mk_retrospect_stage3 "$T1_CARD" "$T1_ROW")
+$_fence")"
+  run_case "DA7_block_malformed_row_${DA7_MALFORMED_NAMES[$_i]}" "block" "$_t"
+done
 
 # DA9-DA11: silent controls. Each drops exactly one of the three structural
 # markers; a scan that fired on any of them would also fire on ordinary tool


### PR DESCRIPTION
> **Stacked on #1028.** Base is `claude/issue-1007-rejected-mutation-reconsent`, not `main` — both PRs need the same structural scanner in `hooks/_lib/_transcript.py`, and building it twice would collide. Retarget to `main` after #1028 merges.

## 결정

**옵션 B — 결정론적 `denied_actions` 레인 + Gate-12. 사용자 거부 절반만 다룬다** (유지보수자 판정).

## 게이트 판정 — 절반 충족

이슈 작업 2의 전제("두 소스 모두 기계적으로 열거 가능")를 시험했고 **갈렸다**:

**충족 — 거부된 승인.** 본문이 가정한 것보다 강하다. 전사가 `toolDenialKind: "user-rejected"` 를 최상위 필드로 싣고 `sourceToolAssistantUUID` 로 거부된 명령까지 복원된다. **휴리스틱 0.**

**미충족 — 차단된 mutation.** fire ledger 에서만 열거되는데 그 레코드는 **명령 텍스트가 없고**, 조잡한 standalone 경로는 `session_id=""` 로 저장해 한 세션으로 필터링조차 안 된다. `hooks/_lib/_fire_ledger.py` 에서 직접 확인했다.

**그래서 범위를 거부 절반으로 좁혔고, 레인 텍스트와 spec 에 그렇게 적었다** — 읽는 사람이 레인을 완전하다고 오해하지 않도록.

## 현재 커버리지가 0인 것도 실측

Stage-2 프리스캔 레인은 정확히 5개(`friction_events`, `successful_patterns`, `tool_census`, `user_correction`, `self_correction`)이고 **거부되거나 차단된 행위라는 개념이 어디에도 없다.** `grep -rci "confess" skills/retrospect/` → 전 파일 0.

## 레인 6 — `denied_actions`

공유 스캐너(`_transcript.scan_user_rejections`)로 전사에서 거부된 행위를 열거한다. 행 필드: `denied` / `tool` / `source` / `confessed` / `disposition`.

**레인 3–5와 달리 스코프 윈도우가 아니라 읽을 수 있는 전사 전체를 읽는다.** 거부는 standing NO 이고, Gate-12 가 같은 집합을 전사 전체에서 다시 유도하므로 더 좁은 레인은 **자신이 본 적 없는 오라클에 대해 차단당하게 된다.**

## Gate-12

Stage 3 리포트를 차단한다 — 살아 있는 전사에 구조적 거부가 1건 이상 있는데 `retrospect:denied_actions` 행이 그중 어느 것도 처분하지 않을 때(펜스 누락/빈 펜스/형식 오류/중복, 또는 `disposition:` 없는 행).

**오라클은 펜스가 아니라 전사다** — Gate-10 이 붙여넣은 블록이 아니라 크리틱의 서브에이전트 반환을 읽는 것과 같은 이유다. Gate-8 의 Stage-4 예외를 공유하고 fail open 한다(python3 없음, 전사 판독 불가·과대 → count 0, 침묵).

## 왜 산문이 아니라 코드인가

이슈가 서술한 산문 전용 형태(confessed 열 + all-yes 재스캔)는 **`stage1-2-analysis.md:322-328`(이슈 #715)이 이 계열에 대해 명시적으로 금지한 형태**다. 게다가 재스캔할 소스 하나가 명령 텍스트를 갖고 있지 않아, 산문 규칙은 만들 후보 행이 없다.

## 검증

```
$ bash tests/hooks/completion-verify/test_retrospect_mix_check.sh
  Cases: 159 passed, 0 failed   Fixtures: 11 passed, 0 failed
$ bash tests/test_retrospect_routing.sh      PASS: 67  FAIL: 0
```

## 미확인

- **훅이 거부한 도구 호출의 전사 형태를 확인하지 못했다.** 이 샌드박스에 훅이 설치돼 있지 않고(403 레코드 중 훅 거부 0건) PreToolUse deny 가 `toolDenialKind` 를 세우는지, 세운다면 어떤 값인지 모른다. **만약 `hook-denied` 같은 값을 세운다면 이슈의 두 번째 소스도 기계화되고 레인을 넓힐 수 있다** — 그때 이 범위 제한을 재검토할 지점이다.
- 본문이 서술한 세션(13,324 레코드, is_error 56건, 크리틱이 회수한 누락 3건)은 이 환경에 없다. 작성자 보고로 취급했고 검증하지 않았다.
- 이슈 스스로 인정한 대로 `confessed` 는 **게임 가능한 프록시**다. 진짜 레버는 독립 크리틱이고, prune 감사에 따르면 그 크리틱은 한 번도 실행된 적이 없다(0/26). 이 PR 은 후보 공급을 기계화할 뿐 선택 편향 자체를 풀지 않는다.

Closes #1013
Refs #1007

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc

---
_Generated by [Claude Code](https://claude.ai/code/session_014Q4o2BtBPpsrr19he6qVpc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added retrospective tracking for rejected tool actions.
  * Reports now include rejected action details and required disposition receipts.
* **Bug Fixes**
  * Completion checks now block reports with missing, malformed, duplicate, empty, or undisposed rejection records.
  * Improved handling of rejected actions across supported tools.
* **Documentation**
  * Updated retrospective guidance and reporting requirements for rejected actions.
* **Tests**
  * Added coverage for valid and invalid rejection receipts, tool-specific rejections, ordinary failures, and completion bypass scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->