### PR TITLE
fix(hooks): guard background poll-waiter chains

### DIFF
--- a/hooks/preflight-gate/foreground-poll-loop-guard/impl.py
+++ b/hooks/preflight-gate/foreground-poll-loop-guard/impl.py
@@ -165,6 +165,9 @@ _SLEEP_ARG_RE = re.compile(r"(\d+(?:\.\d+)?)([smhd]?)[;)]*$")  # 20 / 2.5 / 30s 
 _SLEEP_UNIT_S = {"": 1.0, "s": 1.0, "m": 60.0, "h": 3600.0, "d": 86400.0}
 _SEQ_HEAD_RE = re.compile(r"^[$(`]*seq$")  # seq / $(seq / `seq
 _NUMERIC_RE = re.compile(r"^(\d+)[;)`]*$")  # 40 / 40) / 40`
+# `seq` operands may be signed: `seq 10 -2 2` counts down. Kept separate from
+# _NUMERIC_RE, whose callers read an iteration count and must stay unsigned.
+_SEQ_OPERAND_RE = re.compile(r"^(-?\d+)[;)`]*$")  # 10 / -2 / 2)
 _BRACE_RANGE_RE = re.compile(r"\{(\d+)\.\.(\d+)\}")  # {A..N} / {N..A}
 _C_INIT_RE = re.compile(r"=\s*(\d+)")  # ((i=0; …
 _C_BOUND_RE = re.compile(r"([<>]=?)\s*(\d+)")  # … i<40 / i<=40 …
@@ -336,16 +339,22 @@ def _for_iterations(header: list[str]) -> int | None:
             continue
         nums: list[int] = []
         for nxt in header[i + 1 : i + 4]:
-            nm = _NUMERIC_RE.match(nxt)
+            nm = _SEQ_OPERAND_RE.match(nxt)
             if not nm:
                 break
             nums.append(int(nm.group(1)))
         if len(nums) == 1:  # seq N
-            return nums[0]
-        if len(nums) == 2:  # seq A B → B-A+1 iterations
+            return max(nums[0], 0)
+        if len(nums) == 2:  # seq A B → B-A+1 iterations, 0 when B < A
             return max(nums[1] - nums[0] + 1, 0)
-        if len(nums) == 3 and nums[1] > 0:  # seq A STEP B
-            return max((nums[2] - nums[0]) // nums[1] + 1, 0)
+        if len(nums) == 3:  # seq A STEP B — STEP may be negative (descending)
+            start, step, end = nums
+            if step == 0:
+                return None  # `seq A 0 B` never terminates — not a count
+            span = end - start if step > 0 else start - end
+            if span < 0:
+                return 0  # progression runs away from its end — seq prints nothing
+            return span // abs(step) + 1
         return None
     if any(tok.startswith("((") or tok.endswith("))") for tok in header):
         # C-style ((i=A; i<N; i+=S)) — punctuation-split tokens

--- a/hooks/preflight-gate/foreground-poll-loop-guard/impl.py
+++ b/hooks/preflight-gate/foreground-poll-loop-guard/impl.py
@@ -46,7 +46,9 @@ contains a poll loop that can approach/exceed the 120s ceiling:
      unit suffixes.
 
 Comments and heredoc bodies are stripped before tokenization — loop-shaped
-text bash never executes cannot trigger the gate.
+text bash never executes cannot trigger the gate. `sleep` counts only in
+command position, the same rule the loop keywords already follow: `do echo
+sleep 20; done` passes the word along and waits for nothing.
 
 Exit 0 (pass) otherwise: run_in_background=true, short bounded loops (< ~90s),
 no-sleep loops, leading `sleep` without a loop (the runtime already handles that),
@@ -220,6 +222,28 @@ def _strip_non_executable(command: str) -> str:
     return "\n".join(out)
 
 
+def _command_position_flags(tokens: list[str]) -> list[bool]:
+    """Per token: is it in command position (where bash reads a command name)?
+
+    Command position is the start of the stream, anything after a separator, and
+    the successor of a reserved word that opens a compound command (`do`,
+    `then`, `else`, `elif`) — but only when that word was itself in command
+    position, so a literal word list (`for i in do done`) cannot fake a
+    boundary.
+
+    Every rule this guard states about a bare word — `sleep`, `for`, `done` —
+    is a rule about that word in command position. `echo sleep 20` prints a
+    string; `echo done` closes nothing.
+    """
+    flags: list[bool] = []
+    grants_next = False
+    for i, tok in enumerate(tokens):
+        cmd_pos = i == 0 or tokens[i - 1] in _COMMAND_SEPARATORS or grants_next
+        grants_next = cmd_pos and tok in ("then", "else", "elif", "do")
+        flags.append(cmd_pos)
+    return flags
+
+
 def _iter_loops(tokens: list[str]) -> list[tuple[str, list[str], list[str]]]:
     """Split the token stream into (keyword, header, body) per loop.
 
@@ -233,22 +257,14 @@ def _iter_loops(tokens: list[str]) -> list[tuple[str, list[str], list[str]]]:
     loops: list[tuple[str, list[str], list[str]]] = []
     stack: list[list[int | None]] = []  # [kw_idx, do_idx]
     # Bash honours reserved words only in command position; an argument
-    # (`echo done`) must not open/advance/close a loop frame. A `do` grants
-    # command position to its successor only when it was itself reserved —
-    # tracked via `grants_next`, so a literal word list (`for i in do done`)
-    # cannot fake a boundary.
-    grants_next = False
+    # (`echo done`) must not open/advance/close a loop frame.
+    cmd_positions = _command_position_flags(tokens)
     for i, tok in enumerate(tokens):
-        cmd_pos = i == 0 or tokens[i - 1] in _COMMAND_SEPARATORS or grants_next
-        grants_next = False
-        if not cmd_pos:
+        if not cmd_positions[i]:
             continue
-        if tok in ("then", "else", "elif"):
-            grants_next = True
-        elif tok in _LOOP_KEYWORDS:
+        if tok in _LOOP_KEYWORDS:
             stack.append([i, None])
         elif tok == "do":
-            grants_next = True
             for frame in reversed(stack):
                 if frame[1] is None:
                     frame[1] = i
@@ -268,9 +284,17 @@ def _iter_loops(tokens: list[str]) -> list[tuple[str, list[str], list[str]]]:
 
 
 def _sleep_args(body: list[str]) -> list[float]:
-    """Parseable `sleep N[smhd]` arguments inside a loop body, in seconds."""
+    """Parseable `sleep N[smhd]` arguments inside a loop body, in seconds.
+
+    Command position only: `do echo sleep 20; done` sleeps for nothing. A body
+    slice always begins right after its `do`, so index 0 of the slice is itself
+    command position.
+    """
     out: list[float] = []
+    cmd_positions = _command_position_flags(body)
     for i, tok in enumerate(body[:-1]):
+        if not cmd_positions[i]:
+            continue
         if tok != "sleep" and not tok.endswith("/sleep"):
             continue
         m = _SLEEP_ARG_RE.match(body[i + 1])
@@ -403,6 +427,13 @@ def _waiter_profile(command: str) -> tuple[str, float, str] | None:
     Dropping each `sleep`'s argument, and only that argument, collapses exactly
     that family into one key.
 
+    **`sleep` counts only in command position.** `echo sleep 20` prints a word
+    and waits for nothing; matching it at any token position would register a
+    waiter for a command that does no waiting, and then advise against the next
+    genuine one. The rule is the one `_iter_loops` already applies to `for` /
+    `done` — start of stream, after a separator, or after `do` / `then` /
+    `else` / `elif`.
+
     Only the sleep argument. Dropping bare numerals generally would fold
     `gh run watch 123` and `gh run watch 456` together — two genuinely
     different targets whose sole discriminator is a bare number — and turn the
@@ -416,11 +447,12 @@ def _waiter_profile(command: str) -> tuple[str, float, str] | None:
     total_sleep = 0.0
     saw_sleep = False
     skip_next = False
+    cmd_positions = _command_position_flags(tokens)
     for i, tok in enumerate(tokens):
         if skip_next:
             skip_next = False
             continue
-        if tok != "sleep" and not tok.endswith("/sleep"):
+        if not cmd_positions[i] or (tok != "sleep" and not tok.endswith("/sleep")):
             normalized.append(tok)
             continue
         m = _SLEEP_ARG_RE.match(tokens[i + 1]) if i + 1 < len(tokens) else None

--- a/hooks/preflight-gate/foreground-poll-loop-guard/impl.py
+++ b/hooks/preflight-gate/foreground-poll-loop-guard/impl.py
@@ -173,6 +173,13 @@ _C_STEP_RE = re.compile(r"[+-]=\s*(\d+)")  # … i+=2 ))
 # and `<<-`; a leading `~` is part of the delimiter, not an operator variant).
 _HEREDOC_RE = re.compile(r"<<-?\s*([\"']?)([^\s\"'<>|&;()]+)\1")
 
+# Signature normalization (issue #1063, group-1 rewrites)
+_SHELL_C_WRAPPERS = ("bash", "sh", "zsh", "dash")
+_NOOP_COMMANDS = {"true", ":"}
+_SEQUENCING_SEPARATORS = {";", "&&", "||"}
+_SHORT_NUMERIC_FLAG_RE = re.compile(r"^-\d+$")  # tail -50 / head -20
+
+
 def _strip_comment(line: str) -> str:
     """Cut the line at an unquoted `#` that starts a word (bash comment rule)."""
     in_single = in_double = escaped = False
@@ -408,6 +415,68 @@ def _detect(command: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
+def _inline_shell_c(tokens: list[str]) -> list[str]:
+    """Splice a `bash -c "<script>"` payload into the stream it wraps.
+
+    `bash -c "sleep 240 && tail -50 x"` waits on exactly what the unwrapped
+    form waits on, but the tokenizer hands the whole script back as ONE string
+    token, so the two forms hash differently and the wrapped one reads as a
+    fresh target. Splicing is one level deep on purpose: a script that wraps
+    itself again is not a shape the observed failure takes, and recursion here
+    buys a way for a crafted command to spend the hook's time.
+    """
+    if len(tokens) < 3 or tokens[1] != "-c":
+        return tokens
+    head = tokens[0].rsplit("/", 1)[-1]
+    if head not in _SHELL_C_WRAPPERS:
+        return tokens
+    return safe_tokenize(tokens[2]) + tokens[3:]
+
+
+def _canonical_signature(tokens: list[str]) -> list[str]:
+    """Collapse rewrites that change the text of a waiter but not what it awaits.
+
+    Three of them, each a syntactic no-op an agent reaches for without meaning
+    to evade anything — the observed retries differed only in duration, but
+    nothing makes that the invariant:
+
+    - **Sequencing separators fold together.** `sleep 240; tail x` and
+      `sleep 240 && tail x` wait on one target. `|` and `&` are deliberately
+      NOT in the fold: a pipe feeds one command into another and `&` detaches,
+      so either really does change the shape of the call.
+    - **A leading no-op is dropped.** `true && <waiter>` and `: ; <waiter>` add
+      nothing. Only in command position and only when a separator follows, so
+      the `true` in `while true` — which is not in command position — and a
+      trailing `… && true` both survive.
+    - **A bare `-<digits>` flag folds to `-N`.** `tail -50 x` and `tail -80 x`
+      read the same file. This is narrower than dropping numerals generally,
+      which would fold `gh run watch 123` and `456` — two different targets
+      whose only discriminator is a bare number.
+    """
+    cmd_positions = _command_position_flags(tokens)
+    out: list[str] = []
+    skip_next = False
+    for i, tok in enumerate(tokens):
+        if skip_next:
+            skip_next = False
+            continue
+        if (
+            cmd_positions[i]
+            and tok in _NOOP_COMMANDS
+            and i + 1 < len(tokens)
+            and tokens[i + 1] in _SEQUENCING_SEPARATORS
+        ):
+            skip_next = True
+            continue
+        if tok in _SEQUENCING_SEPARATORS:
+            out.append(";")
+        elif _SHORT_NUMERIC_FLAG_RE.match(tok):
+            out.append("-N")
+        else:
+            out.append(tok)
+    return out
+
+
 def _waiter_profile(command: str) -> tuple[str, float, str] | None:
     """`(target_key, armed_seconds, display)` when this command is a waiter, else None.
 
@@ -439,7 +508,7 @@ def _waiter_profile(command: str) -> tuple[str, float, str] | None:
     different targets whose sole discriminator is a bare number — and turn the
     guard into one that fires on every second background call.
     """
-    tokens = safe_tokenize(_strip_non_executable(command))
+    tokens = _inline_shell_c(safe_tokenize(_strip_non_executable(command)))
     if not tokens:
         return None
 
@@ -467,7 +536,8 @@ def _waiter_profile(command: str) -> tuple[str, float, str] | None:
         return None
 
     armed = _armed_window(tokens, total_sleep)
-    key = hashlib.sha1("\x00".join(normalized).encode("utf-8")).hexdigest()[:16]
+    signature = _canonical_signature(normalized)
+    key = hashlib.sha1("\x00".join(signature).encode("utf-8")).hexdigest()[:16]
     display = " ".join(command.split())
     if len(display) > 120:
         display = display[:117] + "..."

--- a/hooks/preflight-gate/foreground-poll-loop-guard/impl.py
+++ b/hooks/preflight-gate/foreground-poll-loop-guard/impl.py
@@ -61,8 +61,10 @@ passed the guard every time (146 of 500 Bash calls in one session, 9 waiters
 left for the harness to kill hours later). A background call whose whole job is
 to elapse is recorded in a session registry keyed on its sleep-normalized
 command signature; a second such call arriving while the first's armed window
-is still open draws an ADVISORY (stderr, exit 0) naming the already-armed
-waiter and `TaskStop`. It never blocks — the block message hands out
+is still open draws an ADVISORY (exit 0) naming the already-armed waiter and
+`TaskStop`. It is written to BOTH `hookSpecificOutput.additionalContext` — the
+one PreToolUse channel that reaches the model at exit 0 — and stderr, which the
+fire ledger reads to classify the fire as `advise`. It never blocks — the block message hands out
 `run_in_background: true` as the escape, so denying it would contradict the
 guard's own redirect.
 
@@ -546,6 +548,35 @@ def _background_waiter_advisory(command: str, session_id: str | None) -> str | N
     )
 
 
+def _emit_additional_context(advisory: str) -> None:
+    """Write the advisory as `hookSpecificOutput.additionalContext` (issue #1063).
+
+    stderr alone leaves this lane inert. A PreToolUse hook's stderr is fed to the
+    model only when the dispatcher exits 2 (`docs/hook/INDEX.md`); on the exit-0
+    path it reaches the debug log and nothing else, so the advisory would never
+    be seen by the agent it is written for. `additionalContext` is the one
+    PreToolUse channel that does reach the model (`_dispatch.py` forwards and
+    merges it once deny and ask have both missed).
+
+    The stderr write is KEPT alongside it: `_fire_ledger.classify_decision`
+    derives `advise` from stderr, so moving the text to stdout would reclassify
+    every fire as `pass`. Shape mirrors `pipefail-advisory` — `PreToolUse` event
+    name, no top-level `continue` (a PreToolUse stop-processing switch whose
+    default is already what is wanted here).
+    """
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "additionalContext": advisory,
+            }
+        },
+        sys.stdout,
+        ensure_ascii=False,
+    )
+    sys.stdout.write("\n")
+
+
 def _reference_path() -> str:
     """Absolute path to this guard's own spec.md (issue #1012).
 
@@ -657,6 +688,7 @@ def main() -> int:
         advisory = _background_waiter_advisory(command, session_id)
         if advisory:
             sys.stderr.write(advisory + "\n")
+            _emit_additional_context(advisory)
         return 0
 
     reason = _detect(command)

--- a/hooks/preflight-gate/foreground-poll-loop-guard/impl.py
+++ b/hooks/preflight-gate/foreground-poll-loop-guard/impl.py
@@ -105,8 +105,9 @@ already going to block — it can never turn a pass into a deny.
   (tests; an unresolvable value exercises the fail-open escape).
 - `PRAXIS_POLL_LOOP_READ_GATE_AFTER` — prior blocks required before the read-gate
   escalates (default 2 → the 3rd block escalates). Unparseable → default.
-- `PRAXIS_POLL_LOOP_WAITER_TTL` — seconds a loop-shaped background waiter counts
-  as armed (default 900). Unparseable or ≤ 0 → default.
+- `PRAXIS_POLL_LOOP_WAITER_TTL` — seconds a background waiter with no computable
+  end (`while`/`until`, or a `for` over a dynamic list) counts as armed
+  (default 900). Unparseable or ≤ 0 → default.
 
 ## Fail-open
 
@@ -433,16 +434,44 @@ def _waiter_profile(command: str) -> tuple[str, float, str] | None:
     if not saw_sleep:
         return None
 
-    # A loop's sleep is per-iteration and the iteration count is either absent
-    # (`until`) or irrelevant to when the waiter returns, so the summed sleep
-    # is not the armed window for that shape.
-    open_ended = any(_sleep_args(body) for _kw, _header, body in _iter_loops(tokens))
-    armed = _open_ended_ttl() if open_ended else total_sleep
+    armed = _armed_window(tokens, total_sleep)
     key = hashlib.sha1("\x00".join(normalized).encode("utf-8")).hexdigest()[:16]
     display = " ".join(command.split())
     if len(display) > 120:
         display = display[:117] + "..."
     return key, armed, display
+
+
+def _armed_window(tokens: list[str], total_sleep: float) -> float:
+    """Seconds this waiter counts as armed. `total_sleep` = each `sleep` counted once.
+
+    A loop's sleep is per-iteration, so the flat sum undercounts it. When the
+    iteration count is unknowable — `while` / `until`, or a `for` over a dynamic
+    word list — there is no computable end at all and the fixed TTL is the only
+    honest window (`_open_ended_ttl`).
+
+    A `for` loop whose count IS computable is not that shape. `for i in 1 2; do
+    sleep 1; done` returns in ~2s, and arming it for 900s makes a re-launch
+    minutes later — long after it returned — report a live waiter that does not
+    exist. The same `_for_iterations` the block path already uses supplies the
+    count; the body sleeps are each counted once in `total_sleep`, so only the
+    remaining `n - 1` iterations are added.
+
+    Nested finite loops are UNDER-counted: an inner loop's sleeps appear in its
+    own entry and again in its parent's body, and the parent multiplies them
+    only once. An under-counted window expires early, which costs an advisory
+    that does not fire — the same direction every other fail-open here takes.
+    """
+    extra = 0.0
+    for kw, header, body in _iter_loops(tokens):
+        per_iteration = sum(_sleep_args(body))
+        if per_iteration <= 0:
+            continue
+        iterations = _for_iterations(header) if kw == "for" else None
+        if iterations is None:
+            return _open_ended_ttl()
+        extra += max(iterations - 1, 0) * per_iteration
+    return max(total_sleep + extra, 0.0)
 
 
 def _open_ended_ttl() -> float:

--- a/hooks/preflight-gate/foreground-poll-loop-guard/impl.py
+++ b/hooks/preflight-gate/foreground-poll-loop-guard/impl.py
@@ -52,6 +52,20 @@ Exit 0 (pass) otherwise: run_in_background=true, short bounded loops (< ~90s),
 no-sleep loops, leading `sleep` without a loop (the runtime already handles that),
 non-Bash tools.
 
+## Background waiter-chain advisory (issue #1063)
+
+`run_in_background: true` passes the block above — it is the correct redirect.
+It is also where the blocked behaviour moved: chaining short background waiters
+across turns, each one differing from the last only in its `sleep` duration,
+passed the guard every time (146 of 500 Bash calls in one session, 9 waiters
+left for the harness to kill hours later). A background call whose whole job is
+to elapse is recorded in a session registry keyed on its sleep-normalized
+command signature; a second such call arriving while the first's armed window
+is still open draws an ADVISORY (stderr, exit 0) naming the already-armed
+waiter and `TaskStop`. It never blocks — the block message hands out
+`run_in_background: true` as the escape, so denying it would contradict the
+guard's own redirect.
+
 ## Read-gate escalation (issue #1012)
 
 A block that is answered with the same loop shape is a block that was not read.
@@ -89,6 +103,8 @@ already going to block — it can never turn a pass into a deny.
   (tests; an unresolvable value exercises the fail-open escape).
 - `PRAXIS_POLL_LOOP_READ_GATE_AFTER` — prior blocks required before the read-gate
   escalates (default 2 → the 3rd block escalates). Unparseable → default.
+- `PRAXIS_POLL_LOOP_WAITER_TTL` — seconds a loop-shaped background waiter counts
+  as armed (default 900). Unparseable or ≤ 0 → default.
 
 ## Fail-open
 
@@ -97,10 +113,12 @@ exit 0 (pass).
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
 import sys
+import time
 from pathlib import Path as _Path
 
 _HERE = _Path(__file__).resolve()
@@ -116,12 +134,17 @@ if _sys_lib not in sys.path:
 from _fire_ledger import count_session_fires  # type: ignore[import-not-found]  # noqa: E402
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import safe_tokenize  # type: ignore[import-not-found]  # noqa: E402
+from _paths import resolve_cache_file  # type: ignore[import-not-found]  # noqa: E402
 from block_message import emit_block  # type: ignore[import-not-found]  # noqa: E402
 
 _HOOK_NAME = "foreground-poll-loop-guard"  # manifest `name` — the fire-ledger key
+_BYPASS_ENV = "PRAXIS_HOOK_BYPASS_POLL_LOOP_GUARD"
 _FOREGROUND_CEILING_S = 120  # Bash default timeout, seconds
 _SAFE_MARGIN_S = 100  # block when worst-case can approach the ceiling
 _READ_GATE_AFTER_BLOCKS = 2  # prior session blocks before the read-gate escalates
+# A loop-shaped waiter has no computable end, so its armed window is a fixed
+# default rather than its own sleep total (issue #1063).
+_OPEN_ENDED_WAITER_TTL_S = 900.0
 # The read-set owner: its PostToolUse(Read) leg records every `.md` Read of the
 # session, spec.md included, so the escalation reuses that history instead of
 # standing up a second one.
@@ -353,6 +376,176 @@ def _detect(command: str) -> str | None:
     return None
 
 
+# ---------------------------------------------------------------------------
+# Background waiter-chain advisory (issue #1063)
+# ---------------------------------------------------------------------------
+
+
+def _waiter_profile(command: str) -> tuple[str, float, str] | None:
+    """`(target_key, armed_seconds, display)` when this command is a waiter, else None.
+
+    A *waiter* is a call whose whole job is to elapse: it contains a parseable
+    `sleep` in command position. Launching the awaited work itself
+    (`bash run-tests.sh > /tmp/out &`) carries no `sleep` and is therefore
+    never recorded — this lane is about waiting on work, not doing it.
+
+    **The target key is the sleep-normalized command signature.** The three
+    candidates #1063 names are not equally usable. A *job id* names the waiter,
+    not what it waits on, and does not exist yet at PreToolUse time. An *output
+    file path* is present only when the waiter redirects or reads a file, so
+    `until gh pr checks; do sleep 20; done` — a waiter with no file anywhere —
+    would key on nothing. The command signature is the only one every waiting
+    call has, and it is what the observed failure actually looked like: the
+    retries differed from each other *only in the sleep duration* (240 → 595).
+    Dropping each `sleep`'s argument, and only that argument, collapses exactly
+    that family into one key.
+
+    Only the sleep argument. Dropping bare numerals generally would fold
+    `gh run watch 123` and `gh run watch 456` together — two genuinely
+    different targets whose sole discriminator is a bare number — and turn the
+    guard into one that fires on every second background call.
+    """
+    tokens = safe_tokenize(_strip_non_executable(command))
+    if not tokens:
+        return None
+
+    normalized: list[str] = []
+    total_sleep = 0.0
+    saw_sleep = False
+    skip_next = False
+    for i, tok in enumerate(tokens):
+        if skip_next:
+            skip_next = False
+            continue
+        if tok != "sleep" and not tok.endswith("/sleep"):
+            normalized.append(tok)
+            continue
+        m = _SLEEP_ARG_RE.match(tokens[i + 1]) if i + 1 < len(tokens) else None
+        if m is None:
+            normalized.append(tok)  # `sleep $VAR` — unparseable, keep verbatim
+            continue
+        saw_sleep = True
+        total_sleep += float(m.group(1)) * _SLEEP_UNIT_S[m.group(2)]
+        normalized.append("sleep")  # `/bin/sleep` and `sleep` are one shape
+        skip_next = True
+    if not saw_sleep:
+        return None
+
+    # A loop's sleep is per-iteration and the iteration count is either absent
+    # (`until`) or irrelevant to when the waiter returns, so the summed sleep
+    # is not the armed window for that shape.
+    open_ended = any(_sleep_args(body) for _kw, _header, body in _iter_loops(tokens))
+    armed = _open_ended_ttl() if open_ended else total_sleep
+    key = hashlib.sha1("\x00".join(normalized).encode("utf-8")).hexdigest()[:16]
+    display = " ".join(command.split())
+    if len(display) > 120:
+        display = display[:117] + "..."
+    return key, armed, display
+
+
+def _open_ended_ttl() -> float:
+    """Armed window for a loop-shaped waiter. `PRAXIS_POLL_LOOP_WAITER_TTL` overrides."""
+    raw = os.environ.get("PRAXIS_POLL_LOOP_WAITER_TTL", "").strip()
+    if not raw:
+        return _OPEN_ENDED_WAITER_TTL_S
+    try:
+        value = float(raw)
+    except ValueError:
+        return _OPEN_ENDED_WAITER_TTL_S
+    return value if value > 0 else _OPEN_ENDED_WAITER_TTL_S
+
+
+def _waiter_registry_path(session_id: str | None) -> str:
+    key = session_id or str(os.getppid())
+    return resolve_cache_file(f"poll-loop-waiters-{key}.json", session_id=key)
+
+
+def _load_waiters(path: str) -> dict:
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save_waiters(path: str, waiters: dict) -> None:
+    """Publish the registry atomically, staging through a per-process name.
+
+    Per-process because a `<path>.tmp` shared with a sibling hook process on
+    the same `session_id` corrupts rather than loses (DESIGN.md Q0): the
+    shorter write lands over the longer one's tail and every reader's
+    `except ValueError` answers *empty registry*.
+
+    Unlocked, by the same DESIGN.md criterion: no threshold reads this state
+    (the test is "a live entry exists", not an exact count) and no gate decides
+    block-vs-pass from it — this lane is advisory-only. A lost update costs one
+    advisory that does not fire, which is Q3.
+    """
+    tmp_path = f"{path}.{os.getpid()}.tmp"
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as fh:
+            json.dump(waiters, fh)
+        os.replace(tmp_path, path)
+    except OSError:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+
+def _background_waiter_advisory(command: str, session_id: str | None) -> str | None:
+    """Advisory when a live waiter for this same target is already armed, else None.
+
+    Records the waiter as a side effect. An entry is written only when no live
+    one exists for the key: refreshing on every duplicate would push the armed
+    window forward indefinitely and make the reported age of the original
+    waiter a lie.
+    """
+    profile = _waiter_profile(command)
+    if profile is None:
+        return None
+    key, armed, display = profile
+
+    path = _waiter_registry_path(session_id)
+    waiters = _load_waiters(path)
+    now = time.time()
+
+    live = {
+        k: v
+        for k, v in waiters.items()
+        if isinstance(v, dict)
+        and isinstance(v.get("at"), (int, float))
+        and isinstance(v.get("armed"), (int, float))
+        and now - v["at"] < v["armed"]
+    }
+
+    existing = live.get(key)
+    if existing is None:
+        live[key] = {"at": now, "armed": armed, "cmd": display}
+        _save_waiters(path, live)
+        return None
+
+    if live != waiters:  # expired entries pruned — publish the smaller registry
+        _save_waiters(path, live)
+
+    age = int(now - existing["at"])
+    remaining = max(int(existing["armed"] - (now - existing["at"])), 0)
+    return (
+        f"[{_HOOK_NAME}] A background waiter for this same target was launched "
+        f"{age}s ago and stays armed for ~{remaining}s more:\n"
+        f"    $ {existing.get('cmd', '<unknown>')}\n"
+        "This call waits on it a second time. A background call re-invokes Claude "
+        "when it exits, so the notification is already armed — a second waiter "
+        "does not make it arrive sooner, and every one of them outlives the turn "
+        "that launched it.\n"
+        "Correct path: wait for the notification already armed. If waiters have "
+        "piled up, list them (/tasks) and TaskStop every one but the newest — a "
+        "waiter nobody reaps is killed by the harness hours later.\n"
+        f"Set {_BYPASS_ENV}=1 to silence this guard."
+    )
+
+
 def _reference_path() -> str:
     """Absolute path to this guard's own spec.md (issue #1012).
 
@@ -434,7 +627,7 @@ def _read_gate_engaged(payload: dict, reference: str) -> int | None:
 
 @fail_open
 def main() -> int:
-    if os.environ.get("PRAXIS_HOOK_BYPASS_POLL_LOOP_GUARD"):
+    if os.environ.get(_BYPASS_ENV):
         return 0
 
     try:
@@ -446,12 +639,24 @@ def main() -> int:
         return 0
 
     tool_input = payload.get("tool_input", {}) or {}
-    # Backgrounded polling is the CORRECT pattern — never block it.
-    if tool_input.get("run_in_background") is True:
-        return 0
-
     command = tool_input.get("command", "") or ""
     if not command.strip():
+        return 0
+
+    session_id = payload.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        session_id = None
+
+    # Backgrounded polling is the CORRECT pattern and is never blocked. It is,
+    # however, where the behaviour this guard was built to stop moved once the
+    # foreground form started being denied (issue #1063): chaining short
+    # background waiters across turns passed every time. Advisory, not a block —
+    # the guard's own redirect message names `run_in_background: true` as the
+    # correct path, so denying it would contradict the escape it hands out.
+    if tool_input.get("run_in_background") is True:
+        advisory = _background_waiter_advisory(command, session_id)
+        if advisory:
+            sys.stderr.write(advisory + "\n")
         return 0
 
     reason = _detect(command)
@@ -490,7 +695,7 @@ def main() -> int:
         rule_name="foreground poll-loop guard",
         why=why,
         correct_path=correct_path,
-        bypass_env="PRAXIS_HOOK_BYPASS_POLL_LOOP_GUARD",
+        bypass_env=_BYPASS_ENV,
         reference=reference,
     )
     return 2

--- a/hooks/preflight-gate/foreground-poll-loop-guard/spec.md
+++ b/hooks/preflight-gate/foreground-poll-loop-guard/spec.md
@@ -121,7 +121,7 @@ reported age of the original waiter a lie.
 | Situation (all `run_in_background: true`) | Action |
 | --- | --- |
 | First waiter for a target | pass, recorded (exit 0, silent) |
-| Second waiter, same target, only the `sleep` duration changed | **advisory** (exit 0, stderr) |
+| Second waiter, same target, only the `sleep` duration changed | **advisory** (exit 0, `additionalContext` + stderr) |
 | Second waiter, same target, identical loop-shaped command | **advisory** |
 | Concurrent waits on different files / different run ids | pass (silent) |
 | Background call with no `sleep` at all, twice | pass (silent) |
@@ -134,10 +134,22 @@ hands out, and a genuinely-needed second waiter must stay reachable. The
 message names the already-armed waiter, its age and remaining window, and
 `TaskStop` as the way to reap the pile-up.
 
+**Delivery channel: `additionalContext` AND stderr.** A PreToolUse hook's stderr
+is fed to the model only when the dispatcher exits 2 — the deny path
+([`docs/hook/INDEX.md`](../../../docs/hook/INDEX.md)). On this lane's exit-0 path
+stderr reaches the debug log and nothing else, so a stderr-only advisory is inert
+for the agent it is written for. The same text is therefore also written as
+`hookSpecificOutput.additionalContext`, the one PreToolUse channel that does
+reach the model; `_dispatch.run_group` forwards and merges those once deny and
+ask have both missed. stderr is kept because `_fire_ledger.classify_decision`
+derives `advise` from stderr — dropping it would reclassify every fire of this
+lane as `pass` and erase the metric. Shape mirrors `pipefail-advisory`:
+`hookEventName: PreToolUse`, no top-level `continue`.
+
 Known limitation, intentional: PreToolUse cannot see whether the earlier
 background job has already exited or been `TaskStop`ed, so a waiter reaped
 early still counts as armed until its window elapses. The cost of that false
-positive is one stderr line on a call that proceeds.
+positive is one advisory line on a call that proceeds.
 
 **State.** `<PRAXIS_HOME>/cache/poll-loop-waiters-<session_id>.json` via
 `resolve_cache_file` (ppid fallback when the payload carries no `session_id`),

--- a/hooks/preflight-gate/foreground-poll-loop-guard/spec.md
+++ b/hooks/preflight-gate/foreground-poll-loop-guard/spec.md
@@ -62,12 +62,20 @@ stack). An unbounded `while`/`until` whose body contains a parseable `sleep`
 except `while read` / `while IFS= read` line-consumers which terminate on
 input, not time. A `for` loop blocks when `iterations × (sum of body sleeps
 per iteration) ≥ 100s`; the count is parsed from `seq 1 N` / `seq N` /
-`seq A B` (= B−A+1) / `seq A STEP B`, `{A..B}` (either direction), C-style
+`seq A B` (= B−A+1) / `seq A STEP B` (STEP may be negative — `seq 10 -2 2`
+counts down and runs 5 times, not 10), `{A..B}` (either direction), C-style
 `((i=A; i<N; i+=S))` (init, comparison operator, and step honored; missing
 init or comparison → fail-open), or a literal word list (word count; globs
 count as 1 word each — an undercount that only ever passes; `$`/backtick
 expansions in the list → unknowable count → fail-open). `sleep` arguments
 accept `s`/`m`/`h`/`d` unit suffixes.
+
+`seq A B` with `B < A` counts 0, which matches GNU `seq` (it prints nothing)
+and not BSD `seq`, which counts down. The divergence is left in the
+undercounting direction on purpose: an undercount only ever passes, while
+reading it as a descending run would block loops on the platform where it
+prints nothing. A zero step (`seq A 0 B`) never terminates and is not a count →
+fail-open.
 
 Known limitations (intentional): a loop backgrounded at the shell level
 (`… done &`) is still blocked — a `&`-job dies when the Bash tool call

--- a/hooks/preflight-gate/foreground-poll-loop-guard/spec.md
+++ b/hooks/preflight-gate/foreground-poll-loop-guard/spec.md
@@ -74,6 +74,82 @@ Known limitations (intentional): a loop backgrounded at the shell level
 returns, so `run_in_background: true` remains the correct redirect. An
 unparseable iteration count or `sleep $VAR` fails open (pass).
 
+## Background waiter-chain advisory (issue #1063)
+
+`run_in_background: true` passes the block table above by design, and always
+will — it is the redirect the block message hands out. It is also where the
+blocked behaviour moved. In the 2026-08-20 session that opened this issue the
+foreground `sleep N && tail` form was denied 4 times, each retry changing only
+the duration; the behaviour then moved to chaining short background calls
+across turns and the block count went to 0. The cost: 146 of 500 Bash calls
+(29%) spent waiting on one test suite, 40 waiting calls in the densest 4-minute
+window, and 9 waiters the harness killed two hours later. The first call had
+already been the correct one — `run_in_background` with an `until` loop. The
+agent did not wait for the notification it had itself armed.
+
+**What a waiter is.** A background Bash call whose whole job is to elapse: its
+command contains a parseable `sleep` in command position. Launching the awaited
+work (`bash scripts/run-tests.sh > /tmp/out 2>&1`) carries no `sleep` and is
+never recorded — this lane is about waiting on work, not doing it.
+
+**What "same target" is keyed on: the sleep-normalized command signature.** The
+three candidates the issue names are not equally usable.
+
+| Candidate | Why not / why |
+| --- | --- |
+| Job id | Names the *waiter*, not what it waits on — and does not exist yet at PreToolUse time |
+| Output file path | Present only when the waiter redirects or reads a file; `until gh pr checks; do sleep 20; done` would key on nothing |
+| **Command signature** | The only key every waiting call has — **chosen** |
+
+Normalization drops each `sleep`'s argument token and nothing else, then hashes
+the remaining tokens. That is the narrowest rule that closes the observed gap:
+the retries differed from each other *only* in the duration (240 → 595), so
+`sleep 240 && tail -50 /tmp/suite.log` and `sleep 595 && tail -50 /tmp/suite.log`
+collapse to one key. Dropping bare numerals in general would fold
+`gh run view 123` and `gh run view 456` — two genuinely different targets whose
+sole discriminator is a bare number — and turn the guard into one that fires on
+every second background call.
+
+**Armed window.** A recorded waiter counts as live for its own sleep total; past
+that it has returned and re-arming is the correct call, not a duplicate. A
+*loop-shaped* waiter has no computable end — an `until` loop's per-iteration
+sleep says nothing about when it returns — so that shape uses a fixed default
+(900s, `PRAXIS_POLL_LOOP_WAITER_TTL`). A duplicate does not refresh the existing
+entry: refreshing would push the window forward indefinitely and make the
+reported age of the original waiter a lie.
+
+| Situation (all `run_in_background: true`) | Action |
+| --- | --- |
+| First waiter for a target | pass, recorded (exit 0, silent) |
+| Second waiter, same target, only the `sleep` duration changed | **advisory** (exit 0, stderr) |
+| Second waiter, same target, identical loop-shaped command | **advisory** |
+| Concurrent waits on different files / different run ids | pass (silent) |
+| Background call with no `sleep` at all, twice | pass (silent) |
+| Re-arm after the previous waiter's window elapsed | pass (silent) |
+| Same loop-shaped command in the FOREGROUND | **BLOCKED** (exit 2, unchanged) |
+
+**Advisory, never a block.** The block message names `run_in_background: true`
+as the correct path; denying it would contradict the escape the guard itself
+hands out, and a genuinely-needed second waiter must stay reachable. The
+message names the already-armed waiter, its age and remaining window, and
+`TaskStop` as the way to reap the pile-up.
+
+Known limitation, intentional: PreToolUse cannot see whether the earlier
+background job has already exited or been `TaskStop`ed, so a waiter reaped
+early still counts as armed until its window elapses. The cost of that false
+positive is one stderr line on a call that proceeds.
+
+**State.** `<PRAXIS_HOME>/cache/poll-loop-waiters-<session_id>.json` via
+`resolve_cache_file` (ppid fallback when the payload carries no `session_id`),
+a `{signature: {at, armed, cmd}}` map, staged through a per-process `.tmp` name
+and published with `os.replace`. Expired entries are pruned on write.
+Deliberately **unlocked** under the DESIGN.md
+[session-state-concurrency](../../../DESIGN.md#session-state-concurrency)
+criterion: the per-process staging name settles Q0, no threshold reads the
+state (the test is "a live entry exists", not an exact count — Q1), and no gate
+decides block-vs-pass from it (Q2). A lost update costs one advisory that does
+not fire — Q3, no lock.
+
 ## Redirect message
 
 The block message names the alternatives so the caller can self-correct:
@@ -139,11 +215,15 @@ already going to block. It can never turn a pass into a deny.
 - `PRAXIS_POLL_LOOP_READ_GATE_AFTER` — prior session blocks required before the
   read-gate escalates (default `2` → the 3rd block escalates). Unparseable →
   default.
+- `PRAXIS_POLL_LOOP_WAITER_TTL` — seconds a loop-shaped background waiter counts
+  as armed (default `900`). Unparseable or ≤ 0 → default.
 
 ## Fail-open
 
 Malformed stdin JSON, non-Bash tool, empty command, unparseable count/sleep →
-exit 0 (pass). The guard never blocks on infrastructure error. Within the block
+exit 0 (pass). The guard never blocks on infrastructure error. The waiter-chain
+lane is exit 0 on every path, so an unreadable or corrupt registry costs an
+advisory that does not fire, never a denied call. Within the block
 path, the read-gate escalation additionally fails open (base block, no Read
 demanded) on a missing `session_id`, an unresolvable reference path, or any
 error reading the fire ledger or the read-set.
@@ -161,3 +241,14 @@ escalates (the case that fails if `record_group_fires`' row shape ever drifts
 from `count_session_fires`' filter). Silence direction: below threshold, after a
 Read of this spec, unresolvable reference, missing `session_id`, and
 `run_in_background: true` while armed.
+
+Waiter-chain coverage is two-directional for the same reason. Fire: a
+duration-only retry, an identical loop-shaped relaunch. Silence: the FIRST
+waiter, waits on a different file, waits on a different run id (the pair that
+separates this change from "fires on every second background call"), a
+background call that does no waiting, an elapsed armed window, and the same
+loop-shaped command in the foreground — still exit 2.
+
+The suite exports a temp `PRAXIS_HOME`: the guard now records state on the
+background path, so without it the pre-existing `run_in_background: true`
+fixtures write registry files into the developer's real `~/.praxis/cache`.

--- a/hooks/preflight-gate/foreground-poll-loop-guard/spec.md
+++ b/hooks/preflight-gate/foreground-poll-loop-guard/spec.md
@@ -112,17 +112,30 @@ every second background call.
 
 **Armed window.** A recorded waiter counts as live for its own sleep total; past
 that it has returned and re-arming is the correct call, not a duplicate. A
-*loop-shaped* waiter has no computable end — an `until` loop's per-iteration
-sleep says nothing about when it returns — so that shape uses a fixed default
-(900s, `PRAXIS_POLL_LOOP_WAITER_TTL`). A duplicate does not refresh the existing
-entry: refreshing would push the window forward indefinitely and make the
-reported age of the original waiter a lie.
+waiter with **no computable end** — a `while`/`until` loop, or a `for` over a
+dynamic word list — uses a fixed default (900s,
+`PRAXIS_POLL_LOOP_WAITER_TTL`): an `until` loop's per-iteration sleep says
+nothing about when it returns.
+
+A **finite `for` loop is not that shape.** `for i in 1 2; do sleep 1; done`
+returns in ~2s, and arming it for 900s makes a re-launch minutes later report a
+live waiter that has long since exited. The iteration count comes from the same
+`_for_iterations` the block path uses (`seq`, `{A..B}`, C-style, literal word
+list), and the window is iterations × the body's per-iteration sleep total, plus
+any sleep outside a loop. Nested finite loops are deliberately under-counted —
+an inner loop's sleeps are multiplied only once — so the window expires early,
+costing an advisory that does not fire rather than one that fires falsely.
+
+A duplicate does not refresh the existing entry: refreshing would push the
+window forward indefinitely and make the reported age of the original waiter a
+lie.
 
 | Situation (all `run_in_background: true`) | Action |
 | --- | --- |
 | First waiter for a target | pass, recorded (exit 0, silent) |
 | Second waiter, same target, only the `sleep` duration changed | **advisory** (exit 0, `additionalContext` + stderr) |
-| Second waiter, same target, identical loop-shaped command | **advisory** |
+| Second waiter, same target, identical unbounded-loop command | **advisory** |
+| Re-launch of a finite `for` loop past its own computed total | pass (silent) |
 | Concurrent waits on different files / different run ids | pass (silent) |
 | Background call with no `sleep` at all, twice | pass (silent) |
 | Re-arm after the previous waiter's window elapsed | pass (silent) |

--- a/hooks/preflight-gate/foreground-poll-loop-guard/spec.md
+++ b/hooks/preflight-gate/foreground-poll-loop-guard/spec.md
@@ -119,6 +119,37 @@ collapse to one key. Dropping bare numerals in general would fold
 sole discriminator is a bare number — and turn the guard into one that fires on
 every second background call.
 
+**Four rewrites are normalized away before hashing.** Dropping the `sleep`
+argument closes the retry family that was observed, but nothing makes duration
+the invariant — an agent reaches for these without meaning to evade anything,
+and each was measured silent before this was added:
+
+| Rewrite | Normalization |
+| --- | --- |
+| `sleep 240; tail x` vs `sleep 240 && tail x` | `;` / `&&` / `\|\|` fold to one separator token |
+| `true && <waiter>`, `: ; <waiter>` | a no-op in command position followed by a separator is dropped |
+| `tail -50 x` vs `tail -80 x` | a bare `-<digits>` token folds to `-N` |
+| `bash -c "<waiter>"` | the script argument is spliced into the token stream, one level deep |
+
+Each fold is bounded so it cannot reach a genuinely different target. `\|` and
+`&` stay outside the separator fold — a pipe feeds one command into another and
+`&` detaches, so either really does change the call. Only `-<digits>` folds, not
+bare numerals: `gh run view 123` and `456` are two different targets whose sole
+discriminator is that number. The no-op rule needs both command position and a
+following separator, so the `true` in `while true` survives and so does a
+trailing `&& true`. `bash -c` splices once; a script that wraps itself again is
+not a shape the observed failure takes.
+
+**Still out of reach, stated rather than implied.** A waiter rewritten into a
+different pipeline (`sleep 240 && cat x | tail -50` against
+`sleep 240 && tail -50 x`), or into a different waiting shape altogether
+(`until [ -s x ]; do sleep 20; done`), hashes differently and draws no
+advisory. Collapsing those needs the key to model what is being awaited rather
+than how the call is written — a different design than the command signature,
+and out of scope here. A busy-wait with no `sleep` at all
+(`while ! grep -q DONE x; do :; done`) is not a waiter under the definition
+above and is never recorded.
+
 **Armed window.** A recorded waiter counts as live for its own sleep total; past
 that it has returned and re-arming is the correct call, not a duplicate. A
 waiter with **no computable end** — a `while`/`until` loop, or a `for` over a
@@ -144,6 +175,8 @@ lie.
 | First waiter for a target | pass, recorded (exit 0, silent) |
 | Second waiter, same target, only the `sleep` duration changed | **advisory** (exit 0, `additionalContext` + stderr) |
 | Second waiter, same target, identical unbounded-loop command | **advisory** |
+| Second waiter rewritten with `;`, a leading `true &&`, `-80` for `-50`, or `bash -c` | **advisory** |
+| Second waiter rewritten into a different pipeline or a different waiting shape | pass (silent, out of reach) |
 | Re-launch of a finite `for` loop past its own computed total | pass (silent) |
 | Concurrent waits on different files / different run ids | pass (silent) |
 | Background call with no `sleep` at all, twice | pass (silent) |

--- a/hooks/preflight-gate/foreground-poll-loop-guard/spec.md
+++ b/hooks/preflight-gate/foreground-poll-loop-guard/spec.md
@@ -92,6 +92,15 @@ command contains a parseable `sleep` in command position. Launching the awaited
 work (`bash scripts/run-tests.sh > /tmp/out 2>&1`) carries no `sleep` and is
 never recorded — this lane is about waiting on work, not doing it.
 
+*Command position* is the literal rule, not a paraphrase: start of the stream,
+after a separator (`;` `&&` `||` `|` `&` `{`), or after `do` / `then` / `else` /
+`elif`. `echo sleep 20` and `some-tool sleep 20` pass `sleep` along as a word and
+wait for nothing, so neither registers a waiter. This is the same rule
+`_iter_loops` applies to `for` / `done` (`echo done` closes no loop), and it is
+applied at both sites through one helper — including inside a loop body, where
+`do echo sleep 20; done` no longer counts as a sleeping loop for the foreground
+gate either. That narrowing can only turn a block into a pass, never the reverse.
+
 **What "same target" is keyed on: the sleep-normalized command signature.** The
 three candidates the issue names are not equally usable.
 

--- a/tests/hooks/preflight-gate/test_foreground_poll_loop_guard.sh
+++ b/tests/hooks/preflight-gate/test_foreground_poll_loop_guard.sh
@@ -18,6 +18,15 @@ if [ ! -x "$HOOK" ]; then
   exit 1
 fi
 
+# Contain every state write these fixtures cause (issue #1063). The guard now
+# records background waiters under <PRAXIS_HOME>/cache, and the pre-existing
+# `run_in_background: true` cases run through that lane too — without this the
+# suite writes registry files into the developer's real ~/.praxis/cache, one
+# per fixture session id.
+TEST_HOME="$(mktemp -d)" || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+export PRAXIS_HOME="$TEST_HOME"
+trap 'rm -rf "$TEST_HOME"' EXIT
+
 PASS=0
 FAIL=0
 FAILED_NAMES=()
@@ -197,7 +206,7 @@ if [ "$rc" -eq 0 ]; then PASS=$((PASS + 1)); echo "ok    [env-bypass]"; else
 # spec must not demand it be read).
 
 RG_DIR="$(mktemp -d)" || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
-trap 'rm -rf "$RG_DIR"' EXIT
+trap 'rm -rf "$TEST_HOME" "$RG_DIR"' EXIT
 RG_SPEC="$REPO_ROOT/hooks/preflight-gate/foreground-poll-loop-guard/spec.md"
 RG_MD_POST="$REPO_ROOT/hooks/postuse-correction/pre-edit-md-escape-advisory/impl.py"
 RG_LOOP='while true; do gh pr checks 7; sleep 20; done'
@@ -334,6 +343,132 @@ rg_assert "readgate-armed-still-passes-background" nogate 0 "$rc" "$err"
 )
 err=$(rg_run "$RG_DIR/e2e.jsonl" "$RG_DIR/e2e-history.json" "$(rg_payload e2e-sess)"); rc=$?
 rg_assert "readgate-dispatcher-written-count-escalates" gate 2 "$rc" "$err"
+
+# ---- background waiter-chain advisory (issue #1063) ---------------------------
+#
+# `run_in_background: true` passes the block above and always will — it is the
+# redirect the block message hands out. It is also where the blocked behaviour
+# moved: chaining background waiters across turns, each differing from the last
+# only in its sleep duration. A second waiter for the same target while the
+# first is still armed draws an ADVISORY (stderr, exit 0), never a block.
+#
+# Both directions are pinned. Fire: a duration-only retry and an identical
+# loop-shaped relaunch. Silence: the FIRST waiter, waiters on different targets
+# (without which the fire cases are indistinguishable from "fires on every
+# second background call"), a background call that does no waiting at all, and
+# an armed window that has elapsed.
+
+BW_DIR="$(mktemp -d)" || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+trap 'rm -rf "$TEST_HOME" "$RG_DIR" "$BW_DIR"' EXIT
+
+# bw_payload <session_id> <command>
+bw_payload() {
+  python3 - "$1" "$2" <<'PY'
+import json, sys
+sid, cmd = sys.argv[1], sys.argv[2]
+print(json.dumps({
+    "session_id": sid,
+    "tool_name": "Bash",
+    "tool_input": {"command": cmd, "run_in_background": True},
+}))
+PY
+}
+
+# bw_run <home> <session_id> <command> — stderr of one guard run.
+bw_run() {
+  (
+    export PRAXIS_HOME="$1"
+    { bw_payload "$2" "$3" | "$HOOK" >/dev/null; } 2>&1
+  )
+}
+
+# bw_assert <name> <advise|silent> <rc> <stderr>
+bw_assert() {
+  local name="$1" want="$2" rc="$3" err="$4"
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL  [$name] expected exit 0 (advisory never blocks), got $rc"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name"); return
+  fi
+  if [ "$want" = "advise" ] && ! echo "$err" | grep -q 'background waiter for this same target'; then
+    echo "FAIL  [$name] expected the waiter-chain advisory, got: ${err:-<empty>}"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name"); return
+  fi
+  if [ "$want" = "silent" ] && [ -n "$err" ]; then
+    echo "FAIL  [$name] expected silence, got: $err"
+    FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name"); return
+  fi
+  PASS=$((PASS + 1)); echo "ok    [$name]"
+}
+
+# The first waiter is the correct call and must stay silent; the retry that
+# changed only the sleep duration (the observed 240 → 595 shape) is the one
+# that draws the advisory.
+BW_A="$BW_DIR/home-a"
+err=$(bw_run "$BW_A" bw-a 'sleep 240 && tail -50 /tmp/suite.log'); rc=$?
+bw_assert "waiter-first-launch-silent" silent "$rc" "$err"
+err=$(bw_run "$BW_A" bw-a 'sleep 595 && tail -50 /tmp/suite.log'); rc=$?
+bw_assert "waiter-duration-only-retry-advises" advise "$rc" "$err"
+
+# A loop-shaped waiter has no computable end; its armed window is the fixed
+# default, so an identical relaunch inside it advises too.
+BW_B="$BW_DIR/home-b"
+BW_LOOP='until grep -q DONE /tmp/suite.log; do sleep 20; done; tail -50 /tmp/suite.log'
+err=$(bw_run "$BW_B" bw-b "$BW_LOOP"); rc=$?
+bw_assert "waiter-loop-first-launch-silent" silent "$rc" "$err"
+err=$(bw_run "$BW_B" bw-b "$BW_LOOP"); rc=$?
+bw_assert "waiter-loop-relaunch-advises" advise "$rc" "$err"
+
+# False-positive control. Genuinely parallel waits on different targets must
+# stay silent — including the pair whose only discriminator is a bare number,
+# which is why the signature drops the `sleep` argument and nothing else.
+BW_C="$BW_DIR/home-c"
+err=$(bw_run "$BW_C" bw-c 'sleep 60 && tail -50 /tmp/a.log'); rc=$?
+bw_assert "waiter-distinct-target-first" silent "$rc" "$err"
+err=$(bw_run "$BW_C" bw-c 'sleep 60 && tail -50 /tmp/b.log'); rc=$?
+bw_assert "waiter-distinct-file-stays-silent" silent "$rc" "$err"
+err=$(bw_run "$BW_C" bw-c 'until gh run view 123 -q .status | grep -q completed; do sleep 15; done'); rc=$?
+bw_assert "waiter-distinct-run-id-first" silent "$rc" "$err"
+err=$(bw_run "$BW_C" bw-c 'until gh run view 456 -q .status | grep -q completed; do sleep 15; done'); rc=$?
+bw_assert "waiter-distinct-run-id-stays-silent" silent "$rc" "$err"
+
+# Launching the awaited work is not waiting on it — no `sleep`, never recorded.
+BW_D="$BW_DIR/home-d"
+err=$(bw_run "$BW_D" bw-d 'bash scripts/run-tests.sh > /tmp/suite.log 2>&1'); rc=$?
+bw_assert "waiter-non-waiting-background-first" silent "$rc" "$err"
+err=$(bw_run "$BW_D" bw-d 'bash scripts/run-tests.sh > /tmp/suite.log 2>&1'); rc=$?
+bw_assert "waiter-non-waiting-background-stays-silent" silent "$rc" "$err"
+
+# An elapsed armed window releases the target: re-arming a waiter whose
+# predecessor has already returned is the correct call, not a duplicate.
+BW_E="$BW_DIR/home-e"
+err=$(bw_run "$BW_E" bw-e 'sleep 1 && tail -50 /tmp/expired.log'); rc=$?
+bw_assert "waiter-expiry-first-launch-silent" silent "$rc" "$err"
+python3 -c 'import time; time.sleep(1.3)'
+err=$(bw_run "$BW_E" bw-e 'sleep 1 && tail -50 /tmp/expired.log'); rc=$?
+bw_assert "waiter-expired-window-stays-silent" silent "$rc" "$err"
+
+# `PRAXIS_POLL_LOOP_WAITER_TTL` shortens the loop-shaped armed window; a
+# relaunch after it has elapsed is silent, which is also what pins the loop
+# cases above to the TTL rather than to an accident of timing.
+BW_F="$BW_DIR/home-f"
+err=$(PRAXIS_POLL_LOOP_WAITER_TTL=1 bw_run "$BW_F" bw-f "$BW_LOOP"); rc=$?
+bw_assert "waiter-ttl-override-first-launch-silent" silent "$rc" "$err"
+python3 -c 'import time; time.sleep(1.3)'
+err=$(PRAXIS_POLL_LOOP_WAITER_TTL=1 bw_run "$BW_F" bw-f "$BW_LOOP"); rc=$?
+bw_assert "waiter-ttl-override-expired-stays-silent" silent "$rc" "$err"
+
+# The advisory is a background-lane behaviour only: the same command in the
+# FOREGROUND is still the hard block, unchanged.
+BW_G="$BW_DIR/home-g"
+err=$(PRAXIS_HOME="$BW_G" bash -c '{ printf "%s" "$1" | "$2" >/dev/null; } 2>&1' _ \
+  '{"session_id":"bw-g","tool_name":"Bash","tool_input":{"command":"until grep -q DONE /tmp/suite.log; do sleep 20; done"}}' \
+  "$HOOK"); rc=$?
+if [ "$rc" -eq 2 ] && echo "$err" | grep -q 'FOREGROUND POLL-LOOP GUARD blocked'; then
+  PASS=$((PASS + 1)); echo "ok    [waiter-foreground-same-command-still-blocks]"
+else
+  echo "FAIL  [waiter-foreground-same-command-still-blocks] expected exit 2 + block, got rc=$rc: ${err:-<empty>}"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("waiter-foreground-same-command-still-blocks")
+fi
 
 # ---- summary ------------------------------------------------------------------
 echo ""

--- a/tests/hooks/preflight-gate/test_foreground_poll_loop_guard.sh
+++ b/tests/hooks/preflight-gate/test_foreground_poll_loop_guard.sh
@@ -175,6 +175,15 @@ run_case "quoted-loop-in-echo" pass \
 run_case "quoted-seq-no-downgrade" block \
   'for i in $(seq 1 40); do log "seq 1 2"; sleep 3; done'
 
+# ---- pass: `sleep` as an ARGUMENT is not a sleep ------------------------------
+# An unquoted `sleep` that is not in command position waits for nothing — it is
+# a word this command prints or passes along. The control below keeps the rule
+# from being read as "loops with a word-list argument never block".
+run_case "argument-sleep-in-loop-body" pass \
+  'for i in $(seq 1 40); do echo sleep 20; done'
+run_case "argument-sleep-control-still-blocks" block \
+  'for i in $(seq 1 40); do echo waiting; sleep 20; done'
+
 # ---- pass: non-Bash / malformed / empty / bypass ------------------------------
 payload='{"tool_name": "Write", "tool_input": {"file_path": "x", "content": "while true; do sleep 9; done"}}'
 err=$(echo "$payload" | "$HOOK" 2>&1 >/dev/null); rc=$?
@@ -456,6 +465,26 @@ bw_assert "waiter-ttl-override-first-launch-silent" silent "$rc" "$err"
 python3 -c 'import time; time.sleep(1.3)'
 err=$(PRAXIS_POLL_LOOP_WAITER_TTL=1 bw_run "$BW_F" bw-f "$BW_LOOP"); rc=$?
 bw_assert "waiter-ttl-override-expired-stays-silent" silent "$rc" "$err"
+
+# `sleep` counts only in command position. `echo sleep 20` prints a word and
+# waits for nothing — registering it as a waiter would advise against the next
+# genuine wait on that target. The control is the same word after a separator,
+# which IS a wait and must still advise.
+BW_K="$BW_DIR/home-k"
+err=$(bw_run "$BW_K" bw-k 'echo sleep 20 > /tmp/note.txt'); rc=$?
+bw_assert "waiter-argument-sleep-first-silent" silent "$rc" "$err"
+err=$(bw_run "$BW_K" bw-k 'echo sleep 20 > /tmp/note.txt'); rc=$?
+bw_assert "waiter-argument-sleep-never-registers" silent "$rc" "$err"
+err=$(bw_run "$BW_K" bw-k 'some-tool sleep 20'); rc=$?
+bw_assert "waiter-argument-sleep-other-shape-first" silent "$rc" "$err"
+err=$(bw_run "$BW_K" bw-k 'some-tool sleep 20'); rc=$?
+bw_assert "waiter-argument-sleep-other-shape-silent" silent "$rc" "$err"
+
+BW_L="$BW_DIR/home-l"
+err=$(bw_run "$BW_L" bw-l 'touch /tmp/marker; sleep 60 && tail -5 /tmp/sep.log'); rc=$?
+bw_assert "waiter-separator-sleep-first-silent" silent "$rc" "$err"
+err=$(bw_run "$BW_L" bw-l 'touch /tmp/marker; sleep 90 && tail -5 /tmp/sep.log'); rc=$?
+bw_assert "waiter-separator-sleep-advises" advise "$rc" "$err"
 
 # A FINITE `for` loop has a computable end, so it is not the open-ended shape:
 # `for i in 1 2; do sleep 1; done` returns in ~2s and must not stay armed for

--- a/tests/hooks/preflight-gate/test_foreground_poll_loop_guard.sh
+++ b/tests/hooks/preflight-gate/test_foreground_poll_loop_guard.sh
@@ -89,6 +89,19 @@ run_case "bounded-literal-list-25" block \
 run_case "bounded-minute-suffix" block \
   'for i in $(seq 1 5); do foo; sleep 2m; done'
 
+# A descending `seq A -S B` counts down: `seq 10 -2 2` runs 5 times, not 10.
+# The signed step used to be rejected, collapsing the header to `seq N` — so a
+# 60s loop was read as 120s and blocked. Both directions, because the fix must
+# not stop the genuinely-too-long descending loop from blocking.
+run_case "bounded-seq-descending-under-ceiling" pass \
+  'for i in $(seq 10 -2 2); do gh pr checks; sleep 12; done'
+run_case "bounded-seq-descending-over-ceiling" block \
+  'for i in $(seq 20 -2 2); do gh pr checks; sleep 12; done'
+run_case "bounded-seq-zero-step-fails-open" pass \
+  'for i in $(seq 1 0 40); do gh pr checks; sleep 30; done'
+run_case "bounded-seq-step-away-from-end" pass \
+  'for i in $(seq 2 -2 10); do gh pr checks; sleep 30; done'
+
 # ---- block: unbounded while/until + sleep ------------------------------------
 run_case "unbounded-while-true" block \
   'while true; do gh pr checks 777; sleep 20; done'
@@ -500,6 +513,19 @@ bw_assert "waiter-finite-for-inside-window-advises" advise "$rc" "$err"
 python3 -c 'import time; time.sleep(2.3)'
 err=$(bw_run "$BW_I" bw-i "$BW_FINITE"); rc=$?
 bw_assert "waiter-finite-for-past-own-total-stays-silent" silent "$rc" "$err"
+
+# A descending `seq` waiter arms for its OWN total. `seq 6 -2 2` runs 3 times,
+# so the window is 1.5s — reading the signed step as `seq 6` armed it for 3s
+# and a re-launch after it had returned reported a live waiter.
+BW_I2="$BW_DIR/home-i2"
+BW_DESC='for i in $(seq 6 -2 2); do sleep 0.5; done; tail -50 /tmp/desc.log'
+err=$(bw_run "$BW_I2" bw-i2 "$BW_DESC"); rc=$?
+bw_assert "waiter-descending-seq-first-launch-silent" silent "$rc" "$err"
+err=$(bw_run "$BW_I2" bw-i2 "$BW_DESC"); rc=$?
+bw_assert "waiter-descending-seq-inside-window-advises" advise "$rc" "$err"
+python3 -c 'import time; time.sleep(1.8)'
+err=$(bw_run "$BW_I2" bw-i2 "$BW_DESC"); rc=$?
+bw_assert "waiter-descending-seq-past-own-total-stays-silent" silent "$rc" "$err"
 
 # False-positive control for the clause above: an UNBOUNDED loop over the same
 # elapsed span keeps the TTL, so the silence above is the computed window and

--- a/tests/hooks/preflight-gate/test_foreground_poll_loop_guard.sh
+++ b/tests/hooks/preflight-gate/test_foreground_poll_loop_guard.sh
@@ -457,6 +457,46 @@ python3 -c 'import time; time.sleep(1.3)'
 err=$(PRAXIS_POLL_LOOP_WAITER_TTL=1 bw_run "$BW_F" bw-f "$BW_LOOP"); rc=$?
 bw_assert "waiter-ttl-override-expired-stays-silent" silent "$rc" "$err"
 
+# The advisory has to reach the MODEL, not only the debug log. A PreToolUse
+# hook's stderr is fed to the model only when the dispatcher exits 2 (the deny
+# path), so on this exit-0 lane the same text is also written as
+# `hookSpecificOutput.additionalContext`. Pinned here because a stderr-only
+# advisory passes every assertion above while being invisible to the agent.
+
+# bw_stdout <home> <session_id> <command> — stdout of one guard run.
+bw_stdout() {
+  (
+    export PRAXIS_HOME="$1"
+    bw_payload "$2" "$3" | "$HOOK" 2>/dev/null
+  )
+}
+
+BW_H="$BW_DIR/home-h"
+out=$(bw_stdout "$BW_H" bw-h 'sleep 30 && tail -50 /tmp/ctx.log'); rc=$?
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+  PASS=$((PASS + 1)); echo "ok    [waiter-first-launch-emits-no-context]"
+else
+  echo "FAIL  [waiter-first-launch-emits-no-context] expected exit 0 + empty stdout, got rc=$rc: ${out:-<empty>}"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("waiter-first-launch-emits-no-context")
+fi
+
+out=$(bw_stdout "$BW_H" bw-h 'sleep 90 && tail -50 /tmp/ctx.log'); rc=$?
+# The payload must be model-visible context and NOTHING else: a
+# `permissionDecision` key here would mean this lane started denying.
+if [ "$rc" -eq 0 ] && printf '%s' "$out" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+hso = d.get("hookSpecificOutput", {})
+assert hso.get("hookEventName") == "PreToolUse", d
+assert "background waiter for this same target" in hso.get("additionalContext", ""), d
+assert "permissionDecision" not in hso and "decision" not in d, d
+' 2>/dev/null; then
+  PASS=$((PASS + 1)); echo "ok    [waiter-advisory-reaches-model-as-context]"
+else
+  echo "FAIL  [waiter-advisory-reaches-model-as-context] expected exit 0 + additionalContext, got rc=$rc: ${out:-<empty>}"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("waiter-advisory-reaches-model-as-context")
+fi
+
 # The advisory is a background-lane behaviour only: the same command in the
 # FOREGROUND is still the hard block, unchanged.
 BW_G="$BW_DIR/home-g"

--- a/tests/hooks/preflight-gate/test_foreground_poll_loop_guard.sh
+++ b/tests/hooks/preflight-gate/test_foreground_poll_loop_guard.sh
@@ -457,6 +457,31 @@ python3 -c 'import time; time.sleep(1.3)'
 err=$(PRAXIS_POLL_LOOP_WAITER_TTL=1 bw_run "$BW_F" bw-f "$BW_LOOP"); rc=$?
 bw_assert "waiter-ttl-override-expired-stays-silent" silent "$rc" "$err"
 
+# A FINITE `for` loop has a computable end, so it is not the open-ended shape:
+# `for i in 1 2; do sleep 1; done` returns in ~2s and must not stay armed for
+# the 900s TTL. Both directions are pinned — a re-launch INSIDE the computed
+# window still advises (without which "silent" would only prove the entry was
+# never recorded), and one after it has elapsed is silent.
+BW_I="$BW_DIR/home-i"
+BW_FINITE='for i in 1 2; do sleep 1; done; tail -50 /tmp/finite.log'
+err=$(bw_run "$BW_I" bw-i "$BW_FINITE"); rc=$?
+bw_assert "waiter-finite-for-first-launch-silent" silent "$rc" "$err"
+err=$(bw_run "$BW_I" bw-i "$BW_FINITE"); rc=$?
+bw_assert "waiter-finite-for-inside-window-advises" advise "$rc" "$err"
+python3 -c 'import time; time.sleep(2.3)'
+err=$(bw_run "$BW_I" bw-i "$BW_FINITE"); rc=$?
+bw_assert "waiter-finite-for-past-own-total-stays-silent" silent "$rc" "$err"
+
+# False-positive control for the clause above: an UNBOUNDED loop over the same
+# elapsed span keeps the TTL, so the silence above is the computed window and
+# not a timing accident.
+BW_J="$BW_DIR/home-j"
+err=$(bw_run "$BW_J" bw-j "$BW_LOOP"); rc=$?
+bw_assert "waiter-unbounded-loop-first-launch-silent" silent "$rc" "$err"
+python3 -c 'import time; time.sleep(2.3)'
+err=$(bw_run "$BW_J" bw-j "$BW_LOOP"); rc=$?
+bw_assert "waiter-unbounded-loop-keeps-ttl-advises" advise "$rc" "$err"
+
 # The advisory has to reach the MODEL, not only the debug log. A PreToolUse
 # hook's stderr is fed to the model only when the dispatcher exits 2 (the deny
 # path), so on this exit-0 lane the same text is also written as

--- a/tests/hooks/preflight-gate/test_foreground_poll_loop_guard.sh
+++ b/tests/hooks/preflight-gate/test_foreground_poll_loop_guard.sh
@@ -588,7 +588,14 @@ err=$(bw_run "$BW_N2" bw-n2 'sleep 60 && gh run view 123'); rc=$?
 bw_assert "waiter-norm-run-id-first-silent" silent "$rc" "$err"
 err=$(bw_run "$BW_N2" bw-n2 'sleep 60 && gh run view 456'); rc=$?
 bw_assert "waiter-norm-different-run-id-stays-silent" silent "$rc" "$err"
-err=$(bw_run "$BW_N2" bw-n2 'sleep 60 && tail -50 /tmp/other.log'); rc=$?
+
+# Same shape, same flags, different file: the `-N` fold must not reach the
+# path argument. Paired against its own baseline — comparing it to the run-id
+# waiter above would pass for the wrong reason (the whole command differs).
+BW_N5="$BW_DIR/home-n5"
+err=$(bw_run "$BW_N5" bw-n5 'sleep 60 && tail -50 /tmp/a.log'); rc=$?
+bw_assert "waiter-norm-file-baseline-silent" silent "$rc" "$err"
+err=$(bw_run "$BW_N5" bw-n5 'sleep 60 && tail -50 /tmp/b.log'); rc=$?
 bw_assert "waiter-norm-different-file-stays-silent" silent "$rc" "$err"
 
 BW_N3="$BW_DIR/home-n3"

--- a/tests/hooks/preflight-gate/test_foreground_poll_loop_guard.sh
+++ b/tests/hooks/preflight-gate/test_foreground_poll_loop_guard.sh
@@ -564,6 +564,49 @@ else
   FAIL=$((FAIL + 1)); FAILED_NAMES+=("waiter-foreground-same-command-still-blocks")
 fi
 
+# Signature normalization (issue #1063, group-1 rewrites). Four syntactic
+# no-ops that changed the text of a waiter but not what it awaited, each
+# measured silent before the fix. Fire direction first.
+BW_N1="$BW_DIR/home-n1"
+err=$(bw_run "$BW_N1" bw-n1 'sleep 240 && tail -50 /tmp/norm.log'); rc=$?
+bw_assert "waiter-norm-baseline-silent" silent "$rc" "$err"
+err=$(bw_run "$BW_N1" bw-n1 'sleep 240; tail -50 /tmp/norm.log'); rc=$?
+bw_assert "waiter-norm-separator-swap-advises" advise "$rc" "$err"
+err=$(bw_run "$BW_N1" bw-n1 'true && sleep 240 && tail -50 /tmp/norm.log'); rc=$?
+bw_assert "waiter-norm-leading-noop-advises" advise "$rc" "$err"
+err=$(bw_run "$BW_N1" bw-n1 'sleep 240 && tail -80 /tmp/norm.log'); rc=$?
+bw_assert "waiter-norm-numeric-flag-advises" advise "$rc" "$err"
+err=$(bw_run "$BW_N1" bw-n1 'bash -c "sleep 240 && tail -50 /tmp/norm.log"'); rc=$?
+bw_assert "waiter-norm-shell-c-wrapper-advises" advise "$rc" "$err"
+
+# Silence direction — the folds must not reach genuinely different targets.
+# A bare numeral is the sole discriminator between two run ids, `|` and `&`
+# really do change the shape of a call, and a no-op that is not in command
+# position (or has no separator after it) is left alone.
+BW_N2="$BW_DIR/home-n2"
+err=$(bw_run "$BW_N2" bw-n2 'sleep 60 && gh run view 123'); rc=$?
+bw_assert "waiter-norm-run-id-first-silent" silent "$rc" "$err"
+err=$(bw_run "$BW_N2" bw-n2 'sleep 60 && gh run view 456'); rc=$?
+bw_assert "waiter-norm-different-run-id-stays-silent" silent "$rc" "$err"
+err=$(bw_run "$BW_N2" bw-n2 'sleep 60 && tail -50 /tmp/other.log'); rc=$?
+bw_assert "waiter-norm-different-file-stays-silent" silent "$rc" "$err"
+
+BW_N3="$BW_DIR/home-n3"
+err=$(bw_run "$BW_N3" bw-n3 'sleep 60 && tail -5 /tmp/pipe.log'); rc=$?
+bw_assert "waiter-norm-pipe-baseline-silent" silent "$rc" "$err"
+err=$(bw_run "$BW_N3" bw-n3 'sleep 60 | tail -5 /tmp/pipe.log'); rc=$?
+bw_assert "waiter-norm-pipe-not-folded" silent "$rc" "$err"
+err=$(bw_run "$BW_N3" bw-n3 'sleep 60 && tail -5 /tmp/pipe.log && true'); rc=$?
+bw_assert "waiter-norm-trailing-noop-not-dropped" silent "$rc" "$err"
+
+# `while true` keeps its `true`: it is not in command position, so the
+# no-op rule leaves it alone and the loop still registers as a waiter.
+BW_N4="$BW_DIR/home-n4"
+err=$(bw_run "$BW_N4" bw-n4 'while true; do sleep 20; done'); rc=$?
+bw_assert "waiter-norm-while-true-first-silent" silent "$rc" "$err"
+err=$(bw_run "$BW_N4" bw-n4 'while true; do sleep 20; done'); rc=$?
+bw_assert "waiter-norm-while-true-still-advises" advise "$rc" "$err"
+
 # ---- summary ------------------------------------------------------------------
 echo ""
 echo "passed: $PASS  failed: $FAIL"


### PR DESCRIPTION
### 무엇이 바뀌나

같은 대상을 기다리는 대기자가 이미 살아 있는데 새 대기자를 또 띄우면 advisory 가 뜹니다. 이미 무장된 알림을 가리키고, `TaskStop` 으로 정리할 대상을 나열합니다.

### 원인

`foreground-poll-loop-guard` 는 설계상 `run_in_background: true` 를 통과시킵니다 — 차단 메시지가 직접 내주는 우회로이기 때문이고, 그 자체는 옳습니다. 문제는 **막으려던 행동이 정확히 그 자리로 옮겨갔다**는 것입니다.

관측 (2026-08-20 세션):

```
Bash 500회 중 대기성 호출        : 146회 (29%)
가장 조밀한 4분 창              : 40회
백그라운드 기동                 : 68건 (36건이 09:17~09:32 에 집중)
sleep 값                        : 240 → 595 로 상승
에이전트의 TaskStop             : 세션 전체 2회
2시간 뒤 harness 가 죽인 대기자 : 9건 (status: killed)
```

포그라운드 `sleep N && tail` 은 같은 가드에 4회 차단됐고, 그때마다 **지속시간만 바꿔** 재시도했습니다. 그 뒤 백그라운드 연쇄로 옮겨가자 차단은 0건이 됐습니다.

### "같은 대상" 의 키 — 이슈가 열어둔 설계 논점

**sleep 인자를 지운 명령 시그니처**를 택했습니다. 이슈가 나열한 세 후보 중:

- **job id** — 대기자 자신을 가리킬 뿐이고, PreToolUse 시점에는 아직 존재하지도 않습니다.
- **출력 파일 경로** — 파일을 끼지 않는 대기자(`until gh pr checks; do sleep 20; done`)에는 키가 없습니다.
- **명령 시그니처** — 모든 대기 호출에 존재하는 유일한 축입니다.

정규화는 각 `sleep` 의 인자 토큰 **하나만** 지웁니다. 관측된 재시도가 서로 지속시간만 달랐기 때문이고, 숫자 토큰을 일반적으로 지우면 `gh run view 123` 과 `456` 이 한 키로 접혀 **두 번째 백그라운드 호출마다 발동하는 가드**가 됩니다.

무장 창은 대기자 자신의 sleep 총합이며, 끝을 계산할 수 없는 루프형 대기자는 고정 기본값 900초(`PRAXIS_POLL_LOOP_WAITER_TTL`)를 씁니다. 중복 기동은 기존 항목을 갱신하지 **않습니다** — 갱신하면 창이 무한히 밀리고 보고하는 경과 시간이 거짓이 됩니다.

### posture 는 advisory

차단 메시지가 `run_in_background: true` 를 정답으로 내주는데 그것을 거부하면 가드가 자기 우회로와 모순됩니다. 기존 포그라운드 차단 경로는 그대로입니다.

### 부수로 잡은 실제 결함

테스트 스위트가 임시 `PRAXIS_HOME` 을 export 하지 않아, 기존 `run_in_background: true` fixture 들이 개발자의 진짜 `~/.praxis/cache` 에 레지스트리 파일을 남기고 있었습니다(수정 전 2건 실측). 스위트에서 격리했습니다.

### 검증

```
$ bash tests/hooks/preflight-gate/test_foreground_poll_loop_guard.sh
ok    [waiter-expired-window-stays-silent]
ok    [waiter-ttl-override-first-launch-silent]
ok    [waiter-ttl-override-expired-stays-silent]
ok    [waiter-foreground-same-command-still-blocks]

passed: 69  failed: 0
```

오탐 대조군(서로 다른 대상에 대한 병렬 대기는 침묵)과 회귀 케이스(기존 포그라운드 차단 유지)가 포함돼 있습니다.

### 상태 저장의 락 없음 근거

`<PRAXIS_HOME>/cache/poll-loop-waiters-<sid>.json`, `resolve_cache_file` + 프로세스별 `.tmp` + `os.replace`. DESIGN.md 의 session-state-concurrency 기준으로 프로세스별 staging 이름이 Q0 를, 임계값 없음이 Q1 을, block/pass 판정에 쓰이지 않음이 Q2 를 해소합니다. 유실 비용은 발동하지 않는 advisory 1건(Q3)입니다.

Pre-commit verified: `bash tests/hooks/preflight-gate/test_foreground_poll_loop_guard.sh` → 69 passed / 0 failed, `python3 scripts/check-plugin-manifests.py` → `plugin-manifest check OK`
Caller chain verified: N/A — 기존 훅 하나에 lane 을 추가한 변경이며 새 심볼을 외부에 노출하지 않습니다. `hooks/_lib/_state_lock.py` 는 읽기만 하고 수정하지 않았습니다.

Closes #1063


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added advisory detection for repeated background Bash wait loops.
  * Matching active waiters now provide contextual guidance through the command response and diagnostics.
  * Equivalent command forms are recognized, with configurable expiration for ongoing or open-ended waits.
* **Bug Fixes**
  * Improved parsing to distinguish actual `sleep` commands from words used as arguments.
  * Background checks remain non-blocking, while foreground polling and read-gate protections continue to block when appropriate.
  * Registry issues fail open, preventing advisory tracking from interrupting commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->