### PR TITLE
ci(coderabbit): skip auto-review on release PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,18 @@
+# CodeRabbit configuration. Schema: https://coderabbit.ai/integrations/schema.v2.json
+#
+# release-please opens a PR whose entire diff is a CHANGELOG entry and a version
+# bump, so there is nothing for a reviewer to find -- but the review still spends
+# the plan's hourly quota that a real code PR needs (#1047).
+#
+# The discriminator is the title, not the author: release-please runs under a PAT
+# here, so the release PR's author is the repo owner rather than a bot, and
+# ignore_usernames would silence review on every PR they open.
+#
+# The keyword is the full "chore(main): release" prefix rather than bare
+# "release" -- matching is substring, and an ordinary title like
+# "fix(hooks): verify briefing before marker releases merge" contains the shorter
+# form.
+reviews:
+  auto_review:
+    ignore_title_keywords:
+      - "chore(main): release"


### PR DESCRIPTION
release-please 가 여는 릴리스 PR 은 diff 전체가 CHANGELOG 항목과 버전 범프입니다. 리뷰어가 찾을 것이 없는데도 CodeRabbit 이 매번 리뷰하고, 그 리뷰가 실제 코드 PR 이 써야 할 시간당 쿼터를 소비합니다. 2026-08-19 에 #1046 은 `0 remain after this review`, 같은 시간대의 릴리스 PR #1041 은 `Review rate limited` 를 표시했습니다.

리포에 CodeRabbit 설정 파일이 아예 없었으므로 이 파일은 신규 생성입니다.

### 판별자를 제목으로 고른 이유

작성자 필터는 쓸 수 없습니다. release-please 가 PAT 로 도는 구성이라 릴리스 PR 작성자가 봇이 아니라 리포 소유자 본인이고, `ignore_usernames` 를 쓰면 그 사용자가 여는 모든 PR 에서 리뷰가 꺼집니다.

키워드를 바로 `release` 로 두지 않고 `chore(main): release` 전체를 쓴 것은 매칭이 대소문자 무시 부분일치이기 때문입니다. #956 `fix(hooks): verify briefing before marker releases merge` 같은 일반 제목이 짧은 형태에 걸립니다.

라벨(`autorelease: pending`)도 후보였으나 라벨은 PR 생성 이후 붙어 리뷰 시작과 경합할 수 있고, 제목은 생성 시점에 확정되므로 제목을 택했습니다.

### 검증

두 가지를 실행했습니다.

CodeRabbit 이 게시하는 설정 스키마(`coderabbit.ai/integrations/schema.v2.json`)로 파일을 검증했고 통과했습니다. 스키마가 이 키를 `array of string`, 기본 `[]`, 동작을 "Skip reviews when the PR title contains any of these keywords (case-insensitive)" 로 정의합니다.

그리고 이 리포의 실제 PR 제목 120건에 키워드를 그대로 재생해 어느 것이 걸러지는지 확인했습니다. 릴리스 PR 8건만 걸러지고 112건은 리뷰 대상으로 남으며, 부분일치 위험군이던 #956 은 정상적으로 남습니다.

한계: **다음 릴리스 PR 이 열리기 전에는 실제 효과를 관측할 수 없습니다.** 위 두 검증은 설정이 유효하고 키워드가 의도한 집합을 가른다는 것까지만 보이며, CodeRabbit 이 실제로 리뷰를 건너뛰는 것을 본 것이 아닙니다.

Caller chain verified: N/A -- new config file, no symbol introduced and no call site in this repo; the consumer is the CodeRabbit service, which reads `.coderabbit.yaml` from the repo root.

Pre-commit: n/a (repo has no pre-commit hook -- `.pre-commit-config.yaml` absent, `core.hooksPath` unset, common git dir's `hooks/` holds only `.sample` files). Local equivalent run instead: schema validation via jsonschema exited 0, and the 120-title replay reported 8 skip / 112 keep.

Closes #1047
