### PR TITLE
fix(cw): warn when the reaper is not the installed version

### DIFF
--- a/skills/codex-review-wrap/LAUNCHD.md
+++ b/skills/codex-review-wrap/LAUNCHD.md
@@ -80,3 +80,21 @@ this targets, prune it periodically (or point `StandardOutPath` /
 plist points at a specific version. After updating the praxis plugin, **re-run
 the Install steps** to re-render the plist against the new path. (The
 phase-end Step 6 reaper resolves its path at runtime and is unaffected.)
+
+Nothing forces that step, so the reaper reports it instead: when it is running
+from inside the plugin cache and its own directory is not the one the manifest
+installs, it writes one line to the log and carries on.
+
+```text
+WARN version drift: running .../praxis/7.8.0 but the manifest installs .../praxis/7.11.0 — re-run the LAUNCHD.md Install steps to re-render the plist
+```
+
+Two things it deliberately does not do. It never exits non-zero — an old reaper
+still beats no reaper, and the exit code is what `launchctl list` shows, so
+spending it here would hide a real failure. And it cannot fire when the pinned
+version's directory is gone entirely (a cache cleanup): the script never runs,
+so nothing self-checks. That case surfaces as a `No such file or directory`
+line from bash in the same log, every `StartInterval`.
+
+A development checkout is silent by construction — the check runs only for a
+copy inside `$CLAUDE_CONFIG_DIR/plugins/cache`.

--- a/skills/codex-review-wrap/codex-broker-reaper.sh
+++ b/skills/codex-review-wrap/codex-broker-reaper.sh
@@ -56,7 +56,7 @@ STATE_SUFFIX="plugins/data/codex-openai-codex/state"
 # writes its broker.json under the config dir of the SESSION THAT STARTED IT, so
 # a reaper reading only $STATE_DIR cannot resolve the rest: pid+sessionDir
 # matches nothing, owner_status returns `unknown`, and the under-reap bias keeps
-# them forever. Measured on the author's host: 2143 of 2711 skips across 541
+# them forever. Measured on the author's host: 2161 of 2687 skips across 544
 # launchd runs.
 #
 # Candidates are SIBLINGS of CONFIG_DIR rather than a $HOME glob. Production

--- a/skills/codex-review-wrap/codex-broker-reaper.sh
+++ b/skills/codex-review-wrap/codex-broker-reaper.sh
@@ -231,6 +231,49 @@ case "$MAX_AGE_MIN" in
   ''|*[!0-9]*) MAX_AGE_MIN=30 ;;
 esac
 
+# Warn when this copy is not the one the plugin manifest points at (#1059).
+#
+# The launchd plist renders the reaper's path with the plugin version in it
+# (`.../cache/praxis/praxis/<ver>/skills/...`), so updating the plugin leaves the
+# job running the old copy and nothing says so. LAUNCHD.md documents re-running
+# the Install steps, but a manual step nobody is reminded of is a step that gets
+# skipped: this host sat three versions behind for weeks.
+#
+# The check speaks only when the running script is itself inside the plugin
+# cache. A development checkout can never equal installPath, so warning there
+# would fire on every local run and train the reader to ignore the line.
+#
+# A missing or unparseable manifest is silence, not drift -- it is the absence
+# of an answer. Advisory only: nothing here changes what the run does or what it
+# exits with, because running an old reaper still beats running none.
+warn_on_version_drift() {
+  local self plugin_root installed cache_root
+  self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)" || return 0
+  # Both sides are resolved with `pwd -P` before comparing. On macOS /var is a
+  # symlink to /private/var, so a CONFIG_DIR that came in as a literal string
+  # and a path that went through `pwd -P` disagree on the same directory and the
+  # prefix test silently never matches.
+  cache_root="$(cd "$CONFIG_DIR/plugins/cache" 2>/dev/null && pwd -P)" || return 0
+  case "$self" in
+    "$cache_root"/*) ;;
+    *) return 0 ;;
+  esac
+  # <plugin_root>/skills/codex-review-wrap -> <plugin_root>, the shape
+  # installPath records.
+  plugin_root="$(cd "$self/../.." && pwd -P)" || return 0
+  local manifest="$CONFIG_DIR/plugins/installed_plugins.json"
+  [[ -f "$manifest" ]] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  installed="$(jq -r '.plugins["praxis@praxis"][0].installPath // empty' "$manifest" 2>/dev/null || true)"
+  [[ -n "$installed" ]] || return 0
+  # Same resolution on the manifest's side. It records whatever string the
+  # installer wrote, which need not be the physical path.
+  installed="$(cd "$installed" 2>/dev/null && pwd -P)" || return 0
+  [[ "$installed" != "$plugin_root" ]] || return 0
+  echo "WARN version drift: running $plugin_root but the manifest installs $installed — re-run the LAUNCHD.md Install steps to re-render the plist" >&2
+}
+warn_on_version_drift
+
 now=$(date +%s)
 max_age_sec=$(( MAX_AGE_MIN * 60 ))
 

--- a/tests/test_codex_broker_reaper.sh
+++ b/tests/test_codex_broker_reaper.sh
@@ -632,8 +632,8 @@ fi   # jq gate
 # broker records its broker.json under the config dir of the session that
 # started it, so a reaper reading only its OWN config dir cannot resolve those
 # brokers: pid+sessionDir matches nothing, owner_status returns `unknown`, and
-# the under-reap bias keeps them forever. Measured on the author's host: 2143 of
-# 2711 skips over 541 launchd runs were `owner unknown`, and pointing
+# the under-reap bias keeps them forever. Measured on the author's host: 2161 of
+# 2687 skips over 544 launchd runs were `owner unknown`, and pointing
 # CLAUDE_CONFIG_DIR at the sibling flipped 17 of 19 to reapable.
 #
 # The fix reads every config dir that is a SIBLING of CONFIG_DIR. Both halves of

--- a/tests/test_codex_broker_reaper.sh
+++ b/tests/test_codex_broker_reaper.sh
@@ -894,6 +894,91 @@ else
 fi
 
 
+# --- Gate 8: version-drift warning against the plugin manifest (#1059) ------
+# The launchd plist pins the reaper's path down to a plugin version, so an
+# updated plugin leaves the job running an old copy with no signal at all. The
+# reaper compares its own location against the manifest's installPath and says
+# so. Two boundaries the assertions below pin: the check speaks ONLY when the
+# script itself is running from inside the plugin cache (a dev checkout must
+# not warn on every run, or the warning becomes noise nobody reads), and a
+# mismatch never changes what the run does or what it exits with.
+TMPROOT8="${TMPDIR:-/tmp}"; TMPROOT8="${TMPROOT8%/}"
+TMPD8="$(mktemp -d "$TMPROOT8/px1059g8.XXXXXX")" || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+cleanup_gate8() {
+  rm -rf "$TMPD8"
+  declare -F cleanup_gate7 >/dev/null && cleanup_gate7
+  return 0
+}
+trap cleanup_gate8 EXIT INT TERM
+
+if ! command -v jq >/dev/null 2>&1; then
+  skip "#1059 gate 8: needs jq"
+else
+  CONFIG8="$TMPD8/config"
+  CACHE8="$CONFIG8/plugins/cache/praxis/praxis"
+  mkdir -p "$CONFIG8/plugins" "$CACHE8/9.9.9/skills/codex-review-wrap" \
+           "$CACHE8/9.9.8/skills/codex-review-wrap"
+  # The manifest names 9.9.9 as the installed version; a copy of the reaper is
+  # planted under BOTH that path and the older 9.9.8, so the same script can be
+  # run from the current tree and from a stale one.
+  printf '{"plugins":{"praxis@praxis":[{"version":"9.9.9","installPath":"%s/9.9.9"}]}}\n' \
+    "$CACHE8" > "$CONFIG8/plugins/installed_plugins.json"
+  cp "$REAPER" "$CACHE8/9.9.9/skills/codex-review-wrap/codex-broker-reaper.sh"
+  cp "$REAPER" "$CACHE8/9.9.8/skills/codex-review-wrap/codex-broker-reaper.sh"
+
+  # (a) stale copy inside the cache -> warns, and names both versions
+  OUT8_STALE="$(TMPDIR="$TMPD8" CLAUDE_CONFIG_DIR="$CONFIG8" \
+    bash "$CACHE8/9.9.8/skills/codex-review-wrap/codex-broker-reaper.sh" --gc --dry-run 2>&1)"
+  RC8_STALE=$?
+  case "$OUT8_STALE" in
+    *"version drift"*9.9.8*9.9.9*) pass "#1059 gate 8: stale cache copy warns and names both versions" ;;
+    *) fail "#1059 gate 8: expected a version-drift warning naming 9.9.8 and 9.9.9 (output: $OUT8_STALE)" ;;
+  esac
+
+  # (b) the warning is advisory — the run still completes and exits 0
+  if [ "$RC8_STALE" -eq 0 ]; then
+    pass "#1059 gate 8: a drifted run still exits 0"
+  else
+    fail "#1059 gate 8: drifted run exited $RC8_STALE, expected 0"
+  fi
+  case "$OUT8_STALE" in
+    *"codex-broker-reaper: mode=gc"*) pass "#1059 gate 8: a drifted run still does its work" ;;
+    *) fail "#1059 gate 8: drifted run printed no summary line (output: $OUT8_STALE)" ;;
+  esac
+
+  # (c) positive control — the current copy must NOT warn. Without this, a check
+  # that never fires at all would satisfy (a) only by accident of the fixture.
+  OUT8_CUR="$(TMPDIR="$TMPD8" CLAUDE_CONFIG_DIR="$CONFIG8" \
+    bash "$CACHE8/9.9.9/skills/codex-review-wrap/codex-broker-reaper.sh" --gc --dry-run 2>&1)"
+  case "$OUT8_CUR" in
+    *"version drift"*) fail "#1059 gate 8: the current copy warned (output: $OUT8_CUR)" ;;
+    *) pass "#1059 gate 8: the copy the manifest points at stays silent" ;;
+  esac
+
+  # (d) run from outside the cache (this repo's own tree) -> silent, even though
+  # its path can never equal installPath.
+  OUT8_DEV="$(TMPDIR="$TMPD8" CLAUDE_CONFIG_DIR="$CONFIG8" bash "$REAPER" --gc --dry-run 2>&1)"
+  case "$OUT8_DEV" in
+    *"version drift"*) fail "#1059 gate 8: a checkout outside the cache warned (output: $OUT8_DEV)" ;;
+    *) pass "#1059 gate 8: a checkout outside the cache stays silent" ;;
+  esac
+
+  # (e) no manifest at all -> silent. An unreadable manifest is not evidence of
+  # drift, and a warning there would fire on every host that installed the
+  # plugin some other way.
+  CONFIG8B="$TMPD8/config-nomanifest"
+  mkdir -p "$CONFIG8B/plugins/cache/praxis/praxis/9.9.8/skills/codex-review-wrap"
+  cp "$REAPER" "$CONFIG8B/plugins/cache/praxis/praxis/9.9.8/skills/codex-review-wrap/codex-broker-reaper.sh"
+  OUT8_NOMAN="$(TMPDIR="$TMPD8" CLAUDE_CONFIG_DIR="$CONFIG8B" \
+    bash "$CONFIG8B/plugins/cache/praxis/praxis/9.9.8/skills/codex-review-wrap/codex-broker-reaper.sh" \
+    --gc --dry-run 2>&1)"
+  case "$OUT8_NOMAN" in
+    *"version drift"*) fail "#1059 gate 8: warned with no manifest present (output: $OUT8_NOMAN)" ;;
+    *) pass "#1059 gate 8: a missing manifest is not read as drift" ;;
+  esac
+fi
+
+
 echo "=== summary ==="
 echo "PASS: $PASS"
 echo "FAIL: $FAIL"


### PR DESCRIPTION
Closes #1059

### 무엇이 문제였나

launchd plist 는 리퍼 경로를 **플러그인 버전까지 박아서** 렌더됩니다. 플러그인이 업데이트돼도 plist 는 옛 버전을 계속 실행하고, 그 사실을 알려주는 신호가 하나도 없습니다. `LAUNCHD.md` 는 "업데이트 후 Install 단계를 다시 실행하라"고 적어두고 있지만, 아무도 상기시켜 주지 않는 수동 단계는 실제로 누락됩니다 — 이 호스트가 plist 7.8.0 / 매니페스트 7.11.0 으로 **세 버전 뒤처진 채** job 은 계속 종료 코드 0 을 반환하고 있었습니다.

이슈가 "지금은 무해하다"의 근거로 들었던 **버전 간 스크립트 바이트 동일성은 이미 깨졌습니다**(#1058 머지). 즉 이제부터는 격차가 곧 동작 차이입니다.

### 무엇을 했나

인터뷰로 방향을 정했습니다 — **버전 비고정 shim 이 아니라 드리프트 감지**입니다. shim 은 수동 단계 자체를 없애지만 플러그인 캐시 밖에 수명을 관리할 주체가 없는 설치물이 하나 더 생기고, 실패 지점이 "파일 없음(명확)"에서 "런타임 매니페스트 해석(덜 명확)"으로 옮겨갑니다. 감지는 관측된 실제 실패 모드(조용한 stale)를 드러냅니다.

리퍼가 자기 디렉터리와 매니페스트의 `installPath` 를 대조해 다르면 한 줄을 남깁니다.

```text
WARN version drift: running .../praxis/7.8.0 but the manifest installs .../praxis/7.11.0 — re-run the LAUNCHD.md Install steps to re-render the plist
```

경계 두 가지를 인터뷰에서 확정했습니다.

- **캐시 안에서 실행될 때만 말합니다.** 개발 체크아웃은 `installPath` 와 같아질 수 없으므로, 거기서도 경고하면 로컬 실행마다 떠서 읽는 사람이 이 줄을 무시하도록 훈련됩니다.
- **경고는 자문일 뿐 실행을 바꾸지 않습니다.** 작업을 그대로 수행하고 종료 코드도 0 입니다. 옛 리퍼라도 도는 편이 안 도는 것보다 낫고, 종료 코드는 `launchctl list` 가 보여주는 값이라 여기에 써버리면 진짜 실패를 가립니다.

매니페스트가 없거나 못 읽으면 침묵합니다 — 그것은 답의 부재이지 드리프트의 증거가 아닙니다.

### 이 수정이 덮지 못하는 것

이슈가 적은 두 실패 모드 중 **(A) 캐시가 정리돼 스크립트 파일 자체가 사라지는 경우는 구조적으로 감지할 수 없습니다.** 스크립트가 실행되지 않으니 자기 점검도 돌지 않습니다. 그 경우는 로그에 bash 의 `No such file or directory` 줄로 남고, launchd 는 `StartInterval` 마다 계속 재시도하며 계속 실패합니다. 이 PR 이 덮는 것은 **(B) 실행은 되는데 옛 버전인 경우**뿐이며, 이는 방향 선택의 알려진 대가입니다.

### 함께 들어간 정정

`docs(cw): correct the skip figures these comments cite` — 두 주석이 `2143 of 2711 skips` 라고 적고 있었습니다. `2711` 은 skip 이 아니라 **scanned 합계**였고, skip 문장의 분모로 옮겨 적히면서 라벨이 바뀌었습니다. 실측은 scanned 2736 / skipped 2687 / owner unknown 2161, 544 runs 입니다. #1056 과 PR #1058 본문은 발견 당시 정정했는데, 이 두 주석이 그 정정이 닿지 않은 표면이었습니다.

### 이 호스트 적용

인터뷰 결정에 따라 plist 를 지금 재렌더하고 다시 로드했습니다(7.8.0 → 7.11.0). 다만 7.11.0 은 이번 감지 로직 **이전** 릴리즈이므로, 재설치의 즉각적 효과는 세 버전 격차 해소이고 감지 로직은 다음 릴리즈부터 실립니다. 실측은 검증 앵커에 있습니다.

### 커밋

- `fix(cw): warn when the reaper is not the installed version` — 감지 로직 + 게이트 8
- `docs(cw): correct the skip figures these comments cite` — 위 정정
- `docs(cw): say what the reaper now reports about version drift` — LAUNCHD.md

Pre-commit verified: `bash tests/test_codex_broker_reaper.sh` (PASS 66 / FAIL 0 / SKIP 0), `shellcheck skills/codex-review-wrap/codex-broker-reaper.sh tests/test_codex_broker_reaper.sh` (exit 0)
Caller chain verified: `grep -rn 'codex-broker-reaper' --include='*.md' --include='*.mjs' --include='*.py' . | grep -v 'LAUNCHD.md' | grep -v tests/` — 호출자는 `LAUNCHD.md` 의 plist 렌더 경로와 `SKILL.md` Step 6 (`${CLAUDE_PLUGIN_ROOT}/skills/codex-review-wrap/codex-broker-reaper.sh`, SKILL.md:1391·1402) 둘뿐입니다. Step 6 는 곧 `installPath` 에서 실행되므로 대조 결과가 항상 일치해 경고가 뜨지 않습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added advisory detection for version mismatches in cached background services.
  * Logs a warning when a service is running from an outdated installation path while continuing to operate.

* **Documentation**
  * Documented version-drift warnings, cache cleanup behavior, and development checkout behavior.
  * Added guidance for restoring the service configuration after updates.

* **Tests**
  * Added coverage for version mismatches, current versions, development copies, and missing manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->