### PR TITLE
fix(spec-drift): skip Verify commands inside fenced code blocks

### DIFF
--- a/skills/spec-drift/spec_drift.py
+++ b/skills/spec-drift/spec_drift.py
@@ -39,6 +39,10 @@ REQ_RE = re.compile(r"^- \*\*([A-Z]{2,4}-\d+)\*\*:")
 # single backticked span; nested backticks are not supported and would be a
 # spec-authoring error rather than a parse case to guess at.
 VERIFY_RE = re.compile(r"^\s+- Verify:\s*`(.+)`\s*$")
+# A ``` or ~~~ fence line (at any indentation) opens or closes a fenced code
+# block. A `- Verify:` inside such a fence is a documentation example, not an
+# oracle, so it must never be executed (#1093).
+FENCE_RE = re.compile(r"^\s*(?:`{3,}|~{3,})")
 
 IMPLEMENTED, MISSING, UNKNOWN = "implemented", "missing", "UNKNOWN"
 
@@ -82,16 +86,28 @@ def parse_spec(path: Path) -> list[tuple[str, str | None, list[str]]]:
     """
     found: list[tuple[str, str | None, list[str]]] = []
     in_block = False
+    in_fence = False
     for line in path.read_text(encoding="utf-8").splitlines():
         req = REQ_RE.match(line)
         if req:
             found.append((req.group(1), None, []))
             in_block = True
+            in_fence = False
             continue
         if not in_block:
             continue
         if line.strip() and not line[0].isspace():
             in_block = False
+            in_fence = False
+            continue
+        # A column-0 fence has already closed the block above (it is not
+        # indented); this handles an *indented* ``` / ~~~ fence sitting inside a
+        # requirement block. Toggle fence state and skip Verify-matching while a
+        # fence is open, so a `- Verify:` example inside it is never run (#1093).
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
             continue
         verify = VERIFY_RE.match(line)
         if verify:

--- a/tests/test_spec_drift.sh
+++ b/tests/test_spec_drift.sh
@@ -26,6 +26,7 @@
 #  18. A second Verify inside one block is ignored and reported, never silent
 #  19. A timed-out command keeps whatever it printed before it hung
 #  20. A Verify command that reads stdin gets EOF instead of the report's stdin
+#  21. A `- Verify:` inside a fenced code example is NOT executed (#1093)
 #
 # Every case runs against a fixture spec dir. This file is a `Verify:` target
 # for several of 0002's requirements, so running the report over the real spec
@@ -371,6 +372,46 @@ check_lacks "20b stdin-reading Verify does not burn the timeout" "$OUT9" \
 check_has "20c control: a real hang still reports exit 124" "$OUT9" \
   "missing      FR-002  (exit 124)"
 rm -rf "$FIX8"
+
+# --------------------------------------------------------------------------- #
+# Fixture 9 — a `- Verify:` line sitting inside an indented fenced code example
+# (#1093). parse_spec had no fence awareness, so VERIFY_RE matched the example
+# line and the report EXECUTED it — violating the "prose backticks are never
+# executed" contract, and here it would create a sentinel file. FR-002 is the
+# control: a genuine, non-fenced Verify line in the same spec must still run.
+# --------------------------------------------------------------------------- #
+FIX9=$(mktemp -d) || { echo "FATAL: mktemp -d failed" >&2; exit 1; }
+SENTINEL="$FIX9/PWNED"
+cat > "$FIX9/0010-fenced.md" <<EOF
+# Feature Specification: Fenced Verify example
+
+**Issue**: #1093
+
+### Functional Requirements
+
+- **FR-001**: Documents how a Verify line looks, inside a fenced example.
+
+  \`\`\`markdown
+  - Verify: \`touch $SENTINEL && true\`
+  \`\`\`
+
+- **FR-002**: A real, non-fenced Verify line still runs.
+  - Verify: \`sh -c 'echo FENCE_CONTROL_RAN; exit 0'\`
+EOF
+
+OUT10=$("$CLI" --spec-dir "$FIX9" 2>&1)
+
+if [ -e "$SENTINEL" ]; then
+  ng "21 fenced Verify example is NOT executed" "sentinel $SENTINEL was created"
+else
+  ok "21 fenced Verify example is NOT executed"
+fi
+check_lacks "21b fenced Verify command is not run" "$OUT10" \
+  "running      FR-001: touch $SENTINEL"
+check_has "21c fenced-only requirement stays UNKNOWN" "$OUT10" "UNKNOWN      FR-001"
+check_has "21d real non-fenced Verify still runs" "$OUT10" "FENCE_CONTROL_RAN"
+check_has "21e real non-fenced Verify -> implemented" "$OUT10" "implemented  FR-002"
+rm -rf "$FIX9"
 
 echo ""
 echo "Passed: $PASS  Failed: $FAIL"


### PR DESCRIPTION
## What

`spec_drift.py` promised "prose backticks are never executed," but `parse_spec` had no fenced-code awareness, so a `- Verify: \`cmd\`` line inside an indented ```` ``` ```` example was matched and run as a real command — arbitrary shell execution from a documentation example. This tracks fenced-code state and skips `Verify` matches inside a fence.

## Testing
New `test_spec_drift.sh` case: a fenced `- Verify:` is NOT executed (sentinel file not created) while a real non-fenced `Verify` in the same spec still runs.

Closes #1093

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKY5RsgXrBBisMS4Ms5oSP

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKY5RsgXrBBisMS4Ms5oSP)_