### PR TITLE
fix(cmux-delegate): make decision_gate write atomic

### DIFF
--- a/skills/cmux-delegate/decision_gate.py
+++ b/skills/cmux-delegate/decision_gate.py
@@ -62,6 +62,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 
@@ -78,12 +79,36 @@ def _read(path: str) -> _Record | None:
 
 
 def _write(path: str, record: _Record) -> bool:
+    """Atomic write (temp + `os.replace`): `open(path, "w")` truncates before
+    writing, so a concurrent `_read` can observe a half-written file. That
+    read raises `ValueError`, which `_read` cannot tell apart from "no file",
+    and `resolve` then reports the decision as never having been asked
+    (#1031). Same convention as `session-intent`'s `write_state` — a sibling
+    on the same truncate-vs-crash hazard (issue #647 H7).
+
+    The temp file is created in `path`'s own directory (never a fixed
+    fallback like `/tmp`): `os.replace` requires both on the same filesystem,
+    and a missing directory must fail here exactly as the old `open(path,
+    "w")` did, not silently write elsewhere.
+    """
+    parent = os.path.dirname(path) or "."
     try:
-        with open(path, "w", encoding="utf-8") as handle:
-            json.dump(record, handle, ensure_ascii=False)
-        return True
+        fd, tmp_path = tempfile.mkstemp(dir=parent, prefix=".decision-gate-")
     except OSError:
         return False
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(record, handle, ensure_ascii=False)
+        os.replace(tmp_path, path)
+    except Exception:
+        # Broad on purpose: json.dump can raise TypeError, not just OSError;
+        # any failure before os.replace must still unlink the temp file.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        return False
+    return True
 
 
 def _cmux(args: list[str], timeout: float) -> int | None:

--- a/tests/test_decision_gate.py
+++ b/tests/test_decision_gate.py
@@ -231,6 +231,34 @@ def test_concurrent_resolvers_produce_one_verdict_and_one_signal(
     assert _record(decision_file)["status"] == verdicts.pop()
 
 
+def test_a_failed_write_leaves_the_previous_record_readable(
+    decision_file, monkeypatch
+):
+    """The old `open(path, "w")` truncated before writing, so a reader racing
+    a writer could parse nothing (#1031). `_read` reports that as "no file"
+    and `resolve` then answers as if the question had never been asked — a
+    recorded verdict silently becomes an unasked question.
+
+    Failing the write mid-flight is the deterministic stand-in for that race:
+    truncate-then-fail and truncate-then-race leave the same half-file, and
+    only one of them can be scheduled on demand.
+    """
+    gate._write(decision_file, {"status": "pending", "question": "질문"})
+    before = _record(decision_file)
+
+    def failing_dump(record, handle, **kwargs):
+        handle.write('{"status": "app')
+        raise OSError("disk full")
+
+    monkeypatch.setattr(gate.json, "dump", failing_dump)
+    assert gate._write(decision_file, {"status": "approved"}) is False
+
+    monkeypatch.undo()
+    assert _record(decision_file) == before
+    parent = pathlib.Path(decision_file).parent
+    assert [q.name for q in parent.iterdir()] == [pathlib.Path(decision_file).name]
+
+
 def test_a_new_question_clears_the_previous_claim(decision_file, monkeypatch):
     """The claim's lifetime is one question. Left behind, it would make every
     later decision from this workspace unresolvable."""


### PR DESCRIPTION
### 무엇이 바뀌나

기록된 판정이 조용히 "묻지 않은 질문" 으로 둔갑하던 경로를 막습니다.

### 원인

`decision_gate._write()` 가 `open(path, "w")` 로 썼습니다 — truncate 후 기록이라 원자적이지 않습니다. 동시에 읽는 쪽이 잘린 바이트를 보면 `json.load` 가 `ValueError` 를 던지고, `_read` 는 이걸 `None` 으로 돌려줍니다. `_read` 는 "파일이 없다" 와 "파일이 반쯤 쓰였다" 를 구분할 수단이 없으므로, `resolve()` 는 이를 결정 파일 부재로 읽고 `{"state": "none"}` 을 반환합니다.

승인/거부가 이미 기록돼 있는데도 아무도 묻지 않은 것처럼 보이는 상태입니다.

### 어떻게 고쳤나

같은 디렉터리에 임시 파일로 쓰고 `os.replace` 로 교체합니다. 임시 파일을 `path` 자신의 디렉터리에 만드는 것은 선택이 아닙니다 — `os.replace` 는 양쪽이 같은 파일시스템일 것을 요구하고, 디렉터리가 없을 때는 기존 `open(path, "w")` 와 **똑같이 여기서 실패해야지** 다른 곳에 조용히 쓰면 안 되기 때문입니다.

이 리포의 기존 컨벤션을 그대로 미러링했습니다 — `hooks/preflight-gate/session-intent/impl.py:285` 의 `write_state()` 가 같은 truncate-vs-crash 해저드(#647 H7)에 대해 이미 `tempfile.mkstemp(dir=parent, ...)` + `os.fdopen` + `os.replace` + 실패 시 unlink 를 씁니다.

`hooks/_lib/_state_lock.py` 는 쓰지 않았습니다. 그건 read-modify-write 직렬화용이라 단일 write 의 원자성과는 다른 문제입니다. 애초에 `decision_gate.py` 는 `skills/` 아래라 `hooks/_lib` 를 import 할 수 없다는 제약이 모듈 docstring 에 적혀 있습니다.

`session-intent` 와 달리 `os.makedirs` 는 넣지 않았습니다 — 기존 테스트 `test_unwritable_file_is_unavailable` 이 "없는 디렉터리 → 쓰기 실패" 를 요구합니다.

### 커밋 2개 — 수정과, 그 수정을 고정하는 테스트

닫히는 조건이 달라 나눴습니다. 두 번째가 필요했던 이유는 **기존 탐지가 비결정적**이기 때문입니다.

기존 `test_concurrent_resolvers_produce_one_verdict_and_one_signal` 은 이 결함을 잡긴 잡습니다 — 다만 레이스 창이 열릴 때만 잡습니다. 로컬에서 5회 재실행하면 5회 다 통과하므로, 회귀를 넣고도 초록으로 통과할 수 있습니다.

그 비결정성이 오늘 실제로 드러났습니다. 이 결함과 무관한 PR #1069 (`git_commit_titles.py` 만 변경) 의 CI 가 바로 이것으로 죽었습니다.

```
tests/test_decision_gate.py:229: KeyError
>       verdicts = {r["verdict"] for r in results}
E       KeyError: 'verdict'
FAILED tests/test_decision_gate.py::test_concurrent_resolvers_produce_one_verdict_and_one_signal
1 failed, 816 passed, 1 skipped, 1 xfailed in 25.25s
```

`resolve()` 가 `verdict` 키 없는 dict 를 반환한 것 — 이 PR 이 고치는 바로 그 경로입니다 (run 32547485070). 이론적 레이스가 아니라 오늘 CI 를 무너뜨렸고, 무관한 PR 의 작성자가 자기 변경의 회귀 여부를 가릴 수 없게 만듭니다.

그래서 **결정적** 탐지기를 추가했습니다.

> 정정: 이 문단의 최초 판본은 "기존 테스트로는 이 결함이 잡히지 않는다" 고 적었습니다. 근거는 로컬 5회 재실행이었고, 위 CI 실패가 그것을 반증합니다. 기존 테스트는 flaky 탐지기이지 부재하는 탐지기가 아닙니다.

수정 전 코드에 새 테스트만 돌려 확인했습니다.

```
$ python3 -m pytest tests/test_decision_gate.py -q -k failed_write
E   json.decoder.JSONDecodeError: Unterminated string starting at: line 1 column 12 (char 11)
FAILED tests/test_decision_gate.py::test_a_failed_write_leaves_the_previous_record_readable
1 failed, 25 deselected
```

이슈가 말한 바로 그 증상입니다. 동시성 대신 **쓰기 실패**를 쓰는 이유는, truncate 후 실패와 truncate 후 경쟁이 같은 반쪽 파일을 남기는데 마음대로 스케줄할 수 있는 쪽은 전자뿐이기 때문입니다. 임시 파일 잔류 여부도 함께 단언합니다.

### 검증

```
$ python3 -m pytest tests/test_decision_gate.py -q
26 passed

$ bash tests/test_decision_gate_protocol.sh
Passed: 13  Failed: 0

$ python3 -m ruff check skills/cmux-delegate/decision_gate.py tests/test_decision_gate.py
All checks passed!

$ python3 scripts/check-plugin-manifests.py
plugin-manifest check OK
```

양방향이 잠겼습니다 — 수정 전 실패, 수정 후 통과.

### 범위 밖으로 남긴 것

`resolve()` 는 `state=none` 과 `state=pending` 양쪽에서 `verdict` 키 없는 dict 를 반환하고, `pending` 은 정당한 상태입니다. 즉 "모든 반환에 verdict 가 있다" 고 가정하는 쪽이 코드가 아니라 테스트일 수 있습니다. 원자적 쓰기는 관측된 실패 경로를 없애지만 그 계약 질문에는 답하지 않으며, 이슈가 명시적으로 여기서 다루지 말라고 그은 경계입니다.

Pre-commit verified: `python3 -m pytest tests/test_decision_gate.py -q` → 26 passed, `bash tests/test_decision_gate_protocol.sh` → Passed 13 / Failed 0, `python3 -m ruff check` → `All checks passed!`, `python3 scripts/check-plugin-manifests.py` → `plugin-manifest check OK`
Caller chain verified: `_write` 는 `decision_gate.py` 모듈 내부 심볼이고 호출부는 같은 파일의 2곳(`:198`, `:258`)뿐입니다. 시그니처 `(path: str, record: _Record) -> bool` 와 실패 시 `False` 반환 계약은 무변경이라 두 호출부 모두 무접촉입니다. `tests/test_check_memory_frontmatter.py` 의 동명 `_write` 는 무관한 로컬 헬퍼입니다. 훅 매니페스트와는 무관한 `skills/` 파일입니다.

Closes #1031

