### PR TITLE
chore(hooks): retain telemetry 30 days and prefilter its scan

### DIFF
--- a/hooks/_lib/_fire_ledger.py
+++ b/hooks/_lib/_fire_ledger.py
@@ -496,6 +496,25 @@ def record_session_fire(hook: str, role: str, decision: str, session_id: str, to
         return False  # fail-open — never break the hook
 
 
+def _raw_needle(value: str) -> str | None:
+    """The quoted `value` as it appears in a record, or None if it cannot.
+
+    Two things this must NOT do, both of which turn the prefilter from a
+    necessary condition into a wrong one:
+
+    - Include the key and its separator. `"session_id": "x"` assumes one
+      writer's exact spacing, and a record written compactly (no space after
+      the colon) is then skipped while it should have matched.
+    - Assume the value survives JSON encoding unchanged. A quote or a
+      backslash is escaped on the way in, so the raw needle misses every
+      matching record. Such a value returns None and the caller parses every
+      line — the slow path, never the wrong one.
+    """
+    if json.dumps(value, ensure_ascii=False) != f'"{value}"':
+        return None
+    return f'"{value}"'
+
+
 def count_session_fires(hook: str, session_id: str, decision: str | None = None) -> int:
     """Count today's RICH fire records for `(hook, session_id)`; the in-session
     read path this ledger previously lacked (issue #805).
@@ -554,7 +573,26 @@ def count_session_fires(hook: str, session_id: str, decision: str | None = None)
             with os.fdopen(fd, encoding="utf-8", errors="replace") as f:
                 fd = -1  # ownership transferred to the file object
                 count = 0
+                # Substring prefilter before the parse (#1078). A matching
+                # record must contain both literals, so rejecting on them is
+                # exact — and it rejects in C. The ledger is overwhelmingly
+                # coarse records carrying `"session_id": ""`, which is why
+                # parsing every line to discard almost all of them cost 0.83s
+                # against an 87 MB day file.
+                # A matching record contains both values as quoted literals,
+                # so rejecting on them is a necessary condition — and it
+                # rejects in C. The ledger is overwhelmingly coarse records
+                # carrying an empty session_id, which is why parsing every line
+                # to discard almost all of them cost 0.83s against an 87 MB day
+                # file. `_raw_needle` returns None for a value it cannot match
+                # this way; that value falls through to the full parse.
+                needle_hook = _raw_needle(hook)
+                needle_session = _raw_needle(session_id)
                 for line in f:
+                    if needle_hook is not None and needle_hook not in line:
+                        continue
+                    if needle_session is not None and needle_session not in line:
+                        continue
                     line = line.strip()
                     if not line:
                         continue

--- a/hooks/_lib/_fire_ledger.py
+++ b/hooks/_lib/_fire_ledger.py
@@ -92,7 +92,7 @@ from __future__ import annotations
 import json
 import os
 import stat
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 DECISION_BLOCK = "block"
@@ -167,6 +167,91 @@ def suppress_coarse_duplicate() -> None:
     mark_dispatcher_process()
 
 
+# Days of daily telemetry files kept on disk. The ledger is append-only and had
+# no sweep at all: 59 files over ~2.5 months reached 1.7 GB, growing ~680 MB a
+# month (issue #1078). The sibling cache root under ~/.praxis already had a TTL
+# sweep; only telemetry was missing one.
+#
+# 30 rather than `bypass-review`'s 7-day default window: that default is the
+# report's convenience, not its limit (`-d N` takes any N), and the hook-prune
+# audits in docs/ read 30-day windows. Retention shorter than the longest window
+# anyone actually reads would delete the evidence those audits are scored from.
+_DEFAULT_RETENTION_DAYS = 30
+
+# Both families live in one telemetry_dir and `bypass-review fire-rate` joins
+# them, so they age out together — sweeping one alone would leave the report
+# showing fires with no bypasses, or the reverse.
+_SWEEPABLE_PREFIXES = ("fire-events-", "bypass-events-")
+_DATED_SUFFIX = ".jsonl"
+
+
+def retention_days() -> float:
+    """Age past which a daily telemetry file is swept.
+
+    `PRAXIS_TELEMETRY_RETENTION_DAYS` overrides; 0 or a malformed value keeps
+    everything, which is the pre-#1078 behavior.
+    """
+    raw = os.environ.get("PRAXIS_TELEMETRY_RETENTION_DAYS")
+    if raw is None:
+        return _DEFAULT_RETENTION_DAYS
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return 0.0
+
+
+def _file_date(name: str) -> str | None:
+    """The YYYY-MM-DD a daily telemetry filename carries, or None.
+
+    Read from the NAME, not from mtime: these files are the record of what a
+    given day did, and an mtime is changed by anything that touches the file.
+    """
+    for prefix in _SWEEPABLE_PREFIXES:
+        if name.startswith(prefix) and name.endswith(_DATED_SUFFIX):
+            stamp = name[len(prefix):-len(_DATED_SUFFIX)]
+            try:
+                datetime.strptime(stamp, "%Y-%m-%d")
+            except ValueError:
+                return None
+            return stamp
+    return None
+
+
+def prune_telemetry(directory: Path, days: float | None = None) -> int:
+    """Delete daily telemetry files older than the retention window.
+
+    Returns the number removed. Never raises — telemetry housekeeping must not
+    break the hook that triggered it, so every failure is a silent skip.
+
+    Only files matching a known dated family are considered, so anything else a
+    user or a future writer puts in this directory is left alone.
+    """
+    keep = retention_days() if days is None else days
+    if keep <= 0:
+        return 0
+    cutoff = (
+        datetime.now(tz=timezone.utc) - timedelta(days=keep)
+    ).strftime("%Y-%m-%d")
+    removed = 0
+    try:
+        entries = os.scandir(directory)
+    except OSError:
+        return 0
+    with entries:
+        for entry in entries:
+            try:
+                if not entry.is_file(follow_symlinks=False):
+                    continue
+                stamp = _file_date(entry.name)
+                if stamp is None or stamp >= cutoff:
+                    continue
+                os.unlink(entry.path)
+                removed += 1
+            except OSError:
+                continue
+    return removed
+
+
 def _atomic_append(path: Path, lines: list[str]) -> None:
     """Append `lines` as JSONL with per-line atomic writes; best-effort safe.
 
@@ -181,6 +266,13 @@ def _atomic_append(path: Path, lines: list[str]) -> None:
     if not lines:
         return
     path.parent.mkdir(parents=True, exist_ok=True)
+    # Retention sweep (#1078), triggered by the day rolling over rather than by
+    # a stamp file: the target is one file per UTC day, so "today's file does
+    # not exist yet" IS the once-a-day edge, and it costs one stat on a path
+    # this function is about to open anyway. Concurrent first-writers may each
+    # sweep; unlink is idempotent and every error is swallowed, so a duplicate
+    # sweep is wasted work, never damage.
+    first_write_of_the_day = not path.exists()
     try:
         if not stat.S_ISREG(os.lstat(path).st_mode):
             return  # FIFO / device / socket / symlink — refuse to write
@@ -199,6 +291,11 @@ def _atomic_append(path: Path, lines: list[str]) -> None:
             os.write(fd, (line + "\n").encode("utf-8"))
     finally:
         os.close(fd)
+    if first_write_of_the_day:
+        try:
+            _ = prune_telemetry(path.parent)
+        except Exception:
+            pass  # housekeeping never breaks the write that triggered it
 
 
 DEV_LEDGER_DIRNAME = ".praxis-dev-telemetry"

--- a/hooks/postuse-correction/bypass-telemetry/impl.py
+++ b/hooks/postuse-correction/bypass-telemetry/impl.py
@@ -52,7 +52,7 @@ import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
-from _fire_ledger import resolve_telemetry_dir  # type: ignore[import-not-found]  # noqa: E402
+from _fire_ledger import prune_telemetry, resolve_telemetry_dir  # type: ignore[import-not-found]  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -236,10 +236,21 @@ def append_record(record: dict) -> None:
     path = resolve_telemetry_path()
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
+        # Same day-rollover trigger the fire ledger uses (#1078): today's file
+        # not existing yet is the first write of the day, and the only moment
+        # worth paying for a directory sweep. `bypass-events-` is one of the
+        # retention prefixes, and this is the only path that writes it — the
+        # fire ledger's own sweep never runs when fire telemetry is disabled.
+        first_write_of_the_day = not path.exists()
         with path.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(record, ensure_ascii=False) + "\n")
     except Exception:  # noqa: BLE001
-        pass  # fail-open — never block the tool call
+        return  # fail-open — never block the tool call
+    if first_write_of_the_day:
+        try:
+            prune_telemetry(path.parent)
+        except Exception:  # noqa: BLE001
+            pass  # housekeeping never breaks the write that triggered it
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -22,9 +22,9 @@ import os
 import stat
 import subprocess
 import sys
+from datetime import datetime, timedelta, timezone
 import uuid
 from contextlib import redirect_stdout
-from datetime import datetime, timezone
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
@@ -1607,3 +1607,102 @@ def test_bypass_and_fire_writers_share_one_directory():
         _REPO / "hooks" / "postuse-correction" / "bypass-telemetry" / "impl.py",
     )
     assert bypass.resolve_telemetry_path().parent == fl.resolve_telemetry_dir()
+
+
+# ---------------------------------------------------------------------------
+# Retention sweep (#1078)
+# ---------------------------------------------------------------------------
+#
+# The ledger was append-only with no sweep: 59 daily files over ~2.5 months
+# reached 1.7 GB, growing ~680 MB a month. These cover that old files go, that
+# recent ones and foreign files stay, that both dated families age out together
+# (`bypass-review fire-rate` joins them), and that the sweep is reachable from
+# the write path exactly on the day roll-over.
+
+
+def _dated(directory: Path, prefix: str, days_ago: int) -> Path:
+    stamp = (datetime.now(tz=timezone.utc) - timedelta(days=days_ago)).strftime("%Y-%m-%d")
+    p = directory / f"{prefix}{stamp}.jsonl"
+    p.write_text('{"hook": "x"}\n')
+    return p
+
+
+def test_prune_removes_only_files_past_the_window(tmp_path):
+    old = _dated(tmp_path, "fire-events-", 40)
+    edge = _dated(tmp_path, "fire-events-", 30)
+    recent = _dated(tmp_path, "fire-events-", 5)
+    removed = fl.prune_telemetry(tmp_path, days=30)
+    assert not old.exists()
+    assert recent.exists()
+    assert edge.exists()  # exactly at the window is still inside it
+    assert removed == 1
+
+
+def test_prune_ages_both_families_together(tmp_path):
+    """`bypass-review fire-rate` joins the two; sweeping one alone corrupts it."""
+    fires = _dated(tmp_path, "fire-events-", 40)
+    bypasses = _dated(tmp_path, "bypass-events-", 40)
+    assert fl.prune_telemetry(tmp_path, days=30) == 2
+    assert not fires.exists() and not bypasses.exists()
+
+
+def test_prune_leaves_unrelated_files_alone(tmp_path):
+    """Only known dated families are swept — never whatever else lives here."""
+    notes = tmp_path / "notes.md"
+    notes.write_text("keep me")
+    undated = tmp_path / "fire-events-nope.jsonl"
+    undated.write_text("{}\n")
+    assert fl.prune_telemetry(tmp_path, days=1) == 0
+    assert notes.exists() and undated.exists()
+
+
+def test_zero_retention_keeps_everything(tmp_path, monkeypatch):
+    """The pre-#1078 behavior stays reachable by configuration."""
+    monkeypatch.setenv("PRAXIS_TELEMETRY_RETENTION_DAYS", "0")
+    old = _dated(tmp_path, "fire-events-", 400)
+    assert fl.prune_telemetry(tmp_path) == 0
+    assert old.exists()
+
+
+def test_write_sweeps_on_the_day_rollover(tmp_path, monkeypatch):
+    """The first write into a new day's file is the once-a-day sweep trigger."""
+    out = tmp_path / "fire-events-2099-01-01.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    monkeypatch.setenv("PRAXIS_TELEMETRY_RETENTION_DAYS", "30")
+    stale = _dated(tmp_path, "fire-events-", 90)
+
+    fl.record_group_fires([("r", "h", Path("x"))], [(0, "", "")], _payload())
+    assert not stale.exists()          # today's file was new — swept
+
+    survivor = _dated(tmp_path, "fire-events-", 90)
+    fl.record_group_fires([("r", "h", Path("x"))], [(0, "", "")], _payload())
+    assert survivor.exists()           # today's file existed — no second sweep
+
+
+def test_bypass_writer_sweeps_on_the_first_write_of_the_day(tmp_path, monkeypatch):
+    """`bypass-events-` is a retention prefix, so its writer owns a sweep (#1078).
+
+    The fire ledger's sweep runs inside `_atomic_append`, which the bypass hook
+    never calls — with fire telemetry disabled, nothing would ever prune the
+    bypass files (codex review round 1 — confirmed: `prune_telemetry` had one
+    call site and it was in `_fire_ledger` itself).
+    """
+    bt = _load(
+        "bypass_telemetry_sweep",
+        _REPO / "hooks" / "postuse-correction" / "bypass-telemetry" / "impl.py",
+    )
+    stale = _dated(tmp_path, "bypass-events-", 90)
+    today = tmp_path / (
+        "bypass-events-"
+        + datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+        + ".jsonl"
+    )
+    monkeypatch.setenv("PRAXIS_BYPASS_TELEMETRY_FILE", str(today))
+
+    bt.append_record({"event": "first write of the day"})
+    assert not stale.exists()
+
+    revived = _dated(tmp_path, "bypass-events-", 90)
+    bt.append_record({"event": "second write, same day"})
+    assert revived.exists()          # today's file existed — no second sweep

--- a/tests/test_fire_ledger.py
+++ b/tests/test_fire_ledger.py
@@ -1680,6 +1680,78 @@ def test_write_sweeps_on_the_day_rollover(tmp_path, monkeypatch):
     assert survivor.exists()           # today's file existed — no second sweep
 
 
+def test_count_session_fires_prefilter_matches_the_parse(tmp_path, monkeypatch):
+    """The substring prefilter must not change a single count (#1078).
+
+    A record that matches carries both literals, so rejecting on them is exact
+    — but a near-miss (right hook, wrong session; right session, wrong hook)
+    is what would break if the needles were built loosely.
+    """
+    out = tmp_path / "fire-events.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    for hook, sid, dec in (
+        ("gate-a", "sess-1", "block"), ("gate-a", "sess-1", "block"),
+        ("gate-a", "sess-1", "advise"),
+        ("gate-a", "sess-2", "block"),      # right hook, other session
+        ("gate-b", "sess-1", "block"),      # right session, other hook
+    ):
+        fl.record_session_fire(hook, "preflight-gate", dec, sid, "Bash")
+    # A coarse record (session_id "") must never match a real session.
+    fl.record_standalone_fire("gate-a", "preflight-gate", 2)
+
+    assert fl.count_session_fires("gate-a", "sess-1", "block") == 2
+    assert fl.count_session_fires("gate-a", "sess-1") == 3
+    assert fl.count_session_fires("gate-a", "sess-2", "block") == 1
+    assert fl.count_session_fires("gate-b", "sess-1") == 1
+    assert fl.count_session_fires("gate-a", "") == 0
+
+
+def test_count_session_fires_survives_an_escaped_session_id(tmp_path, monkeypatch):
+    """A session_id JSON has to escape must not silently count zero (#1078).
+
+    The prefilter's needle is raw, so a quote or a backslash in the value makes
+    it miss every record the writer escaped on the way in. Such a value drops
+    to the full parse instead (codex review round 1 — confirmed: the needle
+    `"session_id": "abc"def"` is absent from the stored `abc\\"def`).
+    """
+    out = tmp_path / "fire-events.jsonl"
+    monkeypatch.setenv("PRAXIS_FIRE_TELEMETRY_FILE", str(out))
+    monkeypatch.delenv("PRAXIS_FIRE_TELEMETRY_DISABLE", raising=False)
+    for sid in ('abc"def', "back\\slash", "plain-1"):
+        fl.record_session_fire("gate-a", "preflight-gate", "block", sid, "Bash")
+
+    assert fl.count_session_fires("gate-a", 'abc"def', "block") == 1
+    assert fl.count_session_fires("gate-a", "back\\slash", "block") == 1
+    assert fl.count_session_fires("gate-a", "plain-1", "block") == 1
+    # The fast path survives for values that need no escaping.
+    assert fl._raw_needle("plain-1") == '"plain-1"'
+    assert fl._raw_needle('abc"def') is None
+
+
+def test_count_session_fires_reads_a_compactly_written_record(tmp_path):
+    """The prefilter must not assume one writer's JSON spacing (#1078).
+
+    A needle carrying the key and its separator (`"session_id": "x"`) matches
+    only records written with a space after the colon. The escalation ledger in
+    `test_block_commit_without_codex_review.sh` is seeded compactly by hand, and
+    a key-bearing needle skipped it — the second same-session block then read as
+    the first and its escalation banner never appeared.
+    """
+    out = tmp_path / "fire-events.jsonl"
+    out.write_text(
+        '{"granularity":"rich","hook":"gate-a",'
+        '"session_id":"sess-1","decision":"block"}\n',
+        encoding="utf-8",
+    )
+    os.environ["PRAXIS_FIRE_TELEMETRY_FILE"] = str(out)
+    os.environ.pop("PRAXIS_FIRE_TELEMETRY_DISABLE", None)
+    try:
+        assert fl.count_session_fires("gate-a", "sess-1", "block") == 1
+    finally:
+        del os.environ["PRAXIS_FIRE_TELEMETRY_FILE"]
+
+
 def test_bypass_writer_sweeps_on_the_first_write_of_the_day(tmp_path, monkeypatch):
     """`bypass-events-` is a retention prefix, so its writer owns a sweep (#1078).
 


### PR DESCRIPTION
Closes #1078

Caller chain verified: `grep -rn prune_telemetry hooks/` -> definition in _fire_ledger.py plus two call sites (the fire ledger's own append path and the bypass writer this PR wires in); `_raw_needle` is new and has one caller, count_session_fires
Pre-commit verified: ./scripts/run-tests.sh -> ALL TESTS PASSED (the repo has no pre-commit config; this script is what ci.yml mirrors)

두 개의 독립된 변경이라 커밋도 둘로 나눠져 있습니다.

### 1. 30일 지난 텔레메트리를 지웁니다

`fire-events-` 와 `bypass-events-` 파일이 영원히 쌓이고 있었습니다. 새 날짜 파일에 처음 쓰는 순간에만 sweep 이 돌고, 파일의 **이름**에서 날짜를 읽습니다(mtime 은 touch 한 파일을 새 파일로 오인합니다). `PRAXIS_TELEMETRY_RETENTION_DAYS` 로 창을 조절하고 `0` 이면 전부 보존합니다.

bypass writer 도 같은 sweep 을 부릅니다. 이건 fire ledger 의 append 경로를 전혀 타지 않아서, fire 텔레메트리를 끄면 **보존 대상으로 선언해 둔 bypass 파일을 아무도 지우지 않는** 상태였습니다. codex 리뷰 1라운드에서 지적돼 반영했습니다.

<details><summary>호출부가 한 곳뿐이었다는 근거</summary><br>

```
$ grep -rn prune_telemetry hooks/
hooks/_lib/_fire_ledger.py:220:def prune_telemetry(directory: Path, days: float | None = None) -> int:
hooks/_lib/_fire_ledger.py:296:            _ = prune_telemetry(path.parent)
```

bypass writer 는 `path.open("a")` 로 직접 append 하며 `_atomic_append` 를 경유하지 않습니다.

</details>

### 2. 원장 스캔을 파싱 전에 걸러냅니다

`count_session_fires` 가 몇 건을 남기려고 그날 파일의 모든 줄을 파싱했고, 87MB 파일에서 0.83초가 걸렸습니다. 매칭되는 레코드는 hook 과 session id 를 따옴표로 감싼 리터럴로 반드시 포함하므로, 그 부분문자열로 먼저 거르는 것은 필요조건이고 C 레벨에서 끝납니다.

needle 은 **값만** 담고 키와 구분자는 담지 않습니다. 키를 넣으면 한 writer 의 서식에만 맞아서, 압축해 쓴 레코드를 건너뛰게 됩니다. JSON 이 이스케이프해야 하는 값은 애초에 원문으로 매칭할 수 없으므로 전수 파싱으로 내려갑니다.

<details><summary>이스케이프 케이스 — 값을 그대로 찾으면 0 이 나옵니다</summary><br>

```
$ python3 -c "... record_session_fire('gate-a','preflight-gate','block','abc\"def','Bash')"
stored: {"session_id": "abc\"def", "hook": "gate-a", ..., "granularity": "rich"}
old needle would be: '"session_id": "abc"def"'
old needle present in stored line: False
count (fixed): 1 expected 1
plain sid still counted: 1 expected 1
```

</details>

<details><summary>서식 케이스 — 키를 담은 needle 이 실제 게이트를 망가뜨렸습니다</summary><br>

`test_block_commit_without_codex_review.sh` 는 원장을 손으로 압축 JSON 으로 씁니다. 콜론 뒤 공백이 없어 키를 담은 needle 이 이 레코드를 건너뛰었고, 두 번째 같은-세션 차단이 첫 번째로 읽혀 escalation 배너가 뜨지 않았습니다.

```
{"granularity":"rich","hook":"block-commit-without-codex-review","session_id":"sess-escalate-123","decision":"block"}
                                                                 ↑ 콜론 뒤 공백 없음

# 수정 후
$ bash tests/hooks/preflight-gate/test_block_commit_without_codex_review.sh
Results: 54 passed, 0 failed
```

</details>

### 검증

```
$ python3 -m pytest tests/test_fire_ledger.py -q
132 passed

$ ./scripts/run-tests.sh
ALL TESTS PASSED
```

첫 커밋만 단독으로 체크아웃해도 성립합니다:

```
$ pytest tests/test_fire_ledger.py -q   → 129 passed
$ ruff check --no-cache .               → All checks passed!
```
