### PR TITLE
perf(hooks): throttle the cache sweep to once a day

### DIFF
--- a/hooks/_lib/_paths.py
+++ b/hooks/_lib/_paths.py
@@ -89,7 +89,7 @@ def resolve_writable(subdir: str, filename: str, session_id: str | None = None) 
         d = os.path.join(praxis_home(), subdir)
         os.makedirs(d, exist_ok=True)
         if os.access(d, os.W_OK):
-            if subdir == "cache":
+            if subdir == "cache" and _prune_due(d):
                 _ = prune_stale(d, session_id=session_id)
             return os.path.join(d, filename)
     except Exception:
@@ -155,6 +155,111 @@ def _belongs_to_session(name: str, session_id: str) -> bool:
     return bool(head) and _sep != "" and (tail == "" or tail.startswith("."))
 
 
+# Name of the sweep stamp inside the cache dir. Leading dot so it sorts out of
+# the way and cannot collide with a session-keyed entry name.
+_PRUNE_STAMP_NAME = ".prune-stamp"
+_PRUNE_LOCK_SUFFIX = ".lock"
+_DEFAULT_PRUNE_INTERVAL_HOURS = 24.0
+
+
+def cache_prune_interval_hours() -> float:
+    """Minimum gap between cache sweeps.
+
+    `PRAXIS_CACHE_PRUNE_INTERVAL_HOURS` overrides; 0 or a malformed value
+    sweeps on every resolution, which is the pre-#1079 behavior.
+    """
+    raw = os.environ.get("PRAXIS_CACHE_PRUNE_INTERVAL_HOURS")
+    if raw is None:
+        return _DEFAULT_PRUNE_INTERVAL_HOURS
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return 0.0
+
+
+def _prune_due(directory: str) -> bool:
+    """True when the cache sweep should run now (issue #1079).
+
+    `resolve_writable` sits on the write path of every cache consumer, so the
+    sweep it triggers ran on every resolution — a `scandir` plus a full
+    `os.walk` per directory entry, measured at 25ms against 496 entries and
+    growing with the cache. The work is worth doing daily, not per write.
+
+    The stamp is written BEFORE the sweep, not after: a concurrent hook process
+    must see the sweep as already taken rather than starting a second full walk
+    of the same tree. Losing one sweep to a crash between stamp and walk costs a
+    day of delay, which is inside the TTL either way.
+
+    Saying that requires the read and the write to be one indivisible step, and
+    a `stat` followed by an `open` is not: every racer passes the `stat`, and
+    every racer then sweeps (#1079, codex review round 1 — 16 barrier-aligned
+    threads produced 4 to 11 sweeps per trial). `O_EXCL` on a lock beside the
+    stamp is the indivisible step; exactly one caller creates it, and the rest
+    are told so by `FileExistsError`. A lock left behind by a killed process is
+    itself older than the interval, so it is taken over rather than blocking
+    the sweep forever.
+
+    Fail-open: a stamp or lock that cannot be read or written means the throttle
+    cannot work, so the sweep runs — never the other way round, which would
+    leave the cache growing unswept forever. Only losing the lock to another
+    caller returns False, and that is not a failure: someone else is sweeping.
+    """
+    interval = cache_prune_interval_hours()
+    if interval <= 0:
+        return True
+    stamp = os.path.join(directory, _PRUNE_STAMP_NAME)
+    lock = stamp + _PRUNE_LOCK_SUFFIX
+    now = time.time()
+    if not _stamp_expired(stamp, now, interval):
+        return False
+    if not _claim_lock(lock, now, interval):
+        return False
+    try:
+        # Re-read under the lock. A racer that passed the check above may have
+        # swept and refreshed the stamp while we waited for the lock.
+        if not _stamp_expired(stamp, time.time(), interval):
+            return False
+        try:
+            with open(stamp, "a"):
+                pass
+            os.utime(stamp, (now, now))
+        except OSError:
+            pass  # cannot throttle — sweep anyway
+        return True
+    finally:
+        try:
+            os.unlink(lock)
+        except OSError:
+            pass  # a leftover lock ages out and is taken over next time
+
+
+def _stamp_expired(stamp: str, now: float, interval: float) -> bool:
+    """True when the last sweep is older than `interval` hours, or never ran."""
+    try:
+        return now - os.stat(stamp).st_mtime >= interval * 3600
+    except OSError:
+        return True  # no stamp yet, or unreadable — treat as due
+
+
+def _claim_lock(lock: str, now: float, interval: float) -> bool:
+    """True when this caller owns the sweep. `O_EXCL` picks exactly one."""
+    for _ in range(2):
+        try:
+            os.close(os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644))
+            return True
+        except FileExistsError:
+            pass
+        except OSError:
+            return True  # cannot lock — sweep anyway, same as an unwritable stamp
+        try:
+            if now - os.stat(lock).st_mtime < interval * 3600:
+                return False  # someone is sweeping right now
+            os.unlink(lock)  # abandoned by a killed process — take it over
+        except OSError:
+            return False
+    return False
+
+
 def prune_stale(
     directory: str, ttl_days: float | None = None, session_id: str | None = None
 ) -> int:
@@ -194,6 +299,8 @@ def prune_stale(
     with entries:
         for entry in entries:
             try:
+                if entry.name.startswith(_PRUNE_STAMP_NAME):
+                    continue  # the sweep's own bookkeeping, not a cache entry
                 if session_id and _belongs_to_session(entry.name, session_id):
                     continue
                 if entry.name.endswith(LOCK_SUFFIX) and lock_is_held(entry.path):

--- a/tests/hooks/_lib/test_paths_prune.py
+++ b/tests/hooks/_lib/test_paths_prune.py
@@ -199,3 +199,150 @@ def test_resolve_cache_file_threads_session_id(tmp_path: Path) -> None:
     finally:
         del os.environ["PRAXIS_HOME"]
         del os.environ["PRAXIS_CACHE_TTL_DAYS"]
+
+
+# ---------------------------------------------------------------------------
+# Sweep throttle (#1079)
+# ---------------------------------------------------------------------------
+#
+# `resolve_writable` sits on the write path of every cache consumer, so the
+# sweep ran on every resolution: a scandir plus a full os.walk per directory
+# entry, 25ms against 496 entries and growing with the cache. These cover that
+# the throttle skips the repeat, that it does not disable the sweep, and that
+# the interval remains overridable — including back to the old every-time
+# behavior.
+
+
+def _stamp(cache: Path) -> Path:
+    return cache / _paths._PRUNE_STAMP_NAME
+
+
+def test_second_resolution_skips_the_sweep(tmp_path: Path, monkeypatch) -> None:
+    """A stale sibling survives the second resolution — the sweep did not run."""
+    home = tmp_path / "praxis-home"
+    cache = home / "cache"
+    cache.mkdir(parents=True)
+    os.environ["PRAXIS_HOME"] = str(home)
+    os.environ["PRAXIS_CACHE_TTL_DAYS"] = "7"
+    # A shell that exports the interval turns these into a different test —
+    # 0 sweeps every time, a large value never resumes (#1079, codex round 1).
+    monkeypatch.delenv("PRAXIS_CACHE_PRUNE_INTERVAL_HOURS", raising=False)
+    try:
+        first = _file(cache, f"retrospect-active-{OTHER}.json", days=30)
+        _paths.resolve_cache_file(f"session-intent-{SID}.json", session_id=SID)
+        assert not first.exists()          # sweep 1 ran
+        assert _stamp(cache).exists()
+
+        second = _file(cache, f"retrospect-active-{OTHER}.json", days=30)
+        _paths.resolve_cache_file(f"session-intent-{SID}.json", session_id=SID)
+        assert second.exists()             # sweep 2 was throttled away
+    finally:
+        del os.environ["PRAXIS_HOME"]
+        del os.environ["PRAXIS_CACHE_TTL_DAYS"]
+
+
+def test_sweep_resumes_once_the_interval_has_passed(tmp_path: Path, monkeypatch) -> None:
+    """Throttling delays the sweep; it must not cancel it."""
+    home = tmp_path / "praxis-home"
+    cache = home / "cache"
+    cache.mkdir(parents=True)
+    os.environ["PRAXIS_HOME"] = str(home)
+    os.environ["PRAXIS_CACHE_TTL_DAYS"] = "7"
+    # A shell that exports the interval turns these into a different test —
+    # 0 sweeps every time, a large value never resumes (#1079, codex round 1).
+    monkeypatch.delenv("PRAXIS_CACHE_PRUNE_INTERVAL_HOURS", raising=False)
+    try:
+        _paths.resolve_cache_file(f"session-intent-{SID}.json", session_id=SID)
+        _aged(_stamp(cache), days=2)       # stamp older than the 24h interval
+        stale = _file(cache, f"retrospect-active-{OTHER}.json", days=30)
+        _paths.resolve_cache_file(f"session-intent-{SID}.json", session_id=SID)
+        assert not stale.exists()
+    finally:
+        del os.environ["PRAXIS_HOME"]
+        del os.environ["PRAXIS_CACHE_TTL_DAYS"]
+
+
+def test_zero_interval_restores_every_time_sweeping(tmp_path: Path) -> None:
+    """The pre-#1079 behavior stays reachable by configuration."""
+    home = tmp_path / "praxis-home"
+    cache = home / "cache"
+    cache.mkdir(parents=True)
+    os.environ["PRAXIS_HOME"] = str(home)
+    os.environ["PRAXIS_CACHE_TTL_DAYS"] = "7"
+    os.environ["PRAXIS_CACHE_PRUNE_INTERVAL_HOURS"] = "0"
+    try:
+        _paths.resolve_cache_file(f"session-intent-{SID}.json", session_id=SID)
+        stale = _file(cache, f"retrospect-active-{OTHER}.json", days=30)
+        _paths.resolve_cache_file(f"session-intent-{SID}.json", session_id=SID)
+        assert not stale.exists()
+    finally:
+        del os.environ["PRAXIS_HOME"]
+        del os.environ["PRAXIS_CACHE_TTL_DAYS"]
+        del os.environ["PRAXIS_CACHE_PRUNE_INTERVAL_HOURS"]
+
+
+def test_stamp_is_not_itself_swept(tmp_path: Path) -> None:
+    """A stamp aged past the TTL must not be deleted as if it were an entry.
+
+    It would only make the sweep run every time again — a degradation the
+    throttle exists to prevent, and one nothing else would surface.
+    """
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    stamp = _file(cache, _paths._PRUNE_STAMP_NAME, days=30)
+    removed = _paths.prune_stale(str(cache), ttl_days=7)
+    assert stamp.exists()
+    assert removed == 0
+
+
+def test_concurrent_callers_produce_exactly_one_sweep(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The throttle has to serialize, not just delay (#1079, codex round 1).
+
+    `stat` then `open` let every racer through: 16 barrier-aligned threads
+    produced 4 to 11 sweeps per trial before the lock. Both entry paths are
+    covered — no stamp at all, and a stamp already past the interval — because
+    they claim through different branches.
+    """
+    import threading
+
+    monkeypatch.delenv("PRAXIS_CACHE_PRUNE_INTERVAL_HOURS", raising=False)
+
+    def race(directory: Path, n: int = 16) -> int:
+        barrier = threading.Barrier(n)
+        results: list[bool] = []
+        lock = threading.Lock()
+
+        def go() -> None:
+            barrier.wait()
+            due = _paths._prune_due(str(directory))
+            with lock:
+                results.append(due)
+
+        threads = [threading.Thread(target=go) for _ in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        return sum(results)
+
+    fresh = tmp_path / "fresh"
+    fresh.mkdir()
+    assert race(fresh) == 1
+
+    expired = tmp_path / "expired"
+    expired.mkdir()
+    _file(expired, _paths._PRUNE_STAMP_NAME, days=2)
+    assert race(expired) == 1
+
+
+def test_the_sweep_lock_is_not_itself_swept(tmp_path: Path) -> None:
+    """The lock lives beside the stamp and is skipped by the same rule."""
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    lock = _file(
+        cache, _paths._PRUNE_STAMP_NAME + _paths._PRUNE_LOCK_SUFFIX, days=30
+    )
+    assert _paths.prune_stale(str(cache), ttl_days=7) == 0
+    assert lock.exists()


### PR DESCRIPTION
Closes #1079

Caller chain verified: `_prune_due` is new with one caller, `resolve_writable` in the same file; `_stamp_expired` and `_claim_lock` are new with one caller each, `_prune_due`
Pre-commit verified: ./scripts/run-tests.sh -> ALL TESTS PASSED (the repo has no pre-commit config; this script is what ci.yml mirrors)

### 무엇이 문제였나

`resolve_writable` 은 모든 캐시 소비자의 쓰기 경로에 있습니다. 그래서 거기서 부르는 prune 이 **해석할 때마다** 돌았습니다 — scandir 한 번에 항목마다 `os.walk` 한 번, 496개 항목에서 25ms 이고 캐시가 커질수록 늘어납니다. 이 작업은 매 쓰기가 아니라 하루 한 번이면 충분합니다.

### 무엇이 바뀌나

stamp 파일이 마지막 sweep 시각을 들고 있습니다. `PRAXIS_CACHE_PRUNE_INTERVAL_HOURS` 로 간격을 조절하고 `0` 이면 이전의 매번-쓸기 동작으로 돌아갑니다.

선점은 원자적이어야 합니다. `stat` 후 `open` 은 경합자를 전부 통과시켜 모두가 sweep 합니다. stamp 옆의 lock 에 `O_EXCL` 을 거는 것이 그 나눌 수 없는 한 걸음이고, 죽은 프로세스가 남긴 lock 은 간격이 지나면 인수됩니다.

<details><summary>경합 실측 — 수정 전후</summary><br>

배리어로 출발을 맞춘 스레드 16개, 5회 시행:

```
# 수정 전
trial 0: True = 4/16    trial 3: True =  5/16
trial 1: True = 7/16    trial 4: True = 11/16
trial 2: True = 4/16

# 수정 후 — stamp 가 없는 경로와 만료된 경로 양쪽
fresh dir     trial 0~4: True = 1 / 16
expired stamp trial 0~4: True = 1 / 16
```

별도 프로세스 8개로 돌린 첫 프로브는 True 1개를 냈지만 이것은 무효입니다 — 파이썬 기동 시간이 어긋나 경합 창을 못 때렸을 뿐입니다.

</details>

<details><summary>테스트가 셸 환경을 타던 문제</summary><br>

새 테스트들이 `PRAXIS_CACHE_PRUNE_INTERVAL_HOURS` 를 unset 하지 않아, 이 변수를 export 한 셸에서는 다른 테스트가 됩니다.

```
# 수정 전
$ PRAXIS_CACHE_PRUNE_INTERVAL_HOURS=0 pytest tests/hooks/_lib/test_paths_prune.py -q
2 failed, 11 passed

# 수정 후
$ pytest tests/hooks/_lib/test_paths_prune.py -q                              → 15 passed
$ PRAXIS_CACHE_PRUNE_INTERVAL_HOURS=0 pytest tests/hooks/_lib/test_paths_prune.py -q → 15 passed
```

</details>

두 항목 모두 codex 리뷰 1라운드에서 지적돼 반영했습니다.

### 검증

```
$ ./scripts/run-tests.sh
ALL TESTS PASSED
```
