### PR TITLE
fix(cw): read every sibling config dir's broker state

### DIFF
--- a/skills/codex-review-wrap/codex-broker-reaper.sh
+++ b/skills/codex-review-wrap/codex-broker-reaper.sh
@@ -123,6 +123,18 @@ broker_index_ensure() {
            | [(.pid|tostring), .sessionDir,
               (input_filename | rtrimstr("/broker.json"))] | @tsv' \
        "${files[@]}" 2>/dev/null > "$f" || true
+    # A jq that failed leaves an EMPTY index behind, and an empty index is
+    # indistinguishable from "no records exist" at every call site. The reap
+    # pass survives that (no match -> owner undetermined -> broker kept), but
+    # the GC pass would read zero rows and report gc_dirs=0 as if the sweep had
+    # run. Files present + zero rows also happens legitimately when every
+    # record is malformed; both readings call for the same answer, which is why
+    # this reports failure instead of telling them apart -- refusing to sweep is
+    # correct whether jq died or the records are unusable.
+    if [[ ! -s "$f" ]]; then
+      rm -f "$f"
+      return 1
+    fi
   fi
   BROKER_INDEX="$f"
   return 0

--- a/skills/codex-review-wrap/codex-broker-reaper.sh
+++ b/skills/codex-review-wrap/codex-broker-reaper.sh
@@ -551,7 +551,12 @@ fi
 # none, and rm -rf'd the live session's dir (#921).
 session_dir_has_live_claimant() {
   local want="$1" self="$2" opid osdir odir
-  broker_index_ensure || return 1
+  # Fail CLOSED: without an index there is no evidence the dir is unclaimed, and
+  # a non-zero return here is what licenses the caller's rm -rf. The GC pass
+  # gates on the index before it gets here, so this cannot fire today; it is the
+  # convention workspace_has_live_owner already follows, kept consistent so a
+  # future caller cannot inherit the dangerous default.
+  broker_index_ensure || return 0
   # $self is the record under inspection, identified by its state dir -- the
   # index carries no broker.json path, and dirname($self) is exactly the third
   # field. Same per-pass index as state_dir_of_broker: this runs once per GC

--- a/skills/codex-review-wrap/codex-broker-reaper.sh
+++ b/skills/codex-review-wrap/codex-broker-reaper.sh
@@ -103,6 +103,13 @@ state_roots() {
 # appear in either without the plugin having written one.
 BROKER_INDEX=""
 
+# The index row: pid, sessionDir, and the state dir the record was read from.
+# Held in a variable because broker_index_ensure runs it two ways -- once over
+# every file, and once per file on the malformed-record fallback.
+BROKER_INDEX_JQ='select(.pid != null and .sessionDir != null)
+  | [(.pid|tostring), .sessionDir,
+     (input_filename | rtrimstr("/broker.json"))] | @tsv'
+
 broker_index_ensure() {
   [[ -n "$BROKER_INDEX" ]] && return 0
   local f bj
@@ -119,10 +126,26 @@ broker_index_ensure() {
   # keeps its own state dir without a --arg per call. An empty file list must not
   # reach jq: with no arguments it reads stdin and would block.
   if (( ${#files[@]} > 0 )); then
-    jq -r 'select(.pid != null and .sessionDir != null)
-           | [(.pid|tostring), .sessionDir,
-              (input_filename | rtrimstr("/broker.json"))] | @tsv' \
-       "${files[@]}" 2>/dev/null > "$f" || true
+    if ! jq -r "$BROKER_INDEX_JQ" "${files[@]}" 2>/dev/null > "$f"; then
+      # jq treats multiple file arguments as ONE concatenated stream and aborts
+      # the whole stream at the first parse error -- it does not skip the bad
+      # file and continue. Verified: three records with the second malformed
+      # yields only the first record's row and exit 5.
+      #
+      # A truncated index is worse than a slow one. Every record after the bad
+      # file disappears, so a LIVE broker's claim on a sessionDir goes unseen,
+      # session_dir_has_live_claimant reports the dir unclaimed, and the GC pass
+      # deletes a directory still in use -- #921, reached by a different road.
+      # The emptiness check below cannot catch it: the index is short, not empty.
+      #
+      # Re-read file by file so one unparseable record costs only itself. This
+      # is the O(records) spawn path the single call exists to avoid, so it runs
+      # only when a malformed record actually exists.
+      : > "$f"
+      for bj in "${files[@]}"; do
+        jq -r "$BROKER_INDEX_JQ" "$bj" 2>/dev/null >> "$f" || true
+      done
+    fi
     # A jq that failed leaves an EMPTY index behind, and an empty index is
     # indistinguishable from "no records exist" at every call site. The reap
     # pass survives that (no match -> owner undetermined -> broker kept), but

--- a/skills/codex-review-wrap/codex-broker-reaper.sh
+++ b/skills/codex-review-wrap/codex-broker-reaper.sh
@@ -532,11 +532,25 @@ session_dir_has_live_claimant() {
 }
 
 # --- Pass 2: GC stale tmp sessionDirs of dead brokers (both modes) ---
-while IFS= read -r bj; do
-    [[ -n "$bj" ]] || continue
-    pid="$(jq -r '.pid // empty' "$bj" 2>/dev/null || true)"
-    sdir="$(jq -r '.sessionDir // empty' "$bj" 2>/dev/null || true)"
-    [[ -z "$pid" ]] && continue
+# Iterate the per-pass index, not the files. Re-parsing each broker.json here
+# costs two `jq` spawns per record (measured 6.2ms each on the author's host),
+# which is the whole runtime of this script: 998 records made it ~12s while the
+# reap pass above finished in 1.6s. The index already carries every field this
+# loop reads, built by one jq call over all the files at once.
+# `$bj` is reconstructed rather than carried because the only thing downstream
+# wants from it is dirname() -- the state dir, which is the index's third field.
+# Fail CLOSED and SAY SO. Without the index this loop has no input, and
+# `done < ""` would skip every record while the summary still printed
+# gc_dirs=0 -- a silent no-op that reads exactly like "nothing to collect".
+if ! broker_index_ensure || [[ -z "$BROKER_INDEX" || ! -f "$BROKER_INDEX" ]]; then
+  echo "SKIP GC (broker index unavailable — no records inspected)" >&2
+  GC_INPUT="/dev/null"
+else
+  GC_INPUT="$BROKER_INDEX"
+fi
+while IFS=$'\t' read -r pid sdir idir; do
+    [[ -n "$pid" && -n "$idir" ]] || continue
+    bj="$idir/broker.json"
     # Alive brokers are left to the reap pass (idle-gated); GC only dead ones.
     kill -0 "$pid" 2>/dev/null && continue
     if [[ -n "$sdir" ]] && is_safe_session_dir "$sdir" && [[ -d "$sdir" ]]; then
@@ -552,6 +566,6 @@ while IFS= read -r bj; do
       fi
       gc_dirs=$(( gc_dirs + 1 ))
     fi
-done < <(all_broker_jsons)
+done < "$GC_INPUT"
 
 echo "codex-broker-reaper: mode=$MODE dry_run=$DRY_RUN max_age_min=$MAX_AGE_MIN scanned=$scanned reaped=$reaped gc_dirs=$gc_dirs skipped=$skipped"

--- a/skills/codex-review-wrap/codex-broker-reaper.sh
+++ b/skills/codex-review-wrap/codex-broker-reaper.sh
@@ -48,6 +48,102 @@ set -euo pipefail
 
 CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 STATE_DIR="$CONFIG_DIR/plugins/data/codex-openai-codex/state"
+STATE_SUFFIX="plugins/data/codex-openai-codex/state"
+
+# Every state root this host may hold, not just our own (#1056).
+#
+# A host can run several Claude config dirs (~/.claude, ~/.claude-2). The broker
+# writes its broker.json under the config dir of the SESSION THAT STARTED IT, so
+# a reaper reading only $STATE_DIR cannot resolve the rest: pid+sessionDir
+# matches nothing, owner_status returns `unknown`, and the under-reap bias keeps
+# them forever. Measured on the author's host: 2143 of 2711 skips across 541
+# launchd runs.
+#
+# Candidates are SIBLINGS of CONFIG_DIR rather than a $HOME glob. Production
+# CONFIG_DIR is ~/.claude, so the parent is $HOME either way — but keying off
+# the parent is what lets a sandboxed CLAUDE_CONFIG_DIR enumerate sandboxed
+# siblings, i.e. what makes this testable at all.
+#
+# The path suffix is what discriminates, not the directory name: dotglob is
+# needed because the real ones are dotfiles, and a `*` alone would miss every
+# one of them.
+#
+# Widening is only safe if BOTH halves of the sweep widen together. The GC pass
+# rm -rf's sessionDirs named by these records, and its live-claimant guard reads
+# the same roots; widening the records alone would let it delete a dir a sibling
+# config's live broker still claims — #921 on a new axis.
+state_roots() {
+  local d saved
+  # `shopt -p` exits 1 when the option is UNSET, and `set -e` would kill the
+  # subshell this runs in before a single path was emitted.
+  saved="$(shopt -p nullglob dotglob || true)"
+  shopt -s nullglob dotglob
+  { [[ -d "$STATE_DIR" ]] && printf '%s\n' "$STATE_DIR"
+    for d in "$(dirname "$CONFIG_DIR")"/*/"$STATE_SUFFIX"; do
+      [[ -d "$d" ]] && printf '%s\n' "$d"
+    done
+  } | while IFS= read -r d; do
+        # Physical paths: a symlinked config dir must not be swept twice.
+        (cd "$d" 2>/dev/null && pwd -P) || printf '%s\n' "$d"
+      done | awk '!seen[$0]++'
+  eval "$saved"
+}
+
+# One "<pid> <sessionDir> <state-dir>" row per broker.json, built ONCE per pass
+# and reused by every lookup (#1056 review F1).
+#
+# The obvious shape -- re-scan every record for each broker -- costs one grep
+# process per record per broker. Measured on the author's host: 996 records x 7
+# live brokers = 6972 processes for a single pass, while the reaper holds its
+# lock and the launchd job runs every 30 minutes. The record count only grows,
+# since a crashed broker's state dir survives until a later GC sweeps it.
+#
+# Tab-separated because every field can contain spaces: state dirs live under a
+# relocatable CLAUDE_CONFIG_DIR and sessionDirs under $TMPDIR. A tab cannot
+# appear in either without the plugin having written one.
+BROKER_INDEX=""
+
+broker_index_ensure() {
+  [[ -n "$BROKER_INDEX" ]] && return 0
+  local f bj
+  local -a files=()
+  f="$(mktemp "${TMPDIR:-/tmp}/codex-reaper-idx.XXXXXX")" || return 1
+  while IFS= read -r bj; do
+    [[ -n "$bj" ]] || continue
+    files+=("$bj")
+  done < <(all_broker_jsons)
+  # ONE jq process for the whole index, not one per record. A per-record loop is
+  # still O(records) spawns -- 996 here -- and the early test gates invoke the
+  # reaper repeatedly, so it showed up as a suite that no longer finishes.
+  # input_filename yields the file jq is currently reading, which is how each row
+  # keeps its own state dir without a --arg per call. An empty file list must not
+  # reach jq: with no arguments it reads stdin and would block.
+  if (( ${#files[@]} > 0 )); then
+    jq -r 'select(.pid != null and .sessionDir != null)
+           | [(.pid|tostring), .sessionDir,
+              (input_filename | rtrimstr("/broker.json"))] | @tsv' \
+       "${files[@]}" 2>/dev/null > "$f" || true
+  fi
+  BROKER_INDEX="$f"
+  return 0
+}
+
+broker_index_clear() {
+  [[ -n "$BROKER_INDEX" && -f "$BROKER_INDEX" ]] && rm -f "$BROKER_INDEX"
+  BROKER_INDEX=""
+}
+
+# Every broker.json across every state root, one path per line.
+all_broker_jsons() {
+  local root bj saved
+  saved="$(shopt -p nullglob || true)"
+  shopt -s nullglob
+  while IFS= read -r root; do
+    [[ -n "$root" ]] || continue
+    for bj in "$root"/*/broker.json; do printf '%s\n' "$bj"; done
+  done < <(state_roots)
+  eval "$saved"
+}
 BROKER_PATTERN='app-server-broker.mjs'
 
 MODE="gc"
@@ -287,19 +383,17 @@ workspace_has_live_owner() {
 # still leaves 0 or several candidates, the caller must treat the owner as
 # undetermined rather than trust an arbitrary one.
 state_dir_of_broker() {
-  local pid="$1" want="$2" bj found="" n=0
+  local pid="$1" want="$2" ipid isess idir found="" n=0
   [[ -n "$want" ]] || return 0
-  # Read the grep hits line by line instead of splitting a bare command
-  # substitution: CLAUDE_CONFIG_DIR is relocatable (CONTRIBUTING.md), so a path
-  # like "/Volumes/External Drive/.claude" would otherwise be split at the space
-  # and every jq lookup would miss — leaving each broker "unknown" and the reap
-  # pass dead. Process substitution keeps the counters in this shell.
-  while IFS= read -r bj; do
-    [[ -n "$bj" ]] || continue
-    [[ "$(jq -r '.pid // empty' "$bj" 2>/dev/null || true)" == "$pid" ]] || continue
-    [[ "$(jq -r '.sessionDir // empty' "$bj" 2>/dev/null || true)" == "$want" ]] || continue
-    found="$(dirname "$bj")"; n=$(( n + 1 ))
-  done < <(grep -lE "\"pid\"[[:space:]]*:[[:space:]]*$pid([^0-9]|\$)" "$STATE_DIR"/*/broker.json 2>/dev/null || true)
+  broker_index_ensure || return 0
+  # Read whole fields, never word-split: a state dir or sessionDir may contain
+  # spaces (CLAUDE_CONFIG_DIR is relocatable, and the suite's own fixtures are
+  # spaced on purpose to keep that a standing regression).
+  while IFS=$'\t' read -r ipid isess idir; do
+    [[ "$ipid" == "$pid" ]] || continue
+    [[ "$isess" == "$want" ]] || continue
+    found="$idir"; n=$(( n + 1 ))
+  done < "$BROKER_INDEX"
   (( n == 1 )) && printf '%s' "$found"
   return 0
 }
@@ -344,7 +438,7 @@ if ! mkdir "$LOCK" 2>/dev/null; then
     exit 0
   fi
 fi
-trap 'cwd_snapshot_clear; rmdir "$LOCK" 2>/dev/null || true' EXIT
+trap 'cwd_snapshot_clear; broker_index_clear; rmdir "$LOCK" 2>/dev/null || true' EXIT
 
 # --- Pass 1: reap running, idle brokers (only in --reap mode) ---
 if [[ "$MODE" == "reap" ]]; then
@@ -421,23 +515,25 @@ fi
 # #923 gave the reap pass this pid+sessionDir disambiguation; the GC pass had
 # none, and rm -rf'd the live session's dir (#921).
 session_dir_has_live_claimant() {
-  local want="$1" self="$2" other opid osdir
-  shopt -s nullglob
-  for other in "$STATE_DIR"/*/broker.json; do
-    [[ "$other" == "$self" ]] && continue
-    osdir="$(jq -r '.sessionDir // empty' "$other" 2>/dev/null || true)"
+  local want="$1" self="$2" opid osdir odir
+  broker_index_ensure || return 1
+  # $self is the record under inspection, identified by its state dir -- the
+  # index carries no broker.json path, and dirname($self) is exactly the third
+  # field. Same per-pass index as state_dir_of_broker: this runs once per GC
+  # candidate, so a rescan here is the same N-by-M cost the index removes.
+  local selfdir; selfdir="$(dirname "$self")"
+  while IFS=$'\t' read -r opid osdir odir; do
+    [[ "$odir" == "$selfdir" ]] && continue
     [[ "$osdir" == "$want" ]] || continue
-    opid="$(jq -r '.pid // empty' "$other" 2>/dev/null || true)"
     [[ -n "$opid" ]] || continue
     kill -0 "$opid" 2>/dev/null && return 0
-  done
+  done < "$BROKER_INDEX"
   return 1
 }
 
 # --- Pass 2: GC stale tmp sessionDirs of dead brokers (both modes) ---
-if [[ -d "$STATE_DIR" ]]; then
-  shopt -s nullglob
-  for bj in "$STATE_DIR"/*/broker.json; do
+while IFS= read -r bj; do
+    [[ -n "$bj" ]] || continue
     pid="$(jq -r '.pid // empty' "$bj" 2>/dev/null || true)"
     sdir="$(jq -r '.sessionDir // empty' "$bj" 2>/dev/null || true)"
     [[ -z "$pid" ]] && continue
@@ -456,7 +552,6 @@ if [[ -d "$STATE_DIR" ]]; then
       fi
       gc_dirs=$(( gc_dirs + 1 ))
     fi
-  done
-fi
+done < <(all_broker_jsons)
 
 echo "codex-broker-reaper: mode=$MODE dry_run=$DRY_RUN max_age_min=$MAX_AGE_MIN scanned=$scanned reaped=$reaped gc_dirs=$gc_dirs skipped=$skipped"

--- a/tests/test_codex_broker_reaper.sh
+++ b/tests/test_codex_broker_reaper.sh
@@ -833,7 +833,56 @@ else
   if [ -d "$SESS6" ]; then pass "#1056 gate 6: refusal left the sessionDir intact"
   else fail "#1056 gate 6: refusal deleted $SESS6"; fi
 fi
-rm -rf "$TMPD6"
+
+
+
+# --- Gate 7: a malformed record must not truncate the index -----------------
+# jq aborts the whole stream at the first parse error when handed many files,
+# so one unparseable broker.json used to drop every record after it. The GC
+# pass reads that index: a live broker whose record was dropped no longer
+# claims its sessionDir, and the dir gets collected while still in use (#921
+# by another road). The emptiness guard of gate 6 cannot see this — the index
+# is short, not empty.
+TMPROOT7="${TMPDIR:-/tmp}"; TMPROOT7="${TMPROOT7%/}"
+TMPD7="$(mktemp -d "$TMPROOT7/px1056g7.XXXXXX")" || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+cleanup_gate7() {
+  rm -rf "$TMPD7"
+  declare -F cleanup_gate6 >/dev/null && cleanup_gate6
+  return 0
+}
+trap cleanup_gate7 EXIT INT TERM
+
+if ! command -v jq >/dev/null 2>&1; then
+  skip "#1056 gate 7: needs jq"
+else
+  CONFIG7="$TMPD7/config"
+  SHARED7="$TMPD7/cxc-SHARED7"
+  mkdir -p "$SHARED7"
+  # Ordered so the malformed record sits BETWEEN the dead claimant and the live
+  # one. Directory iteration is sorted, so 01/02/03 fixes that order.
+  DEAD7=99999
+  while kill -0 "$DEAD7" 2>/dev/null; do DEAD7=$((DEAD7 - 1)); done
+  mkdir -p "$CONFIG7/plugins/data/codex-openai-codex/state/01-dead" \
+           "$CONFIG7/plugins/data/codex-openai-codex/state/02-broken" \
+           "$CONFIG7/plugins/data/codex-openai-codex/state/03-live"
+  ST7="$CONFIG7/plugins/data/codex-openai-codex/state"
+  printf '{"pid":%s,"sessionDir":"%s"}\n' "$DEAD7" "$SHARED7" > "$ST7/01-dead/broker.json"
+  printf '{"pid":1,"sessionDir":"/nope"\n'                     > "$ST7/02-broken/broker.json"
+  # This shell is alive and claims the same dir — the record that must survive.
+  printf '{"pid":%s,"sessionDir":"%s"}\n' "$$" "$SHARED7"      > "$ST7/03-live/broker.json"
+
+  GC7="$(TMPDIR="$TMPD7" CLAUDE_CONFIG_DIR="$CONFIG7" bash "$REAPER" --gc 2>&1)"
+  if [ -d "$SHARED7" ]; then
+    pass "#1056 gate 7: live claim behind a malformed record still protects the dir"
+  else
+    fail "#1056 gate 7: --gc deleted $SHARED7 despite a live claimant (output: $GC7)"
+  fi
+  case "$GC7" in
+    *"a live broker still claims this sessionDir"*)
+      pass "#1056 gate 7: the skip names the live claim" ;;
+    *) fail "#1056 gate 7: expected a live-claimant SKIP GC line (output: $GC7)" ;;
+  esac
+fi
 
 
 echo "=== summary ==="

--- a/tests/test_codex_broker_reaper.sh
+++ b/tests/test_codex_broker_reaper.sh
@@ -797,6 +797,15 @@ echo ""
 # pass for the wrong reason — which is what the positive control exists to catch.
 TMPROOT6="${TMPDIR:-/tmp}"; TMPROOT6="${TMPROOT6%/}"
 TMPD6="$(mktemp -d "$TMPROOT6/px1056g6.XXXXXX")" || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+# Chain gate 5's handler rather than replacing it: an early exit anywhere below
+# would otherwise leave this fixture behind, since the active trap only knows
+# about $TMPD5.
+cleanup_gate6() {
+  rm -rf "$TMPD6"
+  declare -F cleanup_gate5 >/dev/null && cleanup_gate5
+  return 0
+}
+trap cleanup_gate6 EXIT INT TERM
 CONFIG6="$TMPD6/config"
 SD6="$CONFIG6/plugins/data/codex-openai-codex/state/ws6-deadbeef"
 mkdir -p "$SD6"

--- a/tests/test_codex_broker_reaper.sh
+++ b/tests/test_codex_broker_reaper.sh
@@ -783,6 +783,59 @@ fi   # Darwin gate (5b)
 fi   # jq gate (gate 5)
 
 echo ""
+
+# --- Gate 6: an unusable broker index must not read as an empty sweep --------
+# The GC pass iterates the per-pass index rather than re-parsing every
+# broker.json (two jq spawns per record was the script's whole runtime). That
+# makes a failed index build silently equivalent to "no records exist": the
+# loop reads zero rows and the summary still prints gc_dirs=0, which is exactly
+# what a clean sweep prints. This gate pins the refusal instead.
+# Strip the trailing slash TMPDIR carries on macOS before building a path under
+# it: is_safe_session_dir rejects any path containing "//" outright (its
+# traversal screen), so the doubled separator makes a legitimate sessionDir
+# unsafe and nothing is ever collected. The refusal assertions below would then
+# pass for the wrong reason — which is what the positive control exists to catch.
+TMPROOT6="${TMPDIR:-/tmp}"; TMPROOT6="${TMPROOT6%/}"
+TMPD6="$(mktemp -d "$TMPROOT6/px1056g6.XXXXXX")" || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+CONFIG6="$TMPD6/config"
+SD6="$CONFIG6/plugins/data/codex-openai-codex/state/ws6-deadbeef"
+mkdir -p "$SD6"
+SESS6="$TMPD6/cxc-GATE6"
+mkdir -p "$SESS6"
+# A dead pid whose sessionDir still exists — the one shape --gc collects.
+DEAD6=99999
+while kill -0 "$DEAD6" 2>/dev/null; do DEAD6=$((DEAD6 - 1)); done
+printf '{"pid":%s,"sessionDir":"%s"}\n' "$DEAD6" "$SESS6" > "$SD6/broker.json"
+
+if ! command -v jq >/dev/null 2>&1; then
+  skip "#1056 gate 6: needs jq for the positive control"
+else
+  # Positive control first: without it, a refusal below proves nothing — a
+  # fixture that never collected anything also reports gc_dirs=0.
+  OK6="$(TMPDIR="$TMPD6" CLAUDE_CONFIG_DIR="$CONFIG6" bash "$REAPER" --gc --dry-run 2>&1)"
+  case "$OK6" in
+    *"WOULD GC  dir=$SESS6"*) pass "#1056 gate 6 control: --gc collects the dead record" ;;
+    *) fail "#1056 gate 6 control: --gc should have collected $SESS6 (output: $OK6)" ;;
+  esac
+
+  # Now break the index build by putting a failing `jq` first on PATH.
+  BIN6="$TMPD6/bin"; mkdir -p "$BIN6"
+  printf '#!/bin/sh\nexit 127\n' > "$BIN6/jq"; chmod +x "$BIN6/jq"
+  BAD6="$(PATH="$BIN6:$PATH" TMPDIR="$TMPD6" CLAUDE_CONFIG_DIR="$CONFIG6" \
+          bash "$REAPER" --gc --dry-run 2>&1)"
+  case "$BAD6" in
+    *"WOULD GC"*) fail "#1056 gate 6: --gc collected with an unusable index (output: $BAD6)" ;;
+    *"SKIP GC"*)  pass "#1056 gate 6: unusable index refuses the sweep and says so" ;;
+    *)            fail "#1056 gate 6: unusable index swept silently — no SKIP GC line (output: $BAD6)" ;;
+  esac
+
+  # The refusal must not have deleted anything on the way out.
+  if [ -d "$SESS6" ]; then pass "#1056 gate 6: refusal left the sessionDir intact"
+  else fail "#1056 gate 6: refusal deleted $SESS6"; fi
+fi
+rm -rf "$TMPD6"
+
+
 echo "=== summary ==="
 echo "PASS: $PASS"
 echo "FAIL: $FAIL"

--- a/tests/test_codex_broker_reaper.sh
+++ b/tests/test_codex_broker_reaper.sh
@@ -627,6 +627,161 @@ fi
 
 fi   # jq gate
 
+# --- Gate 5: #1056 sibling CLAUDE_CONFIG_DIR state ---------------------------
+# A host may run more than one Claude config dir (~/.claude, ~/.claude-2). The
+# broker records its broker.json under the config dir of the session that
+# started it, so a reaper reading only its OWN config dir cannot resolve those
+# brokers: pid+sessionDir matches nothing, owner_status returns `unknown`, and
+# the under-reap bias keeps them forever. Measured on the author's host: 2143 of
+# 2711 skips over 541 launchd runs were `owner unknown`, and pointing
+# CLAUDE_CONFIG_DIR at the sibling flipped 17 of 19 to reapable.
+#
+# The fix reads every config dir that is a SIBLING of CONFIG_DIR. Both halves of
+# the sweep must widen together: extending the GC loop across config dirs while
+# leaving the live-claimant check on one dir would let --gc delete a sessionDir
+# a live broker in a sibling config still claims — #921, reintroduced on a new
+# axis. 5a covers that; 5b covers the reap-side resolution.
+if ! command -v jq >/dev/null 2>&1; then
+  skip "gate 5 sibling config dir (needs jq: the reaper reads broker.json with it)"
+else
+
+TMPROOT5="${TMPDIR:-/tmp}"; TMPROOT5="${TMPROOT5%/}"
+TMPD5="$(mktemp -d "$TMPROOT5/px1056.XXXXXX")" || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+# Both spaced on purpose, same standing regression as gates 3 and 4.
+CONFIG5A="$TMPD5/config dir"          # the one CLAUDE_CONFIG_DIR names
+# HIDDEN on purpose. The real siblings are dotfiles (~/.claude-2), so candidate
+# discovery only reaches them with dotglob set -- and a visible fixture name here
+# leaves that load-bearing detail unpinned: dropping dotglob from the fix keeps
+# the whole suite green (measured: 55 PASS / 0 FAIL without dotglob).
+CONFIG5B="$TMPD5/.config dir 2"       # the sibling holding the real records
+STATE5A="$CONFIG5A/plugins/data/codex-openai-codex/state"
+STATE5B="$CONFIG5B/plugins/data/codex-openai-codex/state"
+LIVE5_PID=""
+BROKER5_PID=""
+
+cleanup_gate5() {
+  local kid
+  if [ -n "$BROKER5_PID" ]; then
+    for kid in $(pgrep -P "$BROKER5_PID" 2>/dev/null); do kill -KILL "$kid" 2>/dev/null; done
+    kill -KILL "$BROKER5_PID" 2>/dev/null
+  fi
+  [ -n "$LIVE5_PID" ] && kill -KILL "$LIVE5_PID" 2>/dev/null
+  rm -rf "$TMPD5"
+  declare -F cleanup_gate4 >/dev/null && cleanup_gate4
+  return 0
+}
+trap cleanup_gate5 EXIT INT TERM
+
+# $1 state root, $2 slug, $3 pid, $4 sessionDir
+write_state5() {
+  local root="$1" slug="$2" pid="$3" session="$4" sd
+  sd="$root/$slug"
+  mkdir -p "$sd"
+  printf '{"sessionDir":"%s","pid":%s}\n' "$session" "$pid" > "$sd/broker.json"
+}
+
+# --- 5a: GC reaches sibling records, and respects sibling live claimants -----
+SD5_ORPHAN="$TMPD5/cxc-ORPHAN5"
+SD5_SHARED="$TMPD5/cxc-SHARED5"
+mkdir -p "$SD5_ORPHAN" "$SD5_SHARED"
+
+sleep 600 &
+LIVE5_PID=$!
+
+DEAD5_PID="$(bash -c 'echo $$')"
+dead5_ready=false
+for _ in $(seq 1 30); do
+  if ! kill -0 "$DEAD5_PID" 2>/dev/null; then dead5_ready=true; break; fi
+  sleep 0.1
+done
+
+# Only the SIBLING knows about the orphan — the primary state dir stays empty of
+# it, so a single-dir reaper never sees this record at all.
+write_state5 "$STATE5B" orphan "$DEAD5_PID" "$SD5_ORPHAN"
+# The live claimant lives in the SIBLING; the stale dead record naming the same
+# sessionDir lives in the PRIMARY. A GC that widened its record sweep but not
+# its claimant check reads only the stale one and deletes a live dir.
+write_state5 "$STATE5B" live      "$LIVE5_PID" "$SD5_SHARED"
+write_state5 "$STATE5A" aaastale  "$DEAD5_PID" "$SD5_SHARED"
+
+if [ "$dead5_ready" != true ] || ! kill -0 "$LIVE5_PID" 2>/dev/null; then
+  fail "#1056: gate 5a fixture pids not in the expected state (live=$LIVE5_PID dead=$DEAD5_PID)"
+else
+  GC5_OUT="$(TMPDIR="$TMPD5" CLAUDE_CONFIG_DIR="$CONFIG5A" bash "$REAPER" --gc 2>&1)"
+
+  if [ ! -d "$SD5_ORPHAN" ]; then
+    pass "#1056: --gc sweeps a stale sessionDir recorded only in a sibling config dir"
+  else
+    fail "#1056: --gc missed a sibling config dir's stale record (output: $GC5_OUT)"
+  fi
+
+  if [ -d "$SD5_SHARED" ]; then
+    pass "#1056: --gc keeps a sessionDir a sibling config dir's live broker claims"
+  else
+    fail "#1056: --gc deleted a dir claimed by a live broker in a sibling config dir (output: $GC5_OUT)"
+  fi
+fi
+
+# --- 5b: the reap pass resolves an owner recorded in a sibling config dir ----
+# Signal C (workspaceRoot deleted) is used deliberately: it needs no cwd
+# snapshot, so this case does not depend on lsof. The idle gate reads BSD
+# `stat -f %m`, so the reap half is Darwin-only like gate 3.
+if [ "$(uname -s)" != "Darwin" ]; then
+  skip "gate 5b sibling-config reap decision (needs Darwin: reaper's idle gate uses BSD 'stat -f %m')"
+else
+
+FIXTURE5="$TMPD5/broker-fixture.sh"
+REAPER5="$TMPD5/reaper-copy.sh"
+SD5_REAP="$TMPD5/cxc-REAP5"
+WS5_GONE="$TMPD5/workspace-deleted"
+
+cat > "$FIXTURE5" <<'FIX5'
+#!/bin/bash
+exec 3<> "$PX1056_FIFO"
+read -r -u 3
+FIX5
+
+sed "s|^BROKER_PATTERN=.*|BROKER_PATTERN='$FIXTURE5'|" "$REAPER" > "$REAPER5"
+
+mkdir -p "$SD5_REAP"
+FIFO5="$TMPD5/broker5.fifo"
+mkfifo "$FIFO5"
+# Backdated so the idle gate always passes.
+touch -t 202001010000 "$SD5_REAP/broker.log"
+PX1056_FIFO="$FIFO5" bash "$FIXTURE5" serve --endpoint "unix:$SD5_REAP/broker.sock" >/dev/null 2>&1 &
+BROKER5_PID=$!
+
+# The record lives ONLY in the sibling config dir, and names a workspace root
+# that does not exist — signal C, an unambiguous orphan.
+SD5_STATE="$STATE5B/reapme-$(printf '%s' "$WS5_GONE" | shasum -a 256 | cut -c1-16)"
+mkdir -p "$SD5_STATE/jobs"
+printf '{"sessionDir":"%s","pid":%s}\n' "$SD5_REAP" "$BROKER5_PID" > "$SD5_STATE/broker.json"
+printf '{"workspaceRoot":"%s"}\n' "$WS5_GONE" > "$SD5_STATE/jobs/job.json"
+
+broker5_ready=false
+for _ in $(seq 1 30); do
+  if kill -0 "$BROKER5_PID" 2>/dev/null; then broker5_ready=true; break; fi
+  sleep 0.1
+done
+
+if [ "$broker5_ready" != true ]; then
+  fail "#1056: gate 5b fixture broker did not come up"
+else
+  DRY5_OUT="$(TMPDIR="$TMPD5" CLAUDE_CONFIG_DIR="$CONFIG5A" bash "$REAPER5" --reap --max-age 5 --dry-run 2>&1)"
+  case "$DRY5_OUT" in
+    *"WOULD REAP pid=$BROKER5_PID"*)
+      pass "#1056: reap resolves a broker whose state lives in a sibling config dir" ;;
+    *"owner unknown"*)
+      fail "#1056: sibling-config broker still reads as 'owner unknown' (output: $DRY5_OUT)" ;;
+    *)
+      fail "#1056: expected WOULD REAP for pid=$BROKER5_PID, got: $DRY5_OUT" ;;
+  esac
+fi
+
+fi   # Darwin gate (5b)
+
+fi   # jq gate (gate 5)
+
 echo ""
 echo "=== summary ==="
 echo "PASS: $PASS"

--- a/tests/test_codex_broker_reaper.sh
+++ b/tests/test_codex_broker_reaper.sh
@@ -688,12 +688,12 @@ mkdir -p "$SD5_ORPHAN" "$SD5_SHARED"
 sleep 600 &
 LIVE5_PID=$!
 
-DEAD5_PID="$(bash -c 'echo $$')"
-dead5_ready=false
-for _ in $(seq 1 30); do
-  if ! kill -0 "$DEAD5_PID" 2>/dev/null; then dead5_ready=true; break; fi
-  sleep 0.1
-done
+# A high, currently-unused pid rather than a just-exited one: the kernel can
+# hand a recently freed pid to a new process before the reaper runs, and the
+# record would then read as live, failing this gate for an unrelated reason.
+DEAD5_PID=99999
+while kill -0 "$DEAD5_PID" 2>/dev/null; do DEAD5_PID=$((DEAD5_PID - 1)); done
+dead5_ready=true
 
 # Only the SIBLING knows about the orphan — the primary state dir stays empty of
 # it, so a single-dir reaper never sees this record at all.


### PR DESCRIPTION
## 문제

`codex-broker-reaper.sh` 가 state 디렉터리를 하나만 읽습니다. broker 의 `broker.json` 은 그 broker 를 띄운 **세션의 설정 디렉터리** 아래에 기록되므로, 다른 설정 디렉터리가 소유한 broker 는 pid+sessionDir 매칭이 전부 실패하고 `owner unknown` 으로 떨어집니다. `unknown` 은 설계상 보존(under-reap 편향, #919)이라 결함이 조용합니다 — reaper 는 매번 정상 종료하고, 회수만 일어나지 않습니다.

이 호스트의 설정 디렉터리는 4개(`~/.claude`, `-2`, `-3`, `-4`)였고, launchd job 이 30분마다 544회 도는 동안 skip 2687건 중 **2161건(80.4%)** 이 `owner unknown` 이었습니다 (최초 게시본의 `skip 2711건 중 2143건(79%)` 은 분모 라벨 오기 — 2711 은 skip 이 아니라 scanned 합계였습니다).

## 수정

**후보를 `CONFIG_DIR` 의 형제로 열거합니다.** `$HOME` 글롭이 아닌 이유는 테스트 가능성입니다 — 프로덕션에서는 `CONFIG_DIR=~/.claude` 라 부모가 어차피 `$HOME` 이지만, 부모를 기준으로 삼아야 샌드박스된 `CLAUDE_CONFIG_DIR` 이 샌드박스된 형제를 열거할 수 있습니다. 디렉터리 이름이 아니라 경로 suffix 가 판별자이고, 실제 대상이 dotfile 이라 `dotglob` 이 필요합니다.

**세 소비자가 함께 넓어집니다.** GC 패스는 이 레코드들이 지목하는 sessionDir 을 `rm -rf` 하고, 그 live-claimant 가드도 같은 root 를 읽습니다. 레코드 쪽만 넓히면 `--gc` 가 형제 설정의 살아있는 broker 가 쓰는 디렉터리를 지웁니다.

**per-pass 인덱스.** 넓히기 전 구현은 조회마다 전 레코드를 재탐색해서 996 레코드 × 7 broker = pass 당 6,972 grep 프로세스였고, 그동안 reaper 가 lock 을 쥡니다. jq 1회로 인덱스를 만들어 재사용합니다(996 레코드 0.19초). 위젠과 같은 함수 본문을 다시 쓰기 때문에 커밋을 분리하면 **실행해 본 적 없는 중간 상태**가 게시되므로, 같은 커밋에 두고 `Constraint:` 트레일러로 남겼습니다.

## 부수 발견 — #921 이 이 축에서 이미 재현됨

이슈 본문에는 이 위험을 "수정하면서 새로 만들지 말아야 할 것"으로 적었는데, **이미 존재합니다.** 회귀 테스트 gate 5a 를 수정 전 코드에 돌리면, 기본 모드이자 `--help` 가 "zero risk" 라고 부르는 `--gc` 가 살아있는 broker 의 sessionDir 을 삭제합니다.

```
FAIL  #1056: --gc deleted a dir claimed by a live broker in a sibling config dir
      (output: GC dir=.../cxc-SHARED5 (broker pid 64943 dead))
```

자기 설정 디렉터리의 stale dead-pid 기록만 보이고, 살아있는 claimant 는 형제 쪽에 있어 안 보였기 때문입니다.

## 검증

레포 전체 스위트가 통과합니다. pytest 813 passed / 1 xfailed, 셸 게이트 전 블록 0 failed, ruff·shellcheck 클린.

```
$ env -u PRAXIS_ASK_END_STRICT -u PRAXIS_CODEX_REAP bash scripts/run-tests.sh
813 passed, 1 xfailed, 16943 warnings in 21.49s
...
=== ruff ===
All checks passed!
=== shellcheck ===
=== markdownlint (advisory) ===
no changed markdown files
ALL TESTS PASSED
```

`PRAXIS_ASK_END_STRICT` 를 명시적으로 unset 한 이유는 그것이 작성자 셸에 설정돼 있고, `test_block_ask_end_option.sh` 가 인라인으로 거는 `PRAXIS_ASK_END_ADVISORY=1` 를 덮어써서 advisory 케이스 2건을 실패시키기 때문입니다. 이 PR 과 무관하며 clean `main`(ee1e1a1)에서도 동일하게 재현되고, unset 하면 그 파일이 71 PASS / 0 FAIL 입니다. CI 에는 이 변수가 없습니다.

reaper 자체 스위트는 **55 PASS / 0 FAIL / 0 SKIP** (Darwin + jq 라 gate 3·4·5 전부 실행).

gate 5 는 수정 전 코드에서 3건 실패하고 수정 후 통과합니다. fixture 형제 디렉터리는 **숨김 이름**입니다 — 보이는 이름이면 `dotglob` 을 제거해도 55 PASS 라 아무것도 묶어두지 못했습니다. 숨김으로 바꾼 뒤 같은 제거는 3건 전부 실패합니다.

```
# dotglob 제거 후
exit=1
PASS: 52
FAIL: 3
  - #1056: --gc missed a sibling config dir's stale record
  - #1056: --gc deleted a dir claimed by a live broker in a sibling config dir
  - #1056: sibling-config broker still reads as 'owner unknown'
```

실환경에서 동일한 기본 호출(플래그·환경변수 없음) 전후 대조:

```
# 수정 전
SKIP   pid=1987  (owner unknown: no single state dir matches this pid and sessionDir)
SKIP   pid=55712 (owner unknown: no single state dir matches this pid and sessionDir)
SKIP   pid=56901 (owner unknown: no single state dir matches this pid and sessionDir)
codex-broker-reaper: mode=reap dry_run=true max_age_min=30 scanned=5 reaped=0 gc_dirs=0 skipped=5

# 수정 후
SKIP   pid=1987  (owner alive: workspace .../laplace-airflow-dags-hub-5036 has a live process working in it)
SKIP   pid=55712 (owner alive: workspace .../laplace-gitops-10096 has a live process working in it)
WOULD REAP pid=56901 idle=184672s dir=/var/folders/.../cxc-U6mGBL
codex-broker-reaper: mode=reap dry_run=true max_age_min=30 scanned=5 reaped=1 gc_dirs=0 skipped=4
```

3건 모두 해소되고, 그중 2건은 **보존이 정답**이라 정확히 보존됩니다.

Pre-commit verified: 레포에 pre-commit 훅 설정이 없어(`.pre-commit-config.yaml` 부재, `core.hooksPath` 미설정) CI 가 실제로 도는 `bash scripts/run-tests.sh` 를 직접 실행 — exit 0, ALL TESTS PASSED, pytest 813 passed / 1 xfailed, ruff All checks passed, shellcheck --severity=warning exit 0

Caller chain verified: `grep -rn codex-broker-reaper` 전수 — 호출자는 SKILL.md Step 6(`--gc`, `--reap --max-age 30`), codex-broker-reaper.plist(launchd ProgramArguments), tests/test_codex_broker_reaper.sh(`$REAPER`) 3곳. 이 PR 은 내부 함수(state_roots / all_broker_jsons / broker_index_*)만 추가하고 CLI 플래그·종료 코드·출력 포맷을 바꾸지 않으므로 세 호출자 모두 무영향

## 미검증 / 남는 것

- **과거 2143건을 하나씩 귀속하지 않았습니다.** `owner unknown` 은 크래시한 broker 의 잔여 기록과 pid 재사용으로도 발생합니다(302행 주석이 이미 지적). 측정된 것은 "현재 스냅샷에서 이 원인으로 설명되지 않는 broker 는 0건" 입니다.
- **wall-clock 은 느려졌습니다** — 같은 호출이 main 4.0초 대 이 브랜치 10.3초. 인덱스 탓이 아닙니다(인덱스 빌드 0.19초). owner 가 실제로 해소되면서 main 이 건너뛰던 작업(cwd 스냅샷, 프로세스 트리 순회)을 이제 수행하기 때문입니다. 즉 "일을 하게 되어서 느려진" 것이고, 30분 간격 background job 기준 문제되는 수준은 아니라고 판단했습니다. 이 판단은 재검토 대상입니다.
- **설치된 plist 가 `praxis/7.8.0` 캐시 경로를 하드코딩**하고 있습니다(현재 7.10.0 존재). 지금은 7.8.0 이 남아 있어 동작하지만 캐시 정리 시 job 이 조용히 죽습니다. 이 PR 범위 밖 — #1059 로 분리했습니다.

Closes #1056


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved broker state discovery across multiple configuration directories.
  * Preserved paths containing spaces during broker cleanup.
  * Prevented cleanup operations when broker state cannot be safely indexed.
  * Improved protection for active sessions and broker claims across configurations.
  * Enhanced cleanup behavior on supported macOS environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->