### PR TITLE
fix(hooks): stop counting exit-0 calls as failures

### DIFF
--- a/hooks/postuse-correction/second-failure-advisory/impl.py
+++ b/hooks/postuse-correction/second-failure-advisory/impl.py
@@ -70,6 +70,13 @@ tell it apart from a real one:
 `stderr` before it is used as failure evidence or signature material.
 Genuine content on other lines of the same `stderr` blob survives.
 
+The strip is also gated on `tool_name == "Bash"` — the noise line is a
+verified property of this harness's own Bash execution path, not of `stderr`
+in general. Without the gate, any other tool (or a hypothetical genuine
+failure whose only stderr line happens to match that shape) would have its
+real failure text silently deleted and be misread as a success or merged
+into an unrelated signature.
+
 Signature derivation
 ===================
 
@@ -150,14 +157,22 @@ _WS_RE = re.compile(r"\s+")
 _HARNESS_CWD_RESET_RE = re.compile(r"(?im)^[ \t]*Shell cwd was reset to .*$")
 
 
-def _strip_harness_noise(text: str) -> str:
+def _strip_harness_noise(text: str, tool_name: str) -> str:
     """Remove the harness's own cwd-reset notice from a `stderr` blob.
 
     Verified against real `Bash` `tool_response` payloads (session
     transcripts): this exact line is present on every call regardless of
     success, and nothing else in those payloads carries an `exit` field for
     the failure check below to consult instead.
+
+    Gated on `tool_name == "Bash"` (issue #1071 review) — that verification
+    only covers Bash. Applying the same regex to every tool's `stderr`
+    regardless of origin would delete a non-Bash tool's genuine error text if
+    it happened to match the same line shape, misreading a real failure as a
+    success.
     """
+    if tool_name != "Bash":
+        return text.strip()
     return _HARNESS_CWD_RESET_RE.sub("", text).strip()
 
 
@@ -203,7 +218,7 @@ def _extract_reference(tool_input: dict[str, Any], failure_text: str = "") -> st
     return ""
 
 
-def _derive_failure_text(tool_response: Any) -> str:
+def _derive_failure_text(tool_response: Any, tool_name: str) -> str:
     if not isinstance(tool_response, dict):
         return ""
     if isinstance(tool_response.get("error"), str):
@@ -211,7 +226,7 @@ def _derive_failure_text(tool_response: Any) -> str:
         if error_text:
             return error_text
     if isinstance(tool_response.get("stderr"), str):
-        err = _strip_harness_noise(tool_response.get("stderr", ""))
+        err = _strip_harness_noise(tool_response.get("stderr", ""), tool_name)
         if err:
             return err
     if isinstance(tool_response.get("output"), str):
@@ -225,7 +240,7 @@ def _derive_failure_text(tool_response: Any) -> str:
     return ""
 
 
-def _derive_error_text(tool_response: Any) -> str:
+def _derive_error_text(tool_response: Any, tool_name: str) -> str:
     """Error-channel text only.
 
     Distinct from `_derive_failure_text`, which also reads `output`/`stdout` to
@@ -240,13 +255,13 @@ def _derive_error_text(tool_response: Any) -> str:
         return error_text.strip()
     stderr_text = tool_response.get("stderr")
     if isinstance(stderr_text, str):
-        stripped = _strip_harness_noise(stderr_text)
+        stripped = _strip_harness_noise(stderr_text, tool_name)
         if stripped:
             return stripped
     return ""
 
 
-def _is_failed(tool_response: Any) -> bool:
+def _is_failed(tool_response: Any, tool_name: str) -> bool:
     if not isinstance(tool_response, dict):
         return False
 
@@ -266,7 +281,7 @@ def _is_failed(tool_response: Any) -> bool:
             pass
 
     # Back-compat path: older/malformed payloads that only surfaced text.
-    return bool(_derive_error_text(tool_response))
+    return bool(_derive_error_text(tool_response, tool_name))
 
 
 def _normalize_signature(raw: str) -> str:
@@ -288,7 +303,7 @@ def _normalize_signature(raw: str) -> str:
 
 
 def _compute_signature(tool_name: str, tool_response: Any) -> str:
-    text = _derive_failure_text(tool_response)
+    text = _derive_failure_text(tool_response, tool_name)
     normalized = _normalize_signature(text)
     if not normalized:
         normalized = "<empty>"
@@ -378,13 +393,13 @@ def main() -> int:
         return 0
 
     tool_response = payload.get("tool_response")
-    if not _is_failed(tool_response):
+    if not _is_failed(tool_response, tool_name):
         return 0
 
     signature = _compute_signature(tool_name, tool_response)
     ref = _extract_reference(
         _extract_tool_input(payload),
-        _derive_failure_text(tool_response),
+        _derive_failure_text(tool_response, tool_name),
     )
 
     path = _state_path(session_id)

--- a/hooks/postuse-correction/second-failure-advisory/impl.py
+++ b/hooks/postuse-correction/second-failure-advisory/impl.py
@@ -41,6 +41,35 @@ The hook derives failure from `tool_response`:
 - `exit` is a non-zero integer
 - `error`/`stderr` non-empty with no `exit` field (legacy/SDK shape)
 
+`stderr` is read through the harness-noise filter below before that last
+check runs — see issue #1042.
+
+Harness noise in `stderr` (issue #1042)
+=======================================
+
+The `exit` key this hook was written against is not what real Bash
+`tool_response` payloads carry: verified against live session transcripts
+(`~/.claude/projects/.../*.jsonl`, `toolUseResult` for a `Bash` tool_use),
+the actual shape is `{stdout, stderr, interrupted, isImage,
+noOutputExpected}` — no `exit`, no `isError`. Every one of those calls
+falls straight to the back-compat `error`/`stderr` check, and this harness
+appends `"\nShell cwd was reset to <cwd>"` to `stderr` on **every** Bash
+call, success or not (this repo's own cwd-reset-between-calls behavior).
+That line is not failure evidence, but the back-compat check could not
+tell it apart from a real one:
+
+- Every exit-0 command carrying only that line was counted as a failure
+  (68 firings in one real session, the last 5 all on exit-0 commands).
+- Once normalized, that line is the same string regardless of the
+  command that ran, so unrelated calls collapsed onto one
+  `(tool_name, signature)` pair and one constant signature
+  (`ede370078f51`, confirmed against six independent real session state
+  files, all sharing that exact hash).
+
+`_strip_harness_noise` removes that line (and only that line) from
+`stderr` before it is used as failure evidence or signature material.
+Genuine content on other lines of the same `stderr` blob survives.
+
 Signature derivation
 ===================
 
@@ -56,6 +85,13 @@ retries that differ only by volatile values:
 
 This keeps retries that only changed `/tmp/run-<rand>.log`/timestamps/hash IDs from
 being treated as distinct failures.
+
+The candidate text is drawn from `error`/`stderr`/`output`/`stdout` in that
+order (`_derive_failure_text`); `stderr` goes through the same harness-noise
+filter as failure detection (issue #1042) before it is used, so a failure
+whose `stderr` carries only the harness's cwd-reset notice falls through to
+`output`/`stdout` for its distinguishing text instead of normalizing to the
+same constant string as every other call in the session.
 """
 from __future__ import annotations
 
@@ -108,6 +144,21 @@ _TIMESTAMP_RE = re.compile(
 )
 _ID_RE = re.compile(r"\b([\w.-]*id)[:=]\s*[\"']?[\w-]+[\"']?", re.IGNORECASE)
 _WS_RE = re.compile(r"\s+")
+
+# Injected by this harness into every Bash `stderr`, success or not, when it
+# resets the shell's cwd between calls — not failure evidence (issue #1042).
+_HARNESS_CWD_RESET_RE = re.compile(r"(?im)^[ \t]*Shell cwd was reset to .*$")
+
+
+def _strip_harness_noise(text: str) -> str:
+    """Remove the harness's own cwd-reset notice from a `stderr` blob.
+
+    Verified against real `Bash` `tool_response` payloads (session
+    transcripts): this exact line is present on every call regardless of
+    success, and nothing else in those payloads carries an `exit` field for
+    the failure check below to consult instead.
+    """
+    return _HARNESS_CWD_RESET_RE.sub("", text).strip()
 
 
 def _extract_session_id(payload: dict[str, Any]) -> str | None:
@@ -184,10 +235,14 @@ def _derive_error_text(tool_response: Any) -> str:
     """
     if not isinstance(tool_response, dict):
         return ""
-    for key in ("error", "stderr"):
-        value = tool_response.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
+    error_text = tool_response.get("error")
+    if isinstance(error_text, str) and error_text.strip():
+        return error_text.strip()
+    stderr_text = tool_response.get("stderr")
+    if isinstance(stderr_text, str):
+        stripped = _strip_harness_noise(stderr_text)
+        if stripped:
+            return stripped
     return ""
 
 

--- a/hooks/postuse-correction/second-failure-advisory/impl.py
+++ b/hooks/postuse-correction/second-failure-advisory/impl.py
@@ -211,7 +211,7 @@ def _derive_failure_text(tool_response: Any) -> str:
         if error_text:
             return error_text
     if isinstance(tool_response.get("stderr"), str):
-        err = tool_response.get("stderr", "").strip()
+        err = _strip_harness_noise(tool_response.get("stderr", ""))
         if err:
             return err
     if isinstance(tool_response.get("output"), str):

--- a/hooks/postuse-correction/second-failure-advisory/spec.md
+++ b/hooks/postuse-correction/second-failure-advisory/spec.md
@@ -31,7 +31,30 @@ Supported hosts: all
 - `interrupted is True`이면 실패
 - `exit`가 정수 0이 아니면 실패
 - 위 항목이 없고 `error`/`stderr`에 비어있지 않은 텍스트가 있으면 실패
+  (`stderr`는 아래 harness noise 필터를 거친 뒤 판정합니다)
 - `output`/`stdout`만 있는 응답은 성공으로 처리
+
+## Harness noise 필터 (issue #1042)
+
+이 훅이 전제한 `exit` 키는 실제 Bash `tool_response`에 없습니다. 실 세션
+transcript(`~/.claude/projects/.../*.jsonl`의 `toolUseResult`, `Bash`
+tool_use)로 검증한 실제 형태는 `{stdout, stderr, interrupted, isImage,
+noOutputExpected}`이며 `exit`도 `isError`도 없습니다. 그래서 모든 Bash
+호출이 곧장 `error`/`stderr` 백업 판정으로 떨어지는데, 이 harness는 세션
+호출 사이에 shell cwd를 리셋하면서 성공/실패와 무관하게 매 호출의
+`stderr`에 `"\nShell cwd was reset to <cwd>"`를 덧붙입니다. 이 한 줄은
+실패 근거가 아니지만 백업 판정은 이를 구분하지 못했습니다.
+
+- exit-0 명령이 이 한 줄만 `stderr`에 가지고 있어도 실패로 집계됐습니다
+  (실 세션 1건에서 68회 발화, 마지막 5회 연속이 전부 exit-0 명령).
+- 정규화 후 이 문장은 명령 내용과 무관하게 항상 같은 문자열이 되어, 서로
+  무관한 호출들이 하나의 `(tool_name, signature)` 쌍·하나의 고정
+  signature(`ede370078f51`)로 수렴했습니다 — 독립된 실 세션 상태 파일
+  6개에서 모두 동일 해시로 확인.
+
+`_strip_harness_noise`가 이 줄(그리고 이 줄만)을 실패 판정과 signature
+계산 양쪽에서 사용하기 전에 `stderr`에서 제거합니다. 같은 `stderr` 안의
+다른 줄에 있는 실제 내용은 보존됩니다.
 
 ## Signature 산정
 
@@ -191,5 +214,10 @@ python3 -m pytest tests/test_hook_state_concurrency.py
 - `stdout`/`output`만 있는 성공 응답은 반복돼도 무음
 - 실패 텍스트의 `Reference:` 경로가 advisory와 재진술 지시에 포함됨
 - 비실패/비정상 입력은 fail-open
+- exit-0 Bash 호출이고 `stderr`가 harness cwd-reset 안내뿐이면 5회 반복해도
+  advisory 없음, 상태 파일도 생기지 않음 (issue #1042)
+- 같은 harness noise가 `stderr`에 섞여도 진짜 동일 실패 반복은 여전히
+  2회째부터 advisory (positive control — defect 1 수정이 훅 자체를
+  무력화하지 않았는지 확인)
 - 두 프로세스 동시 실행: 잠금 없이는 증분 유실, 잠금 하에서는 카운트 1→2→3
   과 advisory 2회(2회째·3회째) (`tests/test_hook_state_concurrency.py`)

--- a/hooks/postuse-correction/second-failure-advisory/spec.md
+++ b/hooks/postuse-correction/second-failure-advisory/spec.md
@@ -61,11 +61,14 @@ noOutputExpected}`이며 `exit`도 `isError`도 없습니다. 그래서 모든 B
 `tool_response`에서 실패 텍스트 후보를 다음 순서로 추출합니다.
 
 1. `error`
-2. `stderr`
+2. `stderr` (harness noise 필터를 거친 뒤)
 3. `output`
 4. `stdout`
 
-추출 실패 시 빈 문자열을 쓰고, 실패 키를 보정합니다.
+추출 실패 시 빈 문자열을 쓰고, 실패 키를 보정합니다. `stderr`가 harness
+noise만 담고 있었다면 필터 후 빈 문자열이 되어 `output`/`stdout`으로
+넘어가므로, 진짜 구분 정보가 `stdout`에만 있는 실패(예: `interrupted:true`
+지만 `stderr`는 noise뿐인 경우)도 명령마다 다른 signature를 받습니다.
 
 동일 실패를 추정하기 위해 아래 토큰은 정규화합니다.
 
@@ -219,5 +222,7 @@ python3 -m pytest tests/test_hook_state_concurrency.py
 - 같은 harness noise가 `stderr`에 섞여도 진짜 동일 실패 반복은 여전히
   2회째부터 advisory (positive control — defect 1 수정이 훅 자체를
   무력화하지 않았는지 확인)
+- `stderr`가 noise뿐이고 구분 정보가 `stdout`에만 있는 서로 다른 실패 2건은
+  서로 다른 signature를 받아 카운터가 합쳐지지 않음 (issue #1042 defect 2)
 - 두 프로세스 동시 실행: 잠금 없이는 증분 유실, 잠금 하에서는 카운트 1→2→3
   과 advisory 2회(2회째·3회째) (`tests/test_hook_state_concurrency.py`)

--- a/tests/hooks/postuse-correction/test_second_failure_advisory.sh
+++ b/tests/hooks/postuse-correction/test_second_failure_advisory.sh
@@ -20,6 +20,7 @@
 #  13) interrupted 응답은 실패로 판정
 #  14) exit-0 Bash 호출(stderr가 harness cwd-reset 안내뿐) -> advisory 없음 (issue #1042)
 #  15) harness noise가 섞여도 동일 실패 반복은 여전히 advisory (positive control)
+#  16) stderr가 noise뿐인 서로 다른 실패는 서로 다른 signature (issue #1042)
 #
 # Run:
 #   bash tests/hooks/postuse-correction/test_second_failure_advisory.sh
@@ -566,6 +567,50 @@ if [ "$rc" -eq 0 ] && [ -z "$err" ] && [ -n "$out" ] && assert_match "2회째" "
 else
   assert_fail "15) genuine repeated failure still advises past harness-noise stripping" \
     "rc=$rc out=[$out] err=[$err]"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 16: two structurally unrelated FAILING commands whose `stderr` is
+# ONLY the harness noise (distinguishing text lives in `stdout` instead, as
+# with an `interrupted:true` timeout) must get DIFFERENT signatures and not
+# accumulate into one counter (issue #1042 defect 2).
+# ---------------------------------------------------------------------------
+echo "=== case 16: unrelated failures with noise-only stderr get distinct signatures ==="
+interrupted_noise_payload() {
+  # interrupted_noise_payload <session_id> <stdout>
+  python3 - "$1" "$2" <<'PY'
+import json, sys
+session_id, stdout = sys.argv[1], sys.argv[2]
+print(json.dumps({
+    "session_id": session_id,
+    "tool_name": "Bash",
+    "tool_input": {"command": "irrelevant"},
+    "tool_response": {
+        "stdout": stdout,
+        "stderr": "\nShell cwd was reset to /Users/x/projects/praxis",
+        "interrupted": True,
+        "isImage": False,
+        "noOutputExpected": False,
+    },
+}))
+PY
+}
+
+STATE18="$TMP_DIR/c18.json"
+pipe_hook "$(interrupted_noise_payload sess-1042-sig "waiting on lock A ...\n")" "$STATE18" >/dev/null 2>/dev/null
+pipe_hook "$(interrupted_noise_payload sess-1042-sig "waiting on lock B, unrelated command ...\n")" "$STATE18" >/dev/null 2>/dev/null
+
+distinct_sigs="$(python3 -c "
+import json
+state = json.load(open('$STATE18'))
+print(len(state.get('failures', {})))
+")"
+
+if [ "$distinct_sigs" = "2" ]; then
+  assert_pass "16) unrelated noise-only-stderr failures get distinct signatures"
+else
+  assert_fail "16) unrelated noise-only-stderr failures get distinct signatures" \
+    "expected 2 distinct signature keys, got $distinct_sigs: $(cat "$STATE18")"
 fi
 
 echo

--- a/tests/hooks/postuse-correction/test_second_failure_advisory.sh
+++ b/tests/hooks/postuse-correction/test_second_failure_advisory.sh
@@ -18,6 +18,8 @@
 #  12) 3회째 이상도 계속 advisory (회차 번호 포함) — issue #1012
 #  12b) 첫 회는 여전히 무음 (반대 방향 control)
 #  13) interrupted 응답은 실패로 판정
+#  14) exit-0 Bash 호출(stderr가 harness cwd-reset 안내뿐) -> advisory 없음 (issue #1042)
+#  15) harness noise가 섞여도 동일 실패 반복은 여전히 advisory (positive control)
 #
 # Run:
 #   bash tests/hooks/postuse-correction/test_second_failure_advisory.sh
@@ -471,6 +473,99 @@ if [ "$rc" -eq 0 ] && [ -z "$err" ] && assert_match "2회째" "$out"; then
   assert_pass "13) interrupted response counts as a failure"
 else
   assert_fail "13) interrupted response counts as a failure" "rc=$rc out=[$out] err=[$err]"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 14: exit-0 Bash calls whose only `stderr` is the harness's own
+# cwd-reset notice must never advise (issue #1042).
+#
+# `{stdout, stderr, interrupted, isImage, noOutputExpected}` — no `exit`, no
+# `isError` — is the real `tool_response` shape for a Bash call in this
+# harness (verified against live session `toolUseResult` transcripts); every
+# one of those calls carries `"stderr": "\nShell cwd was reset to <cwd>"`
+# regardless of success. Before the fix, five structurally unrelated exit-0
+# commands in a row (a heredoc, `grep -l`, `head`, a heredoc `cat >`, another
+# heredoc) fired the advisory 4 times running, all under the identical
+# signature `ede370078f51` — reproduced byte-for-byte against the pre-fix
+# code in this exact payload shape.
+# ---------------------------------------------------------------------------
+echo "=== case 14: exit-0 Bash call, harness-noise-only stderr => no advisory ==="
+noise_payload() {
+  # noise_payload <session_id> <stdout>
+  python3 - "$1" "$2" <<'PY'
+import json, sys
+session_id, stdout = sys.argv[1], sys.argv[2]
+print(json.dumps({
+    "session_id": session_id,
+    "tool_name": "Bash",
+    "tool_input": {"command": "irrelevant"},
+    "tool_response": {
+        "stdout": stdout,
+        "stderr": "\nShell cwd was reset to /Users/x/projects/praxis",
+        "interrupted": False,
+        "isImage": False,
+        "noOutputExpected": False,
+    },
+}))
+PY
+}
+
+STATE16="$TMP_DIR/c16.json"
+out_file="$(mktemp)" err_file="$(mktemp)"
+for stdout_text in "OK\n" "README.md\n" "line1\nline2\n" "-rw-r--r-- 1 f\n" "index updated\n"; do
+  pipe_hook "$(noise_payload sess-1042-exit0 "$stdout_text")" "$STATE16" >"$out_file" 2>"$err_file"
+done
+rc=$?
+out=$(cat "$out_file"); err=$(cat "$err_file")
+rm -f "$out_file" "$err_file"
+
+if [ "$rc" -eq 0 ] && [ -z "$out" ] && [ -z "$err" ] && [ ! -s "$STATE16" ]; then
+  assert_pass "14) five exit-0 calls with only harness-noise stderr stay silent"
+else
+  assert_fail "14) five exit-0 calls with only harness-noise stderr stay silent" \
+    "rc=$rc out=[$out] err=[$err] state=[$(cat "$STATE16" 2>/dev/null)]"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 15: regression / positive control — two genuine repeats of the SAME
+# real failure pattern must still advise on the 2nd occurrence, even with
+# the harness-noise line appended to `stderr` (the defect-1 fix must not
+# disable the hook outright).
+# ---------------------------------------------------------------------------
+echo "=== case 15: genuine repeated failure (harness-noise stderr suffix) still advises ==="
+real_failure_payload() {
+  # real_failure_payload <session_id>
+  python3 - "$1" <<'PY'
+import json, sys
+session_id = sys.argv[1]
+print(json.dumps({
+    "session_id": session_id,
+    "tool_name": "Bash",
+    "tool_input": {"command": "python3 script.py"},
+    "tool_response": {
+        "stdout": "",
+        "stderr": "TypeError: unsupported operand type(s)\nShell cwd was reset to /Users/x/projects/praxis",
+        "interrupted": False,
+        "isImage": False,
+        "noOutputExpected": False,
+    },
+}))
+PY
+}
+
+STATE17="$TMP_DIR/c17.json"
+out_file="$(mktemp)" err_file="$(mktemp)"
+pipe_hook "$(real_failure_payload sess-1042-real-fail)" "$STATE17" >/dev/null 2>/dev/null
+pipe_hook "$(real_failure_payload sess-1042-real-fail)" "$STATE17" >"$out_file" 2>"$err_file"
+rc=$?
+out=$(cat "$out_file"); err=$(cat "$err_file")
+rm -f "$out_file" "$err_file"
+
+if [ "$rc" -eq 0 ] && [ -z "$err" ] && [ -n "$out" ] && assert_match "2회째" "$out"; then
+  assert_pass "15) genuine repeated failure still advises past harness-noise stripping"
+else
+  assert_fail "15) genuine repeated failure still advises past harness-noise stripping" \
+    "rc=$rc out=[$out] err=[$err]"
 fi
 
 echo

--- a/tests/hooks/postuse-correction/test_second_failure_advisory.sh
+++ b/tests/hooks/postuse-correction/test_second_failure_advisory.sh
@@ -21,6 +21,7 @@
 #  14) exit-0 Bash 호출(stderr가 harness cwd-reset 안내뿐) -> advisory 없음 (issue #1042)
 #  15) harness noise가 섞여도 동일 실패 반복은 여전히 advisory (positive control)
 #  16) stderr가 noise뿐인 서로 다른 실패는 서로 다른 signature (issue #1042)
+#  17) tool_name이 Bash가 아니면 noise strip 자체를 건너뛰어 진짜 실패로 판정 (PR #1071 리뷰)
 #
 # Run:
 #   bash tests/hooks/postuse-correction/test_second_failure_advisory.sh
@@ -611,6 +612,44 @@ if [ "$distinct_sigs" = "2" ]; then
 else
   assert_fail "16) unrelated noise-only-stderr failures get distinct signatures" \
     "expected 2 distinct signature keys, got $distinct_sigs: $(cat "$STATE18")"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 17: a NON-Bash tool whose `stderr` legitimately matches the harness
+# cwd-reset line shape must still be treated as a failure — the strip is
+# gated on `tool_name == "Bash"` (PR #1071 review finding). Without the
+# gate, this genuine error text would be deleted and misread as a success.
+# ---------------------------------------------------------------------------
+echo "=== case 17: non-Bash tool with harness-noise-shaped stderr is still a failure ==="
+non_bash_noise_shaped_payload() {
+  # non_bash_noise_shaped_payload <session_id>
+  python3 - "$1" <<'PY'
+import json, sys
+session_id = sys.argv[1]
+print(json.dumps({
+    "session_id": session_id,
+    "tool_name": "Read",
+    "tool_input": {"file_path": "/tmp/whatever"},
+    "tool_response": {
+        "stderr": "Shell cwd was reset to /Users/x/projects/praxis",
+    },
+}))
+PY
+}
+
+STATE19="$TMP_DIR/c19.json"
+out_file="$(mktemp)" err_file="$(mktemp)"
+pipe_hook "$(non_bash_noise_shaped_payload sess-1042-non-bash)" "$STATE19" >/dev/null 2>/dev/null
+pipe_hook "$(non_bash_noise_shaped_payload sess-1042-non-bash)" "$STATE19" >"$out_file" 2>"$err_file"
+rc=$?
+out=$(cat "$out_file"); err=$(cat "$err_file")
+rm -f "$out_file" "$err_file"
+
+if [ "$rc" -eq 0 ] && [ -z "$err" ] && [ -n "$out" ] && assert_match "2회째" "$out"; then
+  assert_pass "17) non-Bash tool with harness-noise-shaped stderr still advises"
+else
+  assert_fail "17) non-Bash tool with harness-noise-shaped stderr still advises" \
+    "rc=$rc out=[$out] err=[$err]"
 fi
 
 echo


### PR DESCRIPTION
### 무엇이 바뀌나

성공한 명령이 실패로 집계되어 advisory 가 뜨던 것을 멈춥니다. 그리고 서로 무관한 실패들이 하나의 시그니처로 뭉쳐 한 카운터를 밀어올리던 것도 갈라놓습니다.

### 원인 — 이슈가 관측한 것보다 한 층 아래에 있었습니다

이슈는 "68회 발화, 마지막 5회 연속이 전부 exit 0, 시그니처는 `ede370078f51` 로 고정" 까지 관측했습니다. 실제 payload 를 트랜스크립트(`~/.claude/projects/.../*.jsonl` 의 `toolUseResult`)에서 확인하니 원인이 나왔습니다.

훅은 `tool_response.exit` 를 실패 판정 1순위로 씁니다. 그런데 **실제 payload 에는 `exit` 도 `isError` 도 없습니다** — `{stdout, stderr, interrupted, isImage, noOutputExpected}` 뿐입니다. 그래서 모든 Bash 호출이 곧장 stderr 백업 판정으로 떨어집니다.

그리고 이 하네스는 호출 사이에 shell cwd 를 리셋하면서, 성공 여부와 무관하게 매번 stderr 에 한 줄을 덧붙입니다.

```
Shell cwd was reset to <cwd>
```

실패 근거가 아닌 이 한 줄을 백업 판정이 구분하지 못해 exit-0 명령까지 실패로 셌습니다.

시그니처가 고정된 것도 같은 뿌리입니다. 시그니처의 텍스트 원천도 raw stderr 이라, 진짜 구별점이 stdout 에 있는 실패(`interrupted: true` 에 stderr 는 noise 뿐)는 전부 같은 텍스트로 정규화됩니다.

```
ede370078f51 = sha1("Bash\0shell cwd was reset to <path>")
```

이슈를 촉발한 실 세션 상태 파일 6개(4, 5, 12, 13, 14, 15회)가 전부 이 한 시그니처를 공유한 이유입니다.

### 어떻게 고쳤나 — 결함 2개, 커밋 2개

닫히는 조건이 달라 분리했습니다.

1. **`0951fb3`** — `_derive_error_text()` 가 `_strip_harness_noise()` 로 하네스 고정 문구(그리고 그 문구만) 한 줄을 제거한 뒤에만 실패 여부를 판정합니다.
2. **`cc063df`** — `_derive_failure_text()`(시그니처 원천)에도 같은 필터를 적용해, noise 뿐인 stderr 는 stdout 으로 넘어가 자기 구별점을 찾게 합니다.

1번만 넣으면 exit-0 오발화는 멎지만 서로 다른 실패가 여전히 한 키로 수렴합니다.

### 검증

이슈가 보고한 명령 5개(heredoc `python3`, `grep -l`, `head`, heredoc `cat >`, 또 다른 heredoc `python3`)를 실제 payload 형태 그대로 재현해 **수정 전 4회 연속 발화 / 수정 후 0회** 를 확인했습니다.

양쪽 방향을 다 잠갔습니다.

```
$ bash tests/hooks/postuse-correction/test_second_failure_advisory.sh
  OK  15) genuine repeated failure still advises past harness-noise stripping
  OK  16) unrelated noise-only-stderr failures get distinct signatures

PASS: 21
```

케이스 15 가 없으면 이 변경은 "훅을 꺼버린 것" 과 구분되지 않고, 케이스 16 이 없으면 시그니처 결함이 그대로 남습니다.

### 이 PR 자체가 살아 있는 재현입니다

이 작업을 진행한 세션에서 같은 advisory 가 **50회** 발화했고, 전부 `signature=ede370078f51` 이었으며 대부분 exit 0 인 명령이었습니다.

Pre-commit verified: `bash tests/hooks/postuse-correction/test_second_failure_advisory.sh` → PASS 21, `python3 scripts/check-plugin-manifests.py` → `plugin-manifest check OK`
Caller chain verified: `_strip_harness_noise` / `_derive_error_text` / `_derive_failure_text` 는 `second-failure-advisory/impl.py` 모듈 내부 심볼이며 외부 소비자가 없습니다 (`grep -rn "_derive_error_text\|_derive_failure_text\|_strip_harness_noise" hooks/ scripts/` → 이 훅 디렉터리 밖 0건). 매니페스트 등록은 기존 그대로입니다.

Closes #1042
