### PR TITLE
docs: sync project tagline across manifests

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "praxis",
-  "description": "Development workflow skills for Claude Code — disciplined, fast, resilient",
+  "description": "Workflow rules from CLAUDE.md turned into hooks and skills that actually fire",
   "owner": {
     "name": "devseunggwan"
   },
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "praxis",
-      "description": "Development workflow skills for Claude Code — disciplined, fast, resilient",
+      "description": "Workflow rules from CLAUDE.md turned into hooks and skills that actually fire",
       "version": "7.11.0",
       "author": {
         "name": "devseunggwan"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "praxis",
-  "description": "Development workflow skills for Claude Code — disciplined, fast, resilient",
+  "description": "Workflow rules from CLAUDE.md turned into hooks and skills that actually fire",
   "owner": {
     "name": "devseunggwan"
   },
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "praxis",
-      "description": "Development workflow skills for Claude Code — disciplined, fast, resilient",
+      "description": "Workflow rules from CLAUDE.md turned into hooks and skills that actually fire",
       "version": "7.11.0",
       "author": {
         "name": "devseunggwan"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "praxis",
-  "description": "Development workflow skills for Claude Code — disciplined, fast, resilient",
+  "description": "Workflow rules from CLAUDE.md turned into hooks and skills that actually fire",
   "version": "7.11.0",
   "author": {
     "name": "devseunggwan"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "praxis",
-  "description": "Development workflow skills for Claude Code — disciplined, fast, resilient",
+  "description": "Workflow rules from CLAUDE.md turned into hooks and skills that actually fire",
   "version": "7.11.0",
   "author": {
     "name": "devseunggwan"

--- a/.opencode/plugin.json
+++ b/.opencode/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "praxis",
-  "description": "Development workflow skills for Claude Code — disciplined, fast, resilient",
+  "description": "Workflow rules from CLAUDE.md turned into hooks and skills that actually fire",
   "version": "7.11.0",
   "author": {
     "name": "devseunggwan"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Praxis
 
-Development workflow skills for Claude Code — disciplined, fast, resilient.
+Workflow rules from CLAUDE.md turned into hooks and skills that actually fire.
 
 Each skill is an orchestrator with pluggable steps. External integrations (issue tracker, PR tool, code review) are routed via the project's CLAUDE.md — no hardcoded dependencies.
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "praxis",
-  "description": "Development workflow skills for Claude Code — disciplined, fast, resilient",
+  "description": "Workflow rules from CLAUDE.md turned into hooks and skills that actually fire",
   "version": "7.11.0",
   "author": "devseunggwan",
   "repository": "https://github.com/devseunggwan/praxis",

--- a/manifests/plugin.base.json
+++ b/manifests/plugin.base.json
@@ -1,6 +1,6 @@
 {
   "name": "praxis",
-  "description": "Development workflow skills for Claude Code — disciplined, fast, resilient",
+  "description": "Workflow rules from CLAUDE.md turned into hooks and skills that actually fire",
   "author": {
     "name": "devseunggwan"
   },

--- a/plugins/praxis/.codex-plugin/plugin.json
+++ b/plugins/praxis/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "praxis",
-  "description": "Development workflow skills for Claude Code — disciplined, fast, resilient",
+  "description": "Workflow rules from CLAUDE.md turned into hooks and skills that actually fire",
   "version": "7.11.0",
   "author": {
     "name": "devseunggwan"


### PR DESCRIPTION
### 무엇이 바뀌나

프로젝트 한 줄 소개를 새 문구로 통일합니다.

```
- Development workflow skills for Claude Code — disciplined, fast, resilient
+ Workflow rules from CLAUDE.md turned into hooks and skills that actually fire
```

이전 문구는 형용사만 나열해서 이 플러그인이 무엇을 하는지 말하지 않습니다. PR #1090 에서 README intro 를 그 이유로 다시 썼는데, README 바깥 표면 9개 파일은 옛 문구를 그대로 노출하고 있었습니다 — 그중 5곳은 플러그인 마켓플레이스 목록에 그대로 보이는 자리입니다.

### 어떻게

손으로 고친 파일은 2개뿐입니다.

- `manifests/plugin.base.json` — 정본 `description`
- `AGENTS.md:3` — `CLAUDE.md` 가 이 파일의 심볼릭 링크

나머지 7개 파일(11개 occurrence)은 `scripts/build-plugin-manifests.py` 재실행으로 생성했습니다. 생성물을 직접 편집하지 않았으므로 정본과 어긋날 여지가 없습니다.

### 검증

`scripts/run-tests.sh` — `.github/workflows/ci.yml` 이 부르는 진입점 그대로 실행, exit 0 / `ALL TESTS PASSED` / `PASS` 3651건. 상세 근거는 검증 코멘트에 기록합니다.

잔여 확인: `grep -rn "disciplined, fast, resilient"` → `.git/` 제외 0건.

Pre-commit verified: `git diff --cached --diff-filter=A --name-only | wc -l` -> 0 (신규 추가 파일 없음, 9개 전부 수정)

Caller chain verified: `grep -rn "build-plugin-manifests"` 로 호출부를 열거했습니다. 생성 스크립트를 실제로 import/실행하는 곳은 `scripts/check-plugin-manifests.py:68`(생성 결과와 커밋된 파일의 drift 검사), `tests/test_hook_operating_matrix.sh:10`, `tests/test_build_hosts_filter.sh:14`, `tests/test_build_dispatch_collapse.py:23` 네 곳이며, `scripts/run-tests.sh` 는 이 스크립트를 직접 부르지 않고 위 테스트들을 통해 간접적으로 커버합니다. `.github/workflows/release-please.yml:9,15` 는 주석 참조입니다.

Closes #1110
