### PR TITLE
test(hooks): skip the unwritable-location state_lock case when running as root

### DIFF
--- a/tests/hooks/_lib/test_state_lock.py
+++ b/tests/hooks/_lib/test_state_lock.py
@@ -124,6 +124,11 @@ def test_creates_the_parent_directory(tmp_path):
     assert os.path.isdir(os.path.dirname(state))
 
 
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="chmod 0o500 does not restrict root, so the unwritable-location "
+    "premise cannot hold when the suite runs as root (#1100)",
+)
 def test_unwritable_location_yields_false_without_raising(tmp_path):
     denied = tmp_path / "denied"
     denied.mkdir()


### PR DESCRIPTION
## What

`test_unwritable_location_yields_false_without_raising` creates a `0o500` directory and asserts the lock is refused. As root, `chmod 0o500` doesn't restrict writes, so the lock IS acquired and the assertion fails — turning an otherwise-green tree red under a root runner (CI runs non-root and passes). Guards the case with `skipif(os.geteuid() == 0)`, keeping full coverage for the normal path.

Closes #1100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKY5RsgXrBBisMS4Ms5oSP

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKY5RsgXrBBisMS4Ms5oSP)_