### PR TITLE
fix(ci): retry the apt phase, not just bound it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,17 +53,9 @@ jobs:
       # ubuntu-24.04 ships shellcheck, but install explicitly so the job
       # doesn't silently depend on the runner image. Rules come from
       # .shellcheckrc at the repo root.
-      # Same phase bound as the test job's apt call (#1045): this job carried the
-      # identical unguarded exposure and its own 10-minute budget to lose. The
-      # explicit install stays -- the comment above states why the job refuses to
-      # depend on the image implicitly, and that reason is unchanged.
-      - run: |
-          sudo timeout 300 apt-get -o Acquire::Retries=3 \
-                       -o Acquire::http::Timeout=20 \
-                       -o Acquire::https::Timeout=20 update -y
-          sudo timeout 300 apt-get -o Acquire::Retries=3 \
-                       -o Acquire::http::Timeout=20 \
-                       -o Acquire::https::Timeout=20 install -y shellcheck
+      # The bound from #1046 lives in scripts/ci-apt.sh now, with a retry around
+      # it (#1049): bounding alone only made this job fail faster, never pass.
+      - run: bash scripts/ci-apt.sh shellcheck
       - run: |
           find . -name '*.sh' -not -path './.git/*' -print0 \
             | xargs -0 shellcheck --severity=warning
@@ -114,22 +106,12 @@ jobs:
       # the mirror stall below. markdownlint-cli2 still comes from npm for the
       # same reason ruff is pinned: under PRAXIS_TESTS_STRICT its absence would
       # abort the run (#917).
-      # The Acquire timeouts are load-bearing (#1045). Without them apt waits
-      # indefinitely on a mirror that stops responding mid-fetch, which consumed
-      # the entire 15-minute job budget three times over two days. Retries alone
-      # do not help -- a hang never reaches the retry. Timeout covers the data
-      # transfer, not just connect, which is where the stall actually happened.
-      # Acquire::* bounds each transfer, never the phase: N stalled files still
-      # cost N * 20s, and Retries multiplies that. `timeout` bounds the phase, so
-      # a bad mirror leaves the budget for npm and the suite. sudo wraps timeout
-      # rather than the reverse -- TERM must reach apt, not a sudo that ignores it.
-      - run: |
-          sudo timeout 300 apt-get -o Acquire::Retries=3 \
-                       -o Acquire::http::Timeout=20 \
-                       -o Acquire::https::Timeout=20 update -y
-          sudo timeout 300 apt-get -o Acquire::Retries=3 \
-                       -o Acquire::http::Timeout=20 \
-                       -o Acquire::https::Timeout=20 install -y zsh
+      # The phase bound and the retry around it both live in scripts/ci-apt.sh,
+      # which carries the reasoning (#1046 bounded the stall, #1049 made it
+      # survivable). A stalled mirror was observed killing this step three times
+      # before the bound, and again after it -- bounding made the failure fast,
+      # the retry is what can make it pass.
+      - run: bash scripts/ci-apt.sh zsh
       - run: npm install -g markdownlint-cli2
       # Strict: in CI the toolchain is installed, so a SKIPPED line means the
       # run silently stopped checking something rather than accommodating a

--- a/scripts/ci-apt.sh
+++ b/scripts/ci-apt.sh
@@ -74,16 +74,18 @@ for ((attempt = 1; attempt <= attempts; attempt++)); do
     exit 0
   fi
 
-  # timeout(1) reports the two ways it can end a run with different codes, and
-  # the difference is worth naming: 124 says TERM was enough, 137 says apt
-  # ignored it and only KILL stopped it. Folding 137 into the generic branch
-  # would hide exactly the case --kill-after exists for.
+  # 124 is timeout(1)'s own code for "TERM ended the run", so it identifies a
+  # stall. 137 does not identify anything on its own -- it is the conventional
+  # 128+SIGKILL value, which the --kill-after escalation produces, but so does
+  # an OOM kill, and a command is free to exit 137 by itself. Report what was
+  # observed and list the candidates; folding it into the generic branch would
+  # still lose the one code most worth looking at.
   case "$status" in
     124)
       echo "apt attempt ${attempt} hit the ${per_attempt}s bound (exit 124 -- mirror stalled)" >&2
       ;;
     137)
-      echo "apt attempt ${attempt} ignored TERM and was killed after the ${kill_grace}s grace (exit 137)" >&2
+      echo "apt attempt ${attempt} exited 137 (SIGKILL by convention -- timeout's ${kill_grace}s escalation, an OOM kill, or apt's own status)" >&2
       ;;
     *)
       echo "apt attempt ${attempt} failed with exit ${status}" >&2

--- a/scripts/ci-apt.sh
+++ b/scripts/ci-apt.sh
@@ -18,21 +18,6 @@
 # red further down and make it harder to read.
 set -euo pipefail
 
-if [ "$#" -eq 0 ]; then
-  echo "usage: $0 <package>..." >&2
-  exit 2
-fi
-
-packages=("$@")
-
-# 3 x 120s + 2 x 15s backoff = 6m30s worst case. Measured against the two jobs
-# that call this: `test` spends ~7m on everything else against a 15-minute
-# budget, and `shellcheck` ~35s against 10 minutes, so both absorb the worst
-# case with room left. Overridable so a caller can tune without editing here.
-attempts="${CI_APT_ATTEMPTS:-3}"
-per_attempt="${CI_APT_TIMEOUT:-120}"
-backoff="${CI_APT_BACKOFF:-15}"
-
 # Per-transfer bounds, kept from #1046. They still do useful work inside an
 # attempt; they are simply not sufficient on their own.
 apt_opts=(
@@ -41,15 +26,42 @@ apt_opts=(
   -o Acquire::https::Timeout=20
 )
 
+# One attempt = update followed by install, and it must cost ONE timeout, not
+# one each: two 120s bounds in sequence make an attempt cost up to 240s, which
+# blows the per-job budget the numbers below are chosen against. The script
+# re-invokes itself in this mode so the pair runs inside a single `timeout` and
+# `apt_opts` keeps a single definition. Not a user-facing flag.
+if [ "${1:-}" = "--run-attempt" ]; then
+  shift
+  apt-get "${apt_opts[@]}" update -y
+  apt-get "${apt_opts[@]}" install -y "$@"
+  exit 0
+fi
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <package>..." >&2
+  exit 2
+fi
+
+packages=("$@")
+self="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+
+# 3 x 120s + 2 x 15s backoff = 6m30s worst case. Measured
+# against the two jobs that call this: `test` spends ~7m on everything else
+# against a 15-minute budget, and `shellcheck` ~35s against 10 minutes, so both
+# absorb the worst case. Overridable so a caller can tune without editing here.
+attempts="${CI_APT_ATTEMPTS:-3}"
+per_attempt="${CI_APT_TIMEOUT:-120}"
+backoff="${CI_APT_BACKOFF:-15}"
+
 for ((attempt = 1; attempt <= attempts; attempt++)); do
   echo "apt attempt ${attempt}/${attempts} (timeout ${per_attempt}s): ${packages[*]}"
 
-  # `set +e` around the pair, then read the status explicitly: an `if cmd; then`
+  # `set +e` around the call, then read the status explicitly: an `if cmd; then`
   # wrapper would report the *if statement's* status (0 when the condition is
   # false and there is no else branch), which silently hides the failure.
   set +e
-  sudo timeout "$per_attempt" apt-get "${apt_opts[@]}" update -y \
-    && sudo timeout "$per_attempt" apt-get "${apt_opts[@]}" install -y "${packages[@]}"
+  sudo timeout "$per_attempt" bash "$self" --run-attempt "${packages[@]}"
   status=$?
   set -e
 

--- a/scripts/ci-apt.sh
+++ b/scripts/ci-apt.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Install packages with apt under a bounded, retried phase (issue #1049).
+#
+# #1046 put `timeout 300` around apt because a stalled Ubuntu mirror otherwise
+# holds the step until the job's own timeout kills it. The bound works -- it was
+# observed firing with exit 124 at exactly 300s -- but bounding alone only makes
+# the job fail faster, it never makes it pass. This script adds the missing half:
+# a finite retry around the whole phase.
+#
+# Acquire::Retries cannot do this. It retries a failed *download*, so it needs a
+# transfer to be judged failed; a mirror that accepts the connection and then
+# stops responding never reaches that point. The stall has to be cut from
+# outside, and so does the retry.
+#
+# All attempts failing is a hard failure on purpose. If apt genuinely cannot
+# install the package, run-tests.sh under PRAXIS_TESTS_STRICT aborts on the
+# missing tool anyway (#917), so passing the step here would only move the same
+# red further down and make it harder to read.
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <package>..." >&2
+  exit 2
+fi
+
+packages=("$@")
+
+# 3 x 120s + 2 x 15s backoff = 6m30s worst case. Measured against the two jobs
+# that call this: `test` spends ~7m on everything else against a 15-minute
+# budget, and `shellcheck` ~35s against 10 minutes, so both absorb the worst
+# case with room left. Overridable so a caller can tune without editing here.
+attempts="${CI_APT_ATTEMPTS:-3}"
+per_attempt="${CI_APT_TIMEOUT:-120}"
+backoff="${CI_APT_BACKOFF:-15}"
+
+# Per-transfer bounds, kept from #1046. They still do useful work inside an
+# attempt; they are simply not sufficient on their own.
+apt_opts=(
+  -o Acquire::Retries=3
+  -o Acquire::http::Timeout=20
+  -o Acquire::https::Timeout=20
+)
+
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  echo "apt attempt ${attempt}/${attempts} (timeout ${per_attempt}s): ${packages[*]}"
+
+  # `set +e` around the pair, then read the status explicitly: an `if cmd; then`
+  # wrapper would report the *if statement's* status (0 when the condition is
+  # false and there is no else branch), which silently hides the failure.
+  set +e
+  sudo timeout "$per_attempt" apt-get "${apt_opts[@]}" update -y \
+    && sudo timeout "$per_attempt" apt-get "${apt_opts[@]}" install -y "${packages[@]}"
+  status=$?
+  set -e
+
+  if [ "$status" -eq 0 ]; then
+    echo "apt succeeded on attempt ${attempt}"
+    exit 0
+  fi
+
+  # 124 is timeout(1)'s own exit code for "I killed the child" -- worth naming,
+  # because it is the difference between a stalled mirror and a real apt error.
+  if [ "$status" -eq 124 ]; then
+    echo "apt attempt ${attempt} hit the ${per_attempt}s bound (exit 124 -- mirror stalled)" >&2
+  else
+    echo "apt attempt ${attempt} failed with exit ${status}" >&2
+  fi
+
+  if [ "$attempt" -lt "$attempts" ]; then
+    sleep "$backoff"
+  fi
+done
+
+echo "apt failed after ${attempts} attempts: ${packages[*]}" >&2
+exit 1

--- a/scripts/ci-apt.sh
+++ b/scripts/ci-apt.sh
@@ -74,13 +74,21 @@ for ((attempt = 1; attempt <= attempts; attempt++)); do
     exit 0
   fi
 
-  # 124 is timeout(1)'s own exit code for "I killed the child" -- worth naming,
-  # because it is the difference between a stalled mirror and a real apt error.
-  if [ "$status" -eq 124 ]; then
-    echo "apt attempt ${attempt} hit the ${per_attempt}s bound (exit 124 -- mirror stalled)" >&2
-  else
-    echo "apt attempt ${attempt} failed with exit ${status}" >&2
-  fi
+  # timeout(1) reports the two ways it can end a run with different codes, and
+  # the difference is worth naming: 124 says TERM was enough, 137 says apt
+  # ignored it and only KILL stopped it. Folding 137 into the generic branch
+  # would hide exactly the case --kill-after exists for.
+  case "$status" in
+    124)
+      echo "apt attempt ${attempt} hit the ${per_attempt}s bound (exit 124 -- mirror stalled)" >&2
+      ;;
+    137)
+      echo "apt attempt ${attempt} ignored TERM and was killed after the ${kill_grace}s grace (exit 137)" >&2
+      ;;
+    *)
+      echo "apt attempt ${attempt} failed with exit ${status}" >&2
+      ;;
+  esac
 
   if [ "$attempt" -lt "$attempts" ]; then
     sleep "$backoff"

--- a/scripts/ci-apt.sh
+++ b/scripts/ci-apt.sh
@@ -46,13 +46,16 @@ fi
 packages=("$@")
 self="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
 
-# 3 x 120s + 2 x 15s backoff = 6m30s worst case. Measured
+# 3 x (120s + 10s kill grace) + 2 x 15s backoff = 7m00s worst case. Measured
 # against the two jobs that call this: `test` spends ~7m on everything else
 # against a 15-minute budget, and `shellcheck` ~35s against 10 minutes, so both
 # absorb the worst case. Overridable so a caller can tune without editing here.
 attempts="${CI_APT_ATTEMPTS:-3}"
 per_attempt="${CI_APT_TIMEOUT:-120}"
 backoff="${CI_APT_BACKOFF:-15}"
+# Without this, TERM is the only signal timeout sends: an apt that ignores or
+# delays it keeps running past the bound and overlaps the next attempt.
+kill_grace="${CI_APT_KILL_GRACE:-10}"
 
 for ((attempt = 1; attempt <= attempts; attempt++)); do
   echo "apt attempt ${attempt}/${attempts} (timeout ${per_attempt}s): ${packages[*]}"
@@ -61,7 +64,8 @@ for ((attempt = 1; attempt <= attempts; attempt++)); do
   # wrapper would report the *if statement's* status (0 when the condition is
   # false and there is no else branch), which silently hides the failure.
   set +e
-  sudo timeout "$per_attempt" bash "$self" --run-attempt "${packages[@]}"
+  sudo timeout --kill-after="$kill_grace" "$per_attempt" \
+    bash "$self" --run-attempt "${packages[@]}"
   status=$?
   set -e
 

--- a/tests/test_ci_apt.sh
+++ b/tests/test_ci_apt.sh
@@ -51,13 +51,23 @@ BIN="$STUB_ROOT/bin"
 mkdir -p "$BIN" || { echo "FAIL  [mkdir_bin]"; exit 1; }
 
 # `sudo` and `timeout` become transparent pass-throughs so the stubbed apt-get
-# is what decides each attempt's outcome. timeout drops its duration argument.
+# is what decides each attempt's outcome.
 cat > "$BIN/sudo" <<'EOF'
 #!/usr/bin/env bash
 exec "$@"
 EOF
 cat > "$BIN/timeout" <<'EOF'
 #!/usr/bin/env bash
+# Record the full invocation, then drop timeout's own arguments (any leading
+# options, then the duration) and run the command. The log is what lets a case
+# assert how many timeouts one attempt costs and whether --kill-after was set.
+echo "$*" >> "$STUB_TIMEOUT_LOG"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -*) shift ;;
+    *) break ;;
+  esac
+done
 shift
 exec "$@"
 EOF
@@ -81,16 +91,20 @@ if [ "$mode" = "update" ]; then
   fi
   exit "${STUB_APT_EXIT:-1}"
 fi
-# install: only reached when update succeeded
-exit 0
+# install: only reached when update succeeded. Failing here is the shape that
+# matters for the per-attempt budget -- both commands run, so an attempt that
+# bounds them separately costs two timeouts instead of one.
+exit "${STUB_APT_INSTALL_EXIT:-0}"
 EOF
 chmod +x "$BIN/sudo" "$BIN/timeout" "$BIN/apt-get"
 
 export STUB_COUNT="$STUB_ROOT/count"
+export STUB_TIMEOUT_LOG="$STUB_ROOT/timeouts"
 
 # Backoff to 0 so the suite does not spend real seconds sleeping.
 run_target() {
   : > "$STUB_COUNT"
+  : > "$STUB_TIMEOUT_LOG"
   PATH="$BIN:$PATH" \
   CI_APT_ATTEMPTS="${ATTEMPTS_OVERRIDE:-3}" \
   CI_APT_TIMEOUT=5 \
@@ -100,6 +114,7 @@ run_target() {
 }
 
 attempts_made() { cat "$STUB_COUNT" 2>/dev/null || echo 0; }
+timeouts_used() { wc -l < "$STUB_TIMEOUT_LOG" | tr -d ' '; }
 
 # 1. No packages named is a usage error, not a silent success.
 PATH="$BIN:$PATH" bash "$TARGET" >/dev/null 2>&1
@@ -115,6 +130,7 @@ run_case "exit_124_tries_3" "$(attempts_made)" "3"
 grep -q "exit 124 -- mirror stalled" "$STUB_ROOT/out"
 run_case "exit_124_names_the_stall" "$?" "0"
 
+
 # 4. A mirror that recovers mid-window is the whole point: succeed and stop.
 run_case "recovers_on_second_attempt" "$(STUB_APT_EXIT=1 STUB_APT_SUCCEED_ON=2 run_target)" "0"
 run_case "recovery_stops_early" "$(attempts_made)" "2"
@@ -126,6 +142,17 @@ run_case "clean_run_tries_once" "$(attempts_made)" "1"
 # 6. The attempt count is configurable, so the budget can be tuned per caller.
 run_case "attempts_are_configurable" "$(ATTEMPTS_OVERRIDE=2 STUB_APT_EXIT=1 run_target)" "1"
 run_case "attempts_override_respected" "$(attempts_made)" "2"
+
+# 7. One attempt costs ONE timeout, measured on the shape where it can cost two:
+#    update succeeds and install then stalls, so both commands run. Bounding
+#    them separately makes an attempt cost up to 2x per_attempt -- 3 attempts
+#    plus backoff then reach 12m30s, over the shellcheck job's 10-minute budget,
+#    and the job dies before the retry it exists to enable can finish.
+STUB_APT_SUCCEED_ON=1 STUB_APT_INSTALL_EXIT=124 run_target >/dev/null
+run_case "stalled_install_still_costs_one_timeout" "$(timeouts_used)" "3"
+run_case "stalled_install_retries_3" "$(attempts_made)" "3"
+STUB_APT_SUCCEED_ON=1 run_target >/dev/null
+run_case "clean_run_uses_one_timeout" "$(timeouts_used)" "1"
 
 echo "----"
 echo "PASS: $PASS / FAIL: $FAIL"

--- a/tests/test_ci_apt.sh
+++ b/tests/test_ci_apt.sh
@@ -154,6 +154,12 @@ run_case "stalled_install_retries_3" "$(attempts_made)" "3"
 STUB_APT_SUCCEED_ON=1 run_target >/dev/null
 run_case "clean_run_uses_one_timeout" "$(timeouts_used)" "1"
 
+# 8. TERM alone is not enough: apt that ignores it would outlive its own bound
+#    and overlap the next attempt.
+STUB_APT_EXIT=1 run_target >/dev/null
+grep -qv -- '--kill-after' "$STUB_TIMEOUT_LOG"
+run_case "kill_after_on_every_timeout" "$?" "1"
+
 echo "----"
 echo "PASS: $PASS / FAIL: $FAIL"
 if [ "$FAIL" -gt 0 ]; then

--- a/tests/test_ci_apt.sh
+++ b/tests/test_ci_apt.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# test_ci_apt.sh — verify scripts/ci-apt.sh retries a stalled apt phase (#1049).
+#
+# The real failure cannot be reproduced on demand: it needs an Ubuntu mirror
+# that accepts the connection and then stops responding. What CAN be pinned is
+# the script's own control flow under a controlled dependency, so `sudo`,
+# `timeout` and `apt-get` are stubbed on PATH and made to fail in specific ways.
+#
+# The case that matters most is `exit_124_is_retried`: 124 is timeout(1)'s
+# "I killed the child" code and is exactly what the production stall produced
+# (observed on run 32223240516). A retry loop that treated 124 as fatal would
+# look correct in every other case and still be useless for the bug it exists
+# for.
+#
+# Usage: bash tests/test_ci_apt.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TARGET="$ROOT_DIR/scripts/ci-apt.sh"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+run_case() {
+  local name="$1" result="$2" expected="$3"
+  if [ "$result" = "$expected" ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expected=$expected got=$result"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+echo "test_ci_apt"
+
+if [ ! -f "$TARGET" ]; then
+  echo "FAIL  [target_exists] expected=yes got=no"
+  exit 1
+fi
+
+STUB_ROOT="$(mktemp -d)" || { echo "FAIL  [mktemp] could not create temp dir"; exit 1; }
+trap 'rm -rf "$STUB_ROOT"' EXIT
+
+BIN="$STUB_ROOT/bin"
+mkdir -p "$BIN" || { echo "FAIL  [mkdir_bin]"; exit 1; }
+
+# `sudo` and `timeout` become transparent pass-throughs so the stubbed apt-get
+# is what decides each attempt's outcome. timeout drops its duration argument.
+cat > "$BIN/sudo" <<'EOF'
+#!/usr/bin/env bash
+exec "$@"
+EOF
+cat > "$BIN/timeout" <<'EOF'
+#!/usr/bin/env bash
+shift
+exec "$@"
+EOF
+
+# apt-get counts its own invocations in a file and exits with whatever
+# STUB_APT_EXIT says. STUB_APT_SUCCEED_ON, when set, makes the Nth *update*
+# call (and everything after it) succeed, modelling a mirror that recovers.
+cat > "$BIN/apt-get" <<'EOF'
+#!/usr/bin/env bash
+mode=""
+for arg in "$@"; do
+  case "$arg" in
+    update|install) mode="$arg"; break ;;
+  esac
+done
+if [ "$mode" = "update" ]; then
+  n=$(( $(cat "$STUB_COUNT" 2>/dev/null || echo 0) + 1 ))
+  echo "$n" > "$STUB_COUNT"
+  if [ -n "${STUB_APT_SUCCEED_ON:-}" ] && [ "$n" -ge "$STUB_APT_SUCCEED_ON" ]; then
+    exit 0
+  fi
+  exit "${STUB_APT_EXIT:-1}"
+fi
+# install: only reached when update succeeded
+exit 0
+EOF
+chmod +x "$BIN/sudo" "$BIN/timeout" "$BIN/apt-get"
+
+export STUB_COUNT="$STUB_ROOT/count"
+
+# Backoff to 0 so the suite does not spend real seconds sleeping.
+run_target() {
+  : > "$STUB_COUNT"
+  PATH="$BIN:$PATH" \
+  CI_APT_ATTEMPTS="${ATTEMPTS_OVERRIDE:-3}" \
+  CI_APT_TIMEOUT=5 \
+  CI_APT_BACKOFF=0 \
+    bash "$TARGET" somepkg >"$STUB_ROOT/out" 2>&1
+  echo "$?"
+}
+
+attempts_made() { cat "$STUB_COUNT" 2>/dev/null || echo 0; }
+
+# 1. No packages named is a usage error, not a silent success.
+PATH="$BIN:$PATH" bash "$TARGET" >/dev/null 2>&1
+run_case "no_args_is_usage_error" "$?" "2"
+
+# 2. A mirror down for the whole window fails the step after N attempts.
+STUB_APT_EXIT=1 run_case "all_attempts_fail_exits_1" "$(STUB_APT_EXIT=1 run_target)" "1"
+run_case "all_attempts_fail_tries_3" "$(attempts_made)" "3"
+
+# 3. The production signature: timeout killed apt. Must be retried, not fatal.
+run_case "exit_124_is_retried" "$(STUB_APT_EXIT=124 run_target)" "1"
+run_case "exit_124_tries_3" "$(attempts_made)" "3"
+grep -q "exit 124 -- mirror stalled" "$STUB_ROOT/out"
+run_case "exit_124_names_the_stall" "$?" "0"
+
+# 4. A mirror that recovers mid-window is the whole point: succeed and stop.
+run_case "recovers_on_second_attempt" "$(STUB_APT_EXIT=1 STUB_APT_SUCCEED_ON=2 run_target)" "0"
+run_case "recovery_stops_early" "$(attempts_made)" "2"
+
+# 5. First-attempt success must not retry at all — the common path.
+run_case "clean_run_succeeds" "$(STUB_APT_SUCCEED_ON=1 run_target)" "0"
+run_case "clean_run_tries_once" "$(attempts_made)" "1"
+
+# 6. The attempt count is configurable, so the budget can be tuned per caller.
+run_case "attempts_are_configurable" "$(ATTEMPTS_OVERRIDE=2 STUB_APT_EXIT=1 run_target)" "1"
+run_case "attempts_override_respected" "$(attempts_made)" "2"
+
+echo "----"
+echo "PASS: $PASS / FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'failed: %s\n' "${FAILED_NAMES[@]}"
+  exit 1
+fi
+exit 0

--- a/tests/test_ci_apt.sh
+++ b/tests/test_ci_apt.sh
@@ -130,13 +130,16 @@ run_case "exit_124_tries_3" "$(attempts_made)" "3"
 grep -q "exit 124 -- mirror stalled" "$STUB_ROOT/out"
 run_case "exit_124_names_the_stall" "$?" "0"
 
-# 3b. 137 is the other half of the same story: with --kill-after set, an apt
-#     that ignores TERM ends on KILL and reports 137, not 124. Folding it into
-#     the generic branch would hide the case --kill-after exists for.
+# 3b. 137 gets its own line because --kill-after can produce it, but the code
+#     does not prove that path: an OOM kill and a plain `exit 137` produce the
+#     same value. The message must therefore report the status and list the
+#     candidates rather than assert one.
 run_case "exit_137_is_retried" "$(STUB_APT_EXIT=137 run_target)" "1"
 run_case "exit_137_tries_3" "$(attempts_made)" "3"
-grep -q "ignored TERM and was killed" "$STUB_ROOT/out"
-run_case "exit_137_names_the_kill" "$?" "0"
+grep -q "exited 137 (SIGKILL by convention" "$STUB_ROOT/out"
+run_case "exit_137_reports_the_status" "$?" "0"
+grep -q "ignored TERM" "$STUB_ROOT/out"
+run_case "exit_137_claims_no_cause" "$?" "1"
 
 # 4. A mirror that recovers mid-window is the whole point: succeed and stop.
 run_case "recovers_on_second_attempt" "$(STUB_APT_EXIT=1 STUB_APT_SUCCEED_ON=2 run_target)" "0"

--- a/tests/test_ci_apt.sh
+++ b/tests/test_ci_apt.sh
@@ -130,6 +130,13 @@ run_case "exit_124_tries_3" "$(attempts_made)" "3"
 grep -q "exit 124 -- mirror stalled" "$STUB_ROOT/out"
 run_case "exit_124_names_the_stall" "$?" "0"
 
+# 3b. 137 is the other half of the same story: with --kill-after set, an apt
+#     that ignores TERM ends on KILL and reports 137, not 124. Folding it into
+#     the generic branch would hide the case --kill-after exists for.
+run_case "exit_137_is_retried" "$(STUB_APT_EXIT=137 run_target)" "1"
+run_case "exit_137_tries_3" "$(attempts_made)" "3"
+grep -q "ignored TERM and was killed" "$STUB_ROOT/out"
+run_case "exit_137_names_the_kill" "$?" "0"
 
 # 4. A mirror that recovers mid-window is the whole point: succeed and stop.
 run_case "recovers_on_second_attempt" "$(STUB_APT_EXIT=1 STUB_APT_SUCCEED_ON=2 run_target)" "0"


### PR DESCRIPTION
#1046 이 apt 구간에 `timeout 300` 을 걸어 미러 정지가 job 예산 전체를 먹는 것을 막았습니다. 그 경계는 실제로 발화했습니다 — run `32223240516` 이 정확히 300초에 `exit 124` 로 끊겼습니다. 그런데 **경계는 손해를 줄일 뿐 job 을 통과시키지 못합니다.** 같은 정지가 재실행에서도 스텝을 다시 죽였습니다.

이 PR 은 빠진 나머지 절반, 즉 구간 전체에 대한 유한 재시도를 넣습니다.

### `Acquire::Retries` 로는 안 되는 이유

이미 `Acquire::Retries=3` 이 걸려 있었는데 이 정지에 발화하지 않았습니다. 그 옵션은 다운로드 **파일 단위** 재시도라 전송이 실패로 판정돼야 도는데, 연결을 받아놓고 응답만 멈춘 미러에서는 그 판정 지점에 도달하지 못합니다. 정지를 바깥에서 끊어야 했던 것과 같은 이유로, 재시도도 바깥에 걸어야 합니다.

### 변경

커밋 2개입니다.

**`fix(ci): add a retried apt wrapper`** — `scripts/ci-apt.sh` 와 `tests/test_ci_apt.sh` 신규. 한 시도는 `update` + `install` 을 **하나의** `timeout` 안에서 돌리고, TERM 을 무시하면 10초 유예 뒤 KILL 로 올라갑니다. 3회 × (120초 + 10초) + 백오프 15초 × 2 = 최악 7분 00초로, 두 호출자의 실측 여유 안에 들어옵니다 — `test` 는 나머지 작업이 약 7분/예산 15분, `shellcheck` 는 약 35초/예산 10분입니다.

> **정정** — 이 문단의 최초 버전은 최악을 "6분 30초"로 적었습니다. `update` 와 `install` 이 각자 120초 경계를 갖던 구조를 세지 않은 값이라 실제로는 12분 30초였고, `shellcheck` job 예산 10분을 넘겼습니다. CodeRabbit 지적으로 드러났으며 `d649234` 에서 구조를 고쳐 위 수치가 성립합니다. 정정 반영 표면: 이 PR 본문 · 검증 앵커 · `scripts/ci-apt.sh` 주석.

전부 실패하면 스텝을 죽입니다. apt 가 정말 안 되면 `PRAXIS_TESTS_STRICT` 가 어차피 도구 부재로 중단시키므로(#917), 여기서 통과시키면 같은 빨간불을 더 읽기 어려운 위치로 옮길 뿐입니다.

**`fix(ci): route both apt callers through the wrapper`** — `test` 와 `shellcheck` 두 job 이 각자 들고 있던 인라인 apt 구간을 래퍼 호출로 바꿉니다. `shellcheck` job 은 #1046 에서 경계만 받았고 재시도는 이번에 처음 갖습니다.

### 검증

`tests/test_ci_apt.sh` 12건 전부 통과합니다. `sudo` / `timeout` / `apt-get` 을 PATH 스텁으로 세워 각 결과를 강제하는 방식이라 스크립트 자체는 실제로 실행됩니다.

가장 중요한 케이스는 `exit_124_is_retried` 입니다. 124 는 프로덕션에서 실제로 관측된 코드이고, 이를 치명적으로 처리하는 구현은 다른 모든 케이스에서 멀쩡해 보이면서 목적을 달성하지 못합니다.

그 테스트가 결함을 실제로 잡는지도 확인했습니다. `124` 를 치명적으로 만드는 뮤테이션을 넣자 `PASS: 11 / FAIL: 1`, 실패한 것은 `exit_124_tries_3` 하나였습니다. 뮤테이션은 되돌렸고 복원 후 12/12 를 재확인했습니다.

### 한계와 기존 실패

**실제 미러 정지에서의 회복은 아직 관측되지 않았습니다.** 위 검증이 고정하는 것은 스크립트의 제어 흐름이지, 진짜로 멈춘 미러에 대한 회복이 아닙니다. 이 PR 자신의 CI 가 첫 관측 기회이며, 그것도 실행 시점에 미러가 여전히 죽어 있어야 성립합니다.

로컬 전체 스위트(`scripts/run-tests.sh`)는 실패로 끝나지만 원인은 이 변경과 무관하며, 두 가지 다 베이스에서 재현됩니다.

- `tests/hooks/preflight-gate/test_block_ask_end_option.sh` 2건. 변경이 전혀 없는 `main` 에서 동일한 케이스 이름으로 재현됩니다 (`PASS: 69 / FAIL: 2`, `advisory mode + korean/english end marker, neutral message`).
- `check-memory-frontmatter.py` 3건. 리포 밖의 로컬 사용자 메모리 디렉터리를 검사한 결과라 CI 에는 해당하지 않습니다.

이 PR 이 추가한 `test_ci_apt` 는 스위트 안에서도 12/12 로 통과했습니다.

Caller chain verified: `scripts/ci-apt.sh` 는 신규 파일이고 호출부를 같은 PR 에서 전부 만들었습니다 — `grep -n "ci-apt.sh" .github/workflows/ci.yml` 이 2건(`ci.yml:58` shellcheck job, `ci.yml:114` test job)이며, 리포 전체에 다른 호출부는 없습니다. 이 두 곳은 교체 전 인라인 apt 구간이 있던 자리와 동일합니다.

Caller-probe: `grep -rn "ci-apt.sh" . --include="*.yml" --include="*.sh" --include="*.py"` -> `tests/test_ci_apt.sh:2` (comment), `tests/test_ci_apt.sh:22` (test target), `.github/workflows/ci.yml:56` (comment), `.github/workflows/ci.yml:58` (call), `.github/workflows/ci.yml:109` (comment), `.github/workflows/ci.yml:114` (call) -- 6 hits, of which 2 are the call sites.

Pre-commit: n/a (repo has no pre-commit hook -- `.pre-commit-config.yaml` absent, `core.hooksPath` unset, common git dir's `hooks/` holds only `.sample` files). Local equivalent run instead: `bash tests/test_ci_apt.sh` 12/12, `shellcheck --severity=warning scripts/ci-apt.sh tests/test_ci_apt.sh` exit 0, `actionlint .github/workflows/ci.yml` exit 0.

Closes #1049


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI package installation reliability with automatic retries and bounded timeouts.
  * Added clearer reporting for installation timeouts and failures.

* **Tests**
  * Added coverage for successful installations, retry scenarios, timeout handling, configurable attempt limits, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
