### PR TITLE
docs: rewrite README as a landing document

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ subcommand does not accept (`block-gh-state-all`), a foreground `sleep`-and-poll
 
 Two properties are load-bearing. **Hooks fail open**: a missing `jq`, a malformed stdin
 payload, an unreadable transcript — all exit 0, so a broken hook degrades to no hook
-rather than to a broken session. And a blocking hook that has a bypass variable **prints
-it in its own deny message** (`hooks/_lib/block_message.py`), so the way out arrives with
-the block rather than having to be hunted for.
+rather than to a broken session. And most blocks arrive with their own way out: the
+shared deny-message helper (`hooks/_lib/block_message.py`) prints the hook's bypass
+variable in the message, so you rarely have to go looking for it.
 
 The complete list, with each hook's events, hosts, strict/bypass knobs, and the external
 commands it may run, is the generated
@@ -128,8 +128,8 @@ narrowest to widest.
 **Opt out of one gate.** 38 of the 90 hooks declare an opt-out variable — set it and
 that gate either skips entirely or demotes itself to a warning, depending on the hook.
 Which variable belongs to which hook is the table in
-[`docs/bypass-vars.md`](docs/bypass-vars.md); a blocking hook also prints its own in the
-deny message.
+[`docs/bypass-vars.md`](docs/bypass-vars.md), and the generated
+[Hook Operating Matrix](docs/hook-operating-matrix.md) carries the same mapping per hook.
 
 **Set it where Claude Code can see it** — its own environment, before the session starts:
 
@@ -142,10 +142,11 @@ read `os.environ` of their own process, which never sees a variable scoped to th
 call, so the gate blocks exactly as before. Use the shell export above, or the `env`
 block in your `settings.json`.
 
-Opt-outs whose **name contains `BYPASS`** are recorded by the `bypass-telemetry` hook, so
-`bypass-review` can later show you which gate you keep routing around — usually a sign the
-gate is miscalibrated, not that you are undisciplined. Opt-outs named `*_ADVISORY` are
-outside that filter and leave no trace.
+The `bypass-telemetry` hook logs some of these as they are used, and the `bypass-review`
+CLI reads that log — worth a look if you find yourself routing around the same gate
+repeatedly, which usually means the gate is miscalibrated rather than that you are
+undisciplined. What it captures is narrower than the full set of opt-outs; see
+[`docs/bypass-telemetry.md`](docs/bypass-telemetry.md).
 
 **Escalate instead.** The opposite lever exists too: 20 hooks read a `PRAXIS_*_STRICT`
 variable that promotes them to a hard block — 12 of the 38 advisory hooks, plus 5

--- a/README.md
+++ b/README.md
@@ -143,11 +143,12 @@ undisciplined.
 variable that promotes an advisory into a hard block. Defaults sit on the permissive
 side of that line — an advisory hook stays advisory until you say otherwise.
 
-**All of it.** On a plugin install, the hooks come from the plugin manifest rather than
-from your settings, so the switch is `claude plugin disable praxis` (or `/plugin` in the
-session). Only a manual install registers praxis in `settings.json`, and there you drop
-its hooks entries. Either way skills and hooks are independent — removing the hooks
-leaves every `/praxis:*` skill working.
+**All of it.** On a plugin install, `claude plugin disable praxis` (or `/plugin` in the
+session) switches the whole plugin off — skills and hooks together, since both are
+declared in one manifest and `disable` has no hook-only option. If what you want is the
+gates gone but the `/praxis:*` skills kept, that is the first two levers above, not this
+one. Only a manual install registers praxis hooks in `settings.json` as separate
+entries; there, dropping them leaves the skills working.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,79 +1,151 @@
 # Praxis
 
-Development workflow skills for Claude Code — disciplined, fast, resilient.
+A plugin that turns the workflow rules you already wrote in `CLAUDE.md` into things
+that actually fire at the moment they are needed — a merge that stops while a blocking
+review finding is still open, a "done" that will not go out without evidence behind it,
+a worktree workflow that is not skipped because the change looked small. Skills you
+invoke by name, and hooks that fire whether or not anyone remembers them. One runtime,
+packaged for Claude Code, Codex, Cursor, Gemini, and OpenCode.
 
 > **Note:** Skills may be added, removed, or restructured at any time without prior notice. This is a personal toolbox — not a stable API.
 
+## The name
+
+*Praxis* (πρᾶξις) is theory carried into action — where a stated principle stops being a
+statement and becomes something done. That is this repository's whole design, written in
+[`ETHOS.md`](ETHOS.md) as **spec defines, hook enforces**: every hook here is the
+structural enforcement of a rule that already existed as prose in a `CLAUDE.md` or a
+memory entry, and exists precisely because the prose had already failed at the moment it
+was needed. The skills sit on the same axis — `strike`, `debt`, `spec-drift`, and
+`merge-briefing` all make an already-decided rule reachable at execution time rather
+than deciding anything new.
+
+The word carries none of that domain on its own, which is what the paragraph above is
+for. It is also a crowded name: the Praxis API framework (Ruby), PraxisEMR, and several
+unrelated npm and PyPI packages share it. None of them share a namespace with this
+repository — the surfaces that resolve here are `devseunggwan/praxis`, the `praxis:`
+skill prefix behind `/praxis:retrospect`, and the `PRAXIS_*` environment variables.
+
+## Installation
+
+### Claude Code — plugin (recommended)
+
+```bash
+/plugin marketplace add https://github.com/devseunggwan/praxis
+/plugin install praxis
+```
+
+Claude Code reads `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`
+directly from the repo root.
+
+### Codex — marketplace + plugin
+
+```bash
+# Register the local marketplace (points at this repo's .agents/plugins/marketplace.json)
+codex marketplace add https://github.com/devseunggwan/praxis
+codex plugin install praxis
+```
+
+Codex reads `.agents/plugins/marketplace.json` as the marketplace root and
+`plugins/praxis/.codex-plugin/plugin.json` as the plugin root. The `skills/`,
+`hooks/`, and `scripts/` directories inside `plugins/praxis/` are symlinks
+into the repo-root runtime — there is no source duplication.
+
+### Direct skill install (fallback)
+
+When the plugin surface isn't available:
+
+```bash
+git clone https://github.com/devseunggwan/praxis.git ~/projects/praxis
+claude skill add ~/projects/praxis/skills/<skill-name>
+```
+
 ## Skills
 
-> **Invocation**: praxis entries are *skills*, not subagents. Always call them
-> via `Skill(skill="praxis:<name>")`. `Agent(subagent_type="praxis:<name>")`
-> returns `Agent type not found` — Agent and Skill resolve disjoint namespaces.
-> See [RUNTIME_CONSTRAINTS.md §3](RUNTIME_CONSTRAINTS.md) for the mapping table.
+Eighteen skills, grouped as Discovery, Development, Discipline, and Session Management.
+The full table — trigger keywords, when to use each, example invocation — lives in
+[`docs/skills.md`](docs/skills.md).
 
-> **Trigger keywords** mirror each skill's `SKILL.md` `description` field verbatim
-> and are intentionally kept in their source language (some are Korean) so the
-> README stays in sync with what actually triggers the skill — do not translate them.
+If you are new, start with `/praxis:using-praxis`: it asks what you are trying to do and
+routes you to the skill that fits, which is faster than reading the catalogue. The three
+worth knowing by name on day one:
 
-### Discovery
+| Skill | What it is for |
+| ------- | ---------------- |
+| `/praxis:using-praxis` | Finding the right skill when you don't know what exists yet |
+| `/praxis:retrospect` | After a session that went badly — find the friction's root cause and act on it |
+| `/praxis:merge-briefing` | Before merging — probe all three finding surfaces, then brief and ask |
 
-| Skill | Trigger keywords | When to use | Example invocation |
-| ------- | ----------------- | ------------- | ------------------- |
-| `using-praxis` | `praxis 처음`, `praxis 사용법`, `어떤 skill 부터`, `praxis intro`, `praxis getting started` | To find the right skill when you're new to praxis or unsure which one fits | `/praxis:using-praxis` |
-| `writing-praxis-skill` | `new skill`, `write skill`, `add skill`, `skill template`, `skill spec`, `스킬 작성`, `새 스킬` | To author a new SKILL.md or get a skill-structure guide | `/praxis:writing-praxis-skill` |
-
-### Development
-
-| Skill | Trigger keywords | When to use | Example invocation |
-| ------- | ----------------- | ------------- | ------------------- |
-| `retrospect` | `retrospect`, `what went wrong`, `session review`, `session improvement`, `improve` | To analyze friction patterns / root causes after a session and act on improvements | `/praxis:retrospect` |
-| `codex-review-wrap` | `codex review`, `review codex`, `safe review`, `premise verification`, `flip detection`, `sibling cross-check` | To run `/codex:review` safely in multi-worktree setups, with premise verification and flip detection | `/praxis:codex-review-wrap` |
-| `debt` | `praxis:debt`, `debt ledger`, `지연 결정`, `deferred decision`, `기술 부채 원장`, `commit trailer audit` | To harvest commit-trailer and compounding-comment deferred-decision markers into a report-only ledger | `/praxis:debt` |
-| `surface-enumeration` | `surface enumerate`, `input surface enumeration`, `input parser`, `input validation`, `intent classifier`, `정규식 경계`, `입력 표면 열거` | To enumerate every input variant before implementing a parser/validator/sanitizer so each becomes a required test case | `/praxis:surface-enumeration` |
-| `spec-drift` | `spec drift`, `spec-drift`, `스펙 드리프트`, `미구현 요구`, `unmet requirement`, `requirement status` | To report which requirements in the `~/.praxis/docs/specs/` store the current tree does not yet satisfy, by running each one's `Verify:` command | `/praxis:spec-drift` |
-| `merge-briefing` | `merge briefing`, `pre-merge briefing`, `머지 브리핑`, `머지해도 되나`, `approve merge`, `pre-ask probe`, `merge approval` | To probe all three finding surfaces, grade every finding by its blocking decoration, carry anchor `Unverified` gaps, and surface the six-part briefing before asking for merge approval | `/praxis:merge-briefing` |
-| `worktree-merge-cleanup` | `merge cleanup`, `post-merge cleanup`, `worktree cleanup`, `delete-branch merge`, `squash-ancestry`, `pre-merge worktree`, `머지 후 정리`, `worktree 정리` | To run `gh pr merge --squash --delete-branch` from the right worktree and clean up afterward (submodule `--force`, squash-ancestry guard, no-`&&`-chain) | `/praxis:worktree-merge-cleanup` |
-
-### Discipline
-
-| Skill | Trigger keywords | When to use | Example invocation |
-| ------- | ----------------- | ------------- | ------------------- |
-| `strike` | `/strike`, `/praxis:strike`, `strike 1/2/3`, `삼진` | To explicitly record a rule violation (excludes colloquial uses like "strike a balance") | `/praxis:strike <violation reason>` |
-| `strikes` | `/strikes`, `strike status`, `몇 진`, `check strikes` | To check the current session's strike count and recorded violations | `/praxis:strikes` |
-| `reset-strikes` | `/reset-strikes`, `strike 초기화`, `clear strikes` | To reset the counter and resume responses after a 3-strike block | `/praxis:reset-strikes` |
-
-### Session Management
-
-| Skill | Trigger keywords | When to use | Example invocation |
-| ------- | ----------------- | ------------- | ------------------- |
-| `recover-sessions` | `recover`, `session recovery`, `restore sessions`, `power recovery` | To recover sessions after power loss or a tmux crash (tmux backend) | `/praxis:recover-sessions` |
-| `cmux-recover-sessions` | `터졌다`, `크래시 복구`, `OOM 복구`, `세션 살려야`, `crash recovery`, `power loss recovery`, `cmux session recovery` | To emergency-recover many cmux sessions after a crash / power loss / OOM (`.jsonl` scan based) | `/praxis:cmux-recover-sessions` |
-| `cmux-save-sessions` | `save sessions`, `session save`, `session snapshot`, `cmux save`, `snapshot list` | To save the current cmux session list as JSON for later restore | `/praxis:cmux-save-sessions` |
-| `cmux-resume-sessions` | `resume sessions`, `restore from snapshot`, `rehydrate sessions`, `세션 복원`, `스냅샷 복원` | To restore workspaces from a saved snapshot (for crash recovery, use `cmux-recover-sessions`) | `/praxis:cmux-resume-sessions` |
-| `cmux-session-manager` | `cmux session`, `session management`, `session cleanup`, `cmux status`, `cmux tidy` | To run routine session cleanup or view a status dashboard | `/praxis:cmux-session-manager` |
-| `cmux-delegate` | `delegate`, `cmux delegate`, `new session` | To delegate to an independent session while preserving the current task's context (split review / debugging / implementation) | `/praxis:cmux-delegate` |
-
-> **CLI tools (not skills):** praxis also ships `bypass-review`, a shell wrapper
-> with no `SKILL.md` — it is **not** invocable as `/praxis:*` and is absent from
-> the skills above. It inspects the review bypass-telemetry event logs.
-> See [AGENTS.md → Local Development](AGENTS.md#local-development) for the full
-> list of shipped CLI wrappers.
+Praxis also ships `bypass-review`, a shell wrapper with no `SKILL.md`. It is **not**
+invocable as `/praxis:*`; it reads the review bypass-telemetry event logs. See
+[AGENTS.md → Local Development](AGENTS.md#local-development) for every shipped CLI
+wrapper.
 
 ## Hooks
 
-Praxis ships a set of PreToolUse / PostToolUse / Stop / UserPromptSubmit hooks
-that structurally enforce rules captured in CLAUDE.md (e.g. side-effect
-acknowledgment, completion-evidence requirement, protected-branch edit guard,
-manufactured action-menu detection). Hooks fail-open on infrastructure errors
-and never break Claude Code — they only nudge or block specific patterns.
+Hooks are the larger half of praxis: **90 hooks**, registered at 100 points across
+`PreToolUse`, `PostToolUse`, `Stop`, `UserPromptSubmit`, and `SessionStart`. They run
+without being invoked, so this section is the one to read before installing — it is what
+changes about your session.
 
-See [ARCHITECTURE.md → Hook index](ARCHITECTURE.md#hook-index) for the full
-list and per-hook spec links (specs live at `hooks/<role>/<name>/spec.md`;
-the [`docs/hook/INDEX.md`](docs/hook/INDEX.md) index links to them), and
-[DESIGN.md → Hook Design Contracts](DESIGN.md#hook-design-contracts) for the
-shared design contracts every hook follows. For a generated summary of hook
-roles, events, host filters, and strict/bypass knobs, see the
-[`Hook Operating Matrix`](docs/hook-operating-matrix.md).
+They divide into four roles. Two of them block by default, and a third can be
+promoted into blocking:
+
+| Role | Count | What it does |
+| ------ | ------- | -------------- |
+| `preflight-gate` | 35 | Inspects a tool call before it runs and can deny it |
+| `completion-verify` | 12 | Fires at `Stop` — can block a response that claims completion without evidence |
+| `advisory-nudge` | 38 | Prints a warning to stderr and lets the call through — until its `PRAXIS_*_STRICT` variable is set, which turns the same hook into a hard deny |
+| `postuse-correction` | 5 | Reacts after a tool call — telemetry, follow-up signals |
+
+Concretely, what a gate stops looks like this — `gh issue create` without a duplicate
+search first (`block-gh-issue-create-without-dup-search`), an edit to a file while you
+are standing on a protected branch (`pre-edit-protected-branch-guard`), a merge run from
+the wrong worktree (`gh-merge-worktree-precondition`), `gh search --state all` which that
+subcommand does not accept (`block-gh-state-all`), a foreground `sleep`-and-poll loop
+(`foreground-poll-loop-guard`), a commit whose title breaks the repo's format
+(`commit-title-format-check`).
+
+Two properties are load-bearing. **Hooks fail open**: a missing `jq`, a malformed stdin
+payload, an unreadable transcript — all exit 0, so a broken hook degrades to no hook
+rather than to a broken session. And a blocking hook that has a bypass variable **prints
+it in its own deny message** (`hooks/_lib/block_message.py`), so the way out arrives with
+the block rather than having to be hunted for.
+
+The complete list, with each hook's events, hosts, strict/bypass knobs, and the external
+commands it may run, is the generated
+[Hook Operating Matrix](docs/hook-operating-matrix.md). Per-hook specs live at
+`hooks/<role>/<name>/spec.md`, indexed by [`docs/hook/INDEX.md`](docs/hook/INDEX.md);
+[ARCHITECTURE.md → Hook index](ARCHITECTURE.md#hook-index) maps them to the component
+graph, and [DESIGN.md → Hook Design Contracts](DESIGN.md#hook-design-contracts) covers
+the contracts every hook follows.
+
+## Turning it off
+
+A hook that blocks something you meant to do is not a wall. There are three levers, from
+narrowest to widest.
+
+**Opt out of one gate.** 38 of the 90 hooks declare an opt-out variable — set it and
+that gate either skips entirely or demotes itself to a warning, depending on the hook.
+The form is the variable in front of the command it guards, with a reason:
+
+```bash
+PRAXIS_HOOK_BYPASS_SKILL_GATE=1 <command>   # <one-line reason>
+```
+
+Which variable belongs to which hook is the table in
+[`docs/bypass-vars.md`](docs/bypass-vars.md). Opt-outs are recorded by the
+`bypass-telemetry` hook, so `bypass-review` can later show you which gate you keep
+routing around — usually a sign the gate is miscalibrated, not that you are
+undisciplined.
+
+**Escalate instead.** The opposite lever exists too: 20 hooks read a `PRAXIS_*_STRICT`
+variable that promotes an advisory into a hard block. Defaults sit on the permissive
+side of that line — an advisory hook stays advisory until you say otherwise.
+
+**All of it.** Remove the plugin from Claude Code's `/plugin` interface, or drop the
+praxis entries from your `settings.json` hooks block. Skills and hooks are independent —
+removing the hooks leaves every `/praxis:*` skill working.
 
 ## Prerequisites
 
@@ -109,44 +181,6 @@ the system behaves exactly as before — no errors, no degradation.
 
 See [ARCHITECTURE.md → Provider Routing](ARCHITECTURE.md#provider-routing) for
 the full task-type / complexity routing matrix and fallback policy.
-
-## Installation
-
-Praxis ships a single runtime (`skills/`, `hooks/`, `scripts/`) with
-platform-specific packaging adapters generated from a canonical source in
-`manifests/`. Three install surfaces are supported.
-
-### Claude Code — plugin (recommended)
-
-```bash
-/plugin marketplace add https://github.com/devseunggwan/praxis
-/plugin install praxis
-```
-
-Claude Code reads `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`
-directly from the repo root.
-
-### Codex — marketplace + plugin
-
-```bash
-# Register the local marketplace (points at this repo's .agents/plugins/marketplace.json)
-codex marketplace add https://github.com/devseunggwan/praxis
-codex plugin install praxis
-```
-
-Codex reads `.agents/plugins/marketplace.json` as the marketplace root and
-`plugins/praxis/.codex-plugin/plugin.json` as the plugin root. The `skills/`,
-`hooks/`, and `scripts/` directories inside `plugins/praxis/` are symlinks
-into the repo-root runtime — there is no source duplication.
-
-### Direct skill install (fallback)
-
-When the plugin surface isn't available:
-
-```bash
-git clone https://github.com/devseunggwan/praxis.git ~/projects/praxis
-claude skill add ~/projects/praxis/skills/<skill-name>
-```
 
 ## Packaging internals
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ Eighteen skills, grouped as Discovery, Development, Discipline, and Session Mana
 The full table — trigger keywords, when to use each, example invocation — lives in
 [`docs/skills.md`](docs/skills.md).
 
-If you are new, start with `/praxis:using-praxis`: it asks what you are trying to do and
-routes you to the skill that fits, which is faster than reading the catalogue. The three
-worth knowing by name on day one:
+If you are new, `/praxis:using-praxis` maps situations onto the skill that handles each —
+sessions lost to a crash, a broken rule you want on record, a review whose comments have
+piled up — which is a shorter read than the full table. The three worth knowing by name
+on day one:
 
 | Skill | What it is for |
 | ------- | ---------------- |
@@ -95,7 +96,7 @@ promoted into blocking:
 | ------ | ------- | -------------- |
 | `preflight-gate` | 35 | Inspects a tool call before it runs and can deny it |
 | `completion-verify` | 12 | Fires at `Stop` — can block a response that claims completion without evidence |
-| `advisory-nudge` | 38 | Prints a warning to stderr and lets the call through — 12 of them turn into a hard deny when their `PRAXIS_*_STRICT` variable is set |
+| `advisory-nudge` | 38 | Prints a warning to stderr and lets the call through — 12 read a `PRAXIS_*_STRICT` variable that makes them stop the call instead |
 | `postuse-correction` | 5 | Reacts after a tool call — telemetry, follow-up signals |
 
 Concretely, what a gate stops looks like this — `gh issue create` without a duplicate
@@ -122,14 +123,14 @@ the contracts every hook follows.
 
 ## Turning it off
 
-A hook that blocks something you meant to do is not a wall. There are three levers, from
-narrowest to widest.
+A hook that blocks something you meant to do is not a wall. There are three levers.
 
-**Opt out of one gate.** 38 of the 90 hooks declare an opt-out variable — set it and
-that gate either skips entirely or demotes itself to a warning, depending on the hook.
-Which variable belongs to which hook is the table in
-[`docs/bypass-vars.md`](docs/bypass-vars.md), and the generated
-[Hook Operating Matrix](docs/hook-operating-matrix.md) carries the same mapping per hook.
+**One gate.** 38 of the 90 hooks declare an opt-out variable. Which variable belongs to
+which hook, and what setting it actually does to that hook, is the table in
+[`docs/bypass-vars.md`](docs/bypass-vars.md); the generated
+[Hook Operating Matrix](docs/hook-operating-matrix.md) carries the same mapping with each
+hook's default alongside it. Read the row before setting the variable — the hooks differ
+from each other, which is why this section points at the table instead of summarizing it.
 
 **Set it where Claude Code can see it** — its own environment, before the session starts:
 
@@ -142,24 +143,11 @@ read `os.environ` of their own process, which never sees a variable scoped to th
 call, so the gate blocks exactly as before. Use the shell export above, or the `env`
 block in your `settings.json`.
 
-The `bypass-telemetry` hook logs some of these as they are used, and the `bypass-review`
-CLI reads that log — worth a look if you find yourself routing around the same gate
-repeatedly, which usually means the gate is miscalibrated rather than that you are
-undisciplined. What it captures is narrower than the full set of opt-outs; see
-[`docs/bypass-telemetry.md`](docs/bypass-telemetry.md).
-
-**Escalate instead.** The opposite lever exists too: 20 hooks read a `PRAXIS_*_STRICT`
-variable that promotes them to a hard block — 12 of the 38 advisory hooks, plus 5
-preflight gates and 3 `Stop`-time checks that are advisory until you set it. The other 26
-advisory hooks declare no such variable and stay advisory whatever you set. Defaults sit
-on the permissive side of that line.
-
 **All of it.** On a plugin install, `claude plugin disable praxis` (or `/plugin` in the
 session) switches the whole plugin off — skills and hooks together, since both are
-declared in one manifest and `disable` has no hook-only option. If what you want is the
-gates gone but the `/praxis:*` skills kept, that is the first two levers above, not this
-one. Only a manual install registers praxis hooks in `settings.json` as separate
-entries; there, dropping them leaves the skills working.
+declared in one manifest and `disable` has no hook-only option. To keep the skills and
+stop a gate, use the opt-out above instead. Only a manual install registers praxis hooks
+in `settings.json` as separate entries; there, dropping them leaves the skills working.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -143,9 +143,11 @@ undisciplined.
 variable that promotes an advisory into a hard block. Defaults sit on the permissive
 side of that line — an advisory hook stays advisory until you say otherwise.
 
-**All of it.** Remove the plugin from Claude Code's `/plugin` interface, or drop the
-praxis entries from your `settings.json` hooks block. Skills and hooks are independent —
-removing the hooks leaves every `/praxis:*` skill working.
+**All of it.** On a plugin install, the hooks come from the plugin manifest rather than
+from your settings, so the switch is `claude plugin disable praxis` (or `/plugin` in the
+session). Only a manual install registers praxis in `settings.json`, and there you drop
+its hooks entries. Either way skills and hooks are independent — removing the hooks
+leaves every `/praxis:*` skill working.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ promoted into blocking:
 | ------ | ------- | -------------- |
 | `preflight-gate` | 35 | Inspects a tool call before it runs and can deny it |
 | `completion-verify` | 12 | Fires at `Stop` — can block a response that claims completion without evidence |
-| `advisory-nudge` | 38 | Prints a warning to stderr and lets the call through — until its `PRAXIS_*_STRICT` variable is set, which turns the same hook into a hard deny |
+| `advisory-nudge` | 38 | Prints a warning to stderr and lets the call through — 12 of them turn into a hard deny when their `PRAXIS_*_STRICT` variable is set |
 | `postuse-correction` | 5 | Reacts after a tool call — telemetry, follow-up signals |
 
 Concretely, what a gate stops looks like this — `gh issue create` without a duplicate
@@ -127,21 +127,31 @@ narrowest to widest.
 
 **Opt out of one gate.** 38 of the 90 hooks declare an opt-out variable — set it and
 that gate either skips entirely or demotes itself to a warning, depending on the hook.
-The form is the variable in front of the command it guards, with a reason:
+Which variable belongs to which hook is the table in
+[`docs/bypass-vars.md`](docs/bypass-vars.md); a blocking hook also prints its own in the
+deny message.
+
+**Set it where Claude Code can see it** — its own environment, before the session starts:
 
 ```bash
-PRAXIS_HOOK_BYPASS_SKILL_GATE=1 <command>   # <one-line reason>
+export PRAXIS_HOOK_BYPASS_SKILL_GATE=1   # <one-line reason>
 ```
 
-Which variable belongs to which hook is the table in
-[`docs/bypass-vars.md`](docs/bypass-vars.md). Opt-outs are recorded by the
-`bypass-telemetry` hook, so `bypass-review` can later show you which gate you keep
-routing around — usually a sign the gate is miscalibrated, not that you are
-undisciplined.
+An assignment written in front of the command (`VAR=1 git …`) does **not** work. Hooks
+read `os.environ` of their own process, which never sees a variable scoped to the tool
+call, so the gate blocks exactly as before. Use the shell export above, or the `env`
+block in your `settings.json`.
+
+Opt-outs whose **name contains `BYPASS`** are recorded by the `bypass-telemetry` hook, so
+`bypass-review` can later show you which gate you keep routing around — usually a sign the
+gate is miscalibrated, not that you are undisciplined. Opt-outs named `*_ADVISORY` are
+outside that filter and leave no trace.
 
 **Escalate instead.** The opposite lever exists too: 20 hooks read a `PRAXIS_*_STRICT`
-variable that promotes an advisory into a hard block. Defaults sit on the permissive
-side of that line — an advisory hook stays advisory until you say otherwise.
+variable that promotes them to a hard block — 12 of the 38 advisory hooks, plus 5
+preflight gates and 3 `Stop`-time checks that are advisory until you set it. The other 26
+advisory hooks declare no such variable and stay advisory whatever you set. Defaults sit
+on the permissive side of that line.
 
 **All of it.** On a plugin install, `claude plugin disable praxis` (or `/plugin` in the
 session) switches the whole plugin off — skills and hooks together, since both are

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,58 @@
+# Skills
+
+The full skill reference. For what praxis is and how to install it, see
+[`README.md`](../README.md); if you are new and want a starting point rather
+than a catalogue, run `/praxis:using-praxis`.
+
+> **Invocation**: praxis entries are *skills*, not subagents. Always call them
+> via `Skill(skill="praxis:<name>")`. `Agent(subagent_type="praxis:<name>")`
+> returns `Agent type not found` — Agent and Skill resolve disjoint namespaces.
+> See [RUNTIME_CONSTRAINTS.md §3](../RUNTIME_CONSTRAINTS.md) for the mapping table.
+>
+> **Trigger keywords** mirror each skill's `SKILL.md` `description` field verbatim
+> and are intentionally kept in their source language (some are Korean) so this page
+> stays in sync with what actually triggers the skill — do not translate them.
+
+## Discovery
+
+| Skill | Trigger keywords | When to use | Example invocation |
+| ------- | ----------------- | ------------- | ------------------- |
+| `using-praxis` | `praxis 처음`, `praxis 사용법`, `어떤 skill 부터`, `praxis intro`, `praxis getting started` | To find the right skill when you're new to praxis or unsure which one fits | `/praxis:using-praxis` |
+| `writing-praxis-skill` | `new skill`, `write skill`, `add skill`, `skill template`, `skill spec`, `스킬 작성`, `새 스킬` | To author a new SKILL.md or get a skill-structure guide | `/praxis:writing-praxis-skill` |
+
+## Development
+
+| Skill | Trigger keywords | When to use | Example invocation |
+| ------- | ----------------- | ------------- | ------------------- |
+| `retrospect` | `retrospect`, `what went wrong`, `session review`, `session improvement`, `improve` | To analyze friction patterns / root causes after a session and act on improvements | `/praxis:retrospect` |
+| `codex-review-wrap` | `codex review`, `review codex`, `safe review`, `premise verification`, `flip detection`, `sibling cross-check` | To run `/codex:review` safely in multi-worktree setups, with premise verification and flip detection | `/praxis:codex-review-wrap` |
+| `debt` | `praxis:debt`, `debt ledger`, `지연 결정`, `deferred decision`, `기술 부채 원장`, `commit trailer audit` | To harvest commit-trailer and compounding-comment deferred-decision markers into a report-only ledger | `/praxis:debt` |
+| `surface-enumeration` | `surface enumerate`, `input surface enumeration`, `input parser`, `input validation`, `intent classifier`, `정규식 경계`, `입력 표면 열거` | To enumerate every input variant before implementing a parser/validator/sanitizer so each becomes a required test case | `/praxis:surface-enumeration` |
+| `spec-drift` | `spec drift`, `spec-drift`, `스펙 드리프트`, `미구현 요구`, `unmet requirement`, `requirement status` | To report which requirements in the `~/.praxis/docs/specs/` store the current tree does not yet satisfy, by running each one's `Verify:` command | `/praxis:spec-drift` |
+| `merge-briefing` | `merge briefing`, `pre-merge briefing`, `머지 브리핑`, `머지해도 되나`, `approve merge`, `pre-ask probe`, `merge approval` | To probe all three finding surfaces, grade every finding by its blocking decoration, carry anchor `Unverified` gaps, and surface the six-part briefing before asking for merge approval | `/praxis:merge-briefing` |
+| `worktree-merge-cleanup` | `merge cleanup`, `post-merge cleanup`, `worktree cleanup`, `delete-branch merge`, `squash-ancestry`, `pre-merge worktree`, `머지 후 정리`, `worktree 정리` | To run `gh pr merge --squash --delete-branch` from the right worktree and clean up afterward (submodule `--force`, squash-ancestry guard, no-`&&`-chain) | `/praxis:worktree-merge-cleanup` |
+
+## Discipline
+
+| Skill | Trigger keywords | When to use | Example invocation |
+| ------- | ----------------- | ------------- | ------------------- |
+| `strike` | `/strike`, `/praxis:strike`, `strike 1/2/3`, `삼진` | To explicitly record a rule violation (excludes colloquial uses like "strike a balance") | `/praxis:strike <violation reason>` |
+| `strikes` | `/strikes`, `strike status`, `몇 진`, `check strikes` | To check the current session's strike count and recorded violations | `/praxis:strikes` |
+| `reset-strikes` | `/reset-strikes`, `strike 초기화`, `clear strikes` | To reset the counter and resume responses after a 3-strike block | `/praxis:reset-strikes` |
+
+## Session Management
+
+| Skill | Trigger keywords | When to use | Example invocation |
+| ------- | ----------------- | ------------- | ------------------- |
+| `recover-sessions` | `recover`, `session recovery`, `restore sessions`, `power recovery` | To recover sessions after power loss or a tmux crash (tmux backend) | `/praxis:recover-sessions` |
+| `cmux-recover-sessions` | `터졌다`, `크래시 복구`, `OOM 복구`, `세션 살려야`, `crash recovery`, `power loss recovery`, `cmux session recovery` | To emergency-recover many cmux sessions after a crash / power loss / OOM (`.jsonl` scan based) | `/praxis:cmux-recover-sessions` |
+| `cmux-save-sessions` | `save sessions`, `session save`, `session snapshot`, `cmux save`, `snapshot list` | To save the current cmux session list as JSON for later restore | `/praxis:cmux-save-sessions` |
+| `cmux-resume-sessions` | `resume sessions`, `restore from snapshot`, `rehydrate sessions`, `세션 복원`, `스냅샷 복원` | To restore workspaces from a saved snapshot (for crash recovery, use `cmux-recover-sessions`) | `/praxis:cmux-resume-sessions` |
+| `cmux-session-manager` | `cmux session`, `session management`, `session cleanup`, `cmux status`, `cmux tidy` | To run routine session cleanup or view a status dashboard | `/praxis:cmux-session-manager` |
+| `cmux-delegate` | `delegate`, `cmux delegate`, `new session` | To delegate to an independent session while preserving the current task's context (split review / debugging / implementation) | `/praxis:cmux-delegate` |
+
+> **CLI tools (not skills):** praxis also ships `bypass-review`, a shell wrapper
+> with no `SKILL.md` — it is **not** invocable as `/praxis:*` and is absent from
+> the skills above. It inspects the review bypass-telemetry event logs.
+> See [AGENTS.md → Local Development](../AGENTS.md#local-development) for the full
+> list of shipped CLI wrappers.

--- a/scripts/check-plugin-manifests.py
+++ b/scripts/check-plugin-manifests.py
@@ -30,7 +30,7 @@ Phase 2 (ADR-0001) invariants:
   12. skills/<skill-name>/ on disk matches the EXPECTED_SKILLS frozen set
      (issue #465 — surface freeze gate against silent skill proliferation).
   13. AGENTS.md "## Skills (N)" count and per-skill backtick tokens, and
-     README.md per-skill backtick tokens, all match EXPECTED_SKILLS
+     docs/skills.md per-skill backtick tokens, all match EXPECTED_SKILLS
      (issue #498 — doc drift invariant).
   14. Each manifest `dispatch_groups` (event, matcher) collapses to exactly
      one dispatcher node per platform hooks.json (no member silently left as
@@ -896,9 +896,9 @@ def main() -> int:
     # Rule 13 — Doc skill-count invariant (#498)
     #
     # AGENTS.md carries an explicit "## Skills (N)" header whose count must
-    # equal len(EXPECTED_SKILLS).  Both AGENTS.md and README.md embed skill
-    # names inside table cells as `backtick` tokens; every EXPECTED_SKILLS
-    # member must appear at least once in each document.
+    # equal len(EXPECTED_SKILLS).  Both AGENTS.md and docs/skills.md embed
+    # skill names inside table cells as `backtick` tokens; every
+    # EXPECTED_SKILLS member must appear at least once in each document.
     #
     # Parsing is intentionally coarse — we match the pattern
     # `skill-name` (backtick-delimited) so the check is robust to table
@@ -907,10 +907,7 @@ def main() -> int:
     import re as _re  # local import — avoids polluting module scope
 
     agents_md_path = REPO_ROOT / "AGENTS.md"
-    readme_md_path = REPO_ROOT / "README.md"
-
     agents_text = agents_md_path.read_text()
-    readme_text = readme_md_path.read_text()
 
     # Rule 13a — AGENTS.md "## Skills (N)" count header must match
     count_match = _re.search(r"^##\s+Skills\s+\((\d+)\)", agents_text, _re.MULTILINE)
@@ -939,17 +936,29 @@ def main() -> int:
         )
 
     # Rule 13c — every EXPECTED_SKILLS member appears as the first column of
-    # a README.md skill table row.  We match `| \`skill-name\` |` so that a
+    # a docs/skills.md table row.  We match `| \`skill-name\` |` so that a
     # skill name mentioned only in a description cell (cross-reference noise)
-    # does not satisfy the check.
-    readme_table_skills = set(
-        _re.findall(r"^\|\s*`([^`]+)`\s*\|", readme_text, _re.MULTILINE)
-    )
-    missing_in_readme = EXPECTED_SKILLS - readme_table_skills
-    if missing_in_readme:
+    # does not satisfy the check.  The table moved out of README.md when the
+    # README became a landing document (#1088); README.md now carries only a
+    # pointer, so enforcing the roster there would fight that split.
+    skills_doc_path = REPO_ROOT / "docs" / "skills.md"
+    if not skills_doc_path.exists():
         drifts.append(
-            f"DOC SKILL LIST README.md: {sorted(missing_in_readme)!r} declared in "
-            "EXPECTED_SKILLS but not found as a first-column `backtick` token in a "
+            "DOC SKILL LIST docs/skills.md: file missing — it is the skill "
+            "roster README.md points at"
+        )
+        skills_doc_table = set()
+    else:
+        skills_doc_table = set(
+            _re.findall(
+                r"^\|\s*`([^`]+)`\s*\|", skills_doc_path.read_text(), _re.MULTILINE
+            )
+        )
+    missing_in_skills_doc = EXPECTED_SKILLS - skills_doc_table
+    if missing_in_skills_doc:
+        drifts.append(
+            f"DOC SKILL LIST docs/skills.md: {sorted(missing_in_skills_doc)!r} declared "
+            "in EXPECTED_SKILLS but not found as a first-column `backtick` token in a "
             "table row — add them to the skill table"
         )
 


### PR DESCRIPTION
Closes #1088

### 왜

README 첫 문단이 `disciplined, fast, resilient` 라는 형용사 세 개뿐이라 이 플러그인이
무엇을 막아주는 도구인지 전달되지 않았고, `praxis` 라는 이름 자체가 도메인을 함의하지
않는다는 간극을 문서가 메우지 않았다.

측정된 결함:

- 훅 90개(매니페스트 등록 100건)가 16행으로 뭉개져 있었고 예시는 괄호 안 4개뿐
- 끄는 법이 없었다 — README 에서 `bypass|strict|advisory` 는 3회 매치가 전부이고
  전부 부수적. 실제 opt-out 노브는 38개 훅, strict 노브는 20개 훅에 있다
- 스킬 표가 202행 중 55행(27%)을 차지하는데 "무엇부터"가 없었다
- 설치 절차가 136행에 있었다

### 무엇

- 스킬 표를 `docs/skills.md` 로 이관하고, README 는 `using-praxis` 진입로와
  day-one 스킬 3개만 남긴다
- `The name` 섹션 신설 — 어원과 ETHOS.md 의 `spec defines, hook enforces` 를 연결하고,
  동명 프로젝트(Ruby Praxis, PraxisEMR, npm/PyPI)와 네임스페이스가 겹치지 않음을 명시
- Hooks 섹션을 역할별 개수와 실제 차단 사례 중심으로 확장
- `Turning it off` 섹션 신설 — opt-out / strict / 전체 제거의 세 단계
- Installation 을 스킬 표보다 위로 이동
- `scripts/check-plugin-manifests.py` Rule 13c 가 스킬 로스터를 찾는 위치를
  `docs/skills.md` 로 재조준 (이걸 안 하면 검사기가 깨진다)

### 검증

`bash scripts/run-tests.sh` (CI 진입점) → `ALL TESTS PASSED`, exit 0.
markdownlint 는 README.md·docs/skills.md 둘 다 0건이며, 현재 main 의 README 에 있던
MD028 1건도 함께 해소된다. 스킬 18개 전부 새 표에 첫 열 토큰으로 존재한다.

Codex 리뷰 1라운드에서 나온 지적 1건(P2)을 반영했다 — advisory-nudge 역할이
strict 설정 시 hard deny 로 전환되는데 표가 "lets the call through" 로만 적고 있었다.
근거: `hooks/advisory-nudge/path-probe-gate/impl.py:30` 이 strict 에서 exit 2 로
deny 함을 명시.

GitHub 렌더링 결과는 이 PR 페이지에서 눈으로만 확인 가능하다.

Caller chain verified: grep -rn "check-plugin-manifests" scripts/ .github/workflows/ -> scripts/run-tests.sh:137 이 유일한 호출부이며, CI 는 run-tests.sh 를 통해 이를 실행한다. Rule 13c 는 이 스크립트 내부 함수이고 외부에서 직접 import 하는 호출부는 없다.
Pre-commit verified: bash scripts/run-tests.sh -> ALL TESTS PASSED (exit 0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README with cross-platform installation guidance for Claude Code, Codex, and direct skill installation.
  - Added explanations of project naming, available skills, hook behavior, fail-open and bypass semantics, and how to disable hooks or the plugin.
  - Added a comprehensive skill reference covering invocation rules, trigger keywords, and skill categories.

- **Chores**
  - Updated documentation validation to check the skill roster against the new skill reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->