### PR TITLE
fix(cmux): enumerate all windows in find_orphans

### DIFF
--- a/skills/cmux-session-manager/cmux-session-lib
+++ b/skills/cmux-session-manager/cmux-session-lib
@@ -190,7 +190,12 @@ find_orphans() {
     fi
 
     local pane_cmds
-    pane_cmds=$(tmux list-panes -t "$session_name" -F '#{pane_current_command}' 2>/dev/null) || continue
+    # -s spans every window in the session. Without it tmux lists only the
+    # ACTIVE window's panes, so a session whose active window is a bare shell
+    # classifies as shell-only even while an agent runs in an inactive window.
+    # For a numeric session that means safe_numeric, the one type
+    # cmux-session-cleanup Phase 1 kills without prompting.
+    pane_cmds=$(tmux list-panes -s -t "$session_name" -F '#{pane_current_command}' 2>/dev/null) || continue
 
     local is_shell_only=true
     while IFS= read -r cmd; do

--- a/tests/test_cmux_session_orphan_windows.sh
+++ b/tests/test_cmux_session_orphan_windows.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+# tests/test_cmux_session_orphan_windows.sh — guard find_orphans' pane enumeration
+#
+# find_orphans classifies an orphan tmux session by whether EVERY pane in it
+# runs a bare shell. A NUMERIC session name that comes back shell-only is typed
+# safe_numeric, and safe_numeric is the one branch cmux-session-cleanup Phase 1
+# kills without prompting — every other type takes the report_orphan path with
+# auto_delete:false. So the shell-only verdict must cover the whole session.
+#
+# `tmux list-panes -t <session>` lists only the ACTIVE window's panes. A session
+# whose active window is a bare shell and whose inactive window runs an agent
+# therefore reads as shell-only, and Phase 1 kills the agent unprompted. `-s`
+# spans all windows and is what makes the verdict cover the session.
+#
+# The fixture is numeric on purpose: a named fixture would exercise
+# safe_named -> unsafe_named, which is the report-only path, and would leave a
+# regression on the actual kill path undetected.
+#
+# Run:  ./tests/test_cmux_session_orphan_windows.sh
+# Exit: 0 on success, 1 on first failure (after summary).
+# Only an unusable tmux is a SKIP. Once the server is up, every fixture command
+# and query is checked for failure and fails the run — a broken fixture must
+# never look like an absent prerequisite.
+
+set +e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LIB="$REPO_ROOT/skills/cmux-session-manager/cmux-session-lib"
+
+if [ ! -f "$LIB" ]; then
+  echo "FAIL: cmux-session-lib not found at $LIB" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+SKIPPED_NAMES=()
+
+pass() { PASS=$((PASS + 1)); echo "  PASS  $1"; }
+fail() { FAIL=$((FAIL + 1)); FAILED_NAMES+=("$1"); echo "  FAIL  $1" >&2; }
+skip() { SKIPPED_NAMES+=("$1"); echo "SKIPPED: $1"; }
+
+summary_and_exit() {
+  echo ""
+  echo "Passed: $PASS  Failed: $FAIL  Skipped: ${#SKIPPED_NAMES[@]}"
+  if [ ${#SKIPPED_NAMES[@]} -gt 0 ]; then
+    for n in "${SKIPPED_NAMES[@]}"; do echo "  SKIPPED  $n"; done
+  fi
+  if [ "$FAIL" -gt 0 ]; then
+    for n in "${FAILED_NAMES[@]}"; do echo "  FAILED  $n" >&2; done
+    exit 1
+  fi
+  exit 0
+}
+
+# --- Prerequisites -----------------------------------------------------------
+# An isolated tmux server: -L gives this test its own socket so it can never
+# enumerate, classify, or kill anything in the developer's real tmux server.
+SOCKET="praxis-test-orphan-$$"
+TMUX_T=(tmux -L "$SOCKET")
+# find_orphans types a session safe_numeric only when its name matches ^[0-9]+$.
+SESSION="9$$"
+
+cleanup() { "${TMUX_T[@]}" kill-server 2>/dev/null; }
+trap cleanup EXIT
+
+if ! command -v tmux >/dev/null 2>&1; then
+  skip "tmux absent — pane-enumeration gates cannot run"
+  summary_and_exit
+fi
+
+# The only tolerated prerequisite failure: this environment cannot run a tmux
+# server at all (no socket dir, sandbox restriction). Everything after this
+# point is fixture construction, and a failure there is a real failure.
+if ! "${TMUX_T[@]}" new-session -d -s "$SESSION" -n active-shell 2>/dev/null; then
+  skip "tmux server would not start on an isolated socket — gates cannot run"
+  summary_and_exit
+fi
+
+# --- Fixture -----------------------------------------------------------------
+# Window 0 (active): a bare shell.  Window 1 (inactive): a non-shell process.
+# `sleep` stands in for an agent binary: what matters to find_orphans is only
+# that pane_current_command is not in its shell allowlist.
+# The trailing colon is load-bearing: a bare numeric target is read as a WINDOW
+# INDEX first, so `-t 912345` would add the window to the caller's own session
+# and leave the fixture with one window. `-t 912345:` forces the session
+# reading. (find_orphans itself is safe here — `-s` forces the same reading.)
+if ! "${TMUX_T[@]}" new-window -d -t "$SESSION:" -n hidden-agent 'sleep 300' 2>/dev/null; then
+  fail "fixture: could not create the inactive window (tmux new-window failed)"
+  summary_and_exit
+fi
+if ! "${TMUX_T[@]}" select-window -t "$SESSION:0" 2>/dev/null; then
+  fail "fixture: could not make window 0 active (tmux select-window failed)"
+  summary_and_exit
+fi
+
+active_cmds=$("${TMUX_T[@]}" list-panes -t "$SESSION" -F '#{pane_current_command}' 2>/dev/null)
+active_rc=$?
+all_cmds=$("${TMUX_T[@]}" list-panes -s -t "$SESSION" -F '#{pane_current_command}' 2>/dev/null)
+all_rc=$?
+
+if [ "$active_rc" -ne 0 ] || [ -z "$active_cmds" ]; then
+  fail "fixture: active-window pane query failed (rc=$active_rc, output=[$active_cmds])"
+  summary_and_exit
+fi
+if [ "$all_rc" -ne 0 ] || [ -z "$all_cmds" ]; then
+  fail "fixture: session-wide pane query failed (rc=$all_rc, output=[$all_cmds])"
+  summary_and_exit
+fi
+# Equal output means the second window never materialized. That is a broken
+# fixture, not an absent prerequisite — the gates below would pass vacuously.
+if [ "$active_cmds" = "$all_cmds" ]; then
+  fail "fixture: no hidden window present (active=[$active_cmds] all=[$all_cmds])"
+  summary_and_exit
+fi
+
+# --- Gate 1: the enumeration itself ------------------------------------------
+# Positive control for gate 2: proves the fixture hides a pane that a
+# session-wide enumeration finds, so gate 2's verdict is not vacuous.
+if printf '%s\n' "$all_cmds" | grep -q 'sleep'; then
+  pass "session-wide enumeration sees the inactive window's process"
+else
+  fail "session-wide enumeration missed the inactive window (all=[$all_cmds])"
+fi
+
+if printf '%s\n' "$active_cmds" | grep -q 'sleep'; then
+  fail "active-window enumeration unexpectedly saw the hidden pane — fixture invalid"
+else
+  pass "active-window enumeration alone misses it (the defect's mechanism)"
+fi
+
+# --- Gate 2: find_orphans' verdict -------------------------------------------
+# Source the lib in a subshell under the flags it documents as required, point
+# it at the isolated server, and let it classify the fixture. WS_COUNT=0 stands
+# for "no live cmux workspaces", which is what makes the fixture an orphan and
+# also what keeps the numeric name from matching a live workspace number.
+verdict=$(
+  set -euo pipefail
+  # shellcheck source=/dev/null
+  source "$LIB"
+  tmux() { command tmux -L "$SOCKET" "$@"; }
+  WS_COUNT=0
+  find_orphans
+  i=0
+  while [ "$i" -lt "$ORPHAN_COUNT" ]; do
+    entry="${ORPHAN_DATA[$i]}"
+    name="${entry%%|*}"
+    rest="${entry#*|}"
+    type="${rest%%|*}"
+    if [ "$name" = "$SESSION" ]; then printf '%s' "$type"; fi
+    i=$((i + 1))
+  done
+) 2>/dev/null
+
+case "$verdict" in
+  unsafe_numeric)
+    pass "find_orphans classifies the numeric fixture as unsafe_numeric (Phase 1 will not kill it)"
+    ;;
+  safe_numeric)
+    fail "find_orphans classified the fixture as safe_numeric — Phase 1 would kill the hidden agent unprompted"
+    ;;
+  "")
+    fail "find_orphans did not classify the fixture at all (empty verdict)"
+    ;;
+  *)
+    fail "find_orphans returned '$verdict' — the fixture is numeric, so the verdict must be one of safe_numeric/unsafe_numeric"
+    ;;
+esac
+
+summary_and_exit

--- a/tests/test_cmux_session_orphan_windows.sh
+++ b/tests/test_cmux_session_orphan_windows.sh
@@ -62,7 +62,15 @@ TMUX_T=(tmux -L "$SOCKET")
 # find_orphans types a session safe_numeric only when its name matches ^[0-9]+$.
 SESSION="9$$"
 
-cleanup() { "${TMUX_T[@]}" kill-server 2>/dev/null; }
+# kill-server ends the server process but leaves its socket file on disk, so a
+# run that only kills the server leaks one dead socket inode per invocation.
+# SOCKET_PATH is filled in from the live server below; until then it is empty
+# and cleanup has nothing to unlink.
+SOCKET_PATH=""
+cleanup() {
+  "${TMUX_T[@]}" kill-server 2>/dev/null
+  [ -n "$SOCKET_PATH" ] && rm -f "$SOCKET_PATH"
+}
 trap cleanup EXIT
 
 if ! command -v tmux >/dev/null 2>&1; then
@@ -77,6 +85,10 @@ if ! "${TMUX_T[@]}" new-session -d -s "$SESSION" -n active-shell 2>/dev/null; th
   skip "tmux server would not start on an isolated socket — gates cannot run"
   summary_and_exit
 fi
+
+# Ask the running server where its socket is rather than rebuilding the path
+# from TMUX_TMPDIR/TMPDIR/tmp precedence, which differs per platform.
+SOCKET_PATH=$("${TMUX_T[@]}" display-message -p '#{socket_path}' 2>/dev/null)
 
 # --- Fixture -----------------------------------------------------------------
 # Window 0 (active): a bare shell.  Window 1 (inactive): a non-shell process.


### PR DESCRIPTION
Closes #1124

### 무엇이 문제였나

`find_orphans` 가 고아 tmux 세션을 분류할 때 쓰던
`tmux list-panes -t "$session_name"` 은 **활성 윈도우의 페인만** 열거합니다.
활성 윈도우가 셸뿐이고 숨은 윈도우에서 에이전트가 돌고 있으면 세션 전체가
셸 전용으로 읽힙니다.

숫자 이름 세션에서 그 판정은 `safe_numeric` 이 되고, `safe_numeric` 은
`cmux-session-cleanup` Phase 1 이 **사용자 확인 없이 자동 kill 하는 유일한
분류**입니다. 나머지는 전부 `report_orphan` + `auto_delete:false` 로 보고만
됩니다. 그래서 이건 조용한 데이터 손실 경로였습니다.

### 무엇이 바뀌나

이 PR 이후로는 숨은 윈도우에서 돌고 있는 에이전트가 자동 정리 대상에서
제외됩니다. `-s` 한 플래그가 열거 범위를 세션 전체로 넓힙니다.

부수 효과가 하나 더 있습니다 — tmux 는 숫자로만 된 target 을 세션 이름보다
**윈도우 인덱스로 먼저** 해석하는데, `-s` 는 target 을 세션으로 강제하므로
그 모호성도 같이 사라집니다.

### 회귀 테스트

`tests/test_cmux_session_orphan_windows.sh` 를 추가했습니다. 격리된 tmux
socket 위에 **숫자 이름** 세션을 만들고 활성 윈도우는 셸, 비활성 윈도우는
비셸 프로세스로 채운 뒤 `find_orphans` 가 `unsafe_numeric` 을 내는지 봅니다.

fixture 를 named 로 두면 `safe_named` → `unsafe_named` 전이만 검사하게 되는데
그건 report-only 경로라 자동 kill 회귀를 못 잡습니다. 그래서 numeric 이어야
합니다.

fixture 구성이 실패하면 `SKIPPED` 가 아니라 `FAIL` 합니다. tmux 자체를 쓸 수
없는 환경만 skip 으로 남깁니다 — 깨진 fixture 가 부재한 전제처럼 보이면
스위트가 단언에 닿지 못한 채로 통과합니다.

### 검증

수정 전후 양방향으로 확인했습니다.

```
$ bash tests/test_cmux_session_orphan_windows.sh          # 수정 후
  PASS  session-wide enumeration sees the inactive window's process
  PASS  active-window enumeration alone misses it (the defect's mechanism)
  PASS  find_orphans classifies the numeric fixture as unsafe_numeric (Phase 1 will not kill it)
Passed: 3  Failed: 0  Skipped: 0
EXIT=0
```

```
$ bash tests/test_cmux_session_orphan_windows.sh          # -s 를 되돌린 상태
  FAIL  find_orphans classified the fixture as safe_numeric — Phase 1 would kill the hidden agent unprompted
Passed: 2  Failed: 1  Skipped: 0
EXIT=1
```

두 번째 출력이 이 테스트가 회귀 테스트임을 보증합니다. 실패 시 나오는 값이
정확히 자동 kill 을 부르는 `safe_numeric` 입니다.

CI 진입점 전체도 통과했습니다.

```
$ gh run view --job 97788915422 --log | grep -E 'ALL TESTS PASSED|plugin-manifest check'
test	Run bash scripts/run-tests.sh	plugin-manifest check OK
test	Run bash scripts/run-tests.sh	ALL TESTS PASSED
```

CI 가 이 PR 의 head sha `7308184` 에서 통과했고, PR 체크 10개가 전부 pass 입니다.

로컬에서 같은 진입점을 돌리면 실패하는데, 그건 이 PR 과 무관합니다 — #1123 이
`block-sciomc-finding-commit` 훅을 지울 때 남은 추적되지 않는 `__pycache__`
디렉터리 때문입니다. manifest 검사기가 디렉터리 존재 여부로 판정하고
(`scripts/check-plugin-manifests.py:621`), 새 체크아웃인 CI 에는 그 디렉터리가
없습니다. 자세한 근거는 검증 앵커의 row 3·4 토글에 있습니다.

### 실제 노출

현재 `auto-removable` 로 분류된 23개 세션을 두 호출로 대조했더니 1건이
불일치했습니다.

```
MISMATCH session 69 : skill-sees=[zsh,] all-windows=[zsh,zsh,]
```

세션 69 는 숫자 이름이라 자동 kill 경로 위에 있습니다. 숨은 윈도우가 마침
`zsh` 라 오늘의 판정은 바뀌지 않지만, 메커니즘은 이미 살아 있었습니다.

### 미검증

- **실제 자동 kill 이 일어나는 상황을 끝까지 재현하지는 않았습니다.**
  `cmux-session-cleanup` 을 `DRY_RUN=false` 로 돌리려면 살아 있는 세션을
  실제로 죽여야 해서, `find_orphans` 의 판정값까지만 확인했습니다. Phase 1 이
  그 값을 어떻게 쓰는지는 코드로만 확인했습니다
  (`cmux-session-cleanup:35`).
- **tmux 3.x 이외 버전은 확인하지 않았습니다.** 로컬 tmux 한 버전에서만
  검증했습니다.

### Evidence

Pre-commit verified: CI run 32843811764 on this PR's head sha 7308184 -> conclusion=success; its test job runs `bash scripts/run-tests.sh` and logged `plugin-manifest check OK` then `ALL TESTS PASSED`. All 10 PR checks pass. A local run of the same entrypoint failed, but that was a stale untracked `hooks/preflight-gate/block-sciomc-finding-commit/__pycache__` directory left behind when #1123 deleted that hook -- the manifest checker keys on directory existence (scripts/check-plugin-manifests.py:621), and a fresh CI checkout has no such directory. See the verification anchor rows 3 and 4.

Caller chain verified: find_orphans has exactly two call sites, both enumerated and both consuming the classification -- cmux-session-status:27 (display path, reads otype at :36) and cmux-session-cleanup:17 (kill path, branches on otype at :35). No other caller exists.

Caller-probe: grep -rn 'find_orphans' skills/ | grep -v cmux-session-lib -> skills/cmux-session-manager/cmux-session-status:27:find_orphans ; skills/cmux-session-manager/cmux-session-cleanup:17:find_orphans

Caller-probe: grep -n 'otype' skills/cmux-session-manager/cmux-session-cleanup -> 35: if [[ "$otype" == "safe_numeric" ]]; then (the sole auto-kill branch; every other otype falls through to report_orphan with auto_delete:false)
