### PR TITLE
refactor(hooks): drop the CMUX_DELEGATE exemption

### DIFF
--- a/docs/hook/block-message-format.md
+++ b/docs/hook/block-message-format.md
@@ -48,9 +48,9 @@ Some gates have **no** authoritative self-bypass, and surfacing a bypass would
 defeat the gate. Omit the line in those cases:
 
 - **`pre-merge-approval-gate`** — a merge approval must come from the user, not
-  from a marker the agent can attach to its own command. The only authoritative
-  signal is `CMUX_DELEGATE=1` set in the *session's* shell env at startup, which
-  is not an inline bypass the agent can self-grant.
+  from a marker the agent can attach to its own command. There is no bypass at
+  all: the gate fires in every session, so the surfaced prompt IS the approval
+  path.
 - **`block-gh-state-all`** — `--state all` is simply invalid for `gh search`;
   there is nothing to bypass, only a correct alternative.
 

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -255,7 +255,6 @@ def _emit_for_trigger(trigger: str, directory: str | None) -> str:
 #
 # Fail-open / false-positive containment:
 #   • no readable transcript                 → no escalation (fail open)
-#   • CMUX_DELEGATE=1 (background agent)      → no escalation (mirror sibling)
 #   • PRAXIS_MOMENTUM_MERGE_ADVISORY=1        → demote back to advisory only
 #   • `# briefing-surfaced` + SOME briefing   → demote back to advisory only
 #     (the marker attests completeness, never existence — see issue #940)
@@ -741,10 +740,6 @@ def _correlated_prior_turn_text(entries: list[dict], idxs: list[int],
 
 def _merge_escalation_reason(payload: dict) -> str | None:
     """Return a deny reason when the pre-merge briefing is incomplete, else None."""
-    # Background cmux-delegate agents merge autonomously — the delegation intent
-    # is the approval (mirror pre-merge-approval-gate).
-    if os.environ.get("CMUX_DELEGATE") == "1":
-        return None
     # Demote-to-advisory escape hatch (false-positive relief without full bypass).
     if os.environ.get(MERGE_ADVISORY_ENV) == "1":
         return None

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -175,8 +175,6 @@ approve blindly.
 
 - No readable transcript (`transcript_path` absent/unreadable) → no escalation
   (fail open). The advisory still fires.
-- `CMUX_DELEGATE=1` (background agent) → no escalation — the delegation intent
-  is the approval, mirroring `pre-merge-approval-gate`.
 - `PRAXIS_MOMENTUM_MERGE_ADVISORY=1` → demote back to advisory only (keeps the
   stderr reminder, skips the deny). The escape hatch for a mis-scored briefing.
 - `# briefing-surfaced` in the merge command (an **in-band** marker, issue #826)
@@ -297,7 +295,7 @@ pins both channels per gate name.
 
 Default mode (no env vars): advisory for `dispatch` / `force-push`; the `merge`
 trigger blocks with `deny` only when the pre-merge briefing is incomplete
-(above), otherwise advisory. `CMUX_DELEGATE=1` background sessions never escalate.
+(above), otherwise advisory.
 
 ### Scope (Phase 1 vs Phase 2)
 

--- a/hooks/preflight-gate/gh-merge-worktree-precondition/spec.md
+++ b/hooks/preflight-gate/gh-merge-worktree-precondition/spec.md
@@ -118,7 +118,7 @@ hook wins):
 
 | Hook | Checks | Decision |
 | ------ | -------- | ---------- |
-| `pre-merge-approval-gate` | Direct session vs `CMUX_DELEGATE=1` background agent | `ask` (never blocks outright) |
+| `pre-merge-approval-gate` | Whether the command is a `gh pr merge` at all — every session is gated | `ask` (never blocks outright) |
 | `gh-merge-worktree-precondition` (this hook) | Whether `--delete-branch`'s target branch is checked out in another worktree | `deny` (exit 2) on a confirmed conflict |
 
 ## Tests

--- a/hooks/preflight-gate/pre-merge-approval-gate/impl.py
+++ b/hooks/preflight-gate/pre-merge-approval-gate/impl.py
@@ -1,39 +1,25 @@
 #!/usr/bin/env python3
 """PreToolUse(Bash) guard: require explicit user approval before `gh pr merge`.
 
-Direct interactive Claude sessions MUST receive per-PR merge approval from the
-user — merge is shared-state and irreversible. Background cmux-delegate agents
-(identified by CMUX_DELEGATE=1 in their shell environment) may merge without an
-extra confirmation gate because the task prompt already carries the delegation
-intent.
+Every Claude session MUST receive per-PR merge approval from the user — merge
+is shared-state and irreversible.
 
 Detection: tokenizes the Bash command with the praxis shlex pipeline and scans
-for any segment whose argv[0..2] == ("gh", "pr", "merge"). If found:
+for any segment whose argv[0..2] == ("gh", "pr", "merge"). If found, emit
+permissionDecision "ask" so Claude Code surfaces a confirmation dialog before
+executing the merge.
 
-  - CMUX_DELEGATE=1 in the hook's own env → silent pass-through (background
-    agent; the delegation intent is the approval).
-  - Otherwise → emit permissionDecision "ask" so Claude Code surfaces a
-    confirmation dialog before executing the merge.
-
-No opt-out marker is provided. Issue #180's contract is that direct sessions
-ALWAYS surface a per-PR approval prompt — an agent-attachable comment marker
-would let the agent silently self-bypass the same gate it is meant to enforce.
-The only authoritative bypass is CMUX_DELEGATE=1 set in the *session's* shell
-env at startup (see note below); inline `env CMUX_DELEGATE=1 gh pr merge` does
-not satisfy this because the hook reads its own process env, not the child's.
-
-Note on inline env prefix (`env CMUX_DELEGATE=1 gh pr merge ...`):
-The hook reads its OWN process environment, not the environment of the child
-command. An inline `env CMUX_DELEGATE=1` prefix only sets the env for the child
-command, NOT for this hook process. Therefore `env CMUX_DELEGATE=1 gh pr merge`
-issued from a non-delegate session still triggers the approval gate. This is
-intentional — the only authoritative delegation signal is CMUX_DELEGATE=1 set
-in the session's shell environment at startup.
+No opt-out marker and no environment bypass are provided. Issue #180's contract
+is that a merge ALWAYS surfaces a per-PR approval prompt — an agent-attachable
+comment marker would let the agent silently self-bypass the same gate it is
+meant to enforce. The background-agent exemption that #180 originally carved out
+was removed in #1055: a delegated worker now runs as an ordinary session with a
+live stdin, so the human at the pane answers the prompt just as in a direct
+session.
 """
 from __future__ import annotations
 
 import json
-import os
 import sys
 import sys as _sys
 from pathlib import Path as _Path
@@ -67,8 +53,7 @@ REASON = format_block(
     correct_path="confirm this merge when the dialog surfaces; approval is "
         "per-PR and does not transfer to sibling/companion PRs",
     # No agent-attachable bypass by design — a self-bypass would defeat the
-    # gate. The only authoritative signal is CMUX_DELEGATE=1 set in the
-    # session's shell env at startup (background cmux-delegate agents).
+    # gate.
     bypass_env=None,
     reference="CLAUDE.md → Pre-Merge Reporting / No Approval Transfer Across "
         "Companion PRs; docs/hook/pre-merge-approval-gate.md",
@@ -130,12 +115,6 @@ def main() -> int:
 
     found = any(is_gh_pr_merge(argv) for argv in iter_command_starts(tokens))
     if not found:
-        return 0
-
-    # Background cmux-delegate agents carry CMUX_DELEGATE=1 in their env.
-    # This is the hook's OWN env — inline `env CMUX_DELEGATE=1 gh pr merge`
-    # does NOT satisfy this check (see module docstring).
-    if os.environ.get("CMUX_DELEGATE") == "1":
         return 0
 
     emit_ask(REASON + compound_cascade_hint(command))

--- a/hooks/preflight-gate/pre-merge-approval-gate/spec.md
+++ b/hooks/preflight-gate/pre-merge-approval-gate/spec.md
@@ -3,21 +3,25 @@
 Supported hosts: all
 
 `hooks/pre-merge-approval-gate.py` fires on every PreToolUse(Bash) event and
-intercepts `gh pr merge` invocations. In direct interactive Claude sessions the
-gate emits `permissionDecision: "ask"` so the user sees the merge attempt and
-must approve it in the Claude Code permission UI. Background cmux-delegate
-agents (identified by `CMUX_DELEGATE=1` in their shell environment) pass
-through silently — the delegation intent from the task prompt already carries
-the authorization.
+intercepts `gh pr merge` invocations. The gate emits
+`permissionDecision: "ask"` so the user sees the merge attempt and must approve
+it in the Claude Code permission UI. This applies to every session — there is
+no environment-variable exemption.
 
 ### Why this exists
 
 Merge is shared-state and irreversible. A task prompt containing a
-"fire-and-forget" or "no STOP gate" directive — intended for background agents
-dispatched via `cmux-delegate` — can bleed into direct interactive sessions
-that mistakenly apply the same exemption. This hook removes the exemption
-ambiguity by making the environment variable (`CMUX_DELEGATE=1`) the sole
-signal for the background-agent path.
+"fire-and-forget" or "no STOP gate" directive — historically written for agents
+dispatched via `cmux-delegate` — can bleed into a session where the user is
+actively reading responses. This hook removes the ambiguity by gating every
+`gh pr merge` unconditionally: no directive in a prompt can stand in for the
+per-PR approval.
+
+Issue #180 originally paired this gate with a `CMUX_DELEGATE=1` background-agent
+exemption. Issue #1055 removed it. Nothing in the repository ever set that
+variable, and the delegated worker now runs with a live stdin (#1054 item A /
+PR #1057), so a prompt surfaced inside a delegated pane is answered by the same
+human — the premise "the delegation intent is the approval" no longer holds.
 
 The per-PR approval rule is already codified in the global `~/.claude/CLAUDE.md` (`No
 Approval Transfer Across Companion PRs` and `Pre-Merge Reporting`). This hook
@@ -28,9 +32,8 @@ is not retrieved.
 
 | Scenario | Action |
 | ---------- | -------- |
-| Direct session (no `CMUX_DELEGATE`), any `gh pr merge` | `permissionDecision: "ask"` |
-| Background agent (`CMUX_DELEGATE=1`), any `gh pr merge` | silent pass-through |
-| Inline `env CMUX_DELEGATE=1 gh pr merge` from direct session | `ask` — inline env sets the child's env, not the hook's own env |
+| Any session, any `gh pr merge` | `permissionDecision: "ask"` |
+| Any env-var prefix (`env FOO=1 gh pr merge`) | `ask` — no environment variable exempts a merge |
 | `# merge-approval:ack` marker (or any comment text) | `ask` — no agent-attachable bypass exists by design |
 | Non-merge gh commands (`gh pr view`, `gh pr list`, etc.) | silent pass-through |
 | `git commit -m "merge note"` (merge in message, not a gh call) | silent pass-through |
@@ -47,26 +50,15 @@ is not retrieved.
    #985) — value-flag values are skipped, so `--subject -h` still triggers.
    Heredoc bodies are blanked by `safe_tokenize` for the same reason: a commit
    message quoting `gh pr merge` is prose, not a merge.
-5. If `CMUX_DELEGATE=1` in the hook's own process env → pass.
-6. Otherwise → emit `permissionDecision: "ask"`.
-
-### Inline env limitation (known)
-
-The hook reads its **own** process environment, not the child's. An inline
-`env CMUX_DELEGATE=1 gh pr merge` prefix only sets `CMUX_DELEGATE` for the
-child `gh` process — the hook process sees no `CMUX_DELEGATE`. This is
-intentional: the only authoritative delegation signal is `CMUX_DELEGATE=1`
-set in the session's shell environment at startup (e.g. by `cmux-delegate`
-when spawning the agent workspace).
+5. Emit `permissionDecision: "ask"`.
 
 ### No opt-out marker (deliberate)
 
 Unlike `side-effect-scan` (`# side-effect:ack`), this hook has **no
-agent-attachable bypass**. Issue #180's contract is that direct sessions
-ALWAYS surface a per-PR approval prompt — a comment-style marker would let
-the agent silently self-bypass the same gate it is meant to enforce. The
-only authoritative bypass is `CMUX_DELEGATE=1` in the *session's* shell env
-at startup; inline `env CMUX_DELEGATE=1` does not satisfy this (see above).
+agent-attachable bypass** and, since #1055, no environment bypass either. The
+contract is that a merge ALWAYS surfaces a per-PR approval prompt — a
+comment-style marker would let the agent silently self-bypass the same gate it
+is meant to enforce.
 
 If a legitimate direct-session merge must proceed, approve the surfaced
 prompt — that single confirmation is the approval the rule requires.
@@ -98,8 +90,9 @@ chained side-effects abort with the merge. Single-command merges (just
 bash tests/test_pre_merge_approval_gate.sh
 ```
 
-Covers direct-session ASK paths (bare, `--merge`, `--delete-branch`),
-background-agent SILENT paths, non-merge command SILENT paths,
+Covers ASK paths (bare, `--merge`, `--delete-branch`), ASK under
+`CMUX_DELEGATE=1` (regression guard for the #1055 exemption removal),
+non-merge command SILENT paths,
 chained-command ASK paths, quoted-body SILENT (text mentions "gh pr merge"
 but is not executed), inline-env ASK, non-Bash tool SILENT, malformed-JSON
 SILENT, `gh -R/--repo/--hostname/--color` global-flag handling, and

--- a/hooks/preflight-gate/side-effect-scan/impl.py
+++ b/hooks/preflight-gate/side-effect-scan/impl.py
@@ -46,7 +46,6 @@ recorded here because the label a reason prints changes with it.
 from __future__ import annotations
 
 import json
-import os
 import sys
 import sys as _sys
 from pathlib import Path as _Path
@@ -142,12 +141,8 @@ def argv_matches(argv: list[str], positions, expected) -> bool:
     return True
 
 
-# Codex r3 #187: round 2 bypassed the entire `gh-merge` category under
-# CMUX_DELEGATE=1, which also silenced `gh pr create` and `gh workflow run`
-# (other entries in the same category) — broader than the sibling
-# pre-merge-approval-gate hook's scope. The narrowed bypass below targets
-# only `gh pr merge` (with optional gh global flags), leaving sibling
-# patterns gated.
+# gh global flags that consume one additional argument, skipped so the
+# subcommand pair lands at the right position for `gh -R owner/repo pr merge`.
 GH_GLOBAL_FLAGS_WITH_ARG = frozenset({"-R", "--repo", "--hostname", "--color"})
 
 
@@ -191,11 +186,6 @@ def _gh_subcommand_pair(argv: list[str]) -> tuple[str, str]:
     return (group, action)
 
 
-def _is_gh_pr_merge(argv: list[str]) -> bool:
-    """Return True iff argv is `gh [global flags] pr merge ...`."""
-    return _gh_subcommand_pair(argv) == ("pr", "merge")
-
-
 # Flag-aware gh detector: maps a (group, {actions}) subcommand pair to the
 # CATEGORIES key it triggers. Replaces the fixed-position argv_matches walk
 # for gh so leading global flags can no longer shift the subcommand out of
@@ -221,11 +211,9 @@ def _detect_gh(argv: list[str]) -> list[str]:
     return matched
 
 
-def detect(argv: list[str], delegate_bypass: bool = False) -> list[str]:
+def detect(argv: list[str]) -> list[str]:
     argv = strip_prefix(argv)
     if not argv:
-        return []
-    if delegate_bypass and _is_gh_pr_merge(argv):
         return []
     cmd = argv[0].rsplit("/", 1)[-1]
     if cmd == "gh":
@@ -336,11 +324,9 @@ def main() -> int:
     if not tokens:
         return 0
 
-    delegate_bypass = os.environ.get("CMUX_DELEGATE") == "1"
-
     matched: list[str] = []
     for argv in iter_command_starts(tokens):
-        for cat in detect(argv, delegate_bypass=delegate_bypass):
+        for cat in detect(argv):
             if cat not in matched:
                 matched.append(cat)
 

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -952,9 +952,9 @@ notverified_count_case
 run_merge_escalation_case "merge_escalation_trivial_pr_exempt" \
   "no" "" "momentum-merge-trivial.jsonl"
 
-# Background delegate session → no escalation (mirror pre-merge-approval-gate).
-run_merge_escalation_case "merge_escalation_delegate_skips" \
-  "no" "CMUX_DELEGATE=1" "momentum-merge-incomplete.jsonl"
+# Issue #1055: CMUX_DELEGATE=1 is inert — an incomplete briefing still denies.
+run_merge_escalation_case "merge_escalation_delegate_no_longer_skips" \
+  "yes" "CMUX_DELEGATE=1" "momentum-merge-incomplete.jsonl"
 
 # Demote-to-advisory escape hatch → no deny, advisory still fires.
 run_merge_escalation_case "merge_escalation_advisory_env_demotes" \

--- a/tests/hooks/preflight-gate/test_pre_merge_approval_gate.sh
+++ b/tests/hooks/preflight-gate/test_pre_merge_approval_gate.sh
@@ -28,7 +28,8 @@ FAILED_NAMES=()
 #     "ask"    — stdout JSON has permissionDecision "ask", rc=0
 #     "silent" — stdout empty, rc=0
 #   delegate_env:
-#     "delegate"    — run with CMUX_DELEGATE=1 set
+#     "delegate"    — run with CMUX_DELEGATE=1 set. Since #1055 this grants no
+#                     exemption; the cases below assert it is inert.
 #     "no-delegate" — run with CMUX_DELEGATE unset
 run_case() {
   local name="$1" expectation="$2" delegate="$3" payload="$4"
@@ -83,7 +84,7 @@ except Exception:
 
 echo "test_pre_merge_approval_gate"
 
-# --- Direct session (CMUX_DELEGATE unset) → ASK
+# --- Merge in any session → ASK
 
 run_case "direct session: gh pr merge --squash (ask)" \
   "ask" "no-delegate" \
@@ -97,14 +98,14 @@ run_case "direct session: gh pr merge --delete-branch (ask)" \
   "ask" "no-delegate" \
   '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 99 --squash --delete-branch"}}'
 
-# --- Background agent (CMUX_DELEGATE=1) → SILENT
+# --- #1055: CMUX_DELEGATE=1 no longer exempts anything → ASK
 
-run_case "background agent: gh pr merge (silent)" \
-  "silent" "delegate" \
+run_case "CMUX_DELEGATE=1 session: gh pr merge (ask, exemption removed)" \
+  "ask" "delegate" \
   '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 1"}}'
 
-run_case "background agent: gh pr merge --squash (silent)" \
-  "silent" "delegate" \
+run_case "CMUX_DELEGATE=1 session: gh pr merge --squash (ask, exemption removed)" \
+  "ask" "delegate" \
   '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 1 --squash --delete-branch"}}'
 
 # --- R4-F1: marker removed — agent-attachable bypass cannot exist → ASK
@@ -147,11 +148,11 @@ run_case "direct session: quoted body with gh pr merge text (silent)" \
   "silent" "no-delegate" \
   '{"tool_name":"Bash","tool_input":{"command":"gh pr comment 1 --body \"next step: gh pr merge\""}}'
 
-# --- Inline env prefix DOES NOT satisfy CMUX_DELEGATE check → ASK
-# env CMUX_DELEGATE=1 sets the env for the child process (gh), not for this
-# hook. The hook reads its own process env, so it still sees no CMUX_DELEGATE.
+# --- Env-var prefix on the command line → ASK
+# No environment variable exempts a merge (#1055), and an inline prefix would
+# not reach the hook process anyway.
 
-run_case "inline env CMUX_DELEGATE=1 gh pr merge (ask, not a delegate session)" \
+run_case "inline env CMUX_DELEGATE=1 gh pr merge (ask)" \
   "ask" "no-delegate" \
   '{"tool_name":"Bash","tool_input":{"command":"env CMUX_DELEGATE=1 gh pr merge 1 --squash"}}'
 
@@ -203,7 +204,7 @@ run_case "direct session: gh -R repo pr merge + ack marker no longer bypasses (a
   "ask" "no-delegate" \
   '{"tool_name":"Bash","tool_input":{"command":"gh -R owner/repo pr merge 1 # merge-approval:ack"}}'
 
-run_case "inline CMUX_DELEGATE=1 gh -R owner/repo pr merge (ask, not delegate session)" \
+run_case "inline CMUX_DELEGATE=1 gh -R owner/repo pr merge (ask)" \
   "ask" "no-delegate" \
   '{"tool_name":"Bash","tool_input":{"command":"CMUX_DELEGATE=1 gh -R owner/repo pr merge 1"}}'
 

--- a/tests/hooks/preflight-gate/test_side_effect_scan.sh
+++ b/tests/hooks/preflight-gate/test_side_effect_scan.sh
@@ -266,10 +266,11 @@ run_case "time -f %E git push"      ask  "time -f %E git push origin main"
 run_case "time -o FILE kubectl"     ask  "time -o /tmp/t.log kubectl apply -f x.yaml"
 run_case "time --format= git push"  ask  "time --format=%E git push"
 
-# --- CMUX_DELEGATE bypass (round 2 — issue #180 integration) --------------
-# gh-merge category silently passes under CMUX_DELEGATE=1 so cmux-delegate
-# background agents stay end-to-end autonomous; sibling categories continue
-# to ask.
+# --- CMUX_DELEGATE is inert (issue #1055) ---------------------------------
+# #180 let the gh-merge category pass silently under CMUX_DELEGATE=1. #1055
+# removed that bypass — nothing ever set the variable, and the delegated worker
+# now runs with a live stdin, so it answers prompts like any other session.
+# These cases keep the env var set and assert every category decides normally.
 
 cmux_run() {
   local name="$1" expected="$2" command="$3"
@@ -305,31 +306,17 @@ print(json.dumps({
         echo "PASS  [$name]"; PASS=$((PASS + 1))
       fi
       ;;
-    pass)
-      # Both streams, not just stdout: a delegated bypass that silently started
-      # emitting a stderr advisory is exactly the regression this case exists to
-      # catch, and an stdout-only check reads it as a clean pass.
-      if [ -n "$out" ] || [ -n "$err" ]; then
-        echo "FAIL  [$name] expected silent pass under CMUX_DELEGATE=1, got stdout: ${out:-<empty>} stderr: ${err:-<empty>}"
-        FAIL=$((FAIL + 1)); FAILED_NAMES+=("$name")
-      else
-        echo "PASS  [$name]"; PASS=$((PASS + 1))
-      fi
-      ;;
   esac
 }
 
-cmux_run "delegate gh pr merge silent"        pass "gh pr merge 1 --squash"
-cmux_run "delegate gh -R pr merge silent"     pass "gh -R owner/repo pr merge 1"
-cmux_run "delegate gh --repo pr merge silent" pass "gh --repo owner/repo pr merge 1"
-# Round 3: bypass narrowed to gh pr merge only — siblings in gh-merge category
-# (gh pr create, gh workflow run) must still ask even in delegate sessions.
+cmux_run "delegate gh pr merge now asks"      ask  "gh pr merge 1 --squash"
+cmux_run "delegate gh -R pr merge now asks"   ask  "gh -R owner/repo pr merge 1"
+cmux_run "delegate gh --repo pr merge asks"   ask  "gh --repo owner/repo pr merge 1"
 cmux_run "delegate gh pr create still asks"   ask  "gh pr create --title x --body y"
 cmux_run "delegate gh workflow run still ask" ask  "gh workflow run deploy.yml"
 cmux_run "delegate git push still asks"       ask  "git push origin main"
-# Issue #874: git-commit is ADVISE now, but the delegate bypass is scoped to
-# `gh pr merge` only — a delegate session must still SEE the commit advisory,
-# not have it silenced. `pass` here would hide the bypass widening.
+# Issue #874: git-commit is ADVISE tier — a delegate session must still SEE the
+# commit advisory on stderr, not have it silenced.
 cmux_run "delegate git commit still advises" advise "git commit -m wip"
 cmux_run "delegate kubectl apply still ask"   ask  "kubectl apply -f x.yaml"
 


### PR DESCRIPTION
### 무엇이 바뀌나

`CMUX_DELEGATE=1` 이 설정된 세션에서 `gh pr merge` 가 조용히 빠져나가던 구멍을 닫습니다. 제거된 것은 가드가 아니라 **가드의 탈출구**입니다.

### 왜 폐기인가

#180 이 배경 에이전트용 면제를 넣었는데, 이 변수를 **설정하는 코드가 리포에 한 번도 존재한 적이 없습니다.** 읽는 쪽 훅 3개, 쓰는 쪽 0개입니다.

```
$ grep -rn "CMUX_DELEGATE=" --include='*.py' --include='*.sh' --include='*.md' .
  (전부 spec/docs 산문과 주석 — 대입하는 실행 코드 0건)
```

강제로 켜도 면제 범위는 `gh pr merge` 하나뿐입니다. 그런데 cmux-delegate 완료 프로토콜은 워커에게 `git push` 와 `gh pr create` 를 요구하고 둘은 그대로 `ask` 로 남습니다 — **워커가 실제로 막히는 지점을 덮지 못했습니다.**

여기에 #1054 항목 A(PR #1057, MERGED)로 위임 워커가 stdin 살아 있는 평범한 세션이 되면서, "위임 프롬프트가 승인을 대신 담는다" 는 전제 자체가 사라졌습니다.

### 측정 — 같은 payload, 수정 전후

```
$ echo '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 1 --squash"}}' \
    | CMUX_DELEGATE=1 python3 <수정 전>/side-effect-scan/impl.py
  (빈 출력, rc=0)                                     ← 조용히 통과

$ echo '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 1 --squash"}}' \
    | CMUX_DELEGATE=1 python3 <수정 후>/side-effect-scan/impl.py
  {"hookSpecificOutput": {"permissionDecision": "ask",
   "permissionDecisionReason": "[gh-merge] remote trigger via gh — PR/워크플로 타겟과 의도 재확인. ..."}}
```

머지가 사람 눈을 거치지 않고 나가던 경로가 닫혔습니다.

### 무엇을 지웠나

- `pre-merge-approval-gate` — 면제 분기 제거, 모든 세션에서 무조건 ask
- `side-effect-scan` — `delegate_bypass` 인자와 dead helper 제거
- `momentum-rule-retrieval-gate` — 면제 분기 제거
- spec 3종 + `gh-merge-worktree-precondition/spec.md` + `docs/hook/block-message-format.md` 서술 갱신
- 테스트 3종 — delegate 케이스를 "면제된다" 에서 **"면제가 무효다"** 회귀 가드로 전환. 환경변수는 계속 설정한 채 정상 판정을 단언하므로, 면제가 되살아나면 잡힙니다.

### #180 이 막으려던 것은 그대로 덮입니다

fire-and-forget 위임 문구가 직접 세션으로 번지는 것 — 게이트 자체는 남아 있고 이제 무조건 발화하므로 오히려 더 촘촘합니다. 이 판단은 위 probe 로 확인한 것이지 추론이 아닙니다.

### 리뷰에서 제기된 반론과 그 반증

Codex 리뷰가 P1 을 올렸습니다 — "비대화형 `cmux-delegate --model codex` 워커가 이 면제를 잃으면 `gh pr merge` 를 끝낼 수 없다, 그러니 비대화형 provider 에는 면제를 남겨라."

두 갈래로 반증됩니다.

**첫째, 면제는 어떤 provider 에게도 활성화된 적이 없습니다.** `CMUX_DELEGATE` 를 설정하는 코드가 리포에도 셸 설정에도 없고, 리뷰가 인용한 `cat "$PROMPT_FILE" | codex exec` 실행 줄에도 없습니다.

**둘째, 강제로 켜도 그 경로는 이미 막혀 있었습니다.** 면제가 완전히 살아 있는 이 PR 이전 코드에서 측정한 결과입니다.

```
$ echo '{"tool_name":"Bash","tool_input":{"command":"<cmd>"}}' \
    | CMUX_DELEGATE=1 python3 <이 PR 이전>/side-effect-scan/impl.py

gh pr merge 1 --squash   → (빈 출력 = 통과)
git push origin HEAD     → ask
gh pr create --fill      → ask
```

`push` 와 `create` 는 `merge` 보다 앞 단계입니다. 워커는 애초에 머지에 도달할 수 없었으므로, 면제가 덮고 있던 것은 **도달 불가능한 마지막 단계 하나**입니다. 보존할 동작 경로가 존재하지 않습니다.

다만 리뷰가 건드린 실제 논점은 남습니다 — 비대화형 provider 에게는 승인 경로가 아예 없습니다. 이 PR 이 만든 상태가 아니라 이전부터 그러했고, 별도 이슈로 다룹니다.

### 검증

```
$ bash tests/hooks/preflight-gate/test_pre_merge_approval_gate.sh
Result: 35 passed, 0 failed

$ bash tests/hooks/preflight-gate/test_side_effect_scan.sh
  PASS: 82  FAIL: 0

$ bash tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
Results: 106 passed, 0 failed

$ python3 scripts/check-plugin-manifests.py
plugin-manifest check OK

$ python3 -m ruff check hooks/
All checks passed!
```

세 파일 다 exit=0 이고 FAIL 줄 0건입니다. 비-delegate 경로의 판정(deny / ask / advisory)은 전부 그대로입니다.

Pre-commit verified: 위 세 테스트 파일 전부 exit=0 (35/35, 82/82, 106/106), `python3 scripts/check-plugin-manifests.py` → `plugin-manifest check OK`, `python3 -m ruff check hooks/` → `All checks passed!`
Caller chain verified: `delegate_bypass` 는 리포 전체에서 0건으로 완전 제거됐습니다 (`grep -rn delegate_bypass` → 없음). 훅 impl 중 `CMUX_DELEGATE` 를 읽는 코드도 0건이며, 남은 문자열 참조는 테스트의 회귀 가드와 spec 의 이력 서술뿐입니다. 훅 3개 모두 매니페스트 등록·엔트리포인트·exit code 계약은 무변경입니다.

Closes #1055

