### PR TITLE
fix(hooks): correct sciomc gate bypass instruction

### DIFF
--- a/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
+++ b/hooks/preflight-gate/block-sciomc-finding-commit/impl.py
@@ -622,7 +622,9 @@ def _emit_block_message(matched_markers: list[str]) -> None:
                 "     AskUserQuestion BEFORE committing.",
                 "  2. If user explicitly approved the change in this session, add token",
                 "     [user-approved] or [ratified-by-user] to the commit message.",
-                "  3. One-off bypass: prefix with CLAUDE_HOOK_BYPASS_SCIOMC_GATE=1",
+                "  3. One-off bypass: set CLAUDE_HOOK_BYPASS_SCIOMC_GATE=1 in the session",
+                "     environment, since an inline `VAR=1 git commit ...` prefix never",
+                "     reaches this hook.",
                 "",
                 "CLAUDE.md: Output-Block-Level Falsification Gate / Self-Falsify Before Recommendation Lock",
             ]

--- a/hooks/preflight-gate/block-sciomc-finding-commit/spec.md
+++ b/hooks/preflight-gate/block-sciomc-finding-commit/spec.md
@@ -100,7 +100,9 @@ scope.
 
 - Add `[user-approved]`, `[ratified-by-user]`, or `[user-ratified]` to the
   commit message when the user explicitly approved the change in this session.
-- Set `CLAUDE_HOOK_BYPASS_SCIOMC_GATE=1` for a deliberate one-off bypass.
+- Set `CLAUDE_HOOK_BYPASS_SCIOMC_GATE=1` in the **session environment** for a
+  deliberate one-off bypass, since an inline `VAR=1 git commit …` prefix never
+  reaches this hook — it reads its own process env.
 - Missing / unreadable / oversized (`>50MB`) transcript → silent pass
   (cannot enforce). Malformed stdin → silent fail-open.
 

--- a/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
+++ b/tests/hooks/preflight-gate/test_block_sciomc_finding_commit.sh
@@ -471,6 +471,12 @@ run_case "env var bypass (silent)" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'fix'\"},\"transcript_path\":\"$TX_FINDING\"}" \
   "CLAUDE_HOOK_BYPASS_SCIOMC_GATE=1"
 
+# The deny message points at the env var; an inline command prefix cannot reach
+# this hook's process environment, so it must still block.
+run_case "inline env prefix does NOT bypass (block)" \
+  "block" \
+  "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"CLAUDE_HOOK_BYPASS_SCIOMC_GATE=1 git commit -m 'fix'\"},\"transcript_path\":\"$TX_FINDING\"}"
+
 run_case "missing transcript_path (silent — cannot enforce)" \
   "silent" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'fix'\"}}"


### PR DESCRIPTION
Closes #1112

### 무엇이 바뀌나

`block-sciomc-finding-commit` 이 커밋을 막을 때 내놓던 안내문 3번이, 따라 하면 다시 막히는 방법을 알려주고 있었다.

```
before:  3. One-off bypass: prefix with CLAUDE_HOOK_BYPASS_SCIOMC_GATE=1
after :  3. One-off bypass: set CLAUDE_HOOK_BYPASS_SCIOMC_GATE=1 in the session
            environment, since an inline `VAR=1 git commit ...` prefix never
            reaches this hook.
```

훅은 별개 프로세스로 떠서 자기 `os.environ` 을 읽고(`impl.py:86`), 명령 문자열은 그와 무관하게 따로 읽힌다(`impl.py:92`). 명령 앞에 붙인 `VAR=1` 은 커밋을 실행하는 셸에만 바인딩되므로 86행이 보는 곳에는 나타나지 않는다.

문구는 새로 짓지 않고, 같은 사실을 이미 쓰고 있던 형제 둘의 정형을 그대로 미러링했다 — `hooks/_lib/block_message.py:163`(`block-ask-end-option` 체크리스트)과 `hooks/advisory-nudge/momentum-rule-retrieval-gate/impl.py:833`.

`spec.md` 의 escape-hatch 항목도 같은 구분(세션 환경 vs 인라인 prefix)을 담도록 고쳤다.

### 테스트

인라인 prefix 를 단 커밋이 **여전히 차단**된다는 사실을 고정하는 케이스를 추가했다. 지금까지는 이 방향을 잡아 주는 케이스가 없어서, 안내문이 다시 틀린 쪽으로 바뀌어도 스위트가 조용했다.

Pre-commit verified: `git diff --cached --stat` 로 스테이지된 3파일(+12/-2)을 확인했고, `git diff --cached --diff-filter=A --name-only | wc -l` → `0` 으로 셸이 만든 미추적 신규 파일이 섞이지 않았음을 확인했다.

Caller chain verified: 편집한 `_emit_block_message` 의 호출부는 `hooks/preflight-gate/block-sciomc-finding-commit/impl.py:122` 한 곳뿐이다(`grep -rn "_emit_block_message" hooks/ tests/`). 같은 이름의 함수가 `block-commit-without-codex-review/impl.py:614` 에도 있으나 별개 파일의 별개 정의로, 이 PR 은 건드리지 않는다. 같은 결함(인라인 prefix 안내)이 다른 훅에도 있는지 `grep -rn "prefix" hooks/ --include='*.py' --include='*.md' | grep -iE 'bypass|env'` 로 전수 확인했고, 나머지 두 곳은 이미 올바른 문구를 쓰고 있다.
