### PR TITLE
fix(recover-sessions): harden the recovery CLIs against early abort and bad data

### DIFF
--- a/skills/cmux-recover-sessions/cmux-recover-sessions
+++ b/skills/cmux-recover-sessions/cmux-recover-sessions
@@ -226,17 +226,21 @@ elif [[ "$MODE" == "tabs" ]]; then
     IFS='|' read -r mod_time size session_id project_dir first_msg home_label <<< "${SESSIONS[$i]}"
     resume_cmd=$(build_resume_cmd "$session_id" "$home_label")
 
-    ws_ref=$(create_and_resume "$project_dir" "$resume_cmd")
-    if [[ -n "$ws_ref" ]]; then
-      if [[ "$RENAME" == true ]]; then
-        short_name=$(echo "$first_msg" | cut -c1-30)
-        cmux rename-workspace --workspace "$ws_ref" "$short_name" 2>/dev/null || true
-      fi
-      created=$((created + 1))
-      echo "  ✓ workspace $((i + 1)): ${first_msg:0:50}"
-    else
+    # #1095: skip a single failed workspace instead of aborting the whole
+    # run. Under `set -euo pipefail`, `ws_ref=$(create_and_resume …)` used to
+    # abort the script the moment the helper returned 1, so the old
+    # `else … ✗ failed to create` branch was dead code. Mirror the
+    # `… || { echo …; continue; }` idiom from cmux-resume-sessions.
+    ws_ref=$(create_and_resume "$project_dir" "$resume_cmd") || {
       echo "  ✗ workspace $((i + 1)): failed to create"
+      continue
+    }
+    if [[ "$RENAME" == true ]]; then
+      short_name=$(echo "$first_msg" | cut -c1-30)
+      cmux rename-workspace --workspace "$ws_ref" "$short_name" 2>/dev/null || true
     fi
+    created=$((created + 1))
+    echo "  ✓ workspace $((i + 1)): ${first_msg:0:50}"
   done
 
   echo ""
@@ -262,12 +266,16 @@ elif [[ "$MODE" == "split" ]]; then
     IFS='|' read -r _ _ sid1 dir1 msg1 home1 <<< "${SESSIONS[$i]}"
     resume_cmd1=$(build_resume_cmd "$sid1" "$home1")
 
-    ws_ref=$(create_and_resume "$dir1" "$resume_cmd1")
-    if [[ -z "$ws_ref" ]]; then
+    # #1095: skip a single failed workspace instead of aborting the whole
+    # run. The prior `if [[ -z "$ws_ref" ]]` guard was dead code — under
+    # `set -euo pipefail` the failing command-substitution aborted the
+    # script before it was reached. Mirror cmux-resume-sessions'
+    # `… || { echo …; continue; }` idiom.
+    ws_ref=$(create_and_resume "$dir1" "$resume_cmd1") || {
       echo "  ✗ workspace ${ws_num}: failed to create"
       i=$((i + 1))
       continue
-    fi
+    }
 
     if [[ "$RENAME" == true ]]; then
       cmux rename-workspace --workspace "$ws_ref" "recover-${ws_num}" 2>/dev/null || true

--- a/skills/recover-sessions/claude-recover
+++ b/skills/recover-sessions/claude-recover
@@ -222,11 +222,14 @@ echo ""
 if [[ "$MODE" == "windows" ]]; then
   # Detect terminal app and open accordingly
   TERM_APP=""
-  if [[ "$TERM_PROGRAM" == "ghostty" ]] || pgrep -q Ghostty 2>/dev/null; then
+  # #1095: TERM_PROGRAM is commonly unset under tmux; `${TERM_PROGRAM:-}`
+  # keeps `set -u` from aborting the script and lets detection fall through
+  # to the intended `*)` fallback (attach-manually hint).
+  if [[ "${TERM_PROGRAM:-}" == "ghostty" ]] || pgrep -q Ghostty 2>/dev/null; then
     TERM_APP="Ghostty"
-  elif [[ "$TERM_PROGRAM" == "iTerm.app" ]] || pgrep -q iTerm2 2>/dev/null; then
+  elif [[ "${TERM_PROGRAM:-}" == "iTerm.app" ]] || pgrep -q iTerm2 2>/dev/null; then
     TERM_APP="iTerm"
-  elif [[ "$TERM_PROGRAM" == "Apple_Terminal" ]]; then
+  elif [[ "${TERM_PROGRAM:-}" == "Apple_Terminal" ]]; then
     TERM_APP="Terminal"
   fi
 

--- a/skills/recover-sessions/claude-recover-scan
+++ b/skills/recover-sessions/claude-recover-scan
@@ -436,4 +436,11 @@ if VERBOSE:
     print(f"Surviving:  {surviving} (after dedupe)", file=_sys.stderr)
 
 for mod_time, size_h, sid, cwd, msg, hlabel in results:
+    # #1095: strip pipe characters from the display message before emitting
+    # the pipe-delimited record. A first-message containing "|" would
+    # otherwise shift the fields and corrupt the trailing home_label on the
+    # consumer side (bash `IFS='|' read`). Mirrors sanitize_pipe semantics
+    # from cmux-session-lib (replace "|" with "-"). The "\n"→" " and [:80]
+    # normalisation still happens upstream where msg is built.
+    msg = msg.replace("|", "-")
     print(f"{mod_time}|{size_h}|{sid}|{cwd}|{msg}|{hlabel}")

--- a/tests/test_recover_scan_display_name.sh
+++ b/tests/test_recover_scan_display_name.sh
@@ -77,6 +77,18 @@ print(json.dumps({
 ")
 build_fixture "$PROJ/bbbb2222-2222-2222-2222-222222222222.jsonl" "$B_PAYLOAD"
 
+# Fixture P (#1095): first message contains a literal pipe. The scanner must
+# sanitize it at emit time (replace "|" with "-") so the pipe-delimited record
+# does not shift fields and corrupt the trailing home_label on the consumer.
+P_PAYLOAD=$(python3 -c "
+import json
+print(json.dumps({
+  'type':'user','isSidechain':False,'timestamp':'$NOW','cwd':'$CWD',
+  'message':{'content':'Run foo | grep bar | sort the output'}
+}))
+")
+build_fixture "$PROJ/pppp8888-8888-8888-8888-888888888888.jsonl" "$P_PAYLOAD"
+
 # Fixture C: compact-only "Summary:" form (no Primary/Original labels).
 COMPACT_SHORT='This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.\nSummary: Investigate flaky tests in the integration suite.'
 C_PAYLOAD=$(python3 -c "
@@ -215,6 +227,28 @@ assert_no_prefix "no-original-request-label-leak" \
 assert_equals "plain-first-message" \
   "bbbb2222" \
   "Investigate the broken hook chain in PR 472"
+
+# P (#1095): pipe chars in the message are sanitized to dashes so the record
+# stays 6-field. The display field must carry no literal "|", and the trailing
+# home_label field must be intact ("claude") — a leaked pipe would push the
+# real message tail into the home column.
+assert_equals "pipe-in-message-sanitized" \
+  "pppp8888" \
+  "Run foo - grep bar - sort the output"
+# Consume exactly as the recover scripts do: `IFS='|' read` into 6 fields.
+# With an unsanitized pipe the trailing home_label absorbs the message tail
+# ("grep bar - sort the output|claude"), so this is the faithful regression.
+p_record=$(grep -F "|pppp8888" <<< "$out" | head -1)
+IFS='|' read -r _ _ _ _ _ p_home <<< "$p_record"
+if [[ "$p_home" == "claude" ]]; then
+  echo "PASS  [pipe-record-home-field-intact]  (home='$p_home')"
+  pass=$((pass + 1))
+else
+  echo "FAIL  [pipe-record-home-field-intact]"
+  echo "  expected home field: 'claude'"
+  echo "  actual:              '$p_home'"
+  fail=$((fail + 1))
+fi
 
 # C: "Summary: <body>" short form
 assert_equals "summary-prefix-stripped" \


### PR DESCRIPTION
## What

Three robustness defects in the session-recovery CLIs:

1. **`cmux-recover-sessions`** called `create_and_resume` in a bare command substitution, so under `set -euo pipefail` the first failed workspace aborted the whole recovery and the "failed to create" branch was dead code. Switched to the `|| { echo; continue; }` idiom used by `cmux-resume-sessions`.
2. **`claude-recover-scan`** never stripped `|` from the session's first message, shifting the pipe-delimited record and corrupting the trailing config-home field. Now sanitizes `|` at emit time.
3. **`claude-recover`** read `$TERM_PROGRAM` under `set -u`, crashing when unset (common under tmux). Now `${TERM_PROGRAM:-}`.

## Testing
`test_recover_scan_display_name.sh` extended with a pipe-in-message case (12 passed); `bash -n` clean on both scripts.

Closes #1095

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKY5RsgXrBBisMS4Ms5oSP

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKY5RsgXrBBisMS4Ms5oSP)_