### PR TITLE
perf(hooks): scan the transcript only when a gate needs it

### DIFF
--- a/hooks/completion-verify/retrospect-mix-check/impl.sh
+++ b/hooks/completion-verify/retrospect-mix-check/impl.sh
@@ -68,89 +68,6 @@ command -v praxis_fire_arm >/dev/null 2>&1 && \
 [ "$STOP_HOOK_ACTIVE" = "true" ] && exit 0
 [ ! -f "$TRANSCRIPT_PATH" ] && exit 0
 
-# ── Silent-pass scan + critic-run detection (issue #772) ──────────────────────
-# HOISTED above every gate because Gate-8c's eligibility (below) consumes
-# GATE9_HARD_COUNT (NEW-2). Everything here is FAIL-OPEN: a missing scanner /
-# catalog, or any jq error, must never convert a pass into a crash — all
-# captures use `2>/dev/null` with numeric/string defaults.
-_SP_LIB="$(dirname "$0")/../../_lib"
-SP_SCANNER="$_SP_LIB/scan-silent-pass.sh"
-SP_CATALOG="$_SP_LIB/silent-pass-catalog.json"
-SILENT_PASS_MATCHES=""
-if [ -f "$SP_SCANNER" ] && [ -f "$SP_CATALOG" ]; then
-  SILENT_PASS_MATCHES=$(bash "$SP_SCANNER" --transcript "$TRANSCRIPT_PATH" --catalog "$SP_CATALOG" 2>/dev/null || true)
-fi
-# Count of HARD (zero-FP) silent-pass candidates — drives Gate-9 coverage AND
-# Gate-8c/Gate-10 eligibility. awk emits `c+0` so this is always an integer.
-GATE9_HARD_COUNT=$(printf '%s\n' "$SILENT_PASS_MATCHES" \
-  | awk -F'\t' 'NF>=2 && $2=="hard" { c++ } END { print c+0 }')
-
-# Strong-correction count (transcript-derived eligibility half). This is the SAME
-# regex + jq the Gate-8c floor uses; hoisted here so both Gate-8c and the
-# block-decision Gate-10 read one value (no double jq, no drift). Kept low-FP per
-# issue #722 (see the Gate-8c comment for the dropped everyday tokens).
-SP_STRONG_CORRECTION_RE="하라고 했잖아|that's not what I asked|그렇게 하지 말라고"
-LIVE_STRONG_UC_COUNT=$(jq -r --arg re "$SP_STRONG_CORRECTION_RE" '
-  def human_text_payload:
-    (.message.content // .content // empty) as $c
-    | if ($c|type) == "array" then
-        $c[]? | if type == "object" then
-          if ((.type? // "text") == "text") then (.text? // empty) else empty end
-        else tostring end
-      elif ($c|type) == "string" then $c
-      else empty end;
-  select(type == "object" and .type != "tool_result" and (.message.role == "user" or .role == "user" or .type == "user") and ([human_text_payload] | join("\n") | test($re; "i"))) | 1
-' "$TRANSCRIPT_PATH" 2>/dev/null | wc -l | tr -d '[:space:]')
-LIVE_STRONG_UC_COUNT=${LIVE_STRONG_UC_COUNT:-0}
-
-# Critic-run detection (D-C2 anti-tamper oracle). The authoritative "did the
-# externalized critic actually run" signal is a `critic_roots:` block emitted in
-# the critic subagent's RETURN. A subagent return is delivered to the main agent
-# as a role:user tool_result record, so we extract text ONLY from tool_result
-# blocks — via `.. | objects | select(.type=="tool_result")`, which finds a
-# tool_result at top level OR nested inside a user message's content array. A
-# `retrospect:critic_roots` fence pasted into the MAIN agent's assistant text
-# (isSidechain:false) is display-only and MUST NOT count — that is the C2
-# property (the agent cannot self-certify the tier by pasting a fence), and it is
-# structurally excluded here because assistant text never lives in a tool_result
-# block. Tool_result attribution is reliable with the pinned critic contract, so
-# the plan's isSidechain:true fallback is NOT used. jq errors on a partially
-# written final line fail open (empty text ⇒ CRITIC_RAN=false ⇒ Gate-8c may
-# block an eligible session — the safe direction).
-CRITIC_TR_TEXT=$(jq -rs '
-  def tr_texts:
-    .. | objects | select(.type == "tool_result")
-    | (.content // .text // empty) as $c
-    | if ($c | type) == "array" then
-        ($c[]? | if type == "object" then (.text? // empty)
-                 elif type == "string" then .
-                 else empty end)
-      elif ($c | type) == "string" then $c
-      else empty end;
-  [ .[] | tr_texts ] | join("\n")
-' "$TRANSCRIPT_PATH" 2>/dev/null || true)
-CRITIC_RAN=false
-CRITIC_ROOTS=""
-if printf '%s\n' "$CRITIC_TR_TEXT" | grep -q 'critic_roots:'; then
-  CRITIC_RAN=true
-  # Root-ids are the contiguous `- <root-id>: <one-line>` bullets that follow the
-  # `critic_roots:` header (blank lines inside the block are tolerated). An empty
-  # block (header with no bullets) yields zero roots → CRITIC_RAN=true with empty
-  # CRITIC_ROOTS (critic ran, 0 roots).
-  CRITIC_ROOTS=$(printf '%s\n' "$CRITIC_TR_TEXT" | awk '
-    /critic_roots:/ { f=1; next }
-    f && /^[[:space:]]*$/ { next }
-    f && /^[[:space:]]*-[[:space:]]*[^:]+:/ {
-      s=$0
-      sub(/^[[:space:]]*-[[:space:]]*/, "", s)
-      sub(/:.*/, "", s)
-      gsub(/^[[:space:]]+|[[:space:]]+$/, "", s)
-      if (s != "") print s
-      next
-    }
-    f { exit }
-  ')
-fi
 
 # Extract last assistant message text from the transcript JSONL.
 LAST_TEXT=$(tail -n 400 "$TRANSCRIPT_PATH" | jq -rs '
@@ -277,6 +194,99 @@ fi
 
 if printf '%s' "$MOST_RECENT_BLOCK" | grep -qF '## Actions Executed'; then
   exit 0
+fi
+
+# ── Silent-pass scan + critic-run detection (issue #772) ──────────────────────
+# Placed AFTER every gate that can exit without reading them (issue #1077) —
+# the identifier gates and the Stage 4 carve-out both sit above. These
+# three passes read the WHOLE transcript — a grep sweep, a jq pass, and a `jq
+# -rs` slurp — and at 224 MB the grep alone took 19.98s against this hook's 10s
+# budget, so the hook was SIGKILLed and every gate it holds silently vanished.
+# Nothing here is consumed before Gate-8c (first use ~700 lines below), and no
+# path above can block without HAS_FENCE or the retrospect-active marker, so
+# running them only once a gateable Stage 3 report is in hand is behaviour-
+# preserving: the ordinary Stop, which is nearly every Stop, now does none of
+# it, and neither does a Stage 4 completion report, which exits above.
+# Everything here is FAIL-OPEN: a missing scanner / catalog, or any jq error,
+# must never convert a pass into a crash — all captures use `2>/dev/null` with
+# numeric/string defaults.
+_SP_LIB="$(dirname "$0")/../../_lib"
+SP_SCANNER="$_SP_LIB/scan-silent-pass.sh"
+SP_CATALOG="$_SP_LIB/silent-pass-catalog.json"
+SILENT_PASS_MATCHES=""
+if [ -f "$SP_SCANNER" ] && [ -f "$SP_CATALOG" ]; then
+  SILENT_PASS_MATCHES=$(bash "$SP_SCANNER" --transcript "$TRANSCRIPT_PATH" --catalog "$SP_CATALOG" 2>/dev/null || true)
+fi
+# Count of HARD (zero-FP) silent-pass candidates — drives Gate-9 coverage AND
+# Gate-8c/Gate-10 eligibility. awk emits `c+0` so this is always an integer.
+GATE9_HARD_COUNT=$(printf '%s\n' "$SILENT_PASS_MATCHES" \
+  | awk -F'\t' 'NF>=2 && $2=="hard" { c++ } END { print c+0 }')
+
+# Strong-correction count (transcript-derived eligibility half). This is the SAME
+# regex + jq the Gate-8c floor uses; hoisted here so both Gate-8c and the
+# block-decision Gate-10 read one value (no double jq, no drift). Kept low-FP per
+# issue #722 (see the Gate-8c comment for the dropped everyday tokens).
+SP_STRONG_CORRECTION_RE="하라고 했잖아|that's not what I asked|그렇게 하지 말라고"
+LIVE_STRONG_UC_COUNT=$(jq -r --arg re "$SP_STRONG_CORRECTION_RE" '
+  def human_text_payload:
+    (.message.content // .content // empty) as $c
+    | if ($c|type) == "array" then
+        $c[]? | if type == "object" then
+          if ((.type? // "text") == "text") then (.text? // empty) else empty end
+        else tostring end
+      elif ($c|type) == "string" then $c
+      else empty end;
+  select(type == "object" and .type != "tool_result" and (.message.role == "user" or .role == "user" or .type == "user") and ([human_text_payload] | join("\n") | test($re; "i"))) | 1
+' "$TRANSCRIPT_PATH" 2>/dev/null | wc -l | tr -d '[:space:]')
+LIVE_STRONG_UC_COUNT=${LIVE_STRONG_UC_COUNT:-0}
+
+# Critic-run detection (D-C2 anti-tamper oracle). The authoritative "did the
+# externalized critic actually run" signal is a `critic_roots:` block emitted in
+# the critic subagent's RETURN. A subagent return is delivered to the main agent
+# as a role:user tool_result record, so we extract text ONLY from tool_result
+# blocks — via `.. | objects | select(.type=="tool_result")`, which finds a
+# tool_result at top level OR nested inside a user message's content array. A
+# `retrospect:critic_roots` fence pasted into the MAIN agent's assistant text
+# (isSidechain:false) is display-only and MUST NOT count — that is the C2
+# property (the agent cannot self-certify the tier by pasting a fence), and it is
+# structurally excluded here because assistant text never lives in a tool_result
+# block. Tool_result attribution is reliable with the pinned critic contract, so
+# the plan's isSidechain:true fallback is NOT used. jq errors on a partially
+# written final line fail open (empty text ⇒ CRITIC_RAN=false ⇒ Gate-8c may
+# block an eligible session — the safe direction).
+CRITIC_TR_TEXT=$(jq -rs '
+  def tr_texts:
+    .. | objects | select(.type == "tool_result")
+    | (.content // .text // empty) as $c
+    | if ($c | type) == "array" then
+        ($c[]? | if type == "object" then (.text? // empty)
+                 elif type == "string" then .
+                 else empty end)
+      elif ($c | type) == "string" then $c
+      else empty end;
+  [ .[] | tr_texts ] | join("\n")
+' "$TRANSCRIPT_PATH" 2>/dev/null || true)
+CRITIC_RAN=false
+CRITIC_ROOTS=""
+if printf '%s\n' "$CRITIC_TR_TEXT" | grep -q 'critic_roots:'; then
+  CRITIC_RAN=true
+  # Root-ids are the contiguous `- <root-id>: <one-line>` bullets that follow the
+  # `critic_roots:` header (blank lines inside the block are tolerated). An empty
+  # block (header with no bullets) yields zero roots → CRITIC_RAN=true with empty
+  # CRITIC_ROOTS (critic ran, 0 roots).
+  CRITIC_ROOTS=$(printf '%s\n' "$CRITIC_TR_TEXT" | awk '
+    /critic_roots:/ { f=1; next }
+    f && /^[[:space:]]*$/ { next }
+    f && /^[[:space:]]*-[[:space:]]*[^:]+:/ {
+      s=$0
+      sub(/^[[:space:]]*-[[:space:]]*/, "", s)
+      sub(/:.*/, "", s)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", s)
+      if (s != "") print s
+      next
+    }
+    f { exit }
+  ')
 fi
 
 # Parse distribution-card key/value pairs.


### PR DESCRIPTION
Closes #1077

Caller chain verified: the moved block defines 10 variables and none is read before Gate-8c; `sed -n '263,289p' impl.sh | grep -E '<the 10 names>'` -> exit=1 (no output)
Pre-commit verified: ./scripts/run-tests.sh -> ALL TESTS PASSED (the repo has no pre-commit config; this script is what ci.yml mirrors)

### 무엇이 문제였나

`retrospect-mix-check` 는 훅 맨 위에서 전체 transcript 를 세 번 훑습니다 — grep 한 번, jq 한 번, `jq -rs` slurp 한 번. 224MB 파일에서 grep 만 19.98초가 걸렸고, 이 훅의 예산은 10초입니다. 예산을 넘기면 SIGKILL 되고, 이 훅이 들고 있던 게이트가 전부 조용히 사라집니다.

문제는 그 세 패스가 **아무것도 걸러내기 전에** 돈다는 것입니다. 평범한 Stop — 거의 모든 Stop — 은 그 결과를 한 줄도 안 읽고 바로 빠져나갑니다.

### 무엇이 바뀌나

블록을 아래로 내려, 통과 가능한 Stage 3 보고서가 손에 들어온 뒤에만 돌게 했습니다. Stage 4 완료 보고서(`## Actions Executed`) 도 그 위에서 빠져나가므로 마찬가지로 스캔 값을 치르지 않습니다.

### 동작이 그대로인 근거

<details><summary>옮긴 블록의 변수가 사이 구간에서 쓰이지 않음</summary><br>

블록이 정의하는 10개 변수 중 어느 것도 `MOST_RECENT_BLOCK` 계산과 Stage 4 carve-out 구간(263-289)에서 쓰이지 않습니다.

```
$ sed -n '263,289p' impl.sh | grep -E '_SP_LIB|SP_SCANNER|SP_CATALOG|SILENT_PASS_MATCHES|GATE9_HARD_COUNT|SP_STRONG_CORRECTION_RE|LIVE_STRONG_UC_COUNT|CRITIC_TR_TEXT|CRITIC_RAN|CRITIC_ROOTS'
(출력 없음, exit=1)
```

</details>

<details><summary>사이 구간에 다른 조기 종료가 없음</summary><br>

```
$ sed -n '173,288p' impl.sh | grep -E '^\s*(exit|return)\b'
115:  exit 0      ← 절대행 287, 곧 Stage 4 carve-out 그 자체
```

</details>

### 검증

```
$ bash tests/hooks/completion-verify/test_retrospect_mix_check.sh
PASS  [DA13_pass_stage4_carveout]
Cases:    165 passed, 0 failed
Fixtures: 11 passed, 0 failed

$ bash tests/hooks/completion-verify/test_retrospect_replay_silent_pass.sh
--- retrospect-replay-silent-pass: 5 pass / 0 fail ---

$ ./scripts/run-tests.sh
ALL TESTS PASSED
```

Stage 4 carve-out 을 지나서 도는지는 codex 리뷰 1라운드에서 지적돼 반영했습니다.
