### PR TITLE
fix(hooks): stop path-prefixed gh/git from evading the argv[0] gates

### DIFF
--- a/hooks/_lib/_external_write_body.py
+++ b/hooks/_lib/_external_write_body.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import os
 import re
 
-from _hook_utils import strip_prefix  # type: ignore[import-not-found]
+from _hook_utils import _is_gh_binary, strip_prefix  # type: ignore[import-not-found]
 
 # ---------------------------------------------------------------------------
 # Bash gh detection
@@ -82,7 +82,7 @@ def extract_gh_body(argv: list[str]) -> str | None:
 def is_gh_external_write(argv: list[str]) -> bool:
     """Return True iff argv invokes a gh subcommand that writes to a public surface."""
     argv = strip_prefix(argv)
-    if not argv or argv[0] != "gh":
+    if not argv or not _is_gh_binary(argv[0]):
         return False
 
     i = 1

--- a/hooks/advisory-nudge/cli-flag-incompat-advisory/impl.py
+++ b/hooks/advisory-nudge/cli-flag-incompat-advisory/impl.py
@@ -69,6 +69,18 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     tokenize_with_roles,
 )
 
+# Shell grouping / command-substitution chars that may prefix a binary token
+# when it sits inside a subshell or substitution (`(git …)`, `$(git …)`,
+# `` `git …` ``). Stripped before the basename comparison so the binary-name
+# check is not fooled by the wrapper syntax. Mirrors `_is_git_binary` in the
+# commit-gate hooks and `_is_gh_binary` in `_hook_utils`.
+_GROUP_PREFIX_CHARS = "(){}$`"
+
+
+def _is_git_binary(token: str) -> bool:
+    stripped = token.lstrip(_GROUP_PREFIX_CHARS)
+    return stripped == "git" or stripped.endswith("/git")
+
 
 # ---------------------------------------------------------------------------
 # Role-aware flag-value spec (issue #263)
@@ -123,7 +135,7 @@ def _count_merge_tree_positionals(seg: list[Token]) -> int:
     invocation.
     """
     argv = filter_argv(seg)
-    if not argv or argv[0].text != "git":
+    if not argv or not _is_git_binary(argv[0].text):
         return -1
 
     # Find the merge-tree subcommand token. Skip past command-global
@@ -167,7 +179,7 @@ def _count_merge_tree_positionals(seg: list[Token]) -> int:
 def _check_git(seg: list[Token]) -> Optional[str]:
     """Return advisory text for known git mode-incompatible combos, else None."""
     argv = filter_argv(seg)
-    if not argv or argv[0].text != "git":
+    if not argv or not _is_git_binary(argv[0].text):
         return None
 
     # merge-tree: --name-only + 3+ positionals → legacy/modern conflict

--- a/hooks/advisory-nudge/external-write-path-existence-check/impl.py
+++ b/hooks/advisory-nudge/external-write-path-existence-check/impl.py
@@ -39,6 +39,7 @@ import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    _is_gh_binary,
     iter_command_starts,
     safe_tokenize,
     strip_prefix,
@@ -105,7 +106,7 @@ def _parse_gh_body_file(argv: list[str]) -> str | None:
     Only fires for gh (issue|pr) (create|edit|comment) subcommands.
     """
     argv = strip_prefix(argv)
-    if not argv or argv[0] != "gh":
+    if not argv or not _is_gh_binary(argv[0]):
         return None
 
     # Skip global flags to reach object/subcommand pair.

--- a/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
+++ b/hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py
@@ -47,6 +47,7 @@ from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     GH_MERGE_VALUE_FLAGS,
+    _is_gh_binary,
     is_help_invocation,
     iter_command_starts,
     safe_tokenize,
@@ -64,6 +65,19 @@ from block_message import (  # type: ignore[import-not-found]  # noqa: E402
 # ---------------------------------------------------------------------------
 
 PREFIX = "[praxis:momentum-gate]"
+
+# Shell grouping / command-substitution chars that may prefix a binary token
+# when it sits inside a subshell or substitution (`(git …)`, `$(git …)`,
+# `` `git …` ``). Stripped before the basename comparison so the binary-name
+# check is not fooled by the wrapper syntax. Mirrors `_is_git_binary` in the
+# commit-gate hooks and `_is_gh_binary` in `_hook_utils`.
+_GROUP_PREFIX_CHARS = "(){}$`"
+
+
+def _is_git_binary(token: str) -> bool:
+    stripped = token.lstrip(_GROUP_PREFIX_CHARS)
+    return stripped == "git" or stripped.endswith("/git")
+
 
 # Trigger identifiers — keys for both static rule surfaces and dynamic
 # memory filtering via the `momentum:` frontmatter field.
@@ -601,7 +615,7 @@ def _gh_pr_positional(argv: list[str], verbs: frozenset[str],
     Global flags before the subcommand are walked exactly as `_is_gh_pr_merge`
     does, so a numeric global-flag value cannot be mistaken for the target."""
     argv = strip_prefix(argv)
-    if not argv or argv[0] != "gh":
+    if not argv or not _is_gh_binary(argv[0]):
         return None
     i = 1
     while i < len(argv):
@@ -874,7 +888,7 @@ GIT_GLOBAL_FLAGS_WITH_ARG = frozenset({
 def _is_gh_pr_merge(argv: list[str]) -> bool:
     """Return True iff the argv segment is `gh pr merge`."""
     argv = strip_prefix(argv)
-    if not argv or argv[0] != "gh":
+    if not argv or not _is_gh_binary(argv[0]):
         return False
     i = 1
     while i < len(argv):
@@ -939,9 +953,14 @@ def _is_force_push(argv: list[str]) -> bool:
     silently bypassing the gate for `git -c user.name=x push --force ...`.
     Mirror the gh global-flags-with-arg pattern: skip both the flag and its
     value token. `--flag=value` fused form needs only single-token skip.
+
+    A leading `+` on a refspec forces just that ref — `git push origin +main`
+    and `git push origin '+refs/heads/*'` are force pushes without any
+    `--force`/`-f` flag, so a bare-flag-only scan misses them. Any positional
+    (non-flag) token starting with `+` is treated as a force refspec.
     """
     argv = strip_prefix(argv)
-    if not argv or argv[0] != "git":
+    if not argv or not _is_git_binary(argv[0]):
         return False
     # Walk past git global flags + their value tokens to find the subcommand.
     i = 1
@@ -965,6 +984,10 @@ def _is_force_push(argv: list[str]) -> bool:
     for tok in rest:
         bare = tok.split("=", 1)[0]
         if bare in force_flags or tok in force_flags:
+            return True
+        # A refspec with a leading `+` forces that ref (`+main`,
+        # `+refs/heads/*`, `+HEAD:main`) — force without a `--force` flag.
+        if tok.startswith("+"):
             return True
         # Bundled POSIX short cluster carrying `f` (=`--force`), e.g. `-fu`, `-vf`.
         # All `git push` short opts are value-less, so a bare `^-[a-zA-Z]+$` token

--- a/hooks/advisory-nudge/version-bump-evidence-check/impl.py
+++ b/hooks/advisory-nudge/version-bump-evidence-check/impl.py
@@ -46,6 +46,7 @@ import sys as _sys
 from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    _is_gh_binary,
     iter_command_starts,
     safe_tokenize,
     strip_prefix,
@@ -215,7 +216,7 @@ def _extract_gh_body(argv: list[str]) -> str | None:
 def _is_gh_bump_target(argv: list[str]) -> bool:
     """Return True iff argv invokes a gh subcommand that is in scope for this hook."""
     argv = strip_prefix(argv)
-    if not argv or argv[0] != "gh":
+    if not argv or not _is_gh_binary(argv[0]):
         return False
 
     i = 1

--- a/hooks/preflight-gate/block-gh-state-all/impl.py
+++ b/hooks/preflight-gate/block-gh-state-all/impl.py
@@ -26,6 +26,7 @@ from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     Token,
     TokenRole,
+    _is_gh_binary,
     compound_cascade_hint,
     filter_argv,
     tokenize_with_roles,
@@ -60,7 +61,7 @@ def is_blocked_gh_search(seg: list[Token]) -> bool:
          or `--state=all` (single FLAG token).
     """
     argv = filter_argv(seg)
-    if not argv or argv[0].text != "gh":
+    if not argv or not _is_gh_binary(argv[0].text):
         return False
 
     i = 1

--- a/hooks/preflight-gate/branch-name-check/impl.py
+++ b/hooks/preflight-gate/branch-name-check/impl.py
@@ -52,6 +52,18 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
 )
 from block_message import format_block  # type: ignore[import-not-found]  # noqa: E402
 
+# Shell grouping / command-substitution chars that may prefix a binary token
+# when it sits inside a subshell or substitution (`(git …)`, `$(git …)`,
+# `` `git …` ``). Stripped before the basename comparison so the binary-name
+# check is not fooled by the wrapper syntax. Mirrors `_is_git_binary` in the
+# commit-gate hooks and `_is_gh_binary` in `_hook_utils`.
+_GROUP_PREFIX_CHARS = "(){}$`"
+
+
+def _is_git_binary(token: str) -> bool:
+    stripped = token.lstrip(_GROUP_PREFIX_CHARS)
+    return stripped == "git" or stripped.endswith("/git")
+
 # ---------------------------------------------------------------------------
 # Configuration defaults
 # ---------------------------------------------------------------------------
@@ -275,7 +287,7 @@ def _extract_new_branch(argv: list[str]) -> str | None:
       git worktree add --orphan <path>   (implicit: orphan branch = basename(path))
     """
     argv = strip_prefix(argv)
-    if not argv or argv[0] != "git":
+    if not argv or not _is_git_binary(argv[0]):
         return None
 
     # Drop shell redirect tokens before positional detection so a query like

--- a/hooks/preflight-gate/commit-title-format-check/impl.py
+++ b/hooks/preflight-gate/commit-title-format-check/impl.py
@@ -48,6 +48,7 @@ from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    _is_gh_binary,
     compound_cascade_hint,
     iter_command_starts,
     safe_tokenize,
@@ -134,7 +135,7 @@ def _extract_gh_title(argv: list[str]) -> tuple[str | None, str | None]:
       gh pr create --title="value"
     """
     argv = strip_prefix(argv)
-    if not argv or argv[0] != "gh":
+    if not argv or not _is_gh_binary(argv[0]):
         return None, None
 
     # Expect: gh <subcmd> <subsubcmd> ...

--- a/hooks/preflight-gate/cross-boundary-preflight/impl.py
+++ b/hooks/preflight-gate/cross-boundary-preflight/impl.py
@@ -47,6 +47,7 @@ from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E4
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     Token,
     TokenRole,
+    _is_gh_binary,
     compound_cascade_hint,
     filter_argv,
     tokenize_with_roles,
@@ -162,7 +163,7 @@ def _gh_write_subcommand(seg: list[Token]) -> tuple[str, str] | None:
     common `gh --repo X issue create` (flags before object).
     """
     argv = filter_argv(seg)
-    if not argv or argv[0].text != "gh":
+    if not argv or not _is_gh_binary(argv[0].text):
         return None
 
     n = len(argv)

--- a/hooks/preflight-gate/gh-flag-verify/impl.py
+++ b/hooks/preflight-gate/gh-flag-verify/impl.py
@@ -48,6 +48,7 @@ from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E4
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     Token,
     TokenRole,
+    _is_gh_binary,
     filter_argv,
     tokenize_with_roles,
 )
@@ -406,7 +407,7 @@ def check_gh_flags(seg: list[Token]) -> tuple[bool, str]:
          flag region.
     """
     argv = filter_argv(seg)
-    if not argv or argv[0].text != "gh":
+    if not argv or not _is_gh_binary(argv[0].text):
         return False, ""
 
     n = len(argv)

--- a/hooks/preflight-gate/gh-json-validator/impl.py
+++ b/hooks/preflight-gate/gh-json-validator/impl.py
@@ -44,6 +44,7 @@ from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _paths import praxis_cache_dir  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    _is_gh_binary,
     iter_command_starts,
     safe_tokenize,
     strip_prefix,
@@ -215,9 +216,9 @@ def _resolve_subcommand_tokens(argv: list[str]) -> tuple[str, ...] | None:
     not starting with '-' is consumed as the flag value). This is sufficient
     for subcommand detection; full flag parsing is not needed here.
 
-    Returns None if argv[0] != 'gh' or no subcommand token found.
+    Returns None if argv[0] is not the gh binary or no subcommand token found.
     """
-    if not argv or argv[0] != "gh":
+    if not argv or not _is_gh_binary(argv[0]):
         return None
 
     positionals: list[str] = []
@@ -286,7 +287,7 @@ def _check_segment(
     Returns (is_invalid, reason). is_invalid=True triggers deny.
     """
     argv = strip_prefix(raw_argv)
-    if not argv or argv[0] != "gh":
+    if not argv or not _is_gh_binary(argv[0]):
         return False, ""
 
     subcommand_tokens = _resolve_subcommand_tokens(argv)

--- a/hooks/preflight-gate/gh-label-verify/impl.py
+++ b/hooks/preflight-gate/gh-label-verify/impl.py
@@ -62,6 +62,7 @@ from pathlib import Path as _Path
 _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib"))
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    _is_gh_binary,
     iter_command_starts,
     safe_tokenize,
     strip_prefix,
@@ -139,7 +140,7 @@ def main() -> int:
 
 
 def _process_segment(argv: list[str], cwd: str, deadline: float) -> int:
-    if len(argv) < 3 or argv[0] != "gh":
+    if len(argv) < 3 or not _is_gh_binary(argv[0]):
         return 0
     if (argv[1], argv[2]) not in _LABELED_SUBCMDS:
         return 0

--- a/hooks/preflight-gate/session-intent/impl.py
+++ b/hooks/preflight-gate/session-intent/impl.py
@@ -80,6 +80,7 @@ _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib")
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_runtime import fail_open  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
+    _is_gh_binary,
     iter_command_starts,
     safe_tokenize,
     strip_prefix,
@@ -354,7 +355,7 @@ def _walk_past_gh_globals(argv: list[str], start: int) -> int:
 def is_gh_mutating(argv: list[str]) -> tuple[bool, str]:
     """Detect a mutating gh invocation. Returns (matched, description)."""
     argv = strip_prefix(argv)
-    if not argv or argv[0] != "gh":
+    if not argv or not _is_gh_binary(argv[0]):
         return (False, "")
 
     i = _walk_past_gh_globals(argv, 1)

--- a/hooks/preflight-gate/side-effect-scan/impl.py
+++ b/hooks/preflight-gate/side-effect-scan/impl.py
@@ -53,6 +53,7 @@ _sys.path.insert(0, str(_Path(__file__).resolve().parent.parent.parent / "_lib")
 from _hook_io import emit_decision  # type: ignore[import-not-found]  # noqa: E402
 from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     GH_MERGE_VALUE_FLAGS,
+    _is_gh_binary,
     compound_cascade_hint,
     is_help_invocation,
     iter_command_starts,
@@ -178,7 +179,7 @@ def _gh_subcommand_pair(argv: list[str]) -> tuple[str, str]:
       ['gh', '--repo', 'o/r', 'pr', 'merge']   → ('pr', 'merge')
       ['gh', 'workflow', 'run', ...]           → ('workflow', 'run')
     """
-    if not argv or argv[0] != "gh":
+    if not argv or not _is_gh_binary(argv[0]):
         return ("", "")
     i = _gh_skip_global_flags(argv)
     group = argv[i] if i < len(argv) else ""

--- a/hooks/preflight-gate/verify-commit-flag-override/impl.py
+++ b/hooks/preflight-gate/verify-commit-flag-override/impl.py
@@ -46,6 +46,18 @@ from _hook_utils import (  # type: ignore[import-not-found]  # noqa: E402
     strip_prefix,
 )
 
+# Shell grouping / command-substitution chars that may prefix a binary token
+# when it sits inside a subshell or substitution (`(git …)`, `$(git …)`,
+# `` `git …` ``). Stripped before the basename comparison so the binary-name
+# check is not fooled by the wrapper syntax. Mirrors `_is_git_binary` in the
+# commit-gate hooks and `_is_gh_binary` in `_hook_utils`.
+_GROUP_PREFIX_CHARS = "(){}$`"
+
+
+def _is_git_binary(token: str) -> bool:
+    stripped = token.lstrip(_GROUP_PREFIX_CHARS)
+    return stripped == "git" or stripped.endswith("/git")
+
 # ---------------------------------------------------------------------------
 # Detection
 # ---------------------------------------------------------------------------
@@ -139,7 +151,7 @@ def detect_overrides(argv: list[str]) -> list[str]:
     has no problematic overrides.
     """
     argv = strip_prefix(argv)
-    if not argv or argv[0] != "git":
+    if not argv or not _is_git_binary(argv[0]):
         return []
 
     overrides: list[str] = []

--- a/tests/hooks/advisory-nudge/test_cli_flag_incompat_advisory.sh
+++ b/tests/hooks/advisory-nudge/test_cli_flag_incompat_advisory.sh
@@ -81,6 +81,13 @@ run_case "merge-tree --name-only with 3 positionals" \
   advisory \
   "git merge-tree --name-only abc123 HEAD origin/main"
 
+# #1092: a path-prefixed git binary must not slip past the merge-tree advisory.
+# `argv[0].text == "git"` exact match previously let `/usr/bin/git merge-tree`
+# bypass; `_is_git_binary` closes it.
+run_case "merge-tree --name-only via /usr/bin/git (path-prefix)" \
+  advisory \
+  "/usr/bin/git merge-tree --name-only abc123 HEAD origin/main"
+
 run_case "merge-tree --name-only chained via && (3 positionals)" \
   advisory \
   "git merge-tree --name-only A B C && echo done"

--- a/tests/hooks/advisory-nudge/test_external_write_path_existence_check.sh
+++ b/tests/hooks/advisory-nudge/test_external_write_path_existence_check.sh
@@ -152,6 +152,25 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Case 2b (#1092): a path-prefixed gh binary must not slip past the phantom
+# check. `argv[0] == "gh"` exact match previously let `/usr/bin/gh issue
+# create` bypass; `_is_gh_binary` closes it. Same phantom body as Case 2.
+# ---------------------------------------------------------------------------
+run_with_body "$case2_body" '/usr/bin/gh issue create --title "Bug"' "session-miss-prefix-$$" c2b_err c2b_rc
+
+c2b_ok=1
+[ "$c2b_rc" -eq 0 ] || c2b_ok=0
+echo "$c2b_err" | grep -q "\[phantom-path\]" || c2b_ok=0
+if [ "$c2b_ok" -eq 1 ]; then
+  echo "PASS: missing path via /usr/bin/gh (path-prefix) phantom"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: missing path via /usr/bin/gh (rc=$c2b_rc, stderr='${c2b_err:0:120}')"
+  FAIL=$((FAIL + 1))
+  FAILED_NAMES+=("missing path via /usr/bin/gh path-prefix phantom")
+fi
+
+# ---------------------------------------------------------------------------
 # Case 3: mixed paths — one real, one phantom.
 # Only the phantom should appear in the advisory.
 # ---------------------------------------------------------------------------

--- a/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
+++ b/tests/hooks/advisory-nudge/test_momentum_rule_retrieval_gate.sh
@@ -400,6 +400,33 @@ run_case "strict_mode_blocks_force_push" \
   "PRAXIS_MOMENTUM_STRICT=1" \
   "git push --force"
 
+# #1092: path-prefixed binaries must still trigger. `argv[0] == "gh"` /
+# `argv[0] == "git"` exact matches previously let `/usr/bin/gh pr merge` and
+# `/usr/bin/git push --force` bypass the gate; `_is_gh_binary`/`_is_git_binary`
+# close both.
+run_case "strict_mode_blocks_path_prefixed_merge" \
+  "block" \
+  "PRAXIS_MOMENTUM_STRICT=1" \
+  "/usr/bin/gh pr merge --squash"
+
+run_case "strict_mode_blocks_path_prefixed_force_push" \
+  "block" \
+  "PRAXIS_MOMENTUM_STRICT=1" \
+  "/usr/bin/git push --force"
+
+# #1092: `+refspec` force pushes carry no `--force`/`-f` flag. `_is_force_push`
+# now flags a leading-`+` refspec (`git push origin +main`,
+# `git push origin '+refs/heads/*'`) as a force push.
+run_case "strict_mode_blocks_refspec_plus_force_push" \
+  "block" \
+  "PRAXIS_MOMENTUM_STRICT=1" \
+  "git push origin +main"
+
+run_case "strict_mode_blocks_refspec_plus_glob_force_push" \
+  "block" \
+  "PRAXIS_MOMENTUM_STRICT=1" \
+  "git push origin '+refs/heads/*'"
+
 run_case "strict_mode_with_ack_passes" \
   "advisory:[praxis:momentum-gate]" \
   "PRAXIS_MOMENTUM_STRICT=1 PRAXIS_MOMENTUM_ACK=1" \

--- a/tests/hooks/advisory-nudge/test_version_bump_evidence_check.sh
+++ b/tests/hooks/advisory-nudge/test_version_bump_evidence_check.sh
@@ -160,6 +160,12 @@ print(json.dumps({
 run_case "version pair arrow → triggers" warn \
   'gh issue create --title "bump" --body "Upgrading from v24.0 → v25.0"'
 
+# #1092: a path-prefixed gh binary must not slip past the version-bump check.
+# `argv[0] == "gh"` exact match previously let `/usr/bin/gh issue create`
+# bypass; `_is_gh_binary` closes it.
+run_case "version pair via /usr/bin/gh (path-prefix) → triggers" warn \
+  '/usr/bin/gh issue create --title "bump" --body "Upgrading from v24.0 → v25.0"'
+
 run_case "version pair dash-arrow → triggers" warn \
   'gh pr create --title "bump" --body "migrating v1.2 -> v1.3"'
 

--- a/tests/hooks/preflight-gate/test_block_gh_state_all.sh
+++ b/tests/hooks/preflight-gate/test_block_gh_state_all.sh
@@ -80,6 +80,14 @@ run_case "block: backslash continuation"              block Bash "$(printf 'gh s
 run_case "block: env prefix FOO=1 gh search"         block Bash 'FOO=1 gh search issues "q" --state all'
 run_case "block: sudo wrapper gh search"             block Bash 'sudo gh search issues "q" --state all'
 run_case "block: chained after echo &&"              block Bash 'echo x && gh search issues "q" --state all'
+# #1092: a path-prefixed gh binary must not slip past the gate. `argv[0].text
+# == "gh"` exact match previously let `/usr/bin/gh search ... --state=all`
+# bypass; `_is_gh_binary` closes it. The fused `--state=all` form is used here
+# because the separate-token `--state all` form under a path-prefixed binary
+# relies on subcommand-keyed value-flag resolution in
+# _hook_utils.tokenize_with_roles (keyed on the literal argv[0]), which the
+# fused form does not need.
+run_case "block: /usr/bin/gh search --state=all (path-prefix)" block Bash '/usr/bin/gh search issues "q" --state=all'
 
 # --- PASS: gh search without --state or with valid states --------------------
 run_case "pass: search issues no --state"             pass  Bash 'gh search issues "test"'

--- a/tests/hooks/preflight-gate/test_branch_name_check.sh
+++ b/tests/hooks/preflight-gate/test_branch_name_check.sh
@@ -203,6 +203,13 @@ run_case "checkout -b wrong format (no issue number, block)" \
   "block" \
   '{"tool_name":"Bash","tool_input":{"command":"git checkout -b feature/my-cool-change"}}'
 
+# #1092: a path-prefixed git binary must not slip past the branch-name gate.
+# `argv[0] == "git"` exact match previously let `/usr/bin/git checkout -b`
+# bypass; `_is_git_binary` closes it.
+run_case "checkout -b path-prefixed git (block)" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"/usr/bin/git checkout -b feature/my-cool-change"}}'
+
 run_case "checkout -b missing prefix (block)" \
   "block" \
   '{"tool_name":"Bash","tool_input":{"command":"git checkout -b 434-feat-branch-check"}}'

--- a/tests/hooks/preflight-gate/test_commit_title_format_check.sh
+++ b/tests/hooks/preflight-gate/test_commit_title_format_check.sh
@@ -179,6 +179,13 @@ run_case "block: release: via gh issue create (PR-only exemption does not cover 
   "block" \
   '{"tool_name":"Bash","tool_input":{"command":"gh issue create --title \"release: Production Deploy (2026-06-02)\" --body \"desc\""}}'
 
+# #1092: a path-prefixed gh binary must not slip past the title-format gate.
+# `argv[0] == "gh"` exact match previously let `/usr/bin/gh issue create`
+# bypass; `_is_gh_binary` closes it.
+run_case "block: release: via /usr/bin/gh issue create (path-prefix)" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"/usr/bin/gh issue create --title \"release: Production Deploy (2026-06-02)\" --body \"desc\""}}'
+
 # ---------------------------------------------------------------------------
 # PASS cases — non-commit commands
 # ---------------------------------------------------------------------------

--- a/tests/hooks/preflight-gate/test_cross_boundary_preflight.sh
+++ b/tests/hooks/preflight-gate/test_cross_boundary_preflight.sh
@@ -68,6 +68,12 @@ run_case() {
 run_case "heredoc in gh issue create" block \
   'gh issue create --title "foo" <<EOF'
 
+# #1092: a path-prefixed gh binary must not slip past the boundary gate.
+# `argv[0].text == "gh"` exact match previously let `/usr/bin/gh issue create`
+# bypass; `_is_gh_binary` closes it.
+run_case "heredoc in /usr/bin/gh issue create (path-prefix)" block \
+  '/usr/bin/gh issue create --title "foo" <<EOF'
+
 run_case "heredoc single-quoted in gh issue create" block \
   "gh issue create --title \"foo\" <<'EOF'"
 

--- a/tests/hooks/preflight-gate/test_gh_flag_verify.sh
+++ b/tests/hooks/preflight-gate/test_gh_flag_verify.sh
@@ -112,6 +112,13 @@ run_case "T04: gh issue list --base main (invalid flag for issue list, deny)" \
   "deny" \
   '{"tool_name":"Bash","tool_input":{"command":"gh issue list --base main"}}'
 
+# #1092: a path-prefixed gh binary must not slip past the flag gate.
+# `argv[0].text == "gh"` exact match previously let `/usr/bin/gh issue list
+# --base main` bypass; `_is_gh_binary` closes it.
+run_case "T04b: /usr/bin/gh issue list --base main (path-prefix, deny)" \
+  "deny" \
+  '{"tool_name":"Bash","tool_input":{"command":"/usr/bin/gh issue list --base main"}}'
+
 # T05: gh issue list --state all (valid for issue list, silent)
 run_case "T05: gh issue list --state all (valid for issue list, silent)" \
   "silent" \

--- a/tests/hooks/preflight-gate/test_gh_json_validator.sh
+++ b/tests/hooks/preflight-gate/test_gh_json_validator.sh
@@ -182,6 +182,14 @@ run_case "block: invalid field --json merged" \
   "block:BLOCKED" \
   "gh pr view 1 --json merged"
 
+# #1092: a path-prefixed gh binary must not slip past the --json field gate.
+# `argv[0] == "gh"` exact match previously let `/usr/bin/gh pr view 1 --json
+# merged` bypass; `_is_gh_binary` closes it. (The hook still shells out to the
+# hermetic `gh` stub for the field list regardless of argv[0]'s path.)
+run_case "block: /usr/bin/gh pr view --json merged (path-prefix)" \
+  "block:BLOCKED" \
+  "/usr/bin/gh pr view 1 --json merged"
+
 # ---------------------------------------------------------------------------
 # Case 2: Pass — valid field (`--json state`)
 # `state` IS a valid `gh pr view` JSON field; hook must pass (exit 0).

--- a/tests/hooks/preflight-gate/test_gh_label_verify.sh
+++ b/tests/hooks/preflight-gate/test_gh_label_verify.sh
@@ -190,6 +190,14 @@ run_case "gh pr create --label nope (missing) — block" \
   "block" \
   '{"tool_name":"Bash","tool_input":{"command":"gh pr create --label nope --repo acme/repo --title t --body b"}}'
 
+# #1092: a path-prefixed gh binary must not slip past the label gate.
+# `argv[0] == "gh"` exact match previously let `/usr/bin/gh pr create --label
+# nope` bypass; `_is_gh_binary` closes it. (The hook still shells out to the
+# hermetic `gh` stub for the label listing regardless of argv[0]'s path.)
+run_case "/usr/bin/gh pr create --label nope (path-prefix) — block" \
+  "block" \
+  '{"tool_name":"Bash","tool_input":{"command":"/usr/bin/gh pr create --label nope --repo acme/repo --title t --body b"}}'
+
 # Regression (#803): the listing is row-limited, so a repo with more labels
 # than the limit hides its tail. Absence from the listing must not block on
 # its own — `tail-label` is real and the API says so.

--- a/tests/hooks/preflight-gate/test_session_intent.sh
+++ b/tests/hooks/preflight-gate/test_session_intent.sh
@@ -160,6 +160,19 @@ RC=$?
 case_run "3. gh issue comment after read-intent open → ask" "ask" "$OUT" "$RC"
 
 # -----------------------------------------------------------------------
+# Case 3b (#1092): a path-prefixed gh binary must still be detected as a
+# mutating call. `argv[0] == "gh"` exact match previously let `/usr/bin/gh
+# issue comment` bypass the gate; `_is_gh_binary` closes it.
+# -----------------------------------------------------------------------
+SF=$(new_state)
+run_hook "$SF" "" \
+  '{"hookEventName":"UserPromptSubmit","session_id":"test-session-3b","prompt":"analyze the codebase"}' >/dev/null
+OUT=$(run_hook "$SF" "" \
+  '{"hookEventName":"PreToolUse","session_id":"test-session-3b","tool_name":"Bash","tool_input":{"command":"/usr/bin/gh issue comment 178 --body foo"}}')
+RC=$?
+case_run "3b. /usr/bin/gh issue comment after read-intent open → ask" "ask" "$OUT" "$RC"
+
+# -----------------------------------------------------------------------
 # Case 4: Mutation tool call after read-intent open WITH later mutation
 # verb → silent pass
 # -----------------------------------------------------------------------

--- a/tests/hooks/preflight-gate/test_side_effect_scan.sh
+++ b/tests/hooks/preflight-gate/test_side_effect_scan.sh
@@ -170,6 +170,10 @@ run_case "git-push"                 ask  "git push origin main"
 
 # --- detection: gh remote trigger ------------------------------------------
 run_case "gh pr merge"              ask  "gh pr merge 42 --squash"
+# #1092: a path-prefixed gh binary must not slip past the side-effect scan.
+# `argv[0] == "gh"` exact match (in _gh_subcommand_pair) previously let
+# `/usr/bin/gh pr merge` bypass; `_is_gh_binary` closes it.
+run_case "gh pr merge path-prefixed"  ask  "/usr/bin/gh pr merge 42 --squash"
 run_case "gh pr create"             ask  "gh pr create --title x --body y"
 run_case "gh workflow run"          ask  "gh workflow run deploy.yml"
 

--- a/tests/hooks/preflight-gate/test_verify_commit_flag_override.sh
+++ b/tests/hooks/preflight-gate/test_verify_commit_flag_override.sh
@@ -117,6 +117,12 @@ run_case "B06: git -c core.hooksPath=/tmp/x commit -m msg" deny \
 run_case "B07: short combined -Skeyid" deny \
   "$(payload 'git commit -Sabc123 -m "msg"')"
 
+# #1092: a path-prefixed git binary must not slip past the override gate.
+# `argv[0] == "git"` exact match previously let `/usr/bin/git commit
+# --no-verify` bypass; `_is_git_binary` closes it.
+run_case "B08: /usr/bin/git commit --no-verify (path-prefix, deny)" deny \
+  "$(payload '/usr/bin/git commit --no-verify -m "msg"')"
+
 # ---------------------------------------------------------------------------
 # Pass cases (must NOT deny) — these are the lexical false-positives the
 # port is meant to eliminate. The prior regex-based hook tripped on every


### PR DESCRIPTION
## What

~15 hooks still compared `argv[0]` to the literal `"gh"`/`"git"`, so a path prefix (`/usr/bin/gh`, `/opt/homebrew/bin/git`) or a `.text`-wrapped token bypassed the gate — the hole #511 closed for the migrated siblings. This migrates every straggler to the path-tolerant `_is_gh_binary` / `_is_git_binary` helpers.

Covers the deny gates `verify-commit-flag-override`, `block-gh-state-all`, `gh-label-verify`, `gh-json-validator`, `gh-flag-verify`, `cross-boundary-preflight`, `branch-name-check`, `commit-title-format-check`, `session-intent`, `side-effect-scan`, and `momentum-rule-retrieval-gate`, plus the advisory hooks and `_lib/_external_write_body.is_gh_external_write`. Also teaches momentum's `_is_force_push` to detect `+refspec` force pushes (`git push origin +main`).

## Verified
`/usr/bin/git commit --no-verify` and `/usr/bin/gh search … --state all` now block just like the bare forms; each migrated hook gains a path-prefix test.

## Cross-PR notes
- **Residual gap → #1099 (PR #1108, stacked on this branch).** Migrating `argv[0]` alone does not close the *separated* flag-value form (`/usr/bin/gh search … --state all`), because `_hook_utils._resolve_subcommand` keys the value-flag spec on the literal `argv[0]`. The fused `--state=all` form is closed here; the separated form is closed in #1099.
- **`-m=` test lives in #1097 (PR #1107), not here.** `commit-title-format-check`'s `-m=` case (silent → block) depends on the extractor fix in #1097, so that test change is carried by #1107. This PR keeps that case at its original `silent` expectation so it is green independently; the two touch different hunks of the same file and won't conflict on merge.

Closes #1092

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKY5RsgXrBBisMS4Ms5oSP