### PR TITLE
fix(scripts): align check-memory-frontmatter lint with the runtime parser

### DIFF
--- a/scripts/check-memory-frontmatter.py
+++ b/scripts/check-memory-frontmatter.py
@@ -106,8 +106,19 @@ BRACKET_FIELDS = ("hookKeywords", "hookEvents")
 
 # Mirrors hooks/advisory-nudge/memory-hint/impl.py:60 exactly (TRUTHY_VALUES) —
 # the runtime's own truthy set for `hookable:`, after the same normalization
-# (strip, lowercase, strip quotes) that impl.py:108-113 applies.
+# that impl.py:108-113 applies: strip an inline `# comment` (via
+# _strip_inline_comment, mirrored below), then strip whitespace, lowercase,
+# and strip quotes. Before issue #1094 this lint omitted the inline-comment
+# strip, so `hookable: true # enabled` read as non-truthy here while the
+# runtime read it as truthy — leaving a hookable-but-no-hookKeywords memory
+# (which impl.py silently drops) unflagged.
 HOOKABLE_TRUTHY_VALUES = {"true", "yes"}
+
+# Mirrors hooks/advisory-nudge/memory-hint/impl.py:81 (INLINE_COMMENT_RE) — a
+# YAML inline comment is a `#` preceded by whitespace (YAML 1.2). impl.py
+# strips this from the `hookable:` value before the truthiness test; the lint
+# must do the same or it diverges from the runtime (issue #1094).
+HOOKABLE_INLINE_COMMENT_RE = re.compile(r"\s+#.*$")
 
 
 def frontmatter_block(raw: str) -> str | None:
@@ -191,13 +202,28 @@ def check_file(path: Path) -> list[str]:
                     )
                 elif field == "hookKeywords":
                     close_idx = value.find("]")
-                    inner = value[1:close_idx].strip() if close_idx != -1 else value[1:]
-                    if not inner:
+                    if close_idx == -1:
+                        # Unclosed bracket (issue #1094): a `[`-opened value
+                        # with no closing `]` (`hookKeywords: [kubectl, helm`)
+                        # makes impl.py:127-129 return None outright — the
+                        # whole memory is dropped from the hint index. The
+                        # prior lint took `value[1:]` as the inner list, saw
+                        # non-empty content, and reported clean, diverging
+                        # from the runtime it exists to mirror. Treat a
+                        # missing `]` as a drop, matching the runtime's None.
                         errors.append(
-                            f"`{field}: {value}` is an empty list — the memory-hint parser treats "
-                            "an empty hookKeywords the same as absent and silently drops the entire "
-                            "memory from the hint index (issue #942 F1)"
+                            f"`{field}: {value}` has no closing `]` — the memory-hint parser "
+                            "requires a closing bracket and silently drops the entire memory "
+                            "from the hint index when it is absent (issue #1094)"
                         )
+                    else:
+                        inner = value[1:close_idx].strip()
+                        if not inner:
+                            errors.append(
+                                f"`{field}: {value}` is an empty list — the memory-hint parser treats "
+                                "an empty hookKeywords the same as absent and silently drops the entire "
+                                "memory from the hint index (issue #942 F1)"
+                            )
 
     # F1 (issue #942): `hookable: true` with `hookKeywords` entirely absent is
     # the most direct silent-dark shape and was previously invisible to this
@@ -208,6 +234,12 @@ def check_file(path: Path) -> list[str]:
     hookable_truthy = False
     if "hookable" in occurrences:
         _, hookable_value = occurrences["hookable"][0]
+        # Strip an inline `# comment` before the truthiness test, mirroring
+        # impl.py:108-111 (issue #1094): otherwise `hookable: true # note`
+        # reads non-truthy here but truthy at runtime, so a hookable memory
+        # with no hookKeywords — which the runtime silently drops — goes
+        # unflagged.
+        hookable_value = HOOKABLE_INLINE_COMMENT_RE.sub("", hookable_value)
         hookable_truthy = hookable_value.strip().strip("\"'").lower() in HOOKABLE_TRUTHY_VALUES
     if hookable_truthy and "hookKeywords" not in occurrences:
         errors.append(

--- a/tests/test_check_memory_frontmatter.py
+++ b/tests/test_check_memory_frontmatter.py
@@ -5,6 +5,9 @@ Covers the three shapes the script's docstring commits to:
   - a field duplicated across top-level + `metadata:` (or nested twice) fails
   - `hookKeywords:` / `hookEvents:` in multi-line YAML-block or scalar form
     fail — this is the functional-bug case, not just a style drift
+  - `hookKeywords:` opened with `[` but never closed, and `hookable: true`
+    carrying a YAML inline comment with no hookKeywords, both fail — the lint
+    was diverging from the runtime parser on these two shapes (issue #1094)
   - a normalized entry passes
   - directory resolution honors `PRAXIS_MEMORY_DIR` and skips (rather than
     erroring) when the directory is absent, matching resolve_memory_dir()'s
@@ -159,6 +162,32 @@ body
     assert any("hookable: true" in e and "hookKeywords" in e and "missing" in e for e in errors), errors
 
 
+def test_hookable_inline_comment_with_no_keywords_flagged(tmp_path):
+    # issue #1094: `hookable: true # enabled` carries a YAML inline comment.
+    # impl.py:108-111 runs _strip_inline_comment before the truthiness test,
+    # so the runtime reads `true` (truthy) and — with no hookKeywords — drops
+    # the memory (impl.py:117-119 returns None). The pre-#1094 lint did NOT
+    # strip the inline comment, so its truthiness check read `true # enabled`
+    # as non-truthy and skipped the hookable-but-no-keywords check entirely,
+    # passing a memory the runtime silently drops.
+    p = _write(
+        tmp_path,
+        "feedback_bad_hookable_comment.md",
+        """---
+name: bad-hookable-comment
+description: test
+metadata:
+  type: feedback
+  hookable: true # enabled
+  originSessionId: abc-123
+---
+body
+""",
+    )
+    errors = check.check_file(p)
+    assert any("hookable: true" in e and "hookKeywords" in e and "missing" in e for e in errors), errors
+
+
 def test_hookable_false_missing_hookkeywords_not_flagged(tmp_path):
     # The F1 check is conditional on hookable being truthy — a non-hookable
     # memory has no hint-index behavior to protect, so omitting hookKeywords
@@ -201,6 +230,32 @@ body
     )
     errors = check.check_file(p)
     assert any("hookKeywords" in e and "empty list" in e for e in errors), errors
+
+
+def test_hookkeywords_unclosed_bracket_flagged(tmp_path):
+    # issue #1094: `hookKeywords: [kubectl, helm` opens a `[` but never closes
+    # it. impl.py:127-129 returns None the moment `find("]") == -1`, dropping
+    # the whole memory from the hint index. The pre-#1094 lint took
+    # `value[1:]` as the inner list, saw non-empty content, and reported clean
+    # — passing a memory the runtime silently drops (the exact silent-dark
+    # class this lint exists to catch).
+    p = _write(
+        tmp_path,
+        "feedback_bad_unclosed_keywords.md",
+        """---
+name: bad-unclosed-keywords
+description: test
+metadata:
+  type: feedback
+  hookable: true
+  hookKeywords: [kubectl, helm
+  originSessionId: abc-123
+---
+body
+""",
+    )
+    errors = check.check_file(p)
+    assert any("hookKeywords" in e and "no closing `]`" in e for e in errors), errors
 
 
 def test_hookevents_empty_bracket_not_flagged(tmp_path):


### PR DESCRIPTION
## What

The lint diverged from the runtime parser (`memory-hint/impl.py`) on two shapes, so it passed memories the runtime silently drops — the exact silent-dark class it exists to catch:

1. **Unclosed `hookKeywords` bracket** (`[kubectl, helm` with no `]`) — runtime returns `None`; lint reported clean. Now flagged.
2. **Inline comment on `hookable:`** (`hookable: true # enabled`) — runtime strips the comment and reads it truthy (dropping the memory when no keywords exist); the lint didn't strip and skipped the check. Now strips the inline comment first.

The stale comment claiming the lint mirrors `impl.py` is corrected.

## Testing
New fixtures/cases in `test_check_memory_frontmatter.py` for both shapes (19 passed).

Closes #1094

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKY5RsgXrBBisMS4Ms5oSP

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKY5RsgXrBBisMS4Ms5oSP)_