### PR TITLE
fix(menu-tier): close gap 3 for destructive sequences

### DIFF
--- a/hooks/advisory-nudge/menu-mutation-tier-advisory/impl.py
+++ b/hooks/advisory-nudge/menu-mutation-tier-advisory/impl.py
@@ -418,21 +418,36 @@ DESTRUCTIVE_VERBS_KO = ("삭제",)
 SEQUENCE_CONNECTOR_EN = ("then",)
 SEQUENCE_CONNECTOR_KO = (" 후 ",)
 
+SEQUENCE_SPLIT_RE = re.compile(r"(?<![a-z])then(?![a-z])|\s후\s", re.IGNORECASE)
+
 
 def _has_sequential_destructive_mutation(text: str) -> bool:
-    """True if a destructive verb naming a shared surface trails a sequence
-    connector in the same option that also carries a safe-MODE token (gap 3).
+    """True if any clause performs a destructive mutation the safe mode does
+    not govern — a destructive verb in a clause carrying no safe-MODE token.
 
-    Order is not checked — `Delete the table, then dry-run to confirm` is the
-    same two-clause shape read the other way and is just as unconditional.
-    `_names_shared_surface` supplies the same local-artifact veto Tier 1c
-    uses, so `Dry-run then delete the test fixture` stays silent.
+    Co-occurrence is not enough. `Dry-run the delete operation, then inspect
+    the customer table` holds a connector, a destructive verb and a shared
+    surface, yet every one of its deletes is simulated: the verb sits in the
+    dry-run's own clause, as its object. Judging the option as a whole cannot
+    separate that from `Dry-run then delete the customer table`, where the
+    delete stands in a clause of its own and runs for real.
+
+    Order therefore falls out rather than being special-cased — `Delete the
+    table, then dry-run to confirm` disqualifies on its FIRST clause, which
+    carries the verb and no safe token. `_names_shared_surface` still reads
+    the whole option, so the Tier 1c local-artifact veto keeps `Dry-run then
+    delete the test fixture` silent.
     """
-    if not _matches(text, SEQUENCE_CONNECTOR_KO, SEQUENCE_CONNECTOR_EN):
+    clauses = SEQUENCE_SPLIT_RE.split(text)
+    if len(clauses) < 2:
         return False
-    if not _matches(text, DESTRUCTIVE_VERBS_KO, DESTRUCTIVE_VERBS_EN):
+    if not _names_shared_surface(text):
         return False
-    return _names_shared_surface(text)
+    return any(
+        _matches(clause, DESTRUCTIVE_VERBS_KO, DESTRUCTIVE_VERBS_EN)
+        and not _matches(clause, LOW_BLAST_TOKENS_KO, LOW_BLAST_TOKENS_EN)
+        for clause in clauses
+    )
 
 
 def _en_token_present(token: str, lower_text: str) -> bool:

--- a/hooks/advisory-nudge/menu-mutation-tier-advisory/impl.py
+++ b/hooks/advisory-nudge/menu-mutation-tier-advisory/impl.py
@@ -385,6 +385,55 @@ NEGATION_TOKENS_KO = (
     "안함",
 )
 
+# Tier 1e — sequential destructive mutation behind a safe-MODE token (issue
+# #974, codex round-1 gap 3 on PR #966; PR #1016 pinned this as an open
+# residual). `Dry-run then delete the customer table` is two clauses: the
+# safe mode covers only the first, and the delete is unconditional — unlike
+# `Dry-run the deploy`, where the safe token governs the mutation verb as its
+# own object and nothing else happens. `_is_low_blast` cannot tell those apart
+# from a low-blast token alone, so a menu whose only "safe" option is really a
+# disguised delete stayed silent.
+#
+# Scoped to destructive verbs ONLY (delete/drop/truncate/삭제), not every
+# mutation verb. PR #1016 already built and rejected the broad version — a
+# safe-token-plus-any-mutation-verb veto — because it also fired on `Deploy
+# now` / `Dry-run the deploy`, `Merge now` / `Simulate the merge`, `Send the
+# announcement` / `Report-only pass on the send`, and their KO pair, all of
+# which are the exact single-clause dry-run alternative this hook wants menus
+# to carry. None of those four pair a destructive verb with a shared surface,
+# so the narrower scope leaves them untouched — measured against the full
+# fixture set below, not assumed.
+DESTRUCTIVE_VERBS_EN = (
+    "delete",
+    "drop",
+    "truncate",
+)
+DESTRUCTIVE_VERBS_KO = ("삭제",)
+
+# The connector that marks a second clause rather than a single dry-run
+# action. KO uses `" 후 "` (padded, not bare `후`) because the bare character
+# is a common substring (`이후`, `최후`, `후보`, `오후`) — the padding requires
+# it to stand alone as the postposition "after", the same whole-token
+# discipline the EN lookaround already applies.
+SEQUENCE_CONNECTOR_EN = ("then",)
+SEQUENCE_CONNECTOR_KO = (" 후 ",)
+
+
+def _has_sequential_destructive_mutation(text: str) -> bool:
+    """True if a destructive verb naming a shared surface trails a sequence
+    connector in the same option that also carries a safe-MODE token (gap 3).
+
+    Order is not checked — `Delete the table, then dry-run to confirm` is the
+    same two-clause shape read the other way and is just as unconditional.
+    `_names_shared_surface` supplies the same local-artifact veto Tier 1c
+    uses, so `Dry-run then delete the test fixture` stays silent.
+    """
+    if not _matches(text, SEQUENCE_CONNECTOR_KO, SEQUENCE_CONNECTOR_EN):
+        return False
+    if not _matches(text, DESTRUCTIVE_VERBS_KO, DESTRUCTIVE_VERBS_EN):
+        return False
+    return _names_shared_surface(text)
+
 
 def _en_token_present(token: str, lower_text: str) -> bool:
     """ASCII-letter lookaround match: token not flanked by ASCII letters.
@@ -446,11 +495,18 @@ def _is_low_blast(text: str) -> bool:
 
     A mutation VERB does not disqualify: `deploy to dev first` is a mutating
     verb aimed at a safe surface, which is exactly the alternative this hook
-    asks the menu to carry.
+    asks the menu to carry. A DESTRUCTIVE verb behind a sequence connector
+    does disqualify (gap 3, `_has_sequential_destructive_mutation`): unlike
+    `deploy to dev first`, `dry-run then delete the customer table` performs
+    the mutation unconditionally in its second clause.
     """
     if _names_high_blast_target(text):
         return False
-    return _matches(text, LOW_BLAST_TOKENS_KO, LOW_BLAST_TOKENS_EN)
+    if not _matches(text, LOW_BLAST_TOKENS_KO, LOW_BLAST_TOKENS_EN):
+        return False
+    if _has_sequential_destructive_mutation(text):
+        return False
+    return True
 
 
 def _is_abandon(text: str) -> bool:

--- a/hooks/advisory-nudge/menu-mutation-tier-advisory/spec.md
+++ b/hooks/advisory-nudge/menu-mutation-tier-advisory/spec.md
@@ -249,11 +249,23 @@ precisely the alternative the hook asks for. Only a Tier 1a **target** does.
 
 **Tier 1e — sequential destructive mutation** (issue #974, codex round-1 gap 3
 on PR #966; closes the residual PR #1016 pinned as open): a low-blast token
-does **not** suppress when a DESTRUCTIVE verb naming a shared surface sits
-behind a **sequence connector** in the same option. `Dry-run then delete the
-customer table` is two clauses — the safe mode covers only the first, and the
-delete is unconditional — unlike `Dry-run the deploy`, where the safe token
-governs the mutation verb as its own object and nothing else happens.
+does **not** suppress when a **clause carrying no low-blast token of its own**
+holds a DESTRUCTIVE verb, and the option names a shared surface. The option is
+split on its **sequence connector**; a single-clause option is never in this
+tier. `Dry-run then delete the customer table` splits into a safe first clause
+and a bare `delete the customer table` — the delete is unconditional — unlike
+`Dry-run the deploy`, one clause whose safe token governs the mutation verb as
+its own object.
+
+**Per-clause, not per-option.** Co-occurrence of connector, destructive verb
+and shared surface is not the discriminator: `Dry-run the delete operation,
+then inspect the customer table` has all three, yet its delete is simulated —
+the verb is the dry-run's own object and the trailing clause only reads. An
+option-level test disqualifies it and strict mode then blocks a genuinely safe
+menu, which is the inverse of this hook's purpose (Codex P1 on PR #1072).
+Order needs no special case as a result: `Delete the customer table, then
+dry-run to confirm` disqualifies on its FIRST clause, which carries the verb
+and no safe token.
 
 - Destructive verbs — English (lookaround): `delete`, `drop`, `truncate`.
   Korean (substring): `삭제`.

--- a/hooks/advisory-nudge/menu-mutation-tier-advisory/spec.md
+++ b/hooks/advisory-nudge/menu-mutation-tier-advisory/spec.md
@@ -247,6 +247,39 @@ precisely the alternative the hook asks for. Only a Tier 1a **target** does.
 `development` is listed explicitly because the lookaround is whole-token and
 `dev` does not match inside it.
 
+**Tier 1e — sequential destructive mutation** (issue #974, codex round-1 gap 3
+on PR #966; closes the residual PR #1016 pinned as open): a low-blast token
+does **not** suppress when a DESTRUCTIVE verb naming a shared surface sits
+behind a **sequence connector** in the same option. `Dry-run then delete the
+customer table` is two clauses — the safe mode covers only the first, and the
+delete is unconditional — unlike `Dry-run the deploy`, where the safe token
+governs the mutation verb as its own object and nothing else happens.
+
+- Destructive verbs — English (lookaround): `delete`, `drop`, `truncate`.
+  Korean (substring): `삭제`.
+- Sequence connectors — English: `then`. Korean: `" 후 "` (padded with spaces,
+  not the bare character — `후` alone is a common substring inside `이후`,
+  `최후`, `후보`, `오후`, so the padding requires it to stand alone as the
+  postposition "after", the same whole-token discipline the EN lookaround
+  applies).
+- The shared-surface check reuses `_names_shared_surface`, so its Tier 1c
+  local-artifact veto applies here too: `Dry-run then delete the test
+  fixture` stays silent.
+
+**Scoped to destructive verbs only, not every mutation verb.** PR #1016 built
+and rejected the broad version — any low-blast token beside any mutation verb,
+naming no high-blast target, disqualifies the option — because it also fired
+on `Deploy now` / `Dry-run the deploy`, `Merge now` / `Simulate the merge`,
+`Send the announcement` / `Report-only pass on the send`, and `지금 배포` /
+`배포 드라이런`: the canonical single-clause dry-run menus this hook asks
+authors to add. None of those four pairs a destructive verb with a shared
+surface, so the narrower scope leaves all four silent — re-measured against
+the full fixture set, not assumed. `Merge`, `deploy`, `send`, `trigger`,
+`apply`, `backfill`, `overwrite`, `publish`, `push`, `notify`, `broadcast`,
+`announce`, `submit` stay outside Tier 1e on purpose; a sequential
+`Dry-run then merge the PR` / `Merge the PR` menu is still silent, and closing
+it would need the same rejected broad rule.
+
 Review / inspection levers are in this tier on purpose: re-running a review
 verifies without touching the shared surface, which is precisely the cheaper
 alternative this hook asks the menu to carry. `reviewer` / `codex` / `critic` are
@@ -358,29 +391,25 @@ around the gate.
   stderr-only, and has been wrong since PR #966 rev 5 made the default path
   `emit_decision("ask", …)`. A false fire now costs the user a confirmation
   prompt, which is why Tier 1c is gated rather than simply widened.
-- **Gap 3 is open on purpose — the compound-option VERB axis.** The suppression
-  rule disqualifies a low-blast token only when the option names a high-blast
-  *target*. An option pairing a safe **mode** token with a mutation **verb** and
-  naming no high-blast target still suppresses, so
-  `Dry-run then delete the customer table` / `Delete the customer table` is
-  silent in both modes — while the identical shape with `prod` inserted fires
-  (strict `rc=2`), which is what shows the residual is real.
-  `Report-only pass then send the announcement`, `Simulate then truncate the
-  table` and `드라이런 후 고객 테이블 삭제` behave the same way.
-
-  The verb-axis discriminator was built and rejected on measurement, not taste.
-  It closes all four residual cases and simultaneously fires on `Deploy now` /
-  `Dry-run the deploy`, `Merge now` / `Simulate the merge`, `Send the
-  announcement` / `Report-only pass on the send`, and `지금 배포` /
-  `배포 드라이런`. Those are the canonical phrasings of the exact option this
-  hook asks menus to contain, and a dry run necessarily names the verb it
-  simulates — `Dry-run then delete the table` and `Dry-run the deploy` are the
-  same shape, and no lexical rule separates them. Firing an `ask` at an author
-  who already added the safe tier teaches that adding one does not help, which
-  inverts the hook's purpose. The residual is the price of the target-based
-  discriminator, and both the residual and the four counter-cases are pinned in
-  the fixtures so a future round fails there rather than shipping the trade
-  blind.
+- **Gap 3 is closed for destructive verbs, open for every other mutation
+  verb.** Tier 1e (above) closes the exact residual PR #1016 pinned:
+  `Dry-run then delete the customer table` / `Delete the customer table` now
+  fires (strict `rc=2`), matching the identical shape with `prod` inserted
+  that already fired before this fix. The broad version — any mutation verb,
+  not just destructive ones — was built and rejected on measurement, not
+  taste: it also fires on `Deploy now` / `Dry-run the deploy`, `Merge now` /
+  `Simulate the merge`, `Send the announcement` / `Report-only pass on the
+  send`, and `지금 배포` / `배포 드라이런` — the canonical phrasings of the
+  exact single-clause dry-run option this hook asks menus to contain. A dry
+  run necessarily names the verb it simulates, and no lexical rule separates
+  those four from the residual on the verb axis alone; only the destructive
+  subset (`delete` / `drop` / `truncate` / `삭제`) plus a sequence connector
+  (`then` / `" 후 "`) does. `Dry-run then merge the PR` / `Merge the PR`
+  therefore stays silent — merge, deploy, send, trigger, and the rest of
+  Tier 1b remain outside Tier 1e, and closing them would reproduce the
+  rejected broad rule's false-positive cost. Both the fix and the four
+  rejected-fix counter-cases are pinned in the fixtures, re-measured against
+  the narrower rule.
 - **Tier 1c is invisible outside its noun list.** `Create the audit ledger` /
   `Update the audit ledger` mutates a shared surface no `SHARED_SURFACE_NOUNS`
   entry names, so it stays silent. That list is an enumeration, not a

--- a/tests/hooks/advisory-nudge/test_menu_mutation_tier.sh
+++ b/tests/hooks/advisory-nudge/test_menu_mutation_tier.sh
@@ -397,6 +397,18 @@ run_case "gap3 new-fix control: dry-run→delete a test fixture stays silent" \
 # run of a delete — stays silent, same as the deploy/merge/send counters.
 run_case "gap3 new-fix control: Dry-run the delete (no connector, no target)" \
   pass default "$(build_payload '["Delete now", "Dry-run the delete"]')"
+# Codex P1 on PR #1072. Co-occurrence of connector + destructive verb + shared
+# surface is NOT the discriminator: here every delete is simulated because the
+# verb is the dry-run's own object, and the post-connector clause only reads.
+# The first Tier 1e disqualified this, so strict mode blocked a genuinely safe
+# menu — the opposite of what the hook exists to do.
+run_case "gap3 P1: dry-run OF the delete, then a read-only clause, stays silent" \
+  pass default "$(build_payload '["Delete the customer table", "Dry-run the delete operation, then inspect the customer table"]')"
+# The mirror of the case above, and why the rule is per-clause rather than
+# order-based: the destructive clause comes FIRST and carries no safe token,
+# so the trailing dry-run does not govern it.
+run_case "gap3 reverse order: delete first, dry-run after, still fires" \
+  advisory default "$(build_payload '["Delete the customer table, then dry-run to confirm", "Delete the customer table"]')"
 
 # ---------------------------------------------------------------------------
 # (e) BLOCK — strict mode

--- a/tests/hooks/advisory-nudge/test_menu_mutation_tier.sh
+++ b/tests/hooks/advisory-nudge/test_menu_mutation_tier.sh
@@ -353,34 +353,50 @@ run_case "Tier 0b neg: KO 취소 — 배포하지 않음"             pass defau
 run_case "negation token is scoped to cancel"  advisory default "$(build_payload '["Deploy to prod and notify", "Deploy to prod but do not notify"]')"
 
 # ---------------------------------------------------------------------------
-# (d9) Gap 3 — the compound-option VERB axis, documented and deliberately open
+# (d9) Gap 3 — the compound-option VERB axis, closed for the destructive verbs
 # ---------------------------------------------------------------------------
 # Issue #974 gap 3 asked whether anything remains after (d2)'s row 4 closed the
-# compound-option TARGET axis. Something does: an option pairing a safe MODE
-# token with a mutation verb and naming no high-blast target still suppresses.
-# It is left open on purpose, and these cases pin the reason rather than the
-# wish — a future round that "fixes" it fails here instead of shipping.
+# compound-option TARGET axis. Something did: an option pairing a safe MODE
+# token with a mutation verb and naming no high-blast target still suppressed.
+# PR #1016 built a fix (safe MODE + ANY mutation verb ⇒ not low-blast) and
+# rejected it — it also fired on the canonical single-clause dry-run menus
+# below, where the safe token governs the mutation verb as its own object and
+# nothing else happens.
 #
-# The residual. `pass` records what the hook DOES, not what is wanted.
-run_case "gap3 residual (open): dry-run→delete, no prod"  pass default "$(build_payload '["Dry-run then delete the customer table", "Delete the customer table"]')"
-run_case "gap3 residual (open): KO 드라이런 후 삭제"        pass default "$(build_payload '["드라이런 후 고객 테이블 삭제", "고객 테이블 삭제"]')"
+# The gap closes here on a narrower axis: a DESTRUCTIVE verb (delete / drop /
+# truncate / 삭제) naming a shared surface, behind a sequence connector
+# ("then" / " 후 ") in the same option as a safe-MODE token, is a second
+# unconditional clause — not a dry run. None of the four rejected-fix
+# counter-cases below pair a destructive verb with a shared surface, so the
+# narrower scope leaves all four silent while closing the residual.
+run_case "gap3 fixed: dry-run→delete, no prod, now fires"     advisory default "$(build_payload '["Dry-run then delete the customer table", "Delete the customer table"]')"
+run_case "gap3 fixed: KO 드라이런 후 삭제, now fires"           advisory default "$(build_payload '["드라이런 후 고객 테이블 삭제", "고객 테이블 삭제"]')"
+run_case "strict: gap3 dry-run→delete blocks"                  block    strict  "$(build_payload '["Dry-run then delete the customer table", "Delete the customer table"]')"
 
-# The row-4 control proving the residual is real and not a broken probe: the
-# identical shape with a high-blast target fires, in both modes.
+# The row-4 control proving the residual was real and not a broken probe: the
+# identical shape with a high-blast target already fired before this fix, in
+# both modes, and still does.
 run_case "gap3 control: same shape WITH prod"        advisory default "$(build_payload '["Dry-run then delete the prod table", "Delete the prod table"]')"
 run_case "strict: gap3 control WITH prod blocks"     block    strict  "$(build_payload '["Dry-run then delete the prod table", "Delete the prod table"]')"
 
-# Why it stays open. A verb-axis discriminator (safe MODE + mutation verb and no
-# safe target ⇒ not low-blast) was built and it closes the residual — while also
-# firing on all four menus below. Those are the canonical phrasings of the exact
-# option this hook asks menus to contain, and a dry run necessarily names the
-# verb it simulates: `Dry-run then delete the table` and `Dry-run the deploy` are
-# the same shape. Firing an `ask` at an author who already added the safe tier
-# teaches that adding one does not help, which inverts the hook's purpose.
+# The four rejected-fix counter-cases from PR #1016, re-measured against this
+# narrower discriminator: none pairs a destructive verb with a shared surface,
+# so all four stay silent — the broad version's false-positive cost does not
+# reproduce here.
 run_case "gap3 counter: Dry-run the deploy"        pass default "$(build_payload '["Deploy now", "Dry-run the deploy"]')"
 run_case "gap3 counter: Simulate the merge"        pass default "$(build_payload '["Merge now", "Simulate the merge"]')"
 run_case "gap3 counter: Report-only on the send"   pass default "$(build_payload '["Send the announcement", "Report-only pass on the send"]')"
 run_case "gap3 counter: KO 배포 드라이런"            pass default "$(build_payload '["지금 배포", "배포 드라이런"]')"
+
+# False-positive controls for the new discriminator itself. A destructive verb
+# behind a connector that names a LOCAL artifact (not a shared surface) stays
+# silent — the same Tier 1c veto `_names_shared_surface` already applies.
+run_case "gap3 new-fix control: dry-run→delete a test fixture stays silent" \
+  pass default "$(build_payload '["Dry-run then delete the test fixture", "Delete the test fixture"]')"
+# A destructive verb with no sequence connector at all — a single-clause dry
+# run of a delete — stays silent, same as the deploy/merge/send counters.
+run_case "gap3 new-fix control: Dry-run the delete (no connector, no target)" \
+  pass default "$(build_payload '["Delete now", "Dry-run the delete"]')"
 
 # ---------------------------------------------------------------------------
 # (e) BLOCK — strict mode


### PR DESCRIPTION
### 무엇이 바뀌나

승인 메뉴의 "안전한" 선택지가 사실은 삭제를 품고 있을 때, 지금까지 침묵하던 자리에서 advisory 가 뜹니다.

### 잔여가 실재합니다 — 재현부터 했습니다

이슈 본문은 gap 3 을 "재현하지 않았다" 고 명시했고, PR #1016 은 이 잔여를 d9 픽스처로 **현재(결함 있는) 동작 그대로** 고정해 두었습니다. 그래서 고치기 전에 오늘 코드에서 재현되는지부터 확인했습니다.

같은 두 옵션 메뉴 하나를 수정 전후 impl.py 에 각각 먹였습니다.

```
$ mk "Dry-run then delete the customer table" "Delete the customer table" | python3 <수정 전>/impl.py
  (빈 출력, rc=0)

$ mk "Dry-run then delete the customer table" "Delete the customer table" | python3 <수정 후>/impl.py
  [advisory] AskUserQuestion approval menu offers no non-mutating tier. ...
```

빈 출력이 프로브 실패가 아님을 보이는 양성 대조 — 같은 구조에 `prod` 만 넣으면 수정 전에도 발화합니다. 즉 훅은 살아 있었고, 이 형태만 빠져나갔습니다.

`Dry-run then delete the customer table` 은 절이 두 개입니다. safe 모드는 첫 절만 덮고 delete 는 무조건 실행되는데, `_is_low_blast` 는 low-blast 토큰 하나만 보고 이걸 안전한 선택지로 셌습니다.

### 어떻게 고쳤나 — 넓은 수정은 이미 기각된 적이 있습니다

PR #1016 은 "safe MODE 토큰 + 아무 mutation 동사 ⇒ non-low-blast" 라는 넓은 규칙을 **만들어서 측정하고 기각**했습니다. 이 훅이 메뉴에 담기를 바라는 바로 그 단일절 dry-run 대안 4건에 오발화했기 때문입니다.

그래서 **파괴적 동사**(`delete` / `drop` / `truncate` / `삭제`)로만 범위를 좁힌 Tier 1e 를 넣었습니다. 공유 표면을 지칭하는 파괴적 동사가 연결어(`then` / `" 후 "`) 뒤에 오고 같은 옵션에 safe-MODE 토큰이 있으면 low-blast 판정을 취소합니다.

한국어 연결어는 맨 `후` 가 아니라 **양쪽에 공백을 둔 `" 후 "`** 입니다 — 맨 글자는 `이후`·`최후`·`후보`·`오후` 의 부분 문자열이라, 조사 "후" 로 홀로 설 때만 걸리게 했습니다. 영문 쪽이 이미 쓰는 lookaround 와 같은 규율입니다.

### 기각됐던 4건이 여전히 침묵하는지 재측정했습니다

가정하지 않고 실제로 돌렸습니다.

```
["Deploy now", "Dry-run the deploy"]                        → 침묵
["Merge now", "Simulate the merge"]                         → 침묵
["Send the announcement", "Report-only pass on the send"]   → 침묵
["지금 배포", "배포 드라이런"]                                → 침묵
```

넷 다 파괴적 동사를 쓰지 않아 좁힌 규칙에 닿지 않습니다. 새 판별식 자체에 대한 거짓양성 대조 2건도 함께 넣었습니다 — `Dry-run then delete the test fixture` 는 local-artifact 베토로, 연결어 없는 `Delete now` / `Dry-run the delete` 는 연결어 부재로 각각 침묵합니다.

### 검증

```
$ bash tests/hooks/advisory-nudge/test_menu_mutation_tier.sh
PASS=113 FAIL=0

$ python3 scripts/check-plugin-manifests.py
plugin-manifest check OK

$ python3 -m ruff check hooks/advisory-nudge/menu-mutation-tier-advisory/impl.py
All checks passed!

$ shellcheck tests/hooks/advisory-nudge/test_menu_mutation_tier.sh
(출력 없음 = clean)
```

기존 110건을 전수 재확인했고, 잔여 3건이 advisory×2 + strict-block×1 로 바뀌었습니다.

### 의도적으로 남긴 경계

`Dry-run then merge the PR` 처럼 파괴적이지 않은 동사의 연쇄는 그대로 침묵합니다. 넓히면 위의 기각된 4건이 되살아나기 때문이고, spec.md 의 Tier 1e 절에 새 gap 이 아니라 명시된 범위 경계로 적었습니다.

이 이슈의 작업 3건 중 (1)·(2) 는 PR #1016 이 이미 닫았고, 이 PR 이 마지막 (3) 을 닫습니다.

Pre-commit verified: `bash tests/hooks/advisory-nudge/test_menu_mutation_tier.sh` → PASS 113 / FAIL 0, `python3 scripts/check-plugin-manifests.py` → `plugin-manifest check OK`, `ruff check` → `All checks passed!`, `shellcheck` → clean
Caller chain verified: `_has_sequential_destructive_mutation` 은 `menu-mutation-tier-advisory/impl.py` 모듈 내부 심볼이며 그 디렉터리 밖 소비자가 0건입니다 (`grep -rn "_has_sequential_destructive_mutation"` → impl.py 외 없음). `_is_low_blast` 의 시그니처는 무변경이라 기존 호출부가 그대로입니다. 매니페스트 등록은 기존 그대로입니다.

Closes #974


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved advisories for menu options that combine a safe-mode action with a subsequent destructive action targeting shared resources.
  - Added support for detecting these sequential patterns in English and Korean.
  - Preserved safe alternatives and avoided alerts for non-destructive actions, local-only artifacts, read-only follow-ups, or destructive actions properly covered by safe mode.

- **Documentation**
  - Documented the updated destructive-action detection rules and remaining limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->