### PR TITLE
perf(hooks): bound Stop-gate transcript scans

### DIFF
--- a/hooks/_lib/_transcript.py
+++ b/hooks/_lib/_transcript.py
@@ -196,6 +196,12 @@ def _iter_lines_backwards(path: str, max_bytes: int):
     Stops at the start of the file or once `max_bytes` have been read,
     whichever comes first. Raises `TranscriptReadError` when the file cannot
     be opened or read; callers translate that into their own fail-open value.
+
+    Returns True when the walk reached the start of the file and False when
+    the cap cut it short (read via `StopIteration.value`). A caller cannot
+    infer this from the file size: the transcript is appended to live, so a
+    size sampled before the walk can say "small enough" about a file that has
+    since grown past the cap (codex review #1083 P2).
     """
     try:
         fh = open(path, "rb")
@@ -225,6 +231,7 @@ def _iter_lines_backwards(path: str, max_bytes: int):
             partial = b"" if pos == 0 else lines.pop(0)
             for raw in reversed(lines):
                 yield raw
+        return pos == 0
 
 
 def load_recent_events(
@@ -394,10 +401,6 @@ def read_last_user_message(transcript_path: str) -> str | None:
     """
     if not transcript_path or not os.path.isfile(transcript_path):
         return None
-    try:
-        size = os.path.getsize(transcript_path)
-    except OSError:
-        return None
 
     # Walk in reverse to find the most recent user-role entry whose content
     # includes human-authored text. Reading backwards from the end (#1076):
@@ -406,10 +409,12 @@ def read_last_user_message(transcript_path: str) -> str | None:
     # Driven by hand rather than by `for` so a mid-read failure is
     # distinguishable from exhaustion, without buffering the tail.
     tail = _iter_lines_backwards(transcript_path, CURRENT_TURN_SCAN_MAX_BYTES)
+    reached_start = False
     while True:
         try:
             raw_bytes = next(tail)
-        except StopIteration:
+        except StopIteration as exhausted:
+            reached_start = bool(exhausted.value)
             break
         except TranscriptReadError:
             return None
@@ -470,8 +475,9 @@ def read_last_user_message(transcript_path: str) -> str | None:
     # Nothing found. "" means "read it all, there is no signal" and callers may
     # act on it; that is only true when the backward walk actually reached the
     # start of the file. If the scan cap cut it short, the honest answer is the
-    # unreadable one — None, which every caller fails open on.
-    return "" if size <= CURRENT_TURN_SCAN_MAX_BYTES else None
+    # unreadable one — None, which every caller fails open on. The reader
+    # reports which of the two happened; a size sampled here cannot.
+    return "" if reached_start else None
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/_lib/_transcript.py
+++ b/hooks/_lib/_transcript.py
@@ -37,8 +37,11 @@ last-user-message extraction both skip them.
 Public API:
   TRANSCRIPT_SCAN_LINES                                  — default tail window
   load_transcript(path)                                  -> list[dict]
+  iter_transcript(path)                                  -> Iterator[dict]
   load_transcript_objs(path, max_bytes)                  -> list | None
   read_transcript_tail(path, max_lines, max_bytes)       -> str | None
+  load_recent_events(path, min_events, max_bytes)        -> list[dict]
+  load_current_turn(path, max_bytes)                     -> list[dict]
   get_current_turn(events)                               -> list[dict]
   extract_last_assistant_text(turn)                      -> str
   has_tool_in_turn(turn, tool_name)                      -> bool
@@ -49,6 +52,7 @@ from __future__ import annotations
 
 import json
 import os
+from collections import deque
 from pathlib import Path
 
 # Default tail window (in JSONL lines) for substring scans over the recent
@@ -79,6 +83,32 @@ def load_transcript(path: str) -> list[dict]:
     except Exception:
         pass
     return events
+
+
+def iter_transcript(path: str):
+    """Yield each event dict in `path`, one line at a time. Fail-open.
+
+    Same parse contract as `load_transcript` (non-JSON and non-dict lines are
+    skipped, a missing or unreadable file yields nothing) without holding the
+    whole transcript in memory. For a consumer that genuinely must see the
+    whole session but can reduce as it goes — a 224MB session materialized as
+    a list cost 741MB of RSS per Stop hook (issue #1076).
+    """
+    try:
+        f = open(path, encoding="utf-8", errors="replace")
+    except OSError:
+        return
+    with f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if isinstance(obj, dict):
+                yield obj
 
 
 def load_transcript_objs(path: str, max_bytes: int) -> list | None:
@@ -137,6 +167,165 @@ def _read_bounded_text(path: str, max_bytes: int) -> str | None:
     return data.decode("utf-8", errors="replace")
 
 
+# Bytes scanned backwards from EOF before `load_current_turn` gives up looking
+# for the turn boundary. A turn is one user message and the assistant work that
+# answers it; Claude Code truncates individual tool results, so a real turn does
+# not approach this. The cap exists so a transcript whose tail carries no
+# boundary at all (a corrupted or non-Claude JSONL) degrades to a bounded read
+# instead of the whole-file read this function was written to remove.
+CURRENT_TURN_SCAN_MAX_BYTES = 8 * 1024 * 1024
+
+# Reverse-read granularity. Large enough that the common case (boundary within
+# the last few events) finishes in one seek.
+_TAIL_CHUNK_BYTES = 256 * 1024
+
+
+class TranscriptReadError(OSError):
+    """The backward reader could not finish reading the transcript.
+
+    A read that fails partway is not the same fact as a transcript with no
+    signal in it, and callers act on the two differently: every gate here
+    fails open on "could not read" and acts on "read it all, found nothing".
+    Ending the iterator silently collapsed the first into the second.
+    """
+
+
+def _iter_lines_backwards(path: str, max_bytes: int):
+    """Yield complete lines of `path` as bytes, from the end towards the start.
+
+    Stops at the start of the file or once `max_bytes` have been read,
+    whichever comes first. Raises `TranscriptReadError` when the file cannot
+    be opened or read; callers translate that into their own fail-open value.
+    """
+    try:
+        fh = open(path, "rb")
+    except OSError as exc:
+        raise TranscriptReadError(path) from exc
+    with fh:
+        try:
+            fh.seek(0, os.SEEK_END)
+            pos = fh.tell()
+        except OSError as exc:
+            raise TranscriptReadError(path) from exc
+        partial = b""
+        scanned = 0
+        while pos > 0 and scanned < max_bytes:
+            step = min(_TAIL_CHUNK_BYTES, pos, max_bytes - scanned)
+            pos -= step
+            try:
+                fh.seek(pos)
+                chunk = fh.read(step) + partial
+            except OSError as exc:
+                raise TranscriptReadError(path) from exc
+            scanned += step
+            lines = chunk.split(b"\n")
+            # Unless this chunk reached the start of the file, its first element
+            # is the tail of a line whose head is still unread — carry it into
+            # the next iteration rather than parsing a fragment as a record.
+            partial = b"" if pos == 0 else lines.pop(0)
+            for raw in reversed(lines):
+                yield raw
+
+
+def load_recent_events(
+    path: str,
+    min_events: int = 0,
+    max_bytes: int = CURRENT_TURN_SCAN_MAX_BYTES,
+) -> list[dict]:
+    """Tail of the transcript, read backwards, containing the current turn.
+
+    Returns the last events of `path` — in file order — guaranteed to reach
+    back past the last real user input (the turn boundary) and to hold at
+    least `min_events` events. Reading stops as soon as both hold, so a caller
+    that only needs the current turn pays for the current turn.
+
+    A Stop-event session JSONL reaches hundreds of MB and every gate that
+    needed only the tail was parsing all of it (issue #1076). Same empty-list
+    fail-open as `load_transcript` on a missing or unreadable file.
+
+    `min_events` is for a caller that also reads a fixed recent window past the
+    turn (`events[-80:]`); the boundary alone would not guarantee that window
+    is present.
+
+    Reaching the start of the file without a boundary returns everything
+    scanned, which is what `get_current_turn` returns in the same case
+    (`start = 0`). Exhausting `max_bytes` without one returns `[]` instead:
+    the scan runs end-to-start, so a capped tail holds the *last* slice of an
+    over-long turn and has lost its earliest events — a subset of the turn,
+    not a superset. A gate handed that would miss evidence that is present and
+    block on it, so the honest answer is the same empty fail-open this returns
+    for an unreadable file.
+    """
+    tail: deque[dict] = deque()
+    try:
+        for raw in _iter_lines_backwards(path, max_bytes):
+            obj = _parse_line(raw)
+            if obj is None:
+                continue
+            tail.appendleft(obj)
+            if is_turn_boundary(obj) and len(tail) >= min_events:
+                return list(tail)
+    except TranscriptReadError:
+        return []
+    # The loop ran to completion: either the file start was reached (the tail
+    # is the whole file, boundary or not) or the cap cut it short.
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        return []
+    return list(tail) if size <= max_bytes else []
+
+
+def load_current_turn(
+    path: str, max_bytes: int = CURRENT_TURN_SCAN_MAX_BYTES
+) -> list[dict]:
+    """Events since the last real user input, read from the tail of `path`.
+
+    Same result as `get_current_turn(load_transcript(path))` without parsing
+    the whole transcript — see `load_recent_events` for the bound and for what
+    the two capped terminations return.
+    """
+    return get_current_turn(load_recent_events(path, max_bytes=max_bytes))
+
+
+def _parse_line(raw: bytes) -> dict | None:
+    """Parse one JSONL line into a dict; None for blank, malformed, non-dict.
+
+    Mirrors `load_transcript`, which keeps dicts and skips everything else.
+    """
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        obj = json.loads(raw.decode("utf-8", errors="replace"))
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return obj if isinstance(obj, dict) else None
+
+
+def is_turn_boundary(ev: dict) -> bool:
+    """True when `ev` is a real user input — the event a turn starts after.
+
+    Shared by `get_current_turn` (forward, over an in-memory list) and
+    `load_current_turn` (backward, over a file). One predicate so the two
+    directions cannot drift into disagreeing about where a turn begins.
+    """
+    msg = ev.get("message", {})
+    if not isinstance(msg, dict) or msg.get("role") != "user":
+        return False
+    if ev.get("isSidechain"):
+        return False
+    content = msg.get("content", [])
+    if isinstance(content, str):
+        return True
+    if isinstance(content, list):
+        return any(
+            isinstance(b, dict) and b.get("type") != "tool_result"
+            for b in content
+        )
+    return False
+
+
 def get_current_turn(events: list[dict]) -> list[dict]:
     """Return events since the last real user input (non-tool-result user msg).
 
@@ -145,21 +334,8 @@ def get_current_turn(events: list[dict]) -> list[dict]:
     """
     last_user_idx: int | None = None
     for i, ev in enumerate(events):
-        msg = ev.get("message", {})
-        if not isinstance(msg, dict) or msg.get("role") != "user":
-            continue
-        if ev.get("isSidechain"):
-            continue
-        content = msg.get("content", [])
-        if isinstance(content, str):
+        if is_turn_boundary(ev):
             last_user_idx = i
-        elif isinstance(content, list):
-            non_tool = [
-                b for b in content
-                if isinstance(b, dict) and b.get("type") != "tool_result"
-            ]
-            if non_tool:
-                last_user_idx = i
     start = 0 if last_user_idx is None else last_user_idx + 1
     return events[start:]
 
@@ -219,20 +395,30 @@ def read_last_user_message(transcript_path: str) -> str | None:
     if not transcript_path or not os.path.isfile(transcript_path):
         return None
     try:
-        with open(transcript_path, "r", encoding="utf-8", errors="replace") as f:
-            lines = f.readlines()
+        size = os.path.getsize(transcript_path)
     except OSError:
         return None
 
-    # Walk in reverse to find the most recent user-role entry whose
-    # content includes human-authored text.
-    for raw in reversed(lines):
-        raw = raw.strip()
+    # Walk in reverse to find the most recent user-role entry whose content
+    # includes human-authored text. Reading backwards from the end (#1076):
+    # this used to `readlines()` the whole transcript, which on a long session
+    # is hundreds of MB for a message that sits within the last turn.
+    # Driven by hand rather than by `for` so a mid-read failure is
+    # distinguishable from exhaustion, without buffering the tail.
+    tail = _iter_lines_backwards(transcript_path, CURRENT_TURN_SCAN_MAX_BYTES)
+    while True:
+        try:
+            raw_bytes = next(tail)
+        except StopIteration:
+            break
+        except TranscriptReadError:
+            return None
+        raw = raw_bytes.strip()
         if not raw:
             continue
         try:
-            entry = json.loads(raw)
-        except json.JSONDecodeError:
+            entry = json.loads(raw.decode("utf-8", errors="replace"))
+        except (json.JSONDecodeError, ValueError):
             continue
         if not isinstance(entry, dict):
             continue
@@ -281,7 +467,11 @@ def read_last_user_message(transcript_path: str) -> str | None:
             return text
         # No human text in this entry — keep walking backward.
 
-    return ""
+    # Nothing found. "" means "read it all, there is no signal" and callers may
+    # act on it; that is only true when the backward walk actually reached the
+    # start of the file. If the scan cap cut it short, the honest answer is the
+    # unreadable one — None, which every caller fails open on.
+    return "" if size <= CURRENT_TURN_SCAN_MAX_BYTES else None
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/completion-verify/artifact-verdict-evidence-gate/impl.py
+++ b/hooks/completion-verify/artifact-verdict-evidence-gate/impl.py
@@ -99,8 +99,7 @@ import _fire_ledger  # type: ignore[import-not-found]  # noqa: E402
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
     extract_last_assistant_text,
-    get_current_turn,
-    load_transcript,
+    load_current_turn,
 )
 
 _PREFIX = "[artifact-verdict-evidence-gate]"
@@ -255,11 +254,7 @@ def main() -> int:
     if not transcript_path or not os.path.isfile(transcript_path):
         return 0
 
-    events = load_transcript(transcript_path)
-    if not events:
-        return 0
-
-    turn = get_current_turn(events)
+    turn = load_current_turn(transcript_path)
     last_text = extract_last_assistant_text(turn) if turn else ""
     if not last_text:
         return 0

--- a/hooks/completion-verify/completion-signal-gate/impl.py
+++ b/hooks/completion-verify/completion-signal-gate/impl.py
@@ -50,9 +50,8 @@ from _hook_io import emit_stop_advisory  # type: ignore[import-not-found]  # noq
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
     extract_last_assistant_text,
-    get_current_turn,
     has_tool_in_turn,
-    load_transcript,
+    load_current_turn,
 )
 
 # ---------------------------------------------------------------------------
@@ -461,11 +460,7 @@ def main() -> int:
     if not transcript_path or not os.path.isfile(transcript_path):
         return 0
 
-    events = load_transcript(transcript_path)
-    if not events:
-        return 0
-
-    turn = get_current_turn(events)
+    turn = load_current_turn(transcript_path)
     if not turn:
         return 0
 

--- a/hooks/completion-verify/merge-state-claim-gate/impl.py
+++ b/hooks/completion-verify/merge-state-claim-gate/impl.py
@@ -38,7 +38,7 @@ from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E
 from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
     extract_last_assistant_text,
     get_current_turn,
-    load_transcript,
+    load_recent_events,
 )
 
 _PREFIX = "[merge-state-claim-gate]"
@@ -415,7 +415,9 @@ def main() -> int:
     if not transcript_path or not os.path.isfile(transcript_path):
         return 0
 
-    events = load_transcript(transcript_path)
+    # Bounded tail rather than the whole transcript (#1076). min_events
+    # covers the _EVIDENCE_WINDOW slices below, which read past the turn.
+    events = load_recent_events(transcript_path, min_events=_EVIDENCE_WINDOW)
     if not events:
         return 0
 

--- a/hooks/completion-verify/negative-existence-verdict-gate/impl.py
+++ b/hooks/completion-verify/negative-existence-verdict-gate/impl.py
@@ -82,8 +82,7 @@ import _fire_ledger  # type: ignore[import-not-found]  # noqa: E402
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
     extract_last_assistant_text,
-    get_current_turn,
-    load_transcript,
+    load_current_turn,
 )
 
 _PREFIX = "[negative-existence-verdict-gate]"
@@ -201,11 +200,7 @@ def main() -> int:
     if not transcript_path or not os.path.isfile(transcript_path):
         return 0
 
-    events = load_transcript(transcript_path)
-    if not events:
-        return 0
-
-    turn = get_current_turn(events)
+    turn = load_current_turn(transcript_path)
     last_text = extract_last_assistant_text(turn) if turn else ""
     if not last_text:
         return 0

--- a/hooks/completion-verify/pr-claim-mutation-gate/impl.py
+++ b/hooks/completion-verify/pr-claim-mutation-gate/impl.py
@@ -49,8 +49,7 @@ from _hook_io import (  # type: ignore[import-not-found]  # noqa: E402
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
     extract_last_assistant_text,
-    get_current_turn,
-    load_transcript,
+    load_current_turn,
 )
 
 _PREFIX = "[pr-claim-mutation-gate]"
@@ -309,11 +308,7 @@ def main() -> int:
     if not transcript_path or not os.path.isfile(transcript_path):
         return 0
 
-    events = load_transcript(transcript_path)
-    if not events:
-        return 0
-
-    turn = get_current_turn(events)
+    turn = load_current_turn(transcript_path)
     last_text = extract_last_assistant_text(turn) if turn else ""
     if not last_text:
         return 0

--- a/hooks/completion-verify/pr-report-destination-gate/impl.py
+++ b/hooks/completion-verify/pr-report-destination-gate/impl.py
@@ -82,7 +82,7 @@ sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 import _fire_ledger  # type: ignore[import-not-found]  # noqa: E402
 from _hook_io import emit_stop_advisory  # type: ignore[import-not-found]  # noqa: E402
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
-from _transcript import load_transcript  # type: ignore[import-not-found]  # noqa: E402
+from _transcript import iter_transcript  # type: ignore[import-not-found]  # noqa: E402
 
 _HOOK_NAME = "pr-report-destination-gate"
 _ROLE = "completion-verify"
@@ -129,12 +129,34 @@ def _pr_nums(cmd: str, subs: str) -> list[str]:
     ]
 
 
-def find_unreported_prs(events: list[dict]) -> tuple[list[str], list[str]]:
-    """Return (unreported_context_prs, sample_report_files)."""
+def _add_narrative_prs(acc: set[str], text: str) -> None:
+    """Narrative prose (assistant/user text) referencing a PR is intentional context."""
+    for m in _PR_URL_RE.finditer(text):
+        acc.add(m.group(1))
+
+
+def _add_tool_result_prs(acc: set[str], text: str) -> None:
+    """Count a PR URL from tool output only when the result carries exactly ONE
+    distinct PR (a `gh pr create`/`view` success), never a multi-PR listing
+    (`gh pr list`) which would flood unrelated PRs into context."""
+    urls = {m.group(1) for m in _PR_URL_RE.finditer(text)}
+    if len(urls) == 1:
+        acc.add(next(iter(urls)))
+
+
+def find_unreported_prs(events) -> tuple[list[str], list[str]]:
+    """Return (unreported_context_prs, sample_report_files).
+
+    `events` is any iterable of event dicts — pass `iter_transcript(path)` to
+    stream. This scan genuinely needs the whole session (it looks for a PR
+    touched anywhere in it), so it cannot read a bounded tail like its sibling
+    gates; instead it reduces each text block to the PR numbers it carries and
+    drops the text, so memory tracks the number of distinct PRs rather than the
+    size of the session (issue #1076).
+    """
     tool_uses: list[dict] = []
     result_is_error: dict[str, bool] = {}
-    narrative_parts: list[str] = []       # assistant/user prose — intentional PR references
-    tool_result_texts: list[str] = []     # one combined string per tool_result block
+    context_prs: set[str] = set()
 
     for ev in events:
         msg = ev.get("message")
@@ -142,7 +164,7 @@ def find_unreported_prs(events: list[dict]) -> tuple[list[str], list[str]]:
             continue
         content = msg.get("content")
         if isinstance(content, str):
-            narrative_parts.append(content)
+            _add_narrative_prs(context_prs, content)
             continue
         if not isinstance(content, list):
             continue
@@ -153,7 +175,7 @@ def find_unreported_prs(events: list[dict]) -> tuple[list[str], list[str]]:
             if kind == "text":
                 text = block.get("text")
                 if isinstance(text, str):
-                    narrative_parts.append(text)
+                    _add_narrative_prs(context_prs, text)
             elif kind == "tool_use":
                 tool_uses.append(block)
             elif kind == "tool_result":
@@ -169,7 +191,7 @@ def find_unreported_prs(events: list[dict]) -> tuple[list[str], list[str]]:
                         if isinstance(c, dict) and isinstance(c.get("text"), str):
                             parts.append(c["text"])
                 if parts:
-                    tool_result_texts.append("\n".join(parts))
+                    _add_tool_result_prs(context_prs, "\n".join(parts))
 
     def succeeded(u: dict) -> bool:
         # Missing result (e.g. the final call) counts as success — bias to silence.
@@ -178,7 +200,6 @@ def find_unreported_prs(events: list[dict]) -> tuple[list[str], list[str]]:
             return True
         return result_is_error.get(tid) is not True
 
-    context_prs: set[str] = set()
     posted_prs: set[str] = set()
     report_files: list[str] = []
 
@@ -197,18 +218,6 @@ def find_unreported_prs(events: list[dict]) -> tuple[list[str], list[str]]:
             fp = inp["file_path"]
             if fp.lower().endswith(".md") and (_REPORT_PATH_RE.search(fp) or _REPORT_NAME_RE.search(fp)):
                 report_files.append(fp)
-
-    # Narrative prose (assistant/user text) referencing a PR is intentional context.
-    narrative_text = "\n".join(narrative_parts)
-    for m in _PR_URL_RE.finditer(narrative_text):
-        context_prs.add(m.group(1))
-    # Tool output: count a PR URL only when a result carries exactly ONE distinct
-    # PR (a `gh pr create`/`view` success), never a multi-PR listing (`gh pr list`)
-    # which would flood unrelated PRs into context.
-    for text in tool_result_texts:
-        urls = {m.group(1) for m in _PR_URL_RE.finditer(text)}
-        if len(urls) == 1:
-            context_prs.add(next(iter(urls)))
 
     if not report_files:
         return ([], [])
@@ -258,11 +267,9 @@ def main() -> int:
     if not transcript_path or not os.path.isfile(transcript_path):
         return 0
 
-    events = load_transcript(transcript_path)
-    if not events:
-        return 0
-
-    unreported, report_files = find_unreported_prs(events)
+    unreported, report_files = find_unreported_prs(
+        iter_transcript(transcript_path)
+    )
     if not unreported or not report_files:
         return 0
 

--- a/hooks/completion-verify/pr-report-destination-gate/impl.py
+++ b/hooks/completion-verify/pr-report-destination-gate/impl.py
@@ -144,17 +144,40 @@ def _add_tool_result_prs(acc: set[str], text: str) -> None:
         acc.add(next(iter(urls)))
 
 
+def _reduce_tool_use(block: dict, context_prs: set[str], pending: list) -> None:
+    """Keep only what the success-resolving pass needs, never the block itself."""
+    name = block.get("name")
+    inp = block.get("input") or {}
+    tid = block.get("id")
+    tid = tid if isinstance(tid, str) else None
+    if name == "Bash" and isinstance(inp.get("command"), str):
+        cmd = inp["command"]
+        # Context is success-independent, so it resolves here and needs no buffer.
+        context_prs.update(_pr_nums(cmd, "view|create|diff|checks|checkout|edit|ready|merge"))
+        posted = list(_pr_nums(cmd, "comment|review"))
+        if _is_api_post(cmd):
+            posted.extend(m.group(1) for m in _API_TARGET_RE.finditer(cmd))
+        if posted:
+            pending.append((tid, posted, None))
+    elif name in ("Write", "Edit") and isinstance(inp.get("file_path"), str):
+        fp = inp["file_path"]
+        if fp.lower().endswith(".md") and (_REPORT_PATH_RE.search(fp) or _REPORT_NAME_RE.search(fp)):
+            pending.append((tid, [], fp))
+
+
 def find_unreported_prs(events) -> tuple[list[str], list[str]]:
     """Return (unreported_context_prs, sample_report_files).
 
     `events` is any iterable of event dicts — pass `iter_transcript(path)` to
     stream. This scan genuinely needs the whole session (it looks for a PR
     touched anywhere in it), so it cannot read a bounded tail like its sibling
-    gates; instead it reduces each text block to the PR numbers it carries and
-    drops the text, so memory tracks the number of distinct PRs rather than the
-    size of the session (issue #1076).
+    gates. Every block is reduced on arrival to the PR numbers and report path
+    it carries, and the block itself is dropped: retaining `tool_use` blocks
+    would keep whole Bash command strings alive for the length of the session,
+    which is the cost this gate exists to avoid (issue #1076).
     """
-    tool_uses: list[dict] = []
+    # (tool_use id, PR numbers this call posted to, report file written)
+    pending: list[tuple[str | None, list[str], str | None]] = []
     result_is_error: dict[str, bool] = {}
     context_prs: set[str] = set()
 
@@ -177,7 +200,7 @@ def find_unreported_prs(events) -> tuple[list[str], list[str]]:
                 if isinstance(text, str):
                     _add_narrative_prs(context_prs, text)
             elif kind == "tool_use":
-                tool_uses.append(block)
+                _reduce_tool_use(block, context_prs, pending)
             elif kind == "tool_result":
                 tid = block.get("tool_use_id")
                 if isinstance(tid, str):
@@ -193,31 +216,16 @@ def find_unreported_prs(events) -> tuple[list[str], list[str]]:
                 if parts:
                     _add_tool_result_prs(context_prs, "\n".join(parts))
 
-    def succeeded(u: dict) -> bool:
-        # Missing result (e.g. the final call) counts as success — bias to silence.
-        tid = u.get("id")
-        if not isinstance(tid, str):
-            return True
-        return result_is_error.get(tid) is not True
-
     posted_prs: set[str] = set()
     report_files: list[str] = []
 
-    for u in tool_uses:
-        name = u.get("name")
-        inp = u.get("input") or {}
-        if name == "Bash" and isinstance(inp.get("command"), str):
-            cmd = inp["command"]
-            context_prs.update(_pr_nums(cmd, "view|create|diff|checks|checkout|edit|ready|merge"))
-            if not succeeded(u):
-                continue
-            posted_prs.update(_pr_nums(cmd, "comment|review"))
-            if _is_api_post(cmd):
-                posted_prs.update(m.group(1) for m in _API_TARGET_RE.finditer(cmd))
-        elif name in ("Write", "Edit") and isinstance(inp.get("file_path"), str) and succeeded(u):
-            fp = inp["file_path"]
-            if fp.lower().endswith(".md") and (_REPORT_PATH_RE.search(fp) or _REPORT_NAME_RE.search(fp)):
-                report_files.append(fp)
+    for tid, posted, report_file in pending:
+        # Missing result (e.g. the final call) counts as success — bias to silence.
+        if tid is not None and result_is_error.get(tid) is True:
+            continue
+        posted_prs.update(posted)
+        if report_file is not None:
+            report_files.append(report_file)
 
     if not report_files:
         return ([], [])

--- a/hooks/completion-verify/proposal-premise-gate/impl.py
+++ b/hooks/completion-verify/proposal-premise-gate/impl.py
@@ -63,7 +63,7 @@ Fail-open contract:
   - Any uncaught exception → exit 0 (`@fail_open`)
 
 Scope note (turn-boundary, not session-boundary): probe evidence is checked
-against the CURRENT turn only (`get_current_turn`), matching every sibling
+against the CURRENT turn only (`load_current_turn`), matching every sibling
 completion-verify Stop hook's scanning convention. The issue's proposal
 language says "no probe this session" — narrowing to the current turn is a
 structural convention inherited from the sibling hooks, not a design choice
@@ -83,8 +83,7 @@ import _fire_ledger  # type: ignore[import-not-found]  # noqa: E402
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
     extract_last_assistant_text,
-    get_current_turn,
-    load_transcript,
+    load_current_turn,
 )
 
 _PREFIX = "[proposal-premise-gate]"
@@ -285,11 +284,7 @@ def main() -> int:
     if not transcript_path or not os.path.isfile(transcript_path):
         return 0
 
-    events = load_transcript(transcript_path)
-    if not events:
-        return 0
-
-    turn = get_current_turn(events)
+    turn = load_current_turn(transcript_path)
     last_text = extract_last_assistant_text(turn) if turn else ""
     if not last_text:
         return 0

--- a/hooks/completion-verify/readonly-verify-deferral-gate/impl.py
+++ b/hooks/completion-verify/readonly-verify-deferral-gate/impl.py
@@ -68,8 +68,7 @@ import _fire_ledger  # type: ignore[import-not-found]  # noqa: E402
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
     extract_last_assistant_text,
-    get_current_turn,
-    load_transcript,
+    load_current_turn,
 )
 
 # ---------------------------------------------------------------------------
@@ -337,11 +336,7 @@ def main() -> int:
     if not transcript_path or not os.path.isfile(transcript_path):
         return 0
 
-    events = load_transcript(transcript_path)
-    if not events:
-        return 0
-
-    turn = get_current_turn(events)
+    turn = load_current_turn(transcript_path)
     if not turn:
         return 0
 

--- a/hooks/completion-verify/runtime-state-claim-gate/impl.py
+++ b/hooks/completion-verify/runtime-state-claim-gate/impl.py
@@ -45,6 +45,7 @@ import json
 import os
 import re
 import sys
+from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path as _Path
 
@@ -293,7 +294,7 @@ def extract_verdict_claims(text: str) -> list[dict]:
     return claims
 
 
-def collect_prior_verdict_mentions(prior_events) -> dict[str, str | None]:
+def collect_prior_verdict_mentions(prior_events: Iterable[dict]) -> dict[str, str | None]:
     """Return claim key -> earliest ISO timestamp (or None) it was stated in
     `prior_events` (assistant text, any turn before the current one,
     qualified or not — a qualified prior mention still means the number was
@@ -380,7 +381,7 @@ def iter_events_before_current_turn(path: str):
 
 
 def detect_verdict_restatement(
-    last_text: str, prior_events: list[dict]
+    last_text: str, prior_events: Iterable[dict]
 ) -> tuple[list[str], dict[str, str | None]]:
     """Return (restated claim keys, prior-mention timestamps) for verdict
     numbers in `last_text` that are (a) unqualified here and (b) were already

--- a/hooks/completion-verify/runtime-state-claim-gate/impl.py
+++ b/hooks/completion-verify/runtime-state-claim-gate/impl.py
@@ -385,14 +385,19 @@ def detect_verdict_restatement(
 ) -> tuple[list[str], dict[str, str | None]]:
     """Return (restated claim keys, prior-mention timestamps) for verdict
     numbers in `last_text` that are (a) unqualified here and (b) were already
-    stated somewhere earlier this session."""
+    stated somewhere earlier this session.
+
+    Condition (a) is decided from `last_text` alone, so it is decided first:
+    with nothing unqualified to restate, no prior event can change the answer
+    and `prior_events` is left undrained rather than scanned (issue #1076)."""
+    unqualified = [c for c in extract_verdict_claims(last_text) if not c["qualified"]]
+    if not unqualified:
+        return [], {}
     mentions = collect_prior_verdict_mentions(prior_events)
     if not mentions:
         return [], mentions
     restated: list[str] = []
-    for claim in extract_verdict_claims(last_text):
-        if claim["qualified"]:
-            continue
+    for claim in unqualified:
         key = claim["key"]
         if key in mentions and key not in restated:
             restated.append(key)

--- a/hooks/completion-verify/runtime-state-claim-gate/impl.py
+++ b/hooks/completion-verify/runtime-state-claim-gate/impl.py
@@ -57,8 +57,9 @@ import _fire_ledger  # type: ignore[import-not-found]  # noqa: E402
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _transcript import (  # type: ignore[import-not-found]  # noqa: E402
     extract_last_assistant_text,
-    get_current_turn,
-    load_transcript,
+    is_turn_boundary,
+    iter_transcript,
+    load_current_turn,
 )
 
 _PREFIX = "[runtime-state-claim-gate]"
@@ -292,12 +293,15 @@ def extract_verdict_claims(text: str) -> list[dict]:
     return claims
 
 
-def collect_prior_verdict_mentions(prior_events: list[dict]) -> dict[str, str | None]:
+def collect_prior_verdict_mentions(prior_events) -> dict[str, str | None]:
     """Return claim key -> earliest ISO timestamp (or None) it was stated in
     `prior_events` (assistant text, any turn before the current one,
     qualified or not — a qualified prior mention still means the number was
     already said). ISO8601 `Z`-suffixed timestamps sort correctly as strings,
-    so no datetime parsing is needed to track the minimum."""
+    so no datetime parsing is needed to track the minimum.
+
+    Takes any iterable so the caller can stream the file rather than hold it.
+    """
     mentions: dict[str, str | None] = {}
     for ev in prior_events:
         msg = ev.get("message", {})
@@ -350,6 +354,29 @@ def _elapsed_minutes(ts_from: str | None, ts_to: str | None) -> str:
     except ValueError:
         return "unknown"
     return f"{abs((b - a).total_seconds()) / 60:.1f}"
+
+
+def iter_events_before_current_turn(path: str):
+    """Yield every event that precedes the current turn, streaming (#1076).
+
+    This gate asks whether a verdict number was already stated *earlier this
+    session*, so unlike its seven siblings it cannot work from the turn alone.
+    It used to hold the whole transcript in memory to slice the turn off the
+    end — hundreds of MB on a long session, against a 10s budget.
+
+    Streaming forward gives the same slice without the buffer: events pile up
+    until the next real user input proves they belong to a completed turn, and
+    whatever is still pending at EOF IS the current turn and is dropped. Peak
+    memory is one turn, not one session. The current turn must not leak in —
+    the text being judged would then count as its own prior mention and every
+    claim would read as a restatement.
+    """
+    pending: list[dict] = []
+    for ev in iter_transcript(path):
+        if is_turn_boundary(ev):
+            yield from pending
+            pending = []
+        pending.append(ev)
 
 
 def detect_verdict_restatement(
@@ -458,18 +485,15 @@ def main() -> int:
     if not transcript_path or not os.path.isfile(transcript_path):
         return 0
 
-    events = load_transcript(transcript_path)
-    if not events:
-        return 0
-
-    turn = get_current_turn(events)
+    turn = load_current_turn(transcript_path)
     last_text = extract_last_assistant_text(turn) if turn else ""
     if not last_text:
         return 0
 
     kinds = detect_claims(last_text)
-    prior_events = events[: len(events) - len(turn)] if turn else events
-    restated, mentions = detect_verdict_restatement(last_text, prior_events)
+    restated, mentions = detect_verdict_restatement(
+        last_text, iter_events_before_current_turn(transcript_path)
+    )
     if not kinds and not restated:
         return 0
 

--- a/hooks/completion-verify/runtime-state-claim-gate/impl.py
+++ b/hooks/completion-verify/runtime-state-claim-gate/impl.py
@@ -305,29 +305,46 @@ def collect_prior_verdict_mentions(prior_events: Iterable[dict]) -> dict[str, st
     """
     mentions: dict[str, str | None] = {}
     for ev in prior_events:
-        msg = ev.get("message", {})
-        if not isinstance(msg, dict) or msg.get("role") != "assistant" or ev.get("isSidechain"):
-            continue
-        content = msg.get("content", [])
-        text = ""
-        if isinstance(content, str):
-            text = content
-        elif isinstance(content, list):
-            text = "\n".join(
-                b.get("text", "") for b in content
-                if isinstance(b, dict) and b.get("type") == "text"
-            )
-        if not text:
-            continue
-        ts = ev.get("timestamp")
-        ts = ts if isinstance(ts, str) and ts else None
-        for claim in extract_verdict_claims(text):
-            key = claim["key"]
-            if key not in mentions:
-                mentions[key] = ts
-            elif ts and (mentions[key] is None or ts < mentions[key]):
-                mentions[key] = ts
+        _merge_mentions(mentions, _event_verdict_mentions(ev))
     return mentions
+
+
+def _event_verdict_mentions(ev: dict) -> dict[str, str | None]:
+    """One event reduced to the verdict keys it states, and when.
+
+    This is the whole of what a prior event contributes, so reducing here lets
+    a caller drop the event itself instead of holding it (codex review #1083
+    P1) — a completed turn can be most of a large session.
+    """
+    msg = ev.get("message", {})
+    if not isinstance(msg, dict) or msg.get("role") != "assistant" or ev.get("isSidechain"):
+        return {}
+    content = msg.get("content", [])
+    text = ""
+    if isinstance(content, str):
+        text = content
+    elif isinstance(content, list):
+        text = "\n".join(
+            b.get("text", "") for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        )
+    if not text:
+        return {}
+    ts = ev.get("timestamp")
+    ts = ts if isinstance(ts, str) and ts else None
+    found: dict[str, str | None] = {}
+    for claim in extract_verdict_claims(text):
+        found.setdefault(claim["key"], ts)
+    return found
+
+
+def _merge_mentions(into: dict[str, str | None], new: dict[str, str | None]) -> None:
+    """Fold `new` into `into`, keeping the earliest timestamp per key."""
+    for key, ts in new.items():
+        if key not in into:
+            into[key] = ts
+        elif ts and (into[key] is None or ts < into[key]):
+            into[key] = ts
 
 
 def _last_assistant_timestamp(turn: list[dict]) -> str | None:
@@ -357,31 +374,37 @@ def _elapsed_minutes(ts_from: str | None, ts_to: str | None) -> str:
     return f"{abs((b - a).total_seconds()) / 60:.1f}"
 
 
-def iter_events_before_current_turn(path: str):
-    """Yield every event that precedes the current turn, streaming (#1076).
+def prior_verdict_mentions(path: str) -> dict[str, str | None]:
+    """Verdict mentions from every turn BEFORE the current one, streaming (#1076).
 
     This gate asks whether a verdict number was already stated *earlier this
     session*, so unlike its seven siblings it cannot work from the turn alone.
     It used to hold the whole transcript in memory to slice the turn off the
     end — hundreds of MB on a long session, against a 10s budget.
 
-    Streaming forward gives the same slice without the buffer: events pile up
-    until the next real user input proves they belong to a completed turn, and
-    whatever is still pending at EOF IS the current turn and is dropped. Peak
-    memory is one turn, not one session. The current turn must not leak in —
-    the text being judged would then count as its own prior mention and every
-    claim would read as a restatement.
+    Events pile up until the next real user input proves they belong to a
+    completed turn; whatever is still pending at EOF IS the current turn and is
+    dropped. The current turn must not leak in — the text being judged would
+    then count as its own prior mention and every claim would read as a
+    restatement.
+
+    What is held while waiting for that proof is the reduction, not the events:
+    buffering the events themselves made peak memory track the largest turn,
+    which on a long session is most of it (codex review #1083 P1). Peak now
+    tracks the number of distinct verdict keys.
     """
-    pending: list[dict] = []
+    confirmed: dict[str, str | None] = {}
+    pending: dict[str, str | None] = {}
     for ev in iter_transcript(path):
         if is_turn_boundary(ev):
-            yield from pending
-            pending = []
-        pending.append(ev)
+            _merge_mentions(confirmed, pending)
+            pending = {}
+        _merge_mentions(pending, _event_verdict_mentions(ev))
+    return confirmed
 
 
 def detect_verdict_restatement(
-    last_text: str, prior_events: Iterable[dict]
+    last_text: str, transcript_path: str
 ) -> tuple[list[str], dict[str, str | None]]:
     """Return (restated claim keys, prior-mention timestamps) for verdict
     numbers in `last_text` that are (a) unqualified here and (b) were already
@@ -389,11 +412,11 @@ def detect_verdict_restatement(
 
     Condition (a) is decided from `last_text` alone, so it is decided first:
     with nothing unqualified to restate, no prior event can change the answer
-    and `prior_events` is left undrained rather than scanned (issue #1076)."""
+    and the transcript is not read at all (issue #1076)."""
     unqualified = [c for c in extract_verdict_claims(last_text) if not c["qualified"]]
     if not unqualified:
         return [], {}
-    mentions = collect_prior_verdict_mentions(prior_events)
+    mentions = prior_verdict_mentions(transcript_path)
     if not mentions:
         return [], mentions
     restated: list[str] = []
@@ -497,9 +520,7 @@ def main() -> int:
         return 0
 
     kinds = detect_claims(last_text)
-    restated, mentions = detect_verdict_restatement(
-        last_text, iter_events_before_current_turn(transcript_path)
-    )
+    restated, mentions = detect_verdict_restatement(last_text, transcript_path)
     if not kinds and not restated:
         return 0
 

--- a/tests/test_pr_report_gate_memory.py
+++ b/tests/test_pr_report_gate_memory.py
@@ -1,0 +1,99 @@
+"""The PR-report gate reduces every tool_use on arrival (issue #1076).
+
+This gate cannot read a bounded tail — it looks for a PR touched anywhere in
+the session — so the only thing standing between it and session-sized memory
+is that it never retains a block. A `tool_use` block carries its whole `input`
+dict, Bash command strings included, so buffering them re-creates exactly the
+cost the streaming rewrite was meant to remove.
+
+Run: python3 -m pytest tests/test_pr_report_gate_memory.py -q
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "hooks" / "_lib"))
+
+_spec = importlib.util.spec_from_file_location(
+    "pr_report_destination_gate",
+    REPO_ROOT / "hooks" / "completion-verify" / "pr-report-destination-gate" / "impl.py",
+)
+assert _spec is not None and _spec.loader is not None
+gate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gate)  # type: ignore[union-attr]
+
+_HUGE = "z" * 10_000
+
+
+def _bash(tid: str, cmd: str) -> dict:
+    return {"type": "tool_use", "id": tid, "name": "Bash", "input": {"command": cmd}}
+
+
+def _events(calls: int, pad: int = 4000):
+    """Yield one event at a time — a materialised list would dominate the peak."""
+    for i in range(calls):
+        yield {"message": {"content": [_bash(f"t{i}", f"gh pr view {1000 + i % 7} # " + "x" * pad)]}}
+    yield {"message": {"content": [{"type": "tool_use", "id": "w", "name": "Write",
+                                    "input": {"file_path": "/tmp/pr-report.md"}}]}}
+    yield {"message": {"content": [{"type": "tool_result", "tool_use_id": "w", "is_error": False}]}}
+
+
+def test_reduction_drops_the_block_and_its_command() -> None:
+    pending: list = []
+    context_prs: set[str] = set()
+    gate._reduce_tool_use(
+        _bash("t1", f"gh pr comment 42 --body-file x.md {_HUGE}"), context_prs, pending
+    )
+    assert pending == [("t1", ["42"], None)]
+    assert not any(isinstance(part, dict) for entry in pending for part in entry)
+    assert _HUGE not in repr(pending)
+
+
+def test_context_pr_resolves_without_buffering() -> None:
+    """Context is success-independent, so it must not need a pending entry."""
+    pending: list = []
+    context_prs: set[str] = set()
+    gate._reduce_tool_use(_bash("t2", "gh pr view 77 --json state"), context_prs, pending)
+    assert context_prs == {"77"}
+    assert pending == []
+
+
+def test_failed_post_does_not_count_as_reported() -> None:
+    events = [
+        {"message": {"content": [_bash("c1", "gh pr comment 55 --body-file r.md")]}},
+        {"message": {"content": [{"type": "tool_result", "tool_use_id": "c1", "is_error": True}]}},
+        {"message": {"content": [_bash("v1", "gh pr view 55 --json state")]}},
+        {"message": {"content": [{"type": "tool_use", "id": "w", "name": "Write",
+                                  "input": {"file_path": "/tmp/pr-report.md"}}]}},
+        {"message": {"content": [{"type": "tool_result", "tool_use_id": "w", "is_error": False}]}},
+    ]
+    unreported, reports = gate.find_unreported_prs(iter(events))
+    assert unreported == ["55"] and reports == ["/tmp/pr-report.md"]
+
+
+def test_succeeded_post_counts_as_reported() -> None:
+    """Mirror of the case above — without it a blanket regression reads as a pass."""
+    events = [
+        {"message": {"content": [_bash("c1", "gh pr comment 55 --body-file r.md")]}},
+        {"message": {"content": [{"type": "tool_result", "tool_use_id": "c1", "is_error": False}]}},
+        {"message": {"content": [_bash("v1", "gh pr view 55 --json state")]}},
+        {"message": {"content": [{"type": "tool_use", "id": "w", "name": "Write",
+                                  "input": {"file_path": "/tmp/pr-report.md"}}]}},
+        {"message": {"content": [{"type": "tool_result", "tool_use_id": "w", "is_error": False}]}},
+    ]
+    assert gate.find_unreported_prs(iter(events)) == ([], ["/tmp/pr-report.md"])
+
+
+def test_peak_memory_does_not_track_session_size() -> None:
+    """3000 calls x 4KB of command text retained whole is ~17 MiB; reduced it is ~0.3."""
+    tracemalloc.start()
+    try:
+        gate.find_unreported_prs(_events(3000))
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    assert peak < 2 * 1024 * 1024, f"peak {peak / 1024 / 1024:.2f} MiB — a block is being retained"

--- a/tests/test_runtime_state_claim_scan.py
+++ b/tests/test_runtime_state_claim_scan.py
@@ -14,7 +14,6 @@ import importlib.util
 import sys
 from pathlib import Path
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "hooks" / "_lib"))
@@ -69,6 +68,5 @@ def test_restatement_still_detected_across_prior_turns() -> None:
         }
     ]
     restated, mentions = gate.detect_verdict_restatement(text, iter(prior))
-    if not mentions:
-        pytest.skip("prior-mention collector did not recognise the fixture text")
+    assert mentions, "prior-mention collector did not recognise the fixture text"
     assert key in restated

--- a/tests/test_runtime_state_claim_scan.py
+++ b/tests/test_runtime_state_claim_scan.py
@@ -1,19 +1,21 @@
-"""The runtime-state gate scans prior turns only when one could matter (#1076).
+"""The runtime-state gate reads prior turns lazily, and holds only the reduction.
 
-`detect_verdict_restatement` answers a two-part question: is a verdict claim
-unqualified *here*, and was it already stated earlier. The first half is
-decided from `last_text` alone, so deciding it first keeps the whole-session
-scan off the common path — a turn with no unqualified verdict claim cannot
-have one restated, whatever the history holds.
+Two properties, both about the same scan:
+
+  * it is not run at all when `last_text` carries no unqualified verdict claim,
+    because the first half of the question is answerable from `last_text` alone;
+  * while it runs, what is buffered is the verdict keys seen so far, not the
+    events carrying them — a completed turn can be most of a long session.
 
 Run: python3 -m pytest tests/test_runtime_state_claim_scan.py -q
 """
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
+import tracemalloc
 from pathlib import Path
-
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "hooks" / "_lib"))
@@ -26,47 +28,83 @@ assert _spec is not None and _spec.loader is not None
 gate = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(gate)  # type: ignore[union-attr]
 
-
-class _Tripwire:
-    """Iterating at all is the cost this short-circuit exists to avoid."""
-
-    def __iter__(self):
-        raise AssertionError("prior_events was scanned")
+_VERDICT = "행 3은 PASS 입니다."
 
 
-def test_no_unqualified_claim_leaves_history_unscanned() -> None:
-    restated, mentions = gate.detect_verdict_restatement(
-        "지금 배포 스크립트를 돌리는 중입니다.", _Tripwire()
-    )
-    assert (restated, mentions) == ([], {})
+def _write(path: Path, events: list[dict]) -> str:
+    path.write_text("".join(json.dumps(e) + "\n" for e in events))
+    return str(path)
 
 
-def test_unqualified_claim_still_scans_history() -> None:
+def _assistant(text: str, ts: str | None = None) -> dict:
+    ev: dict = {"type": "assistant", "message": {"role": "assistant",
+                                                 "content": [{"type": "text", "text": text}]}}
+    if ts:
+        ev["timestamp"] = ts
+    return ev
+
+
+def _user(text: str = "다음 단계 진행해줘") -> dict:
+    return {"type": "user", "message": {"role": "user", "content": text}}
+
+
+def test_no_unqualified_claim_leaves_the_transcript_unread(monkeypatch, tmp_path) -> None:
+    def tripwire(_path):
+        raise AssertionError("the transcript was scanned")
+
+    monkeypatch.setattr(gate, "prior_verdict_mentions", tripwire)
+    path = _write(tmp_path / "t.jsonl", [_user(), _assistant(_VERDICT)])
+    assert gate.detect_verdict_restatement("배포 스크립트를 돌리는 중입니다.", path) == ([], {})
+
+
+def test_unqualified_claim_still_reads_the_transcript(monkeypatch, tmp_path) -> None:
     """Mirror of the case above — without it, a gate that never scans passes."""
-    drained = {"n": 0}
+    calls = {"n": 0}
 
-    def counting():
-        drained["n"] += 1
-        yield from ()
+    def counting(_path):
+        calls["n"] += 1
+        return {}
 
-    text = "행 3은 PASS 입니다."
-    assert any(not c["qualified"] for c in gate.extract_verdict_claims(text)), (
+    monkeypatch.setattr(gate, "prior_verdict_mentions", counting)
+    assert any(not c["qualified"] for c in gate.extract_verdict_claims(_VERDICT)), (
         "fixture no longer parses as an unqualified verdict claim"
     )
-    gate.detect_verdict_restatement(text, counting())
-    assert drained["n"] == 1
+    gate.detect_verdict_restatement(_VERDICT, str(tmp_path / "t.jsonl"))
+    assert calls["n"] == 1
 
 
-def test_restatement_still_detected_across_prior_turns() -> None:
-    """The short-circuit must not cost the gate its actual finding."""
-    text = "행 3은 PASS 입니다."
-    key = gate.extract_verdict_claims(text)[0]["key"]
-    prior = [
-        {
-            "timestamp": "2026-08-23T00:00:00Z",
-            "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
-        }
-    ]
-    restated, mentions = gate.detect_verdict_restatement(text, iter(prior))
+def test_restatement_detected_across_a_prior_turn(tmp_path) -> None:
+    """The laziness must not cost the gate its actual finding."""
+    key = gate.extract_verdict_claims(_VERDICT)[0]["key"]
+    path = _write(tmp_path / "t.jsonl", [
+        _user(), _assistant(_VERDICT, "2026-08-23T00:00:00Z"),
+        _user(), _assistant("작업을 이어갑니다."),
+    ])
+    restated, mentions = gate.detect_verdict_restatement(_VERDICT, path)
     assert mentions, "prior-mention collector did not recognise the fixture text"
     assert key in restated
+
+
+def test_current_turn_does_not_count_as_its_own_prior_mention(tmp_path) -> None:
+    """The trailing pending group is the current turn and must be dropped —
+    otherwise the text being judged restates itself and every claim fires."""
+    path = _write(tmp_path / "t.jsonl", [_user(), _assistant(_VERDICT, "2026-08-23T00:00:00Z")])
+    assert gate.prior_verdict_mentions(path) == {}
+    assert gate.detect_verdict_restatement(_VERDICT, path) == ([], {})
+
+
+def test_peak_memory_does_not_track_the_size_of_a_completed_turn(tmp_path) -> None:
+    """Buffering the events made peak follow the largest turn: 8000 events of
+    4KB text peaked at ~39 MiB. Buffering the reduction keeps it flat."""
+    big = "y" * 4000
+    events = [_user()] + [_assistant(big, "2026-08-23T00:00:00Z") for _ in range(4000)]
+    events += [_user(), _assistant("현재 턴")]
+    path = _write(tmp_path / "t.jsonl", events)
+
+    tracemalloc.start()
+    try:
+        gate.prior_verdict_mentions(path)
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    assert peak < 2 * 1024 * 1024, f"peak {peak / 1024 / 1024:.2f} MiB — a turn is being buffered"

--- a/tests/test_runtime_state_claim_scan.py
+++ b/tests/test_runtime_state_claim_scan.py
@@ -1,0 +1,74 @@
+"""The runtime-state gate scans prior turns only when one could matter (#1076).
+
+`detect_verdict_restatement` answers a two-part question: is a verdict claim
+unqualified *here*, and was it already stated earlier. The first half is
+decided from `last_text` alone, so deciding it first keeps the whole-session
+scan off the common path — a turn with no unqualified verdict claim cannot
+have one restated, whatever the history holds.
+
+Run: python3 -m pytest tests/test_runtime_state_claim_scan.py -q
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "hooks" / "_lib"))
+
+_spec = importlib.util.spec_from_file_location(
+    "runtime_state_claim_gate",
+    REPO_ROOT / "hooks" / "completion-verify" / "runtime-state-claim-gate" / "impl.py",
+)
+assert _spec is not None and _spec.loader is not None
+gate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gate)  # type: ignore[union-attr]
+
+
+class _Tripwire:
+    """Iterating at all is the cost this short-circuit exists to avoid."""
+
+    def __iter__(self):
+        raise AssertionError("prior_events was scanned")
+
+
+def test_no_unqualified_claim_leaves_history_unscanned() -> None:
+    restated, mentions = gate.detect_verdict_restatement(
+        "지금 배포 스크립트를 돌리는 중입니다.", _Tripwire()
+    )
+    assert (restated, mentions) == ([], {})
+
+
+def test_unqualified_claim_still_scans_history() -> None:
+    """Mirror of the case above — without it, a gate that never scans passes."""
+    drained = {"n": 0}
+
+    def counting():
+        drained["n"] += 1
+        yield from ()
+
+    text = "행 3은 PASS 입니다."
+    assert any(not c["qualified"] for c in gate.extract_verdict_claims(text)), (
+        "fixture no longer parses as an unqualified verdict claim"
+    )
+    gate.detect_verdict_restatement(text, counting())
+    assert drained["n"] == 1
+
+
+def test_restatement_still_detected_across_prior_turns() -> None:
+    """The short-circuit must not cost the gate its actual finding."""
+    text = "행 3은 PASS 입니다."
+    key = gate.extract_verdict_claims(text)[0]["key"]
+    prior = [
+        {
+            "timestamp": "2026-08-23T00:00:00Z",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+        }
+    ]
+    restated, mentions = gate.detect_verdict_restatement(text, iter(prior))
+    if not mentions:
+        pytest.skip("prior-mention collector did not recognise the fixture text")
+    assert key in restated

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -428,8 +428,11 @@ _CONSUMERS = {
         ["load_current_turn", "extract_last_assistant_text"],
     HOOKS / "completion-verify" / "pr-claim-mutation-gate" / "impl.py":
         ["load_current_turn", "extract_last_assistant_text"],
+    # Also streams the turns BEFORE the current one, reusing the shared boundary
+    # predicate so the backward and forward directions cannot disagree (#1076).
     HOOKS / "completion-verify" / "runtime-state-claim-gate" / "impl.py":
-        ["load_current_turn", "extract_last_assistant_text"],
+        ["load_current_turn", "extract_last_assistant_text",
+         "is_turn_boundary", "iter_transcript"],
     HOOKS / "completion-verify" / "artifact-verdict-evidence-gate" / "impl.py":
         ["load_current_turn", "extract_last_assistant_text"],
     # The one scan that genuinely needs the whole session; it streams instead
@@ -465,6 +468,26 @@ def _load_module(path: Path):
 
 
 class TestSingleSource:
+    def test_consumers_list_every_lib_function_they_import(self):
+        """A hook importing a reader the map omits is unpinned — it could
+        redefine that reader locally and no test above would notice. Constants
+        (`TRANSCRIPT_SCAN_LINES`) are not bindings and are skipped."""
+        import ast
+
+        for impl in sorted(HOOKS.glob("*/*/impl.py")):
+            imported: set[str] = set()
+            for node in ast.walk(ast.parse(impl.read_text())):
+                if isinstance(node, ast.ImportFrom) and node.module == "_transcript":
+                    imported |= {a.name for a in node.names}
+            callables = {s for s in imported if callable(getattr(T, s, None))}
+            if not callables:
+                continue
+            declared = set(_CONSUMERS.get(impl, []))
+            assert callables <= declared, (
+                f"{impl.parent.name} imports {sorted(callables - declared)} "
+                f"but _CONSUMERS does not list them"
+            )
+
     def test_consumers_bind_lib_function_objects(self):
         for path, symbols in _CONSUMERS.items():
             mod = _load_module(path)

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -21,10 +21,14 @@ Run: python3 -m pytest tests/test_transcript.py -q
 """
 from __future__ import annotations
 
+import builtins
 import importlib.util
 import json
+import os
 import sys
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LIB_DIR = REPO_ROOT / "hooks" / "_lib"
@@ -473,3 +477,196 @@ class TestSingleSource:
                 if needle in text:
                     offenders.append(f"{impl}: {needle}")
         assert not offenders, f"local duplicates remain: {offenders}"
+
+
+class TestTailReaders:
+    """The bounded backward readers that replaced the whole-file loads (#1076).
+
+    A Stop-event session JSONL reaches hundreds of MB; nine gates each parsed
+    all of it on every response end. These cover that the tail readers agree
+    with the forward path they replaced, that the bound is real, and that the
+    two capped terminations behave as documented.
+    """
+
+    def test_current_turn_matches_the_forward_path(self, tmp_path):
+        events = [
+            _user(text="first"), _assistant(text="a1"),
+            _user(text="second"), _assistant(text="a2"), _assistant(text="a3"),
+        ]
+        path = _write_jsonl(tmp_path, events)
+        assert T.load_current_turn(path) == T.get_current_turn(T.load_transcript(path))
+
+    def test_tool_result_only_user_entry_is_not_a_boundary(self, tmp_path):
+        """The bridge for tool output is not human input — same rule as forward."""
+        path = _write_jsonl(tmp_path, [
+            _user(text="real input"),
+            _assistant(text="a1"),
+            _user(blocks=[{"type": "tool_result", "content": "out"}]),
+            _assistant(text="a2"),
+        ])
+        turn = T.load_current_turn(path)
+        assert turn == T.get_current_turn(T.load_transcript(path))
+        # The turn reaches back past the tool_result entry to the real input,
+        # so both assistant events are in it — 3 events, not 1.
+        assert len(turn) == 3
+
+    def test_no_boundary_anywhere_returns_every_event(self, tmp_path):
+        """`get_current_turn` returns everything when it finds no user input."""
+        path = _write_jsonl(tmp_path, [_assistant(text="a1"), _assistant(text="a2")])
+        assert T.load_current_turn(path) == T.load_transcript(path)
+
+    def test_missing_file_fails_open_empty(self, tmp_path):
+        assert T.load_current_turn(str(tmp_path / "absent.jsonl")) == []
+
+    def test_boundary_split_across_a_read_chunk(self, tmp_path):
+        """A record straddling the chunk seam must parse whole, not as a fragment.
+
+        The reader carries the leading partial line into the next chunk; without
+        that the boundary record is silently dropped and the turn runs long.
+        """
+        events = [_user(text="B" * (T._TAIL_CHUNK_BYTES // 2))]
+        events += [_assistant(text="x" * 4096) for _ in range(200)]
+        path = _write_jsonl(tmp_path, events)
+        assert T.load_current_turn(path) == T.get_current_turn(T.load_transcript(path))
+
+    def test_min_events_reaches_past_the_turn(self, tmp_path):
+        """merge-state-claim-gate's `events[-N:]` needs the window, not the turn."""
+        events = [_assistant(text=f"old{i}") for i in range(50)]
+        events += [_user(text="now"), _assistant(text="fresh")]
+        path = _write_jsonl(tmp_path, events)
+        full = T.load_transcript(path)
+        assert T.load_recent_events(path, min_events=0) == full[-2:]
+        assert T.load_recent_events(path, min_events=30)[-30:] == full[-30:]
+
+    def test_the_bound_is_enforced(self, tmp_path):
+        """A cap short of the boundary stops the read instead of walking to BOF.
+
+        What it returns is asserted in `TestCappedScanFailsOpen`: the tail it
+        holds has lost the front of the turn, so it fails open rather than
+        passing a subset off as the turn.
+        """
+        events = [_user(text="boundary")] + [_assistant(text="y" * 512) for _ in range(200)]
+        path = _write_jsonl(tmp_path, events)
+        read_bytes = sum(
+            len(raw) + 1 for raw in T._iter_lines_backwards(path, 4096)
+        )
+        assert read_bytes <= 4096 + T._TAIL_CHUNK_BYTES
+        assert read_bytes < os.path.getsize(path)
+
+    def test_last_user_message_matches_the_forward_path(self, tmp_path):
+        path = _write_jsonl(tmp_path, [
+            _user(text="older"), _assistant(text="a"), _user(text="newest"),
+        ])
+        assert T.read_last_user_message(path) == "newest"
+
+    def test_last_user_message_returns_none_when_the_cap_cut_it_short(
+        self, tmp_path, monkeypatch
+    ):
+        """"" means 'read it all, no signal' and callers act on it.
+
+        When the scan cap stopped short of the start of the file that is not
+        true, so the honest answer is the unreadable one — None, which every
+        caller fails open on.
+        """
+        path = _write_jsonl(tmp_path, [
+            _user(text="buried"),
+            *[_assistant(text="z" * 512) for _ in range(50)],
+        ])
+        monkeypatch.setattr(T, "CURRENT_TURN_SCAN_MAX_BYTES", 1024)
+        assert T.read_last_user_message(path) is None
+
+    def test_iter_transcript_matches_load_transcript(self, tmp_path):
+        path = _write_jsonl(tmp_path, [
+            _user(text="hi"), "broken", json.dumps([1]), _assistant(text="a"),
+        ])
+        assert list(T.iter_transcript(path)) == T.load_transcript(path)
+
+    def test_iter_transcript_missing_file_yields_nothing(self, tmp_path):
+        assert list(T.iter_transcript(str(tmp_path / "absent.jsonl"))) == []
+
+
+class TestCappedScanFailsOpen:
+    """A capped backward scan is a subset of the turn, never a superset.
+
+    The scan runs end-to-start, so cutting it short at `max_bytes` drops the
+    *earliest* events of the turn. A gate handed that tail would look for
+    evidence that is present in the turn, not find it, and block (codex review
+    round 1 on #1076, P1 — confirmed against a 1.33 MB turn under a 256 KiB cap:
+    590 events, first event of the turn absent).
+    """
+
+    def _over_cap_turn(self, tmp_path):
+        return _write_jsonl(tmp_path, [
+            _user(text="the real user input"),
+            _assistant(text="FIRST_AFTER_BOUNDARY"),
+            *[_assistant(text="y" * 512) for _ in range(60)],
+        ])
+
+    def test_current_turn_is_empty_when_the_cap_hides_the_boundary(
+        self, tmp_path
+    ):
+        path = self._over_cap_turn(tmp_path)
+        assert T.load_current_turn(path, max_bytes=1024) == []
+
+    def test_recent_events_is_empty_when_the_cap_hides_the_boundary(
+        self, tmp_path
+    ):
+        path = self._over_cap_turn(tmp_path)
+        assert T.load_recent_events(path, max_bytes=1024) == []
+
+    def test_whole_file_without_a_boundary_is_still_returned(self, tmp_path):
+        """Reaching the start of the file is not truncation."""
+        path = _write_jsonl(tmp_path, [
+            _assistant(text="a"), _assistant(text="b"),
+        ])
+        assert len(T.load_recent_events(path, max_bytes=10 * 1024)) == 2
+
+    def test_boundary_found_within_the_cap_is_unaffected(self, tmp_path):
+        path = _write_jsonl(tmp_path, [
+            _user(text="hi"), _assistant(text="one"), _assistant(text="two"),
+        ])
+        turn = T.load_current_turn(path, max_bytes=10 * 1024)
+        assert len(turn) == 2
+
+
+class TestReadFailurePropagates:
+    """A read that fails partway is not a transcript with no signal in it.
+
+    `read_last_user_message` returning "" says "read it all, found nothing" and
+    both preflight callers act on it; only None makes them fail open. An
+    `OSError` raised after `getsize` succeeded used to end the iterator
+    silently and produce "" (codex review round 1 on #1076, P1 — confirmed).
+    """
+
+    def _explode_on_binary_open(self, monkeypatch, path):
+        real_open = builtins.open
+
+        def boom(target, *args, **kwargs):
+            mode = args[0] if args else kwargs.get("mode", "r")
+            if str(target) == str(path) and "b" in mode:
+                raise OSError("simulated read failure")
+            return real_open(target, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", boom)
+
+    def test_last_user_message_is_none_when_the_read_fails(
+        self, tmp_path, monkeypatch
+    ):
+        path = _write_jsonl(tmp_path, [_user(text="hi")])
+        self._explode_on_binary_open(monkeypatch, path)
+        assert T.read_last_user_message(path) is None
+
+    def test_recent_events_fails_open_when_the_read_fails(
+        self, tmp_path, monkeypatch
+    ):
+        path = _write_jsonl(tmp_path, [_user(text="hi"), _assistant(text="a")])
+        self._explode_on_binary_open(monkeypatch, path)
+        assert T.load_recent_events(path) == []
+
+    def test_iter_lines_backwards_raises_rather_than_ending(
+        self, tmp_path, monkeypatch
+    ):
+        path = _write_jsonl(tmp_path, [_user(text="hi")])
+        self._explode_on_binary_open(monkeypatch, path)
+        with pytest.raises(T.TranscriptReadError):
+            list(T._iter_lines_backwards(path, 1024))

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -667,6 +667,61 @@ class TestCappedScanFailsOpen:
         assert len(turn) == 2
 
 
+class TestCapDecidedByTheReader:
+    """`""` vs `None` is decided by whether the walk reached the file start.
+
+    A size sampled before the walk cannot answer it: the transcript is appended
+    to live, so a file that measured under the cap can be over it by the time
+    the reader gets there — and `""` ("read it all, no signal") is acted on
+    while `None` fails open (codex review #1083 P2).
+    """
+
+    @staticmethod
+    def _drain(walk):
+        """The value is carried by the StopIteration that ends the walk — a
+        `for` loop swallows it, and a later `next()` sees a closed generator."""
+        while True:
+            try:
+                next(walk)
+            except StopIteration as done:
+                return done.value
+
+    def test_reader_reports_reaching_the_start(self, tmp_path):
+        path = tmp_path / "t.jsonl"
+        path.write_text("a\nb\nc\n")
+        assert self._drain(T._iter_lines_backwards(str(path), 1024)) is True
+
+    def test_reader_reports_stopping_at_the_cap(self, tmp_path):
+        path = tmp_path / "t.jsonl"
+        path.write_text(("x" * 100 + "\n") * 50)
+        assert self._drain(T._iter_lines_backwards(str(path), 200)) is False
+
+    def test_stale_size_cannot_turn_a_capped_scan_into_no_signal(
+        self, tmp_path, monkeypatch
+    ):
+        path = tmp_path / "t.jsonl"
+        line = json.dumps(
+            {"type": "assistant",
+             "message": {"role": "assistant", "content": [{"type": "text", "text": "x" * 80}]}}
+        )
+        path.write_text((line + "\n") * 60)
+        monkeypatch.setattr(T, "CURRENT_TURN_SCAN_MAX_BYTES", 2000)
+        # A size from before the file grew past the cap — the shape the live
+        # transcript actually produces.
+        real = os.path.getsize
+        monkeypatch.setattr(
+            T.os.path, "getsize", lambda q: 1500 if q == str(path) else real(q)
+        )
+        assert T.read_last_user_message(str(path)) is None
+
+    def test_within_the_cap_still_answers_no_signal(self, tmp_path):
+        """Positive control — `None` everywhere would pass the test above."""
+        path = tmp_path / "t.jsonl"
+        path.write_text(json.dumps({"type": "assistant", "message": {"role": "assistant",
+                                                                     "content": []}}) + "\n")
+        assert T.read_last_user_message(str(path)) == ""
+
+
 class TestReadFailurePropagates:
     """A read that fails partway is not a transcript with no signal in it.
 

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -415,12 +415,27 @@ HOOKS = REPO_ROOT / "hooks"
 
 _CONSUMERS = {
     HOOKS / "completion-verify" / "readonly-verify-deferral-gate" / "impl.py":
-        ["load_transcript", "get_current_turn", "extract_last_assistant_text"],
+        ["load_current_turn", "extract_last_assistant_text"],
     HOOKS / "completion-verify" / "completion-signal-gate" / "impl.py":
-        ["load_transcript", "get_current_turn", "extract_last_assistant_text",
-         "has_tool_in_turn"],
+        ["load_current_turn", "extract_last_assistant_text", "has_tool_in_turn"],
+    # Reads a fixed window past the turn (`events[-_EVIDENCE_WINDOW:]`), so it
+    # binds the min_events reader and slices the turn out itself (#1076).
     HOOKS / "completion-verify" / "merge-state-claim-gate" / "impl.py":
-        ["load_transcript", "get_current_turn", "extract_last_assistant_text"],
+        ["load_recent_events", "get_current_turn", "extract_last_assistant_text"],
+    HOOKS / "completion-verify" / "negative-existence-verdict-gate" / "impl.py":
+        ["load_current_turn", "extract_last_assistant_text"],
+    HOOKS / "completion-verify" / "proposal-premise-gate" / "impl.py":
+        ["load_current_turn", "extract_last_assistant_text"],
+    HOOKS / "completion-verify" / "pr-claim-mutation-gate" / "impl.py":
+        ["load_current_turn", "extract_last_assistant_text"],
+    HOOKS / "completion-verify" / "runtime-state-claim-gate" / "impl.py":
+        ["load_current_turn", "extract_last_assistant_text"],
+    HOOKS / "completion-verify" / "artifact-verdict-evidence-gate" / "impl.py":
+        ["load_current_turn", "extract_last_assistant_text"],
+    # The one scan that genuinely needs the whole session; it streams instead
+    # of materializing it (#1076).
+    HOOKS / "completion-verify" / "pr-report-destination-gate" / "impl.py":
+        ["iter_transcript"],
     HOOKS / "preflight-gate" / "block-gh-issue-create-without-dup-search" / "impl.py":
         ["read_transcript_tail"],
     HOOKS / "preflight-gate" / "block-sciomc-finding-commit" / "impl.py":


### PR DESCRIPTION
Closes #1076

Caller chain verified: grep -rl 'load_current_turn\|load_recent_events\|iter_transcript' hooks/ -> 9 gate impl.py files plus the lib itself; the _CONSUMERS invariant test in tests/test_transcript.py binds each of the 9 to the functions it calls
Pre-commit verified: ./scripts/run-tests.sh -> ALL TESTS PASSED (the repo has no pre-commit config; this script is what ci.yml mirrors)

### 무엇이 문제였나

모든 completion-verify 게이트가 "이번 턴" 만 필요한데도 세션 JSONL 전체를 파싱하고 있었습니다. 이 머신의 923개 파일 중 65개가 10MB를 넘고 최대 225MB입니다. Stop 훅 예산은 10초라, 마지막 몇 개 이벤트를 읽으려고 수백 MB를 파싱하다 SIGKILL 되면 그 훅이 들고 있던 게이트가 전부 조용히 사라집니다.

### 무엇이 바뀌나

- **tail 리더** — 파일 끝에서 256KiB 청크로 거꾸로 읽다가 턴 경계에서 멈춥니다. 현재 턴만 필요한 호출자는 현재 턴 값만 냅니다.
- **6개 게이트** 가 턴을 직접 요청합니다. `merge-state-claim-gate` 는 턴 + 뒤쪽 80이벤트 창이 함께 필요해 다른 호출을 씁니다.
- **2개 게이트는 실제로 세션 전체를 읽습니다** — 어떤 PR이 언급/보고됐는지 묻는 쪽과, 어떤 판정 숫자를 이번 세션에서 이미 말했는지 묻는 쪽. 둘 다 전량 적재 대신 스트리밍으로 줄여 나갑니다.

### 리뷰에서 나온 것

codex 리뷰 1라운드에서 2건이 실측으로 확인돼 반영했고, 1건은 반증해 기각했습니다.

<details><summary>Reader — 캡에 걸린 tail 을 완전한 턴으로 취급하던 문제</summary><br>

뒤에서 읽으므로 캡에 걸리면 턴의 **앞부분**이 잘립니다. 즉 부분집합이지 상위집합이 아닙니다. 게이트가 이걸 받으면 실제로는 있는 증거를 못 찾고 차단합니다.

```
$ python3 -c "... load_current_turn(1.33MB turn, max_bytes=256KiB)"
turn_len=590  has_first_event_of_turn=False  has_boundary=False
# 수정 후
load_current_turn -> []      # fail-open
```

</details>

<details><summary>Reader — 읽기 실패를 "" 로 반환하던 문제</summary><br>

`""` 는 "다 읽었는데 신호가 없다" 는 뜻이라 호출부가 그대로 행동합니다. fail-open 은 `None` 에서만 걸립니다.

```
$ grep -n "user_message is None" hooks/preflight-gate/*/impl.py
block-ask-end-option/impl.py:355:    if user_message is None:
block-manufactured-action-menu/impl.py:461:    if user_message is None:
```

getsize 성공 후 open 이 OSError 를 내는 경우 — 수정 전 `''`, 수정 후 `None`.

</details>

<details><summary>기각 — chunk 경계의 첫 레코드 유실 (반증됨)</summary><br>

`lines.pop(0)` 의 결과는 버려지지 않고 `partial` 에 대입돼 다음 청크의 `fh.read(step) + partial` 로 앞에 붙습니다.

```
# 레코드 경계가 chunk seam 에 정확히 정렬된 768KB 파일 (6144 레코드, 128B 고정 길이)
got=6144 / expected=6144, 순서·개수 완전 일치
```

</details>

### 검증

```
$ ./scripts/run-tests.sh
ALL TESTS PASSED
```

첫 커밋만 단독으로 체크아웃해도 성립합니다:

```
$ ruff check --no-cache .   → All checks passed!
$ pytest -q                 → 841 passed, 1 xfailed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streaming transcript processing for large conversations.
  * Added bounded scanning for recent events and the current conversation turn.
  * Improved turn detection by excluding sidechain and tool-result-only events.
  * Reduced memory usage during report and verification processing.

* **Bug Fixes**
  * Improved safe handling of read failures and incomplete scans.
  * Verification checks now focus on relevant, complete transcript data.

* **Tests**
  * Expanded coverage for streaming, bounded scans, malformed input, and memory usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> **정정 (머지 후)** — 위 `Caller chain verified:` 줄의 grep 패턴에 `|` 가 이스케이프돼 있지 않아,
> 게시된 그대로 실행하면 BRE 에서 `|` 가 리터럴로 읽혀 **exit 1, 출력 0줄**이 납니다. 실제로 돌렸던 것은
> `\|` 로 이스케이프한 형태이고 그 결과가 10개 파일(게이트 impl 9 + 라이브러리 1)입니다. 개수 주장 자체는
> 바뀌지 않으며, 고친 것은 명령 표기입니다. 이 줄은 `block-pr-without-caller-evidence` 게이트를 통과시킨
> 근거였으므로, 재현되지 않는 상태로 두면 게이트가 형식만 충족된 채 남습니다.
