### PR TITLE
fix(hooks): keep safe_tokenize from dropping a line on same-line comments and quoted heredoc lookalikes

### DIFF
--- a/hooks/_lib/_hook_utils.py
+++ b/hooks/_lib/_hook_utils.py
@@ -91,9 +91,12 @@ def _starts_unquoted_comment(line: str, i: int) -> bool:
     return line[i] == "#" and (i == 0 or line[i - 1] in _WORD_BOUNDARY_CHARS)
 
 
-def _heredoc_starts_on_line(line: str) -> list[tuple[str, bool]]:
-    """`(delimiter, dash_form)` for every heredoc opened on one physical line.
+def _heredoc_starts_on_line(
+    line: str, quote: str = ""
+) -> tuple[list[tuple[str, bool]], str]:
+    """`(openers, quote_open_at_eol)` for one physical line.
 
+    `openers` is `(delimiter, dash_form)` for every heredoc opened on the line.
     Scans character-wise rather than by regex because the three constructs that
     must NOT be read as a heredoc all look like `<<` to a pattern match: a
     here-string (`<<<`), an arithmetic left-shift (`$((1 << 3))`), and a literal
@@ -104,10 +107,17 @@ def _heredoc_starts_on_line(line: str) -> list[tuple[str, bool]]:
     `-m "$(cat <<'EOF'`  — the exact shape of a commit-message payload — really
     does open a heredoc. `subst` stacks the suspended quote state so that one is
     seen while a plain `"…<<EOF…"` string stays inert.
+
+    `quote` is the quote character still open from the *previous* physical line;
+    the returned second element is the quote still open at this line's end.
+    Carrying it lets `strip_heredoc_bodies` mirror `_logical_lines`' fold so a
+    `<<WORD` sitting inside a multi-line quoted string is read as data, not as a
+    heredoc opener (issue #1091, extending the #972/#987 quote-fold). A group
+    still open inside a `$(…)` is reported as its outermost suspended quote,
+    exactly as `_quote_open_at_eol` does.
     """
     out: list[tuple[str, bool]] = []
     i, n = 0, len(line)
-    quote = ""
     arith = 0
     subst: list[str] = []
     while i < n:
@@ -164,7 +174,10 @@ def _heredoc_starts_on_line(line: str) -> list[tuple[str, bool]]:
             i += 2
             continue
         i += 1
-    return out
+    # Report the outermost still-open quote so the caller can carry it into the
+    # next physical line — a `$(…)` open at EOL keeps the command going, so its
+    # suspended quote is what bash is still inside (issue #1091).
+    return out, quote or (subst[0] if subst else "")
 
 
 _HEREDOC_WORD_CHARS = re.compile(r"[A-Za-z0-9_.~\-/]")
@@ -215,11 +228,20 @@ def strip_heredoc_bodies(command: str) -> str:
 
     An unterminated heredoc suppresses everything to the end of the command,
     which is what bash does with it too.
+
+    Quote state is carried across physical lines (issue #1091, mirroring the
+    #972/#987 fold in `_logical_lines`): the per-line heredoc scan used to reset
+    to an unquoted state each line, so a `<<WORD` occurring on a later physical
+    line *inside* an open multi-line quoted string was misread as a heredoc
+    opener — blanking the closing-quote line and everything chained after it
+    (`… "notes\nsee <<EOF …\n" && gh pr merge`). Threading the open quote makes
+    that `<<WORD` read as the string data it is.
     """
     if "<<" not in command:
         return command
     out: list[str] = []
     pending: list[tuple[str, bool]] = []
+    quote = ""  # #1091: open quote carried in from the previous physical line
     for line in command.split("\n"):
         if pending:
             delim, dash = pending[0]
@@ -231,7 +253,8 @@ def strip_heredoc_bodies(command: str) -> str:
                 out.append("")
             continue
         out.append(line)
-        pending.extend(_heredoc_starts_on_line(line))
+        openers, quote = _heredoc_starts_on_line(line, quote)
+        pending.extend(openers)
     return "\n".join(out)
 
 
@@ -375,6 +398,91 @@ def _logical_lines(command: str) -> list[str]:
     return out
 
 
+# `# <marker>:ack` opt-out markers that gates read out of the token stream
+# (`# side-effect:ack`, `# title-length:ack`, `# cross-boundary:ack`, …). These
+# must keep tokenizing even though `safe_tokenize` now strips ordinary trailing
+# comments (issue #1091), so the comment strip below skips any comment carrying
+# one. `commenters = ""` on the shlex pass then turns it into `#` + `<marker>`
+# tokens exactly as before.
+_ACK_MARKER_RE = re.compile(r"#\s*[A-Za-z0-9][A-Za-z0-9-]*:ack\b")
+
+
+def _unquoted_comment_start(line: str) -> int:
+    """Index of the `#` opening a genuine unquoted comment in `line`, or -1.
+
+    Shares the exact quote-state walk of `_quote_open_at_eol` — the two must
+    never disagree on where a comment begins, so both defer to
+    `_starts_unquoted_comment` for the word-boundary rule. `safe_tokenize` uses
+    this to strip a real trailing comment before the shlex pass: with
+    `commenters = ""`, an apostrophe inside a same-line comment
+    (`gh pr merge 9 --squash # don't`) otherwise opens a quote shlex never
+    closes, `ValueError` fires, and the fail-open arm dropped the whole line's
+    argv (issue #1091, extending the #972/#987 quote-fold). A `#` inside a quote
+    or after a non-boundary char (`--format=%h#%s`) is not a comment and returns
+    -1 there.
+    """
+    i, n = 0, len(line)
+    quote = ""
+    arith = 0
+    subst: list[str] = []
+    while i < n:
+        ch = line[i]
+        if quote == '"' and line.startswith("$(", i) and not line.startswith("$((", i):
+            subst.append(quote)
+            quote = ""
+            i += 2
+            continue
+        if quote:
+            if ch == "\\" and quote == '"':
+                i += 2
+                continue
+            if ch == quote:
+                quote = ""
+            i += 1
+            continue
+        if ch in "'\"":
+            quote = ch
+            i += 1
+            continue
+        if _starts_unquoted_comment(line, i):
+            return i
+        if ch == "\\":
+            i += 2
+            continue
+        if line.startswith("$((", i):
+            arith += 1
+            i += 3
+            continue
+        if arith and line.startswith("))", i):
+            arith -= 1
+            i += 2
+            continue
+        if ch == ")" and subst and not arith:
+            quote = subst.pop()
+            i += 1
+            continue
+        i += 1
+    return -1
+
+
+def _strip_trailing_comment(line: str) -> str:
+    """Drop a genuine unquoted trailing comment, preserving `:ack` markers.
+
+    Bash reads nothing past an unquoted `#`, so the comment is never a command —
+    but `safe_tokenize` runs shlex with `commenters = ""` (to keep the `:ack`
+    opt-out markers as tokens), which means an apostrophe or unbalanced quote in
+    the comment text crashes the whole line's parse. Stripping the comment first
+    lets the argv before it survive, while a comment that carries an `:ack`
+    marker is left intact so it still tokenizes (issue #1091).
+    """
+    idx = _unquoted_comment_start(line)
+    if idx < 0:
+        return line
+    if _ACK_MARKER_RE.search(line[idx:]):
+        return line  # opt-out marker must still reach the token stream
+    return line[:idx]
+
+
 def safe_tokenize(command: str) -> list[str]:
     """Tokenize with shell operators and line breaks split into tokens.
 
@@ -416,6 +524,15 @@ def safe_tokenize(command: str) -> list[str]:
     marker still tokenizes. Comments are excluded from quote-state tracking
     only — an unquoted ``#`` never opens a quote, so an apostrophe in
     ``git status # don't do this`` cannot swallow the next line's command.
+
+    A *same-line* trailing comment is a second face of that apostrophe hazard:
+    with no newline to fold, ``gh pr merge 9 --squash # don't`` handed the
+    apostrophe-bearing comment straight to shlex, which raised ``ValueError: No
+    closing quotation`` and the ``except ValueError`` arm dropped the entire
+    line's argv (issue #1091, extending #972/#987). Each logical line therefore
+    has its genuine unquoted trailing comment stripped first
+    (``_strip_trailing_comment``) — except a comment carrying a ``:ack`` marker,
+    which is left intact so the opt-out still tokenizes.
     """
     # Splice bash line continuations (`\` + newline) into one logical line so
     # the leading line's argv[0] survives the per-line shlex pass below. A
@@ -424,7 +541,14 @@ def safe_tokenize(command: str) -> list[str]:
     # odd-length run of trailing backslashes.
     command = re.sub(r"(?<!\\)((?:\\\\)*)\\\n", r"\1 ", command)
     command = strip_heredoc_bodies(command)
-    lines = [ln for ln in _logical_lines(command) if ln.strip()]
+    # Strip a genuine unquoted trailing comment from each logical line before
+    # the shlex pass so an apostrophe in it can't crash the parse (issue #1091);
+    # `:ack` opt-out markers are preserved by `_strip_trailing_comment`.
+    lines = [
+        stripped
+        for ln in _logical_lines(command)
+        if (stripped := _strip_trailing_comment(ln)).strip()
+    ]
     if not lines:
         return []
     tokens: list[str] = []

--- a/tests/hooks/advisory-nudge/test_memory_hint.sh
+++ b/tests/hooks/advisory-nudge/test_memory_hint.sh
@@ -177,7 +177,11 @@ malformed_json_test
 run_case "13 silent: tool_name Read"                   silent                    "$FIXTURES_MAIN" Read 'kubectl get'
 run_case "14 silent: empty command"                    silent                    "$FIXTURES_MAIN" Bash ''
 run_case "15 hit: backslash line continuation"         "hit:hook_kubectl.md"     "$FIXTURES_MAIN" Bash "$(printf 'kubectl \\\n  get pods')"
-run_case "16 hit: comment-prefixed token still matches" "hit:hook_kubectl.md"    "$FIXTURES_MAIN" Bash '# kubectl get'
+# A fully commented-out command executes nothing, so #1091 made safe_tokenize
+# strip it and no memory surfaces. A real command with a *trailing* comment is
+# unaffected — its keyword still matches (16b).
+run_case "16 silent: a fully commented-out command runs nothing" silent          "$FIXTURES_MAIN" Bash '# kubectl get'
+run_case "16b hit: keyword before a trailing comment still matches" "hit:hook_kubectl.md" "$FIXTURES_MAIN" Bash 'kubectl get # pods'
 run_case "17 hit: multiple distinct memories fire"     "hit:hook_gh_search.md"   "$FIXTURES_MAIN" Bash 'gh search issues "kubectl"'
 
 # --- AC-21 / AC-22 / AC-23 ---------------------------------------------------

--- a/tests/test_heredoc_help_tokenizer.py
+++ b/tests/test_heredoc_help_tokenizer.py
@@ -85,6 +85,25 @@ def test_command_without_heredoc_is_returned_unchanged() -> None:
     assert strip_heredoc_bodies(command) == command
 
 
+def test_heredoc_lookalike_inside_a_multiline_quote_is_not_an_opener() -> None:
+    """Issue #1091: a `<<WORD` on a later physical line *inside* an open
+    multi-line quoted string was misread as a heredoc opener because the scan
+    reset quote state per physical line — so `strip_heredoc_bodies` blanked the
+    closing-quote line and the chained command riding after it. Carrying quote
+    state across physical lines (mirroring the #972/#987 `_logical_lines` fold)
+    keeps the `<<EOF` as the string data it is, and the `&& gh pr merge`
+    survives. Before the fix `safe_tokenize` of this payload returned ``[]``."""
+    command = f'git commit -m "notes:\nsee <<EOF for details\n" && {MERGE} 9'
+    # strip_heredoc_bodies must leave the whole command untouched — no line is
+    # a heredoc body.
+    assert strip_heredoc_bodies(command) == command
+    assert _has_merge(command)
+    assert safe_tokenize(command) == [
+        "git", "commit", "-m", "notes:\nsee <<EOF for details\n",
+        "&&", "gh", "pr", "merge", "9",
+    ]
+
+
 def test_heredoc_lookalike_in_a_comment_opens_nothing() -> None:
     """`# <<EOF` is a comment; bash reads no operator past it, so the next line
     must stay visible (CodeRabbit, verified against bash)."""

--- a/tests/test_hook_utils.sh
+++ b/tests/test_hook_utils.sh
@@ -488,11 +488,12 @@ run_tokens "heredoc commit followed by a merge survives (#987)" \
   $'git commit -m "$(cat <<\'EOF\'\nbody line\nEOF\n)" && gh pr merge 9 --squash'
 
 # Anti-bypass: an unquoted `#` comment opens no quote, so the apostrophe in
-# `don't` must not swallow the real merge on the next line. Without the
-# comment rule in `_quote_open_at_eol` this returns [] and every merge gate
-# goes blind — a fresh hole traded for the one being closed.
+# `don't` must not swallow the real merge on the next line. #1091 strips the
+# trailing unquoted comment before the shlex pass, so the command's own argv
+# (`git status`) now survives too — the same-line drop and the multi-line
+# comment-line drop were the identical mechanism.
 run_tokens "apostrophe in an unquoted comment does not swallow the next line" \
-  "[';', 'gh', 'pr', 'merge', '9', '--squash']" \
+  "['git', 'status', ';', 'gh', 'pr', 'merge', '9', '--squash']" \
   $'git status # don\'t do this\ngh pr merge 9 --squash'
 
 # The mirror case: a `#` *inside* quotes is literal, not a comment, so the
@@ -509,15 +510,15 @@ run_tokens "hash inside quotes stays inside the token" \
 # three as ordinary text let the apostrophe in `don't` open a quote and
 # swallow the merge on the next line.
 run_tokens "comment after a closing paren does not swallow the next line" \
-  "[';', 'gh', 'pr', 'merge', '9', '--squash']" \
+  "['(echo', 'ok)', ';', 'gh', 'pr', 'merge', '9', '--squash']" \
   $'(echo ok)#don\'t care\ngh pr merge 9 --squash'
 
 run_tokens "comment after an output redirect does not swallow the next line" \
-  "[';', 'gh', 'pr', 'merge', '9', '--squash']" \
+  "[':', '>', ';', 'gh', 'pr', 'merge', '9', '--squash']" \
   $': >#don\'t care\ngh pr merge 9 --squash'
 
 run_tokens "comment after an input redirect does not swallow the next line" \
-  "[';', 'gh', 'pr', 'merge', '9', '--squash']" \
+  "[':', '<', ';', 'gh', 'pr', 'merge', '9', '--squash']" \
   $': <#don\'t care\ngh pr merge 9 --squash'
 
 # The negative control for the three above: mid-word `#` is NOT a comment in

--- a/tests/test_safe_tokenize_multiline_quote.py
+++ b/tests/test_safe_tokenize_multiline_quote.py
@@ -168,6 +168,47 @@ def test_ack_marker_still_tokenizes() -> None:
     ]
 
 
+# ---------------------------------------------------------------------------
+# Same-line trailing comment with an unbalanced quote (issue #1091).
+# ---------------------------------------------------------------------------
+#
+# The apostrophe hazard of #972/#987 has a second face with no newline to fold:
+# a trailing `# don't` hands the apostrophe straight to shlex, which runs with
+# `commenters = ""` so the `:ack` opt-out markers survive, raises
+# ``ValueError: No closing quotation``, and the fail-open arm dropped the whole
+# line's argv. The genuine unquoted comment is now stripped before the shlex
+# pass — but a comment carrying an `:ack` marker is left intact so it still
+# tokenizes.
+
+def test_same_line_comment_with_apostrophe_keeps_argv() -> None:
+    """Bug 1's exact payload. Before the fix this returned ``[]`` because the
+    comment text reached shlex under ``commenters = ""`` and raised on the
+    unbalanced quote."""
+    assert safe_tokenize(MERGE + " 9 --squash # don't") == [
+        "gh", "pr", "merge", "9", "--squash",
+    ]
+
+
+def test_same_line_comment_with_apostrophe_reaches_the_gates() -> None:
+    assert _has_merge(MERGE + " 9 --squash # don't")
+
+
+def test_same_line_ack_marker_survives_alongside_the_comment() -> None:
+    """The `:ack` opt-out marker must still tokenize even though ordinary
+    same-line comments are now stripped — so the argv *and* the `#`/marker
+    tokens both survive when the trailing comment is the ack marker."""
+    assert safe_tokenize(MERGE + " 9 --squash # side-effect:ack") == [
+        "gh", "pr", "merge", "9", "--squash", "#", "side-effect:ack",
+    ]
+
+
+def test_plain_same_line_comment_is_stripped_not_tokenized() -> None:
+    """A non-`:ack` trailing comment is bash-ignored text, never a command, so
+    it is dropped from the stream rather than kept as `#`+word tokens — while
+    the argv before it survives (issue #1091)."""
+    assert safe_tokenize("git status # tidy up later") == ["git", "status"]
+
+
 @pytest.mark.parametrize("name,command", [
     ("unterminated double quote", 'echo "never closed'),
     ("unterminated single quote", "echo 'never closed"),


### PR DESCRIPTION
## What

Two `safe_tokenize` gaps let a command bash runs normally reach the gates with **zero tokens**, silently blinding every tokenizer-based PreToolUse(Bash) gate. Extends #972 / #987.

1. **Same-line comment with an unbalanced quote.** `gh pr merge 9 --squash # don't` raised `ValueError` in the shlex pass (because `commenters=""` keeps the comment text) and the whole line's tokens were dropped. Now a genuine trailing unquoted comment is stripped before the shlex pass, while the `# <marker>:ack` opt-out markers are preserved.
2. **`<<WORD` inside an open multi-line quoted string.** `git commit -m "…\nsee <<EOF…\n" && gh pr merge 9` was misread by `strip_heredoc_bodies` as a heredoc opener, blanking the closing quote and the chained merge. Quote state is now carried across physical lines so an in-quote `<<WORD` is treated as data.

## Testing
- New cases in `test_safe_tokenize_multiline_quote.py` / `test_heredoc_help_tokenizer.py` (same-line comment keeps argv; `:ack` marker survives; heredoc-in-quote keeps the chained command).
- `test_hook_utils.sh` mirror cases updated to the now-correct token stream (the command's own argv before a comment is recovered).
- A fully commented-out command (`# kubectl get`) now executes nothing, so `test_memory_hint.sh` is updated to expect no hint, with a positive case proving a real command + trailing comment still matches.

Closes #1091

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKY5RsgXrBBisMS4Ms5oSP

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKY5RsgXrBBisMS4Ms5oSP)_