### PR TITLE
fix(hooks): gate unqualified verdict restatement

### DIFF
--- a/hooks/completion-verify/runtime-state-claim-gate/impl.py
+++ b/hooks/completion-verify/runtime-state-claim-gate/impl.py
@@ -213,7 +213,7 @@ _VERDICT_NUM_RE = re.compile(
 _VERDICT_BARE_RE = re.compile(rf"{_PASS_WORD}(?!{_FWD_GAP}\d)", re.IGNORECASE)
 
 # Scope-qualifier phrases naming the measured artifact's coverage — "348줄
-# 중", "of 348 lines", "120/348", "34%". A line carrying one of these is
+# 중", "of 348 lines", "120/348", "34%". A clause carrying one of these is
 # transparent about what was actually covered and stays silent even when the
 # same number was already stated (the motivating incident's own first
 # restatement, "348줄 중 FAIL 0", must stay silent per the issue's own
@@ -225,6 +225,14 @@ _QUALIFIER_RE = re.compile(
     r"|\d+\s*%",
     re.IGNORECASE,
 )
+
+
+# A qualifier only qualifies the verdict it shares a CLAUSE with. Scanned per
+# line, ANY percentage or fraction anywhere on the line silenced the verdict —
+# and the incident's own shape is a moving progress number sitting beside a
+# frozen verdict number, so "진행률 80%, 실패 0" read as qualified while the
+# "실패 0" half was exactly the stale restatement this gate exists to catch.
+_CLAUSE_SPLIT_RE = re.compile(r"[,;，、]+|(?<=[.!?。？！])\s+")
 
 
 def _claim_key_from_match(m: "re.Match[str]") -> str | None:
@@ -247,23 +255,27 @@ def _humanize_key(key: str) -> str:
 
 def extract_verdict_claims(text: str) -> list[dict]:
     """Return `{"key", "qualified"}` for each verdict-count claim in `text`,
-    scanned per line (a scope qualifier is read from the same line the
-    number appears on). Quoted lines (`>`) are skipped, matching
-    `detect_claims`."""
+    scanned per line and qualified per CLAUSE — a scope qualifier counts only
+    when it shares a clause with the verdict it is supposed to modify. Quoted
+    lines (`>`) are skipped, matching `detect_claims`."""
     claims: list[dict] = []
     for raw_line in text.splitlines():
         line = raw_line.strip()
         if not line or line.startswith(">"):
             continue
-        qualified = bool(_QUALIFIER_RE.search(line))
         seen: set[str] = set()
-        for m in _VERDICT_NUM_RE.finditer(line):
-            key = _claim_key_from_match(m)
-            if key and key not in seen:
-                seen.add(key)
-                claims.append({"key": key, "qualified": qualified})
-        if _VERDICT_BARE_RE.search(line) and "pass:bare" not in seen:
-            claims.append({"key": "pass:bare", "qualified": qualified})
+        for clause in _CLAUSE_SPLIT_RE.split(line):
+            if not clause:
+                continue
+            qualified = bool(_QUALIFIER_RE.search(clause))
+            for m in _VERDICT_NUM_RE.finditer(clause):
+                key = _claim_key_from_match(m)
+                if key and key not in seen:
+                    seen.add(key)
+                    claims.append({"key": key, "qualified": qualified})
+            if _VERDICT_BARE_RE.search(clause) and "pass:bare" not in seen:
+                seen.add("pass:bare")
+                claims.append({"key": "pass:bare", "qualified": qualified})
     return claims
 
 

--- a/hooks/completion-verify/runtime-state-claim-gate/impl.py
+++ b/hooks/completion-verify/runtime-state-claim-gate/impl.py
@@ -179,11 +179,19 @@ def detect_claims(text: str) -> list[str]:
 _FAIL_WORD = r"(?:FAILs?|fail(?:ed)?|실패|오류|에러|error)"
 _PASS_WORD = r"(?:PASS(?:ED)?|통과|성공|success)"
 
+# Reversed order ("0 FAILED", "0건 실패"): only whitespace and a Korean
+# counter suffix may bridge the number to the word. A permissive `\D{0,3}`
+# lets a range denominator's trailing "중" bridge instead — on "120/348 중
+# FAIL 0" the reversed alternative matches "348 중 FAIL" FIRST, stores
+# `fail:348`, and consumes the real "FAIL 0", so a later unqualified "실패 0"
+# finds no prior mention and the gate never fires.
+_REV_GAP = r"\s*(?:건|개)?\s*"
+
 # A count attached to a fail/pass word, either order, small gap allowed
 # ("FAILs: 0", "0 FAILED", "실패 0", "0건 실패").
 _VERDICT_NUM_RE = re.compile(
-    rf"{_FAIL_WORD}\D{{0,6}}?(\d+)|(\d+)\D{{0,3}}?{_FAIL_WORD}"
-    rf"|{_PASS_WORD}\D{{0,6}}?(\d+)|(\d+)\D{{0,3}}?{_PASS_WORD}",
+    rf"{_FAIL_WORD}\D{{0,6}}?(\d+)|(\d+){_REV_GAP}{_FAIL_WORD}"
+    rf"|{_PASS_WORD}\D{{0,6}}?(\d+)|(\d+){_REV_GAP}{_PASS_WORD}",
     re.IGNORECASE,
 )
 # A bare pass claim carrying no adjacent number ("통과", "PASSED").

--- a/hooks/completion-verify/runtime-state-claim-gate/impl.py
+++ b/hooks/completion-verify/runtime-state-claim-gate/impl.py
@@ -26,6 +26,18 @@ MCP read), emits an advisory. Advisory by default (stdout
 `PRAXIS_RUNTIME_CLAIM_STRICT=1` escalates to `{"decision": "block", ...}`
 (re-prompts the model to probe). Fully fail-open; bypass with
 `PRAXIS_RUNTIME_CLAIM_BYPASS=1`.
+
+Second, unrelated gap closed by issue #1062: the trigger above fires only when
+the USER asks about runtime state. The actual path a partial measurement took
+to a public PR anchor (issue #1062, PR #1058 rev4) was voluntary
+RE-STATEMENT of an already-uttered verdict number ("FAIL 0") with its scope
+qualifier ("348줄 중") silently dropped over several turns, while an unrelated
+progress number (log line count) kept changing beside it — making the
+sentence look fresh. This hook additionally scans the final message for a
+verdict-count claim (`실패 N` / `FAIL N` / bare `통과`) that (a) was already
+stated earlier THIS session, (b) carries no scope qualifier on its line this
+time, and (c) has no fresh probe in the current turn — same evidence gate as
+the running/isolation claim above.
 """
 from __future__ import annotations
 
@@ -33,6 +45,7 @@ import json
 import os
 import re
 import sys
+from datetime import datetime
 from pathlib import Path as _Path
 
 sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
@@ -153,6 +166,163 @@ def detect_claims(text: str) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# Verdict-restatement detection (issue #1062) — a DIFFERENT claim shape from
+# the running/isolation claims above: not "is X currently happening" but "the
+# number I already measured, said again". A claim key is (kind, number),
+# e.g. "fail:0"; a bare pass/fail word with no number ("통과") keys as
+# "pass:bare". Only FAIL/PASS-adjacent vocabulary counts — a standalone "N건"
+# with no fail/pass word nearby is deliberately NOT matched (too broad: "이슈
+# 3건" is not a verdict count) — narrowest change that closes the gap named in
+# the issue, no invented "generic count" abstraction.
+# ---------------------------------------------------------------------------
+
+_FAIL_WORD = r"(?:FAILs?|fail(?:ed)?|실패|오류|에러|error)"
+_PASS_WORD = r"(?:PASS(?:ED)?|통과|성공|success)"
+
+# A count attached to a fail/pass word, either order, small gap allowed
+# ("FAILs: 0", "0 FAILED", "실패 0", "0건 실패").
+_VERDICT_NUM_RE = re.compile(
+    rf"{_FAIL_WORD}\D{{0,6}}?(\d+)|(\d+)\D{{0,3}}?{_FAIL_WORD}"
+    rf"|{_PASS_WORD}\D{{0,6}}?(\d+)|(\d+)\D{{0,3}}?{_PASS_WORD}",
+    re.IGNORECASE,
+)
+# A bare pass claim carrying no adjacent number ("통과", "PASSED").
+_VERDICT_BARE_RE = re.compile(rf"{_PASS_WORD}(?!\D{{0,3}}\d)", re.IGNORECASE)
+
+# Scope-qualifier phrases naming the measured artifact's coverage — "348줄
+# 중", "of 348 lines", "120/348", "34%". A line carrying one of these is
+# transparent about what was actually covered and stays silent even when the
+# same number was already stated (the motivating incident's own first
+# restatement, "348줄 중 FAIL 0", must stay silent per the issue's own
+# false-positive check).
+_QUALIFIER_RE = re.compile(
+    r"\d+\s*(?:줄|line|lines)\s*(?:중|of)"
+    r"|of\s+\d+\s*(?:lines?|줄)?"
+    r"|\d+\s*/\s*\d+"
+    r"|\d+\s*%",
+    re.IGNORECASE,
+)
+
+
+def _claim_key_from_match(m: "re.Match[str]") -> str | None:
+    if m.group(1) is not None:
+        return f"fail:{m.group(1)}"
+    if m.group(2) is not None:
+        return f"fail:{m.group(2)}"
+    if m.group(3) is not None:
+        return f"pass:{m.group(3)}"
+    if m.group(4) is not None:
+        return f"pass:{m.group(4)}"
+    return None
+
+
+def _humanize_key(key: str) -> str:
+    kind, _, num = key.partition(":")
+    word = "FAIL" if kind == "fail" else "PASS"
+    return word if num == "bare" else f"{word} {num}"
+
+
+def extract_verdict_claims(text: str) -> list[dict]:
+    """Return `{"key", "qualified"}` for each verdict-count claim in `text`,
+    scanned per line (a scope qualifier is read from the same line the
+    number appears on). Quoted lines (`>`) are skipped, matching
+    `detect_claims`."""
+    claims: list[dict] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith(">"):
+            continue
+        qualified = bool(_QUALIFIER_RE.search(line))
+        seen: set[str] = set()
+        for m in _VERDICT_NUM_RE.finditer(line):
+            key = _claim_key_from_match(m)
+            if key and key not in seen:
+                seen.add(key)
+                claims.append({"key": key, "qualified": qualified})
+        if _VERDICT_BARE_RE.search(line) and "pass:bare" not in seen:
+            claims.append({"key": "pass:bare", "qualified": qualified})
+    return claims
+
+
+def collect_prior_verdict_mentions(prior_events: list[dict]) -> dict[str, str | None]:
+    """Return claim key -> earliest ISO timestamp (or None) it was stated in
+    `prior_events` (assistant text, any turn before the current one,
+    qualified or not — a qualified prior mention still means the number was
+    already said). ISO8601 `Z`-suffixed timestamps sort correctly as strings,
+    so no datetime parsing is needed to track the minimum."""
+    mentions: dict[str, str | None] = {}
+    for ev in prior_events:
+        msg = ev.get("message", {})
+        if not isinstance(msg, dict) or msg.get("role") != "assistant" or ev.get("isSidechain"):
+            continue
+        content = msg.get("content", [])
+        text = ""
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list):
+            text = "\n".join(
+                b.get("text", "") for b in content
+                if isinstance(b, dict) and b.get("type") == "text"
+            )
+        if not text:
+            continue
+        ts = ev.get("timestamp")
+        ts = ts if isinstance(ts, str) and ts else None
+        for claim in extract_verdict_claims(text):
+            key = claim["key"]
+            if key not in mentions:
+                mentions[key] = ts
+            elif ts and (mentions[key] is None or ts < mentions[key]):
+                mentions[key] = ts
+    return mentions
+
+
+def _last_assistant_timestamp(turn: list[dict]) -> str | None:
+    ts: str | None = None
+    for ev in turn:
+        msg = ev.get("message", {})
+        if isinstance(msg, dict) and msg.get("role") == "assistant" and not ev.get("isSidechain"):
+            t = ev.get("timestamp")
+            if isinstance(t, str) and t:
+                ts = t
+    return ts
+
+
+def _elapsed_minutes(ts_from: str | None, ts_to: str | None) -> str:
+    """Minutes between two ISO8601 timestamps, or "unknown" if either is
+    missing or unparseable — the message degrades gracefully rather than
+    fabricating a number (transcripts predating this hook carry no
+    `timestamp` gap this can't cover)."""
+    if not ts_from or not ts_to:
+        return "unknown"
+    try:
+        a = datetime.fromisoformat(ts_from.replace("Z", "+00:00"))
+        b = datetime.fromisoformat(ts_to.replace("Z", "+00:00"))
+    except ValueError:
+        return "unknown"
+    return f"{abs((b - a).total_seconds()) / 60:.1f}"
+
+
+def detect_verdict_restatement(
+    last_text: str, prior_events: list[dict]
+) -> tuple[list[str], dict[str, str | None]]:
+    """Return (restated claim keys, prior-mention timestamps) for verdict
+    numbers in `last_text` that are (a) unqualified here and (b) were already
+    stated somewhere earlier this session."""
+    mentions = collect_prior_verdict_mentions(prior_events)
+    if not mentions:
+        return [], mentions
+    restated: list[str] = []
+    for claim in extract_verdict_claims(last_text):
+        if claim["qualified"]:
+            continue
+        key = claim["key"]
+        if key in mentions and key not in restated:
+            restated.append(key)
+    return restated, mentions
+
+
+# ---------------------------------------------------------------------------
 # Evidence detection — a probe tool_use in the CURRENT turn. Turn-scoped (not
 # the sibling's 80-event window): runtime state goes stale across turns, and
 # the incident turns contained zero tool calls of any kind. Any read-class
@@ -184,7 +354,7 @@ def has_probe_in_turn(turn: list[dict]) -> bool:
     return False
 
 
-def _advisory(kinds: list[str]) -> str:
+def _advisory_running(kinds: list[str]) -> str:
     return (
         f"{_PREFIX} final message asserts a runtime/execution state "
         f"({'/'.join(kinds)}: e.g. \"X is running in Y\" / \"로컬은 건드리지 "
@@ -195,8 +365,29 @@ def _advisory(kinds: list[str]) -> str:
         "intent (\"요청 기준으로는 X입니다. 실측은 하지 않았습니다\"). "
         "Launch success does not reveal WHERE something runs: remote/isolation "
         "modes fall back silently (issue #809).\n"
-        f"{_PREFIX} bypass: {_BYPASS_ENV}=1\n"
     )
+
+
+def _advisory_restatement(restated: list[str], mentions: dict[str, str | None], now: str | None) -> str:
+    lines = [
+        f"{_PREFIX} the final message restates a verdict number already "
+        "stated earlier this session, WITHOUT a scope qualifier (\"N줄 중\" "
+        "/ \"of N lines\"), and the current turn contains NO probe tool call:"
+    ]
+    for key in restated:
+        elapsed = _elapsed_minutes(mentions.get(key), now)
+        lines.append(
+            f"{_PREFIX}   {_humanize_key(key)} — last stated {elapsed} min "
+            "ago. Re-measure against the CURRENT artifact before restating, "
+            "or keep the scope qualifier every time (\"X줄 중 Y\")."
+        )
+    lines.append(
+        f"{_PREFIX} Rule: a changing progress number beside a frozen verdict "
+        "number (log length growing, FAIL count fixed) makes the sentence "
+        "look fresh even when only the frozen half is being repeated "
+        "(issue #1062).\n"
+    )
+    return "\n".join(lines)
 
 
 @fail_open
@@ -228,17 +419,26 @@ def main() -> int:
         return 0
 
     kinds = detect_claims(last_text)
-    if not kinds:
+    prior_events = events[: len(events) - len(turn)] if turn else events
+    restated, mentions = detect_verdict_restatement(last_text, prior_events)
+    if not kinds and not restated:
         return 0
 
     if has_probe_in_turn(turn):
         return 0
 
+    message = ""
+    if kinds:
+        message += _advisory_running(kinds)
+    if restated:
+        message += _advisory_restatement(restated, mentions, _last_assistant_timestamp(turn))
+    message += f"{_PREFIX} bypass: {_BYPASS_ENV}=1\n"
+
     if os.environ.get(_STRICT_ENV, "").strip() == "1":
-        emit_stop_block(_advisory(kinds))
+        emit_stop_block(message)
         decision = _fire_ledger.DECISION_BLOCK
     else:
-        emit_stop_advisory(_advisory(kinds))
+        emit_stop_advisory(message)
         decision = _fire_ledger.DECISION_ADVISE
     # Rich fire record (issue #847): Stop hooks signal block/advise via a stdout
     # decision while exiting 0, so @fail_open's coarse path records only "pass".

--- a/hooks/completion-verify/runtime-state-claim-gate/impl.py
+++ b/hooks/completion-verify/runtime-state-claim-gate/impl.py
@@ -326,14 +326,15 @@ def collect_prior_verdict_mentions(prior_events: list[dict]) -> dict[str, str | 
 
 
 def _last_assistant_timestamp(turn: list[dict]) -> str | None:
-    ts: str | None = None
-    for ev in turn:
+    # The elapsed time must belong to the message the gate is scoring, so a
+    # final event without a timestamp is `unknown` — not the last event that
+    # happened to carry one, which reports an older, wrong elapsed.
+    for ev in reversed(turn):
         msg = ev.get("message", {})
         if isinstance(msg, dict) and msg.get("role") == "assistant" and not ev.get("isSidechain"):
             t = ev.get("timestamp")
-            if isinstance(t, str) and t:
-                ts = t
-    return ts
+            return t if isinstance(t, str) and t else None
+    return None
 
 
 def _elapsed_minutes(ts_from: str | None, ts_to: str | None) -> str:

--- a/hooks/completion-verify/runtime-state-claim-gate/impl.py
+++ b/hooks/completion-verify/runtime-state-claim-gate/impl.py
@@ -267,6 +267,11 @@ def extract_verdict_claims(text: str) -> list[dict]:
         for clause in _CLAUSE_SPLIT_RE.split(line):
             if not clause:
                 continue
+            # Asking "실패 0인가요?" is not restating a verdict — the spec puts
+            # a question clause on the silent side for BOTH claim kinds, and
+            # the runtime-state path already reads it that way (detect_claims).
+            if _QUESTION_RE.search(clause):
+                continue
             qualified = bool(_QUALIFIER_RE.search(clause))
             numeric = list(_VERDICT_NUM_RE.finditer(clause))
             for m in numeric:

--- a/hooks/completion-verify/runtime-state-claim-gate/impl.py
+++ b/hooks/completion-verify/runtime-state-claim-gate/impl.py
@@ -268,14 +268,22 @@ def extract_verdict_claims(text: str) -> list[dict]:
             if not clause:
                 continue
             qualified = bool(_QUALIFIER_RE.search(clause))
-            for m in _VERDICT_NUM_RE.finditer(clause):
+            numeric = list(_VERDICT_NUM_RE.finditer(clause))
+            for m in numeric:
                 key = _claim_key_from_match(m)
                 if key and key not in seen:
                     seen.add(key)
                     claims.append({"key": key, "qualified": qualified})
-            if _VERDICT_BARE_RE.search(clause) and "pass:bare" not in seen:
-                seen.add("pass:bare")
-                claims.append({"key": "pass:bare", "qualified": qualified})
+            for m in _VERDICT_BARE_RE.finditer(clause):
+                # A reversed count ("0 PASS") puts the number BEFORE the word,
+                # so the bare pattern still matches inside a numerically scoped
+                # claim — minting pass:bare there makes the scoped claim read as
+                # a restatement of an unrelated bare one.
+                if any(n.start() <= m.start() < n.end() for n in numeric):
+                    continue
+                if "pass:bare" not in seen:
+                    seen.add("pass:bare")
+                    claims.append({"key": "pass:bare", "qualified": qualified})
     return claims
 
 

--- a/hooks/completion-verify/runtime-state-claim-gate/impl.py
+++ b/hooks/completion-verify/runtime-state-claim-gate/impl.py
@@ -176,8 +176,17 @@ def detect_claims(text: str) -> list[str]:
 # the issue, no invented "generic count" abstraction.
 # ---------------------------------------------------------------------------
 
-_FAIL_WORD = r"(?:FAILs?|fail(?:ed)?|실패|오류|에러|error)"
-_PASS_WORD = r"(?:PASS(?:ED)?|통과|성공|success)"
+# The EN half needs lookaround boundaries — without them "pass" matched
+# inside "bypass" and "success" inside "successful", recording a bogus
+# `pass:0` prior mention that makes a later GENUINE first verdict fire (and,
+# in strict mode, blocks a correct message). Same `(?<![A-Za-z])…(?![A-Za-z])`
+# convention as the sibling gates' `_en_token_present` (pr-state-refetch-gate,
+# menu-mutation-tier-advisory) — `\b` puts no boundary between Hangul and
+# ASCII. The Korean half needs none: 실패/통과 carry their own boundaries.
+_EN_L = r"(?<![A-Za-z])"
+_EN_R = r"(?![A-Za-z])"
+_FAIL_WORD = rf"(?:{_EN_L}(?:fail(?:ed|s)?|error){_EN_R}|실패|오류|에러)"
+_PASS_WORD = rf"(?:{_EN_L}(?:pass(?:ed)?|success){_EN_R}|통과|성공)"
 
 # Reversed order ("0 FAILED", "0건 실패"): only whitespace and a Korean
 # counter suffix may bridge the number to the word. A permissive `\D{0,3}`
@@ -187,15 +196,21 @@ _PASS_WORD = r"(?:PASS(?:ED)?|통과|성공|success)"
 # finds no prior mention and the gate never fires.
 _REV_GAP = r"\s*(?:건|개)?\s*"
 
+# Forward order ("FAILs: 0", "실패 건수: 0", "실패는 0"): separators, plus the
+# Korean counter/particle that idiomatically attaches to the word. A blanket
+# `\D{0,6}` also bridged an intervening English noun, so "error code 0" keyed
+# `fail:0` — the count belongs to "code", not to the verdict.
+_FWD_GAP = r"[\s:=]{0,3}(?:건수|개수|수|은|는|이|가)?[\s:=]{0,3}"
+
 # A count attached to a fail/pass word, either order, small gap allowed
 # ("FAILs: 0", "0 FAILED", "실패 0", "0건 실패").
 _VERDICT_NUM_RE = re.compile(
-    rf"{_FAIL_WORD}\D{{0,6}}?(\d+)|(\d+){_REV_GAP}{_FAIL_WORD}"
-    rf"|{_PASS_WORD}\D{{0,6}}?(\d+)|(\d+){_REV_GAP}{_PASS_WORD}",
+    rf"{_FAIL_WORD}{_FWD_GAP}(\d+)|(\d+){_REV_GAP}{_FAIL_WORD}"
+    rf"|{_PASS_WORD}{_FWD_GAP}(\d+)|(\d+){_REV_GAP}{_PASS_WORD}",
     re.IGNORECASE,
 )
 # A bare pass claim carrying no adjacent number ("통과", "PASSED").
-_VERDICT_BARE_RE = re.compile(rf"{_PASS_WORD}(?!\D{{0,3}}\d)", re.IGNORECASE)
+_VERDICT_BARE_RE = re.compile(rf"{_PASS_WORD}(?!{_FWD_GAP}\d)", re.IGNORECASE)
 
 # Scope-qualifier phrases naming the measured artifact's coverage — "348줄
 # 중", "of 348 lines", "120/348", "34%". A line carrying one of these is

--- a/hooks/completion-verify/runtime-state-claim-gate/spec.md
+++ b/hooks/completion-verify/runtime-state-claim-gate/spec.md
@@ -92,13 +92,25 @@ happening now" but "the number I already measured, said again". A claim key
 is `(kind, number)` — e.g. `fail:0`; a bare pass/fail word with no adjacent
 number (`통과`) keys as `pass:bare`.
 
-- **Verdict vocabulary**: a count directly adjacent (≤6 non-digit chars) to
+- **Verdict vocabulary**: a count directly adjacent to
   `FAIL(s)`/`fail(ed)`/`실패`/`오류`/`에러`/`error` (kind `fail`), or to
   `PASS(ED)`/`통과`/`성공`/`success` (kind `pass`), in either order
   (`"FAILs: 0"`, `"0 FAILED"`, `"실패 0"`, `"0건 실패"`). A standalone `N건`
   with no fail/pass word nearby is deliberately **not** matched — too broad
   ("이슈 3건" is not a verdict count) — this stays scoped to the vocabulary the
   issue named, no invented generic-count abstraction.
+- **EN vocabulary carries lookaround boundaries**: `(?<![A-Za-z])…(?![A-Za-z])`
+  around `fail(ed|s)`/`error`/`pass(ed)`/`success`, the same convention as the
+  sibling gates' `_en_token_present` (`\b` puts no boundary between Hangul and
+  ASCII). Without them `"bypass 0"` keyed `pass:0` and `"successful 0"` keyed
+  `pass:0` — a bogus prior mention that makes a later **genuine first** verdict
+  fire, and under `PRAXIS_RUNTIME_CLAIM_STRICT=1` blocks a correct message.
+  The Korean half needs no boundary; 실패/통과 carry their own.
+- **The count must belong to the verdict word**: in the forward order only
+  separators (`\s:=`) and the Korean counter/particle that attaches to the
+  word (`건수`/`개수`/`수`/`은`/`는`/`이`/`가`) may sit between them. A blanket
+  `\D{0,6}` bridged an intervening English noun, so `"error code 0"` keyed
+  `fail:0` — the count is "code"'s, not the verdict's.
 - **Reversed order binds tightly**: in the `"0 FAILED"` / `"0건 실패"` order
   only whitespace and a Korean counter suffix (`건`/`개`) may sit between the
   number and the word. A permissive gap lets a range denominator's trailing

--- a/hooks/completion-verify/runtime-state-claim-gate/spec.md
+++ b/hooks/completion-verify/runtime-state-claim-gate/spec.md
@@ -55,7 +55,7 @@ probe before stopping.
 | Final message restates a verdict number (`실패 N`/`FAIL N`/bare `통과`) already stated earlier this session, WITHOUT a scope qualifier, AND the current turn has no probe tool_use | `[runtime-state-claim-gate]` advisory   |
 | Same claim, but the current turn contains a probe-class tool_use (Bash, Read, Grep, Glob, LSP, Task*, Monitor, `mcp__*`) | silent (claim is backed by observation) |
 | Final message has no runtime-state claim                                                                                 | silent                                  |
-| Verdict number restated WITH its scope qualifier on the same line (`"1110줄 중 FAIL 0"`)                                 | silent (transparent about coverage)     |
+| Verdict number restated WITH its scope qualifier in the same clause (`"1110줄 중 FAIL 0"`)                               | silent (transparent about coverage)     |
 | Verdict number appears for the first time this session (no prior mention) — or the number changed (re-measured)          | silent                                  |
 | Claim line is a question (`…돌고 있나요?`) — either kind                                                                 | silent                                  |
 | "running" claim line is future intent (`will run`, `실행하겠습니다`)                                                     | silent (intent, not state)              |
@@ -118,10 +118,19 @@ number (`통과`) keys as `pass:bare`.
   matched `"348 중 FAIL"` first, keyed `fail:348`, and consumed the real
   `"FAIL 0"` — so a later unqualified `"실패 0"` found no prior mention and
   the gate silently never fired.
-- **Scope qualifier**: a line carrying `"N줄 중"` / `"of N lines"` / `"N/M"` /
-  `"N%"` is transparent about what was actually covered and stays silent
-  even when the number was already stated — this is what keeps the
-  motivating incident's own first restatement ("348줄 중 FAIL 0") silent.
+- **Scope qualifier, scoped per clause**: `"N줄 중"` / `"of N lines"` /
+  `"N/M"` / `"N%"` is transparent about what was actually covered and stays
+  silent even when the number was already stated — this is what keeps the
+  motivating incident's own first restatement ("348줄 중 FAIL 0") silent. The
+  qualifier only counts in the **clause it shares with the verdict** (clauses
+  split on `,;，、` and sentence enders). Scanned per line, any percentage or
+  fraction anywhere on the line silenced the verdict — and the incident's own
+  shape is a moving progress number beside a frozen one, so
+  `"진행률 80%, 실패 0"` read as qualified while `"실패 0"` was exactly the
+  stale restatement. The cost of the tighter linkage is that a qualifier
+  parked in its own clause (`"총 348줄, FAIL 0"`) now fires; the advisory it
+  emits asks for `"348줄 중 FAIL 0"`, which is the discipline this gate exists
+  to enforce.
 - **Prior-mention scan**: run over the **whole transcript before the current
   turn** (not the sibling's turn/window scoping) — the incident's
   restatements spanned several turns, each ending its own Stop event, so a

--- a/hooks/completion-verify/runtime-state-claim-gate/spec.md
+++ b/hooks/completion-verify/runtime-state-claim-gate/spec.md
@@ -99,6 +99,13 @@ number (`통과`) keys as `pass:bare`.
   with no fail/pass word nearby is deliberately **not** matched — too broad
   ("이슈 3건" is not a verdict count) — this stays scoped to the vocabulary the
   issue named, no invented generic-count abstraction.
+- **Reversed order binds tightly**: in the `"0 FAILED"` / `"0건 실패"` order
+  only whitespace and a Korean counter suffix (`건`/`개`) may sit between the
+  number and the word. A permissive gap lets a range denominator's trailing
+  `"중"` bridge instead: on `"120/348 중 FAIL 0"` the reversed alternative
+  matched `"348 중 FAIL"` first, keyed `fail:348`, and consumed the real
+  `"FAIL 0"` — so a later unqualified `"실패 0"` found no prior mention and
+  the gate silently never fired.
 - **Scope qualifier**: a line carrying `"N줄 중"` / `"of N lines"` / `"N/M"` /
   `"N%"` is transparent about what was actually covered and stays silent
   even when the number was already stated — this is what keeps the

--- a/hooks/completion-verify/runtime-state-claim-gate/spec.md
+++ b/hooks/completion-verify/runtime-state-claim-gate/spec.md
@@ -49,19 +49,19 @@ Advisory by default — exit 0 + stdout `{"systemMessage": ...}` JSON
 `{"decision": "block", "reason": ...}` JSON, which re-prompts the model to
 probe before stopping.
 
-| Condition                                                                                                                | Result                                  |
-| ------------------------------------------------------------------------------------------------------------------------ | --------------------------------------- |
-| Final message asserts a runtime state (running / isolation) AND the current turn has no probe tool_use                   | `[runtime-state-claim-gate]` advisory   |
+| Condition                                                                                                                                                                          | Result                                  |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| Final message asserts a runtime state (running / isolation) AND the current turn has no probe tool_use                                                                             | `[runtime-state-claim-gate]` advisory   |
 | Final message restates a verdict number (`실패 N`/`FAIL N`/bare `통과`) already stated earlier this session, WITHOUT a scope qualifier, AND the current turn has no probe tool_use | `[runtime-state-claim-gate]` advisory   |
-| Same claim, but the current turn contains a probe-class tool_use (Bash, Read, Grep, Glob, LSP, Task*, Monitor, `mcp__*`) | silent (claim is backed by observation) |
-| Final message has no runtime-state claim                                                                                 | silent                                  |
-| Verdict number restated WITH its scope qualifier in the same clause (`"1110줄 중 FAIL 0"`)                               | silent (transparent about coverage)     |
-| Verdict number appears for the first time this session (no prior mention) — or the number changed (re-measured)          | silent                                  |
-| Claim line is a question (`…돌고 있나요?`) — either kind                                                                 | silent                                  |
-| "running" claim line is future intent (`will run`, `실행하겠습니다`)                                                     | silent (intent, not state)              |
-| Line is quoted (`> …`)                                                                                                   | silent                                  |
-| `PRAXIS_RUNTIME_CLAIM_BYPASS=1`                                                                                          | silent                                  |
-| `stop_hook_active` in payload                                                                                            | silent (re-entrancy guard)              |
+| Same claim, but the current turn contains a probe-class tool_use (Bash, Read, Grep, Glob, LSP, Task*, Monitor, `mcp__*`)                                                           | silent (claim is backed by observation) |
+| Final message has no runtime-state claim                                                                                                                                           | silent                                  |
+| Verdict number restated WITH its scope qualifier in the same clause (`"1110줄 중 FAIL 0"`)                                                                                         | silent (transparent about coverage)     |
+| Verdict number appears for the first time this session (no prior mention) — or the number changed (re-measured)                                                                    | silent                                  |
+| Claim line is a question (`…돌고 있나요?`) — either kind                                                                                                                           | silent                                  |
+| "running" claim line is future intent (`will run`, `실행하겠습니다`)                                                                                                               | silent (intent, not state)              |
+| Line is quoted (`> …`)                                                                                                                                                             | silent                                  |
+| `PRAXIS_RUNTIME_CLAIM_BYPASS=1`                                                                                                                                                    | silent                                  |
+| `stop_hook_active` in payload                                                                                                                                                      | silent (re-entrancy guard)              |
 
 ## Claim model
 

--- a/hooks/completion-verify/runtime-state-claim-gate/spec.md
+++ b/hooks/completion-verify/runtime-state-claim-gate/spec.md
@@ -27,6 +27,21 @@ there. This is the runtime-state sibling of
 [merge-state-claim-gate](../merge-state-claim-gate/spec.md) (#503): a Stop
 hook sees the final assistant text, the exact surface PreToolUse cannot see.
 
+**Second gap, closed by #1062**: the trigger above fires only when the USER
+asks about runtime state. The path a partial measurement actually took to a
+public surface was voluntary RE-STATEMENT, which has no firing point at all.
+PR #1058 anchor rev4: `FAILs: 0` was measured once against a 348-line log
+(6.7% of the eventual 5223-line run); the next sentence carried an accurate
+qualifier ("348줄 중 FAIL 0"), then the same number was restated 4 more times
+over ~2 minutes with the qualifier dropped, while an unrelated progress
+number (log line count: 877/1020/1110) kept changing beside it — making the
+sentence read as fresh. It reached the PR anchor as "실패 0 으로 진행 중"; the
+real failures sat 53.8% into the final log, past the measured window. This
+hook now also scans for a verdict-count claim (`실패 N` / `FAIL N` / bare
+`통과`) that was already stated earlier this session, carries no scope
+qualifier this time, and has no fresh probe in the current turn — same
+evidence gate as the claim above.
+
 ## What is emitted
 
 Advisory by default — exit 0 + stdout `{"systemMessage": ...}` JSON
@@ -37,8 +52,11 @@ probe before stopping.
 | Condition                                                                                                                | Result                                  |
 | ------------------------------------------------------------------------------------------------------------------------ | --------------------------------------- |
 | Final message asserts a runtime state (running / isolation) AND the current turn has no probe tool_use                   | `[runtime-state-claim-gate]` advisory   |
+| Final message restates a verdict number (`실패 N`/`FAIL N`/bare `통과`) already stated earlier this session, WITHOUT a scope qualifier, AND the current turn has no probe tool_use | `[runtime-state-claim-gate]` advisory   |
 | Same claim, but the current turn contains a probe-class tool_use (Bash, Read, Grep, Glob, LSP, Task*, Monitor, `mcp__*`) | silent (claim is backed by observation) |
 | Final message has no runtime-state claim                                                                                 | silent                                  |
+| Verdict number restated WITH its scope qualifier on the same line (`"1110줄 중 FAIL 0"`)                                 | silent (transparent about coverage)     |
+| Verdict number appears for the first time this session (no prior mention) — or the number changed (re-measured)          | silent                                  |
 | Claim line is a question (`…돌고 있나요?`) — either kind                                                                 | silent                                  |
 | "running" claim line is future intent (`will run`, `실행하겠습니다`)                                                     | silent (intent, not state)              |
 | Line is quoted (`> …`)                                                                                                   | silent                                  |
@@ -66,6 +84,41 @@ the claim: "로컬은 건드리지 않습니다" is an isolation assertion (the 
 incident verbatim). Future/question suppressors apply to "running" only;
 "건드리지 않을 겁니다" still projects an unverified isolation guarantee and is
 gated.
+
+## Verdict-restatement model (#1062)
+
+A different claim shape from the SUBJECT+CLAIM model above: not "is X
+happening now" but "the number I already measured, said again". A claim key
+is `(kind, number)` — e.g. `fail:0`; a bare pass/fail word with no adjacent
+number (`통과`) keys as `pass:bare`.
+
+- **Verdict vocabulary**: a count directly adjacent (≤6 non-digit chars) to
+  `FAIL(s)`/`fail(ed)`/`실패`/`오류`/`에러`/`error` (kind `fail`), or to
+  `PASS(ED)`/`통과`/`성공`/`success` (kind `pass`), in either order
+  (`"FAILs: 0"`, `"0 FAILED"`, `"실패 0"`, `"0건 실패"`). A standalone `N건`
+  with no fail/pass word nearby is deliberately **not** matched — too broad
+  ("이슈 3건" is not a verdict count) — this stays scoped to the vocabulary the
+  issue named, no invented generic-count abstraction.
+- **Scope qualifier**: a line carrying `"N줄 중"` / `"of N lines"` / `"N/M"` /
+  `"N%"` is transparent about what was actually covered and stays silent
+  even when the number was already stated — this is what keeps the
+  motivating incident's own first restatement ("348줄 중 FAIL 0") silent.
+- **Prior-mention scan**: run over the **whole transcript before the current
+  turn** (not the sibling's turn/window scoping) — the incident's
+  restatements spanned several turns, each ending its own Stop event, so a
+  turn-scoped or 80-event-scoped prior-mention check would miss the earlier
+  turns entirely. A claim only fires when its key was already stated
+  earlier in the session, qualified or not.
+- **Elapsed-time message**: the advisory names how many minutes ago the
+  claim key was first stated (`ISO8601` transcript timestamps compared as
+  strings for the minimum, parsed with `datetime` for the delta); "unknown"
+  when either timestamp is missing (older transcripts, or a test fixture
+  that omits `timestamp`) rather than fabricating a number.
+- **Evidence gate is shared** with the SUBJECT+CLAIM model: a probe-class
+  tool_use anywhere in the current turn silences both claim kinds together,
+  since both conditions are computed before that gate is checked and folded
+  into one `systemMessage`/`block` emission (never two JSON blobs on one
+  Stop call).
 
 ## Evidence model
 

--- a/tests/hooks/completion-verify/test_runtime_state_claim_gate.sh
+++ b/tests/hooks/completion-verify/test_runtime_state_claim_gate.sh
@@ -319,6 +319,19 @@ build_transcript_verdict \
   none
 run_case silent "verdict-reversed-numeric-is-not-a-bare-pass" '{}'
 
+# --- a verdict stated as a QUESTION stays silent (spec: either kind) --------
+build_transcript_verdict \
+  "348줄 중 FAIL 0" "2026-08-20T09:19:36.000Z" \
+  "실패 0인가요?" "2026-08-20T09:21:48.000Z" \
+  none
+run_case silent "verdict-question-clause-stays-silent" '{}'
+
+build_transcript_verdict \
+  "348줄 중 FAIL 0" "2026-08-20T09:19:36.000Z" \
+  "FAIL 0?" "2026-08-20T09:21:48.000Z" \
+  none
+run_case silent "verdict-en-question-clause-stays-silent" '{}'
+
 # --- same-clause qualifier still silences (EN "of N lines" form) -----------
 build_transcript_verdict \
   "348줄 중 FAIL 0" "2026-08-20T09:19:36.000Z" \

--- a/tests/hooks/completion-verify/test_runtime_state_claim_gate.sh
+++ b/tests/hooks/completion-verify/test_runtime_state_claim_gate.sh
@@ -339,6 +339,34 @@ build_transcript_verdict \
   none
 run_case silent "verdict-same-clause-qualifier-stays-silent" '{}'
 
+# --- elapsed time belongs to the scored message, not an older one ----------
+# A final event carrying no timestamp fell back to an EARLIER assistant event
+# in the same turn, so the advisory reported that event's age ("1 min ago")
+# instead of "unknown". Needs TWO assistant events in the turn to discriminate.
+TRANSCRIPT="$(mktemp)"
+python3 - "$TRANSCRIPT" <<'PY_T'
+import json, sys
+events = [
+    {"message": {"role": "user", "content": "run the suite"}},
+    {"message": {"role": "assistant", "content": [{"type": "text", "text": "348줄 중 FAIL 0"}]},
+     "timestamp": "2026-08-20T09:19:36.000Z"},
+    {"message": {"role": "user", "content": "keep going"}},
+    {"message": {"role": "assistant", "content": [{"type": "text", "text": "계속 진행합니다"}]},
+     "timestamp": "2026-08-20T09:21:00.000Z"},
+    {"message": {"role": "assistant", "content": [{"type": "text", "text": "실패 0 으로 진행 중"}]}},
+]
+with open(sys.argv[1], "w", encoding="utf-8") as f:
+    for e in events:
+        f.write(json.dumps(e, ensure_ascii=False) + "\n")
+PY_T
+elapsed_out=$(python3 -c 'import json,sys; print(json.dumps({"transcript_path": sys.argv[1]}))' "$TRANSCRIPT" \
+  | python3 "$HOOK" 2>/dev/null)
+if printf '%s' "$elapsed_out" | grep -q 'last stated unknown'; then
+  echo "PASS  [verdict-elapsed-unknown-when-final-event-untimed]"; PASS=$((PASS + 1))
+else
+  echo "FAIL  [verdict-elapsed-unknown-when-final-event-untimed] out=<$elapsed_out>"; FAIL=$((FAIL + 1))
+fi
+
 echo ""
 echo "runtime-state-claim-gate: PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/tests/hooks/completion-verify/test_runtime_state_claim_gate.sh
+++ b/tests/hooks/completion-verify/test_runtime_state_claim_gate.sh
@@ -309,6 +309,16 @@ build_transcript_verdict \
   none
 run_case advisory "verdict-unrelated-fraction-not-a-qualifier" '{}'
 
+# --- a bare-PASS key must not be minted from a numerically scoped claim ----
+# "0 PASS" reverses the order, so the bare-PASS pattern matched inside it and
+# recorded pass:bare alongside pass:0 — a prior bare 통과 then read the scoped
+# claim as its own restatement.
+build_transcript_verdict \
+  "12개 중 통과" "2026-08-20T09:19:36.000Z" \
+  "0 PASS 입니다" "2026-08-20T09:21:48.000Z" \
+  none
+run_case silent "verdict-reversed-numeric-is-not-a-bare-pass" '{}'
+
 # --- same-clause qualifier still silences (EN "of N lines" form) -----------
 build_transcript_verdict \
   "348줄 중 FAIL 0" "2026-08-20T09:19:36.000Z" \

--- a/tests/hooks/completion-verify/test_runtime_state_claim_gate.sh
+++ b/tests/hooks/completion-verify/test_runtime_state_claim_gate.sh
@@ -185,6 +185,82 @@ run_case silent "stop-hook-active" '{"stop_hook_active": true}'
 TRANSCRIPT="/nonexistent/transcript.jsonl"
 run_case silent "missing-transcript" '{}'
 
+# ============================================================================
+# Verdict-restatement gate (issue #1062) — PR #1058 anchor rev4 verbatim
+# shape: a verdict number ("FAIL 0") measured once with an accurate scope
+# qualifier ("348줄 중"), then restated bare across later turns while an
+# unrelated progress number (log line count) kept changing beside it.
+# build_transcript_verdict <prior_text> <prior_ts> <final_text> <final_ts> <evidence>
+# -> writes path to $TRANSCRIPT. `prior_text`/`prior_ts` seed an EARLIER turn
+# (separated by a real user message) so the claim is a cross-turn restatement,
+# not a same-message repeat.
+# ============================================================================
+build_transcript_verdict() {
+  local prior_text="$1" prior_ts="$2" final_text="$3" final_ts="$4" evidence="$5"
+  TRANSCRIPT="$(mktemp)"
+  python3 - "$TRANSCRIPT" "$prior_text" "$prior_ts" "$final_text" "$final_ts" "$evidence" <<'PY'
+import json, sys
+path, prior_text, prior_ts, final_text, final_ts, evidence = sys.argv[1:7]
+events = [
+    {"message": {"role": "user", "content": "run the suite"}},
+    {"message": {"role": "assistant", "content": [{"type": "text", "text": prior_text}]},
+     "timestamp": prior_ts},
+    {"message": {"role": "user", "content": "keep going"}},
+]
+if evidence == "bash":
+    events.append({"message": {"role": "assistant", "content": [
+        {"type": "tool_use", "name": "Bash",
+         "input": {"command": "tail -n 50 /tmp/suite.log"}}]}})
+events.append({"message": {"role": "assistant", "content": [
+    {"type": "text", "text": final_text}]}, "timestamp": final_ts})
+with open(path, "w", encoding="utf-8") as f:
+    for e in events:
+        f.write(json.dumps(e, ensure_ascii=False) + "\n")
+PY
+}
+
+# --- gap reproduction: qualified measurement, then bare restatement, no probe
+build_transcript_verdict \
+  "348줄 중 FAIL 0" "2026-08-20T09:19:36.000Z" \
+  "1110줄까지 실패 0 으로 진행 중" "2026-08-20T09:21:48.000Z" \
+  none
+run_case advisory "verdict-restatement-no-qualifier" '{}'
+
+# --- false-positive control: restatement KEEPS the qualifier -> silent ------
+build_transcript_verdict \
+  "348줄 중 FAIL 0" "2026-08-20T09:19:36.000Z" \
+  "1110줄 중 FAIL 0" "2026-08-20T09:21:48.000Z" \
+  none
+run_case silent "verdict-restatement-qualified-stays-silent" '{}'
+
+# --- restatement WITH a fresh probe in the current turn -> silent -----------
+build_transcript_verdict \
+  "348줄 중 FAIL 0" "2026-08-20T09:19:36.000Z" \
+  "실패 0 으로 진행 중" "2026-08-20T09:21:48.000Z" \
+  bash
+run_case silent "verdict-restatement-with-probe" '{}'
+
+# --- first-ever mention (no prior occurrence) -> silent ---------------------
+build_transcript_verdict \
+  "빌드를 시작합니다" "2026-08-20T09:19:36.000Z" \
+  "FAILs: 0 / SKIPPED: 0" "2026-08-20T09:21:48.000Z" \
+  none
+run_case silent "verdict-first-mention-not-restatement" '{}'
+
+# --- a DIFFERENT number is not a restatement (re-measured, not repeated) ----
+build_transcript_verdict \
+  "348줄 중 FAIL 0" "2026-08-20T09:19:36.000Z" \
+  "1110줄까지 실패 2" "2026-08-20T09:21:48.000Z" \
+  none
+run_case silent "verdict-different-number-not-restatement" '{}'
+
+# --- bare 통과 (pass, no number) restated without qualifier ------------------
+build_transcript_verdict \
+  "12개 중 통과" "2026-08-20T09:19:36.000Z" \
+  "여전히 통과 상태로 진행 중입니다" "2026-08-20T09:21:48.000Z" \
+  none
+run_case advisory "verdict-bare-pass-restatement" '{}'
+
 echo ""
 echo "runtime-state-claim-gate: PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/tests/hooks/completion-verify/test_runtime_state_claim_gate.sh
+++ b/tests/hooks/completion-verify/test_runtime_state_claim_gate.sh
@@ -261,6 +261,15 @@ build_transcript_verdict \
   none
 run_case advisory "verdict-bare-pass-restatement" '{}'
 
+# --- range denominator must not pre-empt the verdict count -----------------
+# "120/348 중 FAIL 0" once bound 348 as the fail count and consumed the real
+# "FAIL 0", so the later bare "실패 0" found no prior mention and stayed silent.
+build_transcript_verdict \
+  "120/348 중 FAIL 0" "2026-08-20T09:19:36.000Z" \
+  "실패 0 으로 진행 중" "2026-08-20T09:21:48.000Z" \
+  none
+run_case advisory "verdict-range-denominator-not-the-count" '{}'
+
 echo ""
 echo "runtime-state-claim-gate: PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/tests/hooks/completion-verify/test_runtime_state_claim_gate.sh
+++ b/tests/hooks/completion-verify/test_runtime_state_claim_gate.sh
@@ -270,6 +270,29 @@ build_transcript_verdict \
   none
 run_case advisory "verdict-range-denominator-not-the-count" '{}'
 
+# --- EN vocabulary needs word boundaries -----------------------------------
+# "pass" inside "bypass" once recorded a bogus pass:0 prior mention, so this
+# GENUINE first "PASS 0" fired an advisory (a block, under strict mode).
+build_transcript_verdict \
+  "bypass 0 으로 우회했습니다" "2026-08-20T09:19:36.000Z" \
+  "PASS 0 입니다" "2026-08-20T09:21:48.000Z" \
+  none
+run_case silent "verdict-en-substring-not-a-verdict-word" '{}'
+
+# --- the count must belong to the verdict word, not an intervening noun ----
+build_transcript_verdict \
+  "error code 0 을 확인했습니다" "2026-08-20T09:19:36.000Z" \
+  "실패 0 입니다" "2026-08-20T09:21:48.000Z" \
+  none
+run_case silent "verdict-count-belongs-to-another-noun" '{}'
+
+# --- EN reversed-order restatement still fires (boundary fix is not a mute) -
+build_transcript_verdict \
+  "348줄 중 0 FAILED" "2026-08-20T09:19:36.000Z" \
+  "0 FAILED 로 진행 중" "2026-08-20T09:21:48.000Z" \
+  none
+run_case advisory "verdict-en-reversed-order-restatement" '{}'
+
 echo ""
 echo "runtime-state-claim-gate: PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/tests/hooks/completion-verify/test_runtime_state_claim_gate.sh
+++ b/tests/hooks/completion-verify/test_runtime_state_claim_gate.sh
@@ -293,6 +293,29 @@ build_transcript_verdict \
   none
 run_case advisory "verdict-en-reversed-order-restatement" '{}'
 
+# --- an unrelated progress number is not the verdict's qualifier -----------
+# Scanned per line, the "80%" marked the whole line qualified and the stale
+# "실패 0" beside it passed silently — the incident's own shape (a moving
+# progress number beside a frozen verdict).
+build_transcript_verdict \
+  "348줄 중 FAIL 0" "2026-08-20T09:19:36.000Z" \
+  "진행률 80%, 실패 0 으로 진행 중" "2026-08-20T09:21:48.000Z" \
+  none
+run_case advisory "verdict-unrelated-percent-not-a-qualifier" '{}'
+
+build_transcript_verdict \
+  "348줄 중 FAIL 0" "2026-08-20T09:19:36.000Z" \
+  "작업 3/5 완료, 실패 0" "2026-08-20T09:21:48.000Z" \
+  none
+run_case advisory "verdict-unrelated-fraction-not-a-qualifier" '{}'
+
+# --- same-clause qualifier still silences (EN "of N lines" form) -----------
+build_transcript_verdict \
+  "348줄 중 FAIL 0" "2026-08-20T09:19:36.000Z" \
+  "FAIL 0 of 1110 lines" "2026-08-20T09:21:48.000Z" \
+  none
+run_case silent "verdict-same-clause-qualifier-stays-silent" '{}'
+
 echo ""
 echo "runtime-state-claim-gate: PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
### 무엇이 바뀌나

이미 한 번 측정한 판정 수치를 한정어 없이 다시 말할 때, 지금까지 아무 발동점이 없던 자리에 advisory 를 세웁니다.

### 원인

`runtime-state-claim-gate` 는 **사용자가 런타임 상태를 물었을 때** 발동합니다. 그런데 부분 측정이 공개 표면까지 실려 나간 실제 경로는 질문이 아니라 자발적 재진술이었습니다.

PR #1058 앵커 rev4 에서 관측된 형태입니다. `FAIL 0` 은 09:19:10 에 348줄짜리 로그를 상대로 **한 번** 측정됐고, 바로 다음 문장까지는 한정어가 정확했습니다.

```
09:19:10  FAILs: 0 / SKIPPED: 0          ← 유일한 측정
09:19:36  현재까지 348줄 중 FAIL 0        ← 한정어 정확
09:20:51 ~ 09:21:48  재진술 4회           ← FAIL 재측정 0회
09:31:53  앵커 rev4: "실패 0 으로 진행 중"  ← 한정어 소멸, 공개 표면
```

최종 로그는 5223줄이고 진짜 실패는 2809·2810줄입니다. 측정 시점의 348줄은 전체의 6.7% 였습니다. 갱신되던 숫자(877/1020/1110)는 로그 길이였지 실패 건수가 아니었습니다 — 옆에서 무언가 계속 바뀌면 문장 전체가 신선해 보인다는 것이 이 형태의 위험입니다.

### 어떻게 고쳤나

기존 SUBJECT+CLAIM 트리거와 **독립된 두 번째 트리거**를 붙였습니다. 세션에서 이미 발화한 (종류, 숫자) 키를 한정어(`N줄 중` / `of N lines` / `N/M` / `N%`) 없이 다시 말하고, 그 턴에 재측정 probe 가 없으면 발동합니다. 두 조건은 같은 probe-evidence 게이트를 공유하고 하나의 emission 으로 합쳐집니다.

의도적으로 제외한 것: `fail`/`pass` 어휘 없이 홀로 선 `N건`. "이슈 3건" 같은 문장에서 오발화합니다.

선행 발화 스캔은 현재 턴 이전 **트랜스크립트 전체**를 봅니다 — 사고의 재진술들이 여러 턴에 걸쳐 있었고 각 턴이 자기 Stop 이벤트를 갖기 때문입니다.

### 검증

수정 전에 새 케이스를 먼저 돌려 결함을 재현했습니다.

```
FAIL  [verdict-restatement-no-qualifier] expected=advisory rc=0 out=<> err=<>
PASS  [verdict-restatement-qualified-stays-silent]
PASS  [verdict-first-mention-not-restatement]
FAIL  [verdict-bare-pass-restatement] expected=advisory rc=0 out=<> err=<>
runtime-state-claim-gate: PASS=25 FAIL=2
```

수정 후 27/27 이며 기존 21개 케이스에 회귀가 없습니다. 오탐 대조군(`1110줄 중 FAIL 0` 처럼 한정어가 붙은 재진술은 침묵)이 포함돼 있어, "숫자만 보면 발동한다" 는 회귀와 구분됩니다.

### 이슈 대비 미구현

이슈가 "좁히는 기준" 으로 적은 두 항목 중, 경과시간은 **하드 게이트가 아니라 메시지의 정보 문구**로 넣었고, "진행 중 산출물(열린 로그·실행 중 job) 판별" 은 넣지 않았습니다. 한정어+선행발화 조합만으로 관측된 사고가 재현·차단되며, 그 이상은 요청 범위를 넘는 추상화라고 판단했습니다.

Pre-commit verified: `bash tests/hooks/completion-verify/test_runtime_state_claim_gate.sh` → 27 passed / 0 failed, `python3 scripts/check-plugin-manifests.py` → `plugin-manifest check OK`, `ruff check` → `All checks passed!`
Caller chain verified: N/A — 기존 훅 하나의 발동 조건 확장이며 새 심볼을 외부에 노출하지 않습니다. 매니페스트 등록은 이미 존재해 변경이 없습니다.

Closes #1062


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for repeated, unqualified PASS and FAIL verdict claims across conversation turns.
  * Distinguishes quoted text, scoped claims, fresh evidence, changed counts, and unrelated numbers.
  * Advisory messages now identify runtime-state claims and verdict restatements separately, including elapsed time since earlier verdicts.

* **Documentation**
  * Documented verdict matching, qualifier handling, evidence requirements, and combined enforcement behavior.

* **Tests**
  * Added regression coverage for repeated verdicts, language and ordering variants, qualifiers, and fresh evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->