### PR TITLE
test(hooks): make ask-end-option tests hermetic

### DIFF
--- a/tests/hooks/preflight-gate/test_block_ask_end_option.sh
+++ b/tests/hooks/preflight-gate/test_block_ask_end_option.sh
@@ -80,7 +80,7 @@ run_case() {
   case "$mode" in
     strict)
       # Explicit legacy strict env var (deprecated but still honoured).
-      echo "$payload" | PRAXIS_ASK_END_STRICT=1 "$HOOK" >/dev/null 2>"$err_file"
+      echo "$payload" | env -u PRAXIS_ASK_END_ADVISORY PRAXIS_ASK_END_STRICT=1 "$HOOK" >/dev/null 2>"$err_file"
       ;;
     advisory)
       # Opt-out to advisory via new env var. Unset inherited STRICT to avoid
@@ -89,11 +89,11 @@ run_case() {
       echo "$payload" | env -u PRAXIS_ASK_END_STRICT PRAXIS_ASK_END_ADVISORY=1 "$HOOK" >/dev/null 2>"$err_file"
       ;;
     default|*)
-      # Default is now strict — no env var override. Unset inherited STRICT for
-      # the same reason: if dev has PRAXIS_ASK_END_STRICT set, it would silently
-      # make default behave as explicit-strict. Guard against future default-change
-      # drift by explicitly managing the env rather than relying on absence.
-      echo "$payload" | env -u PRAXIS_ASK_END_STRICT "$HOOK" >/dev/null 2>"$err_file"
+      # Default is now strict — no env var override. Both variables are unset
+      # rather than merely left absent: a dev shell exporting either one decides
+      # this case's mode instead of the default doing so, and ADVISORY=1 flips it
+      # outright (measured: 6 failures). Managing the env beats relying on absence.
+      echo "$payload" | env -u PRAXIS_ASK_END_STRICT -u PRAXIS_ASK_END_ADVISORY "$HOOK" >/dev/null 2>"$err_file"
       ;;
   esac
   rc=$?

--- a/tests/hooks/preflight-gate/test_block_ask_end_option.sh
+++ b/tests/hooks/preflight-gate/test_block_ask_end_option.sh
@@ -83,12 +83,17 @@ run_case() {
       echo "$payload" | PRAXIS_ASK_END_STRICT=1 "$HOOK" >/dev/null 2>"$err_file"
       ;;
     advisory)
-      # Opt-out to advisory via new env var.
-      echo "$payload" | PRAXIS_ASK_END_ADVISORY=1 "$HOOK" >/dev/null 2>"$err_file"
+      # Opt-out to advisory via new env var. Unset inherited STRICT to avoid
+      # dev-env contamination (hook precedence: STRICT > ADVISORY, so inherited
+      # STRICT would override the intended advisory mode and cause false block).
+      echo "$payload" | env -u PRAXIS_ASK_END_STRICT PRAXIS_ASK_END_ADVISORY=1 "$HOOK" >/dev/null 2>"$err_file"
       ;;
     default|*)
-      # Default is now strict — no env var override.
-      echo "$payload" | "$HOOK" >/dev/null 2>"$err_file"
+      # Default is now strict — no env var override. Unset inherited STRICT for
+      # the same reason: if dev has PRAXIS_ASK_END_STRICT set, it would silently
+      # make default behave as explicit-strict. Guard against future default-change
+      # drift by explicitly managing the env rather than relying on absence.
+      echo "$payload" | env -u PRAXIS_ASK_END_STRICT "$HOOK" >/dev/null 2>"$err_file"
       ;;
   esac
   rc=$?


### PR DESCRIPTION
### 무엇이 바뀌나

`test_block_ask_end_option.sh` 가 개발자 셸 환경과 무관하게 같은 결과를 냅니다. 지금은 이 변수를 켜 둔 사람에게만, 자기 변경과 무관한 실패로 보입니다.

### 원인 — 훅은 결함이 없습니다

훅의 모드 결정은 문서화된 우선순위 그대로 동작합니다: `PRAXIS_ASK_END_STRICT` 가 `PRAXIS_ASK_END_ADVISORY` 를 이깁니다. 테스트의 advisory 케이스가 `PRAXIS_ASK_END_ADVISORY=1` 만 인라인으로 주입하고 상속된 STRICT 는 그대로 뒀습니다.

```
$ env | grep PRAXIS_ASK_END
PRAXIS_ASK_END_STRICT=1

$ bash tests/hooks/preflight-gate/test_block_ask_end_option.sh
PASS: 69   FAIL: 2
  - advisory mode + korean end marker, neutral message
  - advisory mode + english end marker, neutral message
```

CI 에는 이 변수가 없어서 CI 는 초록입니다. 그래서 여태 안 잡혔고, 실제로 PR #1066 작업 중 스위트가 `TEST SUITE FAILED` 로 끝나 원인을 가릴 때까지 자기 변경의 회귀 여부를 알 수 없었습니다.

### 커밋 2개 — 같은 계열이 하나 더 있었습니다

첫 커밋이 이슈가 지목한 `STRICT` 누수를 닫습니다. 그런데 **`PRAXIS_ASK_END_ADVISORY` 에도 같은 노출이 있고, 이쪽이 더 크게 깨집니다.**

```
$ PRAXIS_ASK_END_ADVISORY=1 bash tests/hooks/preflight-gate/test_block_ask_end_option.sh
  - [#922-pos] '세션 종료 —' separator label still blocks
  - [#515-d1] "I'm done ..., proceed" is NOT a stop signal → block
  - [#515-d1] 'wrap up the PR tests and deploy' is NOT a stop → block
  ... (6건 실패)
```

default 케이스가 통째로 advisory 로 뒤집힙니다. 두 번째 커밋이 세 갈래(strict / advisory / default) 모두에서 두 변수를 다 해제해, 각 케이스가 자기 전제를 스스로 세우게 합니다. strict 는 우선순위상 영향이 없지만 예외 없이 두는 편이 다음 사람에게 읽힙니다.

### 검증 — 네 가지 환경 상태 전수

```
$ (둘 다 없음)                                        PASS: 71  FAIL: 0
$ PRAXIS_ASK_END_STRICT=1                             PASS: 71  FAIL: 0
$ PRAXIS_ASK_END_ADVISORY=1                           PASS: 71  FAIL: 0
$ PRAXIS_ASK_END_STRICT=1 PRAXIS_ASK_END_ADVISORY=1   PASS: 71  FAIL: 0

$ shellcheck tests/hooks/preflight-gate/test_block_ask_end_option.sh
(출력 없음 = clean)

$ python3 scripts/check-plugin-manifests.py
plugin-manifest check OK
```

변수가 아예 없는 환경에서도 71/71 이라는 것이 `env -u` 가 부재 시에도 안전함을 보이는 대조입니다.

### 다른 테스트 파일의 같은 노출

없습니다. 확인 범위는 `grep -rln "PRAXIS_ASK_END" tests/` 가 낸 나머지 3개 파일(`tests/test_block_message.py`, `tests/test_critic_pre_lock_probe.sh`, `tests/hooks/completion-verify/test_negative_existence_verdict_gate.sh`) 이고, 셋 다 이 변수를 **문자열 리터럴로만** 언급합니다 — 체크리스트 텍스트 assert, spec 인용, sibling 컨벤션 주석입니다. 훅을 실행하며 환경을 상속시키는 자리는 없습니다.

훅 코드와 spec 은 무변경입니다.

Pre-commit verified: `bash tests/hooks/preflight-gate/test_block_ask_end_option.sh` 를 네 가지 환경 조합에서 실행 → 전부 PASS 71 / FAIL 0, `shellcheck` → clean, `python3 scripts/check-plugin-manifests.py` → `plugin-manifest check OK`
Caller chain verified: N/A — 테스트 파일 1개만 바뀌었고 프로덕션 심볼을 추가·변경·제거하지 않았습니다. 훅 `block-ask-end-option` 의 코드·spec·매니페스트 등록은 무변경입니다.

Closes #1070
