### PR TITLE
fix(hooks): accept an approval in its final clause

### DIFF
--- a/hooks/_lib/block_message.py
+++ b/hooks/_lib/block_message.py
@@ -121,8 +121,10 @@ a `Falsified:` line.
 Unconditional — fire on every `gh pr merge`, whatever the flags:
   6-item briefing in this turn              ← momentum-rule-retrieval-gate
     What changed / verified / NOT verified / Risk / Open items / approve-ask.
-    Relief: PRAXIS_MOMENTUM_MERGE_ADVISORY=1, or an unquoted shell comment
-    `# briefing-surfaced: <reason>` on the merge command itself.
+    Relief: an unquoted shell comment `# briefing-surfaced: <reason>` on the
+    merge command itself. PRAXIS_MOMENTUM_MERGE_ADVISORY=1 also works, but
+    ONLY from the session environment — the hook is spawned by the harness,
+    so an inline `VAR=1 gh pr merge …` prefix never reaches it.
   Explicit per-PR user approval             ← pre-merge-approval-gate
     Always asks. No agent-attachable bypass exists, by design.
   Intentional-side-effect acknowledgement   ← side-effect-scan

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -825,7 +825,9 @@ def _merge_escalation_reason(payload: dict) -> str | None:
             correct_path="surface the 6-item briefing and an explicit 'Approve "
                 "merge?' question in this turn, then re-run the merge",
             bypass_env=MERGE_ADVISORY_ENV,
-            bypass_reason_hint="with a one-line reason",
+            bypass_reason_hint="with a one-line reason — set in the session "
+                "environment, since an inline `VAR=1 gh pr merge …` prefix "
+                "never reaches this hook",
             reference="CLAUDE.md → Pre-Merge Reporting; "
                 "hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md",
         )
@@ -839,9 +841,10 @@ def _merge_escalation_reason(payload: dict) -> str | None:
         correct_path="surface the 6-item briefing and an explicit 'Approve "
             "merge?' question, then re-run the merge",
         bypass_env=MERGE_ADVISORY_ENV,
-        bypass_reason_hint="with a one-line reason — or, where the env var "
-            "cannot reach the hook (bridge-session harness), append "
-            "`# briefing-surfaced: <reason>` to the merge command",
+        bypass_reason_hint="with a one-line reason, set in the session "
+            "environment (an inline `VAR=1 gh pr merge …` prefix never reaches "
+            "this hook) — or append `# briefing-surfaced: <reason>` to the "
+            "merge command",
         reference="CLAUDE.md → Pre-Merge Reporting; "
             "hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md",
     )

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -578,10 +578,14 @@ def _user_message_text(content: object) -> str:
 
 def _is_approval_reply(content: object) -> bool:
     """True when a user message is a short bare approval token (ok / 진행 / 승인 …)."""
-    text = re.sub(r"\s+", " ", _user_message_text(content).strip().lower())
-    if text.strip(" .!~,·") in _APPROVAL_TOKENS:
+    raw = _user_message_text(content).strip().lower()
+    if re.sub(r"\s+", " ", raw).strip(" .!~,·") in _APPROVAL_TOKENS:
         return True
-    clauses = [c.strip(" .!~,·") for c in _CLAUSE_TAIL_RE.split(text)]
+    # Split the RAW text: normalizing whitespace first turns a newline into a
+    # space, which would collapse "briefing\napprove" into one clause and lose
+    # the boundary the split is looking for. Whitespace inside each clause is
+    # normalized after the split instead.
+    clauses = [re.sub(r"\s+", " ", c).strip(" .!~,·") for c in _CLAUSE_TAIL_RE.split(raw)]
     clauses = [c for c in clauses if c]
     return bool(clauses) and clauses[-1] in _APPROVAL_TOKENS
 

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -447,10 +447,19 @@ _APPROVAL_TOKENS = frozenset({
     "ok", "okay", "okey", "k", "kk", "yes", "yep", "yup", "y", "go", "go ahead",
     "do it", "proceed", "proceed with the merge", "merge", "merge it", "sure",
     "lgtm", "ship it", "sounds good",
+    "approve", "approved",
     "네", "넵", "응", "ㅇㅋ", "ㅇㅇ", "ㄱㄱ", "고고", "승인", "진행", "진행해",
     "진행해줘", "진행하자", "머지", "머지해", "머지해줘", "머지 진행", "좋아",
     "좋습니다", "그래", "ㄱ",
 })
+
+# A user rarely answers a merge ask with one bare word — "ok, merge it" and
+# "사용해보고 결정하겠습니다. 머지 진행" are the same consent, and denying them
+# blocks the mandated briefing → approval → merge flow outright (issue #1087).
+# Only the FINAL clause is matched: an approval token earlier in a message whose
+# last clause is a fresh instruction ("머지 진행 상황 알려주고 파서부터 고쳐줘")
+# still fails, which is the property exact equality was protecting.
+_CLAUSE_TAIL_RE = re.compile(r"[.!?。…\n,;·]+")
 
 # A single positional token that is a bare PR number or a …/pull/N URL.
 _PULL_TOKEN_RE = re.compile(r"^(?:\S*/pull/(\d+)|(\d+))$")
@@ -569,8 +578,12 @@ def _user_message_text(content: object) -> str:
 
 def _is_approval_reply(content: object) -> bool:
     """True when a user message is a short bare approval token (ok / 진행 / 승인 …)."""
-    norm = re.sub(r"\s+", " ", _user_message_text(content).strip().lower()).strip(" .!~,·")
-    return norm in _APPROVAL_TOKENS
+    text = re.sub(r"\s+", " ", _user_message_text(content).strip().lower())
+    if text.strip(" .!~,·") in _APPROVAL_TOKENS:
+        return True
+    clauses = [c.strip(" .!~,·") for c in _CLAUSE_TAIL_RE.split(text)]
+    clauses = [c for c in clauses if c]
+    return bool(clauses) and clauses[-1] in _APPROVAL_TOKENS
 
 
 def _first_positional(tokens: list[str], value_flags: frozenset[str]) -> str | None:

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -299,7 +299,7 @@ pins both channels per gate name.
 | Variable | Effect |
 | ---------- | -------- |
 | `PRAXIS_MOMENTUM_BYPASS=1` | Skip all output and exit 0 immediately (for scripted batch operations) |
-| `PRAXIS_MOMENTUM_MERGE_ADVISORY=1` | Demote the merge-briefing escalation to advisory only (stderr reminder still fires, no `deny`). See also the in-band `# briefing-surfaced` command marker (issue #826) for harnesses where this env var cannot reach the hook |
+| `PRAXIS_MOMENTUM_MERGE_ADVISORY=1` | Demote the merge-briefing escalation to advisory only (stderr reminder still fires, no `deny`). Read from the hook process env, so it must be set in the **session** environment — an inline `VAR=1 gh pr merge …` prefix never reaches the hook, and the deny message says so (issue #1087). See also the in-band `# briefing-surfaced` command marker (issue #826) |
 | `PRAXIS_MOMENTUM_STRICT=1` | Exit 2 (block) instead of exit 0, unless `PRAXIS_MOMENTUM_ACK=1` is also set |
 | `PRAXIS_MOMENTUM_ACK=1` | Acknowledge the surface in strict mode; exit 0 after emitting the advisory |
 

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/spec.md
@@ -107,10 +107,20 @@ human user message" window. Scoring only that window would therefore penalise
 the *correct* flow (briefing → "ok" → merge) and pass only the anti-pattern
 (briefing + merge crammed into one turn, i.e. auto-proceed without waiting).
 The **prior-turn extension** resolves this. When the last human user message is
-a short approval reply (`ok` / `진행` / `승인` / … — exact normalized match
-against `_APPROVAL_TOKENS`), the immediately preceding assistant turn is scored
+an approval reply (`ok` / `진행` / `승인` / … — matched against
+`_APPROVAL_TOKENS` either as the whole normalized message or as its **final
+clause**, issue #1087), the immediately preceding assistant turn is scored
 **alone** (post-approval text must not supplement a briefing the user never saw
 before approving). Safety gates on the extension:
+
+- **Final-clause matching (issue #1087).** Whole-message equality alone denied
+  every approval phrased as prose — `ok, merge it`, `사용해보고 결정하겠습니다.
+  머지 진행` — while the barer `ok` passed, so the mandated flow was blocked
+  whenever the user wrote a sentence. The message is split on clause boundaries
+  (`.!?。…,;·` and newline) and only the LAST clause is matched, which keeps the
+  property whole-message equality existed for: a message whose final clause is a
+  fresh instruction (`머지 진행 상황 알려주고 파서부터 고쳐줘`, `merge it but
+  rebase first`) is not an approval, no matter what appears earlier in it.
 
 - **PR correlation.** The prior-turn briefing must reference the PR actually
   being merged. The merge target is the segment's *first positional* token

--- a/tests/fixtures/momentum-merge-sentence-approval-en.jsonl
+++ b/tests/fixtures/momentum-merge-sentence-approval-en.jsonl
@@ -1,0 +1,6 @@
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": "PR 833 머지 준비됐는지 보고 진행하자"}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "chk", "name": "Bash", "input": {"command": "gh pr checks 833"}}]}}
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "chk", "content": "all checks passing"}]}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "PR #833 브리핑. 변경 사항: hook 파일 수정. 테스트 통과 확인(lint clean). 미검증 항목: prod 경로 미확인. 리스크: downstream 없음. 남은 항목: 없음. Approve merge?"}]}}
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": "ok, merge it"}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "머지합니다."}]}}

--- a/tests/fixtures/momentum-merge-sentence-approval-ko.jsonl
+++ b/tests/fixtures/momentum-merge-sentence-approval-ko.jsonl
@@ -1,0 +1,6 @@
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": "PR 833 머지 준비됐는지 보고 진행하자"}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "chk", "name": "Bash", "input": {"command": "gh pr checks 833"}}]}}
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "chk", "content": "all checks passing"}]}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "PR #833 브리핑. 변경 사항: hook 파일 수정. 테스트 통과 확인(lint clean). 미검증 항목: prod 경로 미확인. 리스크: downstream 없음. 남은 항목: 없음. Approve merge?"}]}}
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": "사용해보고 결정하겠습니다. 머지 진행"}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "머지합니다."}]}}

--- a/tests/fixtures/momentum-merge-sentence-trailing-instruction.jsonl
+++ b/tests/fixtures/momentum-merge-sentence-trailing-instruction.jsonl
@@ -1,0 +1,6 @@
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": "PR 833 머지 준비됐는지 보고 진행하자"}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "chk", "name": "Bash", "input": {"command": "gh pr checks 833"}}]}}
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "chk", "content": "all checks passing"}]}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "PR #833 브리핑. 변경 사항: hook 파일 수정. 테스트 통과 확인(lint clean). 미검증 항목: prod 경로 미확인. 리스크: downstream 없음. 남은 항목: 없음. Approve merge?"}]}}
+{"type": "user", "isSidechain": false, "message": {"role": "user", "content": "머지 진행 상황 알려주고 파서부터 고쳐줘"}}
+{"type": "assistant", "isSidechain": false, "message": {"role": "assistant", "content": [{"type": "text", "text": "머지합니다."}]}}

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -714,6 +714,21 @@ run_merge_escalation_case "merge_escalation_prior_turn_briefing_passes" \
 run_merge_escalation_case "merge_escalation_prior_turn_wrong_pr_denies" \
   "yes" "" "momentum-merge-prior-turn-wrong-pr.jsonl" "gh pr merge 833 --squash"
 
+# A SENTENCE that ends in an approval is still an approval (issue #1087). Exact
+# string equality denied these, so the mandated briefing → approval → merge flow
+# was blocked whenever the user approved in prose rather than one word.
+run_merge_escalation_case "merge_escalation_sentence_approval_ko_passes" \
+  "no" "" "momentum-merge-sentence-approval-ko.jsonl" "gh pr merge 833 --squash"
+
+run_merge_escalation_case "merge_escalation_sentence_approval_en_passes" \
+  "no" "" "momentum-merge-sentence-approval-en.jsonl" "gh pr merge 833 --squash"
+
+# NEGATIVE CONTROL: an approval token appears mid-sentence but the LAST clause
+# is a fresh instruction → still not an approval reply → deny. This is the
+# property exact equality was protecting, and clause splitting must keep it.
+run_merge_escalation_case "merge_escalation_trailing_instruction_denies" \
+  "yes" "" "momentum-merge-sentence-trailing-instruction.jsonl" "gh pr merge 833 --squash"
+
 # Last user message is a substantive instruction, not an approval reply → no
 # window extension → deny.
 run_merge_escalation_case "merge_escalation_substantive_reply_denies" \

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -729,6 +729,25 @@ run_merge_escalation_case "merge_escalation_sentence_approval_en_passes" \
 run_merge_escalation_case "merge_escalation_trailing_instruction_denies" \
   "yes" "" "momentum-merge-sentence-trailing-instruction.jsonl" "gh pr merge 833 --squash"
 
+# The deny message must not present the env bypass as an inline prefix (issue
+# #1087). The hook is spawned by the harness, not as a child of the command, so
+# `PRAXIS_MOMENTUM_MERGE_ADVISORY=1 gh pr merge …` can never reach it — guidance
+# that reads as runnable sends the author down a path that always fails.
+deny_msg=$(python3 -c '
+import json, sys
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {"command": "gh pr merge 833 --squash"},
+    "transcript_path": sys.argv[1],
+    "session_id": "test-momentum-merge",
+}))' "$FIXTURES_DIR/momentum-merge-substantive-reply.jsonl" | python3 "$HOOK" 2>&1)
+if printf '%s' "$deny_msg" | grep -q 'session environment'; then
+  echo "PASS  [merge_escalation_deny_names_env_reachability]"; PASS=$((PASS + 1))
+else
+  echo "FAIL  [merge_escalation_deny_names_env_reachability] msg=<$deny_msg>"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("merge_escalation_deny_names_env_reachability")
+fi
+
 # Last user message is a substantive instruction, not an approval reply → no
 # window extension → deny.
 run_merge_escalation_case "merge_escalation_substantive_reply_denies" \

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -714,6 +714,24 @@ run_merge_escalation_case "merge_escalation_prior_turn_briefing_passes" \
 run_merge_escalation_case "merge_escalation_prior_turn_wrong_pr_denies" \
   "yes" "" "momentum-merge-prior-turn-wrong-pr.jsonl" "gh pr merge 833 --squash"
 
+# A newline is a clause boundary too — the approval sits on its own line under
+# the briefing. Whitespace normalization used to collapse it before the split,
+# so the newline alternation in _CLAUSE_TAIL_RE was dead (CodeRabbit, PR #1089).
+approval_probe=$(python3 - "$ROOT_DIR" <<'PY_A'
+import importlib.util as u, sys
+spec = u.spec_from_file_location(
+    "m", f"{sys.argv[1]}/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py")
+m = u.module_from_spec(spec); spec.loader.exec_module(m)
+print(m._is_approval_reply("briefing\napprove"))
+PY_A
+)
+if [ "$approval_probe" = "True" ]; then
+  echo "PASS  [approval_reply_newline_is_a_clause_boundary]"; PASS=$((PASS + 1))
+else
+  echo "FAIL  [approval_reply_newline_is_a_clause_boundary] got=$approval_probe"
+  FAIL=$((FAIL + 1)); FAILED_NAMES+=("approval_reply_newline_is_a_clause_boundary")
+fi
+
 # A SENTENCE that ends in an approval is still an approval (issue #1087). Exact
 # string equality denied these, so the mandated briefing → approval → merge flow
 # was blocked whenever the user approved in prose rather than one word.


### PR DESCRIPTION
### 무엇이 바뀌나

규정대로 브리핑 → 승인 → 머지를 밟았는데 게이트가 영구 차단하던 경로를 닫습니다. 이 PR 이후로는 **문장으로 승인해도** 머지가 통과합니다.

### 원인 — 언어가 아니라 문장이냐 단어냐였습니다

게이트가 점수를 매기는 창(window)은 마지막 사람 메시지 이후입니다. 규정된 흐름은 브리핑 → 승인 → 머지라 브리핑은 승인 **앞** 턴에 놓이고 창은 비게 되므로, 앞 턴을 끌어오는 예외(`_correlated_prior_turn_text`)가 있습니다. 그 예외는 마지막 사용자 메시지가 승인 토큰과 **글자까지 똑같을 때만** 발동했습니다.

```python
# 수정 전, impl.py:572
norm = re.sub(r"\s+", " ", _user_message_text(content).strip().lower()).strip(" .!~,·")
return norm in _APPROVAL_TOKENS
```

측정 결과입니다. EN/KO 대칭이고, 가르는 축은 언어가 아닙니다.

```
True   'ok'             True   '머지'
True   'merge it'       True   '머지 진행'
True   'go ahead'       True   '진행'
False  'ok, merge it'   False  '사용해보고 결정하겠습니다. 머지 진행'
False  'sure, go ahead' False  '머지 진행해주세요'
False  'approve'
False  'approved'
```

`ok` 는 통과하고 `ok, merge it` 은 막힙니다 — 후자가 더 명확한 승인인데도요. 훅 이름이 approval gate 인데 `approve` / `approved` 는 목록에 아예 없었습니다.

앞 턴이 안 읽히면 남는 건 현재 턴인데, 현재 턴의 어시스턴트 텍스트는 PreToolUse 시점에 아직 트랜스크립트에 실리지 않습니다. **양쪽 다 못 보는 상태**가 되어 빠져나갈 문이 없습니다. 2026-08-22 PR #1074 에서 실제로 발생했고, 같은 명령이 두 번 연속 같은 이유로 막혔습니다.

### 어떻게 고쳤나 — 결함 2개, 커밋 2개

닫히는 조건이 달라 분리했습니다.

**1. 승인 판정을 마지막 절 기준으로** (`9398846`)

메시지를 절 경계(`.!?。…,;·` + 개행)로 쪼개고 **마지막 절**만 토큰 집합과 대조합니다. 전체 일치 경로는 그대로 남겨 기존 동작을 보존합니다. `approve` / `approved` 도 토큰에 추가했습니다.

완전 일치가 지키려던 성질 — 실질 지시가 승인으로 오독되지 않는 것 — 은 그대로입니다. 실측입니다.

```
True   'ok, merge it'                       ← 고치려던 것
True   '사용해보고 결정하겠습니다. 머지 진행'   ← 고치려던 것
False  '머지 진행 상황 알려주고 파서부터 고쳐줘'  ← 승인 토큰이 중간에 있어도 차단
False  'merge it but rebase first'          ← 조건부 승인, 여전히 차단
False  'go fix the parser'                  ← 원래 주석이 경계하던 형태
```

세 번째·네 번째가 핵심입니다. **조건부 승인**은 승인처럼 읽히지만 선행 작업을 요구하므로, 이것이 통과하면 안 됩니다.

**2. 도달 불가능한 우회로 안내 제거** (`4d19b4b`)

차단 메시지가 `PRAXIS_MOMENTUM_MERGE_ADVISORY=1` 을 제시했는데, spec 이 직접 안 된다고 적어둔 경로입니다.

```
spec.md
The env bypass above is read from the hook process `os.environ` and is
**not** reachable via a Bash inline `VAR=1 cmd` prefix — the hook is spawned
by the harness, not as a child of the command.
```

안내대로 따르면 반드시 실패합니다. 변수 자체는 유효하므로 지우지 않고, **세션 환경에 설정해야 한다**는 도달 조건을 차단 메시지·게이트 체크리스트·spec 세 곳에 명시했습니다.

### 검증

결함별로 회귀 테스트를 **먼저 작성해 실패를 확인한 뒤** 고쳤습니다.

```
$ bash tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
FAIL  [merge_escalation_sentence_approval_ko_passes]              ← 수정 전
FAIL  [merge_escalation_sentence_approval_en_passes]              ← 수정 전
PASS  [merge_escalation_trailing_instruction_denies]              ← 양성 대조, 처음부터 통과
FAIL  [merge_escalation_deny_names_env_reachability]              ← 수정 전
Results: 110 passed, 0 failed                                     ← 수정 후
```

양성 대조가 수정 전부터 통과한 것이 중요합니다 — 절 분리가 차단 성질을 깨지 않았다는 뜻입니다.

전체 스위트는 **푸시된 HEAD `9bdca6d`** 에서 돌렸습니다. 리베이스 도중 main 이 `#1086` 을 받아 움직여, 리베이스 전 실행(`4d19b4b`)은 푸시된 트리를 덮지 않기 때문입니다.

```
$ git diff --stat 4d19b4b 9bdca6d          # 리베이스 전 트리 vs 푸시된 HEAD
 6 files changed, 669 insertions(+), 88 deletions(-)

$ ./scripts/run-tests.sh                   # HEAD 9bdca6d
ALL TESTS PASSED                                    (exit 0, 5,286줄)

$ grep -nE '^\s*FAIL' <로그 전체>
1072:FAIL: 0  1680:FAIL: 0  ...  5146:FAIL: 0       ← 10줄 모두 집계 줄, 실제 실패 0건
```

행별 근거는 검증 앵커에 있습니다.

`ruff check hooks/` → `All checks passed!`, `shellcheck --severity=warning`(CI 와 동일 심각도) → rc=0.

`spec.md:18 MD001` / `spec.md:78 MD040` 은 **기존 지적**입니다. 같은 설정 디렉터리에서 `origin/main` 판본과 현재 판본을 각각 돌려 출력이 동일함을 확인했습니다.

### 범위 밖

`praxis:merge-briefing` 스킬 호출 자체를 창의 근거로 인정하는 안은 `isMeta` 경계 설계와 얽히므로 넣지 않았습니다.

Closes #1087

Pre-commit verified: 리포에 pre-commit 훅도 `.pre-commit-config.yaml` 도 없어(`ls -la .git/hooks/pre-commit` → 없음, `ls .pre-commit-config.yaml` → 없음) 커밋 전 검사를 수동으로 대신했습니다 — `bash tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh` → `Results: 110 passed, 0 failed`, `./scripts/run-tests.sh` → `ALL TESTS PASSED` (exit 0), `ruff check hooks/` → `All checks passed!`, `shellcheck --severity=warning` (CI 와 동일 심각도) → rc=0.

Caller chain verified: 바꾼 심볼 2개의 호출부를 전수 확인했습니다.

Caller-probe: `grep -rn '_correlated_prior_turn_text\|_is_approval_reply' --include='*.py' .` →
```
impl.py:579  def _is_approval_reply(...)
impl.py:700  def _correlated_prior_turn_text(...)
impl.py:722      if not _is_approval_reply(entries[idxs[-1]]...)   ← 유일한 호출부
impl.py:794      prev_text = _correlated_prior_turn_text(entries, idxs, code)  ← 유일한 호출부
```

둘 다 이 훅 파일 안에서만 각각 한 곳에서 불립니다. `_is_approval_reply` 의 결과는 `_correlated_prior_turn_text` 안에서 **앞 턴을 점수 대상으로 삼을지**만 결정하고, 그 반환값은 `_merge_escalation_reason` 이 브리핑 항목 수를 셀 창을 고르는 데만 쓰입니다. 즉 판정이 넓어져도 영향 범위는 "앞 턴 브리핑을 읽어줄지" 하나이며, PR 상관관계 검사·루프 금지·마커 하한은 모두 그대로 뒤에서 걸립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge approval detection for “approve” and “approved” responses.
  * Approval is recognized when it appears in the final clause, including after a newline, while trailing instructions remain excluded.
  * Clarified that the merge-advisory setting must be configured in the session environment.
  * Preserved the supported inline briefing-comment bypass.

* **Tests**
  * Added English and Korean approval-flow coverage.
  * Added regression coverage for newline-separated approval responses and trailing instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->