### PR TITLE
fix(hooks): fall through when a launcher's impl is absent

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -41,6 +41,14 @@ Design mechanisms shared by all hooks:
     `@fail_open` to `main()` in `impl.py` directly (argv-style mains wrap
     a zero-arg `_entry()` instead). Rule 15 in
     `scripts/check-plugin-manifests.py` enforces this invariant.
+  - **Before either path — the launcher (issue #1053).** Both bullets above
+    run *inside* Python, so neither covers an impl that never starts. A
+    missing `impl.py` makes `python3` exit 2, and 2 is this repo's deny code
+    (`_dispatch.py` aggregates on `rc == 2`), so the host reads a partial
+    install as a block nobody decided. Every generated launcher therefore
+    checks `[ -f "$IMPL" ]` before `exec`. It normalizes *nothing* else:
+    flattening non-zero codes would swallow the deliberate exit 2 that every
+    gate blocks with. `tests/test_launcher_fail_open.sh` pins both halves.
 
   Shell hooks (`impl.sh`) have no Python entrypoint, so neither path
   applies to them — they carry their own `set +e` / `|| true` posture, and

--- a/hooks/_dispatch.sh
+++ b/hooks/_dispatch.sh
@@ -3,4 +3,8 @@
 # Source: hooks/_lib/_dispatch.py  (see ADR-0002 dispatch consolidation)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/_lib/_dispatch.py" "$@"
+# See the per-hook wrapper above: a missing impl exits 2, which the host reads
+# as deny. A dispatch group that cannot start must fall through, not block.
+IMPL="$(dirname "$0")/_lib/_dispatch.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/advisory-wrapper-signature-verify.sh
+++ b/hooks/advisory-wrapper-signature-verify.sh
@@ -3,4 +3,10 @@
 # Source: hooks/advisory-nudge/advisory-wrapper-signature-verify/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/advisory-nudge/advisory-wrapper-signature-verify/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/advisory-nudge/advisory-wrapper-signature-verify/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/anchor-comment-gate.sh
+++ b/hooks/anchor-comment-gate.sh
@@ -3,4 +3,10 @@
 # Source: hooks/preflight-gate/anchor-comment-gate/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/preflight-gate/anchor-comment-gate/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/preflight-gate/anchor-comment-gate/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/approval-premise-reread-gate.sh
+++ b/hooks/approval-premise-reread-gate.sh
@@ -3,4 +3,10 @@
 # Source: hooks/preflight-gate/approval-premise-reread-gate/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/preflight-gate/approval-premise-reread-gate/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/preflight-gate/approval-premise-reread-gate/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/artifact-verdict-evidence-gate.sh
+++ b/hooks/artifact-verdict-evidence-gate.sh
@@ -3,4 +3,10 @@
 # Source: hooks/completion-verify/artifact-verdict-evidence-gate/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/completion-verify/artifact-verdict-evidence-gate/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/completion-verify/artifact-verdict-evidence-gate/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/askuserquestion-loop-signal.sh
+++ b/hooks/askuserquestion-loop-signal.sh
@@ -3,4 +3,10 @@
 # Source: hooks/postuse-correction/askuserquestion-loop-signal/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/postuse-correction/askuserquestion-loop-signal/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/postuse-correction/askuserquestion-loop-signal/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/block-ask-end-option.sh
+++ b/hooks/block-ask-end-option.sh
@@ -3,4 +3,10 @@
 # Source: hooks/preflight-gate/block-ask-end-option/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/preflight-gate/block-ask-end-option/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/preflight-gate/block-ask-end-option/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/block-manufactured-action-menu.sh
+++ b/hooks/block-manufactured-action-menu.sh
@@ -3,4 +3,10 @@
 # Source: hooks/preflight-gate/block-manufactured-action-menu/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/preflight-gate/block-manufactured-action-menu/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/preflight-gate/block-manufactured-action-menu/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/block-personal-asset-leak.sh
+++ b/hooks/block-personal-asset-leak.sh
@@ -3,4 +3,10 @@
 # Source: hooks/advisory-nudge/block-personal-asset-leak/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/advisory-nudge/block-personal-asset-leak/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/advisory-nudge/block-personal-asset-leak/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/builtin-task-postuse.sh
+++ b/hooks/builtin-task-postuse.sh
@@ -3,4 +3,10 @@
 # Source: hooks/postuse-correction/builtin-task-postuse/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/postuse-correction/builtin-task-postuse/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/postuse-correction/builtin-task-postuse/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/bulk-write-memory-checkpoint.sh
+++ b/hooks/bulk-write-memory-checkpoint.sh
@@ -3,4 +3,10 @@
 # Source: hooks/advisory-nudge/bulk-write-memory-checkpoint/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/advisory-nudge/bulk-write-memory-checkpoint/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/advisory-nudge/bulk-write-memory-checkpoint/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/bypass-telemetry.sh
+++ b/hooks/bypass-telemetry.sh
@@ -3,4 +3,10 @@
 # Source: hooks/postuse-correction/bypass-telemetry/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/postuse-correction/bypass-telemetry/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/postuse-correction/bypass-telemetry/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/caller-probe-gate.sh
+++ b/hooks/caller-probe-gate.sh
@@ -3,4 +3,10 @@
 # Source: hooks/advisory-nudge/caller-probe-gate/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/advisory-nudge/caller-probe-gate/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/advisory-nudge/caller-probe-gate/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/codex-review-route.sh
+++ b/hooks/codex-review-route.sh
@@ -5,4 +5,8 @@
 # `exec sh impl.sh` would re-route through /bin/sh (dash on Debian)
 # and break Bash-only syntax like [[ ... =~ ... ]] used in
 # retrospect-mix-check / codex-review-route / strike-counter.
-exec "$(dirname "$0")/advisory-nudge/codex-review-route/impl.sh" "$@"
+# Absent impl means the hook cannot judge, so it must not judge — same
+# contract as the python wrapper above.
+IMPL="$(dirname "$0")/advisory-nudge/codex-review-route/impl.sh"
+[ -f "$IMPL" ] || exit 0
+exec "$IMPL" "$@"

--- a/hooks/completion-signal-gate.sh
+++ b/hooks/completion-signal-gate.sh
@@ -3,4 +3,10 @@
 # Source: hooks/completion-verify/completion-signal-gate/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/completion-verify/completion-signal-gate/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/completion-verify/completion-signal-gate/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/completion-verify.sh
+++ b/hooks/completion-verify.sh
@@ -5,4 +5,8 @@
 # `exec sh impl.sh` would re-route through /bin/sh (dash on Debian)
 # and break Bash-only syntax like [[ ... =~ ... ]] used in
 # retrospect-mix-check / codex-review-route / strike-counter.
-exec "$(dirname "$0")/completion-verify/completion-verify/impl.sh" "$@"
+# Absent impl means the hook cannot judge, so it must not judge — same
+# contract as the python wrapper above.
+IMPL="$(dirname "$0")/completion-verify/completion-verify/impl.sh"
+[ -f "$IMPL" ] || exit 0
+exec "$IMPL" "$@"

--- a/hooks/exclusion-probe-gate.sh
+++ b/hooks/exclusion-probe-gate.sh
@@ -3,4 +3,10 @@
 # Source: hooks/advisory-nudge/exclusion-probe-gate/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/advisory-nudge/exclusion-probe-gate/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/advisory-nudge/exclusion-probe-gate/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/external-api-literal-trigger.sh
+++ b/hooks/external-api-literal-trigger.sh
@@ -3,4 +3,10 @@
 # Source: hooks/advisory-nudge/external-api-literal-trigger/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/advisory-nudge/external-api-literal-trigger/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/advisory-nudge/external-api-literal-trigger/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/external-write-falsify-check.sh
+++ b/hooks/external-write-falsify-check.sh
@@ -3,4 +3,10 @@
 # Source: hooks/advisory-nudge/external-write-falsify-check/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/advisory-nudge/external-write-falsify-check/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/advisory-nudge/external-write-falsify-check/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/memory-hint.sh
+++ b/hooks/memory-hint.sh
@@ -3,4 +3,10 @@
 # Source: hooks/advisory-nudge/memory-hint/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/advisory-nudge/memory-hint/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/advisory-nudge/memory-hint/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/menu-mutation-tier-advisory.sh
+++ b/hooks/menu-mutation-tier-advisory.sh
@@ -3,4 +3,10 @@
 # Source: hooks/advisory-nudge/menu-mutation-tier-advisory/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/advisory-nudge/menu-mutation-tier-advisory/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/advisory-nudge/menu-mutation-tier-advisory/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/merge-menu-review-options-advisory.sh
+++ b/hooks/merge-menu-review-options-advisory.sh
@@ -3,4 +3,10 @@
 # Source: hooks/advisory-nudge/merge-menu-review-options-advisory/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/advisory-nudge/merge-menu-review-options-advisory/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/advisory-nudge/merge-menu-review-options-advisory/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/merge-state-claim-gate.sh
+++ b/hooks/merge-state-claim-gate.sh
@@ -3,4 +3,10 @@
 # Source: hooks/completion-verify/merge-state-claim-gate/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/completion-verify/merge-state-claim-gate/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/completion-verify/merge-state-claim-gate/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/negative-existence-verdict-gate.sh
+++ b/hooks/negative-existence-verdict-gate.sh
@@ -3,4 +3,10 @@
 # Source: hooks/completion-verify/negative-existence-verdict-gate/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/completion-verify/negative-existence-verdict-gate/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/completion-verify/negative-existence-verdict-gate/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/output-block-falsify-advisory.sh
+++ b/hooks/output-block-falsify-advisory.sh
@@ -3,4 +3,10 @@
 # Source: hooks/advisory-nudge/output-block-falsify-advisory/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/advisory-nudge/output-block-falsify-advisory/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/advisory-nudge/output-block-falsify-advisory/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/path-probe-gate.sh
+++ b/hooks/path-probe-gate.sh
@@ -3,4 +3,10 @@
 # Source: hooks/advisory-nudge/path-probe-gate/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/advisory-nudge/path-probe-gate/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/advisory-nudge/path-probe-gate/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/postcompact-context.sh
+++ b/hooks/postcompact-context.sh
@@ -3,4 +3,10 @@
 # Source: hooks/advisory-nudge/postcompact-context/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/advisory-nudge/postcompact-context/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/advisory-nudge/postcompact-context/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/pr-claim-mutation-gate.sh
+++ b/hooks/pr-claim-mutation-gate.sh
@@ -3,4 +3,10 @@
 # Source: hooks/completion-verify/pr-claim-mutation-gate/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/completion-verify/pr-claim-mutation-gate/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/completion-verify/pr-claim-mutation-gate/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/pr-report-destination-gate.sh
+++ b/hooks/pr-report-destination-gate.sh
@@ -3,4 +3,10 @@
 # Source: hooks/completion-verify/pr-report-destination-gate/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/completion-verify/pr-report-destination-gate/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/completion-verify/pr-report-destination-gate/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/pr-state-refetch-gate.sh
+++ b/hooks/pr-state-refetch-gate.sh
@@ -3,4 +3,10 @@
 # Source: hooks/preflight-gate/pr-state-refetch-gate/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/preflight-gate/pr-state-refetch-gate/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/preflight-gate/pr-state-refetch-gate/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/pr-thread-resolve-advisory.sh
+++ b/hooks/pr-thread-resolve-advisory.sh
@@ -3,4 +3,10 @@
 # Source: hooks/advisory-nudge/pr-thread-resolve-advisory/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/advisory-nudge/pr-thread-resolve-advisory/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/advisory-nudge/pr-thread-resolve-advisory/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/pre-edit-md-escape-advisory-post.sh
+++ b/hooks/pre-edit-md-escape-advisory-post.sh
@@ -3,4 +3,10 @@
 # Source: hooks/postuse-correction/pre-edit-md-escape-advisory/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/postuse-correction/pre-edit-md-escape-advisory/impl.py" "post" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/postuse-correction/pre-edit-md-escape-advisory/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "post" "$@"

--- a/hooks/pre-edit-md-escape-advisory-pre.sh
+++ b/hooks/pre-edit-md-escape-advisory-pre.sh
@@ -3,4 +3,10 @@
 # Source: hooks/postuse-correction/pre-edit-md-escape-advisory/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/postuse-correction/pre-edit-md-escape-advisory/impl.py" "pre" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/postuse-correction/pre-edit-md-escape-advisory/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "pre" "$@"

--- a/hooks/pre-edit-protected-branch-guard.sh
+++ b/hooks/pre-edit-protected-branch-guard.sh
@@ -3,4 +3,10 @@
 # Source: hooks/preflight-gate/pre-edit-protected-branch-guard/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/preflight-gate/pre-edit-protected-branch-guard/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/preflight-gate/pre-edit-protected-branch-guard/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/pre-output-falsification-gate.sh
+++ b/hooks/pre-output-falsification-gate.sh
@@ -3,4 +3,10 @@
 # Source: hooks/advisory-nudge/pre-output-falsification-gate/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/advisory-nudge/pre-output-falsification-gate/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/advisory-nudge/pre-output-falsification-gate/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/proposal-premise-gate.sh
+++ b/hooks/proposal-premise-gate.sh
@@ -3,4 +3,10 @@
 # Source: hooks/completion-verify/proposal-premise-gate/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/completion-verify/proposal-premise-gate/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/completion-verify/proposal-premise-gate/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/protected-paths-guard.sh
+++ b/hooks/protected-paths-guard.sh
@@ -3,4 +3,10 @@
 # Source: hooks/advisory-nudge/protected-paths-guard/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/advisory-nudge/protected-paths-guard/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/advisory-nudge/protected-paths-guard/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/push-remote-ref-verify.sh
+++ b/hooks/push-remote-ref-verify.sh
@@ -3,4 +3,10 @@
 # Source: hooks/advisory-nudge/push-remote-ref-verify/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/advisory-nudge/push-remote-ref-verify/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/advisory-nudge/push-remote-ref-verify/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/readonly-verify-deferral-gate.sh
+++ b/hooks/readonly-verify-deferral-gate.sh
@@ -3,4 +3,10 @@
 # Source: hooks/completion-verify/readonly-verify-deferral-gate/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/completion-verify/readonly-verify-deferral-gate/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/completion-verify/readonly-verify-deferral-gate/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/retrospect-active-marker.sh
+++ b/hooks/retrospect-active-marker.sh
@@ -3,4 +3,10 @@
 # Source: hooks/preflight-gate/retrospect-active-marker/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/preflight-gate/retrospect-active-marker/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/preflight-gate/retrospect-active-marker/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/retrospect-mix-check.sh
+++ b/hooks/retrospect-mix-check.sh
@@ -5,4 +5,8 @@
 # `exec sh impl.sh` would re-route through /bin/sh (dash on Debian)
 # and break Bash-only syntax like [[ ... =~ ... ]] used in
 # retrospect-mix-check / codex-review-route / strike-counter.
-exec "$(dirname "$0")/completion-verify/retrospect-mix-check/impl.sh" "$@"
+# Absent impl means the hook cannot judge, so it must not judge — same
+# contract as the python wrapper above.
+IMPL="$(dirname "$0")/completion-verify/retrospect-mix-check/impl.sh"
+[ -f "$IMPL" ] || exit 0
+exec "$IMPL" "$@"

--- a/hooks/runtime-state-claim-gate.sh
+++ b/hooks/runtime-state-claim-gate.sh
@@ -3,4 +3,10 @@
 # Source: hooks/completion-verify/runtime-state-claim-gate/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/completion-verify/runtime-state-claim-gate/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/completion-verify/runtime-state-claim-gate/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/second-failure-advisory.sh
+++ b/hooks/second-failure-advisory.sh
@@ -3,4 +3,10 @@
 # Source: hooks/postuse-correction/second-failure-advisory/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/postuse-correction/second-failure-advisory/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/postuse-correction/second-failure-advisory/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/secret-print-redaction-advisory.sh
+++ b/hooks/secret-print-redaction-advisory.sh
@@ -3,4 +3,10 @@
 # Source: hooks/advisory-nudge/secret-print-redaction-advisory/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/advisory-nudge/secret-print-redaction-advisory/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/advisory-nudge/secret-print-redaction-advisory/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/session-intent.sh
+++ b/hooks/session-intent.sh
@@ -3,4 +3,10 @@
 # Source: hooks/preflight-gate/session-intent/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/preflight-gate/session-intent/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/preflight-gate/session-intent/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/source-citation-probe-gate.sh
+++ b/hooks/source-citation-probe-gate.sh
@@ -3,4 +3,10 @@
 # Source: hooks/advisory-nudge/source-citation-probe-gate/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/advisory-nudge/source-citation-probe-gate/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/advisory-nudge/source-citation-probe-gate/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/strike-counter.sh
+++ b/hooks/strike-counter.sh
@@ -5,4 +5,8 @@
 # `exec sh impl.sh` would re-route through /bin/sh (dash on Debian)
 # and break Bash-only syntax like [[ ... =~ ... ]] used in
 # retrospect-mix-check / codex-review-route / strike-counter.
-exec "$(dirname "$0")/completion-verify/strike-counter/impl.sh" "$@"
+# Absent impl means the hook cannot judge, so it must not judge — same
+# contract as the python wrapper above.
+IMPL="$(dirname "$0")/completion-verify/strike-counter/impl.sh"
+[ -f "$IMPL" ] || exit 0
+exec "$IMPL" "$@"

--- a/hooks/worktree-edit-gate.sh
+++ b/hooks/worktree-edit-gate.sh
@@ -3,4 +3,10 @@
 # Source: hooks/preflight-gate/worktree-edit-gate/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/preflight-gate/worktree-edit-gate/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/preflight-gate/worktree-edit-gate/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/hooks/write-decision-consistency-gate.sh
+++ b/hooks/write-decision-consistency-gate.sh
@@ -3,4 +3,10 @@
 # Source: hooks/preflight-gate/write-decision-consistency-gate/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/preflight-gate/write-decision-consistency-gate/impl.py" "$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/preflight-gate/write-decision-consistency-gate/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"

--- a/scripts/build-plugin-manifests.py
+++ b/scripts/build-plugin-manifests.py
@@ -93,7 +93,13 @@ WRAPPER_PY_TEMPLATE = """\
 # Source: hooks/{role}/{name}/impl.py  (see ADR-0001 §2.3)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/{role}/{name}/impl.py" {baked_args}"$@"
+# A missing impl makes python3 exit 2, which is this repo's deny code — the
+# launcher would hand the host a block nobody decided. Absent impl means the
+# hook cannot judge, so it must not judge. Normalizing every non-zero code
+# instead would swallow the deliberate exit 2 of every gate.
+IMPL="$(dirname "$0")/{role}/{name}/impl.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" {baked_args}"$@"
 """
 
 WRAPPER_SH_TEMPLATE = """\
@@ -104,7 +110,11 @@ WRAPPER_SH_TEMPLATE = """\
 # `exec sh impl.sh` would re-route through /bin/sh (dash on Debian)
 # and break Bash-only syntax like [[ ... =~ ... ]] used in
 # retrospect-mix-check / codex-review-route / strike-counter.
-exec "$(dirname "$0")/{role}/{name}/impl.sh" "$@"
+# Absent impl means the hook cannot judge, so it must not judge — same
+# contract as the python wrapper above.
+IMPL="$(dirname "$0")/{role}/{name}/impl.sh"
+[ -f "$IMPL" ] || exit 0
+exec "$IMPL" "$@"
 """
 
 # ADR-0002 — single-process dispatch runner wrapper. A dispatch-group hooks.json
@@ -116,7 +126,11 @@ WRAPPER_DISPATCH_TEMPLATE = """\
 # Source: hooks/_lib/_dispatch.py  (see ADR-0002 dispatch consolidation)
 set +e
 command -v python3 >/dev/null 2>&1 || exit 0
-exec python3 "$(dirname "$0")/_lib/_dispatch.py" "$@"
+# See the per-hook wrapper above: a missing impl exits 2, which the host reads
+# as deny. A dispatch group that cannot start must fall through, not block.
+IMPL="$(dirname "$0")/_lib/_dispatch.py"
+[ -f "$IMPL" ] || exit 0
+exec python3 "$IMPL" "$@"
 """
 DISPATCH_WRAPPER_NAME = "_dispatch.sh"
 

--- a/tests/test_launcher_fail_open.sh
+++ b/tests/test_launcher_fail_open.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# test_launcher_fail_open.sh — the generated hook launchers must fall through
+# when their impl cannot be found, and must still forward a real deny (#1053).
+#
+# Two halves, and the second is the one that keeps the fix honest:
+#   1. impl absent  -> exit 0. python3 exits 2 on "can't open file", and 2 is
+#      this repo's deny code (_dispatch.py aggregates on rc == 2), so an absent
+#      impl otherwise reaches the host as a block nobody decided.
+#   2. impl exits 2 -> exit 2. The reviewed alternative (`python3 … || exit 0`)
+#      passes half 1 and silently disarms every gate in the repo.
+#
+# The launchers under test are copied into a scratch tree with a stub impl, so
+# no real impl is executed and the repo is never mutated.
+#
+# Usage: bash tests/test_launcher_fail_open.sh
+# Exit:  0 = all pass; 1 = at least one fail
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+run_case() {
+  local name="$1" result="$2" expected="$3"
+  if [ "$result" = "$expected" ]; then
+    echo "PASS  [$name]"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  [$name] expected=$expected got=$result"
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES+=("$name")
+  fi
+}
+
+echo "test_launcher_fail_open"
+
+TMP="$(mktemp -d)" || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+trap 'rm -rf "$TMP"' EXIT
+
+# Resolve one launcher per template from the generated tree, so the test breaks
+# if a template stops being emitted rather than silently covering nothing.
+PY_LAUNCHER="$ROOT_DIR/hooks/approval-premise-reread-gate.sh"
+PY_IMPL_REL="preflight-gate/approval-premise-reread-gate/impl.py"
+SH_LAUNCHER="$ROOT_DIR/hooks/strike-counter.sh"
+SH_IMPL_REL="completion-verify/strike-counter/impl.sh"
+DISPATCH_LAUNCHER="$ROOT_DIR/hooks/_dispatch.sh"
+DISPATCH_IMPL_REL="_lib/_dispatch.py"
+
+for f in "$PY_LAUNCHER" "$SH_LAUNCHER" "$DISPATCH_LAUNCHER"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL  [launcher_present] missing $f"
+    exit 1
+  fi
+done
+run_case "launchers_present" "yes" "yes"
+
+# stage <launcher> <impl-rel-path> -> scratch copy, impl NOT created yet
+stage() {
+  local launcher="$1" impl_rel="$2" dir="$3"
+  rm -rf "$dir"
+  mkdir -p "$dir/$(dirname "$impl_rel")"
+  cp "$launcher" "$dir/launcher.sh"
+  chmod +x "$dir/launcher.sh"
+}
+
+# --- python-wrapper template -------------------------------------------------
+
+PY_DIR="$TMP/py"
+stage "$PY_LAUNCHER" "$PY_IMPL_REL" "$PY_DIR"
+
+echo '{}' | sh "$PY_DIR/launcher.sh" >/dev/null 2>&1
+run_case "py_missing_impl_is_fail_open" "$?" "0"
+
+printf 'import sys\nsys.exit(2)\n' > "$PY_DIR/$PY_IMPL_REL"
+echo '{}' | sh "$PY_DIR/launcher.sh" >/dev/null 2>&1
+run_case "py_deny_is_forwarded" "$?" "2"
+
+printf 'import sys\nsys.exit(0)\n' > "$PY_DIR/$PY_IMPL_REL"
+echo '{}' | sh "$PY_DIR/launcher.sh" >/dev/null 2>&1
+run_case "py_pass_is_forwarded" "$?" "0"
+
+# A crashing impl keeps its own non-blocking code — Claude Code treats 1 as a
+# non-blocking error, so flattening it to 0 would only hide the breakage.
+printf 'raise RuntimeError("boom")\n' > "$PY_DIR/$PY_IMPL_REL"
+echo '{}' | sh "$PY_DIR/launcher.sh" >/dev/null 2>&1
+run_case "py_crash_is_not_deny" "$?" "1"
+
+# --- body-as-sh wrapper template ---------------------------------------------
+
+SH_DIR="$TMP/sh"
+stage "$SH_LAUNCHER" "$SH_IMPL_REL" "$SH_DIR"
+
+echo '{}' | sh "$SH_DIR/launcher.sh" >/dev/null 2>&1
+run_case "sh_missing_impl_is_fail_open" "$?" "0"
+
+printf '#!/bin/bash\nexit 2\n' > "$SH_DIR/$SH_IMPL_REL"
+chmod +x "$SH_DIR/$SH_IMPL_REL"
+echo '{}' | sh "$SH_DIR/launcher.sh" >/dev/null 2>&1
+run_case "sh_deny_is_forwarded" "$?" "2"
+
+# --- dispatch wrapper template -----------------------------------------------
+
+D_DIR="$TMP/dispatch"
+stage "$DISPATCH_LAUNCHER" "$DISPATCH_IMPL_REL" "$D_DIR"
+
+echo '{}' | sh "$D_DIR/launcher.sh" >/dev/null 2>&1
+run_case "dispatch_missing_impl_is_fail_open" "$?" "0"
+
+printf 'import sys\nsys.exit(2)\n' > "$D_DIR/$DISPATCH_IMPL_REL"
+echo '{}' | sh "$D_DIR/launcher.sh" >/dev/null 2>&1
+run_case "dispatch_deny_is_forwarded" "$?" "2"
+
+echo
+echo "test_launcher_fail_open: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'failed: %s\n' "${FAILED_NAMES[*]}"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
### 무엇이 바뀌나

훅 런처가 자기 impl 을 못 띄울 때, 아무도 내리지 않은 차단이 호스트에 나가던 것을 막습니다. 이 PR 이후 impl 이 없으면 그 훅은 판정하지 않고 통과시킵니다.

### 원인

`@fail_open` 은 impl **안에서** 도는 장치라, impl 이 뜨지 못한 경우에는 손쓸 자리가 없습니다. 그리고 파이썬은 파일을 못 열면 `exit 2` 를 내는데, 이 리포에서 2 는 deny 입니다 — `_dispatch.py` 가 `rc == 2` 로 결정을 집계합니다.

```
$ python3 -c "import subprocess,sys; p=subprocess.run([sys.executable,'/definitely/missing.py'],capture_output=True); print('missing-file exit:',p.returncode)"
missing-file exit: 2
```

부분 설치, 플러그인 디렉터리 드리프트, `hosts` 필터가 런처만 쓰고 impl 을 안 쓴 경우가 실제 발생 경로입니다.

### 어떻게 고쳤나

`scripts/build-plugin-manifests.py` 의 템플릿 3개(python / body-as-sh / dispatch) 모두 `exec` 앞에 impl 존재 확인을 넣고, 런처 49개를 재생성했습니다.

```sh
IMPL="$(dirname "$0")/{role}/{name}/impl.py"
[ -f "$IMPL" ] || exit 0
exec python3 "$IMPL" {baked_args}"$@"
```

`exec` 과 shebang 존중은 그대로이고 프로세스도 늘지 않습니다.

### 기각한 대안 — 비0 일괄 정규화

PR #1052 의 CodeRabbit 리뷰가 제안한 `python3 … || exit 0` 은 비0 을 구분 없이 접습니다. 이 리포에서는 그것이 `return 2` 로 차단하는 훅 41개의 deny 를 함께 삼킵니다. 측정으로 확인했습니다:

```
$ echo '{}' | sh cr.sh          # CodeRabbit 제안 형태, impl 은 sys.exit(2)
CODERABBIT deny -> exit=0       # 2 가 나와야 하는 자리
```

근거와 함께 해당 스레드에 회신하고 닫았습니다.

### 이슈 본문의 서술도 정정합니다

#1053 은 "문법 오류가 하나 들어가면 매칭되는 모든 호출이 세션 내내 막힌다"고 적었는데, 성립하지 않습니다. Claude Code 에서 PreToolUse 를 차단하는 코드는 `exit 2` 하나뿐이고 `exit 1` 은 non-blocking 입니다 ([hooks 문서](https://code.claude.com/docs/en/hooks)). 실제 차단 경로는 impl 부재 하나이며, 이 PR 이 닫는 것도 그것입니다. 이슈 본문에 반영했습니다.

Pre-commit verified: `python3 scripts/check-plugin-manifests.py` → `plugin-manifest check OK`, `bash tests/test_launcher_fail_open.sh` → 9 passed / 0 failed
Caller chain verified: 런처 49개는 전부 이 생성기의 산출물이며(`grep -c "^# AUTO-GENERATED by scripts/build-plugin-manifests.py" hooks/*.sh` → 49), 재생성 후 `check-plugin-manifests.py` 의 wrapper-drift 규칙이 전량 일치를 확인합니다. 템플릿 문자열의 다른 소비자는 없습니다.

Closes #1053


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Missing hook implementations now fail open instead of being treated as blocking denials.
  - Intentional denial results and other implementation errors continue to pass through unchanged.

- **Tests**
  - Added coverage for missing implementations, deliberate denials, successful execution, and runtime failures.

- **Documentation**
  - Documented launcher behavior when an implementation is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->